### PR TITLE
example: C Win32 terminal - integration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 > The `windows` branch is the default and contains all Windows-specific work
 > rebased on top of upstream `main`, which is synced daily.
 >
-> **Status:** Foundation done, working on renderer and app shell
+> **Status:** Foundation done, C Win32 example wiring app + renderer + input
 >
 > **MVWT** Minimum Viewable Windows Terminal
-> `[█████████░░░░░░░░░░░] 45%`
+> `[█████████░░░░░░░░░░░] 48%`
 >
 > **MVT** Moonshot Viable Terminal ([#26](https://github.com/deblasis/ghostty/issues/26))
 > `[░░░░░░░░░░░░░░░░░░░░]  0%`

--- a/build.zig
+++ b/build.zig
@@ -176,6 +176,12 @@ pub fn build(b: *std.Build) !void {
             lib_shared.installHeader(); // Only need one header
             if (config.target.result.os.tag == .windows) {
                 lib_shared.install("ghostty.dll");
+                if (lib_shared.implib) |implib| {
+                    b.getInstallStep().dependOn(&b.addInstallLibFile(
+                        implib,
+                        "ghostty.lib",
+                    ).step);
+                }
                 lib_static.install("ghostty-static.lib");
             } else {
                 lib_shared.install("libghostty.so");

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -3,3 +3,6 @@ dist/
 node_modules/
 example.wasm*
 build/
+*.exe
+*.pdb
+*.dll

--- a/example/c-win32-terminal/README.md
+++ b/example/c-win32-terminal/README.md
@@ -12,23 +12,70 @@ renderer, terminal, PTY).
 ## Prerequisites
 
 - Windows 10 or later
-- ghostty.dll and ghostty.lib built from the repo root:
+- ghostty.dll built from the repo root:
   ```
   just build-dll
   ```
-- MSVC (Visual Studio 2022) or MinGW-w64
+- An import library (ghostty.lib) -- see below
+- Zig 0.15+ (used as C compiler), or MSVC, or MinGW-w64
+
+## Creating the Import Library
+
+The build produces ghostty.dll but not the import library needed by the
+linker. Generate it from the DLL exports:
+
+```bash
+# From the repo root, after just build-dll:
+python3 -c "
+import struct
+dll = 'zig-out/lib/ghostty.dll'
+with open(dll, 'rb') as f: data = f.read()
+pe = struct.unpack_from('<I', data, 0x3C)[0]
+ns = struct.unpack_from('<H', data, pe+6)[0]
+so = pe + 264
+def r2o(rva):
+    for i in range(ns):
+        s = so + i*40
+        va = struct.unpack_from('<I', data, s+12)[0]
+        vs = struct.unpack_from('<I', data, s+8)[0]
+        ro = struct.unpack_from('<I', data, s+20)[0]
+        if va <= rva < va+vs: return rva-va+ro
+erva = struct.unpack_from('<I', data, pe+24+112)[0]
+eo = r2o(erva)
+nn = struct.unpack_from('<I', data, eo+24)[0]
+nto = r2o(struct.unpack_from('<I', data, eo+32)[0])
+names = []
+for i in range(nn):
+    nr = struct.unpack_from('<I', data, nto+i*4)[0]
+    no = r2o(nr); e = data.index(b'\0', no)
+    names.append(data[no:e].decode())
+with open('zig-out/lib/ghostty.def','w') as f:
+    f.write('LIBRARY ghostty\nEXPORTS\n')
+    for n in sorted(names): f.write(f'    {n}\n')
+"
+zig dlltool -m i386:x86-64 -d zig-out/lib/ghostty.def -l zig-out/lib/ghostty.lib
+```
 
 ## Build
 
-### MSVC
+### Using Zig as C compiler (recommended)
+
+```bash
+cd example/c-win32-terminal
+zig cc -target x86_64-windows-msvc src/main.c -I ../../include ../../zig-out/lib/ghostty.lib -luser32 -lgdi32 -o c_win32_terminal.exe
+```
+
+### MSVC (from Developer Command Prompt)
 
 ```bat
+cd example\c-win32-terminal
 cl.exe /I..\..\include src\main.c /link /LIBPATH:..\..\zig-out\lib ghostty.lib user32.lib
 ```
 
 ### MinGW-w64
 
 ```bash
+cd example/c-win32-terminal
 gcc -I../../include src/main.c -L../../zig-out/lib -lghostty -luser32 -o c_win32_terminal.exe
 ```
 

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -274,6 +274,11 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdLine, int show) {
     (void)hPrev; (void)cmdLine;
 
+    // Attach to parent console or allocate one so we can see stderr/stdout.
+    if (!AttachConsole(ATTACH_PARENT_PROCESS)) AllocConsole();
+    freopen("CONOUT$", "w", stdout);
+    freopen("CONOUT$", "w", stderr);
+
     // 1. Register window class
     WNDCLASSEX wc = {
         .cbSize = sizeof(wc),

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -10,8 +10,10 @@ const LipoStep = @import("LipoStep.zig");
 /// The step that generates the file.
 step: *std.Build.Step,
 
-/// The final static library file
+/// The final library file (DLL or static .lib/.a).
 output: std.Build.LazyPath,
+/// The import library for DLL builds on Windows (.lib), null otherwise.
+implib: ?std.Build.LazyPath = null,
 dsym: ?std.Build.LazyPath,
 
 pub fn initStatic(
@@ -157,6 +159,10 @@ pub fn initShared(
     return .{
         .step = &lib.step,
         .output = lib.getEmittedBin(),
+        .implib = if (deps.config.target.result.os.tag == .windows)
+            lib.getEmittedImplib()
+        else
+            null,
         .dsym = dsymutil,
     };
 }

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -140,7 +140,13 @@ pub fn initShaders(
 
 pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
     if (self.device) |dev| {
-        return .{ .width = dev.width, .height = dev.height };
+        // Query the actual window size, not the swap chain buffer size.
+        // The swap chain buffer is only resized in beginFrame, so returning
+        // dev.width/height here would create a circular dependency: drawFrame
+        // compares surfaceSize() against self.size.screen to detect resize,
+        // but dev.width/height only change after the resize is detected.
+        const ws = dev.windowSize();
+        return .{ .width = ws.width, .height = ws.height };
     }
     return .{ .width = 0, .height = 0 };
 }
@@ -159,6 +165,23 @@ pub inline fn beginFrame(
     target: *Target,
 ) !Frame {
     _ = self;
+
+    // Resize the swap chain if the target dimensions don't match the
+    // back buffer. initTarget can't do this because it receives the
+    // API by value (const), but beginFrame has mutable access through
+    // the renderer. device is ?Device (inline), so we need &renderer.api.
+    if (renderer.api.device) |*dev| {
+        const w: u32 = @intCast(target.width);
+        const h: u32 = @intCast(target.height);
+        if (dev.width != w or dev.height != h) {
+            dev.resize(w, h) catch |err| {
+                log.err("swap chain resize failed: {}", .{err});
+                return error.PresentFailed;
+            };
+            target.rtv = dev.rtv;
+        }
+    }
+
     return try Frame.begin(.{}, renderer, target);
 }
 
@@ -185,9 +208,22 @@ pub inline fn bufferOptions(self: DirectX11) bufferpkg.Options {
 /// bound to the IA stage as vertex data via IASetVertexBuffers.
 pub const instanceBufferOptions = bufferOptions;
 pub const fgBufferOptions = bufferOptions;
-pub const bgBufferOptions = bufferOptions;
 pub const imageBufferOptions = bufferOptions;
 pub const bgImageBufferOptions = bufferOptions;
+
+/// Cell background buffer is bound as StructuredBuffer<uint> in HLSL,
+/// not as a vertex buffer. It needs SHADER_RESOURCE binding and a
+/// structure stride so the GPU can index into it by element.
+pub inline fn bgBufferOptions(self: DirectX11) bufferpkg.Options {
+    const dev = self.device orelse @panic("DX11 device not initialized");
+    return .{
+        .device = dev.device,
+        .context = dev.context,
+        .usage = .dynamic,
+        .bind_flags = d3d11.D3D11_BIND_SHADER_RESOURCE,
+        .structure_byte_stride = @sizeOf(u32),
+    };
+}
 
 /// Uniform buffers are bound as constant buffers (HLSL cbuffer).
 /// DX11 requires constant buffer sizes to be a multiple of 16 bytes.

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -45,4 +45,9 @@ pub fn complete(self: *@This(), sync: bool) void {
             log.err("present failed: {}", .{err});
         };
     }
+
+    // Release the frame back to the swap chain so the next drawFrame
+    // can acquire it. Without this, the semaphore in SwapChain.nextFrame
+    // runs out of permits after buf_count frames and blocks forever.
+    self.renderer.frameCompleted(.healthy);
 }

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -6,6 +6,7 @@ const DirectX11 = @import("../DirectX11.zig");
 const Renderer = @import("../generic.zig").Renderer(DirectX11);
 const Target = @import("Target.zig");
 const RenderPass = @import("RenderPass.zig");
+const Health = @import("../../renderer.zig").Health;
 
 /// Options for beginning a frame.
 pub const Options = struct {};
@@ -40,14 +41,16 @@ pub fn complete(self: *@This(), sync: bool) void {
     _ = sync;
     // DX11 immediate mode: draw commands already executed on the device
     // context. Present the swap chain to show the frame.
+    var health: Health = .healthy;
     if (self.renderer.api.device) |*dev| {
         dev.present() catch |err| {
             log.err("present failed: {}", .{err});
+            health = .unhealthy;
         };
     }
 
     // Release the frame back to the swap chain so the next drawFrame
     // can acquire it. Without this, the semaphore in SwapChain.nextFrame
     // runs out of permits after buf_count frames and blocks forever.
-    self.renderer.frameCompleted(.healthy);
+    self.renderer.frameCompleted(health);
 }

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -1,4 +1,7 @@
 //! Frame context for DX11 draw commands.
+const std = @import("std");
+const log = std.log.scoped(.directx11);
+
 const DirectX11 = @import("../DirectX11.zig");
 const Renderer = @import("../generic.zig").Renderer(DirectX11);
 const Target = @import("Target.zig");
@@ -34,8 +37,12 @@ pub inline fn renderPass(
 }
 
 pub fn complete(self: *@This(), sync: bool) void {
-    // DX11 immediate mode: commands already executed. Present happens in
-    // presentLastTarget(), called by GenericRenderer after frame completion.
-    _ = self;
     _ = sync;
+    // DX11 immediate mode: draw commands already executed on the device
+    // context. Present the swap chain to show the frame.
+    if (self.renderer.api.device) |*dev| {
+        dev.present() catch |err| {
+            log.err("present failed: {}", .{err});
+        };
+    }
 }

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -128,16 +128,15 @@ pub fn step(self: *@This(), s: Step) void {
         .triangle_strip => .TRIANGLESTRIP,
     });
 
-    // Bind vertex buffers with stride from the pipeline's input layout.
-    // Why: Metal reserves slot 0 for vertex data and slot 1 for uniforms,
-    // starting additional buffers at slot 2. DX11 doesn't need that
-    // workaround -- uniforms go through constant buffers (a separate
-    // binding point), so vertex buffers bind at their natural index.
-    for (s.buffers, 0..) |buf_opt, i| {
-        if (buf_opt) |buf| {
+    // Bind buffers[0] as vertex buffer, buffers[1..] as SRVs.
+    // Mirrors OpenGL which binds buffers[0] as vertex data and
+    // buffers[1..] as storage buffers (SSBOs). In DX11, the SSBO
+    // equivalent is a StructuredBuffer bound via an SRV.
+    if (s.buffers.len > 0) {
+        if (s.buffers[0]) |buf| {
             ctx.IASetVertexBuffers(
-                @intCast(i),
-                &.{@as(?*d3d11.ID3D11Buffer, buf)},
+                0,
+                &.{@as(?*d3d11.ID3D11Buffer, buf.ptr)},
                 &.{s.pipeline.instance_stride},
                 &.{@as(u32, 0)},
             );
@@ -149,16 +148,33 @@ pub fn step(self: *@This(), s: Step) void {
     // buffers, so slot 0 here doesn't conflict with IASetVertexBuffers
     // slot 0 above. Metal uses buffer index 1 for uniforms instead.
     if (s.uniforms) |buf| {
-        ctx.VSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf)});
-        ctx.PSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf)});
+        ctx.VSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf.ptr)});
+        ctx.PSSetConstantBuffers(0, &.{@as(?*d3d11.ID3D11Buffer, buf.ptr)});
     }
 
     // Bind textures as shader resource views for both VS and PS.
