### PR TITLE
renderer/dx11: implement Buffer, Texture, Sampler GPU primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@
 > **DX11 renderer infrastructure** (in fork)
 >
 > - [x] COM interface definitions (d3d11, dxgi) with vtable bindings
-> - [x] DX11 device lifecycle, swap chain for XAML composition
+> - [x] DX11 device lifecycle with dual surface support (HWND for standalone/embedding, SwapChainPanel for WinUI host)
 > - [x] Instanced cell grid renderer with pre-compiled HLSL shaders
+> - [x] HLSL build step (HlslStep.zig) mirroring Metal's MetallibStep
 > - [x] Backend enum with `directx11` variant
+> - [x] GraphicsAPI contract stubs for GenericRenderer
 >
 > **SwapChainPanel spike** (in fork, [demo video](https://www.youtube.com/watch?v=-Cn9mlxX_GA))
 >
@@ -89,10 +91,23 @@
 > - [x] `--version` flag working from command line
 > - [x] Interop test suite (7 tests against the real DLL)
 >
+> ### Architecture: Dual Surface Support
+>
+> The DX11 renderer is dual-channel at the library level so that libghostty
+> consumers can pick whichever surface model fits their host:
+> - **HWND** -- `CreateSwapChainForHwnd`, for standalone windows, test harnesses, and third-party embedders
+> - **SwapChainPanel** (composition) -- `CreateSwapChainForComposition`, for WinUI 3 / XAML hosts
+>
+> We are iterating on SwapChainPanel with the information we have today but
+> the choice is not set in stone -- the dual-channel design means we can
+> change our mind later without breaking embedders.
+>
+> The device picks the path based on what the caller provides. No compile-time flags.
+>
 > ### What is next
 >
-> - [ ] Implement GenericRenderer GraphicsAPI contract for DX11
-> - [ ] Windows platform enum and C# scaffold integration
+> - [x] DX11 clear-to-color: wire GenericRenderer contract, first pixels on screen
+> - [ ] Cell rendering: instance buffer, texture atlas, text on screen
 > - [ ] DirectWrite font backend
 > - [ ] ConPTY shell spawning
 > - [ ] Keyboard, mouse, clipboard

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -343,6 +343,7 @@ pub const App = struct {
 pub const Platform = union(PlatformTag) {
     macos: MacOS,
     ios: IOS,
+    windows: Windows,
 
     // If our build target for libghostty is not darwin then we do
     // not include macos support at all.
@@ -356,6 +357,11 @@ pub const Platform = union(PlatformTag) {
         uiview: objc.Object,
     } else void;
 
+    pub const Windows = if (builtin.target.os.tag == .windows) struct {
+        /// The HWND to render into, or null for composition swap chain.
+        hwnd: ?std.os.windows.HANDLE,
+    } else void;
+
     // The C ABI compatible version of this union. The tag is expected
     // to be stored elsewhere.
     pub const C = extern union {
@@ -365,6 +371,10 @@ pub const Platform = union(PlatformTag) {
 
         ios: extern struct {
             uiview: ?*anyopaque,
+        },
+
+        windows: extern struct {
+            hwnd: ?*anyopaque,
         },
     };
 
@@ -385,6 +395,10 @@ pub const Platform = union(PlatformTag) {
                     break :ios error.UIViewMustBeSet);
                 break :ios .{ .ios = .{ .uiview = uiview } };
             } else error.UnsupportedPlatform,
+
+            .windows => if (Windows != void) .{ .windows = .{
+                .hwnd = c_platform.windows.hwnd,
+            } } else error.UnsupportedPlatform,
         };
     }
 };
@@ -395,6 +409,7 @@ pub const PlatformTag = enum(c_int) {
 
     macos = 1,
     ios = 2,
+    windows = 3,
 };
 
 pub const EnvVar = extern struct {

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -17,6 +17,8 @@ const font = @import("../font/main.zig");
 const rendererpkg = @import("../renderer.zig");
 const Renderer = rendererpkg.GenericRenderer(DirectX11);
 const shadertoy = @import("shadertoy.zig");
+const apprt = @import("../apprt.zig");
+const log = std.log.scoped(.directx11);
 
 // --- GraphicsAPI contract: types ---
 
@@ -62,7 +64,8 @@ pub const dxgi = @import("directx11/dxgi.zig");
 
 // --- Sub-module re-exports: renderer components from 025 ---
 
-pub const Device = @import("directx11/device.zig").Device;
+const devicepkg = @import("directx11/device.zig");
+pub const Device = devicepkg.Device;
 pub const CellPipeline = @import("directx11/cell_pipeline.zig").Pipeline;
 pub const Constants = @import("directx11/cell_pipeline.zig").Constants;
 pub const CellGrid = @import("directx11/cell_grid.zig").CellGrid;
@@ -73,17 +76,45 @@ pub const CellInstance = @import("directx11/cell_grid.zig").CellInstance;
 /// Runtime blending mode, set by GenericRenderer when config changes.
 blending: configpkg.Config.AlphaBlending = .native,
 
+/// The DX11 device managing the swap chain and render target.
+device: ?Device = null,
+
 // --- GraphicsAPI contract: functions ---
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
     _ = alloc;
-    _ = opts;
-    @panic("TODO: DX11 init");
+
+    const device = device: {
+        if (comptime @hasField(@TypeOf(opts.rt_surface.*), "platform")) {
+            switch (opts.rt_surface.platform) {
+                .windows => |w| {
+                    const surface: devicepkg.Surface = if (w.hwnd) |hwnd|
+                        .{ .hwnd = hwnd }
+                    else
+                        @panic("composition swap chain requires an ISwapChainPanelNative pointer");
+
+                    const size = opts.size.screen;
+                    break :device Device.init(surface, size.width, size.height) catch |err| {
+                        log.err("DX11 device init failed: {}", .{err});
+                        return error.DeviceInitFailed;
+                    };
+                },
+                else => @panic("unsupported platform for DX11"),
+            }
+        } else {
+            break :device null;
+        }
+    };
+
+    return .{
+        .device = device,
+    };
 }
 
 pub fn deinit(self: *DirectX11) void {
-    _ = self;
-    @panic("TODO: DX11 deinit");
+    if (self.device) |*dev| {
+        dev.deinit();
+    }
 }
 
 pub fn drawFrameStart(self: *DirectX11) void {
@@ -108,15 +139,15 @@ pub fn initShaders(
 }
 
 pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
-    _ = self;
-    @panic("TODO: DX11 surfaceSize");
+    if (self.device) |dev| {
+        return .{ .width = dev.width, .height = dev.height };
+    }
+    return .{ .width = 0, .height = 0 };
 }
 
 pub fn initTarget(self: *const DirectX11, width: usize, height: usize) !Target {
     _ = self;
-    _ = width;
-    _ = height;
-    @panic("TODO: DX11 initTarget");
+    return .{ .width = width, .height = height };
 }
 
 pub inline fn beginFrame(
@@ -129,8 +160,12 @@ pub inline fn beginFrame(
 }
 
 pub fn presentLastTarget(self: *DirectX11) !void {
-    _ = self;
-    @panic("TODO: DX11 presentLastTarget");
+    if (self.device) |*dev| {
+        dev.present() catch |err| {
+            log.err("present failed: {}", .{err});
+            return error.PresentFailed;
+        };
+    }
 }
 
 pub inline fn bufferOptions(self: DirectX11) bufferpkg.Options {

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -170,25 +170,49 @@ pub fn presentLastTarget(self: *DirectX11) !void {
 }
 
 pub inline fn bufferOptions(self: DirectX11) bufferpkg.Options {
-    _ = self;
-    return .{};
+    const dev = self.device orelse @panic("DX11 device not initialized");
+    return .{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_VERTEX_BUFFER,
+    };
 }
 
+/// Instance buffers use the same options as vertex buffers -- both are
+/// bound to the IA stage as vertex data via IASetVertexBuffers.
 pub const instanceBufferOptions = bufferOptions;
-pub const uniformBufferOptions = bufferOptions;
 pub const fgBufferOptions = bufferOptions;
 pub const bgBufferOptions = bufferOptions;
 pub const imageBufferOptions = bufferOptions;
 pub const bgImageBufferOptions = bufferOptions;
 
+/// Uniform buffers are bound as constant buffers (HLSL cbuffer).
+/// DX11 requires constant buffer sizes to be a multiple of 16 bytes.
+pub inline fn uniformBufferOptions(self: DirectX11) bufferpkg.Options {
+    const dev = self.device orelse @panic("DX11 device not initialized");
+    return .{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_CONSTANT_BUFFER,
+    };
+}
+
 pub inline fn textureOptions(self: DirectX11) Texture.Options {
-    _ = self;
-    return .{};
+    const dev = self.device orelse @panic("DX11 device not initialized");
+    return .{
+        .device = dev.device,
+        .context = dev.context,
+        .format = .B8G8R8A8_UNORM,
+    };
 }
 
 pub inline fn samplerOptions(self: DirectX11) Sampler.Options {
-    _ = self;
-    return .{};
+    const dev = self.device orelse @panic("DX11 device not initialized");
+    return .{
+        .device = dev.device,
+    };
 }
 
 pub inline fn imageTextureOptions(
@@ -196,19 +220,44 @@ pub inline fn imageTextureOptions(
     format: ImageTextureFormat,
     srgb: bool,
 ) Texture.Options {
-    _ = self;
-    _ = format;
-    _ = srgb;
-    return .{};
+    _ = srgb; // DX11 sRGB handled via SRV format, not implemented yet
+    const dev = self.device orelse @panic("DX11 device not initialized");
+    const dxgi_format: dxgi.DXGI_FORMAT = switch (format) {
+        .gray => .R8_UNORM,
+        .rgba => .R8G8B8A8_UNORM,
+        .bgra => .B8G8R8A8_UNORM,
+    };
+    return .{
+        .device = dev.device,
+        .context = dev.context,
+        .format = dxgi_format,
+    };
 }
 
 pub fn initAtlasTexture(
     self: *const DirectX11,
     atlas: *const font.Atlas,
 ) Texture.Error!Texture {
-    _ = self;
-    _ = atlas;
-    @panic("TODO: DX11 initAtlasTexture");
+    const dev = self.device orelse @panic("DX11 device not initialized");
+
+    // Map font atlas format to DXGI format.
+    // Metal uses r8unorm / bgra8unorm_srgb; we use the DX11 equivalents.
+    const dxgi_format: dxgi.DXGI_FORMAT = switch (atlas.format) {
+        .grayscale => .R8_UNORM,
+        .bgra => .B8G8R8A8_UNORM,
+        else => std.debug.panic("unsupported atlas format for DX11 texture: {}", .{atlas.format}),
+    };
+
+    return try Texture.init(
+        .{
+            .device = dev.device,
+            .context = dev.context,
+            .format = dxgi_format,
+        },
+        @intCast(atlas.size),
+        @intCast(atlas.size),
+        atlas.data,
+    );
 }
 
 test {

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -9,6 +9,7 @@
 //! already in place from prior work in the directx11/ subdirectory.
 pub const DirectX11 = @This();
 
+const builtin = @import("builtin");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -85,13 +86,15 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
     _ = alloc;
 
     const device = device: {
-        if (comptime @hasField(@TypeOf(opts.rt_surface.*), "platform")) {
+        if (comptime builtin.os.tag != .windows) {
+            break :device null;
+        } else {
             switch (opts.rt_surface.platform) {
                 .windows => |w| {
                     const surface: devicepkg.Surface = if (w.hwnd) |hwnd|
                         .{ .hwnd = hwnd }
                     else
-                        @panic("composition swap chain requires an ISwapChainPanelNative pointer");
+                        @panic("HWND surface requires a non-null hwnd");
 
                     const size = opts.size.screen;
                     break :device Device.init(surface, size.width, size.height) catch |err| {
@@ -101,8 +104,6 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
                 },
                 else => @panic("unsupported platform for DX11"),
             }
-        } else {
-            break :device null;
         }
     };
 

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -1,5 +1,4 @@
 //! Frame context for DX11 draw commands.
-//! TODO: Implement with ID3D11DeviceContext deferred or immediate context.
 const DirectX11 = @import("../DirectX11.zig");
 const Renderer = @import("../generic.zig").Renderer(DirectX11);
 const Target = @import("Target.zig");
@@ -24,16 +23,29 @@ pub fn begin(
 }
 
 pub inline fn renderPass(
-    self: *const @This(),
+    self: *@This(),
     attachments: []const RenderPass.Options.Attachment,
 ) RenderPass {
-    _ = self;
-    _ = attachments;
-    @panic("TODO: DX11 Frame.renderPass");
+    // Clear the render target using the first attachment's clear color.
+    if (self.renderer.api.device) |*dev| {
+        for (attachments) |att| {
+            if (att.clear_color) |color| {
+                dev.clearRenderTarget(.{
+                    @floatCast(color[0]),
+                    @floatCast(color[1]),
+                    @floatCast(color[2]),
+                    @floatCast(color[3]),
+                });
+                break;
+            }
+        }
+    }
+    return .{};
 }
 
 pub fn complete(self: *@This(), sync: bool) void {
+    // DX11 immediate mode: commands already executed. Present happens in
+    // presentLastTarget(), called by GenericRenderer after frame completion.
     _ = self;
     _ = sync;
-    @panic("TODO: DX11 Frame.complete");
 }

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -5,6 +5,7 @@ const Sampler = @import("Sampler.zig");
 const Target = @import("Target.zig");
 const Texture = @import("Texture.zig");
 const bufferpkg = @import("buffer.zig");
+const RawBuffer = bufferpkg.RawBuffer;
 
 /// Options for beginning a render pass.
 pub const Options = struct {
@@ -22,8 +23,8 @@ pub const Options = struct {
 /// A single step in a render pass.
 pub const Step = struct {
     pipeline: Pipeline,
-    uniforms: ?bufferpkg.Buffer(u8) = null,
-    buffers: []const ?bufferpkg.Buffer(u8) = &.{},
+    uniforms: ?RawBuffer = null,
+    buffers: []const ?RawBuffer = &.{},
     textures: []const ?Texture = &.{},
     samplers: []const ?Sampler = &.{},
     draw: Draw,

--- a/src/renderer/directx11/Sampler.zig
+++ b/src/renderer/directx11/Sampler.zig
@@ -1,20 +1,62 @@
 //! Texture sampler wrapper for DX11.
-//! TODO: Implement with ID3D11SamplerState.
+//!
+//! Wraps an ID3D11SamplerState with hardcoded linear filtering and
+//! clamp-to-edge addressing.
+//!
+//! Why hardcode instead of parameterize: Metal exposes filter/address
+//! mode options because ObjC property setting makes it free. In DX11
+//! it's a struct you fill out -- parameterizing just moves the same
+//! constants from init() to the caller. The GenericRenderer only ever
+//! creates one sampler with linear + clamp-to-edge (for font atlas
+//! sampling). If we ever need a second configuration, adding Options
+//! fields is trivial.
+const Self = @This();
+
+const std = @import("std");
+const d3d11 = @import("d3d11.zig");
+const com = @import("com.zig");
+
+const log = std.log.scoped(.directx11);
 
 /// Options for initializing a sampler.
-pub const Options = struct {};
+pub const Options = struct {
+    device: *d3d11.ID3D11Device,
+};
 
 pub const Error = error{
     /// A DirectX 11 API call failed.
     DirectXFailed,
 };
 
-pub fn init(opts: Options) Error!@This() {
-    _ = opts;
-    @panic("TODO: DX11 Sampler.init");
+/// The underlying ID3D11SamplerState.
+sampler: *d3d11.ID3D11SamplerState,
+
+pub fn init(opts: Options) Error!Self {
+    const desc = d3d11.D3D11_SAMPLER_DESC{
+        .Filter = .MIN_MAG_MIP_LINEAR,
+        .AddressU = .CLAMP,
+        .AddressV = .CLAMP,
+        .AddressW = .CLAMP,
+        .MipLODBias = 0.0,
+        .MaxAnisotropy = 1,
+        .ComparisonFunc = 0, // D3D11_COMPARISON_NEVER (not used with standard filtering)
+        .BorderColor = .{ 0.0, 0.0, 0.0, 0.0 },
+        .MinLOD = 0.0,
+        .MaxLOD = std.math.floatMax(f32),
+    };
+
+    var sampler: ?*d3d11.ID3D11SamplerState = null;
+    const hr = opts.device.CreateSamplerState(&desc, &sampler);
+    if (com.FAILED(hr)) {
+        log.err("CreateSamplerState failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+        return error.DirectXFailed;
+    }
+
+    return .{
+        .sampler = sampler orelse return error.DirectXFailed,
+    };
 }
 
-pub fn deinit(self: @This()) void {
-    _ = self;
-    @panic("TODO: DX11 Sampler.deinit");
+pub fn deinit(self: Self) void {
+    _ = self.sampler.Release();
 }

--- a/src/renderer/directx11/Sampler.zig
+++ b/src/renderer/directx11/Sampler.zig
@@ -39,7 +39,7 @@ pub fn init(opts: Options) Error!Self {
         .AddressW = .CLAMP,
         .MipLODBias = 0.0,
         .MaxAnisotropy = 1,
-        .ComparisonFunc = 0, // D3D11_COMPARISON_NEVER (not used with standard filtering)
+        .ComparisonFunc = 1, // D3D11_COMPARISON_NEVER (unused with non-comparison filters, but 0 is not a valid enum value)
         .BorderColor = .{ 0.0, 0.0, 0.0, 0.0 },
         .MinLOD = 0.0,
         .MaxLOD = std.math.floatMax(f32),

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -13,6 +13,7 @@ width: usize = 0,
 height: usize = 0,
 
 pub fn deinit(self: *@This()) void {
-    _ = self;
-    @panic("TODO: DX11 Target.deinit");
+    // Backbuffer is owned by the swap chain, nothing to release here.
+    self.width = 0;
+    self.height = 0;
 }

--- a/src/renderer/directx11/Texture.zig
+++ b/src/renderer/directx11/Texture.zig
@@ -1,53 +1,179 @@
 //! GPU texture wrapper for DX11.
-//! TODO: Implement with ID3D11Texture2D and ID3D11ShaderResourceView.
+//!
+//! Wraps an ID3D11Texture2D and its ID3D11ShaderResourceView. These are
+//! always created as a pair: the texture holds pixel data, the SRV is
+//! what shaders actually sample from. DX11 separates them because you
+//! can have textures without SRVs (render targets) or multiple SRVs on
+//! one texture (different format interpretations). For font atlas textures
+//! we always need both, so we pair them.
+//!
+//! Uses DEFAULT usage (GPU-optimal memory) with UpdateSubresource for
+//! uploads, rather than DYNAMIC + Map/Unmap. This is the opposite choice
+//! from Buffer, and for good reason: textures are sampled every frame by
+//! the pixel shader but only written when new glyphs are rasterized (rare
+//! after the initial burst). DEFAULT textures sit in GPU-optimal memory
+//! for fast sampling. The occasional UpdateSubresource cost is worth the
+//! per-frame read speed.
+const Self = @This();
+
+const std = @import("std");
+const d3d11 = @import("d3d11.zig");
+const dxgi = @import("dxgi.zig");
+const com = @import("com.zig");
+
+const log = std.log.scoped(.directx11);
 
 /// Options for initializing a texture.
-pub const Options = struct {};
+pub const Options = struct {
+    device: *d3d11.ID3D11Device,
+    context: *d3d11.ID3D11DeviceContext,
+    format: dxgi.DXGI_FORMAT = .B8G8R8A8_UNORM,
+};
 
 pub const Error = error{
     /// A DirectX 11 API call failed.
     DirectXFailed,
 };
 
-/// The width of this texture.
-width: usize = 0,
-/// The height of this texture.
-height: usize = 0,
-/// Bytes per pixel for this texture.
-bpp: usize = 0,
+/// The underlying ID3D11Texture2D.
+texture: *d3d11.ID3D11Texture2D,
 
+/// Shader resource view for sampling this texture in shaders.
+srv: *d3d11.ID3D11ShaderResourceView,
+
+/// Saved options for replaceRegion (needs the context).
+opts: Options,
+
+/// The width of this texture in pixels.
+width: usize,
+/// The height of this texture in pixels.
+height: usize,
+
+/// Bytes per pixel, derived from the DXGI format at init time.
+bpp: usize,
+
+/// Initialize a texture.
+///
+/// Creates an ID3D11Texture2D with DEFAULT usage and a matching SRV.
+/// If `data` is non-null, it's passed as initial data so the texture
+/// is populated at creation time (no extra upload step needed).
 pub fn init(
     opts: Options,
     width: usize,
     height: usize,
     data: ?[]const u8,
-) Error!@This() {
-    _ = opts;
-    _ = width;
-    _ = height;
-    _ = data;
-    @panic("TODO: DX11 Texture.init");
+) Error!Self {
+    const bpp = bppOf(opts.format);
+
+    const desc = d3d11.D3D11_TEXTURE2D_DESC{
+        .Width = @intCast(width),
+        .Height = @intCast(height),
+        .MipLevels = 1,
+        .ArraySize = 1,
+        .Format = opts.format,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .Usage = .DEFAULT,
+        .BindFlags = d3d11.D3D11_BIND_SHADER_RESOURCE,
+        .CPUAccessFlags = 0,
+        .MiscFlags = 0,
+    };
+
+    // If we have initial data, provide it so the texture is populated
+    // at creation time. This avoids an extra UpdateSubresource call.
+    const initial_data: ?*const d3d11.D3D11_SUBRESOURCE_DATA = if (data) |d| &d3d11.D3D11_SUBRESOURCE_DATA{
+        .pSysMem = @ptrCast(d.ptr),
+        .SysMemPitch = @intCast(width * bpp),
+        .SysMemSlicePitch = 0,
+    } else null;
+
+    var texture: ?*d3d11.ID3D11Texture2D = null;
+    var hr = opts.device.CreateTexture2D(&desc, initial_data, &texture);
+    if (com.FAILED(hr)) {
+        log.err("CreateTexture2D failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+        return error.DirectXFailed;
+    }
+    const tex = texture orelse return error.DirectXFailed;
+
+    // Create SRV so shaders can sample this texture.
+    const srv_desc = d3d11.D3D11_SHADER_RESOURCE_VIEW_DESC{
+        .Format = opts.format,
+        .ViewDimension = .TEXTURE2D,
+        .MostDetailedMip = 0,
+        .MipLevels = 1,
+    };
+
+    var srv: ?*d3d11.ID3D11ShaderResourceView = null;
+    hr = opts.device.CreateShaderResourceView(@ptrCast(tex), &srv_desc, &srv);
+    if (com.FAILED(hr)) {
+        log.err("CreateShaderResourceView failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+        _ = tex.Release();
+        return error.DirectXFailed;
+    }
+
+    return .{
+        .texture = tex,
+        .srv = srv orelse {
+            _ = tex.Release();
+            return error.DirectXFailed;
+        },
+        .opts = opts,
+        .width = width,
+        .height = height,
+        .bpp = bpp,
+    };
 }
 
-pub fn deinit(self: @This()) void {
-    _ = self;
-    @panic("TODO: DX11 Texture.deinit");
+/// Release both the SRV and texture.
+/// SRV is released first (reverse creation order) to ensure
+/// no dangling references to the underlying texture.
+pub fn deinit(self: Self) void {
+    _ = self.srv.Release();
+    _ = self.texture.Release();
 }
 
 /// Replace a region of the texture with new data.
+///
+/// Uses UpdateSubresource with a D3D11_BOX to upload a sub-region.
+/// This works with DEFAULT textures -- the runtime handles the staging
+/// copy internally. For our use case (font atlas updates), this is
+/// called when new glyphs are rasterized, which is infrequent after
+/// the initial burst of text rendering.
 pub fn replaceRegion(
-    self: @This(),
+    self: Self,
     x: usize,
     y: usize,
     width: usize,
     height: usize,
     data: []const u8,
 ) error{}!void {
-    _ = self;
-    _ = x;
-    _ = y;
-    _ = width;
-    _ = height;
-    _ = data;
-    @panic("TODO: DX11 Texture.replaceRegion");
+    const box = d3d11.D3D11_BOX{
+        .left = @intCast(x),
+        .top = @intCast(y),
+        .front = 0,
+        .right = @intCast(x + width),
+        .bottom = @intCast(y + height),
+        .back = 1,
+    };
+
+    self.opts.context.UpdateSubresource(
+        @ptrCast(self.texture),
+        0,
+        &box,
+        @ptrCast(data.ptr),
+        @intCast(width * self.bpp),
+        0,
+    );
+}
+
+/// Returns bytes per pixel for the given DXGI format.
+///
+/// Only the two formats used by the font atlas are supported.
+/// Adding a new format is one switch arm -- no architectural change.
+fn bppOf(format: dxgi.DXGI_FORMAT) usize {
+    return switch (format) {
+        .R8_UNORM => 1,
+        .B8G8R8A8_UNORM => 4,
+        .R8G8B8A8_UNORM => 4,
+        else => std.debug.panic("unsupported DXGI_FORMAT for DX11 texture: {}", .{format}),
+    };
 }

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -3,6 +3,14 @@ const std = @import("std");
 /// Options for initializing a buffer.
 pub const Options = struct {};
 
+/// Opaque stand-in for an ID3D11Buffer COM pointer.
+/// Used as the native handle type in Buffer(T).buffer so that GenericRenderer
+/// can pass type-erased buffer references to RenderPass.Step without knowing T.
+/// TODO: Replace with *d3d11.ID3D11Buffer when the full pipeline is implemented.
+pub const RawBuffer = struct {
+    // placeholder - no real GPU resource yet
+};
+
 /// DX11 GPU data buffer for a set of equal-typed elements.
 /// TODO: Implement with ID3D11Buffer (DYNAMIC usage, Map/Unmap for CPU writes).
 pub fn Buffer(comptime T: type) type {
@@ -11,6 +19,11 @@ pub fn Buffer(comptime T: type) type {
 
         opts: Options,
         len: usize,
+
+        /// Type-erased handle for passing to RenderPass.Step. Mirrors the
+        /// .buffer field on Metal (objc.Object) and OpenGL (gl.Buffer) buffers
+        /// so GenericRenderer can pass uniform/vertex buffers without knowing T.
+        buffer: RawBuffer = .{},
 
         pub fn init(opts: Options, len: usize) !Self {
             _ = opts;

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -4,6 +4,11 @@ const com = @import("com.zig");
 
 const log = std.log.scoped(.directx11);
 
+/// Type-erased buffer handle for passing to RenderPass.Step.
+/// Mirrors Metal's objc.Object and OpenGL's gl.Buffer -- lets
+/// GenericRenderer pass uniform/vertex buffers without knowing T.
+pub const RawBuffer = *d3d11.ID3D11Buffer;
+
 /// Options for initializing a buffer.
 pub const Options = struct {
     device: *d3d11.ID3D11Device,

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -226,7 +226,7 @@ pub fn Buffer(comptime T: type) type {
             if (opts.bind_flags & d3d11.D3D11_BIND_CONSTANT_BUFFER != 0) {
                 if (byte_size % 16 != 0) {
                     std.debug.panic(
-                        "Constant buffer size must be a multiple of 16 bytes, got {} (T={}, len={})",
+                        "Constant buffer size must be a multiple of 16 bytes, got {} (T={s}, len={})",
                         .{ byte_size, @typeName(T), len },
                     );
                 }

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -4,12 +4,8 @@ const std = @import("std");
 pub const Options = struct {};
 
 /// Opaque stand-in for an ID3D11Buffer COM pointer.
-/// Used as the native handle type in Buffer(T).buffer so that GenericRenderer
-/// can pass type-erased buffer references to RenderPass.Step without knowing T.
 /// TODO: Replace with *d3d11.ID3D11Buffer when the full pipeline is implemented.
-pub const RawBuffer = struct {
-    // placeholder - no real GPU resource yet
-};
+pub const RawBuffer = struct {};
 
 /// DX11 GPU data buffer for a set of equal-typed elements.
 /// TODO: Implement with ID3D11Buffer (DYNAMIC usage, Map/Unmap for CPU writes).

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -1,70 +1,259 @@
 const std = @import("std");
+const d3d11 = @import("d3d11.zig");
+const com = @import("com.zig");
+
+const log = std.log.scoped(.directx11);
 
 /// Options for initializing a buffer.
-pub const Options = struct {};
+pub const Options = struct {
+    device: *d3d11.ID3D11Device,
+    context: *d3d11.ID3D11DeviceContext,
+    usage: Usage = .dynamic,
+    bind_flags: d3d11.D3D11_BIND_FLAG = d3d11.D3D11_BIND_VERTEX_BUFFER,
+};
 
-/// Opaque stand-in for an ID3D11Buffer COM pointer.
-/// TODO: Replace with *d3d11.ID3D11Buffer when the full pipeline is implemented.
-pub const RawBuffer = struct {};
+pub const Usage = enum {
+    /// CPU writes every frame via Map/Unmap with WRITE_DISCARD.
+    /// The driver internally rotates allocations to avoid CPU/GPU stalls,
+    /// similar to Metal's explicit triple-buffering.
+    dynamic,
+    // default and immutable are not yet needed. Add them when we have
+    // a consumer (e.g. static vertex data for screen quads).
+};
 
 /// DX11 GPU data buffer for a set of equal-typed elements.
-/// TODO: Implement with ID3D11Buffer (DYNAMIC usage, Map/Unmap for CPU writes).
+///
+/// Wraps an ID3D11Buffer with DYNAMIC usage and CPU_ACCESS_WRITE.
+/// The buffer is parameterized over element type T so that sync/map
+/// operations work in terms of typed slices rather than raw bytes.
+///
+/// Why DYNAMIC + Map/Unmap instead of DEFAULT + UpdateSubresource:
+/// Buffers are written every frame (uniforms, cell instance data).
+/// Map/Unmap is one copy (CPU -> driver-managed memory).
+/// UpdateSubresource does CPU -> staging -> GPU, an extra copy per frame.
+/// DYNAMIC buffers live in CPU-accessible memory, which the GPU reads
+/// slightly slower, but for data that changes every frame this is the
+/// right trade-off.
 pub fn Buffer(comptime T: type) type {
     return struct {
         const Self = @This();
 
+        /// The options this buffer was initialized with.
         opts: Options,
+
+        /// The underlying ID3D11Buffer COM object.
+        buffer: *d3d11.ID3D11Buffer,
+
+        /// The allocated capacity in number of T elements (not bytes).
         len: usize,
 
-        /// Type-erased handle for passing to RenderPass.Step. Mirrors the
-        /// .buffer field on Metal (objc.Object) and OpenGL (gl.Buffer) buffers
-        /// so GenericRenderer can pass uniform/vertex buffers without knowing T.
-        buffer: RawBuffer = .{},
-
         pub fn init(opts: Options, len: usize) !Self {
-            _ = opts;
-            _ = len;
-            @panic("TODO: DX11 Buffer.init");
+            const byte_size = validateAndComputeSize(opts, len);
+            const buffer = try createBuffer(opts, byte_size, null);
+            return .{ .opts = opts, .buffer = buffer, .len = len };
         }
 
+        /// Init the buffer filled with the given data.
         pub fn initFill(opts: Options, data: []const T) !Self {
-            _ = opts;
-            _ = data;
-            @panic("TODO: DX11 Buffer.initFill");
+            const byte_size = validateAndComputeSize(opts, data.len);
+            const initial_data = d3d11.D3D11_SUBRESOURCE_DATA{
+                .pSysMem = @ptrCast(data.ptr),
+                .SysMemPitch = 0,
+                .SysMemSlicePitch = 0,
+            };
+            const buffer = try createBuffer(opts, byte_size, &initial_data);
+            return .{ .opts = opts, .buffer = buffer, .len = data.len };
         }
 
         pub fn deinit(self: *const Self) void {
-            _ = self;
-            @panic("TODO: DX11 Buffer.deinit");
+            _ = self.buffer.Release();
         }
 
+        /// Sync new contents to the buffer, replacing everything.
+        ///
+        /// If the data exceeds current capacity, the buffer is reallocated
+        /// at 2x the required size. This amortizes reallocation cost over
+        /// the lifetime of the buffer (same strategy as Metal and std.ArrayList).
+        ///
+        /// Uses Map with WRITE_DISCARD, which tells the driver "I'm replacing
+        /// the entire buffer." The driver hands back a fresh allocation from
+        /// its internal pool so there's no stall even if the GPU is still
+        /// reading the previous frame's data.
+        pub fn sync(self: *Self, data: []const T) !void {
+            const req_bytes = data.len * @sizeOf(T);
+
+            // If we need more space than our buffer has, reallocate.
+            // WRITE_DISCARD rotates which allocation you write to, but
+            // it can't grow the allocation -- that requires a new buffer.
+            if (req_bytes > self.len * @sizeOf(T)) {
+                _ = self.buffer.Release();
+                // Allocate 2x what we need to amortize future growth.
+                const new_len = data.len * 2;
+                const new_byte_size = validateAndComputeSize(self.opts, new_len);
+                self.buffer = try createBuffer(self.opts, new_byte_size, null);
+                self.len = new_len;
+            }
+
+            // Map the buffer for writing. WRITE_DISCARD means we get a
+            // fresh allocation -- no need to worry about what the GPU is reading.
+            var mapped: d3d11.D3D11_MAPPED_SUBRESOURCE = undefined;
+            const hr = self.opts.context.Map(
+                @ptrCast(self.buffer),
+                0,
+                .WRITE_DISCARD,
+                0,
+                &mapped,
+            );
+            if (com.FAILED(hr)) {
+                log.err("Buffer.sync Map failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.DirectXFailed;
+            }
+
+            const dst: [*]u8 = @ptrCast(mapped.pData orelse {
+                log.warn("Buffer.sync: Map returned null pData", .{});
+                self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+                return error.DirectXFailed;
+            });
+            const src: [*]const u8 = @ptrCast(data.ptr);
+            @memcpy(dst[0..req_bytes], src[0..req_bytes]);
+
+            self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+        }
+
+        /// Like sync but takes data from an array of ArrayLists.
+        /// Returns the number of items synced.
+        ///
+        /// Used by GenericRenderer to flatten per-row cell data
+        /// (stored as separate ArrayLists) into a single GPU buffer.
+        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+            var total_len: usize = 0;
+            for (lists) |list| {
+                total_len += list.items.len;
+            }
+
+            const req_bytes = total_len * @sizeOf(T);
+
+            if (req_bytes > self.len * @sizeOf(T)) {
+                _ = self.buffer.Release();
+                const new_len = total_len * 2;
+                const new_byte_size = validateAndComputeSize(self.opts, new_len);
+                self.buffer = try createBuffer(self.opts, new_byte_size, null);
+                self.len = new_len;
+            }
+
+            var mapped: d3d11.D3D11_MAPPED_SUBRESOURCE = undefined;
+            const hr = self.opts.context.Map(
+                @ptrCast(self.buffer),
+                0,
+                .WRITE_DISCARD,
+                0,
+                &mapped,
+            );
+            if (com.FAILED(hr)) {
+                log.err("Buffer.syncFromArrayLists Map failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.DirectXFailed;
+            }
+
+            const dst: [*]u8 = @ptrCast(mapped.pData orelse {
+                log.warn("Buffer.syncFromArrayLists: Map returned null pData", .{});
+                self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+                return error.DirectXFailed;
+            });
+
+            var offset: usize = 0;
+            for (lists) |list| {
+                const chunk_bytes = list.items.len * @sizeOf(T);
+                const src: [*]const u8 = @ptrCast(list.items.ptr);
+                @memcpy(dst[offset..][0..chunk_bytes], src[0..chunk_bytes]);
+                offset += chunk_bytes;
+            }
+
+            self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+
+            return total_len;
+        }
+
+        /// Map the buffer for direct write access.
+        ///
+        /// Returns a typed slice. The caller MUST call unmap() when done.
+        /// Uses WRITE_DISCARD so the previous contents are invalidated.
         pub fn map(self: *Self, len: usize) ![]T {
-            _ = self;
-            _ = len;
-            @panic("TODO: DX11 Buffer.map");
+            std.debug.assert(len <= self.len);
+
+            var mapped: d3d11.D3D11_MAPPED_SUBRESOURCE = undefined;
+            const hr = self.opts.context.Map(
+                @ptrCast(self.buffer),
+                0,
+                .WRITE_DISCARD,
+                0,
+                &mapped,
+            );
+            if (com.FAILED(hr)) {
+                log.err("Buffer.map failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.DirectXFailed;
+            }
+
+            const ptr: [*]T = @ptrCast(@alignCast(mapped.pData orelse {
+                log.warn("Buffer.map: Map returned null pData", .{});
+                self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+                return error.DirectXFailed;
+            }));
+            return ptr[0..len];
         }
 
         pub fn unmap(self: *Self) void {
-            _ = self;
-            @panic("TODO: DX11 Buffer.unmap");
+            self.opts.context.Unmap(@ptrCast(self.buffer), 0);
         }
 
+        /// Resize the buffer, discarding old contents.
+        ///
+        /// Used when the terminal grid size changes and we need
+        /// a buffer of a completely different capacity.
         pub fn resize(self: *Self, new_len: usize) !void {
-            _ = self;
-            _ = new_len;
-            @panic("TODO: DX11 Buffer.resize");
+            _ = self.buffer.Release();
+            const byte_size = validateAndComputeSize(self.opts, new_len);
+            self.buffer = try createBuffer(self.opts, byte_size, null);
+            self.len = new_len;
         }
 
-        pub fn sync(self: *Self, data: []const T) !void {
-            _ = self;
-            _ = data;
-            @panic("TODO: DX11 Buffer.sync");
+        /// Compute byte size and validate DX11 constraints.
+        ///
+        /// DX11 requires constant buffer sizes to be a multiple of 16 bytes.
+        /// This is because the GPU reads constant buffers in 16-byte chunks
+        /// (float4-sized), and a misaligned buffer would read garbage at the end.
+        fn validateAndComputeSize(opts: Options, len: usize) u32 {
+            const byte_size = len * @sizeOf(T);
+            if (opts.bind_flags & d3d11.D3D11_BIND_CONSTANT_BUFFER != 0) {
+                if (byte_size % 16 != 0) {
+                    std.debug.panic(
+                        "Constant buffer size must be a multiple of 16 bytes, got {} (T={}, len={})",
+                        .{ byte_size, @typeName(T), len },
+                    );
+                }
+            }
+            return @intCast(byte_size);
         }
 
-        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
-            _ = self;
-            _ = lists;
-            @panic("TODO: DX11 Buffer.syncFromArrayLists");
+        fn createBuffer(
+            opts: Options,
+            byte_size: u32,
+            initial_data: ?*const d3d11.D3D11_SUBRESOURCE_DATA,
+        ) !*d3d11.ID3D11Buffer {
+            const desc = d3d11.D3D11_BUFFER_DESC{
+                .ByteWidth = byte_size,
+                .Usage = .DYNAMIC,
+                .BindFlags = opts.bind_flags,
+                .CPUAccessFlags = d3d11.D3D11_CPU_ACCESS_WRITE,
+                .MiscFlags = 0,
+                .StructureByteStride = 0,
+            };
+            var buffer: ?*d3d11.ID3D11Buffer = null;
+            const hr = opts.device.CreateBuffer(&desc, initial_data, &buffer);
+            if (com.FAILED(hr)) {
+                log.err("CreateBuffer failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.DirectXFailed;
+            }
+            return buffer orelse error.DirectXFailed;
         }
     };
 }

--- a/src/renderer/directx11/com.zig
+++ b/src/renderer/directx11/com.zig
@@ -62,4 +62,5 @@ pub const Reserved = *const fn () callconv(.winapi) void;
 
 test {
     _ = @import("com_test.zig");
+    _ = @import("gpu_test.zig");
 }

--- a/src/renderer/directx11/com_test.zig
+++ b/src/renderer/directx11/com_test.zig
@@ -131,3 +131,17 @@ test "ID3D11Texture2D IID" {
     try std.testing.expectEqual(iid.data2, 0xd208);
     try std.testing.expectEqual(iid.data3, 0x4e89);
 }
+
+test "Buffer Options has device and context fields" {
+    const BufferOpts = @import("buffer.zig").Options;
+    try std.testing.expect(@hasField(BufferOpts, "device"));
+    try std.testing.expect(@hasField(BufferOpts, "context"));
+    try std.testing.expect(@hasField(BufferOpts, "bind_flags"));
+}
+
+test "Buffer type instantiation compiles" {
+    const buffer_mod = @import("buffer.zig");
+    _ = buffer_mod.Buffer(f32);
+    _ = buffer_mod.Buffer(extern struct { x: f32, y: f32 });
+    _ = buffer_mod.Buffer(u8);
+}

--- a/src/renderer/directx11/com_test.zig
+++ b/src/renderer/directx11/com_test.zig
@@ -60,6 +60,26 @@ test "D3D11_MAPPED_SUBRESOURCE size" {
     try std.testing.expectEqual(@sizeOf(d3d11.D3D11_MAPPED_SUBRESOURCE), expected);
 }
 
+test "D3D11_TEXTURE2D_DESC size" {
+    // D3D11_TEXTURE2D_DESC: 4 u32s + DXGI_FORMAT(u32) + DXGI_SAMPLE_DESC(8) + D3D11_USAGE(u32) + 3 u32s = 44 bytes.
+    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_TEXTURE2D_DESC), 44);
+}
+
+test "D3D11_SHADER_RESOURCE_VIEW_DESC size" {
+    // Format(4) + ViewDimension(4) + union(16) = 24 bytes.
+    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_SHADER_RESOURCE_VIEW_DESC), 24);
+}
+
+test "D3D11_SAMPLER_DESC size" {
+    // Filter(4) + 3 AddressMode(4 each) + MipLODBias(4) + MaxAnisotropy(4) + ComparisonFunc(4) + BorderColor(16) + MinLOD(4) + MaxLOD(4) = 52 bytes.
+    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_SAMPLER_DESC), 52);
+}
+
+test "D3D11_BOX size" {
+    // 6 u32s = 24 bytes.
+    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_BOX), 24);
+}
+
 // Verify vtable pointer layout - COM objects are a single pointer to a vtable.
 
 test "IDXGIDevice is a single vtable pointer" {

--- a/src/renderer/directx11/com_test.zig
+++ b/src/renderer/directx11/com_test.zig
@@ -152,3 +152,8 @@ test "Texture Options has expected fields" {
     try std.testing.expect(@hasField(Texture.Options, "context"));
     try std.testing.expect(@hasField(Texture.Options, "format"));
 }
+
+test "Sampler Options has device field" {
+    const Sampler = @import("Sampler.zig");
+    try std.testing.expect(@hasField(Sampler.Options, "device"));
+}

--- a/src/renderer/directx11/com_test.zig
+++ b/src/renderer/directx11/com_test.zig
@@ -145,3 +145,10 @@ test "Buffer type instantiation compiles" {
     _ = buffer_mod.Buffer(extern struct { x: f32, y: f32 });
     _ = buffer_mod.Buffer(u8);
 }
+
+test "Texture Options has expected fields" {
+    const Texture = @import("Texture.zig");
+    try std.testing.expect(@hasField(Texture.Options, "device"));
+    try std.testing.expect(@hasField(Texture.Options, "context"));
+    try std.testing.expect(@hasField(Texture.Options, "format"));
+}

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -505,10 +505,21 @@ pub const ID3D11Device = extern struct {
         ) callconv(.winapi) HRESULT,
         // slots 4-6
         CreateTexture1D: Reserved,
-        CreateTexture2D: Reserved,
+        // slot 5: CreateTexture2D
+        CreateTexture2D: *const fn (
+            *ID3D11Device,
+            *const D3D11_TEXTURE2D_DESC,
+            ?*const D3D11_SUBRESOURCE_DATA,
+            *?*ID3D11Texture2D,
+        ) callconv(.winapi) HRESULT,
         CreateTexture3D: Reserved,
-        // slot 7
-        CreateShaderResourceView: Reserved,
+        // slot 7: CreateShaderResourceView
+        CreateShaderResourceView: *const fn (
+            *ID3D11Device,
+            *ID3D11Resource,
+            ?*const D3D11_SHADER_RESOURCE_VIEW_DESC,
+            *?*ID3D11ShaderResourceView,
+        ) callconv(.winapi) HRESULT,
         // slot 8
         CreateUnorderedAccessView: Reserved,
         // slot 9: CreateRenderTargetView
@@ -559,8 +570,12 @@ pub const ID3D11Device = extern struct {
         CreateBlendState: Reserved,
         CreateDepthStencilState: Reserved,
         CreateRasterizerState: Reserved,
-        // slot 23
-        CreateSamplerState: Reserved,
+        // slot 23: CreateSamplerState
+        CreateSamplerState: *const fn (
+            *ID3D11Device,
+            *const D3D11_SAMPLER_DESC,
+            *?*ID3D11SamplerState,
+        ) callconv(.winapi) HRESULT,
         // slots 24-26
         CreateQuery: Reserved,
         CreatePredicate: Reserved,
@@ -639,6 +654,32 @@ pub const ID3D11Device = extern struct {
         pixel_shader: *?*ID3D11PixelShader,
     ) HRESULT {
         return self.vtable.CreatePixelShader(self, shader_bytecode, bytecode_length, class_linkage, pixel_shader);
+    }
+
+    pub inline fn CreateTexture2D(
+        self: *ID3D11Device,
+        desc: *const D3D11_TEXTURE2D_DESC,
+        initial_data: ?*const D3D11_SUBRESOURCE_DATA,
+        texture: *?*ID3D11Texture2D,
+    ) HRESULT {
+        return self.vtable.CreateTexture2D(self, desc, initial_data, texture);
+    }
+
+    pub inline fn CreateShaderResourceView(
+        self: *ID3D11Device,
+        resource: *ID3D11Resource,
+        desc: ?*const D3D11_SHADER_RESOURCE_VIEW_DESC,
+        srv: *?*ID3D11ShaderResourceView,
+    ) HRESULT {
+        return self.vtable.CreateShaderResourceView(self, resource, desc, srv);
+    }
+
+    pub inline fn CreateSamplerState(
+        self: *ID3D11Device,
+        desc: *const D3D11_SAMPLER_DESC,
+        sampler: *?*ID3D11SamplerState,
+    ) HRESULT {
+        return self.vtable.CreateSamplerState(self, desc, sampler);
     }
 
     pub inline fn QueryInterface(self: *ID3D11Device, riid: *const GUID, ppvObject: *?*anyopaque) HRESULT {
@@ -874,7 +915,15 @@ pub const ID3D11DeviceContext = extern struct {
         // slot 47: CopyResource
         _reserved47: Reserved,
         // slot 48: UpdateSubresource
-        _reserved48: Reserved,
+        UpdateSubresource: *const fn (
+            *ID3D11DeviceContext,
+            *ID3D11Resource,       // pDstResource
+            u32,                   // DstSubresource
+            ?*const D3D11_BOX,     // pDstBox (null = entire resource)
+            *const anyopaque,      // pSrcData
+            u32,                   // SrcRowPitch
+            u32,                   // SrcDepthPitch
+        ) callconv(.winapi) void,
         // slot 49: CopyStructureCount
         _reserved49: Reserved,
         // slot 50: ClearRenderTargetView
@@ -1090,6 +1139,18 @@ pub const ID3D11DeviceContext = extern struct {
 
     pub inline fn ClearRenderTargetView(self: *ID3D11DeviceContext, rtv: *ID3D11RenderTargetView, color: *const [4]f32) void {
         self.vtable.ClearRenderTargetView(self, rtv, color);
+    }
+
+    pub inline fn UpdateSubresource(
+        self: *ID3D11DeviceContext,
+        resource: *ID3D11Resource,
+        subresource: u32,
+        dst_box: ?*const D3D11_BOX,
+        src_data: *const anyopaque,
+        src_row_pitch: u32,
+        src_depth_pitch: u32,
+    ) void {
+        self.vtable.UpdateSubresource(self, resource, subresource, dst_box, src_data, src_row_pitch, src_depth_pitch);
     }
 
     pub inline fn Release(self: *ID3D11DeviceContext) u32 {

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -118,6 +118,84 @@ pub const D3D11_MAPPED_SUBRESOURCE = extern struct {
     DepthPitch: u32,
 };
 
+pub const D3D11_TEXTURE2D_DESC = extern struct {
+    Width: u32,
+    Height: u32,
+    MipLevels: u32,
+    ArraySize: u32,
+    Format: DXGI_FORMAT,
+    SampleDesc: dxgi.DXGI_SAMPLE_DESC,
+    Usage: D3D11_USAGE,
+    BindFlags: D3D11_BIND_FLAG,
+    CPUAccessFlags: D3D11_CPU_ACCESS_FLAG,
+    MiscFlags: u32,
+};
+
+pub const D3D11_SRV_DIMENSION = enum(u32) {
+    UNKNOWN = 0,
+    BUFFER = 1,
+    TEXTURE1D = 2,
+    TEXTURE1DARRAY = 3,
+    TEXTURE2D = 4,
+    TEXTURE2DARRAY = 5,
+    TEXTURE2DMS = 6,
+    TEXTURE2DMSARRAY = 7,
+    TEXTURE3D = 8,
+    TEXTURECUBE = 9,
+    TEXTURECUBEARRAY = 10,
+    BUFFEREX = 11,
+};
+
+/// Describes a shader resource view. We only support the Texture2D dimension.
+/// The full C type has a union of all SRV dimensions at offset 8 -- we model
+/// only Texture2D because that's all the font atlas needs. If other SRV types
+/// are needed later, this struct would need the full union.
+pub const D3D11_SHADER_RESOURCE_VIEW_DESC = extern struct {
+    Format: DXGI_FORMAT,
+    ViewDimension: D3D11_SRV_DIMENSION,
+    // Texture2D union member: { MostDetailedMip: u32, MipLevels: u32 }
+    // followed by padding to fill the 16-byte union.
+    MostDetailedMip: u32,
+    MipLevels: u32,
+    _pad: [2]u32 = .{ 0, 0 },
+};
+
+pub const D3D11_FILTER = enum(u32) {
+    MIN_MAG_MIP_POINT = 0,
+    MIN_MAG_MIP_LINEAR = 0x15,
+    _,
+};
+
+pub const D3D11_TEXTURE_ADDRESS_MODE = enum(u32) {
+    WRAP = 1,
+    MIRROR = 2,
+    CLAMP = 3,
+    BORDER = 4,
+    MIRROR_ONCE = 5,
+};
+
+pub const D3D11_SAMPLER_DESC = extern struct {
+    Filter: D3D11_FILTER,
+    AddressU: D3D11_TEXTURE_ADDRESS_MODE,
+    AddressV: D3D11_TEXTURE_ADDRESS_MODE,
+    AddressW: D3D11_TEXTURE_ADDRESS_MODE,
+    MipLODBias: f32,
+    MaxAnisotropy: u32,
+    ComparisonFunc: u32, // D3D11_COMPARISON_FUNC, not enumerated here
+    BorderColor: [4]f32,
+    MinLOD: f32,
+    MaxLOD: f32,
+};
+
+pub const D3D11_BOX = extern struct {
+    left: u32,
+    top: u32,
+    front: u32,
+    right: u32,
+    bottom: u32,
+    back: u32,
+};
+
 // ID3D11DeviceChild
 pub const ID3D11DeviceChild = extern struct {
     vtable: *const VTable,

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -101,21 +101,22 @@ pub const Device = struct {
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
         var panel_native: ?*dxgi.ISwapChainPanelNative = null;
 
+        var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+            .Width = width,
+            .Height = height,
+            .Format = .B8G8R8A8_UNORM,
+            .Stereo = 0,
+            .SampleDesc = .{ .Count = 1, .Quality = 0 },
+            .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+            .BufferCount = 2,
+            .Scaling = .STRETCH,
+            .SwapEffect = .FLIP_DISCARD,
+            .AlphaMode = .UNSPECIFIED,
+            .Flags = 0,
+        };
+
         switch (surface) {
             .hwnd => |hwnd| {
-                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-                    .Width = width,
-                    .Height = height,
-                    .Format = .B8G8R8A8_UNORM,
-                    .Stereo = 0,
-                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
-                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                    .BufferCount = 2,
-                    .Scaling = .STRETCH,
-                    .SwapEffect = .FLIP_SEQUENTIAL,
-                    .AlphaMode = .UNSPECIFIED,
-                    .Flags = 0,
-                };
                 hr = factory.CreateSwapChainForHwnd(
                     @ptrCast(dev),
                     hwnd,
@@ -127,19 +128,7 @@ pub const Device = struct {
             },
             .swap_chain_panel => |panel| {
                 panel_native = panel;
-                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-                    .Width = width,
-                    .Height = height,
-                    .Format = .B8G8R8A8_UNORM,
-                    .Stereo = 0,
-                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
-                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                    .BufferCount = 2,
-                    .Scaling = .STRETCH,
-                    .SwapEffect = .FLIP_SEQUENTIAL,
-                    .AlphaMode = .PREMULTIPLIED,
-                    .Flags = 0,
-                };
+                desc.AlphaMode = .PREMULTIPLIED;
                 hr = factory.CreateSwapChainForComposition(
                     @ptrCast(dev),
                     &desc,
@@ -163,6 +152,9 @@ pub const Device = struct {
                 return InitError.SetSwapChainFailed;
             }
         }
+        errdefer if (panel_native) |panel| {
+            _ = panel.SetSwapChain(null);
+        };
 
         // Get the back buffer and create a render target view.
         const rtv = createRenderTargetView(dev, sc) orelse {

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -8,12 +8,18 @@ const HRESULT = com.HRESULT;
 const GUID = com.GUID;
 const IUnknown = com.IUnknown;
 const IDXGISwapChain = dxgi.IDXGISwapChain;
+const HWND = dxgi.HWND;
+
+pub const Surface = union(enum) {
+    hwnd: HWND,
+    swap_chain_panel: *dxgi.ISwapChainPanelNative,
+};
 
 pub const Device = struct {
     device: *d3d11.ID3D11Device,
     context: *d3d11.ID3D11DeviceContext,
     swap_chain: *dxgi.IDXGISwapChain1,
-    panel_native: *dxgi.ISwapChainPanelNative,
+    panel_native: ?*dxgi.ISwapChainPanelNative,
     rtv: ?*d3d11.ID3D11RenderTargetView,
     width: u32,
     height: u32,
@@ -29,11 +35,8 @@ pub const Device = struct {
         RenderTargetViewFailed,
     };
 
-    pub fn init(panel_native_ptr: *anyopaque, width: u32, height: u32) InitError!Device {
-        log.info("init called: panel=0x{x}, size={}x{}", .{ @intFromPtr(panel_native_ptr), width, height });
-
-        // Cast the opaque pointer to ISwapChainPanelNative.
-        const panel_native: *dxgi.ISwapChainPanelNative = @ptrCast(@alignCast(panel_native_ptr));
+    pub fn init(surface: Surface, width: u32, height: u32) InitError!Device {
+        log.info("init called: size={}x{}", .{ width, height });
 
         // Create D3D11 device and immediate context.
         var device: ?*d3d11.ID3D11Device = null;
@@ -92,42 +95,74 @@ pub const Device = struct {
         const factory: *dxgi.IDXGIFactory2 = @ptrCast(@alignCast(factory_opt.?));
         defer _ = factory.Release();
 
-        // Create swap chain for composition.
-        const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-            .Width = width,
-            .Height = height,
-            .Format = .B8G8R8A8_UNORM,
-            .Stereo = 0,
-            .SampleDesc = .{ .Count = 1, .Quality = 0 },
-            .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-            .BufferCount = 2,
-            .Scaling = .STRETCH,
-            .SwapEffect = .FLIP_SEQUENTIAL,
-            .AlphaMode = .PREMULTIPLIED,
-            .Flags = 0,
-        };
-
+        // Create swap chain. Descriptor differs by surface type:
+        // - HWND: opaque window, DXGI_ALPHA_MODE_UNSPECIFIED
+        // - Composition: premultiplied alpha for XAML integration
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
-        hr = factory.CreateSwapChainForComposition(
-            @ptrCast(dev),
-            &desc,
-            null,
-            &swap_chain,
-        );
+        var panel_native: ?*dxgi.ISwapChainPanelNative = null;
+
+        switch (surface) {
+            .hwnd => |hwnd| {
+                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                    .Width = width,
+                    .Height = height,
+                    .Format = .B8G8R8A8_UNORM,
+                    .Stereo = 0,
+                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    .BufferCount = 2,
+                    .Scaling = .STRETCH,
+                    .SwapEffect = .FLIP_SEQUENTIAL,
+                    .AlphaMode = .UNSPECIFIED,
+                    .Flags = 0,
+                };
+                hr = factory.CreateSwapChainForHwnd(
+                    @ptrCast(dev),
+                    hwnd,
+                    &desc,
+                    null,
+                    null,
+                    &swap_chain,
+                );
+            },
+            .swap_chain_panel => |panel| {
+                panel_native = panel;
+                const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                    .Width = width,
+                    .Height = height,
+                    .Format = .B8G8R8A8_UNORM,
+                    .Stereo = 0,
+                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    .BufferCount = 2,
+                    .Scaling = .STRETCH,
+                    .SwapEffect = .FLIP_SEQUENTIAL,
+                    .AlphaMode = .PREMULTIPLIED,
+                    .Flags = 0,
+                };
+                hr = factory.CreateSwapChainForComposition(
+                    @ptrCast(dev),
+                    &desc,
+                    null,
+                    &swap_chain,
+                );
+            },
+        }
         if (com.FAILED(hr) or swap_chain == null) {
-            log.err("CreateSwapChainForComposition failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+            log.err("swap chain creation failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
             return InitError.SwapChainCreationFailed;
         }
         const sc = swap_chain.?;
         errdefer _ = sc.Release();
 
-        // Attach the swap chain to the SwapChainPanel.
-        hr = panel_native.SetSwapChain(@ptrCast(sc));
-        if (com.FAILED(hr)) {
-            log.err("SetSwapChain failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-            return InitError.SetSwapChainFailed;
+        // For composition surfaces, attach swap chain to the panel.
+        if (panel_native) |panel| {
+            hr = panel.SetSwapChain(@ptrCast(sc));
+            if (com.FAILED(hr)) {
+                log.err("SetSwapChain failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return InitError.SetSwapChainFailed;
+            }
         }
-        errdefer _ = panel_native.SetSwapChain(null);
 
         // Get the back buffer and create a render target view.
         const rtv = createRenderTargetView(dev, sc) orelse {
@@ -155,8 +190,10 @@ pub const Device = struct {
             self.rtv = null;
         }
 
-        // Detach swap chain from the panel.
-        _ = self.panel_native.SetSwapChain(null);
+        // Detach swap chain from the panel (composition surfaces only).
+        if (self.panel_native) |panel| {
+            _ = panel.SetSwapChain(null);
+        }
 
         // Release in reverse creation order.
         _ = self.swap_chain.Release();

--- a/src/renderer/directx11/dxgi.zig
+++ b/src/renderer/directx11/dxgi.zig
@@ -38,6 +38,7 @@ pub const DXGI_ALPHA_MODE = enum(u32) {
 pub const DXGI_USAGE = u32;
 pub const DXGI_USAGE_RENDER_TARGET_OUTPUT: DXGI_USAGE = 0x00000020;
 
+/// Win32 HWND is a pointer-sized handle, same underlying type as HANDLE.
 pub const HWND = std.os.windows.HANDLE;
 
 // --- Structs ---

--- a/src/renderer/directx11/dxgi.zig
+++ b/src/renderer/directx11/dxgi.zig
@@ -9,8 +9,9 @@ const IUnknown = com.IUnknown;
 pub const DXGI_FORMAT = enum(u32) {
     UNKNOWN = 0,
     R32G32B32A32_FLOAT = 2,
-    R32_UINT = 42,
     R8G8B8A8_UNORM = 28,
+    R32_UINT = 42,
+    R8_UNORM = 61,
     B8G8R8A8_UNORM = 87,
     _,
 };

--- a/src/renderer/directx11/dxgi.zig
+++ b/src/renderer/directx11/dxgi.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const com = @import("com.zig");
 const GUID = com.GUID;
 const HRESULT = com.HRESULT;
@@ -36,6 +37,8 @@ pub const DXGI_ALPHA_MODE = enum(u32) {
 
 pub const DXGI_USAGE = u32;
 pub const DXGI_USAGE_RENDER_TARGET_OUTPUT: DXGI_USAGE = 0x00000020;
+
+pub const HWND = std.os.windows.HANDLE;
 
 // --- Structs ---
 
@@ -430,7 +433,15 @@ pub const IDXGIFactory2 = extern struct {
         IsCurrent: Reserved,
         // IDXGIFactory2 (slots 14-24)
         IsWindowedStereoEnabled: Reserved,
-        CreateSwapChainForHwnd: Reserved,
+        CreateSwapChainForHwnd: *const fn (
+            self: *IDXGIFactory2,
+            pDevice: *IUnknown,
+            hWnd: HWND,
+            pDesc: *const DXGI_SWAP_CHAIN_DESC1,
+            pFullscreenDesc: ?*const anyopaque,
+            pRestrictToOutput: ?*anyopaque,
+            ppSwapChain: *?*IDXGISwapChain1,
+        ) callconv(.winapi) HRESULT,
         CreateSwapChainForCoreWindow: Reserved,
         GetSharedResourceAdapterLuid: Reserved,
         RegisterStereoStatusWindow: Reserved,
@@ -456,6 +467,18 @@ pub const IDXGIFactory2 = extern struct {
         swap_chain: *?*IDXGISwapChain1,
     ) HRESULT {
         return self.vtable.CreateSwapChainForComposition(self, device, desc, restrict_to_output, swap_chain);
+    }
+
+    pub inline fn CreateSwapChainForHwnd(
+        self: *IDXGIFactory2,
+        device: *IUnknown,
+        hwnd: HWND,
+        desc: *const DXGI_SWAP_CHAIN_DESC1,
+        fullscreen_desc: ?*const anyopaque,
+        restrict_to_output: ?*anyopaque,
+        swap_chain: *?*IDXGISwapChain1,
+    ) HRESULT {
+        return self.vtable.CreateSwapChainForHwnd(self, device, hwnd, desc, fullscreen_desc, restrict_to_output, swap_chain);
     }
 
     pub inline fn Release(self: *IDXGIFactory2) u32 {

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -1,0 +1,254 @@
+//! Integration tests for DX11 GPU resource types.
+//!
+//! These tests create a real D3D11 device (headless, no window/swap chain)
+//! and exercise Buffer, Texture, and Sampler create/use/destroy cycles.
+//! They only run on Windows -- on other platforms they're skipped.
+const std = @import("std");
+const builtin = @import("builtin");
+const d3d11 = @import("d3d11.zig");
+const dxgi = @import("dxgi.zig");
+const com = @import("com.zig");
+const buffer_mod = @import("buffer.zig");
+const Texture = @import("Texture.zig");
+const Sampler = @import("Sampler.zig");
+
+const Buffer = buffer_mod.Buffer;
+
+/// Create a D3D11 device for testing. Returns null on non-Windows or if
+/// device creation fails (e.g. no GPU in CI).
+fn createTestDevice() ?struct { device: *d3d11.ID3D11Device, context: *d3d11.ID3D11DeviceContext } {
+    if (comptime builtin.os.tag != .windows) return null;
+
+    var device: ?*d3d11.ID3D11Device = null;
+    var context: ?*d3d11.ID3D11DeviceContext = null;
+    const feature_levels = [_]d3d11.D3D_FEATURE_LEVEL{.@"11_0"};
+
+    const hr = d3d11.D3D11CreateDevice(
+        null,
+        .HARDWARE,
+        null,
+        d3d11.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+        &feature_levels,
+        feature_levels.len,
+        d3d11.D3D11_SDK_VERSION,
+        &device,
+        null,
+        &context,
+    );
+
+    if (com.FAILED(hr)) return null;
+    if (device == null or context == null) return null;
+
+    return .{ .device = device.?, .context = context.? };
+}
+
+test "Buffer: create, sync, deinit" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    const TestFloat = buffer_mod.Buffer(f32);
+    var buf = try TestFloat.init(.{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_VERTEX_BUFFER,
+    }, 64);
+    defer buf.deinit();
+
+    // Sync some data.
+    const data = [_]f32{ 1.0, 2.0, 3.0, 4.0 };
+    try buf.sync(&data);
+}
+
+test "Buffer: sync triggers realloc when data exceeds capacity" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    const TestU32 = buffer_mod.Buffer(u32);
+    var buf = try TestU32.init(.{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_VERTEX_BUFFER,
+    }, 4); // Start small.
+    defer buf.deinit();
+
+    // Sync data that exceeds capacity -- should realloc.
+    var big_data: [100]u32 = undefined;
+    for (&big_data, 0..) |*v, i| v.* = @intCast(i);
+    try buf.sync(&big_data);
+
+    // After realloc, capacity should be >= 100.
+    try std.testing.expect(buf.len >= 100);
+}
+
+test "Buffer: syncFromArrayLists concatenates correctly" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    const TestU32 = buffer_mod.Buffer(u32);
+    var buf = try TestU32.init(.{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_VERTEX_BUFFER,
+    }, 64);
+    defer buf.deinit();
+
+    // Create two ArrayLists.
+    var list1 = std.ArrayListUnmanaged(u32){};
+    defer list1.deinit(std.testing.allocator);
+    try list1.appendSlice(std.testing.allocator, &.{ 1, 2, 3 });
+
+    var list2 = std.ArrayListUnmanaged(u32){};
+    defer list2.deinit(std.testing.allocator);
+    try list2.appendSlice(std.testing.allocator, &.{ 4, 5 });
+
+    const total = try buf.syncFromArrayLists(&.{ list1, list2 });
+    try std.testing.expectEqual(total, 5);
+}
+
+test "Buffer: map and unmap" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    const TestF32 = buffer_mod.Buffer(f32);
+    var buf = try TestF32.init(.{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_VERTEX_BUFFER,
+    }, 16);
+    defer buf.deinit();
+
+    const slice = try buf.map(4);
+    slice[0] = 1.0;
+    slice[1] = 2.0;
+    slice[2] = 3.0;
+    slice[3] = 4.0;
+    buf.unmap();
+}
+
+test "Buffer: resize" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    const TestU8 = buffer_mod.Buffer(u8);
+    var buf = try TestU8.init(.{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_VERTEX_BUFFER,
+    }, 16);
+    defer buf.deinit();
+
+    try buf.resize(1024);
+    try std.testing.expectEqual(buf.len, 1024);
+}
+
+test "Buffer: constant buffer init" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    // 16 bytes = 1 float4, valid constant buffer size.
+    const Uniforms = extern struct { x: f32, y: f32, z: f32, w: f32 };
+    const TestCB = buffer_mod.Buffer(Uniforms);
+    var buf = try TestCB.init(.{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_CONSTANT_BUFFER,
+    }, 1);
+    defer buf.deinit();
+
+    try buf.sync(&.{Uniforms{ .x = 1.0, .y = 2.0, .z = 3.0, .w = 4.0 }});
+}
+
+test "Texture: create with initial data and deinit" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    // 4x4 R8_UNORM texture (16 bytes).
+    var data: [16]u8 = undefined;
+    for (&data, 0..) |*v, i| v.* = @intCast(i);
+
+    const tex = try Texture.init(
+        .{
+            .device = dev.device,
+            .context = dev.context,
+            .format = .R8_UNORM,
+        },
+        4,
+        4,
+        &data,
+    );
+    defer tex.deinit();
+
+    try std.testing.expectEqual(tex.width, 4);
+    try std.testing.expectEqual(tex.height, 4);
+    try std.testing.expectEqual(tex.bpp, 1);
+}
+
+test "Texture: create BGRA and replaceRegion" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    // 8x8 B8G8R8A8_UNORM texture (256 bytes).
+    const tex = try Texture.init(
+        .{
+            .device = dev.device,
+            .context = dev.context,
+            .format = .B8G8R8A8_UNORM,
+        },
+        8,
+        8,
+        null, // No initial data.
+    );
+    defer tex.deinit();
+
+    try std.testing.expectEqual(tex.bpp, 4);
+
+    // Replace a 2x2 sub-region.
+    const region_data = [_]u8{0xFF} ** (2 * 2 * 4);
+    try tex.replaceRegion(1, 1, 2, 2, &region_data);
+}
+
+test "Texture: create without initial data" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    const tex = try Texture.init(
+        .{
+            .device = dev.device,
+            .context = dev.context,
+            .format = .R8_UNORM,
+        },
+        32,
+        32,
+        null,
+    );
+    defer tex.deinit();
+
+    try std.testing.expectEqual(tex.width, 32);
+    try std.testing.expectEqual(tex.height, 32);
+}
+
+test "Sampler: create and deinit" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    const sampler = try Sampler.init(.{
+        .device = dev.device,
+    });
+    defer sampler.deinit();
+}

--- a/test/windows/test_dx11_clear.zig
+++ b/test/windows/test_dx11_clear.zig
@@ -1,5 +1,8 @@
 //! Standalone DX11 clear-to-color test harness.
 //!
+//! This file intentionally duplicates COM types from src/renderer/directx11/
+//! to remain a self-contained smoke test with no project imports.
+//!
 //! Creates a Win32 window, initializes D3D11 via raw COM vtables,
 //! and clears to an early-sunrise orange for 3 seconds.
 //!
@@ -55,7 +58,7 @@ const DXGI_FORMAT = enum(u32) {
     B8G8R8A8_UNORM = 87,
     _,
 };
-const DXGI_SWAP_EFFECT = enum(u32) { FLIP_SEQUENTIAL = 3, _ };
+const DXGI_SWAP_EFFECT = enum(u32) { FLIP_SEQUENTIAL = 3, FLIP_DISCARD = 4, _ };
 const DXGI_SCALING = enum(u32) { STRETCH = 0, _ };
 const DXGI_ALPHA_MODE = enum(u32) { UNSPECIFIED = 0, _ };
 const DXGI_USAGE = u32;
@@ -642,7 +645,7 @@ pub fn main() !void {
         .BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
         .BufferCount = 2,
         .Scaling = .STRETCH,
-        .SwapEffect = .FLIP_SEQUENTIAL,
+        .SwapEffect = .FLIP_DISCARD,
         .AlphaMode = .UNSPECIFIED,
         .Flags = 0,
     };

--- a/test/windows/test_dx11_clear.zig
+++ b/test/windows/test_dx11_clear.zig
@@ -1,0 +1,731 @@
+//! Standalone DX11 clear-to-color test harness.
+//!
+//! Creates a Win32 window, initializes D3D11 via raw COM vtables,
+//! and clears to an early-sunrise orange for 3 seconds.
+//!
+//! Build:
+//!   zig build-exe test/windows/test_dx11_clear.zig ^
+//!     -lc -ld3d11 -ldxgi ^
+//!     -target x86_64-windows-msvc ^
+//!     --name test_dx11_clear
+//!
+//! Run (from repo root):
+//!   test_dx11_clear.exe
+//!
+//! Success = an 800x600 orange window appears for ~3 seconds, then
+//! "DX11 clear-to-color test passed." prints and the process exits.
+
+const std = @import("std");
+const windows = std.os.windows;
+
+// ---------- basic COM types --------------------------------------------------
+
+const HRESULT = i32;
+const GUID = extern struct {
+    data1: u32,
+    data2: u16,
+    data3: u16,
+    data4: [8]u8,
+};
+const IUnknown = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        QueryInterface: *const fn (*IUnknown, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IUnknown) callconv(.winapi) u32,
+        Release: *const fn (*IUnknown) callconv(.winapi) u32,
+    };
+    pub inline fn QueryInterface(self: *IUnknown, riid: *const GUID, pp: *?*anyopaque) HRESULT {
+        return self.vtable.QueryInterface(self, riid, pp);
+    }
+    pub inline fn Release(self: *IUnknown) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+inline fn FAILED(hr: HRESULT) bool {
+    return hr < 0;
+}
+
+const Reserved = *const fn () callconv(.winapi) void;
+
+// ---------- DXGI types -------------------------------------------------------
+
+const DXGI_FORMAT = enum(u32) {
+    UNKNOWN = 0,
+    B8G8R8A8_UNORM = 87,
+    _,
+};
+const DXGI_SWAP_EFFECT = enum(u32) { FLIP_SEQUENTIAL = 3, _ };
+const DXGI_SCALING = enum(u32) { STRETCH = 0, _ };
+const DXGI_ALPHA_MODE = enum(u32) { UNSPECIFIED = 0, _ };
+const DXGI_USAGE = u32;
+const DXGI_USAGE_RENDER_TARGET_OUTPUT: DXGI_USAGE = 0x00000020;
+
+const DXGI_SAMPLE_DESC = extern struct { Count: u32, Quality: u32 };
+const DXGI_SWAP_CHAIN_DESC1 = extern struct {
+    Width: u32,
+    Height: u32,
+    Format: DXGI_FORMAT,
+    Stereo: i32,
+    SampleDesc: DXGI_SAMPLE_DESC,
+    BufferUsage: DXGI_USAGE,
+    BufferCount: u32,
+    Scaling: DXGI_SCALING,
+    SwapEffect: DXGI_SWAP_EFFECT,
+    AlphaMode: DXGI_ALPHA_MODE,
+    Flags: u32,
+};
+
+// IDXGIDevice - we only call GetAdapter (slot 7).
+const IDXGIDevice = extern struct {
+    vtable: *const VTable,
+    pub const IID = GUID{
+        .data1 = 0x54ec77fa,
+        .data2 = 0x1377,
+        .data3 = 0x44e6,
+        .data4 = .{ 0x8c, 0x32, 0x88, 0xfd, 0x5f, 0x44, 0xc8, 0x4c },
+    };
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIDevice (7)
+        GetAdapter: *const fn (*IDXGIDevice, *?*IDXGIAdapter) callconv(.winapi) HRESULT,
+    };
+    pub inline fn GetAdapter(self: *IDXGIDevice, adapter: *?*IDXGIAdapter) HRESULT {
+        return self.vtable.GetAdapter(self, adapter);
+    }
+    pub inline fn Release(self: *IDXGIDevice) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// IDXGIAdapter - we only call GetParent (slot 6, IDXGIObject).
+const IDXGIAdapter = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: *const fn (*IDXGIAdapter, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+    };
+    pub inline fn GetParent(self: *IDXGIAdapter, riid: *const GUID, parent: *?*anyopaque) HRESULT {
+        return self.vtable.GetParent(self, riid, parent);
+    }
+    pub inline fn Release(self: *IDXGIAdapter) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// IDXGISwapChain1 - we call Present (8), GetBuffer (9).
+const IDXGISwapChain1 = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIDeviceSubObject (7)
+        GetDevice: Reserved,
+        // IDXGISwapChain (8-17)
+        Present: *const fn (*IDXGISwapChain1, u32, u32) callconv(.winapi) HRESULT,
+        GetBuffer: *const fn (*IDXGISwapChain1, u32, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        SetFullscreenState: Reserved,
+        GetFullscreenState: Reserved,
+        GetDesc: Reserved,
+        ResizeBuffers: Reserved,
+        ResizeTarget: Reserved,
+        GetContainingOutput: Reserved,
+        GetFrameStatistics: Reserved,
+        GetLastPresentCount: Reserved,
+        // IDXGISwapChain1 (18-28) - not called, reserved
+        GetDesc1: Reserved,
+        GetFullscreenDesc: Reserved,
+        GetHwnd: Reserved,
+        GetCoreWindow: Reserved,
+        Present1: Reserved,
+        IsTemporaryMonoSupported: Reserved,
+        GetRestrictToOutput: Reserved,
+        SetBackgroundColor: Reserved,
+        GetBackgroundColor: Reserved,
+        SetRotation: Reserved,
+        GetRotation: Reserved,
+    };
+    pub inline fn Present(self: *IDXGISwapChain1, sync_interval: u32, flags: u32) HRESULT {
+        return self.vtable.Present(self, sync_interval, flags);
+    }
+    pub inline fn GetBuffer(self: *IDXGISwapChain1, buffer: u32, riid: *const GUID, surface: *?*anyopaque) HRESULT {
+        return self.vtable.GetBuffer(self, buffer, riid, surface);
+    }
+    pub inline fn Release(self: *IDXGISwapChain1) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// IDXGIFactory2 - we call CreateSwapChainForHwnd (slot 15).
+const IDXGIFactory2 = extern struct {
+    vtable: *const VTable,
+    pub const IID = GUID{
+        .data1 = 0x50c83a1c,
+        .data2 = 0xe072,
+        .data3 = 0x4c48,
+        .data4 = .{ 0x87, 0xb0, 0x36, 0x30, 0xfa, 0x36, 0xa6, 0xd0 },
+    };
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: Reserved,
+        // IDXGIObject (3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIFactory (7-11)
+        EnumAdapters: Reserved,
+        MakeWindowAssociation: Reserved,
+        GetWindowAssociation: Reserved,
+        CreateSwapChain: Reserved,
+        CreateSoftwareAdapter: Reserved,
+        // IDXGIFactory1 (12-13)
+        EnumAdapters1: Reserved,
+        IsCurrent: Reserved,
+        // IDXGIFactory2 (14-24)
+        IsWindowedStereoEnabled: Reserved,
+        CreateSwapChainForHwnd: *const fn (
+            *IDXGIFactory2,
+            *IUnknown,
+            windows.HANDLE,
+            *const DXGI_SWAP_CHAIN_DESC1,
+            ?*const anyopaque,
+            ?*anyopaque,
+            *?*IDXGISwapChain1,
+        ) callconv(.winapi) HRESULT,
+        CreateSwapChainForCoreWindow: Reserved,
+        GetSharedResourceAdapterLuid: Reserved,
+        RegisterStereoStatusWindow: Reserved,
+        RegisterStereoStatusEvent: Reserved,
+        UnregisterStereoStatus: Reserved,
+        RegisterOcclusionStatusWindow: Reserved,
+        RegisterOcclusionStatusEvent: Reserved,
+        UnregisterOcclusionStatus: Reserved,
+        CreateSwapChainForComposition: Reserved,
+    };
+    pub inline fn CreateSwapChainForHwnd(
+        self: *IDXGIFactory2,
+        device: *IUnknown,
+        hwnd: windows.HANDLE,
+        desc: *const DXGI_SWAP_CHAIN_DESC1,
+        fullscreen_desc: ?*const anyopaque,
+        restrict_to_output: ?*anyopaque,
+        swap_chain: *?*IDXGISwapChain1,
+    ) HRESULT {
+        return self.vtable.CreateSwapChainForHwnd(
+            self,
+            device,
+            hwnd,
+            desc,
+            fullscreen_desc,
+            restrict_to_output,
+            swap_chain,
+        );
+    }
+    pub inline fn Release(self: *IDXGIFactory2) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// ---------- D3D11 types ------------------------------------------------------
+
+const D3D_FEATURE_LEVEL = enum(u32) { @"11_0" = 0xb000, _ };
+const D3D_DRIVER_TYPE = enum(u32) { HARDWARE = 1, _ };
+const D3D11_CREATE_DEVICE_FLAG = u32;
+const D3D11_CREATE_DEVICE_BGRA_SUPPORT: D3D11_CREATE_DEVICE_FLAG = 0x20;
+const D3D11_SDK_VERSION: u32 = 7;
+
+const D3D11_VIEWPORT = extern struct {
+    TopLeftX: f32,
+    TopLeftY: f32,
+    Width: f32,
+    Height: f32,
+    MinDepth: f32,
+    MaxDepth: f32,
+};
+
+// ID3D11Resource - base type for GetBuffer result cast.
+const ID3D11Resource = extern struct { vtable: *const anyopaque };
+
+// ID3D11Texture2D - IID needed for GetBuffer.
+const ID3D11Texture2D = extern struct {
+    vtable: *const anyopaque,
+    pub const IID = GUID{
+        .data1 = 0x6f15aaf2,
+        .data2 = 0xd208,
+        .data3 = 0x4e89,
+        .data4 = .{ 0x9a, 0xb4, 0x48, 0x95, 0x35, 0xd3, 0x4f, 0x9c },
+    };
+    pub inline fn Release(self: *ID3D11Texture2D) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// ID3D11RenderTargetView - we call Release.
+const ID3D11RenderTargetView = extern struct {
+    vtable: *const anyopaque,
+    pub const IID = GUID{
+        .data1 = 0xdfdba067,
+        .data2 = 0x0b8d,
+        .data3 = 0x4865,
+        .data4 = .{ 0x87, 0x5b, 0xd7, 0xb4, 0x51, 0x6c, 0xc1, 0x64 },
+    };
+    pub inline fn Release(self: *ID3D11RenderTargetView) u32 {
+        const unk: *IUnknown = @ptrCast(self);
+        return unk.vtable.Release(unk);
+    }
+};
+
+// ID3D11DeviceContext - we call OMSetRenderTargets (33), RSSetViewports (44),
+// ClearRenderTargetView (50), Release (2).
+const ID3D11DeviceContext = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*ID3D11DeviceContext) callconv(.winapi) u32,
+        // ID3D11DeviceChild (3-6)
+        GetDevice: Reserved,
+        GetPrivateData: Reserved,
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        // ID3D11DeviceContext (7-32)
+        VSSetConstantBuffers: Reserved,
+        PSSetShaderResources: Reserved,
+        PSSetShader: Reserved,
+        PSSetSamplers: Reserved,
+        VSSetShader: Reserved,
+        DrawIndexed: Reserved,
+        Draw: Reserved,
+        Map: Reserved,
+        Unmap: Reserved,
+        PSSetConstantBuffers: Reserved,
+        IASetInputLayout: Reserved,
+        IASetVertexBuffers: Reserved,
+        IASetIndexBuffer: Reserved,
+        DrawIndexedInstanced: Reserved,
+        DrawInstanced: Reserved,
+        GSSetConstantBuffers: Reserved,
+        GSSetShader: Reserved,
+        IASetPrimitiveTopology: Reserved,
+        VSSetShaderResources: Reserved,
+        VSSetSamplers: Reserved,
+        Begin: Reserved,
+        End: Reserved,
+        GetData: Reserved,
+        SetPredication: Reserved,
+        GSSetShaderResources: Reserved,
+        GSSetSamplers: Reserved,
+        // slot 33: OMSetRenderTargets
+        OMSetRenderTargets: *const fn (
+            *ID3D11DeviceContext,
+            u32,
+            [*]const ?*ID3D11RenderTargetView,
+            ?*anyopaque,
+        ) callconv(.winapi) void,
+        // slot 34: OMSetRenderTargetsAndUnorderedAccessViews
+        OMSetRenderTargetsAndUnorderedAccessViews: Reserved,
+        OMSetBlendState: Reserved,
+        OMSetDepthStencilState: Reserved,
+        SOSetTargets: Reserved,
+        DrawAuto: Reserved,
+        DrawIndexedInstancedIndirect: Reserved,
+        DrawInstancedIndirect: Reserved,
+        Dispatch: Reserved,
+        DispatchIndirect: Reserved,
+        RSSetState: Reserved,
+        // slot 44: RSSetViewports
+        RSSetViewports: *const fn (*ID3D11DeviceContext, u32, [*]const D3D11_VIEWPORT) callconv(.winapi) void,
+        RSSetScissorRects: Reserved,
+        CopySubresourceRegion: Reserved,
+        CopyResource: Reserved,
+        UpdateSubresource: Reserved,
+        CopyStructureCount: Reserved,
+        // slot 50: ClearRenderTargetView
+        ClearRenderTargetView: *const fn (
+            *ID3D11DeviceContext,
+            *ID3D11RenderTargetView,
+            *const [4]f32,
+        ) callconv(.winapi) void,
+    };
+    pub inline fn OMSetRenderTargets(
+        self: *ID3D11DeviceContext,
+        rtvs: []const ?*ID3D11RenderTargetView,
+        dsv: ?*anyopaque,
+    ) void {
+        self.vtable.OMSetRenderTargets(self, @intCast(rtvs.len), rtvs.ptr, dsv);
+    }
+    pub inline fn RSSetViewports(self: *ID3D11DeviceContext, viewports: []const D3D11_VIEWPORT) void {
+        self.vtable.RSSetViewports(self, @intCast(viewports.len), viewports.ptr);
+    }
+    pub inline fn ClearRenderTargetView(self: *ID3D11DeviceContext, rtv: *ID3D11RenderTargetView, color: *const [4]f32) void {
+        self.vtable.ClearRenderTargetView(self, rtv, color);
+    }
+    pub inline fn Release(self: *ID3D11DeviceContext) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// ID3D11Device - we call CreateRenderTargetView (9), QueryInterface (0),
+// Release (2).
+const ID3D11Device = extern struct {
+    vtable: *const VTable,
+    pub const VTable = extern struct {
+        // IUnknown (0-2)
+        QueryInterface: *const fn (*ID3D11Device, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*ID3D11Device) callconv(.winapi) u32,
+        Release: *const fn (*ID3D11Device) callconv(.winapi) u32,
+        // slots 3-8
+        CreateBuffer: Reserved,
+        CreateTexture1D: Reserved,
+        CreateTexture2D: Reserved,
+        CreateTexture3D: Reserved,
+        CreateShaderResourceView: Reserved,
+        CreateUnorderedAccessView: Reserved,
+        // slot 9: CreateRenderTargetView
+        CreateRenderTargetView: *const fn (
+            *ID3D11Device,
+            *ID3D11Resource,
+            ?*const anyopaque,
+            *?*ID3D11RenderTargetView,
+        ) callconv(.winapi) HRESULT,
+    };
+    pub inline fn QueryInterface(self: *ID3D11Device, riid: *const GUID, pp: *?*anyopaque) HRESULT {
+        return self.vtable.QueryInterface(self, riid, pp);
+    }
+    pub inline fn CreateRenderTargetView(
+        self: *ID3D11Device,
+        resource: *ID3D11Resource,
+        desc: ?*const anyopaque,
+        rtv: *?*ID3D11RenderTargetView,
+    ) HRESULT {
+        return self.vtable.CreateRenderTargetView(self, resource, desc, rtv);
+    }
+    pub inline fn Release(self: *ID3D11Device) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// D3D11CreateDevice entry point from d3d11.dll.
+const D3D11CreateDevice = @extern(*const fn (
+    pAdapter: ?*anyopaque,
+    DriverType: D3D_DRIVER_TYPE,
+    Software: ?windows.HMODULE,
+    Flags: D3D11_CREATE_DEVICE_FLAG,
+    pFeatureLevels: ?[*]const D3D_FEATURE_LEVEL,
+    FeatureLevels: u32,
+    SDKVersion: u32,
+    ppDevice: ?*?*ID3D11Device,
+    pFeatureLevel: ?*D3D_FEATURE_LEVEL,
+    ppImmediateContext: ?*?*ID3D11DeviceContext,
+) callconv(.winapi) HRESULT, .{
+    .library_name = "d3d11",
+    .name = "D3D11CreateDevice",
+});
+
+// ---------- Win32 window types -----------------------------------------------
+
+const ATOM = u16;
+const WPARAM = usize;
+const LPARAM = isize;
+const LRESULT = isize;
+const WNDPROC = *const fn (windows.HWND, u32, WPARAM, LPARAM) callconv(.winapi) LRESULT;
+
+const WNDCLASSEXW = extern struct {
+    cbSize: u32,
+    style: u32,
+    lpfnWndProc: WNDPROC,
+    cbClsExtra: i32,
+    cbWndExtra: i32,
+    hInstance: windows.HMODULE,
+    hIcon: ?windows.HANDLE,
+    hCursor: ?windows.HANDLE,
+    hbrBackground: ?windows.HANDLE,
+    lpszMenuName: ?[*:0]const u16,
+    lpszClassName: [*:0]const u16,
+    hIconSm: ?windows.HANDLE,
+};
+
+const MSG = extern struct {
+    hwnd: ?windows.HWND,
+    message: u32,
+    wParam: WPARAM,
+    lParam: LPARAM,
+    time: u32,
+    pt_x: i32,
+    pt_y: i32,
+};
+
+const WM_DESTROY: u32 = 0x0002;
+const PM_REMOVE: u32 = 0x0001;
+const WS_OVERLAPPEDWINDOW: u32 = 0x00CF0000;
+const CW_USEDEFAULT: i32 = @bitCast(@as(u32, 0x80000000));
+
+extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
+extern "user32" fn CreateWindowExW(
+    dwExStyle: u32,
+    lpClassName: [*:0]const u16,
+    lpWindowName: [*:0]const u16,
+    dwStyle: u32,
+    X: i32,
+    Y: i32,
+    nWidth: i32,
+    nHeight: i32,
+    hWndParent: ?windows.HWND,
+    hMenu: ?windows.HANDLE,
+    hInstance: windows.HMODULE,
+    lpParam: ?*anyopaque,
+) callconv(.winapi) ?windows.HWND;
+extern "user32" fn ShowWindow(hWnd: windows.HWND, nCmdShow: i32) callconv(.winapi) i32;
+extern "user32" fn PeekMessageW(lpMsg: *MSG, hWnd: ?windows.HWND, wMsgFilterMin: u32, wMsgFilterMax: u32, wRemoveMsg: u32) callconv(.winapi) i32;
+extern "user32" fn TranslateMessage(lpMsg: *const MSG) callconv(.winapi) i32;
+extern "user32" fn DispatchMessageW(lpMsg: *const MSG) callconv(.winapi) LRESULT;
+extern "user32" fn DefWindowProcW(hWnd: windows.HWND, Msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT;
+extern "user32" fn PostQuitMessage(nExitCode: i32) callconv(.winapi) void;
+extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?windows.HMODULE;
+extern "kernel32" fn QueryPerformanceCounter(lpPerformanceCount: *i64) callconv(.winapi) i32;
+extern "kernel32" fn QueryPerformanceFrequency(lpFrequency: *i64) callconv(.winapi) i32;
+
+fn windowProc(hwnd: windows.HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
+    if (msg == WM_DESTROY) {
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProcW(hwnd, msg, wparam, lparam);
+}
+
+// ---------- main -------------------------------------------------------------
+
+pub fn main() !void {
+    const class_name = std.unicode.utf8ToUtf16LeStringLiteral("DX11TestClass");
+    const window_title = std.unicode.utf8ToUtf16LeStringLiteral("DX11 Clear Test");
+
+    const hinstance = GetModuleHandleW(null) orelse {
+        std.debug.print("GetModuleHandleW failed\n", .{});
+        return error.GetModuleHandleFailed;
+    };
+
+    // Register window class.
+    const wc = WNDCLASSEXW{
+        .cbSize = @sizeOf(WNDCLASSEXW),
+        .style = 0,
+        .lpfnWndProc = windowProc,
+        .cbClsExtra = 0,
+        .cbWndExtra = 0,
+        .hInstance = hinstance,
+        .hIcon = null,
+        .hCursor = null,
+        .hbrBackground = null,
+        .lpszMenuName = null,
+        .lpszClassName = class_name,
+        .hIconSm = null,
+    };
+    if (RegisterClassExW(&wc) == 0) {
+        std.debug.print("RegisterClassExW failed\n", .{});
+        return error.RegisterClassFailed;
+    }
+
+    // Create window.
+    const hwnd = CreateWindowExW(
+        0,
+        class_name,
+        window_title,
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        800,
+        600,
+        null,
+        null,
+        hinstance,
+        null,
+    ) orelse {
+        std.debug.print("CreateWindowExW failed\n", .{});
+        return error.CreateWindowFailed;
+    };
+    _ = ShowWindow(hwnd, 1); // SW_SHOWNORMAL
+
+    // Create D3D11 device and immediate context.
+    var device_opt: ?*ID3D11Device = null;
+    var context_opt: ?*ID3D11DeviceContext = null;
+    const feature_levels = [_]D3D_FEATURE_LEVEL{.@"11_0"};
+    var hr = D3D11CreateDevice(
+        null,
+        .HARDWARE,
+        null,
+        D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+        &feature_levels,
+        feature_levels.len,
+        D3D11_SDK_VERSION,
+        &device_opt,
+        null,
+        &context_opt,
+    );
+    if (FAILED(hr)) {
+        std.debug.print("D3D11CreateDevice failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.D3D11CreateDeviceFailed;
+    }
+    const device = device_opt.?;
+    defer _ = device.Release();
+    const context = context_opt.?;
+    defer _ = context.Release();
+
+    std.debug.print("D3D11CreateDevice OK\n", .{});
+
+    // QueryInterface device -> IDXGIDevice.
+    var dxgi_device_opt: ?*anyopaque = null;
+    hr = device.QueryInterface(&IDXGIDevice.IID, &dxgi_device_opt);
+    if (FAILED(hr) or dxgi_device_opt == null) {
+        std.debug.print("QI IDXGIDevice failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.QIIDXGIDeviceFailed;
+    }
+    const dxgi_device: *IDXGIDevice = @ptrCast(@alignCast(dxgi_device_opt.?));
+    defer _ = dxgi_device.Release();
+
+    // Get adapter.
+    var adapter_opt: ?*IDXGIAdapter = null;
+    hr = dxgi_device.GetAdapter(&adapter_opt);
+    if (FAILED(hr) or adapter_opt == null) {
+        std.debug.print("GetAdapter failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.GetAdapterFailed;
+    }
+    const adapter = adapter_opt.?;
+    defer _ = adapter.Release();
+
+    // Get IDXGIFactory2 from adapter.
+    var factory_opt: ?*anyopaque = null;
+    hr = adapter.GetParent(&IDXGIFactory2.IID, &factory_opt);
+    if (FAILED(hr) or factory_opt == null) {
+        std.debug.print("GetParent IDXGIFactory2 failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.GetFactoryFailed;
+    }
+    const factory: *IDXGIFactory2 = @ptrCast(@alignCast(factory_opt.?));
+    defer _ = factory.Release();
+
+    // Create swap chain for HWND.
+    const sc_desc = DXGI_SWAP_CHAIN_DESC1{
+        .Width = 800,
+        .Height = 600,
+        .Format = .B8G8R8A8_UNORM,
+        .Stereo = 0,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
+        .BufferCount = 2,
+        .Scaling = .STRETCH,
+        .SwapEffect = .FLIP_SEQUENTIAL,
+        .AlphaMode = .UNSPECIFIED,
+        .Flags = 0,
+    };
+    var swap_chain_opt: ?*IDXGISwapChain1 = null;
+    hr = factory.CreateSwapChainForHwnd(
+        @ptrCast(device),
+        hwnd,
+        &sc_desc,
+        null,
+        null,
+        &swap_chain_opt,
+    );
+    if (FAILED(hr) or swap_chain_opt == null) {
+        std.debug.print("CreateSwapChainForHwnd failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.CreateSwapChainFailed;
+    }
+    const swap_chain = swap_chain_opt.?;
+    defer _ = swap_chain.Release();
+
+    std.debug.print("Swap chain created OK\n", .{});
+
+    // Get back buffer and create render target view.
+    var back_buffer_opt: ?*anyopaque = null;
+    hr = swap_chain.GetBuffer(0, &ID3D11Texture2D.IID, &back_buffer_opt);
+    if (FAILED(hr) or back_buffer_opt == null) {
+        std.debug.print("GetBuffer failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.GetBufferFailed;
+    }
+    const back_buffer: *ID3D11Texture2D = @ptrCast(@alignCast(back_buffer_opt.?));
+    defer _ = back_buffer.Release();
+
+    var rtv_opt: ?*ID3D11RenderTargetView = null;
+    hr = device.CreateRenderTargetView(@ptrCast(back_buffer), null, &rtv_opt);
+    if (FAILED(hr) or rtv_opt == null) {
+        std.debug.print("CreateRenderTargetView failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+        return error.CreateRTVFailed;
+    }
+    const rtv = rtv_opt.?;
+    defer _ = rtv.Release();
+
+    std.debug.print("RTV created OK -- running render loop for 3 seconds\n", .{});
+
+    // Early-sunrise orange: R=0.98, G=0.45, B=0.25, A=1.0
+    const clear_color = [4]f32{ 0.98, 0.45, 0.25, 1.0 };
+
+    // Measure 3 seconds via QueryPerformanceCounter.
+    var freq: i64 = 0;
+    var start: i64 = 0;
+    _ = QueryPerformanceFrequency(&freq);
+    _ = QueryPerformanceCounter(&start);
+    const duration: i64 = freq * 3;
+
+    var msg: MSG = std.mem.zeroes(MSG);
+    while (true) {
+        // Drain the message queue.
+        while (PeekMessageW(&msg, null, 0, 0, PM_REMOVE) != 0) {
+            _ = TranslateMessage(&msg);
+            _ = DispatchMessageW(&msg);
+        }
+
+        // Render frame.
+        const viewport = D3D11_VIEWPORT{
+            .TopLeftX = 0.0,
+            .TopLeftY = 0.0,
+            .Width = 800.0,
+            .Height = 600.0,
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        };
+        context.RSSetViewports(&.{viewport});
+        context.OMSetRenderTargets(&.{rtv}, null);
+        context.ClearRenderTargetView(rtv, &clear_color);
+        hr = swap_chain.Present(1, 0);
+        if (FAILED(hr)) {
+            std.debug.print("Present failed: hr=0x{x}\n", .{@as(u32, @bitCast(hr))});
+            return error.PresentFailed;
+        }
+
+        // Check elapsed time.
+        var now: i64 = 0;
+        _ = QueryPerformanceCounter(&now);
+        if (now - start >= duration) break;
+    }
+
+    std.debug.print("DX11 clear-to-color test passed.\n", .{});
+}


### PR DESCRIPTION
## Summary

- Implement `Buffer(T)` generic GPU buffer with DYNAMIC usage and Map/Unmap for per-frame writes
- Implement `Texture` with DEFAULT usage and UpdateSubresource for GPU-optimal atlas sampling
- Implement `Sampler` with hardcoded linear filtering and clamp-to-edge addressing
- Wire up COM vtable entries: CreateTexture2D, CreateShaderResourceView, CreateSamplerState, UpdateSubresource
- Add supporting D3D11 structs: TEXTURE2D_DESC, SHADER_RESOURCE_VIEW_DESC, SAMPLER_DESC, BOX, filter/address enums
- Connect DirectX11.zig Options functions with real device/context pointers
- Implement `initAtlasTexture` mapping font atlas formats to DXGI formats
- Add 10 GPU integration tests exercising all three types against a real D3D11 device

These are the foundational GPU resource types that the GenericRenderer contract requires. They replace panic stubs with real D3D11 resource wrappers. RenderPass, Pipeline, and shader wiring come in the next PR.

## Design decisions

Each type has detailed "why" comments in the code, but the key ones:

- **Buffer: DYNAMIC + Map/Unmap** -- buffers are written every frame, so we optimize for write speed. WRITE_DISCARD lets the driver rotate allocations to avoid CPU/GPU stalls. 2x growth on realloc amortizes resize cost.
- **Texture: DEFAULT + UpdateSubresource** -- font atlas textures are sampled every frame but written rarely. DEFAULT memory is GPU-optimal for reads. The occasional UpdateSubresource cost is worth the per-frame sampling speed.
- **Sampler: hardcoded config** -- GenericRenderer only creates one sampler (linear + clamp). Parameterizing would just move constants from init to the caller with no benefit.
- **Constant buffer 16-byte alignment** enforced at creation time (DX11 requirement).
- **Texture + SRV paired** -- always created and destroyed together because our use case (font atlas sampling) always needs both.

## Test plan

- [x] Struct size tests verify all new D3D11 structs match the C ABI
- [x] Compile-time tests verify Options fields and Buffer generic instantiation
- [x] GPU integration tests create a real D3D11 device (headless, no window) and exercise:
  - Buffer: create, sync, realloc on growth, syncFromArrayLists, map/unmap, resize, constant buffer
  - Texture: create with/without initial data, BGRA format, replaceRegion
  - Sampler: create and destroy
- [x] All 36 tests passing on Windows
- [x] Build compiles with `zig build -Dapp-runtime=none`

## What I Learnt

- **WRITE_DISCARD does not grow buffers.** It rotates which fixed-size allocation the driver gives you, but you still can't write past the original CreateBuffer size. The realloc path (release + create at 2x) is separate from the WRITE_DISCARD rotation.
- **DEFAULT vs DYNAMIC is about read vs write frequency.** DYNAMIC buffers live in CPU-accessible memory (slower GPU reads, faster CPU writes). DEFAULT textures live in GPU-optimal memory (faster GPU reads, slower CPU writes via staging copy). The access pattern determines which wins.
- **COM vtable slot accuracy is critical.** Wrong slot = calling a different function through a valid pointer. No crash, just silent corruption. The existing struct size tests and working test harness are the safety net.
- **D3D11_COMPARISON_FUNC starts at 1, not 0.** Value 0 is undefined in the enum even though it compiles.