### PR TITLE
chore: update progress bars (MVWT 45%, MVT 0%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@
 >
 > **Status:** Foundation done, working on renderer and app shell
 >
+> **MVWT** Minimum Viewable Windows Terminal
+> `[█████████░░░░░░░░░░░] 45%`
+>
+> **MVT** Moonshot Viable Terminal ([#26](https://github.com/deblasis/ghostty/issues/26))
+> `[░░░░░░░░░░░░░░░░░░░░]  0%`
+>
 > The Windows app is a native C# GUI wrapping `libghostty.dll`, same architecture
 > as macOS where Swift wraps `libghostty`. All terminal emulation stays in Zig.
 > The C# layer handles windowing, input, and platform integration via P/Invoke.


### PR DESCRIPTION
## Summary

Adds MVWT and MVT progress bars to the fork README.

## MVWT Breakdown (45%)

| Chunk | Weight | Done | Weighted |
|-------|--------|------|----------|
| Build infra (CI, DLL, 17 upstream PRs) | 15% | 100% | 15.0% |
| DX11 infra (COM, device, pipelines, shaders) | 15% | 90% | 13.5% |
| App scaffold (C# WinUI 3, P/Invoke, spike) | 10% | 75% | 7.5% |
| Cell rendering (buffers, atlas, text) | 20% | 35% | 7.0% |
| DirectWrite font backend | 15% | 5% | 0.75% |
| ConPTY shell spawning | 10% | 10% | 1.0% |
| Keyboard, mouse, clipboard | 10% | 5% | 0.5% |
| DPI, dark/light theming | 5% | 0% | 0.0% |
| **Total** | | | **45.25%** |

Cell rendering will jump once the current render-loop-wiring branch lands.

## MVT Breakdown (0%)

0 of 56 checkboxes in #26 are checked. The foundational work enables them but none are individually complete yet.