### PR TITLE
example: C Win32 terminal - input handling

### DIFF
--- a/example/c-win32-terminal/README.md
+++ b/example/c-win32-terminal/README.md
@@ -2,9 +2,8 @@
 
 Minimal C program that embeds libghostty in a Win32 window.
 Uses the ghostty C API to create an app and surface with DX11
-rendering. This is the skeleton -- it creates the window, initializes
-ghostty, and hands over the HWND, but does not forward keyboard or
-mouse input yet (that comes in later PRs).
+rendering. Creates the window, initializes ghostty, and forwards
+keyboard, mouse, resize, focus, and DPI events to the surface.
 
 Unlike the `c-vt-*` examples which use the VT parser library,
 this example uses the full libghostty runtime (app, surface,

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -64,6 +64,30 @@ static void close_surface_cb(void* userdata, bool process_alive) {
     if (g_hwnd) PostMessage(g_hwnd, WM_CLOSE, 0, 0);
 }
 
+// --- Input helpers ---
+
+// Extract the Win32 scancode from WM_KEYDOWN/WM_KEYUP lParam.
+// Bits 16-23 are the scancode. Bit 24 is the extended key flag.
+// Extended keys (arrows, numpad, etc.) need the 0xE000 prefix.
+static uint32_t scancode_from_lparam(LPARAM lp) {
+    uint32_t sc = (lp >> 16) & 0xFF;
+    if (lp & (1 << 24)) sc |= 0xE000;  // extended key
+    return sc;
+}
+
+// Map Win32 modifier state to ghostty mods.
+static ghostty_input_mods_e current_mods(void) {
+    ghostty_input_mods_e mods = GHOSTTY_MODS_NONE;
+    if (GetKeyState(VK_SHIFT) & 0x8000) mods |= GHOSTTY_MODS_SHIFT;
+    if (GetKeyState(VK_CONTROL) & 0x8000) mods |= GHOSTTY_MODS_CTRL;
+    if (GetKeyState(VK_MENU) & 0x8000) mods |= GHOSTTY_MODS_ALT;
+    if (GetKeyState(VK_LWIN) & 0x8000 || GetKeyState(VK_RWIN) & 0x8000)
+        mods |= GHOSTTY_MODS_SUPER;
+    if (GetKeyState(VK_CAPITAL) & 0x0001) mods |= GHOSTTY_MODS_CAPS;
+    if (GetKeyState(VK_NUMLOCK) & 0x0001) mods |= GHOSTTY_MODS_NUM;
+    return mods;
+}
+
 // --- Window procedure ---
 
 static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
@@ -71,6 +95,51 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     case WM_GHOSTTY_WAKEUP:
         if (g_app) ghostty_app_tick(g_app);
         return 0;
+
+    case WM_KEYDOWN:
+    case WM_SYSKEYDOWN: {
+        if (!g_surface) break;
+        ghostty_input_key_s key = {
+            .action = (lp & (1 << 30)) ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS,
+            .mods = current_mods(),
+            .consumed_mods = GHOSTTY_MODS_NONE,
+            .keycode = scancode_from_lparam(lp),
+            .text = NULL,
+            .composing = false,
+            .unshifted_codepoint = 0,
+        };
+        ghostty_surface_key(g_surface, key);
+        return 0;
+    }
+
+    case WM_KEYUP:
+    case WM_SYSKEYUP: {
+        if (!g_surface) break;
+        ghostty_input_key_s key = {
+            .action = GHOSTTY_ACTION_RELEASE,
+            .mods = current_mods(),
+            .consumed_mods = GHOSTTY_MODS_NONE,
+            .keycode = scancode_from_lparam(lp),
+            .text = NULL,
+            .composing = false,
+            .unshifted_codepoint = 0,
+        };
+        ghostty_surface_key(g_surface, key);
+        return 0;
+    }
+
+    case WM_CHAR: {
+        if (!g_surface) break;
+        // wp is a UTF-16 code unit. Convert to UTF-8.
+        wchar_t wc_buf[2] = { (wchar_t)wp, 0 };
+        char utf8[8] = {0};
+        int len = WideCharToMultiByte(CP_UTF8, 0, wc_buf, 1, utf8, sizeof(utf8) - 1, NULL, NULL);
+        if (len > 0) {
+            utf8[len] = '\0';
+            ghostty_surface_text(g_surface, utf8, (uintptr_t)len);
+        }
+        return 0;
+    }
 
     case WM_SIZE:
         if (g_surface) {

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -86,6 +86,22 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         if (g_surface) ghostty_surface_set_focus(g_surface, false);
         return 0;
 
+    case WM_DPICHANGED: {
+        if (g_surface) {
+            UINT new_dpi = HIWORD(wp);
+            double new_scale = (double)new_dpi / 96.0;
+            ghostty_surface_set_content_scale(g_surface, new_scale, new_scale);
+        }
+        // Resize to the suggested rect
+        RECT* suggested = (RECT*)lp;
+        SetWindowPos(g_hwnd, NULL,
+            suggested->left, suggested->top,
+            suggested->right - suggested->left,
+            suggested->bottom - suggested->top,
+            SWP_NOZORDER | SWP_NOACTIVATE);
+        return 0;
+    }
+
     case WM_DESTROY:
         PostQuitMessage(0);
         return 0;

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -202,6 +202,18 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
                 GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, current_mods());
         return 0;
 
+    case WM_MBUTTONDOWN:
+        if (g_surface)
+            ghostty_surface_mouse_button(g_surface,
+                GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_MIDDLE, current_mods());
+        return 0;
+
+    case WM_MBUTTONUP:
+        if (g_surface)
+            ghostty_surface_mouse_button(g_surface,
+                GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_MIDDLE, current_mods());
+        return 0;
+
     case WM_MOUSEWHEEL: {
         if (!g_surface) break;
         double delta = (double)GET_WHEEL_DELTA_WPARAM(wp) / WHEEL_DELTA;
@@ -286,8 +298,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdLine, int show) {
     }
 
     // 3. Initialize ghostty global state
-    const char* argv[] = { "ghostty-example" };
-    if (ghostty_init(1, argv) != GHOSTTY_SUCCESS) {
+    char* argv[] = { "ghostty-example" };
+    if (ghostty_init(1, argv) != 0) {
         fprintf(stderr, "ghostty_init failed\n");
         return 1;
     }

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -2,11 +2,11 @@
 //
 // Minimal Win32 host for libghostty. Creates an HWND and passes it to
 // ghostty which creates a surface with DX11 rendering and ConPTY.
-// This is the skeleton -- no input forwarding yet, so the terminal
-// won't accept keyboard or mouse input.
+// Forwards keyboard, mouse, resize, focus, and DPI events to ghostty.
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <windowsx.h>
 #include <ghostty.h>
 #include <stdio.h>
 
@@ -15,6 +15,7 @@
 static HWND g_hwnd = NULL;
 static ghostty_app_t g_app = NULL;
 static ghostty_surface_t g_surface = NULL;
+static WCHAR g_high_surrogate = 0;
 
 // --- Forward declarations ---
 
@@ -130,10 +131,33 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 
     case WM_CHAR: {
         if (!g_surface) break;
-        // wp is a UTF-16 code unit. Convert to UTF-8.
-        wchar_t wc_buf[2] = { (wchar_t)wp, 0 };
+        // wp is a UTF-16 code unit. Characters outside the BMP arrive as
+        // two WM_CHAR messages (high surrogate then low surrogate).
+        WCHAR wc = (WCHAR)wp;
+        wchar_t wc_buf[3] = {0};
+        int count;
+
+        if (IS_HIGH_SURROGATE(wc)) {
+            g_high_surrogate = wc;
+            return 0;
+        }
+        if (IS_LOW_SURROGATE(wc)) {
+            if (g_high_surrogate) {
+                wc_buf[0] = g_high_surrogate;
+                wc_buf[1] = wc;
+                g_high_surrogate = 0;
+                count = 2;
+            } else {
+                return 0;  // orphaned low surrogate
+            }
+        } else {
+            g_high_surrogate = 0;
+            wc_buf[0] = wc;
+            count = 1;
+        }
+
         char utf8[8] = {0};
-        int len = WideCharToMultiByte(CP_UTF8, 0, wc_buf, 1, utf8, sizeof(utf8) - 1, NULL, NULL);
+        int len = WideCharToMultiByte(CP_UTF8, 0, wc_buf, count, utf8, sizeof(utf8) - 1, NULL, NULL);
         if (len > 0) {
             utf8[len] = '\0';
             ghostty_surface_text(g_surface, utf8, (uintptr_t)len);
@@ -143,8 +167,9 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 
     case WM_MOUSEMOVE:
         if (g_surface) {
-            double x = (double)LOWORD(lp);
-            double y = (double)HIWORD(lp);
+            // GET_X/Y_LPARAM handles sign correctly during mouse capture
+            double x = (double)GET_X_LPARAM(lp);
+            double y = (double)GET_Y_LPARAM(lp);
             ghostty_surface_mouse_pos(g_surface, x, y, current_mods());
         }
         return 0;
@@ -180,8 +205,14 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     case WM_MOUSEWHEEL: {
         if (!g_surface) break;
         double delta = (double)GET_WHEEL_DELTA_WPARAM(wp) / WHEEL_DELTA;
-        // ghostty_input_scroll_mods_t is a packed int. 0 = no precision scroll.
         ghostty_surface_mouse_scroll(g_surface, 0, delta, 0);
+        return 0;
+    }
+
+    case WM_MOUSEHWHEEL: {
+        if (!g_surface) break;
+        double delta = (double)GET_WHEEL_DELTA_WPARAM(wp) / WHEEL_DELTA;
+        ghostty_surface_mouse_scroll(g_surface, delta, 0, 0);
         return 0;
     }
 
@@ -220,8 +251,10 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         return 0;
 
     default:
-        return DefWindowProc(hwnd, msg, wp, lp);
+        break;
     }
+
+    return DefWindowProc(hwnd, msg, wp, lp);
 }
 
 // --- Entry point ---

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -141,6 +141,50 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         return 0;
     }
 
+    case WM_MOUSEMOVE:
+        if (g_surface) {
+            double x = (double)LOWORD(lp);
+            double y = (double)HIWORD(lp);
+            ghostty_surface_mouse_pos(g_surface, x, y, current_mods());
+        }
+        return 0;
+
+    case WM_LBUTTONDOWN:
+        if (g_surface) {
+            SetCapture(g_hwnd);
+            ghostty_surface_mouse_button(g_surface,
+                GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, current_mods());
+        }
+        return 0;
+
+    case WM_LBUTTONUP:
+        if (g_surface) {
+            ReleaseCapture();
+            ghostty_surface_mouse_button(g_surface,
+                GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, current_mods());
+        }
+        return 0;
+
+    case WM_RBUTTONDOWN:
+        if (g_surface)
+            ghostty_surface_mouse_button(g_surface,
+                GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, current_mods());
+        return 0;
+
+    case WM_RBUTTONUP:
+        if (g_surface)
+            ghostty_surface_mouse_button(g_surface,
+                GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, current_mods());
+        return 0;
+
+    case WM_MOUSEWHEEL: {
+        if (!g_surface) break;
+        double delta = (double)GET_WHEEL_DELTA_WPARAM(wp) / WHEEL_DELTA;
+        // ghostty_input_scroll_mods_t is a packed int. 0 = no precision scroll.
+        ghostty_surface_mouse_scroll(g_surface, 0, delta, 0);
+        return 0;
+    }
+
     case WM_SIZE:
         if (g_surface) {
             ghostty_surface_set_size(g_surface, LOWORD(lp), HIWORD(lp));

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -124,7 +124,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdLine, int show) {
     }
 
     // 3. Initialize ghostty global state
-    char* argv[] = { "ghostty-example" };
+    const char* argv[] = { "ghostty-example" };
     if (ghostty_init(1, argv) != GHOSTTY_SUCCESS) {
         fprintf(stderr, "ghostty_init failed\n");
         return 1;


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked!
> - This PR
> - #70 <- **start here and bubble up**

## Summary

- WM_SIZE, WM_SETFOCUS, WM_KILLFOCUS, WM_DPICHANGED handlers
- Keyboard: scancode extraction from lParam (bits 16-23 + extended flag),
  modifier mapping, WM_KEYDOWN/WM_KEYUP/WM_CHAR forwarding with UTF-16
  surrogate pair handling for emoji and supplementary characters
- Mouse: WM_MOUSEMOVE, WM_LBUTTON*, WM_RBUTTON*, WM_MOUSEWHEEL,
  WM_MOUSEHWHEEL (horizontal scroll)
- GET_X_LPARAM/GET_Y_LPARAM for correct signed mouse coordinates during
  capture
- DefWindowProc fallthrough for unhandled messages when surface is not yet
  created

## Test plan

- [x] Code review: input handling matches ghostty C API signatures
- [x] Code review: UTF-16 surrogate pairs handled for supplementary chars
- [x] Code review: signed mouse coordinates via GET_X_LPARAM/GET_Y_LPARAM
- [x] Code review: DefWindowProc reached from all switch paths
- [x] Builds clean with MSVC (one pre-existing const warning)

Manual testing (keyboard, mouse, resize, DPI, scroll) blocked by DLL init
crash at this stage -- verified end-to-end in the next PR in the stack.

## What I learnt

- Win32 scancodes live in lParam bits 16-23, with bit 24 as the extended key
  flag (arrows, numpad). Extended keys need the 0xE000 prefix to match what
  ghostty expects
- ghostty_surface_text() takes UTF-8 but WM_CHAR gives UTF-16 code units -
  need WideCharToMultiByte conversion. Characters outside the BMP (emoji etc.)
  arrive as two separate WM_CHAR messages (high surrogate then low surrogate)
  that must be combined before converting
- Mouse capture (SetCapture/ReleaseCapture) is needed so drag events keep
  arriving even when the cursor leaves the window. LOWORD/HIWORD truncate
  negative coordinates -- use GET_X_LPARAM/GET_Y_LPARAM from windowsx.h
- When switch cases break out of a !g_surface guard, they must still reach
  DefWindowProc -- put it after the switch, not only in default