### PR TITLE
build: refactor checkGhosttyHEnum to use @hasDecl for Windows compatibility

### DIFF
--- a/src/lib/enum.zig
+++ b/src/lib/enum.zig
@@ -105,30 +105,27 @@ pub fn checkGhosttyHEnum(
     try std.testing.expect(info.@"enum".tag_type == c_int);
     try std.testing.expect(info.@"enum".is_exhaustive == true);
 
-    @setEvalBranchQuota(10_000_000);
+    @setEvalBranchQuota(100_000);
 
     const c = @import("ghostty.h");
 
     var set: std.EnumSet(T) = .initFull();
 
-    const c_decls = @typeInfo(c).@"struct".decls;
     const enum_fields = info.@"enum".fields;
 
     inline for (enum_fields) |field| {
-        const upper_name = comptime u: {
-            var buf: [128]u8 = undefined;
-            break :u std.ascii.upperString(&buf, field.name);
+        const expected_name: *const [prefix.len + field.name.len]u8 = comptime e: {
+            var buf: [prefix.len + field.name.len]u8 = undefined;
+            @memcpy(buf[0..prefix.len], prefix);
+            for (buf[prefix.len..], field.name) |*d, s| {
+                d.* = std.ascii.toUpper(s);
+            }
+            break :e &buf;
         };
 
-        inline for (c_decls) |decl| {
-            if (!comptime std.mem.startsWith(u8, decl.name, prefix)) continue;
-
-            const suffix = decl.name[prefix.len..];
-
-            if (!comptime std.mem.eql(u8, suffix, upper_name)) continue;
-
-            std.testing.expectEqual(field.value, @field(c, decl.name)) catch |e| {
-                std.log.err(@typeName(T) ++ " key " ++ field.name ++ " does not have the same backing int as " ++ decl.name, .{});
+        if (@hasDecl(c, expected_name)) {
+            std.testing.expectEqual(field.value, @field(c, expected_name)) catch |e| {
+                std.log.err(@typeName(T) ++ " key " ++ field.name ++ " does not have the same backing int as " ++ expected_name, .{});
                 return e;
             };
 


### PR DESCRIPTION
## Summary
- Refactor `checkGhosttyHEnum` in `src/lib/enum.zig` to use `@hasDecl` instead of a nested `inline for` over all translate-c declarations
- Removes the need for a large comptime branch quota entirely — down from 10M to 100K

## Context
The original `checkGhosttyHEnum` function used a nested `inline for` loop: for each enum field, it iterated over every declaration in the translated `ghostty.h` module doing comptime string comparisons. This is O(N×M) where N = enum fields and M = translate-c declarations.

On Linux/Mac, M is ~1502 declarations and the 1M quota was enough. On MSVC, `<sys/types.h>` and `<BaseTsd.h>` pull in Windows SDK headers, inflating M to ~2173. For `Action.Key` (138 variants), this generates ~6M comptime branches (138 × 2173 × ~20), exceeding even a 1M quota.

Rather than just bumping the quota to 10M, we realised we don't need to search at all. We already know the expected declaration name for each enum field: it's `prefix ++ UPPER(field.name)`. So we can use `@hasDecl` to check directly — O(N) instead of O(N×M), platform-independent, and the quota drops to 100K.

## How
Before (O(N×M)):
```zig
@setEvalBranchQuota(10_000_000);
inline for (enum_fields) |field| {
    const upper_name = comptime upperString(field.name);
    inline for (c_decls) |decl| {                    // 2173 decls on MSVC
        if (startsWith(decl.name, prefix) and eql(suffix, upper_name)) {
            // check value, remove from set
        }
    }
}
```

After (O(N)):
```zig
@setEvalBranchQuota(100_000);
inline for (enum_fields) |field| {
    const expected_name = comptime prefix ++ upper(field.name);
    if (@hasDecl(c, expected_name)) {
        // check value, remove from set
    }
}
```

## Stack
Stacked on 016-windows/fix-libcxx-msvc.

## Test plan

### Cross-platform results (`zig build test` / `zig build -Dapp-runtime=none test` on Windows)

| | Windows | Linux | Mac |
|---|---|---|---|
| **BEFORE** (016, ce9930051) | FAIL - 49/51, 2630/2654, 1 test failed, 23 skipped | PASS - 86/86, 2655/2678, 23 skipped | PASS - 160/160, 2655/2662, 7 skipped |
| **AFTER** (017, 81e21e4d0) | PASS - 49/51, 2631/2654, 23 skipped | PASS | PASS |

### Windows: what changed (2630 -> 2631 tests, MouseShape fixed)

**Fixed by this PR:**
- `ghostty.h MouseShape` test — was failing because the nested `inline for` exhausted the comptime branch quota, silently preventing matching. The refactored code uses direct `@hasDecl` lookups so it works regardless of how many declarations are in the translate-c output.

**Remaining failure (pre-existing, unrelated):**
- `config.Config.test.clone can then change conditional state` — segfaults (exit code 3) on Windows. We investigated this and it looked familiar — cherry-picking the CommaSplitter fix from PR 11782 resolved it. The backslash path handling in CommaSplitter breaks theme path parsing on Windows, which is exactly what that PR addresses. So once that lands, we should be in a good place... ready to ship to Windows users! (just kidding)

### Linux/macOS: no regressions
Confirmed all tests pass on both platforms after refactor.

## What I Learnt
- When you have a comptime loop searching for a specific item in a collection, check if the language provides a direct lookup first. `@hasDecl` is O(1) vs scanning all declarations with `inline for` which is O(M). The nested loop approach was doing `inline for (c_decls)` which generates comptime branches proportional to the total number of declarations, not just the ones you care about.
- Comptime branch quotas are a symptom, not the problem. The initial fix (bumping from 1M to 10M) treated the symptom. The real fix was changing the algorithm from O(N×M) to O(N), making the quota irrelevant — 100K is more than enough on all platforms now.
- Platform-specific translate-c output sizes (1502 decls on Linux vs 2173 on MSVC) can silently break comptime code that works fine on one platform. Writing platform-independent algorithms is better than tuning quotas per platform.