### PR TITLE
renderer/dx11: RenderPass and Pipeline wiring

### DIFF
--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -136,7 +136,7 @@ pub fn initShaders(
     _ = self;
     _ = alloc;
     _ = custom_shaders;
-    @panic("TODO: DX11 initShaders");
+    return shaders.Shaders.init();
 }
 
 pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -40,12 +40,11 @@ pub inline fn renderPass(
             }
         }
     }
-    const dev = if (self.renderer.api.device) |*d| d else null;
-    return RenderPass.begin(
-        if (dev) |d| d.context else null,
-        if (dev) |d| d.device else null,
-        .{ .attachments = attachments },
-    );
+    if (self.renderer.api.device) |*dev| {
+        return RenderPass.begin(dev.context, dev.device, .{ .attachments = attachments });
+    } else {
+        return RenderPass.begin(null, null, .{ .attachments = attachments });
+    }
 }
 
 pub fn complete(self: *@This(), sync: bool) void {

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -40,7 +40,7 @@ pub inline fn renderPass(
             }
         }
     }
-    return .{};
+    return .{ .context = null, .device = null };
 }
 
 pub fn complete(self: *@This(), sync: bool) void {

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -40,7 +40,12 @@ pub inline fn renderPass(
             }
         }
     }
-    return .{ .context = null, .device = null };
+    const dev = if (self.renderer.api.device) |*d| d else null;
+    return RenderPass.begin(
+        if (dev) |d| d.context else null,
+        if (dev) |d| d.device else null,
+        .{ .attachments = attachments },
+    );
 }
 
 pub fn complete(self: *@This(), sync: bool) void {

--- a/src/renderer/directx11/Pipeline.zig
+++ b/src/renderer/directx11/Pipeline.zig
@@ -1,15 +1,27 @@
 //! Generic render pipeline wrapper for DX11.
 //!
-//! Wraps a vertex + pixel shader pair, analogous to Metal's Pipeline.zig
-//! which wraps MTLRenderPipelineState. Distinct from cell_pipeline.zig (the
-//! concrete cell pipeline from branch 025).
+//! Wraps an optional vertex shader + pixel shader + input layout triple,
+//! analogous to Metal's Pipeline.zig which wraps MTLRenderPipelineState.
 //!
-//! TODO: Implement with ID3D11VertexShader + ID3D11PixelShader.
+//! When all fields are null, the pipeline is "empty" (no shaders loaded).
+//! GenericRenderer skips draw calls for empty pipelines via the has_shaders
+//! check. This lets initShaders return default-initialized pipelines before
+//! HLSL shaders are written.
+const d3d11 = @import("d3d11.zig");
 
 /// Options for initializing a render pipeline.
-pub const Options = struct {};
+pub const Options = struct {
+    device: *d3d11.ID3D11Device,
+    vs_bytecode: ?[]const u8 = null,
+    ps_bytecode: ?[]const u8 = null,
+};
+
+vertex_shader: ?*d3d11.ID3D11VertexShader = null,
+pixel_shader: ?*d3d11.ID3D11PixelShader = null,
+input_layout: ?*d3d11.ID3D11InputLayout = null,
 
 pub fn deinit(self: *const @This()) void {
-    _ = self;
-    @panic("TODO: DX11 Pipeline.deinit");
+    if (self.input_layout) |layout| _ = layout.Release();
+    if (self.pixel_shader) |ps| _ = ps.Release();
+    if (self.vertex_shader) |vs| _ = vs.Release();
 }

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -92,13 +92,15 @@ pub fn step(self: *@This(), s: Step) void {
     });
 
     // Bind vertex buffers.
