### PR TITLE
build: fix zlib compilation on Windows with MSVC

### DIFF
--- a/pkg/zlib/build.zig
+++ b/pkg/zlib/build.zig
@@ -32,8 +32,16 @@ pub fn build(b: *std.Build) !void {
             "-DHAVE_SYS_TYPES_H",
             "-DHAVE_STDINT_H",
             "-DHAVE_STDDEF_H",
-            "-DZ_HAVE_UNISTD_H",
         });
+        if (target.result.os.tag != .windows) {
+            try flags.append(b.allocator, "-DZ_HAVE_UNISTD_H");
+        }
+        if (target.result.abi == .msvc) {
+            try flags.appendSlice(b.allocator, &.{
+                "-D_CRT_SECURE_NO_DEPRECATE",
+                "-D_CRT_NONSTDC_NO_DEPRECATE",
+            });
+        }
         lib.addCSourceFiles(.{
             .root = upstream.path(""),
             .files = srcs,


### PR DESCRIPTION
## Summary
- Gate `Z_HAVE_UNISTD_H` behind a non-Windows check since `unistd.h` does not exist with MSVC
- Add `_CRT_SECURE_NO_DEPRECATE` and `_CRT_NONSTDC_NO_DEPRECATE` for MSVC to suppress deprecation errors for standard C functions that zlib uses

## Context
Part of the effort to get `zig build -Dapp-runtime=none test` passing on Windows. This unblocks freetype, harfbuzz, libpng, and dcimgui which all depend on zlib.

## Stack
This is branch 010 in the stacked branches series. Independent fix, no dependencies on other branches.

## Test plan

### test-lib-vt

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** | 3791/3839 passed, 48 skipped | 3791/3839 passed, 48 skipped | 3807/3839 passed, 32 skipped |
| **AFTER** | 3791/3839 passed, 48 skipped | 3791/3839 passed, 48 skipped | 3807/3839 passed, 32 skipped |
| **Delta** | no change | no change | no change |

### all tests (`zig build test` / `zig build -Dapp-runtime=none test` on Windows)

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** | FAIL — 35/51 build steps, 6 failed | 2655/2678 passed, 23 skipped (86/86 steps) | 2655/2662 passed, 7 skipped (160/160 steps) |
| **AFTER** | FAIL — 37/51 build steps, 6 failed | 2655/2678 passed, 23 skipped (86/86 steps) | 2655/2662 passed, 7 skipped (160/160 steps) |
| **Delta** | +2 build steps (zlib + png unblocked) | no change | no change |

- Zero regressions on any platform
- Windows improved: zlib and png now compile (35 -> 37 steps)
- Remaining 6 Windows build failures (`ssize_t`, `helpgen`, `framegen`, `harfbuzz`, `dcimgui`) are addressed by other PRs in the stack

## What I Learnt
- Always run tests with `--summary all` to get actual pass/skip/fail counts. Without it, zig just exits 0 or 1 and you have no numbers to compare. "You get confident if you got the numbers."
- Build dependencies cascade: fixing zlib also unblocked png (which depends on it), giving us +2 build steps from a one-file change.