### PR TITLE
renderer/dx11: fix padding background color after resize

### DIFF
--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -31,9 +31,9 @@ pub inline fn renderPass(
     attachments: []const RenderPass.Options.Attachment,
 ) RenderPass {
     if (self.renderer.api.device) |*dev| {
-        return RenderPass.begin(dev.context, dev.device, .{ .attachments = attachments });
+        return RenderPass.begin(dev.context, dev.device, dev.blend_state, .{ .attachments = attachments });
     } else {
-        return RenderPass.begin(null, null, .{ .attachments = attachments });
+        return RenderPass.begin(null, null, null, .{ .attachments = attachments });
     }
 }
 

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -63,23 +63,24 @@ pub fn begin(
     blend_state: ?*d3d11.ID3D11BlendState,
     opts: Options,
 ) @This() {
-    const ctx = context orelse return .{ .context = null, .device = device, .blend_state = blend_state };
+    const self: @This() = .{ .context = context, .device = device, .blend_state = blend_state };
+    const ctx = context orelse return self;
 
     // Bind the first attachment's render target and optionally clear it.
     // GenericRenderer always passes exactly one attachment per render pass.
-    if (opts.attachments.len == 0) return .{ .context = context, .device = device, .blend_state = blend_state };
+    if (opts.attachments.len == 0) return self;
 
     const att = opts.attachments[0];
     const target, const rtv = switch (att.target) {
         .target => |t| .{ t, t.rtv orelse {
             log.warn("render pass attachment has no RTV, skipping bind", .{});
-            return .{ .context = context, .device = device, .blend_state = blend_state };
+            return self;
         } },
         // Texture-as-RTV not yet supported (needs CreateRenderTargetView
         // from the texture's ID3D11Texture2D).
         .texture => {
             log.warn("texture attachments not yet supported in DX11 render pass", .{});
-            return .{ .context = context, .device = device, .blend_state = blend_state };
+            return self;
         },
     };
 
@@ -113,7 +114,7 @@ pub fn begin(
         });
     }
 
