### PR TITLE
renderer/dx11: enable D3D11 multithread protection on device context

### DIFF
--- a/src/renderer/DirectX11.zig
+++ b/src/renderer/DirectX11.zig
@@ -225,6 +225,10 @@ pub inline fn beginFrame(
         const h: u32 = @intCast(target.height);
         if (dev.width != w or dev.height != h) {
             if (renderer.api.shared_target) |*st| {
+                // Flush pending GPU commands before releasing the old RTV.
+                // Without this the command buffer may still reference the
+                // old render target, causing an ACCESS_VIOLATION in d3d11.dll.
+                dev.context.Flush();
                 // Shared texture mode: Target owns the texture, resize it.
                 st.resizeSharedTexture(dev.device, w, h) catch |err| {
                     log.err("shared texture resize failed: {}", .{err});

--- a/src/renderer/directx11/com_test.zig
+++ b/src/renderer/directx11/com_test.zig
@@ -109,6 +109,10 @@ test "ID3D11DeviceContext is a single vtable pointer" {
     try std.testing.expectEqual(@sizeOf(d3d11.ID3D11DeviceContext), @sizeOf(*anyopaque));
 }
 
+test "ID3D11Multithread is a single vtable pointer" {
+    try std.testing.expectEqual(@sizeOf(d3d11.ID3D11Multithread), @sizeOf(*anyopaque));
+}
+
 // Verify GUID constants are the right values (cross-referenced with
 // Windows SDK headers).
 
@@ -141,6 +145,14 @@ test "ID3D11Texture2D IID" {
     try std.testing.expectEqual(iid.data1, 0x6f15aaf2);
     try std.testing.expectEqual(iid.data2, 0xd208);
     try std.testing.expectEqual(iid.data3, 0x4e89);
+}
+
+test "ID3D11Multithread IID" {
+    const iid = d3d11.ID3D11Multithread.IID;
+    try std.testing.expectEqual(iid.data1, 0x9B7E4E00);
+    try std.testing.expectEqual(iid.data2, 0x342C);
+    try std.testing.expectEqual(iid.data3, 0x4106);
+    try std.testing.expectEqualSlices(u8, &iid.data4, &[_]u8{ 0xA1, 0x9F, 0x4F, 0x27, 0x04, 0xF6, 0x89, 0xF0 });
 }
 
 test "Buffer Options has device and context fields" {

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -1293,6 +1293,10 @@ pub const ID3D11DeviceContext = extern struct {
     pub inline fn Flush(self: *ID3D11DeviceContext) void {
         self.vtable.Flush(self);
     }
+
+    pub inline fn QueryInterface(self: *ID3D11DeviceContext, riid: *const GUID, ppvObject: *?*anyopaque) HRESULT {
+        return self.vtable.QueryInterface(self, riid, ppvObject);
+    }
 };
 
 /// Opaque type - we never call methods on class instances directly.

--- a/src/renderer/directx11/d3d11.zig
+++ b/src/renderer/directx11/d3d11.zig
@@ -1298,6 +1298,46 @@ pub const ID3D11DeviceContext = extern struct {
 /// Opaque type - we never call methods on class instances directly.
 pub const ID3D11ClassInstance = opaque {};
 
+// ID3D11Multithread
+// Vtable order from d3d11.h (inherits IUnknown 0-2):
+//   0: QueryInterface
+//   1: AddRef
+//   2: Release
+//   3: Enter
+//   4: Leave
+//   5: SetMultithreadProtected
+//   6: GetMultithreadProtected
+pub const ID3D11Multithread = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0x9B7E4E00,
+        .data2 = 0x342C,
+        .data3 = 0x4106,
+        .data4 = .{ 0xA1, 0x9F, 0x4F, 0x27, 0x04, 0xF6, 0x89, 0xF0 },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*ID3D11Multithread, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*ID3D11Multithread) callconv(.winapi) u32,
+        Release: *const fn (*ID3D11Multithread) callconv(.winapi) u32,
+        // ID3D11Multithread (slots 3-6)
+        Enter: *const fn (*ID3D11Multithread) callconv(.winapi) void,
+        Leave: *const fn (*ID3D11Multithread) callconv(.winapi) void,
+        SetMultithreadProtected: *const fn (*ID3D11Multithread, i32) callconv(.winapi) i32,
+        GetMultithreadProtected: *const fn (*ID3D11Multithread) callconv(.winapi) i32,
+    };
+
+    pub inline fn SetMultithreadProtected(self: *ID3D11Multithread, protect: i32) i32 {
+        return self.vtable.SetMultithreadProtected(self, protect);
+    }
+
+    pub inline fn Release(self: *ID3D11Multithread) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
 // D3D11CreateDevice - imported from d3d11.dll
 pub const D3D11CreateDevice = @extern(*const fn (
     pAdapter: ?*anyopaque, // IDXGIAdapter

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -104,6 +104,32 @@ pub const Device = struct {
 
         log.debug("D3D11CreateDevice OK: device=0x{x}", .{@intFromPtr(dev)});
 
+        // Enable D3D11 multithread protection so the runtime serialises
+        // context calls across threads.  Without this, a host process that
+        // already owns D3D11 devices (e.g. Unity, Unreal) can crash when
+        // its threads and ghostty's renderer thread touch shared driver
+        // state concurrently.
+        {
+            var mt_opt: ?*anyopaque = null;
+            const mt_hr = ctx.vtable.QueryInterface(
+                @ptrCast(ctx),
+                &d3d11.ID3D11Multithread.IID,
+                &mt_opt,
+            );
+            if (com.SUCCEEDED(mt_hr)) {
+                if (mt_opt) |mt_raw| {
+                    const mt: *d3d11.ID3D11Multithread = @ptrCast(@alignCast(mt_raw));
+                    _ = mt.SetMultithreadProtected(1);
+                    _ = mt.Release();
+                    log.debug("D3D11 multithread protection enabled", .{});
+                }
+            } else {
+                // Not fatal -- standalone processes work fine without it,
+                // but log a warning since embedding scenarios may be fragile.
+                log.warn("ID3D11Multithread QI failed: hr=0x{x}", .{@as(u32, @bitCast(mt_hr))});
+            }
+        }
+
         // Shared texture mode: no swap chain needed, skip DXGI factory queries.
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
         var panel_native: ?*dxgi.ISwapChainPanelNative = null;

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -111,8 +111,7 @@ pub const Device = struct {
         // state concurrently.
         {
             var mt_opt: ?*anyopaque = null;
-            const mt_hr = ctx.vtable.QueryInterface(
-                @ptrCast(ctx),
+            const mt_hr = ctx.QueryInterface(
                 &d3d11.ID3D11Multithread.IID,
                 &mt_opt,
             );

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -16,6 +16,7 @@ const RenderPass = @import("RenderPass.zig");
 const Device = @import("device.zig").Device;
 const dcomp = @import("dcomp.zig");
 const Surface = @import("device.zig").Surface;
+const Target = @import("Target.zig");
 
 const Buffer = buffer_mod.Buffer;
 
@@ -449,4 +450,71 @@ test "Device: shared texture mode has no dcomp objects" {
     try std.testing.expectEqual(device.dcomp_device, null);
     try std.testing.expectEqual(device.dcomp_target, null);
     try std.testing.expectEqual(device.dcomp_visual, null);
+}
+
+test "Device: multithread protection is enabled after init" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    const HANDLE = std.os.windows.HANDLE;
+    var shared_handle: ?HANDLE = null;
+
+    var device = Device.init(.{ .shared_texture = .{
+        .handle_out = &shared_handle,
+        .width = 640,
+        .height = 480,
+    } }, 640, 480) catch return;
+    defer device.deinit();
+
+    // Query ID3D11Multithread from the context and verify protection is on.
+    // Guards against accidentally removing SetMultithreadProtected(TRUE)
+    // from Device.init -- without it, embedding hosts (Unity, Unreal) crash.
+    var mt_opt: ?*anyopaque = null;
+    const hr = device.context.QueryInterface(&d3d11.ID3D11Multithread.IID, &mt_opt);
+    try std.testing.expect(com.SUCCEEDED(hr));
+    try std.testing.expect(mt_opt != null);
+    const mt: *d3d11.ID3D11Multithread = @ptrCast(@alignCast(mt_opt.?));
+    defer _ = mt.Release();
+
+    // GetMultithreadProtected returns non-zero when protection is enabled.
+    try std.testing.expect(mt.vtable.GetMultithreadProtected(mt) != 0);
+}
+
+test "Device: shared texture resize after GPU work does not crash" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    const HANDLE = std.os.windows.HANDLE;
+    var shared_handle: ?HANDLE = null;
+
+    var device = Device.init(.{ .shared_texture = .{
+        .handle_out = &shared_handle,
+        .width = 640,
+        .height = 480,
+    } }, 640, 480) catch return;
+    defer device.deinit();
+
+    // Create a shared texture target (simulates what the renderer does).
+    var target = Target.initSharedTexture(device.device, 640, 480, &shared_handle) catch return;
+    defer target.deinit();
+
+    // Issue GPU work against the RTV, then flush and resize -- this is
+    // the sequence that crashed in-process hosts before the Flush() fix.
+    // ClearRenderTargetView puts commands in the GPU command buffer that
+    // reference the current RTV. Without Flush() before resize, releasing
+    // the old RTV while those commands are in-flight causes an AV.
+    const clear_color = [4]f32{ 0.0, 0.0, 0.0, 1.0 };
+    device.context.ClearRenderTargetView(target.rtv.?, &clear_color);
+
+    // Flush before resize (this is what beginFrame now does).
+    device.context.Flush();
+
+    // Resize -- releases old RTV/texture, creates new ones.
+    try target.resizeSharedTexture(device.device, 1280, 720);
+
+    try std.testing.expect(target.rtv != null);
+    try std.testing.expectEqual(@as(usize, 1280), target.width);
+    try std.testing.expectEqual(@as(usize, 720), target.height);
+
+    // Issue work against the new RTV to confirm it's valid.
+    device.context.ClearRenderTargetView(target.rtv.?, &clear_color);
+    device.context.Flush();
 }


### PR DESCRIPTION
## Summary

- Add `ID3D11Multithread` COM interface bindings to `d3d11.zig`
- After `D3D11CreateDevice`, query the context for `ID3D11Multithread` and call `SetMultithreadProtected(TRUE)` so the runtime serialises context calls across threads
- Fixes crash when ghostty runs inside a host process that already owns D3D11 devices (e.g. Unity), where concurrent thread access to shared GPU/driver state causes an access violation ~50ms after surface creation

Enabled for all surface modes since the overhead is negligible.

Closes # 95

## What I Learnt

**ID3D11Multithread**: D3D11 devices are created without single-threaded mode by default, but that doesn't mean they're thread-safe. The runtime needs an explicit `SetMultithreadProtected(TRUE)` call to actually serialise access. Without it, the driver assumes the app handles synchronisation itself. In a standalone process this is fine (ghostty's renderer thread is the only D3D11 user), but in an embedding scenario the host's threads share driver state and can collide.

**Why all surface modes**: Even HWND mode benefits -- if a future host creates an HWND surface but also has its own D3D11 work on other threads, the same crash would happen. The cost of the runtime lock is negligible compared to GPU work.