### PR TITLE
renderer/dx11: remove duplicate RawBuffer definition

### DIFF
--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -26,10 +26,6 @@ pub const Usage = enum {
     // a consumer (e.g. static vertex data for screen quads).
 };
 
-/// Opaque stand-in for an ID3D11Buffer COM pointer.
-/// TODO: Replace with *d3d11.ID3D11Buffer when the full pipeline is implemented.
-pub const RawBuffer = struct {};
-
 /// DX11 GPU data buffer for a set of equal-typed elements.
 ///
 /// Wraps an ID3D11Buffer with DYNAMIC usage and CPU_ACCESS_WRITE.
@@ -55,11 +51,6 @@ pub fn Buffer(comptime T: type) type {
 
         /// The allocated capacity in number of T elements (not bytes).
         len: usize,
-
-        /// Type-erased handle for passing to RenderPass.Step. Mirrors the
-        /// .buffer field on Metal (objc.Object) and OpenGL (gl.Buffer) buffers
-        /// so GenericRenderer can pass uniform/vertex buffers without knowing T.
-        buffer: RawBuffer = .{},
 
         pub fn init(opts: Options, len: usize) !Self {
             const byte_size = validateAndComputeSize(opts, len);


### PR DESCRIPTION
## Summary

- Remove stale RawBuffer placeholder (empty struct) that was left behind after a squash merge
- Remove duplicate buffer field in Buffer(T) that conflicted with the real buffer field
- The real RawBuffer (*d3d11.ID3D11Buffer) defined at line 10 is the correct one

This caused compile errors on all platforms since Zig sees duplicate struct member names.

## Test plan

- [x] Windows build passes: `zig build -Dapp-runtime=none` (65/65 steps)
- [ ] Cross-platform verification pending