### PR TITLE
build: fix freetype compilation on Windows with MSVC

### DIFF
--- a/pkg/freetype/build.zig
+++ b/pkg/freetype/build.zig
@@ -84,11 +84,14 @@ fn buildLib(b: *std.Build, module: *std.Build.Module, options: anytype) !*std.Bu
 
         "-DFT_CONFIG_OPTION_SYSTEM_ZLIB=1",
 
-        "-DHAVE_UNISTD_H",
-        "-DHAVE_FCNTL_H",
-
         "-fno-sanitize=undefined",
     });
+    if (target.result.os.tag != .windows) {
+        try flags.appendSlice(b.allocator, &.{
+            "-DHAVE_UNISTD_H",
+            "-DHAVE_FCNTL_H",
+        });
+    }
 
     if (target.result.os.tag == .freebsd or target.result.abi == .musl) {
         try flags.append(b.allocator, "-fPIC");


### PR DESCRIPTION
## Summary
- Gate `HAVE_UNISTD_H` and `HAVE_FCNTL_H` behind a non-Windows check since these headers do not exist with MSVC
- Freetype's gzip module includes zlib headers which conditionally include `unistd.h` based on this define

## Context
Same pattern as the zlib fix (010). Freetype passes `-DHAVE_UNISTD_H` unconditionally, which causes zlib's `zconf.h` to try including `unistd.h` when freetype compiles its gzip support. The fix follows the same approach used in `pkg/zlib/build.zig` (line 36-38).

## Stack
Stacked on 013-windows/fix-helpgen-framegen.

## Test plan

### Cross-platform results (`zig build test` / `zig build -Dapp-runtime=none test` on Windows)

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** (f9d3b1aaf) | FAIL - 44/51 steps, 2 failed | PASS - 86/86, 2655/2678 tests, 23 skipped | PASS - 160/160, 2655/2662 tests, 7 skipped |
| **AFTER** (d5aef6e84) | FAIL - 47/51 steps, 1 failed | PASS - 86/86, 2655/2678 tests, 23 skipped | PASS - 160/160, 2655/2662 tests, 7 skipped |

### Windows: what changed (44 to 47 steps, 2 to 1 failure)

**Fixed by this PR:**
- `compile lib freetype` - was `2 errors` (unistd.h/fcntl.h not found) -> `success`
- 3 additional steps that depended on freetype now succeed

**Remaining failure (pre-existing, tracked separately):**
- `translate-c` - 3 errors (`ssize_t` unknown in ghostty.h on MSVC)

### Linux/macOS: no regressions
Identical pass counts and test results before and after.

## Discussion

### Other build files with the same pattern
`pkg/fontconfig/build.zig` and `pkg/harfbuzz/build.zig` also pass `-DHAVE_UNISTD_H` and/or `-DHAVE_FCNTL_H` unconditionally. They are not in the Windows build path today, but will need the same fix when they are.

## What I Learnt
_To be filled in after review_