### PR TITLE
sync: pull origin/windows before upstream rebase

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,5 +35,7 @@ build-dll:
 sync force="":
     @if [ "{{ force }}" != "--force" ] && [ "$(git branch --show-current)" != "windows" ]; then echo "WARNING: you are on '$(git branch --show-current)', not 'windows'. Switch to windows branch first. Use 'just sync --force' to override." && exit 1; fi
     git fetch upstream
+    git fetch origin windows
+    git merge --ff-only origin/windows
     git rebase upstream/main
     @echo "Rebase complete. Review any conflicts, then: git push --force-with-lease origin windows"


### PR DESCRIPTION
## Summary

- Add `git fetch origin windows` and `git merge --ff-only origin/windows` to the `just sync` recipe, before the upstream rebase step
- This ensures the local `windows` branch picks up squash-merged PRs from GitHub before rebasing on upstream

## Problem

After squash-merging a PR on GitHub, the local `windows` branch was stale. `just sync` only ran `git fetch upstream` + `git rebase upstream/main`, so it never pulled the squash-merged commits from `origin/windows`. Feature branches rebased on this stale base would be missing the merged work, leading to confusion and potential conflicts.

## Fix

Insert two lines before the upstream rebase:
1. `git fetch origin windows` - fetch the latest origin/windows ref
2. `git merge --ff-only origin/windows` - fast-forward the local branch to include squash-merged PRs

Using `--ff-only` keeps it safe: if the local branch has diverged from origin (which shouldn't happen in normal workflow), the merge fails instead of creating a merge commit.

## Test plan

- [x] Run `just sync` on `windows` branch after squash-merging a PR on GitHub
- [x] Verify local branch includes the squash-merged commit before rebasing on upstream
- [x] Verify `just sync` still fails gracefully when not on `windows` branch (without `--force`)

## What I Learnt

The `just sync` recipe was modeled on a simple "fetch upstream + rebase" workflow, which works fine when you only push from local. But once PRs get squash-merged on GitHub, `origin/windows` moves ahead of the local branch. Without pulling those changes first, the local branch is stuck behind origin. The fix order matters: pull origin first (to get squash-merged work), then rebase on upstream (to get latest upstream changes on top).