### PR TITLE
renderer: DX11 clear-to-color with dual surface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@
 > **DX11 renderer infrastructure** (in fork)
 >
 > - [x] COM interface definitions (d3d11, dxgi) with vtable bindings
-> - [x] DX11 device lifecycle, swap chain for XAML composition
+> - [x] DX11 device lifecycle with dual surface support (HWND for standalone/embedding, SwapChainPanel for WinUI host)
 > - [x] Instanced cell grid renderer with pre-compiled HLSL shaders
+> - [x] HLSL build step (HlslStep.zig) mirroring Metal's MetallibStep
 > - [x] Backend enum with `directx11` variant
+> - [x] GraphicsAPI contract stubs for GenericRenderer
 >
 > **SwapChainPanel spike** (in fork, [demo video](https://www.youtube.com/watch?v=-Cn9mlxX_GA))
 >
@@ -89,10 +91,23 @@
 > - [x] `--version` flag working from command line
 > - [x] Interop test suite (7 tests against the real DLL)
 >
+> ### Architecture: Dual Surface Support
+>
+> The DX11 renderer is dual-channel at the library level so that libghostty
+> consumers can pick whichever surface model fits their host:
+> - **HWND** -- `CreateSwapChainForHwnd`, for standalone windows, test harnesses, and third-party embedders
+> - **SwapChainPanel** (composition) -- `CreateSwapChainForComposition`, for WinUI 3 / XAML hosts
+>
+> We are iterating on SwapChainPanel with the information we have today but
+> the choice is not set in stone -- the dual-channel design means we can
+> change our mind later without breaking embedders.
+>
+> The device picks the path based on what the caller provides. No compile-time flags.
+>
 > ### What is next
 >
-> - [ ] Implement GenericRenderer GraphicsAPI contract for DX11
-> - [ ] Windows platform enum and C# scaffold integration
+> - [x] DX11 clear-to-color: wire GenericRenderer contract, first pixels on screen
+> - [ ] Cell rendering: instance buffer, texture atlas, text on screen
 > - [ ] DirectWrite font backend
 > - [ ] ConPTY shell spawning
 > - [ ] Keyboard, mouse, clipboard

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -343,6 +343,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    windows: Windows,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -356,6 +357,11 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    pub const Windows = if (builtin.target.os.tag == .windows) struct {
+        /// The HWND to render into, or null for composition swap chain.
+        hwnd: ?std.os.windows.HANDLE,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -365,6 +371,10 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        windows: extern struct {
+            hwnd: ?*anyopaque,
         },
     };
 
@@ -385,6 +395,10 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .windows => if (Windows != void) .{ .windows = .{
+                .hwnd = c_platform.windows.hwnd,
+            } } else error.UnsupportedPlatform,
         };
     }
 };
