### PR TITLE
build: fix oniguruma compilation on Windows with MSVC

### DIFF
--- a/pkg/oniguruma/build.zig
+++ b/pkg/oniguruma/build.zig
@@ -68,6 +68,7 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
         .linkage = .static,
     });
     const t = target.result;
+    const is_windows = t.os.tag == .windows;
     lib.linkLibC();
 
     if (target.result.os.tag.isDarwin()) {
@@ -86,13 +87,13 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
             .PACKAGE_VERSION = "6.9.9",
             .VERSION = "6.9.9",
             .HAVE_ALLOCA = true,
-            .HAVE_ALLOCA_H = true,
-            .USE_CRNL_AS_LINE_TERMINATOR = false,
+            .HAVE_ALLOCA_H = !is_windows,
+            .USE_CRNL_AS_LINE_TERMINATOR = is_windows,
             .HAVE_STDINT_H = true,
-            .HAVE_SYS_TIMES_H = true,
-            .HAVE_SYS_TIME_H = true,
+            .HAVE_SYS_TIMES_H = !is_windows,
+            .HAVE_SYS_TIME_H = !is_windows,
             .HAVE_SYS_TYPES_H = true,
-            .HAVE_UNISTD_H = true,
+            .HAVE_UNISTD_H = !is_windows,
             .HAVE_INTTYPES_H = true,
             .SIZEOF_INT = t.cTypeByteSize(.int),
             .SIZEOF_LONG = t.cTypeByteSize(.long),


### PR DESCRIPTION
## Summary
- Conditionally disable POSIX-only header defines (`alloca.h`, `sys/times.h`, `sys/time.h`, `unistd.h`) on Windows since they do not exist with MSVC
- Enable `USE_CRNL_AS_LINE_TERMINATOR` on Windows for correct line endings

## Context
Oniguruma's `config.h` template had all POSIX header availability defines hardcoded to `true`. On MSVC, these headers don't exist, causing 24 compilation errors (all `alloca.h` file not found).

Uses a comptime `is_windows` constant to flip the config values, same pattern as PR #8 (zlib).

## Stack
Stacked on 010-windows/fix-zlib-msvc.

## Test plan

### test-lib-vt

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** | 3791/3839 passed, 48 skipped | 3791/3839 passed, 48 skipped | 3807/3839 passed, 32 skipped |
| **AFTER** | 3791/3839 passed, 48 skipped | 3791/3839 passed, 48 skipped | 3807/3839 passed, 32 skipped |
| **Delta** | no change | no change | no change |

### all tests (`zig build test` / `zig build -Dapp-runtime=none test` on Windows)

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** | FAIL — 37/51 steps, 6 failed | 2655/2678 passed, 23 skipped (86/86 steps) | 2655/2662 passed, 7 skipped (160/160 steps) |
| **AFTER** | FAIL — 38/51 steps, 5 failed | 2655/2678 passed, 23 skipped (86/86 steps) | 2655/2662 passed, 7 skipped (160/160 steps) |
| **Delta** | +1 step, -1 failure (oniguruma unblocked) | no change | no change |

- Zero regressions on any platform
- Windows improved: oniguruma now compiles (37 -> 38 steps, 6 -> 5 failures)
- Remaining 5 Windows failures (`translate-c`/ssize_t, `helpgen`, `framegen`, `glslang`, `harfbuzz` via freetype) are addressed by other PRs in the stack

## What I Learnt
_To be filled in after review_