### PR TITLE
chore: update progress bars (MVWT 39%, MVT 0%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@
 >
 > **Status:** Foundation done, working on renderer and app shell
 >
+> **MVWT** Minimum Viewable Windows Terminal
+> `[████████░░░░░░░░░░░░] 39%`
+>
+> **MVT** Moonshot Viable Terminal ([#26](https://github.com/deblasis/ghostty/issues/26))
+> `[░░░░░░░░░░░░░░░░░░░░]  0%`
+>
 > The Windows app is a native C# GUI wrapping `libghostty.dll`, same architecture
 > as macOS where Swift wraps `libghostty`. All terminal emulation stays in Zig.
 > The C# layer handles windowing, input, and platform integration via P/Invoke.


### PR DESCRIPTION
## Summary

- Added MVWT and MVT progress bars to the fork README

## MVWT breakdown (39%)

| Chunk | Weight | Completion | Weighted |
|-------|--------|------------|----------|
| Build infra (CI, DLL, upstream PRs) | 15% | 95% | 14.25% |
| DX11 infra (COM, device, pipelines, shaders) | 15% | 85% | 12.75% |
| App scaffold (C#, P/Invoke, spike) | 10% | 25% | 2.50% |
| Cell rendering (buffers, atlas, text) | 20% | 45% | 9.00% |
| DirectWrite font backend | 15% | 0% | 0.00% |
| ConPTY shell spawning | 10% | 0% | 0.00% |
| Keyboard, mouse, clipboard | 10% | 0% | 0.00% |
| DPI, dark/light theming | 5% | 10% | 0.50% |
| **Total** | | | **39%** |

## MVT breakdown (0%)

0 of 56 checkboxes checked in #26.