-    // Metal convention: index 0 is the vertex buffer, index 1+ is additional data.
-    // DX11: all go through IASetVertexBuffers at their respective slots.
+    // Why: Metal reserves slot 0 for vertex data and slot 1 for uniforms,
+    // starting additional buffers at slot 2. DX11 doesn't need that
+    // workaround -- uniforms go through constant buffers (a separate
+    // binding point), so vertex buffers bind at their natural index.
     for (s.buffers, 0..) |buf_opt, i| {
         if (buf_opt) |buf| {
-            // Stride of 0 lets the shader use SV_VertexID for procedural geometry.
-            // When real vertex data is bound, the stride will come from the pipeline
-            // (future work when HLSL shaders define their input layouts).
+            // TODO: stride must come from Pipeline's input layout once
+            // HLSL shaders define their vertex formats. Stride 0 for now
+            // lets shaders use SV_VertexID for procedural geometry.
             ctx.IASetVertexBuffers(
                 @intCast(i),
                 &.{@as(?*d3d11.ID3D11Buffer, buf)},
@@ -109,6 +111,9 @@ pub fn step(self: *@This(), s: Step) void {
     }
 
     // Bind uniforms as constant buffer at slot 0 for both VS and PS.
+    // Why: DX11 constant buffers are a separate namespace from vertex
+    // buffers, so slot 0 here doesn't conflict with IASetVertexBuffers
+    // slot 0 above. Metal uses buffer index 1 for uniforms instead.
     if (s.uniforms) |buf| {
         ctx.VSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf)});
         ctx.PSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf)});

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -1,11 +1,18 @@
 //! Render pass for DX11 draw steps.
-//! TODO: Implement with ID3D11DeviceContext draw calls.
+//!
+//! Stores the device context and issues immediate-mode draw commands.
+//! Unlike Metal (which records into a command buffer), DX11 commands
+//! execute immediately when called on the device context.
+const std = @import("std");
+const d3d11 = @import("d3d11.zig");
 const Pipeline = @import("Pipeline.zig");
 const Sampler = @import("Sampler.zig");
 const Target = @import("Target.zig");
 const Texture = @import("Texture.zig");
 const bufferpkg = @import("buffer.zig");
 const RawBuffer = bufferpkg.RawBuffer;
+
+const log = std.log.scoped(.directx11);
 
 /// Options for beginning a render pass.
 pub const Options = struct {
@@ -41,18 +48,99 @@ pub const Step = struct {
     };
 };
 