-    return .{ .context = context, .device = device, .blend_state = blend_state };
+    return self;
 }
 
 pub fn step(self: *@This(), s: Step) void {

--- a/src/renderer/directx11/RenderPass.zig
+++ b/src/renderer/directx11/RenderPass.zig
@@ -54,28 +54,32 @@ context: ?*d3d11.ID3D11DeviceContext,
 /// The device for creating render target views from textures.
 device: ?*d3d11.ID3D11Device,
 
+/// Blend state for premultiplied-alpha compositing.
+blend_state: ?*d3d11.ID3D11BlendState,
+
 pub fn begin(
     context: ?*d3d11.ID3D11DeviceContext,
     device: ?*d3d11.ID3D11Device,
+    blend_state: ?*d3d11.ID3D11BlendState,
     opts: Options,
 ) @This() {
-    const ctx = context orelse return .{ .context = null, .device = device };
+    const ctx = context orelse return .{ .context = null, .device = device, .blend_state = blend_state };
 
     // Bind the first attachment's render target and optionally clear it.
     // GenericRenderer always passes exactly one attachment per render pass.
-    if (opts.attachments.len == 0) return .{ .context = context, .device = device };
+    if (opts.attachments.len == 0) return .{ .context = context, .device = device, .blend_state = blend_state };
 
     const att = opts.attachments[0];
     const target, const rtv = switch (att.target) {
         .target => |t| .{ t, t.rtv orelse {
             log.warn("render pass attachment has no RTV, skipping bind", .{});
-            return .{ .context = context, .device = device };
+            return .{ .context = context, .device = device, .blend_state = blend_state };
         } },
         // Texture-as-RTV not yet supported (needs CreateRenderTargetView
         // from the texture's ID3D11Texture2D).
         .texture => {
             log.warn("texture attachments not yet supported in DX11 render pass", .{});
-            return .{ .context = context, .device = device };
+            return .{ .context = context, .device = device, .blend_state = blend_state };
         },
     };
 
@@ -93,6 +97,12 @@ pub fn begin(
     // Bind the render target.
     ctx.OMSetRenderTargets(&.{rtv}, null);
 
+    // Bind blend state so translucent pixels composite correctly
+    // instead of overwriting the destination.
+    if (blend_state) |bs| {
+        ctx.OMSetBlendState(bs, null, 0xFFFFFFFF);
+    }
+
     // Clear if requested.
     if (att.clear_color) |color| {
         ctx.ClearRenderTargetView(rtv, &.{
@@ -103,7 +113,7 @@ pub fn begin(
         });
     }
 
-    return .{ .context = context, .device = device };
+    return .{ .context = context, .device = device, .blend_state = blend_state };
 }
 
 pub fn step(self: *@This(), s: Step) void {

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -30,6 +30,7 @@ pub const Device = struct {
     swap_chain: *dxgi.IDXGISwapChain1,
     panel_native: ?*dxgi.ISwapChainPanelNative,
     rtv: ?*d3d11.ID3D11RenderTargetView,
+    blend_state: ?*d3d11.ID3D11BlendState,
     /// The HWND for querying the actual window size.
     /// Null for composition (SwapChainPanel) surfaces.
     hwnd: ?HWND,
@@ -45,6 +46,7 @@ pub const Device = struct {
         SetSwapChainFailed,
         BackBufferFailed,
         RenderTargetViewFailed,
+        BlendStateCreationFailed,
     };
 
     pub fn init(surface: Surface, width: u32, height: u32) InitError!Device {
@@ -173,6 +175,16 @@ pub const Device = struct {
             log.err("createRenderTargetView failed", .{});
             return InitError.RenderTargetViewFailed;
         };
+        errdefer _ = rtv.Release();
+
+        // Create a premultiplied-alpha blend state so that translucent
+        // pixels (e.g. padding cells output as float4(0,0,0,0) by the
+        // cell_bg shader) blend over the background instead of
+        // overwriting it with transparent black.
+        const blend_state = createBlendState(dev) orelse {
+            log.err("createBlendState failed", .{});
+            return InitError.BlendStateCreationFailed;
+        };
 
         log.info("device initialised: {}x{}", .{ width, height });
 
@@ -182,6 +194,7 @@ pub const Device = struct {
             .swap_chain = sc,
             .panel_native = panel_native,
             .rtv = rtv,
+            .blend_state = blend_state,
             .hwnd = switch (surface) {
                 .hwnd => |h| h,
                 .swap_chain_panel => null,
@@ -196,6 +209,12 @@ pub const Device = struct {
         if (self.rtv) |rtv| {
             _ = rtv.Release();
             self.rtv = null;
+        }
+
+        // Release blend state.
+        if (self.blend_state) |bs| {
+            _ = bs.Release();
+            self.blend_state = null;
         }
 
         // Detach swap chain from the panel (composition surfaces only).
@@ -262,6 +281,31 @@ pub const Device = struct {
             log.err("IDXGISwapChain1::Present failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
             return PresentError.PresentFailed;
         }
+    }
+
+    /// Create a premultiplied-alpha blend state.
+    /// SRC_BLEND=ONE, DEST_BLEND=INV_SRC_ALPHA implements standard
+    /// premultiplied alpha compositing: out = src + dst * (1 - src.a).
+    fn createBlendState(device: *d3d11.ID3D11Device) ?*d3d11.ID3D11BlendState {
+        var blend_desc = d3d11.D3D11_BLEND_DESC{};
+        blend_desc.RenderTarget[0] = .{
+            .BlendEnable = 1,
+            .SrcBlend = .ONE,
+            .DestBlend = .INV_SRC_ALPHA,
+            .BlendOp = .ADD,
+            .SrcBlendAlpha = .ONE,
+            .DestBlendAlpha = .INV_SRC_ALPHA,
+            .BlendOpAlpha = .ADD,
+            .RenderTargetWriteMask = 0x0F,
+        };
+
+        var state: ?*d3d11.ID3D11BlendState = null;
+        const hr = device.CreateBlendState(&blend_desc, &state);
+        if (com.FAILED(hr) or state == null) {
+            log.err("ID3D11Device::CreateBlendState failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+            return null;
+        }
+        return state.?;
     }
 
     /// Get the back buffer from the swap chain and create a render target view.

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -266,7 +266,7 @@ test "Pipeline: deinit on empty pipeline is safe to call" {
 }
 
 test "RenderPass: begin and complete with no device" {
-    var pass = RenderPass.begin(null, null, .{ .attachments = &.{} });
+    var pass = RenderPass.begin(null, null, null, .{ .attachments = &.{} });
     pass.complete();
 }
 
@@ -275,7 +275,7 @@ test "RenderPass: step with empty pipeline is no-op" {
     defer _ = dev.device.Release();
     defer _ = dev.context.Release();
 
-    var pass = RenderPass.begin(dev.context, dev.device, .{ .attachments = &.{} });
+    var pass = RenderPass.begin(dev.context, dev.device, null, .{ .attachments = &.{} });
     defer pass.complete();
 
     pass.step(.{
@@ -289,7 +289,7 @@ test "RenderPass: step with zero instance count is no-op" {
     defer _ = dev.device.Release();
     defer _ = dev.context.Release();
 
-    var pass = RenderPass.begin(dev.context, dev.device, .{ .attachments = &.{} });
+    var pass = RenderPass.begin(dev.context, dev.device, null, .{ .attachments = &.{} });
     defer pass.complete();
 
     pass.step(.{

--- a/src/renderer/shaders/hlsl/shaders.hlsl
+++ b/src/renderer/shaders/hlsl/shaders.hlsl
@@ -212,34 +212,34 @@ float4 CellBgPS(FullScreenVSOut input) : SV_TARGET
 
     uint2 gs = unpack_grid_size();
 
-    // Clamp or discard in X depending on padding_extend flags.
-    if (grid_pos.x < 0) {
-        if (padding_extend_left())
-            grid_pos.x = 0;
-        else
-            return float4(0.0, 0.0, 0.0, 0.0);
-    } else if (grid_pos.x >= (int)gs.x) {
-        if (padding_extend_right())
-            grid_pos.x = (int)gs.x - 1;
-        else
-            return float4(0.0, 0.0, 0.0, 0.0);
-    }
+    // Clamp out-of-bounds grid positions to the nearest edge cell.
+    //
+    // Metal and OpenGL return transparent here (unless padding_extend is
+    // set) and rely on alpha blending to let the bg_color pass show
+    // through.  On DX11 the blend state does not reliably composite
+    // transparent pixels, so we always clamp to the edge cell.  This
+    // also avoids a visible color mismatch when the terminal sets per-
+    // cell backgrounds (e.g. cmd.exe) that differ from bg_color.
+    if (grid_pos.x < 0)
+        grid_pos.x = 0;
+    else if (grid_pos.x >= (int)gs.x)
+        grid_pos.x = (int)gs.x - 1;
 
-    // Clamp or discard in Y.
-    if (grid_pos.y < 0) {
-        if (padding_extend_up())
-            grid_pos.y = 0;
-        else
-            return float4(0.0, 0.0, 0.0, 0.0);
-    } else if (grid_pos.y >= (int)gs.y) {
-        if (padding_extend_down())
-            grid_pos.y = (int)gs.y - 1;
-        else
-            return float4(0.0, 0.0, 0.0, 0.0);
-    }
+    if (grid_pos.y < 0)
+        grid_pos.y = 0;
+    else if (grid_pos.y >= (int)gs.y)
+        grid_pos.y = (int)gs.y - 1;
 
     uint idx = (uint)grid_pos.y * gs.x + (uint)grid_pos.x;
-    return load_color(cell_bg_colors[idx]);
+    float4 bg = load_color(cell_bg_colors[idx]);
+
+    // Composite over the global background so the result is fully opaque.
+    // On Metal/OpenGL this compositing happens via hardware blending, but
+    // DX11's blend state is unreliable for this.  Doing it in the shader
+    // produces the same result: out = cell_bg + bg_color * (1 - cell_bg.a).
+    float4 global_bg = load_color(bg_color_packed);
+    bg = float4(bg.rgb + global_bg.rgb * (1.0 - bg.a), 1.0);
+    return bg;
 }
 
 // ===========================================================================

--- a/src/renderer/shaders/hlsl/shaders.hlsl
+++ b/src/renderer/shaders/hlsl/shaders.hlsl
@@ -95,6 +95,9 @@ uint2 unpack_grid_size()
     return uint2(grid_size_packed & 0xFFFFu, (grid_size_packed >> 16u) & 0xFFFFu);
 }
 
+// TODO: re-enable padding_extend once DX11 blend state reliably composites
+// transparent pixels.  Until then, CellBgPS always clamps to the nearest
+// edge cell instead of returning transparent for non-extended padding.
 bool padding_extend_left()  { return (padding_extend_packed & EXTEND_LEFT)  != 0u; }
 bool padding_extend_right() { return (padding_extend_packed & EXTEND_RIGHT) != 0u; }
 bool padding_extend_up()    { return (padding_extend_packed & EXTEND_UP)    != 0u; }


### PR DESCRIPTION
## Summary

Fixes #73. The DX11 renderer's padding area showed dark gaps because transparent pixels from the cell_bg shader overwrote the background instead of compositing over it.

Two changes fix this:

1. **Blend state** (commit 1): Create a premultiplied-alpha blend state (`SRC=ONE`, `DST=INV_SRC_ALPHA`) and bind it each render pass. This is the standard DX11 approach and will be needed for future compositing (images, overlays).

2. **Shader-side compositing** (commit 2): The blend state alone is unreliable on some DX11 drivers. CellBgPS now:
   - Always clamps out-of-bounds grid positions to the nearest edge cell instead of returning transparent. This also avoids a visible color mismatch when the terminal sets per-cell backgrounds (e.g. cmd.exe) that differ from the configured bg_color.
   - Composites cell_bg over bg_color directly in the shader: `out = cell_bg + bg_color * (1 - cell_bg.a)`, with alpha forced to 1.0 so the DWM does not show the desktop through padding pixels.

> **IMPORTANT:** This is part of the DX11 renderer stack. Independent of # 74 (resize stepping).

**Known divergence:** DX11 currently ignores `padding_extend` flags and always extends edge cells into padding. Metal and OpenGL conditionally return transparent for non-extended edges and rely on hardware blending. This will be revisited once the DX11 blend state reliably composites transparent pixels. The `padding_extend_*()` HLSL helpers are kept but unused for now.

## What I Learnt

- D3D11's default blend state has `BlendEnable=0`, meaning every pixel shader output overwrites the render target -- no alpha compositing at all. Metal enables blending per-pipeline descriptor, but DX11 sets it globally on the output-merger stage.
- Premultiplied alpha (`SRC=ONE`) vs straight alpha (`SRC=SRC_ALPHA`) -- premultiplied is what the HLSL shaders output, so `ONE` is correct here. Using `SRC_ALPHA` would double-multiply and produce wrong colors.
- Hardware blend state is unreliable for compositing on some DX11 drivers. Doing the compositing in the pixel shader (`out = src + dst * (1 - src.a)`) is more portable and produces identical results.
- `errdefer` on COM resources in init chains -- if a later creation step fails, earlier resources leak without it. Added `errdefer _ = rtv.Release()` to cover the RTV when blend state creation fails.
- Padding pixels with alpha=0 cause the Windows DWM to composite the desktop through them, even with `DXGI_ALPHA_MODE_UNSPECIFIED`. Forcing alpha to 1.0 on all cell_bg output prevents this.
- When the terminal sets per-cell backgrounds (like cmd.exe does), returning `bg_color` for padding creates a visible mismatch. Clamping to the nearest edge cell matches what the user actually sees.

## Test plan

- [x] Build DLL: `zig build -Dapp-runtime=none`
- [x] Build and run example: resize window, verify padding strips match background color (no black gaps)
- [x] `zig build test -Dapp-runtime=none` passes
- [x] Resize window from multiple edges/corners -- padding area stays consistent with background
- [x] Try different window sizes (maximize, restore, drag-resize) -- no black flicker in padding
- [x] Cross-platform: Linux and Mac tests pass (HLSL is DX11-only, no impact on other renderers)