### PR TITLE
renderer/dx11: add shared DXGI texture surface mode (no HWND, no composition)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 > **DX11 renderer infrastructure** (in fork)
 >
 > - [x] COM interface definitions (d3d11, dxgi) with vtable bindings
-> - [x] DX11 device lifecycle with dual surface support (HWND for standalone/embedding, SwapChainPanel for WinUI host)
+> - [x] DX11 device lifecycle with triple surface support (HWND, SwapChainPanel, shared DXGI texture)
 > - [x] Instanced cell grid renderer with pre-compiled HLSL shaders
 > - [x] HLSL build step (HlslStep.zig) mirroring Metal's MetallibStep
 > - [x] Backend enum with `directx11` variant
@@ -97,16 +97,13 @@
 > - [x] `--version` flag working from command line
 > - [x] Interop test suite (7 tests against the real DLL)
 >
-> ### Architecture: Dual Surface Support
+> ### Architecture: Surface Modes
 >
-> The DX11 renderer is dual-channel at the library level so that libghostty
-> consumers can pick whichever surface model fits their host:
+> The DX11 renderer supports three surface modes at the library level so that
+> libghostty consumers can pick whichever model fits their host:
 > - **HWND** -- `CreateSwapChainForHwnd`, for standalone windows, test harnesses, and third-party embedders
 > - **SwapChainPanel** (composition) -- `CreateSwapChainForComposition`, for WinUI 3 / XAML hosts
->
-> We are iterating on SwapChainPanel with the information we have today but
-> the choice is not set in stone -- the dual-channel design means we can
-> change our mind later without breaking embedders.
+> - **Shared texture** -- renders to a standalone `ID3D11Texture2D` with a DXGI shared handle, for game engines (Unity, Unreal, Godot), custom renderers, and offscreen scenarios
 >
 > The device picks the path based on what the caller provides. No compile-time flags.
 >

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1131,6 +1131,16 @@ GHOSTTY_EXPORT void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32
 // consumers should call OpenSharedResource on this device to avoid cross-device
 // synchronization issues. Returns NULL on non-DX11 builds.
 GHOSTTY_EXPORT void* ghostty_surface_get_d3d11_device(ghostty_surface_t);