-pub fn begin(opts: Options) @This() {
+/// The device context for issuing draw commands.
+context: ?*d3d11.ID3D11DeviceContext,
+
+/// The device for creating render target views from textures.
+device: ?*d3d11.ID3D11Device,
+
+pub fn begin(
+    context: ?*d3d11.ID3D11DeviceContext,
+    device: ?*d3d11.ID3D11Device,
+    opts: Options,
+) @This() {
+    // Clearing and render target binding is handled by Frame.renderPass()
+    // via device.clearRenderTarget(), which sets the viewport, binds the
+    // swap chain's RTV, and clears it. Per-attachment RTV creation from
+    // Texture/Target is a future task (Target doesn't hold an
+    // ID3D11Texture2D yet).
     _ = opts;
-    @panic("TODO: DX11 RenderPass.begin");
+
+    return .{ .context = context, .device = device };
 }
 
 pub fn step(self: *@This(), s: Step) void {
-    _ = self;
-    _ = s;
-    @panic("TODO: DX11 RenderPass.step");
+    const ctx = self.context orelse return;
+
+    // Skip if the pipeline has no shaders loaded yet.
+    if (s.pipeline.vertex_shader == null and s.pipeline.pixel_shader == null) return;
+
+    // Skip zero-instance draws.
+    if (s.draw.instance_count == 0) return;
+
+    // Bind pipeline state: shaders and input layout.
+    ctx.VSSetShader(s.pipeline.vertex_shader);
+    ctx.PSSetShader(s.pipeline.pixel_shader);
+    if (s.pipeline.input_layout) |layout| {
+        ctx.IASetInputLayout(layout);
+    }
+
+    // Set primitive topology.
+    ctx.IASetPrimitiveTopology(switch (s.draw.type) {
+        .triangle => .TRIANGLELIST,
+        .triangle_strip => .TRIANGLESTRIP,
+    });
+
+    // Bind vertex buffers.
+    // Metal convention: index 0 is the vertex buffer, index 1+ is additional data.
+    // DX11: all go through IASetVertexBuffers at their respective slots.
+    for (s.buffers, 0..) |buf_opt, i| {
+        if (buf_opt) |buf| {
+            // Stride of 0 lets the shader use SV_VertexID for procedural geometry.
+            // When real vertex data is bound, the stride will come from the pipeline
+            // (future work when HLSL shaders define their input layouts).
+            ctx.IASetVertexBuffers(
+                @intCast(i),
+                &.{@as(?*d3d11.ID3D11Buffer, buf)},
+                &.{@as(u32, 0)},
+                &.{@as(u32, 0)},
+            );
+        }
+    }
+
+    // Bind uniforms as constant buffer at slot 0 for both VS and PS.
+    if (s.uniforms) |buf| {
+        ctx.VSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf)});
+        ctx.PSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf)});
+    }
+
+    // Bind textures as shader resource views for both VS and PS.
+    for (s.textures, 0..) |tex_opt, i| {
+        if (tex_opt) |tex| {
+            const srv = @as(?*d3d11.ID3D11ShaderResourceView, tex.srv);
+            ctx.VSSetShaderResources(@intCast(i), &.{srv});
+            ctx.PSSetShaderResources(@intCast(i), &.{srv});
+        }
+    }
+
+    // Bind samplers for the pixel shader.
+    for (s.samplers, 0..) |samp_opt, i| {
+        if (samp_opt) |samp| {
+            ctx.PSSetSamplers(@intCast(i), &.{@as(?*d3d11.ID3D11SamplerState, samp.sampler)});
+        }
+    }
+
+    // Draw.
+    ctx.DrawInstanced(
+        @intCast(s.draw.vertex_count),
+        @intCast(s.draw.instance_count),
+        0,
+        0,
+    );
 }
 
 pub fn complete(self: *const @This()) void {
+    // DX11 immediate mode: commands already executed on the context.
+    // Nothing to finalize (unlike Metal which calls endEncoding).
     _ = self;
-    @panic("TODO: DX11 RenderPass.complete");
 }

