### PR TITLE
dx11: fix composition swap chain resize detection and alpha

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1713,6 +1713,10 @@ pub const CAPI = struct {
     /// to the pty and the renderer.
     export fn ghostty_surface_set_size(surface: *Surface, w: u32, h: u32) void {
         surface.updateSize(w, h);
+        // For composition surfaces (no HWND), the renderer cannot query
+        // the window size via GetClientRect. Forward the desired dimensions
+        // so the resize detection loop in drawFrame picks up the change.
+        surface.core_surface.renderer.setTargetSize(w, h);
     }
 
     /// Return the size information a surface has.

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -140,6 +140,15 @@ pub fn initShaders(
     return shaders.Shaders.init(d3d_device);
 }
 
+/// Notify the DX11 device of the desired surface dimensions.
+/// For composition surfaces (no HWND), windowSize() will return these
+/// values so the renderer's resize detection loop can pick them up.
+pub fn setTargetSize(self: *DirectX11, width: u32, height: u32) void {
+    if (self.device) |*dev| {
+        dev.setTargetSize(width, height);
+    }
+}
+
 pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
     if (self.device) |dev| {
         // Query the actual window size, not the swap chain buffer size.

--- a/src/renderer/directx11/Frame.zig
+++ b/src/renderer/directx11/Frame.zig
@@ -31,6 +31,19 @@ pub inline fn renderPass(
     attachments: []const RenderPass.Options.Attachment,
 ) RenderPass {
     if (self.renderer.api.device) |*dev| {
+        // Composition surfaces use premultiplied alpha, so the clear
+        // color must be opaque to prevent the host background from
+        // showing through uncovered pixels. HWND surfaces use
+        // UNSPECIFIED alpha mode where alpha is ignored anyway.
+        if (dev.hwnd == null) {
+            var patched: [8]RenderPass.Options.Attachment = undefined;
+            const n = @min(attachments.len, patched.len);
+            for (attachments[0..n], patched[0..n]) |src, *dst| {
+                dst.* = src;
+                if (dst.clear_color) |*c| c[3] = 1.0;
+            }
+            return RenderPass.begin(dev.context, dev.device, dev.blend_state, .{ .attachments = patched[0..n] });
+        }
         return RenderPass.begin(dev.context, dev.device, dev.blend_state, .{ .attachments = attachments });
     } else {
         return RenderPass.begin(null, null, null, .{ .attachments = attachments });

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -36,6 +36,11 @@ pub const Device = struct {
     hwnd: ?HWND,
     width: u32,
     height: u32,
+    /// Desired size set by the embedder (via ghostty_surface_set_size).
+    /// Used by windowSize() for composition surfaces where there is no
+    /// HWND to query. Zero means "use current buffer size".
+    target_width: u32 = 0,
+    target_height: u32 = 0,
 
     pub const InitError = error{
         DeviceCreationFailed,
@@ -49,7 +54,11 @@ pub const Device = struct {
         BlendStateCreationFailed,
     };
 
-    pub fn init(surface: Surface, width: u32, height: u32) InitError!Device {
+    pub fn init(surface: Surface, w_in: u32, h_in: u32) InitError!Device {
+        // Clamp to at least 1x1 -- CreateSwapChainForComposition with 0x0
+        // produces a degenerate swap chain that ResizeBuffers cannot recover.
+        const width = @max(w_in, 1);
+        const height = @max(h_in, 1);
         log.info("init called: size={}x{}", .{ width, height });
 
         // Create D3D11 device and immediate context.
@@ -231,9 +240,10 @@ pub const Device = struct {
         _ = self.device.Release();
     }
 
-    /// Return the actual window client area size.
-    /// Falls back to the swap chain buffer dimensions when there's
-    /// no HWND (composition surfaces).
+    /// Return the desired surface size.
+    /// HWND path: queries GetClientRect for the actual window size.
+    /// Composition path: returns the target size set by the embedder
+    /// via setTargetSize, falling back to the current buffer size.
     pub fn windowSize(self: *const Device) struct { width: u32, height: u32 } {
         if (self.hwnd) |hwnd| {
             var rc: RECT = undefined;
@@ -243,7 +253,20 @@ pub const Device = struct {
                 if (w > 0 and h > 0) return .{ .width = w, .height = h };
             }
         }
+        // Composition: use embedder-supplied target size if available.
+        if (self.target_width > 0 and self.target_height > 0) {
+            return .{ .width = self.target_width, .height = self.target_height };
+        }
         return .{ .width = self.width, .height = self.height };
+    }
+
+    /// Set the desired surface size for composition surfaces.
+    /// Called when the embedder reports a size change (ghostty_surface_set_size).
+    /// The actual swap chain resize happens in beginFrame when the renderer
+    /// detects the mismatch between windowSize() and the buffer dimensions.
+    pub fn setTargetSize(self: *Device, width: u32, height: u32) void {
+        self.target_width = width;
+        self.target_height = height;
     }
 
     pub const ResizeError = error{

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -877,6 +877,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
         }
 
+        /// Notify the graphics API of the desired surface dimensions.
+        /// Used by composition surfaces (no HWND) where the renderer
+        /// cannot query the window size directly.
+        pub fn setTargetSize(self: *Self, width: u32, height: u32) void {
+            if (@hasDecl(GraphicsAPI, "setTargetSize")) {
+                self.api.setTargetSize(width, height);
+            }
+        }
+
         /// Callback called by renderer.Thread when it begins.
         pub fn threadEnter(self: *const Self, surface: *apprt.Surface) !void {
             // If our API has to do things on thread enter, let it.


### PR DESCRIPTION
## Summary

Two fixes for the composition (SwapChainPanel) rendering path that were discovered while building the WinUI 3 example in deblasis/libghostty-dotnet.

### 1. Resize detection deadlock for composition surfaces

The renderer's draw loop detects size changes by comparing `surfaceSize()` against `self.size.screen`. For HWND surfaces this works because `surfaceSize()` calls `GetClientRect`, which returns the actual window dimensions independently of the swap chain buffer. For composition surfaces (no HWND), `surfaceSize()` fell back to `dev.width`/`dev.height` -- the **current buffer size**. This created a circular dependency:

- `surfaceSize()` returns the buffer size (e.g. 1x1 after initial creation)
- `self.size.screen` syncs to match on the first frame
- `ghostty_surface_set_size(2564, 984)` updates the core surface but NOT the renderer's `self.size.screen`
- Next frame: `surfaceSize()` still returns 1x1, `self.size.screen` is 1x1, `size_changed = false` -- **resize never triggers**

The terminal rendered at its initial (tiny) size and never grew to fill the panel, regardless of `SetSize` calls.

**Fix:** Add `target_width`/`target_height` fields to `Device`, set them from `ghostty_surface_set_size` via a new `setTargetSize` path through `DirectX11` -> `Device`, and return them from `windowSize()` for composition surfaces. The renderer's existing resize detection loop then picks up the mismatch naturally and calls `ResizeBuffers` in `beginFrame`.

### 2. Transparent clear color with premultiplied alpha

The render pass clear color was `(0, 0, 0, 0)` -- fully transparent black. For HWND surfaces with `AlphaMode=UNSPECIFIED`, alpha is ignored so this was harmless. For composition surfaces with `AlphaMode=PREMULTIPLIED`, any pixels not covered by the terminal cell grid (padding area, borders) were transparent, showing the host application's background color through the swap chain.

**Fix:** Change clear alpha to 1.0. The terminal background color is drawn by a shader step (not the clear), so changing the clear alpha only affects pixels outside the rendered grid area. For HWND surfaces with `UNSPECIFIED` alpha mode, the alpha channel is still ignored -- no behavioral change.

### 3. Clamp initial swap chain size to 1x1

`CreateSwapChainForComposition` with `Width=0, Height=0` (which happens when the surface is created before the embedder has a valid panel size) produces a degenerate swap chain. Clamped to at least 1x1.

## Files changed

| File | Change |
|------|--------|
| `src/renderer/directx11/device.zig` | `target_width`/`target_height` fields, `setTargetSize()`, updated `windowSize()`, size clamp in `init` |
| `src/renderer/DirectX11.zig` | `setTargetSize()` forwarding to device |
| `src/apprt/embedded.zig` | `ghostty_surface_set_size` calls `setTargetSize` on the graphics API |
| `src/renderer/generic.zig` | Clear color alpha 0.0 -> 1.0 |

## Test plan

- [x] `zig build -Dapp-runtime=none` -- clean build
- [x] WinUI 3 example in libghostty-dotnet: terminal fills the full SwapChainPanel, resizes correctly, no transparent gaps
- [x] Existing HWND examples (Win32, WinForms, WPF) unaffected -- `windowSize()` still uses `GetClientRect`, clear alpha ignored with `UNSPECIFIED`