### PR TITLE
libghostty: expose composition swap chain path through C API

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -457,6 +457,7 @@ typedef struct {
 
 typedef struct {
   void* hwnd;
+  void* swap_chain_panel;
 } ghostty_platform_windows_s;
 
 typedef union {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -360,6 +360,8 @@ pub const Platform = union(PlatformTag) {
     pub const Windows = if (builtin.target.os.tag == .windows) struct {
         /// The HWND to render into, or null for composition swap chain.
         hwnd: ?std.os.windows.HANDLE,
+        /// ISwapChainPanelNative pointer for composition swap chain, or null for HWND path.
+        swap_chain_panel: ?*anyopaque = null,
     } else void;
 
     // The C ABI compatible version of this union. The tag is expected
@@ -375,6 +377,7 @@ pub const Platform = union(PlatformTag) {
 
         windows: extern struct {
             hwnd: ?*anyopaque,
+            swap_chain_panel: ?*anyopaque,
         },
     };
 
@@ -398,6 +401,7 @@ pub const Platform = union(PlatformTag) {
 
             .windows => if (Windows != void) .{ .windows = .{
                 .hwnd = c_platform.windows.hwnd,
+                .swap_chain_panel = c_platform.windows.swap_chain_panel,
             } } else error.UnsupportedPlatform,
         };
     }

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -92,8 +92,10 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
                 .windows => |w| {
                     const surface: devicepkg.Surface = if (w.hwnd) |hwnd|
                         .{ .hwnd = hwnd }
+                    else if (w.swap_chain_panel) |panel|
+                        .{ .swap_chain_panel = @ptrCast(@alignCast(panel)) }
                     else
-                        @panic("HWND surface requires a non-null hwnd");
+                        @panic("Windows surface requires either hwnd or swap_chain_panel");
 
                     const size = opts.size.screen;
                     break :device Device.init(surface, size.width, size.height) catch |err| {


### PR DESCRIPTION
## Summary

- Add `swap_chain_panel` field to `ghostty_platform_windows_s` in the C API
- Thread the pointer through `apprt/embedded.zig` to the DX11 renderer
- Embedders pass either an HWND (traditional) or an `ISwapChainPanelNative*` (composition, e.g. WinUI 3 SwapChainPanel)

The `Device` layer already supports both swap chain creation paths (`CreateSwapChainForHwnd` vs `CreateSwapChainForComposition`). This connects the C API plumbing so external consumers can actually reach the composition path.

Unblocks the WinUI 3 example in deblasis/libghostty-dotnet#3.

## Test plan

- [x] `zig build -Dapp-runtime=none` -- clean build
- [x] `zig build test` -- full suite passes
- [x] `zig build test-lib-vt` -- passes
- [ ] Manual: WinUI 3 example in libghostty-dotnet consumes the new field