--- a/src/renderer/directx11/Sampler.zig
+++ b/src/renderer/directx11/Sampler.zig
@@ -39,7 +39,7 @@ pub fn init(opts: Options) Error!Self {
         .AddressW = .CLAMP,
         .MipLODBias = 0.0,
         .MaxAnisotropy = 1,
-        .ComparisonFunc = 1, // D3D11_COMPARISON_NEVER (unused with non-comparison filters, but 0 is not a valid enum value)
+        .ComparisonFunc = .NEVER, // unused with non-comparison filters, but 0 is not a valid enum value
         .BorderColor = .{ 0.0, 0.0, 0.0, 0.0 },
         .MinLOD = 0.0,
         .MaxLOD = std.math.floatMax(f32),

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -66,6 +66,7 @@ pub const D3D_PRIMITIVE_TOPOLOGY = enum(u32) {
     _,
 };
 
+// D3D11 blend enum values start at 1, not 0.
 pub const D3D11_BLEND = enum(u32) {
     ZERO = 1,
     ONE = 2,

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -66,6 +66,36 @@ pub const D3D_PRIMITIVE_TOPOLOGY = enum(u32) {
     _,
 };
 
+pub const D3D11_BLEND = enum(u32) {
+    ZERO = 1,
+    ONE = 2,
+    SRC_COLOR = 3,
+    INV_SRC_COLOR = 4,
+    SRC_ALPHA = 5,
+    INV_SRC_ALPHA = 6,
+    DEST_ALPHA = 7,
+    INV_DEST_ALPHA = 8,
+    DEST_COLOR = 9,
+    INV_DEST_COLOR = 10,
+    SRC_ALPHA_SAT = 11,
+    BLEND_FACTOR = 14,
+    INV_BLEND_FACTOR = 15,
+    SRC1_COLOR = 16,
+    INV_SRC1_COLOR = 17,
+    SRC1_ALPHA = 18,
+    INV_SRC1_ALPHA = 19,
+    _,
+};
+
+pub const D3D11_BLEND_OP = enum(u32) {
+    ADD = 1,
+    SUBTRACT = 2,
+    REV_SUBTRACT = 3,
+    MIN = 4,
+    MAX = 5,
+    _,
+};
+
 pub const D3D11_CREATE_DEVICE_FLAG = u32;
 pub const D3D11_CREATE_DEVICE_SINGLETHREADED: D3D11_CREATE_DEVICE_FLAG = 0x1;
 pub const D3D11_CREATE_DEVICE_DEBUG: D3D11_CREATE_DEVICE_FLAG = 0x2;
@@ -174,6 +204,17 @@ pub const D3D11_TEXTURE_ADDRESS_MODE = enum(u32) {
     MIRROR_ONCE = 5,
 };
 
+pub const D3D11_COMPARISON_FUNC = enum(u32) {
+    NEVER = 1,
+    LESS = 2,
+    EQUAL = 3,
+    LESS_EQUAL = 4,
+    GREATER = 5,
+    NOT_EQUAL = 6,
+    GREATER_EQUAL = 7,
+    ALWAYS = 8,
+};
+
 pub const D3D11_SAMPLER_DESC = extern struct {
     Filter: D3D11_FILTER,
     AddressU: D3D11_TEXTURE_ADDRESS_MODE,
@@ -181,10 +222,27 @@ pub const D3D11_SAMPLER_DESC = extern struct {
     AddressW: D3D11_TEXTURE_ADDRESS_MODE,
     MipLODBias: f32,
     MaxAnisotropy: u32,
-    ComparisonFunc: u32, // D3D11_COMPARISON_FUNC, not enumerated here
+    ComparisonFunc: D3D11_COMPARISON_FUNC,
     BorderColor: [4]f32,
     MinLOD: f32,
     MaxLOD: f32,
+};
+
+pub const D3D11_RENDER_TARGET_BLEND_DESC = extern struct {
+    BlendEnable: u32 = 0,
+    SrcBlend: D3D11_BLEND = .ONE,
+    DestBlend: D3D11_BLEND = .ZERO,
+    BlendOp: D3D11_BLEND_OP = .ADD,
+    SrcBlendAlpha: D3D11_BLEND = .ONE,
+    DestBlendAlpha: D3D11_BLEND = .ZERO,
+    BlendOpAlpha: D3D11_BLEND_OP = .ADD,
+    RenderTargetWriteMask: u8 = 0x0F,
+};
+
+pub const D3D11_BLEND_DESC = extern struct {
+    AlphaToCoverageEnable: u32 = 0,
+    IndependentBlendEnable: u32 = 0,
+    RenderTarget: [8]D3D11_RENDER_TARGET_BLEND_DESC = [_]D3D11_RENDER_TARGET_BLEND_DESC{.{}} ** 8,
 };
 
 pub const D3D11_BOX = extern struct {
@@ -443,6 +501,28 @@ pub const ID3D11ShaderResourceView = extern struct {
     }
 };
 
+pub const ID3D11BlendState = extern struct {
+    vtable: *const VTable,
+
+    const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*ID3D11BlendState) callconv(.winapi) u32,
+        // ID3D11DeviceChild (slots 3-6)
+        GetDevice: Reserved,
+        GetPrivateData: Reserved,
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        // ID3D11BlendState (slot 7)
+        GetDesc: Reserved,
+    };
+
+    pub inline fn Release(self: *ID3D11BlendState) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
 // ID3D11Device
 // Vtable order from d3d11.h:
 //   0: QueryInterface
@@ -566,8 +646,12 @@ pub const ID3D11Device = extern struct {
         CreateComputeShader: Reserved,
         // slot 19
         CreateClassLinkage: Reserved,
-        // slots 20-22
-        CreateBlendState: Reserved,
+        // slot 20: CreateBlendState
+        CreateBlendState: *const fn (
+            *ID3D11Device,
+            *const D3D11_BLEND_DESC,
+            *?*ID3D11BlendState,
+        ) callconv(.winapi) HRESULT,
         CreateDepthStencilState: Reserved,
         CreateRasterizerState: Reserved,
         // slot 23: CreateSamplerState
@@ -672,6 +756,10 @@ pub const ID3D11Device = extern struct {
         srv: *?*ID3D11ShaderResourceView,
     ) HRESULT {
         return self.vtable.CreateShaderResourceView(self, resource, desc, srv);
+    }
+
+    pub inline fn CreateBlendState(self: *ID3D11Device, desc: *const D3D11_BLEND_DESC, state: *?*ID3D11BlendState) HRESULT {
+        return self.vtable.CreateBlendState(self, desc, state);
     }
 
     pub inline fn CreateSamplerState(
@@ -806,7 +894,11 @@ pub const ID3D11DeviceContext = extern struct {
         // slot 12: DrawIndexed
         DrawIndexed: Reserved,
         // slot 13: Draw
-        Draw: Reserved,
+        Draw: *const fn (
+            *ID3D11DeviceContext,
+            VertexCount: u32,
+            StartVertexLocation: u32,
+        ) callconv(.winapi) void,
         // slot 14: Map
         Map: *const fn (
             *ID3D11DeviceContext,
@@ -823,7 +915,12 @@ pub const ID3D11DeviceContext = extern struct {
             u32, // Subresource
         ) callconv(.winapi) void,
         // slot 16: PSSetConstantBuffers
-        _reserved16: Reserved,
+        PSSetConstantBuffers: *const fn (
+            *ID3D11DeviceContext,
+            StartSlot: u32,
+            NumBuffers: u32,
+            ppConstantBuffers: [*]const ?*ID3D11Buffer,
+        ) callconv(.winapi) void,
         // slot 17: IASetInputLayout
         IASetInputLayout: *const fn (
             *ID3D11DeviceContext,
@@ -860,7 +957,12 @@ pub const ID3D11DeviceContext = extern struct {
             D3D_PRIMITIVE_TOPOLOGY,
         ) callconv(.winapi) void,
         // slot 25: VSSetShaderResources
-        _reserved25: Reserved,
+        VSSetShaderResources: *const fn (
+            *ID3D11DeviceContext,
+            StartSlot: u32,
+            NumViews: u32,
+            ppShaderResourceViews: [*]const ?*ID3D11ShaderResourceView,
+        ) callconv(.winapi) void,
         // slot 26: VSSetSamplers
         _reserved26: Reserved,
         // slot 27: Begin
@@ -885,7 +987,12 @@ pub const ID3D11DeviceContext = extern struct {
         // slot 34: OMSetRenderTargetsAndUnorderedAccessViews
         _reserved34: Reserved,
         // slot 35: OMSetBlendState
-        _reserved35: Reserved,
+        OMSetBlendState: *const fn (
+            *ID3D11DeviceContext,
+            ?*ID3D11BlendState,
+            ?*const [4]f32,
+            u32,
+        ) callconv(.winapi) void,
         // slot 36: OMSetDepthStencilState
         _reserved36: Reserved,
         // slot 37: SOSetTargets
@@ -1062,6 +1169,10 @@ pub const ID3D11DeviceContext = extern struct {
         _reserved114: Reserved,
     };
 
+    pub inline fn Draw(self: *ID3D11DeviceContext, vertex_count: u32, start_vertex: u32) void {
+        self.vtable.Draw(self, vertex_count, start_vertex);
+    }
+
     pub inline fn VSSetConstantBuffers(self: *ID3D11DeviceContext, start_slot: u32, buffers: []const ?*ID3D11Buffer) void {
         self.vtable.VSSetConstantBuffers(self, start_slot, @intCast(buffers.len), buffers.ptr);
     }
@@ -1093,6 +1204,10 @@ pub const ID3D11DeviceContext = extern struct {
         return self.vtable.Map(self, resource, subresource, map_type, map_flags, mapped);
     }
 
+    pub inline fn PSSetConstantBuffers(self: *ID3D11DeviceContext, start_slot: u32, buffers: []const ?*ID3D11Buffer) void {
+        self.vtable.PSSetConstantBuffers(self, start_slot, @intCast(buffers.len), buffers.ptr);
+    }
+
     pub inline fn Unmap(self: *ID3D11DeviceContext, resource: *ID3D11Resource, subresource: u32) void {
         self.vtable.Unmap(self, resource, subresource);
     }
@@ -1115,6 +1230,10 @@ pub const ID3D11DeviceContext = extern struct {
         self.vtable.IASetPrimitiveTopology(self, topology);
     }
 
+    pub inline fn VSSetShaderResources(self: *ID3D11DeviceContext, start_slot: u32, views: []const ?*ID3D11ShaderResourceView) void {
+        self.vtable.VSSetShaderResources(self, start_slot, @intCast(views.len), views.ptr);
+    }
+
     pub inline fn DrawInstanced(
         self: *ID3D11DeviceContext,
         vertex_count: u32,
@@ -1123,6 +1242,10 @@ pub const ID3D11DeviceContext = extern struct {
         start_instance: u32,
     ) void {
         self.vtable.DrawInstanced(self, vertex_count, instance_count, start_vertex, start_instance);
+    }
+
+    pub inline fn OMSetBlendState(self: *ID3D11DeviceContext, state: ?*ID3D11BlendState, blend_factor: ?*const [4]f32, sample_mask: u32) void {
+        self.vtable.OMSetBlendState(self, state, blend_factor, sample_mask);
     }
 
     pub inline fn OMSetRenderTargets(

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -11,6 +11,8 @@ const com = @import("com.zig");
 const buffer_mod = @import("buffer.zig");
 const Texture = @import("Texture.zig");
 const Sampler = @import("Sampler.zig");
+const Pipeline = @import("Pipeline.zig");
+const RenderPass = @import("RenderPass.zig");
 
 const Buffer = buffer_mod.Buffer;
 
@@ -251,4 +253,48 @@ test "Sampler: create and deinit" {
         .device = dev.device,
     });
     defer sampler.deinit();
+}
+
+test "Pipeline: default init and deinit" {
+    var pipeline = Pipeline{};
+    pipeline.deinit();
+}
+
+test "Pipeline: deinit is idempotent on empty pipeline" {
+    var pipeline = Pipeline{};
+    pipeline.deinit();
+    pipeline.deinit();
+}
+
+test "RenderPass: begin and complete with no device" {
+    var pass = RenderPass.begin(null, null, .{ .attachments = &.{} });
+    pass.complete();
+}
+
+test "RenderPass: step with empty pipeline is no-op" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    var pass = RenderPass.begin(dev.context, dev.device, .{ .attachments = &.{} });
+    defer pass.complete();
+
+    pass.step(.{
+        .pipeline = .{},
+        .draw = .{ .type = .triangle, .vertex_count = 3 },
+    });
+}
+
+test "RenderPass: step with zero instance count is no-op" {
+    const dev = createTestDevice() orelse return;
+    defer _ = dev.device.Release();
+    defer _ = dev.context.Release();
+
+    var pass = RenderPass.begin(dev.context, dev.device, .{ .attachments = &.{} });
+    defer pass.complete();
+
+    pass.step(.{
+        .pipeline = .{},
+        .draw = .{ .type = .triangle_strip, .vertex_count = 4, .instance_count = 0 },
+    });
 }

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -260,9 +260,8 @@ test "Pipeline: default init and deinit" {
     pipeline.deinit();
 }
 
-test "Pipeline: deinit is idempotent on empty pipeline" {
+test "Pipeline: deinit on empty pipeline is safe to call" {
     var pipeline = Pipeline{};
-    pipeline.deinit();
     pipeline.deinit();
 }
 

--- a/src/renderer/directx11/shaders.zig
+++ b/src/renderer/directx11/shaders.zig
@@ -13,7 +13,6 @@ const math = @import("../../math.zig");
 const Pipeline = @import("Pipeline.zig");
 
 /// Shader management for DX11.
-/// TODO: Implement HLSL shader compilation and caching.
 pub const Shaders = struct {
     pipelines: Pipelines = .{},
     post_pipelines: []const Pipeline = &.{},
@@ -27,10 +26,25 @@ pub const Shaders = struct {
         bg_image: Pipeline = .{},
     };
 
+    /// Return default-initialized pipelines (all shader pointers null).
+    /// RenderPass.step() skips pipelines with no shaders loaded.
+    pub fn init() Shaders {
+        return .{};
+    }
+
     pub fn deinit(self: *Shaders, alloc: std.mem.Allocator) void {
-        _ = self;
-        _ = alloc;
-        @panic("TODO: DX11 Shaders.deinit");
+        for (self.post_pipelines) |p| {
+            p.deinit();
+        }
+        if (self.post_pipelines.len > 0) {
+            alloc.free(self.post_pipelines);
+        }
+
+        self.pipelines.bg_color.deinit();
+        self.pipelines.cell_bg.deinit();
+        self.pipelines.cell_text.deinit();
+        self.pipelines.image.deinit();
+        self.pipelines.bg_image.deinit();
     }
 };
 

--- a/src/renderer/directx11/shaders.zig
+++ b/src/renderer/directx11/shaders.zig
@@ -39,12 +39,14 @@ pub const Shaders = struct {
         if (self.post_pipelines.len > 0) {
             alloc.free(self.post_pipelines);
         }
+        self.post_pipelines = &.{};
 
         self.pipelines.bg_color.deinit();
         self.pipelines.cell_bg.deinit();
         self.pipelines.cell_text.deinit();
         self.pipelines.image.deinit();
         self.pipelines.bg_image.deinit();
+        self.pipelines = .{};
     }
 };
 


### PR DESCRIPTION
## Summary

Wire up the RenderPass and Pipeline types so GenericRenderer's draw loop can execute against the DX11 immediate context instead of panicking.

- **Pipeline**: wraps optional VS+PS+InputLayout triple. Defaults to all-null (empty pipeline, no shaders yet)
- **RenderPass**: stores device context, binds shaders/buffers/textures/samplers per step, calls DrawInstanced
- **Frame**: passes real device context into RenderPass.begin()
- **initShaders**: returns default-initialized Shaders with empty pipelines instead of panicking
- **d3d11.zig**: wires up Draw, PSSetConstantBuffers, VSSetShaderResources, CreateBlendState, OMSetBlendState vtable slots plus blend state types

Empty pipelines are gracefully skipped in RenderPass.step() so the draw loop runs end-to-end without crashing. No pixels rendered yet since HLSL shaders for the 5 pipelines (bg_color, cell_bg, cell_text, image, bg_image) are not written yet.

> **IMPORTANT**: This is part of a stacked branch series for DX11 renderer work.
> Stack order: 029 (GPU primitives, merged) -> **030 (this PR: RenderPass/Pipeline wiring)**
> Next: HLSL shaders for the 5 pipelines

## What I Learnt

- DX11 immediate mode means RenderPass.complete() is a no-op, unlike Metal which calls endEncoding on a command encoder. Commands execute when you call them, not when you submit a buffer.
- Pipeline in DX11 is not a monolithic state object like Metal's MTLRenderPipelineState. VS, PS, and InputLayout are separate COM objects bound individually to the context.
- The GenericRenderer draw loop in generic.zig binds uniforms at a special slot (Metal uses index 1), textures/samplers by index, and vertex buffers starting at slot 0. DX11 maps these to VSSetConstantBuffers/PSSetConstantBuffers, *SetShaderResources, PSSetSamplers, and IASetVertexBuffers.

## Test plan

- [x] Build passes: `zig build -Dapp-runtime=none`
- [x] GPU tests pass for Pipeline default init/deinit
- [x] GPU tests pass for RenderPass with null device (no-op path)
- [x] GPU tests pass for RenderPass step with empty pipeline (skip path)
- [x] GPU tests pass for RenderPass step with zero instance count (skip path)
- [x] No remaining TODO panics in Pipeline.zig, RenderPass.zig, Frame.zig, shaders.zig, DirectX11.zig
- [x] Cross-platform: needs Linux build verification (fixed issues in #62 and #63)