### PR TITLE
terminal/c: fix crash on invalid enum in C API get functions

### DIFF
--- a/src/terminal/c/build_info.zig
+++ b/src/terminal/c/build_info.zig
@@ -42,7 +42,10 @@ pub fn get(
         };
     }
 
+    if (data == .invalid) return .invalid_value;
+
     return switch (data) {
+        .invalid => unreachable,
         inline else => |comptime_data| getTyped(
             comptime_data,
             @ptrCast(@alignCast(out)),

--- a/src/terminal/c/cell.zig
+++ b/src/terminal/c/cell.zig
@@ -109,7 +109,10 @@ pub fn get(
         };
     }
 
+    if (data == .invalid) return .invalid_value;
+
     return switch (data) {
+        .invalid => unreachable,
         inline else => |comptime_data| getTyped(
             cell_,
             comptime_data,

--- a/src/terminal/c/render.zig
+++ b/src/terminal/c/render.zig
@@ -192,7 +192,10 @@ pub fn get(
         };
     }
 
+    if (data == .invalid) return .invalid_value;
+
     return switch (data) {
+        .invalid => unreachable,
         inline else => |comptime_data| getTyped(
             state_,
             comptime_data,
@@ -336,11 +339,7 @@ pub fn colors_get(
         out_colors.cursor_has_value = colors.cursor != null;
     }
 
-    if (lib.structSizedFieldFits(
-        Colors,
-        out_size,
-        "palette",
-    )) {
+    {
         const palette_offset = @offsetOf(Colors, "palette");
         if (out_size > palette_offset) {
             const available = out_size - palette_offset;
@@ -466,7 +465,10 @@ pub fn row_cells_get(
         };
     }
 
+    if (data == .invalid) return .invalid_value;
+
     return switch (data) {
+        .invalid => unreachable,
         inline else => |comptime_data| rowCellsGetTyped(
             cells_,
             comptime_data,
@@ -565,7 +567,10 @@ pub fn row_get(
         };
     }
 
+    if (data == .invalid) return .invalid_value;
+
     return switch (data) {
+        .invalid => unreachable,
         inline else => |comptime_data| rowGetTyped(
             iterator_,
             comptime_data,

--- a/src/terminal/c/row.zig
+++ b/src/terminal/c/row.zig
@@ -72,7 +72,10 @@ pub fn get(
         };
     }
 
+    if (data == .invalid) return .invalid_value;
+
     return switch (data) {
+        .invalid => unreachable,
         inline else => |comptime_data| getTyped(
             row_,
             comptime_data,

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -195,7 +195,10 @@ pub fn get(
         };
     }
 
+    if (data == .invalid) return .invalid_value;
+
     return switch (data) {
+        .invalid => unreachable,
         inline else => |comptime_data| getTyped(
             terminal_,
             comptime_data,


### PR DESCRIPTION
## What

All `get` functions in the C API crash when called with `.invalid` and a null output pointer. This affects `build_info`, `cell`, `render` (3 functions), `row`, and `terminal` - 7 functions total.

Also `colors_get` never copies partial palette entries even though the code to do so exists.

## Why it crashes

The `get` functions use `inline else` on an enum switch to dispatch to a typed helper. `inline else` generates code for every variant, including `.invalid`. When `.invalid` is used with `null` as the output pointer:

```zig
@ptrCast(@alignCast(out))  // out is null
```

This casts null to a non-optional `*void` - safety panic. The typed helper would just return `.invalid_value` without touching the pointer, but we never get there.

## Fix

Return early before the switch for `.invalid`, mark it `unreachable` in the switch so `inline else` doesn't generate code for it:

```zig
if (data == .invalid) return .invalid_value;

return switch (data) {
    .invalid => unreachable,
    inline else => |comptime_data| getTyped(...),
};
```

For `colors_get`: removed the `structSizedFieldFits` guard around the palette copy. That check requires the full 256-entry array to fit, but the inner logic already calculates how many entries fit and copies only those. The guard was preventing it from ever running for truncated structs.

## Testing

All existing tests pass on Windows, macOS (arm64), Linux (x86_64). The `get invalid` tests that were crashing now pass.

## Notes

Draft tracking PR on the fork. Will clean up before submitting upstream.