### PR TITLE
renderer: add DX11 GraphicsAPI contract stubs for GenericRenderer

### DIFF
--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -40,10 +40,7 @@ pub const Renderer = switch (build_config.renderer) {
     .metal => GenericRenderer(Metal),
     .opengl => GenericRenderer(OpenGL),
     .webgl => WebGL,
-    // DirectX11 does not implement GenericRenderer yet. Use OpenGL as a
-    // placeholder so shared code (Surface, message, etc.) compiles. The
-    // actual DX11 rendering is driven through DirectX11.Device directly.
-    .directx11 => GenericRenderer(OpenGL),
+    .directx11 => GenericRenderer(DirectX11),
 };
 
 /// The health status of a renderer. These must be shared across all

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -1,26 +1,180 @@
 //! Graphics API wrapper for DirectX 11.
 //!
-//! This module mirrors the structure of Metal.zig: it is the public surface
-//! for the DX11 renderer, re-exporting sub-modules and (eventually) providing
-//! the GraphicsAPI contract required by GenericRenderer.
+//! This module provides the GraphicsAPI contract required by GenericRenderer,
+//! mirroring the structure of Metal.zig and OpenGL.zig.
 //!
-//! Current status: infrastructure only - COM bindings, device lifecycle,
-//! swap chain management, and an instanced cell-grid pipeline. The
-//! GenericRenderer integration (Target, Frame, RenderPass, Buffer, Texture,
-//! Sampler, shaders) is planned for follow-up work.
+//! Current status: stub - all functions panic at runtime. The contract is
+//! satisfied at compile time so that GenericRenderer(DirectX11) compiles.
+//! Infrastructure (COM bindings, device lifecycle, cell grid pipeline) is
+//! already in place from prior work in the directx11/ subdirectory.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const configpkg = @import("../config.zig");
+const font = @import("../font/main.zig");
+const rendererpkg = @import("../renderer.zig");
+const shadertoy = @import("shadertoy.zig");
+
 pub const DirectX11 = @This();
 
-// Sub-module re-exports - low-level D3D11/DXGI/COM bindings.
+// --- GraphicsAPI contract: types ---
+
+pub const GraphicsAPI = DirectX11;
+pub const Target = @import("directx11/Target.zig");
+pub const Frame = @import("directx11/Frame.zig");
+pub const RenderPass = @import("directx11/RenderPass.zig");
+pub const Pipeline = @import("directx11/Pipeline.zig");
+pub const Sampler = @import("directx11/Sampler.zig");
+pub const Texture = @import("directx11/Texture.zig");
+
+const bufferpkg = @import("directx11/buffer.zig");
+pub const Buffer = bufferpkg.Buffer;
+
+pub const shaders = @import("directx11/shaders.zig");
+
+// TODO: custom shaders not yet supported on DX11. Using .glsl as placeholder;
+// DX11 will need its own shadertoy.Target variant (.hlsl) when custom shaders
+// are implemented. Can't add it without modifying upstream shadertoy.zig.
+pub const custom_shader_target: shadertoy.Target = .glsl;
+
+/// DX11 uses top-left origin, same as Metal.
+pub const custom_shader_y_is_down = true;
+
+/// Standard DXGI double-buffering.
+pub const swap_chain_count = 2;
+
+/// Pixel format for image texture options.
+pub const ImageTextureFormat = enum {
+    /// 1 byte per pixel grayscale.
+    gray,
+    /// 4 bytes per pixel RGBA.
+    rgba,
+    /// 4 bytes per pixel BGRA.
+    bgra,
+};
+
+// --- Sub-module re-exports: low-level D3D11/DXGI/COM bindings ---
+
 pub const com = @import("directx11/com.zig");
 pub const d3d11 = @import("directx11/d3d11.zig");
 pub const dxgi = @import("directx11/dxgi.zig");
 
-// Renderer components.
+// --- Sub-module re-exports: renderer components from 025 ---
+
 pub const Device = @import("directx11/device.zig").Device;
