### PR TITLE
renderer/dx11: wire render loop end-to-end through real pipeline path

### DIFF
--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -3,10 +3,9 @@
 //! This module provides the GraphicsAPI contract required by GenericRenderer,
 //! mirroring the structure of Metal.zig and OpenGL.zig.
 //!
-//! Current status: stub - all functions panic at runtime. The contract is
-//! satisfied at compile time so that GenericRenderer(DirectX11) compiles.
-//! Infrastructure (COM bindings, device lifecycle, cell grid pipeline) is
-//! already in place from prior work in the directx11/ subdirectory.
+//! Current status: device init, shader loading, and render loop wiring are
+//! functional. The bg_color pipeline renders the terminal background through
+//! the real Frame -> RenderPass -> step() path.
 pub const DirectX11 = @This();
 
 const builtin = @import("builtin");
@@ -147,8 +146,11 @@ pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
 }
 
 pub fn initTarget(self: *const DirectX11, width: usize, height: usize) !Target {
-    _ = self;
-    return .{ .width = width, .height = height };
+    return .{
+        .rtv = if (self.device) |dev| dev.rtv else null,
+        .width = width,
+        .height = height,
+    };
 }
 
 pub inline fn beginFrame(

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -26,20 +26,6 @@ pub inline fn renderPass(
     self: *@This(),
     attachments: []const RenderPass.Options.Attachment,
 ) RenderPass {
-    // Clear the render target using the first attachment's clear color.
-    if (self.renderer.api.device) |*dev| {
-        for (attachments) |att| {
-            if (att.clear_color) |color| {
-                dev.clearRenderTarget(.{
-                    @floatCast(color[0]),
-                    @floatCast(color[1]),
-                    @floatCast(color[2]),
-                    @floatCast(color[3]),
-                });
-                break;
-            }
-        }
-    }
     if (self.renderer.api.device) |*dev| {
         return RenderPass.begin(dev.context, dev.device, .{ .attachments = attachments });
     } else {

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -59,12 +59,46 @@ pub fn begin(
     device: ?*d3d11.ID3D11Device,
     opts: Options,
 ) @This() {
-    // Clearing and render target binding is handled by Frame.renderPass()
-    // via device.clearRenderTarget(), which sets the viewport, binds the
-    // swap chain's RTV, and clears it. Per-attachment RTV creation from
-    // Texture/Target is a future task (Target doesn't hold an
-    // ID3D11Texture2D yet).
-    _ = opts;
+    const ctx = context orelse return .{ .context = null, .device = device };
+
+    // Bind the first attachment's render target and optionally clear it.
+    // GenericRenderer always passes exactly one attachment per render pass.
+    for (opts.attachments) |att| {
+        const rtv = switch (att.target) {
+            .target => |t| t.rtv orelse continue,
+            // Texture-as-RTV not yet supported (needs CreateRenderTargetView
+            // from the texture's ID3D11Texture2D). Skipped for now.
+            .texture => continue,
+        };
+
+        // Set viewport to target dimensions.
+        const target = att.target.target;
+        const viewport = d3d11.D3D11_VIEWPORT{
+            .TopLeftX = 0.0,
+            .TopLeftY = 0.0,
+            .Width = @floatFromInt(target.width),
+            .Height = @floatFromInt(target.height),
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        };
+        ctx.RSSetViewports(&.{viewport});
+
+        // Bind the render target.
+        ctx.OMSetRenderTargets(&.{rtv}, null);
+
+        // Clear if requested.
+        if (att.clear_color) |color| {
+            ctx.ClearRenderTargetView(rtv, &.{
+                @floatCast(color[0]),
+                @floatCast(color[1]),
+                @floatCast(color[2]),
+                @floatCast(color[3]),
+            });
+        }
+
+        // Only bind the first attachment -- DX11 MRT is not needed.
+        break;
+    }
 
     return .{ .context = context, .device = device };
 }

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -63,41 +63,44 @@ pub fn begin(
 
     // Bind the first attachment's render target and optionally clear it.
     // GenericRenderer always passes exactly one attachment per render pass.
-    for (opts.attachments) |att| {
-        const rtv = switch (att.target) {
-            .target => |t| t.rtv orelse continue,
-            // Texture-as-RTV not yet supported (needs CreateRenderTargetView
-            // from the texture's ID3D11Texture2D). Skipped for now.
-            .texture => continue,
-        };
+    if (opts.attachments.len == 0) return .{ .context = context, .device = device };
 
-        // Set viewport to target dimensions.
-        const target = att.target.target;
-        const viewport = d3d11.D3D11_VIEWPORT{
-            .TopLeftX = 0.0,
-            .TopLeftY = 0.0,
-            .Width = @floatFromInt(target.width),
-            .Height = @floatFromInt(target.height),
-            .MinDepth = 0.0,
-            .MaxDepth = 1.0,
-        };
-        ctx.RSSetViewports(&.{viewport});
+    const att = opts.attachments[0];
+    const target, const rtv = switch (att.target) {
+        .target => |t| .{ t, t.rtv orelse {
+            log.warn("render pass attachment has no RTV, skipping bind", .{});
+            return .{ .context = context, .device = device };
+        } },
+        // Texture-as-RTV not yet supported (needs CreateRenderTargetView
+        // from the texture's ID3D11Texture2D).
+        .texture => {
+            log.warn("texture attachments not yet supported in DX11 render pass", .{});
+            return .{ .context = context, .device = device };
+        },
+    };
 
-        // Bind the render target.
-        ctx.OMSetRenderTargets(&.{rtv}, null);
+    // Set viewport to target dimensions.
+    const viewport = d3d11.D3D11_VIEWPORT{
+        .TopLeftX = 0.0,
+        .TopLeftY = 0.0,
+        .Width = @floatFromInt(target.width),
+        .Height = @floatFromInt(target.height),
+        .MinDepth = 0.0,
+        .MaxDepth = 1.0,
+    };
+    ctx.RSSetViewports(&.{viewport});
 
-        // Clear if requested.
-        if (att.clear_color) |color| {
-            ctx.ClearRenderTargetView(rtv, &.{
-                @floatCast(color[0]),
-                @floatCast(color[1]),
-                @floatCast(color[2]),
-                @floatCast(color[3]),
-            });
-        }
+    // Bind the render target.
+    ctx.OMSetRenderTargets(&.{rtv}, null);
 
-        // Only bind the first attachment -- DX11 MRT is not needed.
-        break;
+    // Clear if requested.
+    if (att.clear_color) |color| {
+        ctx.ClearRenderTargetView(rtv, &.{
+            @floatCast(color[0]),
+            @floatCast(color[1]),
+            @floatCast(color[2]),
+            @floatCast(color[3]),
+        });
     }
 
     return .{ .context = context, .device = device };

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -1,19 +1,24 @@
 //! Render target for DX11.
-//! TODO: Implement with ID3D11Texture2D + ID3D11RenderTargetView.
+//!
+//! Wraps an ID3D11RenderTargetView that draw commands render into.
+//! For swap chain targets the RTV is owned by Device -- Target borrows
+//! the pointer. For future off-screen targets, Target will own the
+//! RTV and its backing ID3D11Texture2D.
+const d3d11 = @import("d3d11.zig");
 
-/// Options for initializing a target.
-pub const Options = struct {
-    width: usize,
-    height: usize,
-};
+/// The render target view to draw into.
+/// Null when running without a device (non-Windows builds).
+rtv: ?*d3d11.ID3D11RenderTargetView = null,
 
-/// Current width of this target.
+/// Current width of this target in pixels.
 width: usize = 0,
-/// Current height of this target.
+/// Current height of this target in pixels.
 height: usize = 0,
 
 pub fn deinit(self: *@This()) void {
-    // Backbuffer is owned by the swap chain, nothing to release here.
+    // Swap chain RTV is owned by Device, not by Target.
+    // When we add off-screen targets we will Release() here.
+    self.rtv = null;
     self.width = 0;
     self.height = 0;
 }

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -233,26 +233,6 @@ pub const Device = struct {
         }
     }
 
-    pub fn clearRenderTarget(self: *Device, color: [4]f32) void {
-        const rtv = self.rtv orelse return;
-
-        // Set viewport to full swap chain dimensions.
-        const viewport = d3d11.D3D11_VIEWPORT{
-            .TopLeftX = 0.0,
-            .TopLeftY = 0.0,
-            .Width = @floatFromInt(self.width),
-            .Height = @floatFromInt(self.height),
-            .MinDepth = 0.0,
-            .MaxDepth = 1.0,
-        };
-        self.context.RSSetViewports(&.{viewport});
-
-        // Bind the render target.
-        self.context.OMSetRenderTargets(&.{rtv}, null);
-
-        // Clear to the specified color.
-        self.context.ClearRenderTargetView(rtv, &color);
-    }
 
     /// Get the back buffer from the swap chain and create a render target view.
     fn createRenderTargetView(

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -233,7 +233,6 @@ pub const Device = struct {
         }
     }
 
-
     /// Get the back buffer from the swap chain and create a render target view.
     fn createRenderTargetView(
         device: *d3d11.ID3D11Device,


### PR DESCRIPTION
## Summary

- Target now holds a real RTV (render target view) borrowed from Device's swap chain back buffer
- RenderPass.begin() extracts the RTV from attachments, sets viewport, binds via OMSetRenderTargets, and clears
- Frame.renderPass() is now a thin passthrough -- the old device.clearRenderTarget() hack is removed
- initTarget() populates Target with the device's RTV so GenericRenderer's pipeline path is connected
- Removed the now-dead Device.clearRenderTarget() method

## What changed

Before: GenericRenderer called drawFrame(), but Frame.renderPass() short-circuited by calling device.clearRenderTarget() directly, bypassing the shader pipeline entirely.

After: The full render path works. GenericRenderer calls initTarget() (which now carries the RTV), beginFrame(), frame.renderPass() (which passes through to RenderPass), and pass.step() for the bg_color pipeline, which actually runs the HLSL shader against the real back buffer.

The other pipelines (cell_bg, cell_text, image, bg_image) still no-op because they have zero instances or no textures -- that is the next branch.

## What I Learnt

- **RTV ownership matters.** The swap chain's back buffer RTV is owned by Device. Target borrows the pointer without calling AddRef/Release. On resize, Device releases and recreates the RTV, then initTarget() re-borrows the new one. Double-free would happen if Target also Released.
- **Attachment binding belongs in RenderPass, not Frame.** Metal's render pass descriptor binds attachments the same way. Putting it in Frame was a hack that ignored the attachments entirely. Moving it to RenderPass means the same code path will work for off-screen targets later.
- **DX11 immediate mode simplifies the frame lifecycle.** Metal needs command buffers and completion handlers. DX11 executes draw calls immediately on the device context, so Frame and RenderPass are thin wrappers -- no deferred command recording needed.

## Test plan

- [x] `zig build -Dapp-runtime=none` compiles clean
- [x] `zig build test -Dapp-runtime=none` passes (all existing tests)
- [x] Visual: standalone harness opens window, clears to orange through real RenderPass attachment binding