@@ -395,6 +409,7 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    windows = 3,
 };
 
 pub const EnvVar = extern struct {

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -17,6 +17,8 @@ const font = @import("../font/main.zig");
 const rendererpkg = @import("../renderer.zig");
 const Renderer = rendererpkg.GenericRenderer(DirectX11);
 const shadertoy = @import("shadertoy.zig");
+const apprt = @import("../apprt.zig");
+const log = std.log.scoped(.directx11);
 
 // --- GraphicsAPI contract: types ---
 
@@ -62,7 +64,8 @@ pub const dxgi = @import("directx11/dxgi.zig");
 
 // --- Sub-module re-exports: renderer components from 025 ---
 
-pub const Device = @import("directx11/device.zig").Device;
+const devicepkg = @import("directx11/device.zig");
+pub const Device = devicepkg.Device;
 pub const CellPipeline = @import("directx11/cell_pipeline.zig").Pipeline;
 pub const Constants = @import("directx11/cell_pipeline.zig").Constants;
 pub const CellGrid = @import("directx11/cell_grid.zig").CellGrid;
@@ -73,17 +76,45 @@ pub const CellInstance = @import("directx11/cell_grid.zig").CellInstance;
 /// Runtime blending mode, set by GenericRenderer when config changes.
 blending: configpkg.Config.AlphaBlending = .native,
 
+/// The DX11 device managing the swap chain and render target.
+device: ?Device = null,
+
 // --- GraphicsAPI contract: functions ---
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
     _ = alloc;
-    _ = opts;
-    @panic("TODO: DX11 init");
+
+    const device = device: {
+        if (comptime @hasField(@TypeOf(opts.rt_surface.*), "platform")) {
+            switch (opts.rt_surface.platform) {
+                .windows => |w| {
+                    const surface: devicepkg.Surface = if (w.hwnd) |hwnd|
+                        .{ .hwnd = hwnd }
+                    else
+                        @panic("composition swap chain requires an ISwapChainPanelNative pointer");
+
+                    const size = opts.size.screen;
+                    break :device Device.init(surface, size.width, size.height) catch |err| {
+                        log.err("DX11 device init failed: {}", .{err});
+                        return error.DeviceInitFailed;
+                    };
+                },
+                else => @panic("unsupported platform for DX11"),
+            }
+        } else {
+            break :device null;
+        }
+    };
+
+    return .{
+        .device = device,
+    };
 }
 
 pub fn deinit(self: *DirectX11) void {
-    _ = self;
-    @panic("TODO: DX11 deinit");
+    if (self.device) |*dev| {
+        dev.deinit();
+    }
 }
 
 pub fn drawFrameStart(self: *DirectX11) void {
@@ -108,15 +139,15 @@ pub fn initShaders(
 }
 
 pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
-    _ = self;
-    @panic("TODO: DX11 surfaceSize");
+    if (self.device) |dev| {
+        return .{ .width = dev.width, .height = dev.height };
+    }
+    return .{ .width = 0, .height = 0 };
 }
 
 pub fn initTarget(self: *const DirectX11, width: usize, height: usize) !Target {
     _ = self;
-    _ = width;
-    _ = height;
-    @panic("TODO: DX11 initTarget");
+    return .{ .width = width, .height = height };
 }
 
 pub inline fn beginFrame(
@@ -129,8 +160,12 @@ pub inline fn beginFrame(
 }
 
 pub fn presentLastTarget(self: *DirectX11) !void {
-    _ = self;
-    @panic("TODO: DX11 presentLastTarget");
+    if (self.device) |*dev| {
+        dev.present() catch |err| {
+            log.err("present failed: {}", .{err});
+            return error.PresentFailed;
+        };
+    }
 }
 
 pub inline fn bufferOptions(self: DirectX11) bufferpkg.Options {

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -9,6 +9,7 @@
 //! already in place from prior work in the directx11/ subdirectory.
 pub const DirectX11 = @This();
 
+const builtin = @import("builtin");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -85,13 +86,15 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
     _ = alloc;
 
     const device = device: {
-        if (comptime @hasField(@TypeOf(opts.rt_surface.*), "platform")) {
+        if (comptime builtin.os.tag != .windows) {
+            break :device null;
+        } else {
             switch (opts.rt_surface.platform) {
                 .windows => |w| {
                     const surface: devicepkg.Surface = if (w.hwnd) |hwnd|
                         .{ .hwnd = hwnd }
                     else
-                        @panic("composition swap chain requires an ISwapChainPanelNative pointer");
+                        @panic("HWND surface requires a non-null hwnd");
 
                     const size = opts.size.screen;
                     break :device Device.init(surface, size.width, size.height) catch |err| {
@@ -101,8 +104,6 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
                 },
                 else => @panic("unsupported platform for DX11"),
             }
-        } else {
-            break :device null;
         }
     };
 

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -1,5 +1,4 @@
 //! Frame context for DX11 draw commands.
-//! TODO: Implement with ID3D11DeviceContext deferred or immediate context.
 const DirectX11 = @import("../DirectX11.zig");
 const Renderer = @import("../generic.zig").Renderer(DirectX11);
 const Target = @import("Target.zig");
@@ -24,16 +23,29 @@ pub fn begin(
 }
 
 pub inline fn renderPass(
-    self: *const @This(),
+    self: *@This(),
     attachments: []const RenderPass.Options.Attachment,
 ) RenderPass {
-    _ = self;
-    _ = attachments;
-    @panic("TODO: DX11 Frame.renderPass");
+    // Clear the render target using the first attachment's clear color.
+    if (self.renderer.api.device) |*dev| {
+        for (attachments) |att| {
+            if (att.clear_color) |color| {
+                dev.clearRenderTarget(.{
+                    @floatCast(color[0]),
+                    @floatCast(color[1]),
+                    @floatCast(color[2]),
+                    @floatCast(color[3]),
+                });
+                break;
+            }
+        }
+    }
+    return .{};
 }
 
 pub fn complete(self: *@This(), sync: bool) void {
+    // DX11 immediate mode: commands already executed. Present happens in
+    // presentLastTarget(), called by GenericRenderer after frame completion.
     _ = self;
     _ = sync;
-    @panic("TODO: DX11 Frame.complete");
 }

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -5,6 +5,7 @@ const Sampler = @import("Sampler.zig");
 const Target = @import("Target.zig");
 const Texture = @import("Texture.zig");
 const bufferpkg = @import("buffer.zig");
+const RawBuffer = bufferpkg.RawBuffer;
 
 /// Options for beginning a render pass.
 pub const Options = struct {
@@ -22,8 +23,8 @@ pub const Options = struct {
 /// A single step in a render pass.
 pub const Step = struct {
     pipeline: Pipeline,
-    uniforms: ?bufferpkg.Buffer(u8) = null,
-    buffers: []const ?bufferpkg.Buffer(u8) = &.{},
+    uniforms: ?RawBuffer = null,
+    buffers: []const ?RawBuffer = &.{},
     textures: []const ?Texture = &.{},
     samplers: []const ?Sampler = &.{},
     draw: Draw,

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -13,6 +13,7 @@ width: usize = 0,
 height: usize = 0,
 
 pub fn deinit(self: *@This()) void {
-    _ = self;
-    @panic("TODO: DX11 Target.deinit");
+    // Backbuffer is owned by the swap chain, nothing to release here.
+    self.width = 0;
+    self.height = 0;
 }

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -3,6 +3,14 @@ const std = @import("std");
 /// Options for initializing a buffer.
 pub const Options = struct {};
 
+/// Opaque stand-in for an ID3D11Buffer COM pointer.
+/// Used as the native handle type in Buffer(T).buffer so that GenericRenderer
+/// can pass type-erased buffer references to RenderPass.Step without knowing T.
+/// TODO: Replace with *d3d11.ID3D11Buffer when the full pipeline is implemented.
+pub const RawBuffer = struct {
+    // placeholder - no real GPU resource yet
+};
+
 /// DX11 GPU data buffer for a set of equal-typed elements.
 /// TODO: Implement with ID3D11Buffer (DYNAMIC usage, Map/Unmap for CPU writes).
 pub fn Buffer(comptime T: type) type {
@@ -11,6 +19,11 @@ pub fn Buffer(comptime T: type) type {
 
         opts: Options,
         len: usize,
+
+        /// Type-erased handle for passing to RenderPass.Step. Mirrors the
+        /// .buffer field on Metal (objc.Object) and OpenGL (gl.Buffer) buffers
+        /// so GenericRenderer can pass uniform/vertex buffers without knowing T.
+        buffer: RawBuffer = .{},
 
         pub fn init(opts: Options, len: usize) !Self {
             _ = opts;

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -4,12 +4,8 @@ const std = @import("std");
 pub const Options = struct {};
 
 /// Opaque stand-in for an ID3D11Buffer COM pointer.
-/// Used as the native handle type in Buffer(T).buffer so that GenericRenderer
-/// can pass type-erased buffer references to RenderPass.Step without knowing T.
 /// TODO: Replace with *d3d11.ID3D11Buffer when the full pipeline is implemented.
-pub const RawBuffer = struct {
-    // placeholder - no real GPU resource yet
-};
+pub const RawBuffer = struct {};
 
 /// DX11 GPU data buffer for a set of equal-typed elements.
 /// TODO: Implement with ID3D11Buffer (DYNAMIC usage, Map/Unmap for CPU writes).

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -101,21 +101,22 @@ pub const Device = struct {
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
         var panel_native: ?*dxgi.ISwapChainPanelNative = null;
 
+        var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+            .Width = width,
+            .Height = height,
+            .Format = .B8G8R8A8_UNORM,
+            .Stereo = 0,
+            .SampleDesc = .{ .Count = 1, .Quality = 0 },
+            .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+            .BufferCount = 2,
+            .Scaling = .STRETCH,
+            .SwapEffect = .FLIP_DISCARD,
+            .AlphaMode = .UNSPECIFIED,
+            .Flags = 0,
+        };
+
         switch (surface) {
             .hwnd => |hwnd| {
-                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-                    .Width = width,
-                    .Height = height,
-                    .Format = .B8G8R8A8_UNORM,
-                    .Stereo = 0,
-                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
-                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                    .BufferCount = 2,
-                    .Scaling = .STRETCH,
-                    .SwapEffect = .FLIP_SEQUENTIAL,
-                    .AlphaMode = .UNSPECIFIED,
-                    .Flags = 0,
-                };
                 hr = factory.CreateSwapChainForHwnd(
                     @ptrCast(dev),
                     hwnd,
@@ -127,19 +128,7 @@ pub const Device = struct {
             },
             .swap_chain_panel => |panel| {
                 panel_native = panel;
-                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-                    .Width = width,
-                    .Height = height,
-                    .Format = .B8G8R8A8_UNORM,
-                    .Stereo = 0,
-                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
-                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                    .BufferCount = 2,
-                    .Scaling = .STRETCH,
-                    .SwapEffect = .FLIP_SEQUENTIAL,
-                    .AlphaMode = .PREMULTIPLIED,
-                    .Flags = 0,
-                };
+                desc.AlphaMode = .PREMULTIPLIED;
                 hr = factory.CreateSwapChainForComposition(
                     @ptrCast(dev),
                     &desc,
@@ -163,6 +152,9 @@ pub const Device = struct {
                 return InitError.SetSwapChainFailed;
             }
         }
+        errdefer if (panel_native) |panel| {
+            _ = panel.SetSwapChain(null);
+        };
 
         // Get the back buffer and create a render target view.
         const rtv = createRenderTargetView(dev, sc) orelse {

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -8,12 +8,18 @@ const HRESULT = com.HRESULT;
 const GUID = com.GUID;
 const IUnknown = com.IUnknown;
 const IDXGISwapChain = dxgi.IDXGISwapChain;
+const HWND = dxgi.HWND;
+
+pub const Surface = union(enum) {
+    hwnd: HWND,
+    swap_chain_panel: *dxgi.ISwapChainPanelNative,
+};
 
 pub const Device = struct {
     device: *d3d11.ID3D11Device,
     context: *d3d11.ID3D11DeviceContext,
     swap_chain: *dxgi.IDXGISwapChain1,
-    panel_native: *dxgi.ISwapChainPanelNative,
+    panel_native: ?*dxgi.ISwapChainPanelNative,
     rtv: ?*d3d11.ID3D11RenderTargetView,
     width: u32,
     height: u32,
@@ -29,11 +35,8 @@ pub const Device = struct {
         RenderTargetViewFailed,
     };
 
-    pub fn init(panel_native_ptr: *anyopaque, width: u32, height: u32) InitError!Device {
-        log.info("init called: panel=0x{x}, size={}x{}", .{ @intFromPtr(panel_native_ptr), width, height });
-
-        // Cast the opaque pointer to ISwapChainPanelNative.
-        const panel_native: *dxgi.ISwapChainPanelNative = @ptrCast(@alignCast(panel_native_ptr));
+    pub fn init(surface: Surface, width: u32, height: u32) InitError!Device {
+        log.info("init called: size={}x{}", .{ width, height });
 
         // Create D3D11 device and immediate context.
         var device: ?*d3d11.ID3D11Device = null;
@@ -92,42 +95,74 @@ pub const Device = struct {
         const factory: *dxgi.IDXGIFactory2 = @ptrCast(@alignCast(factory_opt.?));
         defer _ = factory.Release();
 
-        // Create swap chain for composition.
-        const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-            .Width = width,
-            .Height = height,
-            .Format = .B8G8R8A8_UNORM,
-            .Stereo = 0,
-            .SampleDesc = .{ .Count = 1, .Quality = 0 },
-            .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-            .BufferCount = 2,
-            .Scaling = .STRETCH,
-            .SwapEffect = .FLIP_SEQUENTIAL,
-            .AlphaMode = .PREMULTIPLIED,
-            .Flags = 0,
-        };
-
+        // Create swap chain. Descriptor differs by surface type:
+        // - HWND: opaque window, DXGI_ALPHA_MODE_UNSPECIFIED
+        // - Composition: premultiplied alpha for XAML integration
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
-        hr = factory.CreateSwapChainForComposition(
-            @ptrCast(dev),
-            &desc,
-            null,
-            &swap_chain,
-        );
+        var panel_native: ?*dxgi.ISwapChainPanelNative = null;
+
+        switch (surface) {
+            .hwnd => |hwnd| {
+                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                    .Width = width,
+                    .Height = height,
+                    .Format = .B8G8R8A8_UNORM,
+                    .Stereo = 0,
+                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    .BufferCount = 2,
+                    .Scaling = .STRETCH,
+                    .SwapEffect = .FLIP_SEQUENTIAL,
+                    .AlphaMode = .UNSPECIFIED,
+                    .Flags = 0,
+                };
+                hr = factory.CreateSwapChainForHwnd(
+                    @ptrCast(dev),
+                    hwnd,
+                    &desc,
+                    null,
+                    null,
+                    &swap_chain,
+                );
+            },
+            .swap_chain_panel => |panel| {
+                panel_native = panel;
+                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                    .Width = width,
+                    .Height = height,
+                    .Format = .B8G8R8A8_UNORM,
+                    .Stereo = 0,
+                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    .BufferCount = 2,
+                    .Scaling = .STRETCH,
+                    .SwapEffect = .FLIP_SEQUENTIAL,
+                    .AlphaMode = .PREMULTIPLIED,
+                    .Flags = 0,
+                };
+                hr = factory.CreateSwapChainForComposition(
+                    @ptrCast(dev),
+                    &desc,
+                    null,
+                    &swap_chain,
+                );
+            },
+        }
         if (com.FAILED(hr) or swap_chain == null) {
-            log.err("CreateSwapChainForComposition failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+            log.err("swap chain creation failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
             return InitError.SwapChainCreationFailed;
         }
         const sc = swap_chain.?;
         errdefer _ = sc.Release();
 
-        // Attach the swap chain to the SwapChainPanel.
-        hr = panel_native.SetSwapChain(@ptrCast(sc));
-        if (com.FAILED(hr)) {
-            log.err("SetSwapChain failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-            return InitError.SetSwapChainFailed;
+        // For composition surfaces, attach swap chain to the panel.
+        if (panel_native) |panel| {
+            hr = panel.SetSwapChain(@ptrCast(sc));
+            if (com.FAILED(hr)) {
+                log.err("SetSwapChain failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return InitError.SetSwapChainFailed;
+            }
         }
-        errdefer _ = panel_native.SetSwapChain(null);
 
         // Get the back buffer and create a render target view.
         const rtv = createRenderTargetView(dev, sc) orelse {
@@ -155,8 +190,10 @@ pub const Device = struct {
             self.rtv = null;
         }
 
-        // Detach swap chain from the panel.
-        _ = self.panel_native.SetSwapChain(null);
+        // Detach swap chain from the panel (composition surfaces only).
+        if (self.panel_native) |panel| {
+            _ = panel.SetSwapChain(null);
+        }
 
         // Release in reverse creation order.
         _ = self.swap_chain.Release();

--- a/src/renderer/directx11/dxgi.zig
+++ b/src/renderer/directx11/dxgi.zig
@@ -38,6 +38,7 @@ pub const DXGI_ALPHA_MODE = enum(u32) {
 pub const DXGI_USAGE = u32;
 pub const DXGI_USAGE_RENDER_TARGET_OUTPUT: DXGI_USAGE = 0x00000020;
 
+/// Win32 HWND is a pointer-sized handle, same underlying type as HANDLE.
 pub const HWND = std.os.windows.HANDLE;
 
 // --- Structs ---

--- a/src/renderer/directx11/dxgi.zig
+++ b/src/renderer/directx11/dxgi.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const com = @import("com.zig");
 const GUID = com.GUID;
 const HRESULT = com.HRESULT;
@@ -36,6 +37,8 @@ pub const DXGI_ALPHA_MODE = enum(u32) {
 
 pub const DXGI_USAGE = u32;
 pub const DXGI_USAGE_RENDER_TARGET_OUTPUT: DXGI_USAGE = 0x00000020;
+
+pub const HWND = std.os.windows.HANDLE;
 
 // --- Structs ---
 
@@ -430,7 +433,15 @@ pub const IDXGIFactory2 = extern struct {
         IsCurrent: Reserved,
         // IDXGIFactory2 (slots 14-24)
         IsWindowedStereoEnabled: Reserved,
-        CreateSwapChainForHwnd: Reserved,
+        CreateSwapChainForHwnd: *const fn (
+            self: *IDXGIFactory2,
+            pDevice: *IUnknown,
+            hWnd: HWND,
+            pDesc: *const DXGI_SWAP_CHAIN_DESC1,
+            pFullscreenDesc: ?*const anyopaque,
+            pRestrictToOutput: ?*anyopaque,
+            ppSwapChain: *?*IDXGISwapChain1,
+        ) callconv(.winapi) HRESULT,
         CreateSwapChainForCoreWindow: Reserved,
         GetSharedResourceAdapterLuid: Reserved,
         RegisterStereoStatusWindow: Reserved,
@@ -456,6 +467,18 @@ pub const IDXGIFactory2 = extern struct {
         swap_chain: *?*IDXGISwapChain1,
     ) HRESULT {
         return self.vtable.CreateSwapChainForComposition(self, device, desc, restrict_to_output, swap_chain);
+    }
+
+    pub inline fn CreateSwapChainForHwnd(
+        self: *IDXGIFactory2,
+        device: *IUnknown,
+        hwnd: HWND,
+        desc: *const DXGI_SWAP_CHAIN_DESC1,
+        fullscreen_desc: ?*const anyopaque,
+        restrict_to_output: ?*anyopaque,
+        swap_chain: *?*IDXGISwapChain1,
+    ) HRESULT {
+        return self.vtable.CreateSwapChainForHwnd(self, device, hwnd, desc, fullscreen_desc, restrict_to_output, swap_chain);
     }
 
     pub inline fn Release(self: *IDXGIFactory2) u32 {

--- a/test/windows/test_dx11_clear.zig
+++ b/test/windows/test_dx11_clear.zig
@@ -1,5 +1,8 @@
 //! Standalone DX11 clear-to-color test harness.
 //!
+//! This file intentionally duplicates COM types from src/renderer/directx11/
+//! to remain a self-contained smoke test with no project imports.
+//!
 //! Creates a Win32 window, initializes D3D11 via raw COM vtables,
 //! and clears to an early-sunrise orange for 3 seconds.
 //!
@@ -55,7 +58,7 @@ const DXGI_FORMAT = enum(u32) {
     B8G8R8A8_UNORM = 87,
     _,
 };
-const DXGI_SWAP_EFFECT = enum(u32) { FLIP_SEQUENTIAL = 3, _ };
+const DXGI_SWAP_EFFECT = enum(u32) { FLIP_SEQUENTIAL = 3, FLIP_DISCARD = 4, _ };
 const DXGI_SCALING = enum(u32) { STRETCH = 0, _ };
 const DXGI_ALPHA_MODE = enum(u32) { UNSPECIFIED = 0, _ };
 const DXGI_USAGE = u32;
@@ -642,7 +645,7 @@ pub fn main() !void {
         .BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
         .BufferCount = 2,
         .Scaling = .STRETCH,
-        .SwapEffect = .FLIP_SEQUENTIAL,
+        .SwapEffect = .FLIP_DISCARD,
         .AlphaMode = .UNSPECIFIED,
         .Flags = 0,
     };

--- a/test/windows/test_dx11_clear.zig
+++ b/test/windows/test_dx11_clear.zig
@@ -1,0 +1,731 @@
+//! Standalone DX11 clear-to-color test harness.
+//!
+//! Creates a Win32 window, initializes D3D11 via raw COM vtables,
+//! and clears to an early-sunrise orange for 3 seconds.
+//!
+//! Build:
+//!   zig build-exe test/windows/test_dx11_clear.zig ^
+//!     -lc -ld3d11 -ldxgi ^
+//!     -target x86_64-windows-msvc ^
+//!     --name test_dx11_clear
+//!
+//! Run (from repo root):
+//!   test_dx11_clear.exe
+//!
+//! Success = an 800x600 orange window appears for ~3 seconds, then
+//! "DX11 clear-to-color test passed." prints and the process exits.
+
+const std = @import("std");
+const windows = std.os.windows;
+
+// ---------- basic COM types --------------------------------------------------
+
+const HRESULT = i32;
+const GUID = extern struct {
+    data1: u32,
+    data2: u16,
+    data3: u16,
+    data4: [8]u8,
+};
+const IUnknown = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        QueryInterface: *const fn (*IUnknown, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IUnknown) callconv(.winapi) u32,
+        Release: *const fn (*IUnknown) callconv(.winapi) u32,
+    };
+    pub inline fn QueryInterface(self: *IUnknown, riid: *const GUID, pp: *?*anyopaque) HRESULT {
+        return self.vtable.QueryInterface(self, riid, pp);
+    }
+    pub inline fn Release(self: *IUnknown) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+inline fn FAILED(hr: HRESULT) bool {
+    return hr < 0;
+}
+
+const Reserved = *const fn () callconv(.winapi) void;
+
+// ---------- DXGI types -------------------------------------------------------
+
+const DXGI_FORMAT = enum(u32) {
+    UNKNOWN = 0,
+    B8G8R8A8_UNORM = 87,
+    _,
+};
+const DXGI_SWAP_EFFECT = enum(u32) { FLIP_SEQUENTIAL = 3, _ };
+const DXGI_SCALING = enum(u32) { STRETCH = 0, _ };
+const DXGI_ALPHA_MODE = enum(u32) { UNSPECIFIED = 0, _ };
+const DXGI_USAGE = u32;
+const DXGI_USAGE_RENDER_TARGET_OUTPUT: DXGI_USAGE = 0x00000020;
+
+const DXGI_SAMPLE_DESC = extern struct { Count: u32, Quality: u32 };
+const DXGI_SWAP_CHAIN_DESC1 = extern struct {
+    Width: u32,
+    Height: u32,
+    Format: DXGI_FORMAT,
+    Stereo: i32,
+    SampleDesc: DXGI_SAMPLE_DESC,
+    BufferUsage: DXGI_USAGE,
+    BufferCount: u32,
+    Scaling: DXGI_SCALING,
+    SwapEffect: DXGI_SWAP_EFFECT,
+    AlphaMode: DXGI_ALPHA_MODE,
+    Flags: u32,
+};
+
+// IDXGIDevice - we only call GetAdapter (slot 7).
+const IDXGIDevice = extern struct {
+    vtable: *const VTable,
+    pub const IID = GUID{
+        .data1 = 0x54ec77fa,
+        .data2 = 0x1377,
+        .data3 = 0x44e6,
+        .data4 = .{ 0x8c, 0x32, 0x88, 0xfd, 0x5f, 0x44, 0xc8, 0x4c },
+    };
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIDevice (7)
+        GetAdapter: *const fn (*IDXGIDevice, *?*IDXGIAdapter) callconv(.winapi) HRESULT,
+    };
+    pub inline fn GetAdapter(self: *IDXGIDevice, adapter: *?*IDXGIAdapter) HRESULT {
+        return self.vtable.GetAdapter(self, adapter);
+    }
+    pub inline fn Release(self: *IDXGIDevice) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// IDXGIAdapter - we only call GetParent (slot 6, IDXGIObject).
+const IDXGIAdapter = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: *const fn (*IDXGIAdapter, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    };
+    pub inline fn GetParent(self: *IDXGIAdapter, riid: *const GUID, parent: *?*anyopaque) HRESULT {
+        return self.vtable.GetParent(self, riid, parent);
+    }
+    pub inline fn Release(self: *IDXGIAdapter) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// IDXGISwapChain1 - we call Present (8), GetBuffer (9).
+const IDXGISwapChain1 = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIDeviceSubObject (7)
+        GetDevice: Reserved,
+        // IDXGISwapChain (8-17)
+        Present: *const fn (*IDXGISwapChain1, u32, u32) callconv(.winapi) HRESULT,
+        GetBuffer: *const fn (*IDXGISwapChain1, u32, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        SetFullscreenState: Reserved,
+        GetFullscreenState: Reserved,
+        GetDesc: Reserved,
+        ResizeBuffers: Reserved,
+        ResizeTarget: Reserved,
+        GetContainingOutput: Reserved,
+        GetFrameStatistics: Reserved,
+        GetLastPresentCount: Reserved,
+        // IDXGISwapChain1 (18-28) - not called, reserved
+        GetDesc1: Reserved,
+        GetFullscreenDesc: Reserved,
+        GetHwnd: Reserved,
+        GetCoreWindow: Reserved,
+        Present1: Reserved,
+        IsTemporaryMonoSupported: Reserved,
+        GetRestrictToOutput: Reserved,
+        SetBackgroundColor: Reserved,
+        GetBackgroundColor: Reserved,
+        SetRotation: Reserved,
+        GetRotation: Reserved,
+    };
+    pub inline fn Present(self: *IDXGISwapChain1, sync_interval: u32, flags: u32) HRESULT {
+        return self.vtable.Present(self, sync_interval, flags);
+    }
+    pub inline fn GetBuffer(self: *IDXGISwapChain1, buffer: u32, riid: *const GUID, surface: *?*anyopaque) HRESULT {
+        return self.vtable.GetBuffer(self, buffer, riid, surface);
+    }
+    pub inline fn Release(self: *IDXGISwapChain1) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// IDXGIFactory2 - we call CreateSwapChainForHwnd (slot 15).
+const IDXGIFactory2 = extern struct {
+    vtable: *const VTable,
+    pub const IID = GUID{
+        .data1 = 0x50c83a1c,
+        .data2 = 0xe072,
+        .data3 = 0x4c48,
+        .data4 = .{ 0x87, 0xb0, 0x36, 0x30, 0xfa, 0x36, 0xa6, 0xd0 },
+    };
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIFactory (7-11)
+        EnumAdapters: Reserved,
+        MakeWindowAssociation: Reserved,
+        GetWindowAssociation: Reserved,
+        CreateSwapChain: Reserved,
+        CreateSoftwareAdapter: Reserved,
+        // IDXGIFactory1 (12-13)
+        EnumAdapters1: Reserved,
+        IsCurrent: Reserved,
+        // IDXGIFactory2 (14-24)
+        IsWindowedStereoEnabled: Reserved,
+        CreateSwapChainForHwnd: *const fn (
+            *IDXGIFactory2,
+            *IUnknown,
+            windows.HANDLE,
+            *const DXGI_SWAP_CHAIN_DESC1,
+            ?*const anyopaque,
+            ?*anyopaque,
+            *?*IDXGISwapChain1,
+        ) callconv(.winapi) HRESULT,
+        CreateSwapChainForCoreWindow: Reserved,
+        GetSharedResourceAdapterLuid: Reserved,
+        RegisterStereoStatusWindow: Reserved,
+        RegisterStereoStatusEvent: Reserved,
+        UnregisterStereoStatus: Reserved,
+        RegisterOcclusionStatusWindow: Reserved,
+        RegisterOcclusionStatusEvent: Reserved,
+        UnregisterOcclusionStatus: Reserved,
+        CreateSwapChainForComposition: Reserved,
+    };
+    pub inline fn CreateSwapChainForHwnd(
+        self: *IDXGIFactory2,
+        device: *IUnknown,
+        hwnd: windows.HANDLE,
+        desc: *const DXGI_SWAP_CHAIN_DESC1,
+        fullscreen_desc: ?*const anyopaque,
+        restrict_to_output: ?*anyopaque,
+        swap_chain: *?*IDXGISwapChain1,
+    ) HRESULT {
+        return self.vtable.CreateSwapChainForHwnd(
+            self,
+            device,
+            hwnd,
+            desc,
+            fullscreen_desc,
+            restrict_to_output,
+            swap_chain,
+        );
+    }
+    pub inline fn Release(self: *IDXGIFactory2) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// ---------- D3D11 types ------------------------------------------------------
+
+const D3D_FEATURE_LEVEL = enum(u32) { @"11_0" = 0xb000, _ };
+const D3D_DRIVER_TYPE = enum(u32) { HARDWARE = 1, _ };
+const D3D11_CREATE_DEVICE_FLAG = u32;
+const D3D11_CREATE_DEVICE_BGRA_SUPPORT: D3D11_CREATE_DEVICE_FLAG = 0x20;
+const D3D11_SDK_VERSION: u32 = 7;
+
+const D3D11_VIEWPORT = extern struct {
+    TopLeftX: f32,
+    TopLeftY: f32,
+    Width: f32,
+    Height: f32,
+    MinDepth: f32,
+    MaxDepth: f32,
+};
+
+// ID3D11Resource - base type for GetBuffer result cast.
+const ID3D11Resource = extern struct { vtable: *const anyopaque };
+
+// ID3D11Texture2D - IID needed for GetBuffer.
+const ID3D11Texture2D = extern struct {
+    vtable: *const anyopaque,
+    pub const IID = GUID{
+        .data1 = 0x6f15aaf2,
+        .data2 = 0xd208,
+        .data3 = 0x4e89,
+        .data4 = .{ 0x9a, 0xb4, 0x48, 0x95, 0x35, 0xd3, 0x4f, 0x9c },
+    };
+    pub inline fn Release(self: *ID3D11Texture2D) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// ID3D11RenderTargetView - we call Release.
+const ID3D11RenderTargetView = extern struct {
+    vtable: *const anyopaque,
+    pub const IID = GUID{
+        .data1 = 0xdfdba067,
+        .data2 = 0x0b8d,
+        .data3 = 0x4865,
+        .data4 = .{ 0x87, 0x5b, 0xd7, 0xb4, 0x51, 0x6c, 0xc1, 0x64 },
+    };
+    pub inline fn Release(self: *ID3D11RenderTargetView) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// ID3D11DeviceContext - we call OMSetRenderTargets (33), RSSetViewports (44),
+// ClearRenderTargetView (50), Release (2).
+const ID3D11DeviceContext = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*ID3D11DeviceContext) callconv(.winapi) u32,
+        // ID3D11DeviceChild (3-6)
+        GetDevice: Reserved,
+        GetPrivateData: Reserved,
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        // ID3D11DeviceContext (7-32)
+        VSSetConstantBuffers: Reserved,
+        PSSetShaderResources: Reserved,
+        PSSetShader: Reserved,
+        PSSetSamplers: Reserved,
+        VSSetShader: Reserved,
+        DrawIndexed: Reserved,
+        Draw: Reserved,
+        Map: Reserved,
+        Unmap: Reserved,
+        PSSetConstantBuffers: Reserved,
+        IASetInputLayout: Reserved,
+        IASetVertexBuffers: Reserved,
+        IASetIndexBuffer: Reserved,
+        DrawIndexedInstanced: Reserved,
+        DrawInstanced: Reserved,
+        GSSetConstantBuffers: Reserved,
+        GSSetShader: Reserved,
+        IASetPrimitiveTopology: Reserved,
+        VSSetShaderResources: Reserved,
+        VSSetSamplers: Reserved,
+        Begin: Reserved,
+        End: Reserved,
+        GetData: Reserved,
+        SetPredication: Reserved,
+        GSSetShaderResources: Reserved,
+        GSSetSamplers: Reserved,
+        // slot 33: OMSetRenderTargets
+        OMSetRenderTargets: *const fn (
+            *ID3D11DeviceContext,
+            u32,
+            [*]const ?*ID3D11RenderTargetView,
+            ?*anyopaque,
+        ) callconv(.winapi) void,
+        // slot 34: OMSetRenderTargetsAndUnorderedAccessViews
+        OMSetRenderTargetsAndUnorderedAccessViews: Reserved,
+        OMSetBlendState: Reserved,
+        OMSetDepthStencilState: Reserved,
+        SOSetTargets: Reserved,
+        DrawAuto: Reserved,
+        DrawIndexedInstancedIndirect: Reserved,
+        DrawInstancedIndirect: Reserved,
+        Dispatch: Reserved,
+        DispatchIndirect: Reserved,
+        RSSetState: Reserved,
+        // slot 44: RSSetViewports
+        RSSetViewports: *const fn (*ID3D11DeviceContext, u32, [*]const D3D11_VIEWPORT) callconv(.winapi) void,
+        RSSetScissorRects: Reserved,
+        CopySubresourceRegion: Reserved,
+        CopyResource: Reserved,
+        UpdateSubresource: Reserved,
+        CopyStructureCount: Reserved,
+        // slot 50: ClearRenderTargetView
+        ClearRenderTargetView: *const fn (
+            *ID3D11DeviceContext,
+            *ID3D11RenderTargetView,
+            *const [4]f32,
+        ) callconv(.winapi) void,
+    };
+    pub inline fn OMSetRenderTargets(
+        self: *ID3D11DeviceContext,
+        rtvs: []const ?*ID3D11RenderTargetView,
+        dsv: ?*anyopaque,
+    ) void {
+        self.vtable.OMSetRenderTargets(self, @intCast(rtvs.len), rtvs.ptr, dsv);
+    }
+    pub inline fn RSSetViewports(self: *ID3D11DeviceContext, viewports: []const D3D11_VIEWPORT) void {
+        self.vtable.RSSetViewports(self, @intCast(viewports.len), viewports.ptr);
+    }
+    pub inline fn ClearRenderTargetView(self: *ID3D11DeviceContext, rtv: *ID3D11RenderTargetView, color: *const [4]f32) void {
+        self.vtable.ClearRenderTargetView(self, rtv, color);
+    }
+    pub inline fn Release(self: *ID3D11DeviceContext) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// ID3D11Device - we call CreateRenderTargetView (9), QueryInterface (0),
+// Release (2).
+const ID3D11Device = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: *const fn (*ID3D11Device, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*ID3D11Device) callconv(.winapi) u32,
+        Release: *const fn (*ID3D11Device) callconv(.winapi) u32,
+        // slots 3-8
+        CreateBuffer: Reserved,
+        CreateTexture1D: Reserved,
+        CreateTexture2D: Reserved,
+        CreateTexture3D: Reserved,
+        CreateShaderResourceView: Reserved,
+        CreateUnorderedAccessView: Reserved,
+        // slot 9: CreateRenderTargetView
+        CreateRenderTargetView: *const fn (
+            *ID3D11Device,
+            *ID3D11Resource,
+            ?*const anyopaque,
+            *?*ID3D11RenderTargetView,
+        ) callconv(.winapi) HRESULT,
+    };
+    pub inline fn QueryInterface(self: *ID3D11Device, riid: *const GUID, pp: *?*anyopaque) HRESULT {
+        return self.vtable.QueryInterface(self, riid, pp);
+    }
+    pub inline fn CreateRenderTargetView(
+        self: *ID3D11Device,
+        resource: *ID3D11Resource,
+        desc: ?*const anyopaque,
+        rtv: *?*ID3D11RenderTargetView,
+    ) HRESULT {
+        return self.vtable.CreateRenderTargetView(self, resource, desc, rtv);
+    }
+    pub inline fn Release(self: *ID3D11Device) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// D3D11CreateDevice entry point from d3d11.dll.
+const D3D11CreateDevice = @extern(*const fn (
+    pAdapter: ?*anyopaque,
+    DriverType: D3D_DRIVER_TYPE,
+    Software: ?windows.HMODULE,
+    Flags: D3D11_CREATE_DEVICE_FLAG,
+    pFeatureLevels: ?[*]const D3D_FEATURE_LEVEL,
+    FeatureLevels: u32,
+    SDKVersion: u32,
+    ppDevice: ?*?*ID3D11Device,
+    pFeatureLevel: ?*D3D_FEATURE_LEVEL,
+    ppImmediateContext: ?*?*ID3D11DeviceContext,
+) callconv(.winapi) HRESULT, .{
+    .library_name = "d3d11",
+    .name = "D3D11CreateDevice",
+});
+
+// ---------- Win32 window types -----------------------------------------------
+
+const ATOM = u16;
+const WPARAM = usize;
+const LPARAM = isize;
+const LRESULT = isize;
+const WNDPROC = *const fn (windows.HWND, u32, WPARAM, LPARAM) callconv(.winapi) LRESULT;
+
+const WNDCLASSEXW = extern struct {
+    cbSize: u32,
+    style: u32,
+    lpfnWndProc: WNDPROC,
+    cbClsExtra: i32,
+    cbWndExtra: i32,
+    hInstance: windows.HMODULE,
+    hIcon: ?windows.HANDLE,
+    hCursor: ?windows.HANDLE,
+    hbrBackground: ?windows.HANDLE,
+    lpszMenuName: ?[*:0]const u16,
+    lpszClassName: [*:0]const u16,
+    hIconSm: ?windows.HANDLE,
+};
+
+const MSG = extern struct {
+    hwnd: ?windows.HWND,
+    message: u32,
+    wParam: WPARAM,
+    lParam: LPARAM,
+    time: u32,
+    pt_x: i32,
+    pt_y: i32,
+};
+
+const WM_DESTROY: u32 = 0x0002;
+const PM_REMOVE: u32 = 0x0001;
+const WS_OVERLAPPEDWINDOW: u32 = 0x00CF0000;
+const CW_USEDEFAULT: i32 = @bitCast(@as(u32, 0x80000000));
+
+extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
+extern "user32" fn CreateWindowExW(
+    dwExStyle: u32,
+    lpClassName: [*:0]const u16,
+    lpWindowName: [*:0]const u16,
+    dwStyle: u32,
+    X: i32,
+    Y: i32,
+    nWidth: i32,
+    nHeight: i32,
+    hWndParent: ?windows.HWND,
+    hMenu: ?windows.HANDLE,
+    hInstance: windows.HMODULE,
+    lpParam: ?*anyopaque,
+) callconv(.winapi) ?windows.HWND;
+extern "user32" fn ShowWindow(hWnd: windows.HWND, nCmdShow: i32) callconv(.winapi) i32;
+extern "user32" fn PeekMessageW(lpMsg: *MSG, hWnd: ?windows.HWND, wMsgFilterMin: u32, wMsgFilterMax: u32, wRemoveMsg: u32) callconv(.winapi) i32;
+extern "user32" fn TranslateMessage(lpMsg: *const MSG) callconv(.winapi) i32;
+extern "user32" fn DispatchMessageW(lpMsg: *const MSG) callconv(.winapi) LRESULT;
+extern "user32" fn DefWindowProcW(hWnd: windows.HWND, Msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT;
+extern "user32" fn PostQuitMessage(nExitCode: i32) callconv(.winapi) void;
+extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?windows.HMODULE;
+extern "kernel32" fn QueryPerformanceCounter(lpPerformanceCount: *i64) callconv(.winapi) i32;
+extern "kernel32" fn QueryPerformanceFrequency(lpFrequency: *i64) callconv(.winapi) i32;
+
+fn windowProc(hwnd: windows.HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
+    if (msg == WM_DESTROY) {
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProcW(hwnd, msg, wparam, lparam);
+}
+
+// ---------- main -------------------------------------------------------------
+
+pub fn main() !void {
+    const class_name = std.unicode.utf8ToUtf16LeStringLiteral("DX11TestClass");
+    const window_title = std.unicode.utf8ToUtf16LeStringLiteral("DX11 Clear Test");
+
+    const hinstance = GetModuleHandleW(null) orelse {
+        std.debug.print("GetModuleHandleW failed\n", .{});
+        return error.GetModuleHandleFailed;
+    };
+
+    // Register window class.
+    const wc = WNDCLASSEXW{
+        .cbSize = @sizeOf(WNDCLASSEXW),
+        .style = 0,
+        .lpfnWndProc = windowProc,
+        .cbClsExtra = 0,
+        .cbWndExtra = 0,
+        .hInstance = hinstance,
+        .hIcon = null,
+        .hCursor = null,
+        .hbrBackground = null,
+        .lpszMenuName = null,
+        .lpszClassName = class_name,
+        .hIconSm = null,
+    };
+    if (RegisterClassExW(&wc) == 0) {
+        std.debug.print("RegisterClassExW failed\n", .{});
+        return error.RegisterClassFailed;
+    }
+
+    // Create window.
+    const hwnd = CreateWindowExW(
+        0,
+        class_name,
+        window_title,
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        800,
+        600,
+        null,
+        null,
+        hinstance,
+        null,
+    ) orelse {
+        std.debug.print("CreateWindowExW failed\n", .{});
+        return error.CreateWindowFailed;
+    };
+    _ = ShowWindow(hwnd, 1); // SW_SHOWNORMAL
+
+    // Create D3D11 device and immediate context.
+    var device_opt: ?*ID3D11Device = null;
+    var context_opt: ?*ID3D11DeviceContext = null;
+    const feature_levels = [_]D3D_FEATURE_LEVEL{.@"11_0"};
+    var hr = D3D11CreateDevice(
+        null,
+        .HARDWARE,
+        null,
+        D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+        &feature_levels,
+        feature_levels.len,
+        D3D11_SDK_VERSION,
+        &device_opt,
+        null,
+        &context_opt,
+    );
+    if (FAILED(hr)) {
+        std.debug.print("D3D11CreateDevice failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.D3D11CreateDeviceFailed;
+    }
+    const device = device_opt.?;
+    defer _ = device.Release();
+    const context = context_opt.?;
+    defer _ = context.Release();
+
+    std.debug.print("D3D11CreateDevice OK\n", .{});
+
+    // QueryInterface device -> IDXGIDevice.
+    var dxgi_device_opt: ?*anyopaque = null;
+    hr = device.QueryInterface(&IDXGIDevice.IID, &dxgi_device_opt);
+    if (FAILED(hr) or dxgi_device_opt == null) {
+        std.debug.print("QI IDXGIDevice failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.QIIDXGIDeviceFailed;
+    }
+    const dxgi_device: *IDXGIDevice = @ptrCast(@alignCast(dxgi_device_opt.?));
+    defer _ = dxgi_device.Release();
+
+    // Get adapter.
+    var adapter_opt: ?*IDXGIAdapter = null;
+    hr = dxgi_device.GetAdapter(&adapter_opt);
+    if (FAILED(hr) or adapter_opt == null) {
+        std.debug.print("GetAdapter failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.GetAdapterFailed;
+    }
+    const adapter = adapter_opt.?;
+    defer _ = adapter.Release();
+
+    // Get IDXGIFactory2 from adapter.
+    var factory_opt: ?*anyopaque = null;
+    hr = adapter.GetParent(&IDXGIFactory2.IID, &factory_opt);
+    if (FAILED(hr) or factory_opt == null) {
+        std.debug.print("GetParent IDXGIFactory2 failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.GetFactoryFailed;
+    }
+    const factory: *IDXGIFactory2 = @ptrCast(@alignCast(factory_opt.?));
+    defer _ = factory.Release();
+
+    // Create swap chain for HWND.
+    const sc_desc = DXGI_SWAP_CHAIN_DESC1{
+        .Width = 800,
+        .Height = 600,
+        .Format = .B8G8R8A8_UNORM,
+        .Stereo = 0,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
+        .BufferCount = 2,
+        .Scaling = .STRETCH,
+        .SwapEffect = .FLIP_SEQUENTIAL,
+        .AlphaMode = .UNSPECIFIED,
+        .Flags = 0,
+    };
+    var swap_chain_opt: ?*IDXGISwapChain1 = null;
+    hr = factory.CreateSwapChainForHwnd(
+        @ptrCast(device),
+        hwnd,
+        &sc_desc,
+        null,
+        null,
+        &swap_chain_opt,
+    );
+    if (FAILED(hr) or swap_chain_opt == null) {
+        std.debug.print("CreateSwapChainForHwnd failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.CreateSwapChainFailed;
+    }
+    const swap_chain = swap_chain_opt.?;
+    defer _ = swap_chain.Release();
+
+    std.debug.print("Swap chain created OK\n", .{});
+
+    // Get back buffer and create render target view.
+    var back_buffer_opt: ?*anyopaque = null;
+    hr = swap_chain.GetBuffer(0, &ID3D11Texture2D.IID, &back_buffer_opt);
+    if (FAILED(hr) or back_buffer_opt == null) {
+        std.debug.print("GetBuffer failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.GetBufferFailed;
+    }
+    const back_buffer: *ID3D11Texture2D = @ptrCast(@alignCast(back_buffer_opt.?));
+    defer _ = back_buffer.Release();
+
+    var rtv_opt: ?*ID3D11RenderTargetView = null;
+    hr = device.CreateRenderTargetView(@ptrCast(back_buffer), null, &rtv_opt);
+    if (FAILED(hr) or rtv_opt == null) {
+        std.debug.print("CreateRenderTargetView failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.CreateRTVFailed;
+    }
+    const rtv = rtv_opt.?;
+    defer _ = rtv.Release();
+
+    std.debug.print("RTV created OK -- running render loop for 3 seconds\n", .{});
+
+    // Early-sunrise orange: R=0.98, G=0.45, B=0.25, A=1.0
+    const clear_color = [4]f32{ 0.98, 0.45, 0.25, 1.0 };
+
+    // Measure 3 seconds via QueryPerformanceCounter.
+    var freq: i64 = 0;
+    var start: i64 = 0;
+    _ = QueryPerformanceFrequency(&freq);
+    _ = QueryPerformanceCounter(&start);
+    const duration: i64 = freq * 3;
+
+    var msg: MSG = std.mem.zeroes(MSG);
+    while (true) {
+        // Drain the message queue.
+        while (PeekMessageW(&msg, null, 0, 0, PM_REMOVE) != 0) {
+            _ = TranslateMessage(&msg);
+            _ = DispatchMessageW(&msg);
+        }
+
+        // Render frame.
+        const viewport = D3D11_VIEWPORT{
+            .TopLeftX = 0.0,
+            .TopLeftY = 0.0,
+            .Width = 800.0,
+            .Height = 600.0,
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        };
+        context.RSSetViewports(&.{viewport});
+        context.OMSetRenderTargets(&.{rtv}, null);
+        context.ClearRenderTargetView(rtv, &clear_color);
+        hr = swap_chain.Present(1, 0);
+        if (FAILED(hr)) {
+            std.debug.print("Present failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+            return error.PresentFailed;
+        }
+
+        // Check elapsed time.
+        var now: i64 = 0;
+        _ = QueryPerformanceCounter(&now);
+        if (now - start >= duration) break;
+    }
+
+    std.debug.print("DX11 clear-to-color test passed.\n", .{});
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked!
> - This PR
> - #43
> - #33
> - #31 <- **start here and bubble up**

## Summary

First pixels on screen for the DX11 renderer. Wire the GenericRenderer contract into DirectX11.zig enough to clear the screen to a solid color and present it.

- Add dual surface support to `device.zig`: HWND (standalone/library) and composition swap chain (WinUI host)
- Add `CreateSwapChainForHwnd` binding to `IDXGIFactory2`
- Add `windows` variant to embedded apprt `Platform` union (HWND surface)
- Implement GenericRenderer contract: `init`, `deinit`, `surfaceSize`, `initTarget`, `beginFrame`, `presentLastTarget`
- Frame.renderPass() clears render target, Frame.complete() is no-op (DX11 immediate mode)
- Standalone Win32 test harness proves the HWND path end-to-end (orange sunrise window)

## Architecture: Dual Surface Support

The DX11 renderer supports two swap chain creation paths:
- **HWND** -- `CreateSwapChainForHwnd`, opaque alpha, for standalone test harnesses and third-party embedders
- **SwapChainPanel** (composition) -- `CreateSwapChainForComposition`, premultiplied alpha, for WinUI 3 C# host

`device.zig` picks the path based on a `Surface` tagged union. No compile-time flags.

## What I Learnt

- **GenericRenderer drives the backend**: the API module just provides primitives (device, frame, target). GenericRenderer orchestrates init -> beginFrame -> renderPass -> complete -> present
- **DX11 immediate mode vs Metal command buffers**: Metal encodes commands into a command buffer and submits it. DX11's immediate context executes commands inline, so Frame.complete() is a no-op -- the work already happened during renderPass
- **`@hasField` comptime check**: the `none` apprt (used for tests) has an empty Surface with no `platform` field. Using `@hasField` at comptime lets init() return a null device for test builds without touching the Platform switch
- **HWND vs composition swap chains**: HWND uses `DXGI_ALPHA_MODE_UNSPECIFIED` (opaque window), composition uses `PREMULTIPLIED` for XAML transparency. The rest of the device (clear, present, resize) is surface-agnostic

## Test plan

- [x] `zig build -Drenderer=directx11 -Dapp-runtime=none` compiles (65/65 steps)
- [x] `zig build -Dapp-runtime=none test` passes (2624/2677 tests, 53 skipped)
- [x] Standalone test harness builds and runs -- orange sunrise window for 3 seconds, clean exit
- [ ] Linux/Mac builds unaffected (HlslStep returns null, windows Platform is void on non-Windows)