-pub const Pipeline = @import("directx11/cell_pipeline.zig").Pipeline;
+pub const CellPipeline = @import("directx11/cell_pipeline.zig").Pipeline;
 pub const Constants = @import("directx11/cell_pipeline.zig").Constants;
 pub const CellGrid = @import("directx11/cell_grid.zig").CellGrid;
 pub const CellInstance = @import("directx11/cell_grid.zig").CellInstance;
+
+// --- GraphicsAPI contract: mutable state ---
+
+/// Runtime blending mode, set by GenericRenderer when config changes.
+blending: configpkg.Config.AlphaBlending = .native,
+
+// --- GraphicsAPI contract: functions ---
+
+pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
+    _ = alloc;
+    _ = opts;
+    @panic("TODO: DX11 init");
+}
+
+pub fn deinit(self: *DirectX11) void {
+    _ = self;
+    @panic("TODO: DX11 deinit");
+}
+
+pub fn drawFrameStart(self: *DirectX11) void {
+    _ = self;
+    // No-op. Metal uses this for autorelease pools.
+}
+
+pub fn drawFrameEnd(self: *DirectX11) void {
+    _ = self;
+    // No-op.
+}
+
+const Renderer = rendererpkg.GenericRenderer(DirectX11);
+
+pub fn initShaders(
+    self: *const DirectX11,
+    alloc: Allocator,
+    custom_shaders: []const [:0]const u8,
+) !shaders.Shaders {
+    _ = self;
+    _ = alloc;
+    _ = custom_shaders;
+    @panic("TODO: DX11 initShaders");
+}
+
+pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
+    _ = self;
+    @panic("TODO: DX11 surfaceSize");
+}
+
+pub fn initTarget(self: *const DirectX11, width: usize, height: usize) !Target {
+    _ = self;
+    _ = width;
+    _ = height;
+    @panic("TODO: DX11 initTarget");
+}
+
+pub inline fn beginFrame(
+    self: *const DirectX11,
+    renderer: *Renderer,
+    target: *Target,
+) !Frame {
+    _ = self;
+    return try Frame.begin(.{}, renderer, target);
+}
+
+pub fn presentLastTarget(self: *DirectX11) !void {
+    _ = self;
+    @panic("TODO: DX11 presentLastTarget");
+}
+
+pub inline fn bufferOptions(self: DirectX11) bufferpkg.Options {
+    _ = self;
+    return .{};
+}
+
+pub const instanceBufferOptions = bufferOptions;
+pub const uniformBufferOptions = bufferOptions;
+pub const fgBufferOptions = bufferOptions;
+pub const bgBufferOptions = bufferOptions;
+pub const imageBufferOptions = bufferOptions;
+pub const bgImageBufferOptions = bufferOptions;
+
+pub inline fn textureOptions(self: DirectX11) Texture.Options {
+    _ = self;
+    return .{};
+}
+
+pub inline fn samplerOptions(self: DirectX11) Sampler.Options {
+    _ = self;
+    return .{};
+}
+
+pub inline fn imageTextureOptions(
+    self: DirectX11,
+    format: ImageTextureFormat,
+    srgb: bool,
+) Texture.Options {
+    _ = self;
+    _ = format;
+    _ = srgb;
+    return .{};
+}
+
+pub fn initAtlasTexture(
+    self: *const DirectX11,
+    atlas: *const font.Atlas,
+) Texture.Error!Texture {
+    _ = self;
+    _ = atlas;
+    @panic("TODO: DX11 initAtlasTexture");
+}
 
 test {
     _ = com;

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -7,15 +7,16 @@
 //! satisfied at compile time so that GenericRenderer(DirectX11) compiles.
 //! Infrastructure (COM bindings, device lifecycle, cell grid pipeline) is
 //! already in place from prior work in the directx11/ subdirectory.
+pub const DirectX11 = @This();
+
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
 const rendererpkg = @import("../renderer.zig");
+const Renderer = rendererpkg.GenericRenderer(DirectX11);
 const shadertoy = @import("shadertoy.zig");
-
-pub const DirectX11 = @This();
 
 // --- GraphicsAPI contract: types ---
 
@@ -94,8 +95,6 @@ pub fn drawFrameEnd(self: *DirectX11) void {
     _ = self;
     // No-op.
 }
-
-const Renderer = rendererpkg.GenericRenderer(DirectX11);
 
 pub fn initShaders(
     self: *const DirectX11,

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -1,0 +1,39 @@
+//! Frame context for DX11 draw commands.
+//! TODO: Implement with ID3D11DeviceContext deferred or immediate context.
+const DirectX11 = @import("../DirectX11.zig");
+const Renderer = @import("../generic.zig").Renderer(DirectX11);
+const Target = @import("Target.zig");
+const RenderPass = @import("RenderPass.zig");
+
+/// Options for beginning a frame.
+pub const Options = struct {};
+
+renderer: *Renderer,
+target: *Target,
+
+pub fn begin(
+    opts: Options,
+    renderer: *Renderer,
+    target: *Target,
+) !@This() {
+    _ = opts;
+    return .{
+        .renderer = renderer,
+        .target = target,
+    };
+}
+
+pub inline fn renderPass(
+    self: *const @This(),
+    attachments: []const RenderPass.Options.Attachment,
+) RenderPass {
+    _ = self;
+    _ = attachments;
+    @panic("TODO: DX11 Frame.renderPass");
+}
+
+pub fn complete(self: *@This(), sync: bool) void {
+    _ = self;
+    _ = sync;
+    @panic("TODO: DX11 Frame.complete");
+}

--- a/src/renderer/directx11/Pipeline.zig
+++ b/src/renderer/directx11/Pipeline.zig
@@ -1,0 +1,15 @@
+//! Generic render pipeline wrapper for DX11.
+//!
+//! Wraps a vertex + pixel shader pair, analogous to Metal's Pipeline.zig
+//! which wraps MTLRenderPipelineState. Distinct from cell_pipeline.zig (the
+//! concrete cell pipeline from branch 025).
+//!
+//! TODO: Implement with ID3D11VertexShader + ID3D11PixelShader.
+
+/// Options for initializing a render pipeline.
+pub const Options = struct {};
+
+pub fn deinit(self: *const @This()) void {
+    _ = self;
+    @panic("TODO: DX11 Pipeline.deinit");
+}

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -1,0 +1,57 @@
+//! Render pass for DX11 draw steps.
+//! TODO: Implement with ID3D11DeviceContext draw calls.
+const Pipeline = @import("Pipeline.zig");
+const Sampler = @import("Sampler.zig");
+const Target = @import("Target.zig");
+const Texture = @import("Texture.zig");
+const bufferpkg = @import("buffer.zig");
+
+/// Options for beginning a render pass.
+pub const Options = struct {
+    attachments: []const Attachment,
+
+    pub const Attachment = struct {
+        target: union(enum) {
+            texture: Texture,
+            target: Target,
+        },
+        clear_color: ?[4]f64 = null,
+    };
+};
+
+/// A single step in a render pass.
+pub const Step = struct {
+    pipeline: Pipeline,
+    uniforms: ?bufferpkg.Buffer(u8) = null,
+    buffers: []const ?bufferpkg.Buffer(u8) = &.{},
+    textures: []const ?Texture = &.{},
+    samplers: []const ?Sampler = &.{},
+    draw: Draw,
+
+    pub const Draw = struct {
+        type: DrawType,
+        vertex_count: usize,
+        instance_count: usize = 1,
+    };
+
+    pub const DrawType = enum {
+        triangle,
+        triangle_strip,
+    };
+};
+
+pub fn begin(opts: Options) @This() {
+    _ = opts;
+    @panic("TODO: DX11 RenderPass.begin");
+}
+
+pub fn step(self: *@This(), s: Step) void {
+    _ = self;
+    _ = s;
+    @panic("TODO: DX11 RenderPass.step");
+}
+
+pub fn complete(self: *const @This()) void {
+    _ = self;
+    @panic("TODO: DX11 RenderPass.complete");
+}

--- a/src/renderer/directx11/Sampler.zig
+++ b/src/renderer/directx11/Sampler.zig
@@ -1,0 +1,20 @@
+//! Texture sampler wrapper for DX11.
+//! TODO: Implement with ID3D11SamplerState.
+
+/// Options for initializing a sampler.
+pub const Options = struct {};
+
+pub const Error = error{
+    /// A DirectX 11 API call failed.
+    DirectXFailed,
+};
+
+pub fn init(opts: Options) Error!@This() {
+    _ = opts;
+    @panic("TODO: DX11 Sampler.init");
+}
+
+pub fn deinit(self: *@This()) void {
+    _ = self;
+    @panic("TODO: DX11 Sampler.deinit");
+}

--- a/src/renderer/directx11/Sampler.zig
+++ b/src/renderer/directx11/Sampler.zig
@@ -14,7 +14,7 @@ pub fn init(opts: Options) Error!@This() {
     @panic("TODO: DX11 Sampler.init");
 }
 
-pub fn deinit(self: *@This()) void {
+pub fn deinit(self: @This()) void {
     _ = self;
     @panic("TODO: DX11 Sampler.deinit");
 }

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -1,0 +1,18 @@
+//! Render target for DX11.
+//! TODO: Implement with ID3D11Texture2D + ID3D11RenderTargetView.
+
+/// Options for initializing a target.
+pub const Options = struct {
+    width: usize,
+    height: usize,
+};
+
+/// Current width of this target.
+width: usize = 0,
+/// Current height of this target.
+height: usize = 0,
+
+pub fn deinit(self: *@This()) void {
+    _ = self;
+    @panic("TODO: DX11 Target.deinit");
+}

--- a/src/renderer/directx11/Texture.zig
+++ b/src/renderer/directx11/Texture.zig
@@ -1,0 +1,53 @@
+//! GPU texture wrapper for DX11.
+//! TODO: Implement with ID3D11Texture2D and ID3D11ShaderResourceView.
+
+/// Options for initializing a texture.
+pub const Options = struct {};
+
+pub const Error = error{
+    /// A DirectX 11 API call failed.
+    DirectXFailed,
+};
+
+/// The width of this texture.
+width: usize = 0,
+/// The height of this texture.
+height: usize = 0,
+/// Bytes per pixel for this texture.
+bpp: usize = 0,
+
+pub fn init(
+    opts: Options,
+    width: usize,
+    height: usize,
+    data: ?[]const u8,
+) Error!@This() {
+    _ = opts;
+    _ = width;
+    _ = height;
+    _ = data;
+    @panic("TODO: DX11 Texture.init");
+}
+
+pub fn deinit(self: @This()) void {
+    _ = self;
+    @panic("TODO: DX11 Texture.deinit");
+}
+
+/// Replace a region of the texture with new data.
+pub fn replaceRegion(
+    self: @This(),
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+    data: []const u8,
+) error{}!void {
+    _ = self;
+    _ = x;
+    _ = y;
+    _ = width;
+    _ = height;
+    _ = data;
+    @panic("TODO: DX11 Texture.replaceRegion");
+}

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+
+/// Options for initializing a buffer.
+pub const Options = struct {};
+
+/// DX11 GPU data buffer for a set of equal-typed elements.
+/// TODO: Implement with ID3D11Buffer (DYNAMIC usage, Map/Unmap for CPU writes).
+pub fn Buffer(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        opts: Options,
+        len: usize,
+
+        pub fn init(opts: Options, len: usize) !Self {
+            _ = opts;
+            _ = len;
+            @panic("TODO: DX11 Buffer.init");
+        }
+
+        pub fn initFill(opts: Options, data: []const T) !Self {
+            _ = opts;
+            _ = data;
+            @panic("TODO: DX11 Buffer.initFill");
+        }
+
+        pub fn deinit(self: *Self) void {
+            _ = self;
+            @panic("TODO: DX11 Buffer.deinit");
+        }
+
+        pub fn map(self: *Self, len: usize) ![]T {
+            _ = self;
+            _ = len;
+            @panic("TODO: DX11 Buffer.map");
+        }
+
+        pub fn unmap(self: *Self) void {
+            _ = self;
+            @panic("TODO: DX11 Buffer.unmap");
+        }
+
+        pub fn resize(self: *Self, new_len: usize) !void {
+            _ = self;
+            _ = new_len;
+            @panic("TODO: DX11 Buffer.resize");
+        }
+
+        pub fn sync(self: *Self, data: []const T) !void {
+            _ = self;
+            _ = data;
+            @panic("TODO: DX11 Buffer.sync");
+        }
+
+        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+            _ = self;
+            _ = lists;
+            @panic("TODO: DX11 Buffer.syncFromArrayLists");
+        }
+    };
+}

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -24,7 +24,7 @@ pub fn Buffer(comptime T: type) type {
             @panic("TODO: DX11 Buffer.initFill");
         }
 
-        pub fn deinit(self: *Self) void {
+        pub fn deinit(self: *const Self) void {
             _ = self;
             @panic("TODO: DX11 Buffer.deinit");
         }

--- a/src/renderer/directx11/shaders.zig
+++ b/src/renderer/directx11/shaders.zig
@@ -4,6 +4,9 @@
 //! Metal's layout since GenericRenderer writes to them directly. The actual
 //! HLSL shaders will interpret these differently but the CPU-side layout is
 //! shared across backends.
+//!
+//! TODO: add comptime assertions cross-referencing @sizeOf against Metal's
+//! data structs to catch layout drift across backends.
 const std = @import("std");
 const math = @import("../../math.zig");
 

--- a/src/renderer/directx11/shaders.zig
+++ b/src/renderer/directx11/shaders.zig
@@ -1,0 +1,128 @@
+//! Shader management and GPU data structs for DX11.
+//!
+//! The data structs (Uniforms, CellText, CellBg, Image, BgImage) must match
+//! Metal's layout since GenericRenderer writes to them directly. The actual
+//! HLSL shaders will interpret these differently but the CPU-side layout is
+//! shared across backends.
+const std = @import("std");
+const math = @import("../../math.zig");
+
+const Pipeline = @import("Pipeline.zig");
+
+/// Shader management for DX11.
+/// TODO: Implement HLSL shader compilation and caching.
+pub const Shaders = struct {
+    pipelines: Pipelines = .{},
+    post_pipelines: []const Pipeline = &.{},
+    defunct: bool = false,
+
+    pub const Pipelines = struct {
+        bg_color: Pipeline = .{},
+        cell_bg: Pipeline = .{},
+        cell_text: Pipeline = .{},
+        image: Pipeline = .{},
+        bg_image: Pipeline = .{},
+    };
+
+    pub fn deinit(self: *Shaders, alloc: std.mem.Allocator) void {
+        _ = self;
+        _ = alloc;
+        @panic("TODO: DX11 Shaders.deinit");
+    }
+};
+
+/// GPU uniform values for the cell shaders.
+pub const Uniforms = extern struct {
+    projection_matrix: math.Mat align(16),
+    screen_size: [2]f32 align(8),
+    cell_size: [2]f32 align(8),
+    grid_size: [2]u16 align(4),
+    grid_padding: [4]f32 align(16),
+    padding_extend: PaddingExtend align(1),
+    min_contrast: f32 align(4),
+    cursor_pos: [2]u16 align(4),
+    cursor_color: [4]u8 align(4),
+    bg_color: [4]u8 align(4),
+
+    bools: extern struct {
+        cursor_wide: bool align(1),
+        use_display_p3: bool align(1),
+        use_linear_blending: bool align(1),
+        use_linear_correction: bool align(1) = false,
+    },
+
+    const PaddingExtend = packed struct(u8) {
+        left: bool = false,
+        right: bool = false,
+        up: bool = false,
+        down: bool = false,
+        _padding: u4 = 0,
+    };
+};
+
+/// Single parameter for the cell text shader.
+pub const CellText = extern struct {
+    glyph_pos: [2]u32 align(8) = .{ 0, 0 },
+    glyph_size: [2]u32 align(8) = .{ 0, 0 },
+    bearings: [2]i16 align(4) = .{ 0, 0 },
+    grid_pos: [2]u16 align(4),
+    color: [4]u8 align(4),
+    atlas: Atlas align(1),
+    bools: packed struct(u8) {
+        no_min_contrast: bool = false,
+        is_cursor_glyph: bool = false,
+        _padding: u6 = 0,
+    } align(1) = .{},
+
+    pub const Atlas = enum(u8) {
+        grayscale = 0,
+        color = 1,
+    };
+
+    test {
+        try std.testing.expectEqual(32, @sizeOf(CellText));
+    }
+};
+
+/// Single parameter for the cell bg shader.
+pub const CellBg = [4]u8;
+
+/// Single parameter for the image shader.
+pub const Image = extern struct {
+    grid_pos: [2]f32,
+    cell_offset: [2]f32,
+    source_rect: [4]f32,
+    dest_size: [2]f32,
+};
+
+/// Single parameter for the bg image shader.
+pub const BgImage = extern struct {
+    opacity: f32 align(4),
+    info: Info align(1),
+
+    pub const Info = packed struct(u8) {
+        position: Position,
+        fit: Fit,
+        repeat: bool,
+        _padding: u1 = 0,
+
+        pub const Position = enum(u4) {
+            tl = 0,
+            tc = 1,
+            tr = 2,
+            ml = 3,
+            mc = 4,
+            mr = 5,
+            bl = 6,
+            bc = 7,
+            br = 8,
+        };
+
+        pub const Fit = enum(u2) {
+            contain = 0,
+            cover = 1,
+            stretch = 2,
+            none = 3,
+        };
+    };
+};


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked!
> - This PR
> - #31 <- **start here and bubble up**

## Summary

- Wire GenericRenderer(DirectX11) into the renderer switch
- Add stub types (Pipeline, Buffer, Texture, Sampler, Target, Frame, RenderPass, shaders) satisfying the full GraphicsAPI contract at compile time
- All methods panic at runtime - compile-time contract satisfaction only
- Shader data structs (Uniforms, CellText, CellBg, Image, BgImage) match Metal's layout

## What I Learnt

- **GenericRenderer contract surface**: ~9 types, 3 constants, ~20 functions, plus sub-contracts on Target/Frame/RenderPass/Buffer/Texture/Sampler/Shaders
- **Texture.deinit must be by-value**: Metal takes self by value, not pointer. GenericRenderer passes *const which won't coerce to *T
- **replaceRegion not replace**: GenericRenderer calls replaceRegion (matching Metal's naming), not replace
- **Target needs width/height fields**: GenericRenderer reads target.width and target.height directly
- **present() is internal**: GenericRenderer only calls presentLastTarget(). The present(target, sync) call lives in Frame.zig's completion handler
- **Buffer aliasing pattern**: Metal uses pub const instanceBufferOptions = bufferOptions for shared option functions. Same pattern here

## Test plan

- [x] `zig build -Drenderer=directx11 -Dapp-runtime=none` compiles
- [x] Default renderer builds unaffected on Linux/macOS (verified no changes to Metal/OpenGL files)
- [x] `@sizeOf(CellText) == 32` comptime assert passes
- [x] No changes to existing Metal/OpenGL backends