### PR TITLE
windows: fix XDG-related test failures on Windows

### DIFF
--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -132,7 +132,7 @@ test {
 test "cache directory paths" {
     const testing = std.testing;
     const alloc = testing.allocator;
-    const mock_home = "/Users/test";
+    const mock_home = if (builtin.os.tag == .windows) "C:\\Users\\test" else "/Users/test";
 
     // Test when XDG_CACHE_HOME is not set
     {
@@ -140,7 +140,9 @@ test "cache directory paths" {
         {
             const cache_path = try cache(alloc, .{ .home = mock_home });
             defer alloc.free(cache_path);
-            try testing.expectEqualStrings("/Users/test/.cache", cache_path);
+            const expected = try std.fs.path.join(alloc, &.{ mock_home, ".cache" });
+            defer alloc.free(expected);
+            try testing.expectEqualStrings(expected, cache_path);
         }
 
         // Test with subdir
@@ -150,7 +152,9 @@ test "cache directory paths" {
                 .subdir = "ghostty",
             });
             defer alloc.free(cache_path);
-            try testing.expectEqualStrings("/Users/test/.cache/ghostty", cache_path);
+            const expected = try std.fs.path.join(alloc, &.{ mock_home, ".cache", "ghostty" });
+            defer alloc.free(expected);
+            try testing.expectEqualStrings(expected, cache_path);
         }
     }
 }

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -670,6 +670,8 @@ fn setupXdgDataDirs(
 }
 
 test "xdg: empty XDG_DATA_DIRS" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const testing = std.testing;
 
     var arena = ArenaAllocator.init(testing.allocator);
@@ -696,6 +698,8 @@ test "xdg: empty XDG_DATA_DIRS" {
 }
 
 test "xdg: existing XDG_DATA_DIRS" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const testing = std.testing;
 
     var arena = ArenaAllocator.init(testing.allocator);


### PR DESCRIPTION
## What

Two fixes for tests that fail on Windows due to Unix-specific assumptions.

1. The "cache directory paths" test in xdg.zig hardcodes Unix paths like `/Users/test/.cache` in expected values. The function under test uses `std.fs.path.join` which produces native separators, so the expectations need to match. Fixed by using `std.fs.path.join` for expected values too, with a platform-appropriate mock home path.

2. Two shell integration tests for `setupXdgDataDirs` hardcode Unix path separators (`:`) and Unix default paths (`/usr/local/share:/usr/share`). These are not applicable on Windows where the delimiter is `;` and `XDG_DATA_DIRS` is not a standard concept. Skipped on Windows with `SkipZigTest`.

## Why skip instead of fix for the shell integration tests?

`setupXdgDataDirs` is used by fish, elvish, and nushell. On Windows, `XDG_DATA_DIRS` is not standard. The equivalent would be `%ProgramData%` (what Go's `adrg/xdg`, Python's `platformdirs`, and others map to). Fixing this properly means adding a Windows-appropriate default, which is a separate change.

Worth noting: the production code on line 664 of `shell_integration.zig` hardcodes the fallback to `"/usr/local/share:/usr/share"` with `:` separators, while `prependEnv` correctly uses `std.fs.path.delimiter` (`;` on Windows). If a shell that uses this runs on Windows, you would get mixed separators. Tracked separately.

## Verified

- `zig build test-lib-vt` passes on Windows (exit 0)
- No behavior change on Linux/macOS (xdg.zig fix produces same paths, shell_integration skip only triggers on Windows)

## What I Learnt

- `std.fs.path.join` uses the native path separator, so tests that hardcode `/` in expected paths will fail on Windows even if the production code is correct. Better to use `path.join` in test expectations too.
- The XDG Base Directory spec is Unix-only but cross-platform libraries have converged on mappings. Ghostty maps to `%LOCALAPPDATA%` which matches common conventions. The missing piece is `XDG_DATA_DIRS` which has no Windows default and falls through to Unix paths.