+    // Textures occupy t-register slots 0..N-1.
     for (s.textures, 0..) |tex_opt, i| {
         if (tex_opt) |tex| {
             const srv = @as(?*d3d11.ID3D11ShaderResourceView, tex.srv);
             ctx.VSSetShaderResources(@intCast(i), &.{srv});
             ctx.PSSetShaderResources(@intCast(i), &.{srv});
+        }
+    }
+
+    // Bind structured buffers (buffers[1..]) as SRVs, continuing
+    // after the texture slots. HLSL registers are:
+    //   bg_color/cell_bg: cell_bg_colors at t0 (no textures)
+    //   cell_text: atlases at t0,t1, cell_bg_colors at t2
+    if (s.buffers.len > 1) {
+        for (s.buffers[1..], 0..) |buf_opt, i| {
+            if (buf_opt) |buf| {
+                if (buf.srv) |srv| {
+                    const slot: u32 = @intCast(s.textures.len + i);
+                    ctx.VSSetShaderResources(slot, &.{@as(?*d3d11.ID3D11ShaderResourceView, srv)});
+                    ctx.PSSetShaderResources(slot, &.{@as(?*d3d11.ID3D11ShaderResourceView, srv)});
+                }
+            }
         }
     }
 

--- a/src/renderer/directx11/buffer.zig
+++ b/src/renderer/directx11/buffer.zig
@@ -7,7 +7,14 @@ const log = std.log.scoped(.directx11);
 /// Type-erased buffer handle for passing to RenderPass.Step.
 /// Mirrors Metal's objc.Object and OpenGL's gl.Buffer -- lets
 /// GenericRenderer pass uniform/vertex buffers without knowing T.