+// Returns the ID3D11DeviceContext* ghostty uses for rendering. Consumers
+// need this for CopyResource from the shared texture. Enable multithread
+// protection when accessing from a non-render thread. Returns NULL on
+// non-DX11 builds.
+GHOSTTY_EXPORT void* ghostty_surface_get_d3d11_context(ghostty_surface_t);
+// Returns the ID3D11Texture2D* ghostty renders to in shared texture mode.
+// Same-process consumers can CopyResource from this directly. The texture
+// pointer changes on resize -- re-read after ghostty_surface_set_size.
+// Returns NULL if not in shared texture mode.
+GHOSTTY_EXPORT void* ghostty_surface_get_d3d11_texture(ghostty_surface_t);
 GHOSTTY_EXPORT ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_EXPORT void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -458,6 +458,9 @@ typedef struct {
 typedef struct {
   void* hwnd;
   void* swap_chain_panel;
+  // OUT: receives the DXGI shared handle for the render texture.
+  // Open with OpenSharedResource on the device returned by
+  // ghostty_surface_get_d3d11_device to avoid cross-device sync issues.
   void* shared_texture_out;
   uint32_t texture_width;
   uint32_t texture_height;
@@ -1124,6 +1127,10 @@ GHOSTTY_EXPORT void ghostty_surface_set_content_scale(ghostty_surface_t, double,
 GHOSTTY_EXPORT void ghostty_surface_set_focus(ghostty_surface_t, bool);
 GHOSTTY_EXPORT void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_EXPORT void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
+// Returns the ID3D11Device* used by this surface's renderer. Shared texture
+// consumers should call OpenSharedResource on this device to avoid cross-device
+// synchronization issues. Returns NULL on non-DX11 builds.
+GHOSTTY_EXPORT void* ghostty_surface_get_d3d11_device(ghostty_surface_t);
 GHOSTTY_EXPORT ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_EXPORT void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -458,6 +458,9 @@ typedef struct {
 typedef struct {
   void* hwnd;
   void* swap_chain_panel;
+  void* shared_texture_out;
+  uint32_t texture_width;
+  uint32_t texture_height;
 } ghostty_platform_windows_s;
 
 typedef union {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1721,6 +1721,16 @@ pub const CAPI = struct {
         surface.draw();
     }
 
+    /// Return the ID3D11Device pointer that ghostty uses for rendering.
+    /// Shared texture consumers should open the DXGI shared handle on
+    /// this same device to avoid cross-device synchronization issues.
+    /// Returns null on non-DX11 builds or if the device is not initialized.
+    export fn ghostty_surface_get_d3d11_device(surface: *Surface) ?*anyopaque {
+        if (comptime builtin.os.tag != .windows) return null;
+        const dev = surface.core_surface.renderer.api.device orelse return null;
+        return @ptrCast(dev.device);
+    }
+
     /// Update the size of a surface. This will trigger resize notifications
     /// to the pty and the renderer.
     export fn ghostty_surface_set_size(surface: *Surface, w: u32, h: u32) void {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -358,10 +358,16 @@ pub const Platform = union(PlatformTag) {
     } else void;
 
     pub const Windows = if (builtin.target.os.tag == .windows) struct {
-        /// The HWND to render into, or null for composition swap chain.
+        /// The HWND to render into, or null for composition/shared texture modes.
         hwnd: ?std.os.windows.HANDLE,
-        /// ISwapChainPanelNative pointer for composition swap chain, or null for HWND path.
+        /// ISwapChainPanelNative pointer for composition swap chain, or null.
         swap_chain_panel: ?*anyopaque = null,
+        /// OUT pointer for shared texture DXGI handle, or null.
+        shared_texture_out: ?*anyopaque = null,
+        /// Width of the shared texture in pixels. Required when shared_texture_out is set.
+        texture_width: u32 = 0,
+        /// Height of the shared texture in pixels. Required when shared_texture_out is set.
+        texture_height: u32 = 0,
     } else void;
 
     // The C ABI compatible version of this union. The tag is expected
@@ -378,6 +384,9 @@ pub const Platform = union(PlatformTag) {
         windows: extern struct {
             hwnd: ?*anyopaque,
             swap_chain_panel: ?*anyopaque,
+            shared_texture_out: ?*anyopaque,
+            texture_width: u32,
+            texture_height: u32,
         },
     };
 
@@ -402,6 +411,9 @@ pub const Platform = union(PlatformTag) {
             .windows => if (Windows != void) .{ .windows = .{
                 .hwnd = c_platform.windows.hwnd,
                 .swap_chain_panel = c_platform.windows.swap_chain_panel,
+                .shared_texture_out = c_platform.windows.shared_texture_out,
+                .texture_width = c_platform.windows.texture_width,
+                .texture_height = c_platform.windows.texture_height,
             } } else error.UnsupportedPlatform,
         };
     }

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1731,6 +1731,27 @@ pub const CAPI = struct {
         return @ptrCast(dev.device);
     }
 
+    /// Return the ID3D11DeviceContext pointer that ghostty uses for
+    /// rendering. Consumers need this to call CopyResource from the
+    /// shared texture. Enable multithread protection on the context
+    /// when accessing from a non-render thread.
+    /// Returns null on non-DX11 builds or if the device is not initialized.
+    export fn ghostty_surface_get_d3d11_context(surface: *Surface) ?*anyopaque {
+        if (comptime builtin.os.tag != .windows) return null;
+        const dev = surface.core_surface.renderer.api.device orelse return null;
+        return @ptrCast(dev.context);
+    }
+
+    /// Return the ID3D11Texture2D pointer that ghostty renders to in
+    /// shared texture mode. Same-process consumers can CopyResource
+    /// directly from this pointer using ghostty's device context.
+    /// Returns null on non-DX11 builds or if not in shared texture mode.
+    export fn ghostty_surface_get_d3d11_texture(surface: *Surface) ?*anyopaque {
+        if (comptime builtin.os.tag != .windows) return null;
+        const st = surface.core_surface.renderer.api.shared_target orelse return null;
+        return @ptrCast(st.texture orelse return null);
+    }
+
     /// Update the size of a surface. This will trigger resize notifications
     /// to the pty and the renderer.
     export fn ghostty_surface_set_size(surface: *Surface, w: u32, h: u32) void {

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -224,14 +224,14 @@ pub inline fn beginFrame(
         const w: u32 = @intCast(target.width);
         const h: u32 = @intCast(target.height);
         if (dev.width != w or dev.height != h) {
-            if (renderer.api.shared_target != null) {
+            if (renderer.api.shared_target) |*st| {
                 // Shared texture mode: Target owns the texture, resize it.
-                renderer.api.shared_target.?.resizeSharedTexture(dev.device, w, h) catch |err| {
+                st.resizeSharedTexture(dev.device, w, h) catch |err| {
                     log.err("shared texture resize failed: {}", .{err});
                     return error.PresentFailed;
                 };
                 // Update the borrowed view's rtv (texture stays null -- borrowed).
-                target.rtv = renderer.api.shared_target.?.rtv;
+                target.rtv = st.rtv;
                 dev.width = w;
                 dev.height = h;
             } else {

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -79,41 +79,70 @@ blending: configpkg.Config.AlphaBlending = .native,
 /// The DX11 device managing the swap chain and render target.
 device: ?Device = null,
 
+/// Target for shared texture mode. Owns the texture and RTV.
+/// Null for swap chain modes (Target borrows from Device).
+shared_target: ?Target = null,
+
 // --- GraphicsAPI contract: functions ---
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX11 {
     _ = alloc;
 
-    const device = device: {
-        if (comptime builtin.os.tag != .windows) {
-            break :device null;
-        } else {
-            switch (opts.rt_surface.platform) {
-                .windows => |w| {
-                    const surface: devicepkg.Surface = if (w.hwnd) |hwnd|
-                        .{ .hwnd = hwnd }
-                    else if (w.swap_chain_panel) |panel|
-                        .{ .swap_chain_panel = @ptrCast(@alignCast(panel)) }
-                    else
-                        @panic("Windows surface requires either hwnd or swap_chain_panel");
+    var result = DirectX11{};
 
-                    const size = opts.size.screen;
-                    break :device Device.init(surface, size.width, size.height) catch |err| {
-                        log.err("DX11 device init failed: {}", .{err});
-                        return error.DeviceInitFailed;
-                    };
-                },
-                else => @panic("unsupported platform for DX11"),
+    if (comptime builtin.os.tag != .windows) {
+        return result;
+    }
+
+    switch (opts.rt_surface.platform) {
+        .windows => |w| {
+            const surface: devicepkg.Surface = if (w.hwnd) |hwnd|
+                .{ .hwnd = hwnd }
+            else if (w.swap_chain_panel) |panel|
+                .{ .swap_chain_panel = @ptrCast(@alignCast(panel)) }
+            else if (w.shared_texture_out) |out_ptr|
+                .{ .shared_texture = .{
+                    .handle_out = @ptrCast(@alignCast(out_ptr)),
+                    .width = w.texture_width,
+                    .height = w.texture_height,
+                } }
+            else
+                @panic("Windows surface requires hwnd, swap_chain_panel, or shared_texture_out");
+
+            const size = opts.size.screen;
+            result.device = Device.init(surface, size.width, size.height) catch |err| {
+                log.err("DX11 device init failed: {}", .{err});
+                return error.DeviceInitFailed;
+            };
+
+            // For shared texture mode, create the Target now since it
+            // owns the texture and RTV (instead of borrowing from Device).
+            if (surface == .shared_texture) {
+                const cfg = surface.shared_texture;
+                result.shared_target = Target.initSharedTexture(
+                    result.device.?.device,
+                    cfg.width,
+                    cfg.height,
+                    cfg.handle_out,
+                ) catch |err| {
+                    log.err("shared texture init failed: {}", .{err});
+                    result.device.?.deinit();
+                    result.device = null;
+                    return error.DeviceInitFailed;
+                };
             }
-        }
-    };
+        },
+        else => @panic("unsupported platform for DX11"),
+    }
 
-    return .{
-        .device = device,
-    };
+    return result;
 }
 
 pub fn deinit(self: *DirectX11) void {
+    if (self.shared_target) |*t| {
+        t.deinit();
+        self.shared_target = null;
+    }
     if (self.device) |*dev| {
         dev.deinit();
     }
@@ -163,6 +192,16 @@ pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
 }
 
 pub fn initTarget(self: *const DirectX11, width: usize, height: usize) !Target {
+    // Shared texture mode: Target already owns RTV and texture.
+    if (self.shared_target) |st| {
+        return .{
+            .rtv = st.rtv,
+            .width = st.width,
+            .height = st.height,
+            .texture = st.texture,
+            .handle_out = st.handle_out,
+        };
+    }
     return .{
         .rtv = if (self.device) |dev| dev.rtv else null,
         .width = width,
@@ -185,11 +224,24 @@ pub inline fn beginFrame(
         const w: u32 = @intCast(target.width);
         const h: u32 = @intCast(target.height);
         if (dev.width != w or dev.height != h) {
-            dev.resize(w, h) catch |err| {
-                log.err("swap chain resize failed: {}", .{err});
-                return error.PresentFailed;
-            };
-            target.rtv = dev.rtv;
+            if (renderer.api.shared_target != null) {
+                // Shared texture mode: Target owns the texture, resize it.
+                renderer.api.shared_target.?.resizeSharedTexture(dev.device, w, h) catch |err| {
+                    log.err("shared texture resize failed: {}", .{err});
+                    return error.PresentFailed;
+                };
+                target.rtv = renderer.api.shared_target.?.rtv;
+                target.texture = renderer.api.shared_target.?.texture;
+                dev.width = w;
+                dev.height = h;
+            } else {
+                // Swap chain mode: Device owns the back buffer, resize it.
+                dev.resize(w, h) catch |err| {
+                    log.err("swap chain resize failed: {}", .{err});
+                    return error.PresentFailed;
+                };
+                target.rtv = dev.rtv;
+            }
         }
     }
 

--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -192,14 +192,14 @@ pub fn surfaceSize(self: *const DirectX11) !struct { width: u32, height: u32 } {
 }
 
 pub fn initTarget(self: *const DirectX11, width: usize, height: usize) !Target {
-    // Shared texture mode: Target already owns RTV and texture.
+    // Shared texture mode: return a borrowed view of the shared target.
+    // Only copy rtv and dimensions -- leave texture and handle_out null
+    // so releaseOwnedResources treats this as borrowed (no double-release).
     if (self.shared_target) |st| {
         return .{
             .rtv = st.rtv,
             .width = st.width,
             .height = st.height,
-            .texture = st.texture,
-            .handle_out = st.handle_out,
         };
     }
     return .{
@@ -230,8 +230,8 @@ pub inline fn beginFrame(
                     log.err("shared texture resize failed: {}", .{err});
                     return error.PresentFailed;
                 };
+                // Update the borrowed view's rtv (texture stays null -- borrowed).
                 target.rtv = renderer.api.shared_target.?.rtv;
-                target.texture = renderer.api.shared_target.?.texture;
                 dev.width = w;
                 dev.height = h;
             } else {

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -31,7 +31,7 @@ texture: ?*d3d11.ID3D11Texture2D = null,
 /// Non-null only in owned mode. Updated on init and resize.
 handle_out: ?*?HANDLE = null,
 
-pub const InitError = error{
+pub const SharedTextureError = error{
     TextureCreationFailed,
     SharedHandleFailed,
     RenderTargetViewFailed,
@@ -45,19 +45,12 @@ pub fn initSharedTexture(
     width: u32,
     height: u32,
     handle_out: *?HANDLE,
-) InitError!@This() {
+) SharedTextureError!@This() {
     var self = @This(){};
     self.handle_out = handle_out;
     try self.createSharedTextureResources(device, width, height);
     return self;
 }
-
-pub const ResizeError = error{
-    TextureCreationFailed,
-    SharedHandleFailed,
-    RenderTargetViewFailed,
-    QueryInterfaceFailed,
-};
 
 /// Recreate the shared texture at a new size. Releases old resources
 /// and writes the new DXGI shared handle to *handle_out.
@@ -66,7 +59,7 @@ pub fn resizeSharedTexture(
     device: *d3d11.ID3D11Device,
     width: u32,
     height: u32,
-) ResizeError!void {
+) SharedTextureError!void {
     self.releaseOwnedResources();
     try self.createSharedTextureResources(device, width, height);
 }
@@ -102,7 +95,7 @@ fn createSharedTextureResources(
     device: *d3d11.ID3D11Device,
     width: u32,
     height: u32,
-) InitError!void {
+) SharedTextureError!void {
     // Create a render-target texture with the shared flag so consumers
     // can open it on their own D3D11 device via OpenSharedResource.
     const desc = d3d11.D3D11_TEXTURE2D_DESC{
@@ -122,7 +115,7 @@ fn createSharedTextureResources(
     var hr = device.CreateTexture2D(&desc, null, &texture_opt);
     if (com.FAILED(hr) or texture_opt == null) {
         log.err("CreateTexture2D (shared) failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-        return InitError.TextureCreationFailed;
+        return SharedTextureError.TextureCreationFailed;
     }
     const texture = texture_opt.?;
     errdefer _ = texture.Release();
@@ -132,7 +125,7 @@ fn createSharedTextureResources(
     hr = device.CreateRenderTargetView(@ptrCast(texture), null, &rtv_opt);
     if (com.FAILED(hr) or rtv_opt == null) {
         log.err("CreateRenderTargetView (shared texture) failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-        return InitError.RenderTargetViewFailed;
+        return SharedTextureError.RenderTargetViewFailed;
     }
     errdefer _ = rtv_opt.?.Release();
 
@@ -141,7 +134,7 @@ fn createSharedTextureResources(
     hr = texture.vtable.QueryInterface(texture, &dxgi.IDXGIResource.IID, &dxgi_resource_opt);
     if (com.FAILED(hr) or dxgi_resource_opt == null) {
         log.err("QI for IDXGIResource failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-        return InitError.QueryInterfaceFailed;
+        return SharedTextureError.QueryInterfaceFailed;
     }
     const dxgi_resource: *dxgi.IDXGIResource = @ptrCast(@alignCast(dxgi_resource_opt.?));
     defer _ = dxgi_resource.Release();
@@ -150,7 +143,7 @@ fn createSharedTextureResources(
     hr = dxgi_resource.GetSharedHandle(&shared_handle);
     if (com.FAILED(hr)) {
         log.err("GetSharedHandle failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-        return InitError.SharedHandleFailed;
+        return SharedTextureError.SharedHandleFailed;
     }
 
     // Write the handle to the consumer's output slot.
@@ -202,19 +195,69 @@ test "shared texture lifecycle" {
     try std.testing.expectEqual(@as(usize, 640), target.width);
     try std.testing.expectEqual(@as(usize, 480), target.height);
 
-    // Resize.
+    // Resize -- new texture means new shared handle.
+    const old_handle = shared_handle;
     try target.resizeSharedTexture(device, 1280, 720);
 
     try std.testing.expect(target.rtv != null);
     try std.testing.expect(target.texture != null);
     try std.testing.expectEqual(@as(usize, 1280), target.width);
     try std.testing.expectEqual(@as(usize, 720), target.height);
-    // Handle should still be valid after resize.
     try std.testing.expect(shared_handle != null);
+    // Handle must differ after resize (new texture = new DXGI resource).
+    try std.testing.expect(shared_handle != old_handle);
 
     // Deinit.
     target.deinit();
     try std.testing.expect(target.rtv == null);
     try std.testing.expect(target.texture == null);
     try std.testing.expectEqual(@as(usize, 0), target.width);
+}
+
+test "borrowed target deinit does not release owned resources" {
+    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
+
+    const d3d11_ = @import("d3d11.zig");
+    const com_ = @import("com.zig");
+
+    var device_opt: ?*d3d11_.ID3D11Device = null;
+    var context_opt: ?*d3d11_.ID3D11DeviceContext = null;
+    const feature_levels = [_]d3d11_.D3D_FEATURE_LEVEL{.@"11_0"};
+    const hr = d3d11_.D3D11CreateDevice(
+        null,
+        .HARDWARE,
+        null,
+        d3d11_.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+        &feature_levels,
+        feature_levels.len,
+        d3d11_.D3D11_SDK_VERSION,
+        &device_opt,
+        null,
+        &context_opt,
+    );
+    if (com_.FAILED(hr)) return error.SkipZigTest;
+    const device = device_opt.?;
+    defer _ = device.Release();
+    defer _ = context_opt.?.Release();
+
+    var shared_handle: ?HANDLE = null;
+    var owner = try initSharedTexture(device, 640, 480, &shared_handle);
+    defer owner.deinit();
+
+    // Create a borrowed view the same way initTarget does: copy rtv and
+    // dimensions but leave texture/handle_out null.
+    var borrowed = @This(){
+        .rtv = owner.rtv,
+        .width = owner.width,
+        .height = owner.height,
+    };
+
+    // Deinit on the borrowed view must not release the RTV (texture is
+    // null so releaseOwnedResources treats it as borrowed).
+    borrowed.deinit();
+    try std.testing.expect(borrowed.rtv == null);
+
+    // Owner's resources must still be intact.
+    try std.testing.expect(owner.rtv != null);
+    try std.testing.expect(owner.texture != null);
 }

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -66,9 +66,7 @@ pub fn resizeSharedTexture(
 
 pub fn deinit(self: *@This()) void {
     self.releaseOwnedResources();
-    self.rtv = null;
-    self.width = 0;
-    self.height = 0;
+    self.* = undefined;
 }
 
 /// Release texture and RTV if this Target owns them (shared texture mode).
@@ -157,33 +155,33 @@ fn createSharedTextureResources(
     log.info("shared texture created: {}x{}", .{ width, height });
 }
 
-test "shared texture lifecycle" {
-    // This test requires a real D3D11 device, so skip on non-Windows.
+fn createTestDevice() !*d3d11.ID3D11Device {
     if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
 
-    const d3d11_ = @import("d3d11.zig");
-    const com_ = @import("com.zig");
-
-    // Create a D3D11 device.
-    var device_opt: ?*d3d11_.ID3D11Device = null;
-    var context_opt: ?*d3d11_.ID3D11DeviceContext = null;
-    const feature_levels = [_]d3d11_.D3D_FEATURE_LEVEL{.@"11_0"};
-    const hr = d3d11_.D3D11CreateDevice(
+    var device_opt: ?*d3d11.ID3D11Device = null;
+    var context_opt: ?*d3d11.ID3D11DeviceContext = null;
+    const feature_levels = [_]d3d11.D3D_FEATURE_LEVEL{.@"11_0"};
+    const hr = d3d11.D3D11CreateDevice(
         null,
         .HARDWARE,
         null,
-        d3d11_.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+        d3d11.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
         &feature_levels,
         feature_levels.len,
-        d3d11_.D3D11_SDK_VERSION,
+        d3d11.D3D11_SDK_VERSION,
         &device_opt,
         null,
         &context_opt,
     );
-    if (com_.FAILED(hr)) return error.SkipZigTest;
-    const device = device_opt.?;
+    if (com.FAILED(hr)) return error.SkipZigTest;
+    // Release the context -- Target tests only need the device.
+    if (context_opt) |ctx| _ = ctx.Release();
+    return device_opt orelse error.SkipZigTest;
+}
+
+test "shared texture lifecycle" {
+    const device = createTestDevice() catch return;
     defer _ = device.Release();
-    defer _ = context_opt.?.Release();
 
     // Init shared texture.
     var shared_handle: ?HANDLE = null;
@@ -207,38 +205,13 @@ test "shared texture lifecycle" {
     // Handle must differ after resize (new texture = new DXGI resource).
     try std.testing.expect(shared_handle != old_handle);
 
-    // Deinit.
+    // Deinit -- self.* = undefined catches double-deinit in debug.
     target.deinit();
-    try std.testing.expect(target.rtv == null);
-    try std.testing.expect(target.texture == null);
-    try std.testing.expectEqual(@as(usize, 0), target.width);
 }
 
 test "borrowed target deinit does not release owned resources" {
-    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
-
-    const d3d11_ = @import("d3d11.zig");
-    const com_ = @import("com.zig");
-
-    var device_opt: ?*d3d11_.ID3D11Device = null;
-    var context_opt: ?*d3d11_.ID3D11DeviceContext = null;
-    const feature_levels = [_]d3d11_.D3D_FEATURE_LEVEL{.@"11_0"};
-    const hr = d3d11_.D3D11CreateDevice(
-        null,
-        .HARDWARE,
-        null,
-        d3d11_.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
-        &feature_levels,
-        feature_levels.len,
-        d3d11_.D3D11_SDK_VERSION,
-        &device_opt,
-        null,
-        &context_opt,
-    );
-    if (com_.FAILED(hr)) return error.SkipZigTest;
-    const device = device_opt.?;
+    const device = createTestDevice() catch return;
     defer _ = device.Release();
-    defer _ = context_opt.?.Release();
 
     var shared_handle: ?HANDLE = null;
     var owner = try initSharedTexture(device, 640, 480, &shared_handle);
@@ -255,9 +228,8 @@ test "borrowed target deinit does not release owned resources" {
     // Deinit on the borrowed view must not release the RTV (texture is
     // null so releaseOwnedResources treats it as borrowed).
     borrowed.deinit();
-    try std.testing.expect(borrowed.rtv == null);
 
-    // Owner's resources must still be intact.
+    // Owner's resources must still be intact after borrowed deinit.
     try std.testing.expect(owner.rtv != null);
     try std.testing.expect(owner.texture != null);
 }

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -161,9 +161,5 @@ fn createSharedTextureResources(
     self.width = @intCast(width);
     self.height = @intCast(height);
 
-    log.info("shared texture created: {}x{}, handle=0x{x}", .{
-        width,
-        height,
-        @intFromPtr(shared_handle orelse @as(HANDLE, @ptrFromInt(0))),
-    });
+    log.info("shared texture created: {}x{}", .{ width, height });
 }

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -2,9 +2,16 @@
 //!
 //! Wraps an ID3D11RenderTargetView that draw commands render into.
 //! For swap chain targets the RTV is owned by Device -- Target borrows
-//! the pointer. For future off-screen targets, Target will own the
-//! RTV and its backing ID3D11Texture2D.
+//! the pointer. For shared texture targets, Target owns the RTV and
+//! its backing ID3D11Texture2D.
+const std = @import("std");
+const log = std.log.scoped(.directx11);
+const com = @import("com.zig");
 const d3d11 = @import("d3d11.zig");
+const dxgi = @import("dxgi.zig");
+
+const HANDLE = std.os.windows.HANDLE;
+const HRESULT = com.HRESULT;
 
 /// The render target view to draw into.
 /// Null when running without a device (non-Windows builds).
@@ -15,10 +22,148 @@ width: usize = 0,
 /// Current height of this target in pixels.
 height: usize = 0,
 
+/// The shared texture backing the RTV. Non-null only in owned mode
+/// (shared texture surfaces). In borrowed mode (swap chain surfaces)
+/// this is null -- Device owns the back buffer.
+texture: ?*d3d11.ID3D11Texture2D = null,
+
+/// Pointer to consumer's output slot for the DXGI shared handle.
+/// Non-null only in owned mode. Updated on init and resize.
+handle_out: ?*?HANDLE = null,
+
+pub const InitError = error{
+    TextureCreationFailed,
+    SharedHandleFailed,
+    RenderTargetViewFailed,
+    QueryInterfaceFailed,
+};
+
+/// Create a shared texture and its RTV. Writes the DXGI shared
+/// handle to *handle_out so the consumer can open it on their device.
+pub fn initSharedTexture(
+    device: *d3d11.ID3D11Device,
+    width: u32,
+    height: u32,
+    handle_out: *?HANDLE,
+) InitError!@This() {
+    var self = @This(){};
+    self.handle_out = handle_out;
+    try self.createSharedTextureResources(device, width, height);
+    return self;
+}
+
+pub const ResizeError = error{
+    TextureCreationFailed,
+    SharedHandleFailed,
+    RenderTargetViewFailed,
+    QueryInterfaceFailed,
+};
+
+/// Recreate the shared texture at a new size. Releases old resources
+/// and writes the new DXGI shared handle to *handle_out.
+pub fn resizeSharedTexture(
+    self: *@This(),
+    device: *d3d11.ID3D11Device,
+    width: u32,
+    height: u32,
+) ResizeError!void {
+    self.releaseOwnedResources();
+    try self.createSharedTextureResources(device, width, height);
+}
+
 pub fn deinit(self: *@This()) void {
-    // Swap chain RTV is owned by Device, not by Target.
-    // When we add off-screen targets we will Release() here.
+    self.releaseOwnedResources();
     self.rtv = null;
     self.width = 0;
     self.height = 0;
+}
+
+/// Release texture and RTV if this Target owns them (shared texture mode).
+/// No-op in borrowed mode (swap chain surfaces).
+fn releaseOwnedResources(self: *@This()) void {
+    if (self.rtv) |rtv| {
+        if (self.texture != null) {
+            // Owned mode: we created this RTV, so we release it.
+            _ = rtv.Release();
+            self.rtv = null;
+        }
+        // Borrowed mode: RTV belongs to Device, don't release.
+    }
+    if (self.texture) |tex| {
+        _ = tex.Release();
+        self.texture = null;
+    }
+}
+
+/// Create the D3D11 texture, RTV, and query the shared handle.
+/// Used by both initSharedTexture and resizeSharedTexture.
+fn createSharedTextureResources(
+    self: *@This(),
+    device: *d3d11.ID3D11Device,
+    width: u32,
+    height: u32,
+) InitError!void {
+    // Create a render-target texture with the shared flag so consumers
+    // can open it on their own D3D11 device via OpenSharedResource.
+    const desc = d3d11.D3D11_TEXTURE2D_DESC{
+        .Width = width,
+        .Height = height,
+        .MipLevels = 1,
+        .ArraySize = 1,
+        .Format = .B8G8R8A8_UNORM,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .Usage = .DEFAULT,
+        .BindFlags = d3d11.D3D11_BIND_RENDER_TARGET,
+        .CPUAccessFlags = 0,
+        .MiscFlags = d3d11.D3D11_RESOURCE_MISC_SHARED,
+    };
+
+    var texture_opt: ?*d3d11.ID3D11Texture2D = null;
+    var hr = device.CreateTexture2D(&desc, null, &texture_opt);
+    if (com.FAILED(hr) or texture_opt == null) {
+        log.err("CreateTexture2D (shared) failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+        return InitError.TextureCreationFailed;
+    }
+    const texture = texture_opt.?;
+    errdefer _ = texture.Release();
+
+    // Create render target view from the texture.
+    var rtv_opt: ?*d3d11.ID3D11RenderTargetView = null;
+    hr = device.CreateRenderTargetView(@ptrCast(texture), null, &rtv_opt);
+    if (com.FAILED(hr) or rtv_opt == null) {
+        log.err("CreateRenderTargetView (shared texture) failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+        return InitError.RenderTargetViewFailed;
+    }
+    errdefer _ = rtv_opt.?.Release();
+
+    // Query IDXGIResource to get the shared handle.
+    var dxgi_resource_opt: ?*anyopaque = null;
+    hr = texture.vtable.QueryInterface(texture, &dxgi.IDXGIResource.IID, &dxgi_resource_opt);
+    if (com.FAILED(hr) or dxgi_resource_opt == null) {
+        log.err("QI for IDXGIResource failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+        return InitError.QueryInterfaceFailed;
+    }
+    const dxgi_resource: *dxgi.IDXGIResource = @ptrCast(@alignCast(dxgi_resource_opt.?));
+    defer _ = dxgi_resource.Release();
+
+    var shared_handle: ?HANDLE = null;
+    hr = dxgi_resource.GetSharedHandle(&shared_handle);
+    if (com.FAILED(hr)) {
+        log.err("GetSharedHandle failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+        return InitError.SharedHandleFailed;
+    }
+
+    // Write the handle to the consumer's output slot.
+    self.handle_out.?.* = shared_handle;
+
+    self.texture = texture;
+    self.rtv = rtv_opt.?;
+    self.width = @intCast(width);
+    self.height = @intCast(height);
+
+    log.info("shared texture created: {}x{}, handle=0x{x}", .{
+        width,
+        height,
+        @intFromPtr(shared_handle orelse @as(HANDLE, @ptrFromInt(0))),
+    });
 }

--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -163,3 +163,58 @@ fn createSharedTextureResources(
 
     log.info("shared texture created: {}x{}", .{ width, height });
 }
+
+test "shared texture lifecycle" {
+    // This test requires a real D3D11 device, so skip on non-Windows.
+    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
+
+    const d3d11_ = @import("d3d11.zig");
+    const com_ = @import("com.zig");
+
+    // Create a D3D11 device.
+    var device_opt: ?*d3d11_.ID3D11Device = null;
+    var context_opt: ?*d3d11_.ID3D11DeviceContext = null;
+    const feature_levels = [_]d3d11_.D3D_FEATURE_LEVEL{.@"11_0"};
+    const hr = d3d11_.D3D11CreateDevice(
+        null,
+        .HARDWARE,
+        null,
+        d3d11_.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+        &feature_levels,
+        feature_levels.len,
+        d3d11_.D3D11_SDK_VERSION,
+        &device_opt,
+        null,
+        &context_opt,
+    );
+    if (com_.FAILED(hr)) return error.SkipZigTest;
+    const device = device_opt.?;
+    defer _ = device.Release();
+    defer _ = context_opt.?.Release();
+
+    // Init shared texture.
+    var shared_handle: ?HANDLE = null;
+    var target = try initSharedTexture(device, 640, 480, &shared_handle);
+
+    try std.testing.expect(target.rtv != null);
+    try std.testing.expect(target.texture != null);
+    try std.testing.expect(shared_handle != null);
+    try std.testing.expectEqual(@as(usize, 640), target.width);
+    try std.testing.expectEqual(@as(usize, 480), target.height);
+
+    // Resize.
+    try target.resizeSharedTexture(device, 1280, 720);
+
+    try std.testing.expect(target.rtv != null);
+    try std.testing.expect(target.texture != null);
+    try std.testing.expectEqual(@as(usize, 1280), target.width);
+    try std.testing.expectEqual(@as(usize, 720), target.height);
+    // Handle should still be valid after resize.
+    try std.testing.expect(shared_handle != null);
+
+    // Deinit.
+    target.deinit();
+    try std.testing.expect(target.rtv == null);
+    try std.testing.expect(target.texture == null);
+    try std.testing.expectEqual(@as(usize, 0), target.width);
+}

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -50,6 +50,7 @@ pub const D3D11_CPU_ACCESS_READ: D3D11_CPU_ACCESS_FLAG = 0x20000;
 
 pub const D3D11_RESOURCE_MISC_FLAG = u32;
 pub const D3D11_RESOURCE_MISC_BUFFER_STRUCTURED: D3D11_RESOURCE_MISC_FLAG = 0x40;
+pub const D3D11_RESOURCE_MISC_SHARED: D3D11_RESOURCE_MISC_FLAG = 0x2;
 
 pub const D3D11_MAP = enum(u32) {
     READ = 1,
@@ -1169,7 +1170,7 @@ pub const ID3D11DeviceContext = extern struct {
         // slot 110: ClearState
         _reserved110: Reserved,
         // slot 111: Flush
-        _reserved111: Reserved,
+        Flush: *const fn (*ID3D11DeviceContext) callconv(.winapi) void,
         // slot 112: GetType
         _reserved112: Reserved,
         // slot 113: GetContextFlags
@@ -1287,6 +1288,10 @@ pub const ID3D11DeviceContext = extern struct {
 
     pub inline fn Release(self: *ID3D11DeviceContext) u32 {
         return self.vtable.Release(self);
+    }
+
+    pub inline fn Flush(self: *ID3D11DeviceContext) void {
+        self.vtable.Flush(self);
     }
 };
 

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -41,8 +41,6 @@ pub const Device = struct {
     /// The HWND for querying the actual window size.
     /// Null for composition (SwapChainPanel) or shared texture surfaces.
     hwnd: ?HWND,
-    /// True when using shared texture mode (no swap chain).
-    shared_texture_mode: bool,
     width: u32,
     height: u32,
     /// Desired size set by the embedder (via ghostty_surface_set_size).
@@ -102,9 +100,7 @@ pub const Device = struct {
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
         var panel_native: ?*dxgi.ISwapChainPanelNative = null;
         var rtv: ?*d3d11.ID3D11RenderTargetView = null;
-        const shared_texture_mode = surface == .shared_texture;
-
-        if (!shared_texture_mode) {
+        if (surface != .shared_texture) {
             // QueryInterface device -> IDXGIDevice
             var dxgi_device_opt: ?*anyopaque = null;
             hr = dev.QueryInterface(&dxgi.IDXGIDevice.IID, &dxgi_device_opt);
@@ -237,7 +233,6 @@ pub const Device = struct {
                 .hwnd => |h| h,
                 .swap_chain_panel, .shared_texture => null,
             },
-            .shared_texture_mode = shared_texture_mode,
             .width = width,
             .height = height,
         };
@@ -302,8 +297,8 @@ pub const Device = struct {
     };
 
     pub fn resize(self: *Device, width: u32, height: u32) ResizeError!void {
-        if (self.shared_texture_mode) {
-            // In shared texture mode there is no swap chain; Target handles
+        if (self.swap_chain == null) {
+            // Shared texture mode: no swap chain. Target handles
             // the actual texture recreation on resize.
             self.width = width;
             self.height = height;
@@ -337,8 +332,8 @@ pub const Device = struct {
     };
 
     pub fn present(self: *Device) PresentError!void {
-        if (self.shared_texture_mode) {
-            // Shared texture mode has no swap chain; flush the immediate
+        if (self.swap_chain == null) {
+            // Shared texture mode: no swap chain. Flush the immediate
             // context so the rendered content is visible to the consumer.
             self.context.Flush();
             return;

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -13,6 +13,13 @@ const HWND = dxgi.HWND;
 pub const Surface = union(enum) {
     hwnd: HWND,
     swap_chain_panel: *dxgi.ISwapChainPanelNative,
+    shared_texture: SharedTextureConfig,
+};
+
+pub const SharedTextureConfig = struct {
+    handle_out: *?std.os.windows.HANDLE,
+    width: u32,
+    height: u32,
 };
 
 pub const RECT = extern struct {
@@ -27,13 +34,15 @@ extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) i3
 pub const Device = struct {
     device: *d3d11.ID3D11Device,
     context: *d3d11.ID3D11DeviceContext,
-    swap_chain: *dxgi.IDXGISwapChain1,
+    swap_chain: ?*dxgi.IDXGISwapChain1,
     panel_native: ?*dxgi.ISwapChainPanelNative,
     rtv: ?*d3d11.ID3D11RenderTargetView,
     blend_state: ?*d3d11.ID3D11BlendState,
     /// The HWND for querying the actual window size.
-    /// Null for composition (SwapChainPanel) surfaces.
+    /// Null for composition (SwapChainPanel) or shared texture surfaces.
     hwnd: ?HWND,
+    /// True when using shared texture mode (no swap chain).
+    shared_texture_mode: bool,
     width: u32,
     height: u32,
     /// Desired size set by the embedder (via ghostty_surface_set_size).
@@ -121,25 +130,26 @@ pub const Device = struct {
         // Create swap chain. Descriptor differs by surface type:
         // - HWND: opaque window, DXGI_ALPHA_MODE_UNSPECIFIED
         // - Composition: premultiplied alpha for XAML integration
+        // - Shared texture: no swap chain, Target owns the texture
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
         var panel_native: ?*dxgi.ISwapChainPanelNative = null;
-
-        var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-            .Width = width,
-            .Height = height,
-            .Format = .B8G8R8A8_UNORM,
-            .Stereo = 0,
-            .SampleDesc = .{ .Count = 1, .Quality = 0 },
-            .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-            .BufferCount = 2,
-            .Scaling = .NONE,
-            .SwapEffect = .FLIP_DISCARD,
-            .AlphaMode = .UNSPECIFIED,
-            .Flags = 0,
-        };
+        var shared_texture_mode = false;
 
         switch (surface) {
             .hwnd => |hwnd| {
+                var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                    .Width = width,
+                    .Height = height,
+                    .Format = .B8G8R8A8_UNORM,
+                    .Stereo = 0,
+                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    .BufferCount = 2,
+                    .Scaling = .NONE,
+                    .SwapEffect = .FLIP_DISCARD,
+                    .AlphaMode = .UNSPECIFIED,
+                    .Flags = 0,
+                };
                 hr = factory.CreateSwapChainForHwnd(
                     @ptrCast(dev),
                     hwnd,
@@ -151,10 +161,21 @@ pub const Device = struct {
             },
             .swap_chain_panel => |panel| {
                 panel_native = panel;
-                desc.AlphaMode = .PREMULTIPLIED;
-                // Composition surfaces need scaling -- the panel may not
-                // match the buffer size exactly, unlike HWND surfaces.
-                desc.Scaling = .STRETCH;
+                var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                    .Width = width,
+                    .Height = height,
+                    .Format = .B8G8R8A8_UNORM,
+                    .Stereo = 0,
+                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    .BufferCount = 2,
+                    .Scaling = .STRETCH,
+                    .SwapEffect = .FLIP_DISCARD,
+                    // Composition surfaces need premultiplied alpha for XAML
+                    // integration; HWND surfaces use UNSPECIFIED.
+                    .AlphaMode = .PREMULTIPLIED,
+                    .Flags = 0,
+                };
                 hr = factory.CreateSwapChainForComposition(
                     @ptrCast(dev),
                     &desc,
@@ -162,17 +183,24 @@ pub const Device = struct {
                     &swap_chain,
                 );
             },
+            .shared_texture => {
+                // No swap chain in shared texture mode; Target owns the
+                // texture and exposes it via a shared DXGI handle.
+                shared_texture_mode = true;
+            },
         }
-        if (com.FAILED(hr) or swap_chain == null) {
-            log.err("swap chain creation failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-            return InitError.SwapChainCreationFailed;
+        if (!shared_texture_mode) {
+            if (com.FAILED(hr) or swap_chain == null) {
+                log.err("swap chain creation failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return InitError.SwapChainCreationFailed;
+            }
         }
-        const sc = swap_chain.?;
-        errdefer _ = sc.Release();
+        const sc = swap_chain;
+        errdefer if (sc) |s| { _ = s.Release(); };
 
         // For composition surfaces, attach swap chain to the panel.
         if (panel_native) |panel| {
-            hr = panel.SetSwapChain(@ptrCast(sc));
+            hr = panel.SetSwapChain(@ptrCast(sc.?));
             if (com.FAILED(hr)) {
                 log.err("SetSwapChain failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
                 return InitError.SetSwapChainFailed;
@@ -182,12 +210,15 @@ pub const Device = struct {
             _ = panel.SetSwapChain(null);
         };
 
-        // Get the back buffer and create a render target view.
-        const rtv = createRenderTargetView(dev, sc) orelse {
-            log.err("createRenderTargetView failed", .{});
-            return InitError.RenderTargetViewFailed;
-        };
-        errdefer _ = rtv.Release();
+        // Get the back buffer and create a render target view (swap chain modes only).
+        var rtv: ?*d3d11.ID3D11RenderTargetView = null;
+        if (sc) |s| {
+            rtv = createRenderTargetView(dev, s) orelse {
+                log.err("createRenderTargetView failed", .{});
+                return InitError.RenderTargetViewFailed;
+            };
+        }
+        errdefer if (rtv) |r| { _ = r.Release(); };
 
         // Create a premultiplied-alpha blend state so that translucent
         // pixels (e.g. padding cells output as float4(0,0,0,0) by the
@@ -209,8 +240,9 @@ pub const Device = struct {
             .blend_state = blend_state,
             .hwnd = switch (surface) {
                 .hwnd => |h| h,
-                .swap_chain_panel => null,
+                .swap_chain_panel, .shared_texture => null,
             },
+            .shared_texture_mode = shared_texture_mode,
             .width = width,
             .height = height,
         };
@@ -235,15 +267,15 @@ pub const Device = struct {
         }
 
         // Release in reverse creation order.
-        _ = self.swap_chain.Release();
+        if (self.swap_chain) |sc| { _ = sc.Release(); }
         _ = self.context.Release();
         _ = self.device.Release();
     }
 
     /// Return the desired surface size.
     /// HWND path: queries GetClientRect for the actual window size.
-    /// Composition path: returns the target size set by the embedder
-    /// via setTargetSize, falling back to the current buffer size.
+    /// Composition and shared texture paths: returns the target size
+    /// set by the embedder, falling back to the current buffer size.
     pub fn windowSize(self: *const Device) struct { width: u32, height: u32 } {
         if (self.hwnd) |hwnd| {
             var rc: RECT = undefined;
@@ -275,6 +307,14 @@ pub const Device = struct {
     };
 
     pub fn resize(self: *Device, width: u32, height: u32) ResizeError!void {
+        if (self.shared_texture_mode) {
+            // In shared texture mode there is no swap chain; Target handles
+            // the actual texture recreation on resize.
+            self.width = width;
+            self.height = height;
+            return;
+        }
+
         // Release current render target view.
         if (self.rtv) |rtv| {
             _ = rtv.Release();
@@ -282,14 +322,14 @@ pub const Device = struct {
         }
 
         // Resize swap chain buffers.
-        const hr = self.swap_chain.ResizeBuffers(0, width, height, .UNKNOWN, 0);
+        const hr = self.swap_chain.?.ResizeBuffers(0, width, height, .UNKNOWN, 0);
         if (com.FAILED(hr)) {
             log.err("IDXGISwapChain1::ResizeBuffers failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
             return ResizeError.ResizeBuffersFailed;
         }
 
         // Recreate render target view.
-        self.rtv = createRenderTargetView(self.device, self.swap_chain) orelse {
+        self.rtv = createRenderTargetView(self.device, self.swap_chain.?) orelse {
             return ResizeError.RenderTargetViewFailed;
         };
 
@@ -302,7 +342,13 @@ pub const Device = struct {
     };
 
     pub fn present(self: *Device) PresentError!void {
-        const hr = self.swap_chain.Present(1, 0);
+        if (self.shared_texture_mode) {
+            // Shared texture mode has no swap chain; flush the immediate
+            // context so the rendered content is visible to the consumer.
+            self.context.Flush();
+            return;
+        }
+        const hr = self.swap_chain.?.Present(1, 0);
         if (com.FAILED(hr)) {
             log.err("IDXGISwapChain1::Present failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
             return PresentError.PresentFailed;

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -98,126 +98,121 @@ pub const Device = struct {
 
         log.debug("D3D11CreateDevice OK: device=0x{x}", .{@intFromPtr(dev)});
 
-        // QueryInterface device -> IDXGIDevice
-        var dxgi_device_opt: ?*anyopaque = null;
-        hr = dev.QueryInterface(&dxgi.IDXGIDevice.IID, &dxgi_device_opt);
-        if (com.FAILED(hr) or dxgi_device_opt == null) {
-            log.err("QI for IDXGIDevice failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-            return InitError.QueryInterfaceFailed;
-        }
-        const dxgi_device: *dxgi.IDXGIDevice = @ptrCast(@alignCast(dxgi_device_opt.?));
-        defer _ = dxgi_device.Release();
-
-        // Get the adapter from the DXGI device.
-        var adapter: ?*dxgi.IDXGIAdapter = null;
-        hr = dxgi_device.GetAdapter(&adapter);
-        if (com.FAILED(hr) or adapter == null) {
-            log.err("GetAdapter failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-            return InitError.GetAdapterFailed;
-        }
-        defer _ = adapter.?.Release();
-
-        // Get IDXGIFactory2 from the adapter.
-        var factory_opt: ?*anyopaque = null;
-        hr = adapter.?.GetParent(&dxgi.IDXGIFactory2.IID, &factory_opt);
-        if (com.FAILED(hr) or factory_opt == null) {
-            log.err("GetParent(IDXGIFactory2) failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-            return InitError.GetFactoryFailed;
-        }
-        const factory: *dxgi.IDXGIFactory2 = @ptrCast(@alignCast(factory_opt.?));
-        defer _ = factory.Release();
-
-        // Create swap chain. Descriptor differs by surface type:
-        // - HWND: opaque window, DXGI_ALPHA_MODE_UNSPECIFIED
-        // - Composition: premultiplied alpha for XAML integration
-        // - Shared texture: no swap chain, Target owns the texture
+        // Shared texture mode: no swap chain needed, skip DXGI factory queries.
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
         var panel_native: ?*dxgi.ISwapChainPanelNative = null;
-        var shared_texture_mode = false;
+        var rtv: ?*d3d11.ID3D11RenderTargetView = null;
+        const shared_texture_mode = surface == .shared_texture;
 
-        switch (surface) {
-            .hwnd => |hwnd| {
-                var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-                    .Width = width,
-                    .Height = height,
-                    .Format = .B8G8R8A8_UNORM,
-                    .Stereo = 0,
-                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
-                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                    .BufferCount = 2,
-                    .Scaling = .NONE,
-                    .SwapEffect = .FLIP_DISCARD,
-                    .AlphaMode = .UNSPECIFIED,
-                    .Flags = 0,
-                };
-                hr = factory.CreateSwapChainForHwnd(
-                    @ptrCast(dev),
-                    hwnd,
-                    &desc,
-                    null,
-                    null,
-                    &swap_chain,
-                );
-            },
-            .swap_chain_panel => |panel| {
-                panel_native = panel;
-                var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
-                    .Width = width,
-                    .Height = height,
-                    .Format = .B8G8R8A8_UNORM,
-                    .Stereo = 0,
-                    .SampleDesc = .{ .Count = 1, .Quality = 0 },
-                    .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                    .BufferCount = 2,
-                    .Scaling = .STRETCH,
-                    .SwapEffect = .FLIP_DISCARD,
-                    // Composition surfaces need premultiplied alpha for XAML
-                    // integration; HWND surfaces use UNSPECIFIED.
-                    .AlphaMode = .PREMULTIPLIED,
-                    .Flags = 0,
-                };
-                hr = factory.CreateSwapChainForComposition(
-                    @ptrCast(dev),
-                    &desc,
-                    null,
-                    &swap_chain,
-                );
-            },
-            .shared_texture => {
-                // No swap chain in shared texture mode; Target owns the
-                // texture and exposes it via a shared DXGI handle.
-                shared_texture_mode = true;
-            },
-        }
         if (!shared_texture_mode) {
+            // QueryInterface device -> IDXGIDevice
+            var dxgi_device_opt: ?*anyopaque = null;
+            hr = dev.QueryInterface(&dxgi.IDXGIDevice.IID, &dxgi_device_opt);
+            if (com.FAILED(hr) or dxgi_device_opt == null) {
+                log.err("QI for IDXGIDevice failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return InitError.QueryInterfaceFailed;
+            }
+            const dxgi_device: *dxgi.IDXGIDevice = @ptrCast(@alignCast(dxgi_device_opt.?));
+            defer _ = dxgi_device.Release();
+
+            // Get the adapter from the DXGI device.
+            var adapter: ?*dxgi.IDXGIAdapter = null;
+            hr = dxgi_device.GetAdapter(&adapter);
+            if (com.FAILED(hr) or adapter == null) {
+                log.err("GetAdapter failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return InitError.GetAdapterFailed;
+            }
+            defer _ = adapter.?.Release();
+
+            // Get IDXGIFactory2 from the adapter.
+            var factory_opt: ?*anyopaque = null;
+            hr = adapter.?.GetParent(&dxgi.IDXGIFactory2.IID, &factory_opt);
+            if (com.FAILED(hr) or factory_opt == null) {
+                log.err("GetParent(IDXGIFactory2) failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                return InitError.GetFactoryFailed;
+            }
+            const factory: *dxgi.IDXGIFactory2 = @ptrCast(@alignCast(factory_opt.?));
+            defer _ = factory.Release();
+
+            // Create swap chain. Descriptor differs by surface type:
+            // - HWND: opaque window, DXGI_ALPHA_MODE_UNSPECIFIED
+            // - Composition: premultiplied alpha for XAML integration
+            switch (surface) {
+                .hwnd => |hwnd| {
+                    var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                        .Width = width,
+                        .Height = height,
+                        .Format = .B8G8R8A8_UNORM,
+                        .Stereo = 0,
+                        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                        .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                        .BufferCount = 2,
+                        .Scaling = .NONE,
+                        .SwapEffect = .FLIP_DISCARD,
+                        .AlphaMode = .UNSPECIFIED,
+                        .Flags = 0,
+                    };
+                    hr = factory.CreateSwapChainForHwnd(
+                        @ptrCast(dev),
+                        hwnd,
+                        &desc,
+                        null,
+                        null,
+                        &swap_chain,
+                    );
+                },
+                .swap_chain_panel => |panel| {
+                    panel_native = panel;
+                    var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+                        .Width = width,
+                        .Height = height,
+                        .Format = .B8G8R8A8_UNORM,
+                        .Stereo = 0,
+                        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                        .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                        .BufferCount = 2,
+                        .Scaling = .STRETCH,
+                        .SwapEffect = .FLIP_DISCARD,
+                        // Composition surfaces need premultiplied alpha for XAML
+                        // integration; HWND surfaces use UNSPECIFIED.
+                        .AlphaMode = .PREMULTIPLIED,
+                        .Flags = 0,
+                    };
+                    hr = factory.CreateSwapChainForComposition(
+                        @ptrCast(dev),
+                        &desc,
+                        null,
+                        &swap_chain,
+                    );
+                },
+                .shared_texture => unreachable,
+            }
             if (com.FAILED(hr) or swap_chain == null) {
                 log.err("swap chain creation failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
                 return InitError.SwapChainCreationFailed;
             }
-        }
-        const sc = swap_chain;
-        errdefer if (sc) |s| { _ = s.Release(); };
 
-        // For composition surfaces, attach swap chain to the panel.
-        if (panel_native) |panel| {
-            hr = panel.SetSwapChain(@ptrCast(sc.?));
-            if (com.FAILED(hr)) {
-                log.err("SetSwapChain failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
-                return InitError.SetSwapChainFailed;
+            // For composition surfaces, attach swap chain to the panel.
+            if (panel_native) |panel| {
+                hr = panel.SetSwapChain(@ptrCast(swap_chain.?));
+                if (com.FAILED(hr)) {
+                    log.err("SetSwapChain failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                    _ = swap_chain.?.Release();
+                    return InitError.SetSwapChainFailed;
+                }
             }
-        }
-        errdefer if (panel_native) |panel| {
-            _ = panel.SetSwapChain(null);
-        };
 
-        // Get the back buffer and create a render target view (swap chain modes only).
-        var rtv: ?*d3d11.ID3D11RenderTargetView = null;
-        if (sc) |s| {
-            rtv = createRenderTargetView(dev, s) orelse {
+            // Get the back buffer and create a render target view.
+            rtv = createRenderTargetView(dev, swap_chain.?) orelse {
                 log.err("createRenderTargetView failed", .{});
+                if (panel_native) |panel| _ = panel.SetSwapChain(null);
+                _ = swap_chain.?.Release();
                 return InitError.RenderTargetViewFailed;
             };
         }
+        const sc = swap_chain;
+        errdefer if (sc) |s| { _ = s.Release(); };
+        errdefer if (panel_native) |panel| { _ = panel.SetSwapChain(null); };
         errdefer if (rtv) |r| { _ = r.Release(); };
 
         // Create a premultiplied-alpha blend state so that translucent

--- a/src/renderer/directx11/dxgi.zig
+++ b/src/renderer/directx11/dxgi.zig
@@ -116,6 +116,46 @@ pub const IDXGIDeviceSubObject = extern struct {
     };
 };
 
+// IDXGIResource
+// Inherits IDXGIDeviceSubObject. Slot we call: GetSharedHandle (slot 8)
+pub const IDXGIResource = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0x035f3ab4,
+        .data2 = 0x482e,
+        .data3 = 0x4e50,
+        .data4 = .{ 0xb4, 0x1f, 0x8a, 0x7f, 0x8b, 0xd8, 0x96, 0x0b },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDXGIResource, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDXGIResource) callconv(.winapi) u32,
+        Release: *const fn (*IDXGIResource) callconv(.winapi) u32,
+        // IDXGIObject (slots 3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIDeviceSubObject (slot 7)
+        GetDevice: Reserved,
+        // IDXGIResource (slots 8-11)
+        GetSharedHandle: *const fn (*IDXGIResource, *?std.os.windows.HANDLE) callconv(.winapi) HRESULT,
+        GetUsage: Reserved,
+        SetEvictionPriority: Reserved,
+        GetEvictionPriority: Reserved,
+    };
+
+    pub inline fn GetSharedHandle(self: *IDXGIResource, handle: *?std.os.windows.HANDLE) HRESULT {
+        return self.vtable.GetSharedHandle(self, handle);
+    }
+
+    pub inline fn Release(self: *IDXGIResource) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
 // IDXGISwapChain
 // Slots we call: Present (8), GetBuffer (9)
 pub const IDXGISwapChain = extern struct {

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -339,6 +339,36 @@ test "BlendState: premultiplied alpha config" {
     try std.testing.expectEqual(rt0.RenderTargetWriteMask, 0x0F);
 }
 
+test "Device: shared texture mode skips swap chain" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    const HANDLE = std.os.windows.HANDLE;
+    var shared_handle: ?HANDLE = null;
+
+    var device = Device.init(.{ .shared_texture = .{
+        .handle_out = &shared_handle,
+        .width = 640,
+        .height = 480,
+    } }, 640, 480) catch return; // Skip if no GPU.
+    defer device.deinit();
+
+    // Shared texture mode: no swap chain, no RTV on Device (Target owns those).
+    try std.testing.expect(device.swap_chain == null);
+    try std.testing.expect(device.rtv == null);
+    try std.testing.expect(device.shared_texture_mode);
+    try std.testing.expectEqual(device.hwnd, null);
+    try std.testing.expectEqual(device.width, 640);
+    try std.testing.expectEqual(device.height, 480);
+
+    // present() should flush without error.
+    try device.present();
+
+    // resize() should update dimensions without touching a swap chain.
+    try device.resize(1280, 720);
+    try std.testing.expectEqual(device.width, 1280);
+    try std.testing.expectEqual(device.height, 720);
+}
+
 test "SwapChain: HWND surface uses SCALING_NONE" {
     if (comptime builtin.os.tag != .windows) return;
 

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -355,7 +355,6 @@ test "Device: shared texture mode skips swap chain" {
     // Shared texture mode: no swap chain, no RTV on Device (Target owns those).
     try std.testing.expect(device.swap_chain == null);
     try std.testing.expect(device.rtv == null);
-    try std.testing.expect(device.shared_texture_mode);
     try std.testing.expectEqual(device.hwnd, null);
     try std.testing.expectEqual(device.width, 640);
     try std.testing.expectEqual(device.height, 480);

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -390,7 +390,7 @@ test "SwapChain: HWND surface uses SCALING_NONE" {
     // Query the swap chain descriptor and verify scaling.
     // Guards against regression to STRETCH (PR #76).
     var desc: dxgi.DXGI_SWAP_CHAIN_DESC1 = undefined;
-    const hr = device.swap_chain.GetDesc1(&desc);
+    const hr = device.swap_chain.?.GetDesc1(&desc);
     try std.testing.expect(!com.FAILED(hr));
     try std.testing.expectEqual(desc.Scaling, .NONE);
 }


### PR DESCRIPTION
## Summary

Adds a third DX11 surface mode where ghostty renders to a standalone D3D11 texture and exposes a DXGI shared handle. Consumers (game engines, custom renderers, offscreen scenarios) open the handle on their own device and sample the texture directly.

- Extends `ghostty_platform_windows_s` with `shared_texture_out`, `texture_width`, `texture_height`
- Mode selected via null-inference: both `hwnd` and `swap_chain_panel` null + `shared_texture_out` non-null
- Target owns the texture and RTV in shared texture mode (Device skips swap chain creation)
- Resize flows through existing `beginFrame()` path, consumer re-reads handle after size change
- Legacy `GetSharedHandle` for now, NT handle path as follow-up when D3D12/Vulkan consumers appear

Closes #91

## What I Learnt

**Surface vs Target**: Surface is the input configuration (HWND, XAML panel, or shared texture) that tells Device what infrastructure to create. Target is the per-frame render destination wrapping the RTV. In swap chain modes Target borrows the RTV from Device. In shared texture mode Target owns the texture and RTV directly -- fulfilling the comment that was already in Target.zig anticipating this.

**DXGI shared handles**: `IDXGIResource::GetSharedHandle()` returns a legacy handle for D3D11 `OpenSharedResource`. NT handle path via `IDXGIResource1::CreateSharedHandle()` needed for D3D12/Vulkan interop -- left as follow-up.

## Test plan

- [x] Build compiles clean (`zig build -Dapp-runtime=none -Drenderer=directx11`)
- [x] Existing gpu_test passes (updated for optional swap_chain)
- [x] New shared texture lifecycle test (init 640x480, resize 1280x720, deinit)
- [x] Full test suite passes