-pub const RawBuffer = *d3d11.ID3D11Buffer;
+///
+/// Carries an optional SRV for buffers that are bound as
+/// StructuredBuffer in HLSL (e.g. cell_bg_colors at register(t0)).
+/// Vertex and constant buffers leave srv as null.
+pub const RawBuffer = struct {
+    ptr: *d3d11.ID3D11Buffer,
+    srv: ?*d3d11.ID3D11ShaderResourceView = null,
+};
 
 /// Options for initializing a buffer.
 pub const Options = struct {
@@ -15,6 +22,10 @@ pub const Options = struct {
     context: *d3d11.ID3D11DeviceContext,
     usage: Usage = .dynamic,
     bind_flags: d3d11.D3D11_BIND_FLAG = d3d11.D3D11_BIND_VERTEX_BUFFER,
+    /// Set to @sizeOf(T) for StructuredBuffer bindings.
+    /// When non-zero, the buffer is created with MISC_BUFFER_STRUCTURED
+    /// and an SRV is created for shader access.
+    structure_byte_stride: u32 = 0,
 };
 
 pub const Usage = enum {
@@ -46,16 +57,17 @@ pub fn Buffer(comptime T: type) type {
         /// The options this buffer was initialized with.
         opts: Options,
 
-        /// The underlying ID3D11Buffer COM object.
-        buffer: *d3d11.ID3D11Buffer,
+        /// The underlying ID3D11Buffer and optional SRV for structured buffers.
+        buffer: RawBuffer,
 
         /// The allocated capacity in number of T elements (not bytes).
         len: usize,
 
         pub fn init(opts: Options, len: usize) !Self {
             const byte_size = validateAndComputeSize(opts, len);
-            const buffer = try createBuffer(opts, byte_size, null);
-            return .{ .opts = opts, .buffer = buffer, .len = len };
+            const buf = try createBuffer(opts, byte_size, null);
+            const srv = try createSRV(opts, buf, len);
+            return .{ .opts = opts, .buffer = .{ .ptr = buf, .srv = srv }, .len = len };
         }
 
         /// Init the buffer filled with the given data.
@@ -66,12 +78,14 @@ pub fn Buffer(comptime T: type) type {
                 .SysMemPitch = 0,
                 .SysMemSlicePitch = 0,
             };
-            const buffer = try createBuffer(opts, byte_size, &initial_data);
-            return .{ .opts = opts, .buffer = buffer, .len = data.len };
+            const buf = try createBuffer(opts, byte_size, &initial_data);
+            const srv = try createSRV(opts, buf, data.len);
+            return .{ .opts = opts, .buffer = .{ .ptr = buf, .srv = srv }, .len = data.len };
         }
 
         pub fn deinit(self: *const Self) void {
-            _ = self.buffer.Release();
+            if (self.buffer.srv) |srv| _ = srv.Release();
+            _ = self.buffer.ptr.Release();
         }
 
         /// Sync new contents to the buffer, replacing everything.
@@ -91,11 +105,14 @@ pub fn Buffer(comptime T: type) type {
             // WRITE_DISCARD rotates which allocation you write to, but
             // it can't grow the allocation -- that requires a new buffer.
             if (req_bytes > self.len * @sizeOf(T)) {
-                _ = self.buffer.Release();
+                if (self.buffer.srv) |srv| _ = srv.Release();
+                _ = self.buffer.ptr.Release();
                 // Allocate 2x what we need to amortize future growth.
                 const new_len = data.len * 2;
                 const new_byte_size = validateAndComputeSize(self.opts, new_len);
-                self.buffer = try createBuffer(self.opts, new_byte_size, null);
+                const buf = try createBuffer(self.opts, new_byte_size, null);
+                const srv = try createSRV(self.opts, buf, new_len);
+                self.buffer = .{ .ptr = buf, .srv = srv };
                 self.len = new_len;
             }
 
@@ -103,7 +120,7 @@ pub fn Buffer(comptime T: type) type {
             // fresh allocation -- no need to worry about what the GPU is reading.
             var mapped: d3d11.D3D11_MAPPED_SUBRESOURCE = undefined;
             const hr = self.opts.context.Map(
-                @ptrCast(self.buffer),
+                @ptrCast(self.buffer.ptr),
                 0,
                 .WRITE_DISCARD,
                 0,
@@ -116,13 +133,13 @@ pub fn Buffer(comptime T: type) type {
 
             const dst: [*]u8 = @ptrCast(mapped.pData orelse {
                 log.warn("Buffer.sync: Map returned null pData", .{});
-                self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+                self.opts.context.Unmap(@ptrCast(self.buffer.ptr), 0);
                 return error.DirectXFailed;
             });
             const src: [*]const u8 = @ptrCast(data.ptr);
             @memcpy(dst[0..req_bytes], src[0..req_bytes]);
 
-            self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+            self.opts.context.Unmap(@ptrCast(self.buffer.ptr), 0);
         }
 
         /// Like sync but takes data from an array of ArrayLists.
@@ -139,16 +156,19 @@ pub fn Buffer(comptime T: type) type {
             const req_bytes = total_len * @sizeOf(T);
 
             if (req_bytes > self.len * @sizeOf(T)) {
-                _ = self.buffer.Release();
+                if (self.buffer.srv) |srv| _ = srv.Release();
+                _ = self.buffer.ptr.Release();
                 const new_len = total_len * 2;
                 const new_byte_size = validateAndComputeSize(self.opts, new_len);
-                self.buffer = try createBuffer(self.opts, new_byte_size, null);
+                const buf = try createBuffer(self.opts, new_byte_size, null);
+                const new_srv = try createSRV(self.opts, buf, new_len);
+                self.buffer = .{ .ptr = buf, .srv = new_srv };
                 self.len = new_len;
             }
 
             var mapped: d3d11.D3D11_MAPPED_SUBRESOURCE = undefined;
             const hr = self.opts.context.Map(
-                @ptrCast(self.buffer),
+                @ptrCast(self.buffer.ptr),
                 0,
                 .WRITE_DISCARD,
                 0,
@@ -161,7 +181,7 @@ pub fn Buffer(comptime T: type) type {
 
             const dst: [*]u8 = @ptrCast(mapped.pData orelse {
                 log.warn("Buffer.syncFromArrayLists: Map returned null pData", .{});
-                self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+                self.opts.context.Unmap(@ptrCast(self.buffer.ptr), 0);
                 return error.DirectXFailed;
             });
 
@@ -173,7 +193,7 @@ pub fn Buffer(comptime T: type) type {
                 offset += chunk_bytes;
             }
 
-            self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+            self.opts.context.Unmap(@ptrCast(self.buffer.ptr), 0);
 
             return total_len;
         }
@@ -187,7 +207,7 @@ pub fn Buffer(comptime T: type) type {
 
             var mapped: d3d11.D3D11_MAPPED_SUBRESOURCE = undefined;
             const hr = self.opts.context.Map(
-                @ptrCast(self.buffer),
+                @ptrCast(self.buffer.ptr),
                 0,
                 .WRITE_DISCARD,
                 0,
@@ -200,14 +220,14 @@ pub fn Buffer(comptime T: type) type {
 
             const ptr: [*]T = @ptrCast(@alignCast(mapped.pData orelse {
                 log.warn("Buffer.map: Map returned null pData", .{});
-                self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+                self.opts.context.Unmap(@ptrCast(self.buffer.ptr), 0);
                 return error.DirectXFailed;
             }));
             return ptr[0..len];
         }
 
         pub fn unmap(self: *Self) void {
-            self.opts.context.Unmap(@ptrCast(self.buffer), 0);
+            self.opts.context.Unmap(@ptrCast(self.buffer.ptr), 0);
         }
 
         /// Resize the buffer, discarding old contents.
@@ -215,9 +235,12 @@ pub fn Buffer(comptime T: type) type {
         /// Used when the terminal grid size changes and we need
         /// a buffer of a completely different capacity.
         pub fn resize(self: *Self, new_len: usize) !void {
-            _ = self.buffer.Release();
+            if (self.buffer.srv) |srv| _ = srv.Release();
+            _ = self.buffer.ptr.Release();
             const byte_size = validateAndComputeSize(self.opts, new_len);
-            self.buffer = try createBuffer(self.opts, byte_size, null);
+            const buf = try createBuffer(self.opts, byte_size, null);
+            const srv = try createSRV(self.opts, buf, new_len);
+            self.buffer = .{ .ptr = buf, .srv = srv };
             self.len = new_len;
         }
 
@@ -244,13 +267,14 @@ pub fn Buffer(comptime T: type) type {
             byte_size: u32,
             initial_data: ?*const d3d11.D3D11_SUBRESOURCE_DATA,
         ) !*d3d11.ID3D11Buffer {
+            const is_structured = opts.structure_byte_stride > 0;
             const desc = d3d11.D3D11_BUFFER_DESC{
                 .ByteWidth = byte_size,
                 .Usage = .DYNAMIC,
                 .BindFlags = opts.bind_flags,
                 .CPUAccessFlags = d3d11.D3D11_CPU_ACCESS_WRITE,
-                .MiscFlags = 0,
-                .StructureByteStride = 0,
+                .MiscFlags = if (is_structured) d3d11.D3D11_RESOURCE_MISC_BUFFER_STRUCTURED else 0,
+                .StructureByteStride = opts.structure_byte_stride,
             };
             var buffer: ?*d3d11.ID3D11Buffer = null;
             const hr = opts.device.CreateBuffer(&desc, initial_data, &buffer);
@@ -259,6 +283,36 @@ pub fn Buffer(comptime T: type) type {
                 return error.DirectXFailed;
             }
             return buffer orelse error.DirectXFailed;
+        }
+
+        /// Create an SRV for structured buffers so the shader can read
+        /// them as StructuredBuffer<T>. Returns null for non-structured
+        /// buffers (vertex, constant).
+        fn createSRV(
+            opts: Options,
+            buf: *d3d11.ID3D11Buffer,
+            num_elements: usize,
+        ) !?*d3d11.ID3D11ShaderResourceView {
+            if (opts.structure_byte_stride == 0) return null;
+
+            const desc = d3d11.D3D11_SHADER_RESOURCE_VIEW_DESC{
+                .Format = .UNKNOWN,
+                .ViewDimension = .BUFFER,
+                // Buffer union: FirstElement = MostDetailedMip, NumElements = MipLevels
+                .MostDetailedMip = 0,
+                .MipLevels = @intCast(num_elements),
+            };
+            var srv: ?*d3d11.ID3D11ShaderResourceView = null;
+            const hr = opts.device.CreateShaderResourceView(
+                @ptrCast(buf),
+                &desc,
+                &srv,
+            );
+            if (com.FAILED(hr)) {
+                log.err("CreateShaderResourceView for structured buffer failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.DirectXFailed;
+            }
+            return srv orelse error.DirectXFailed;
         }
     };
 }

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -48,6 +48,9 @@ pub const D3D11_CPU_ACCESS_FLAG = u32;
 pub const D3D11_CPU_ACCESS_WRITE: D3D11_CPU_ACCESS_FLAG = 0x10000;
 pub const D3D11_CPU_ACCESS_READ: D3D11_CPU_ACCESS_FLAG = 0x20000;
 
+pub const D3D11_RESOURCE_MISC_FLAG = u32;
+pub const D3D11_RESOURCE_MISC_BUFFER_STRUCTURED: D3D11_RESOURCE_MISC_FLAG = 0x40;
+
 pub const D3D11_MAP = enum(u32) {
     READ = 1,
     WRITE = 2,
@@ -177,15 +180,16 @@ pub const D3D11_SRV_DIMENSION = enum(u32) {
     BUFFEREX = 11,
 };
 
-/// Describes a shader resource view. We only support the Texture2D dimension.
-/// The full C type has a union of all SRV dimensions at offset 8 -- we model
-/// only Texture2D because that's all the font atlas needs. If other SRV types
-/// are needed later, this struct would need the full union.
+/// Describes a shader resource view.
+/// The union at offset 8 overlaps Texture2D { MostDetailedMip, MipLevels }
+/// with Buffer { FirstElement, NumElements }. Both are two u32s at the same
+/// offset, so we name the fields after the Texture2D variant and reuse them
+/// for buffer SRVs (FirstElement = MostDetailedMip, NumElements = MipLevels).
 pub const D3D11_SHADER_RESOURCE_VIEW_DESC = extern struct {
     Format: DXGI_FORMAT,
     ViewDimension: D3D11_SRV_DIMENSION,
-    // Texture2D union member: { MostDetailedMip: u32, MipLevels: u32 }
-    // followed by padding to fill the 16-byte union.
+    // Texture2D: { MostDetailedMip, MipLevels }
+    // Buffer:    { FirstElement, NumElements }
     MostDetailedMip: u32,
     MipLevels: u32,
     _pad: [2]u32 = .{ 0, 0 },

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -15,12 +15,24 @@ pub const Surface = union(enum) {
     swap_chain_panel: *dxgi.ISwapChainPanelNative,
 };
 
+pub const RECT = extern struct {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+};
+
+extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) i32;
+
 pub const Device = struct {
     device: *d3d11.ID3D11Device,
     context: *d3d11.ID3D11DeviceContext,
     swap_chain: *dxgi.IDXGISwapChain1,
     panel_native: ?*dxgi.ISwapChainPanelNative,
     rtv: ?*d3d11.ID3D11RenderTargetView,
+    /// The HWND for querying the actual window size.
+    /// Null for composition (SwapChainPanel) surfaces.
+    hwnd: ?HWND,
     width: u32,
     height: u32,
 
@@ -170,6 +182,10 @@ pub const Device = struct {
             .swap_chain = sc,
             .panel_native = panel_native,
             .rtv = rtv,
+            .hwnd = switch (surface) {
+                .hwnd => |h| h,
+                .swap_chain_panel => null,
+            },
             .width = width,
             .height = height,
         };
@@ -191,6 +207,21 @@ pub const Device = struct {
         _ = self.swap_chain.Release();
         _ = self.context.Release();
         _ = self.device.Release();
+    }
+
+    /// Return the actual window client area size.
+    /// Falls back to the swap chain buffer dimensions when there's
+    /// no HWND (composition surfaces).
+    pub fn windowSize(self: *const Device) struct { width: u32, height: u32 } {
+        if (self.hwnd) |hwnd| {
+            var rc: RECT = undefined;
+            if (GetClientRect(hwnd, &rc) != 0) {
+                const w: u32 = @intCast(rc.right - rc.left);
+                const h: u32 = @intCast(rc.bottom - rc.top);
+                if (w > 0 and h > 0) return .{ .width = w, .height = h };
+            }
+        }
+        return .{ .width = self.width, .height = self.height };
     }
 
     pub const ResizeError = error{

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -252,8 +252,11 @@ pub fn focusGained(
         // only do this if it isn't already running. We use the termios
         // callback because that'll trigger an immediate state check AND
         // start the timer.
-        if (execdata.termios_timer_c.state() != .active) {
-            _ = termiosTimer(td, undefined, undefined, {});
+        // Skip on Windows where termios polling is not yet implemented.
+        if (comptime builtin.os.tag != .windows) {
+            if (execdata.termios_timer_c.state() != .active) {
+                _ = termiosTimer(td, undefined, undefined, {});
+            }
         }
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked!
> - This PR
> - #71
> - #70 <- **start here and bubble up**

## Summary

- **build: install import library alongside ghostty.dll** - `getEmittedImplib()`
  produces `ghostty.lib` so the example can link without manual `dlltool` steps
- **fix: guard termios timer in focusGained on Windows** - the POSIX timer call
  panicked on Windows, now guarded with a comptime os check
- **fix: set surface visible and focused after ShowWindow** - without
  `ghostty_surface_set_occlusion(true)` + `set_focus(true)`, the renderer
  skipped all draw calls
- **fix: present swap chain after full frame redraw** - `Frame.complete()` was
  a no-op so the DX11 back buffer was never shown (window stayed white)
- **fix: release swap chain frame after present** - `frameCompleted(.healthy)`
  was missing, so the swap chain semaphore ran out of permits after 2 frames
  and `nextFrame()` blocked forever

After these fixes the example renders a working cmd.exe terminal with text,
cursor, and cell backgrounds visible.

<img width="1136" height="628" alt="image" src="https://github.com/user-attachments/assets/9205f104-76d5-4c2e-ac34-9c533b19d06a" />



## Test plan

- [x] `zig build -Dapp-runtime=none` builds the DLL
- [x] Example compiles and runs showing a cmd.exe prompt
- [x] Text is visible and keyboard input works
- [x] Window doesn't freeze after 2 frames (the semaphore fix)

## What I learnt

- DX11 immediate mode means draw commands execute right away on the device
  context, unlike Metal which records into a command buffer. But you still
  need to call Present() to flip the swap chain - "executed" doesn't mean
  "visible"
- GenericRenderer uses a semaphore-based swap chain with buf_count permits.
  Every nextFrame() takes a permit, every frameCompleted() returns one.
  Missing the return = deadlock after buf_count frames. It's like a bounded
  channel in Go - if nobody reads, the writer blocks
- The "white window" and "frozen after 2 frames" were two separate bugs in
  the same function (Frame.complete). Easy to conflate during debugging but
  they have different root causes: missing present vs missing semaphore release