### PR TITLE
renderer/dx11: use DirectComposition for HWND surfaces

### DIFF
--- a/src/renderer/directx11/dcomp.zig
+++ b/src/renderer/directx11/dcomp.zig
@@ -1,0 +1,119 @@
+const std = @import("std");
+const com = @import("com.zig");
+const dxgi = @import("dxgi.zig");
+const GUID = com.GUID;
+const HRESULT = com.HRESULT;
+const IUnknown = com.IUnknown;
+const Reserved = com.Reserved;
+const HWND = dxgi.HWND;
+
+// IDCompositionDevice
+// Slots we call: Commit (3), CreateTargetForHwnd (6), CreateVisual (7)
+pub const IDCompositionDevice = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0xc37ea93a,
+        .data2 = 0xe7aa,
+        .data3 = 0x450d,
+        .data4 = .{ 0xb1, 0x6f, 0x97, 0x46, 0xcb, 0x04, 0x07, 0xf3 },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDCompositionDevice, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDCompositionDevice) callconv(.winapi) u32,
+        Release: *const fn (*IDCompositionDevice) callconv(.winapi) u32,
+        // IDCompositionDevice (slots 3-7)
+        Commit: *const fn (*IDCompositionDevice) callconv(.winapi) HRESULT,
+        WaitForCommitCompletion: Reserved,
+        GetFrameStatistics: Reserved,
+        CreateTargetForHwnd: *const fn (*IDCompositionDevice, hwnd: HWND, topmost: i32, target: *?*IDCompositionTarget) callconv(.winapi) HRESULT,
+        CreateVisual: *const fn (*IDCompositionDevice, visual: *?*IDCompositionVisual) callconv(.winapi) HRESULT,
+    };
+
+    pub inline fn Commit(self: *IDCompositionDevice) HRESULT {
+        return self.vtable.Commit(self);
+    }
+
+    pub inline fn CreateTargetForHwnd(self: *IDCompositionDevice, hwnd: HWND, topmost: i32, target: *?*IDCompositionTarget) HRESULT {
+        return self.vtable.CreateTargetForHwnd(self, hwnd, topmost, target);
+    }
+
+    pub inline fn CreateVisual(self: *IDCompositionDevice, visual: *?*IDCompositionVisual) HRESULT {
+        return self.vtable.CreateVisual(self, visual);
+    }
+
+    pub inline fn Release(self: *IDCompositionDevice) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// IDCompositionTarget
+// Slot we call: SetRoot (3)
+pub const IDCompositionTarget = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDCompositionTarget, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDCompositionTarget) callconv(.winapi) u32,
+        Release: *const fn (*IDCompositionTarget) callconv(.winapi) u32,
+        // IDCompositionTarget (slot 3)
+        SetRoot: *const fn (*IDCompositionTarget, visual: ?*IDCompositionVisual) callconv(.winapi) HRESULT,
+    };
+
+    pub inline fn SetRoot(self: *IDCompositionTarget, visual: ?*IDCompositionVisual) HRESULT {
+        return self.vtable.SetRoot(self, visual);
+    }
+
+    pub inline fn Release(self: *IDCompositionTarget) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// IDCompositionVisual
+// Slot we call: SetContent (15)
+pub const IDCompositionVisual = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDCompositionVisual, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDCompositionVisual) callconv(.winapi) u32,
+        Release: *const fn (*IDCompositionVisual) callconv(.winapi) u32,
+        // IDCompositionVisual (slots 3-14, reserved)
+        SetOffsetX_float: Reserved,
+        SetOffsetX_animation: Reserved,
+        SetOffsetY_float: Reserved,
+        SetOffsetY_animation: Reserved,
+        SetTransform_matrix: Reserved,
+        SetTransform_transform: Reserved,
+        SetTransformParent: Reserved,
+        SetEffect: Reserved,
+        SetBitmapInterpolationMode: Reserved,
+        SetBorderMode: Reserved,
+        SetClip_rect: Reserved,
+        SetClip_clip: Reserved,
+        // IDCompositionVisual (slot 15)
+        SetContent: *const fn (*IDCompositionVisual, content: ?*IUnknown) callconv(.winapi) HRESULT,
+        // IDCompositionVisual (slots 16-18, reserved)
+        AddVisual: Reserved,
+        RemoveVisual: Reserved,
+        RemoveAllVisuals: Reserved,
+    };
+
+    pub inline fn SetContent(self: *IDCompositionVisual, content: ?*IUnknown) HRESULT {
+        return self.vtable.SetContent(self, content);
+    }
+
+    pub inline fn Release(self: *IDCompositionVisual) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+pub extern "dcomp" fn DCompositionCreateDevice(
+    dxgiDevice: ?*IUnknown,
+    iid: *const GUID,
+    dcompositionDevice: *?*anyopaque,
+) callconv(.winapi) HRESULT;

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -427,6 +427,10 @@ pub const Device = struct {
             log.err("IDXGISwapChain1::Present failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
             return PresentError.PresentFailed;
         }
+        // Flush the DirectComposition tree so DWM sees the new frame.
+        if (self.dcomp_device) |dcomp_dev| {
+            _ = dcomp_dev.Commit();
+        }
     }
 
     /// Create a premultiplied-alpha blend state.

--- a/src/renderer/directx11/device.zig
+++ b/src/renderer/directx11/device.zig
@@ -3,6 +3,7 @@ const log = std.log.scoped(.directx11);
 const com = @import("com.zig");
 const dxgi = @import("dxgi.zig");
 const d3d11 = @import("d3d11.zig");
+const dcomp = @import("dcomp.zig");
 
 const HRESULT = com.HRESULT;
 const GUID = com.GUID;
@@ -41,6 +42,12 @@ pub const Device = struct {
     /// The HWND for querying the actual window size.
     /// Null for composition (SwapChainPanel) or shared texture surfaces.
     hwnd: ?HWND,
+    /// DirectComposition objects for HWND surfaces. The dcomp visual tree
+    /// attaches the swap chain to the window via DWM composition, enabling
+    /// per-pixel transparency and independent flip when opaque.
+    dcomp_device: ?*dcomp.IDCompositionDevice = null,
+    dcomp_target: ?*dcomp.IDCompositionTarget = null,
+    dcomp_visual: ?*dcomp.IDCompositionVisual = null,
     width: u32,
     height: u32,
     /// Desired size set by the embedder (via ghostty_surface_set_size).
@@ -56,6 +63,7 @@ pub const Device = struct {
         GetFactoryFailed,
         SwapChainCreationFailed,
         SetSwapChainFailed,
+        DCompCreationFailed,
         BackBufferFailed,
         RenderTargetViewFailed,
         BlendStateCreationFailed,
@@ -100,6 +108,9 @@ pub const Device = struct {
         var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
         var panel_native: ?*dxgi.ISwapChainPanelNative = null;
         var rtv: ?*d3d11.ID3D11RenderTargetView = null;
+        var dcomp_dev: ?*dcomp.IDCompositionDevice = null;
+        var dcomp_target_local: ?*dcomp.IDCompositionTarget = null;
+        var dcomp_visual_local: ?*dcomp.IDCompositionVisual = null;
         if (surface != .shared_texture) {
             // QueryInterface device -> IDXGIDevice
             var dxgi_device_opt: ?*anyopaque = null;
@@ -130,11 +141,45 @@ pub const Device = struct {
             const factory: *dxgi.IDXGIFactory2 = @ptrCast(@alignCast(factory_opt.?));
             defer _ = factory.Release();
 
-            // Create swap chain. Descriptor differs by surface type:
-            // - HWND: opaque window, DXGI_ALPHA_MODE_UNSPECIFIED
-            // - Composition: premultiplied alpha for XAML integration
+            // Create swap chain. Both HWND and XAML paths use
+            // CreateSwapChainForComposition with premultiplied alpha.
+            // HWND attaches via DirectComposition, XAML via ISwapChainPanelNative.
             switch (surface) {
                 .hwnd => |hwnd| {
+                    // Create DirectComposition device, target, and visual.
+                    // The dcomp visual tree gives us DWM composition: per-pixel
+                    // transparency when needed, independent flip when opaque.
+                    var dcomp_device_opt: ?*anyopaque = null;
+                    hr = dcomp.DCompositionCreateDevice(
+                        @ptrCast(dxgi_device),
+                        &dcomp.IDCompositionDevice.IID,
+                        &dcomp_device_opt,
+                    );
+                    if (com.FAILED(hr) or dcomp_device_opt == null) {
+                        log.err("DCompositionCreateDevice failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                        return InitError.DCompCreationFailed;
+                    }
+                    dcomp_dev = @ptrCast(@alignCast(dcomp_device_opt.?));
+
+                    var dcomp_tgt: ?*dcomp.IDCompositionTarget = null;
+                    hr = dcomp_dev.?.CreateTargetForHwnd(hwnd, 0, &dcomp_tgt);
+                    if (com.FAILED(hr) or dcomp_tgt == null) {
+                        log.err("CreateTargetForHwnd failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                        return InitError.DCompCreationFailed;
+                    }
+                    dcomp_target_local = dcomp_tgt;
+
+                    var dcomp_vis: ?*dcomp.IDCompositionVisual = null;
+                    hr = dcomp_dev.?.CreateVisual(&dcomp_vis);
+                    if (com.FAILED(hr) or dcomp_vis == null) {
+                        log.err("CreateVisual failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                        return InitError.DCompCreationFailed;
+                    }
+                    dcomp_visual_local = dcomp_vis;
+
+                    // Composition swap chain with premultiplied alpha.
+                    // DWM picks independent flip when fully opaque, composed flip
+                    // when transparency is present.
                     var desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
                         .Width = width,
                         .Height = height,
@@ -143,16 +188,14 @@ pub const Device = struct {
                         .SampleDesc = .{ .Count = 1, .Quality = 0 },
                         .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
                         .BufferCount = 2,
-                        .Scaling = .NONE,
+                        .Scaling = .STRETCH,
                         .SwapEffect = .FLIP_DISCARD,
-                        .AlphaMode = .UNSPECIFIED,
+                        .AlphaMode = .PREMULTIPLIED,
                         .Flags = 0,
                     };
-                    hr = factory.CreateSwapChainForHwnd(
+                    hr = factory.CreateSwapChainForComposition(
                         @ptrCast(dev),
-                        hwnd,
                         &desc,
-                        null,
                         null,
                         &swap_chain,
                     );
@@ -169,8 +212,6 @@ pub const Device = struct {
                         .BufferCount = 2,
                         .Scaling = .STRETCH,
                         .SwapEffect = .FLIP_DISCARD,
-                        // Composition surfaces need premultiplied alpha for XAML
-                        // integration; HWND surfaces use UNSPECIFIED.
                         .AlphaMode = .PREMULTIPLIED,
                         .Flags = 0,
                     };
@@ -198,6 +239,29 @@ pub const Device = struct {
                 }
             }
 
+            // For HWND surfaces, attach swap chain to the DirectComposition
+            // visual tree and commit to make it visible.
+            if (dcomp_visual_local) |visual| {
+                hr = visual.SetContent(@ptrCast(swap_chain.?));
+                if (com.FAILED(hr)) {
+                    log.err("IDCompositionVisual::SetContent failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                    _ = swap_chain.?.Release();
+                    return InitError.DCompCreationFailed;
+                }
+                hr = dcomp_target_local.?.SetRoot(visual);
+                if (com.FAILED(hr)) {
+                    log.err("IDCompositionTarget::SetRoot failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                    _ = swap_chain.?.Release();
+                    return InitError.DCompCreationFailed;
+                }
+                hr = dcomp_dev.?.Commit();
+                if (com.FAILED(hr)) {
+                    log.err("IDCompositionDevice::Commit failed: hr=0x{x}", .{@as(u32, @bitCast(hr))});
+                    _ = swap_chain.?.Release();
+                    return InitError.DCompCreationFailed;
+                }
+            }
+
             // Get the back buffer and create a render target view.
             rtv = createRenderTargetView(dev, swap_chain.?) orelse {
                 log.err("createRenderTargetView failed", .{});
@@ -210,6 +274,9 @@ pub const Device = struct {
         errdefer if (sc) |s| { _ = s.Release(); };
         errdefer if (panel_native) |panel| { _ = panel.SetSwapChain(null); };
         errdefer if (rtv) |r| { _ = r.Release(); };
+        errdefer if (dcomp_visual_local) |v| { _ = v.Release(); };
+        errdefer if (dcomp_target_local) |t| { _ = t.Release(); };
+        errdefer if (dcomp_dev) |d| { _ = d.Release(); };
 
         // Create a premultiplied-alpha blend state so that translucent
         // pixels (e.g. padding cells output as float4(0,0,0,0) by the
@@ -233,6 +300,9 @@ pub const Device = struct {
                 .hwnd => |h| h,
                 .swap_chain_panel, .shared_texture => null,
             },
+            .dcomp_device = dcomp_dev,
+            .dcomp_target = dcomp_target_local,
+            .dcomp_visual = dcomp_visual_local,
             .width = width,
             .height = height,
         };
@@ -249,6 +319,20 @@ pub const Device = struct {
         if (self.blend_state) |bs| {
             _ = bs.Release();
             self.blend_state = null;
+        }
+
+        // Release DirectComposition objects in reverse creation order.
+        if (self.dcomp_visual) |visual| {
+            _ = visual.Release();
+            self.dcomp_visual = null;
+        }
+        if (self.dcomp_target) |target| {
+            _ = target.Release();
+            self.dcomp_target = null;
+        }
+        if (self.dcomp_device) |dcomp_dev| {
+            _ = dcomp_dev.Release();
+            self.dcomp_device = null;
         }
 
         // Detach swap chain from the panel (composition surfaces only).

--- a/src/renderer/directx11/gpu_test.zig
+++ b/src/renderer/directx11/gpu_test.zig
@@ -14,6 +14,8 @@ const Sampler = @import("Sampler.zig");
 const Pipeline = @import("Pipeline.zig");
 const RenderPass = @import("RenderPass.zig");
 const Device = @import("device.zig").Device;
+const dcomp = @import("dcomp.zig");
+const Surface = @import("device.zig").Surface;
 
 const Buffer = buffer_mod.Buffer;
 
@@ -368,7 +370,7 @@ test "Device: shared texture mode skips swap chain" {
     try std.testing.expectEqual(device.height, 720);
 }
 
-test "SwapChain: HWND surface uses SCALING_NONE" {
+test "SwapChain: HWND surface uses DirectComposition with PREMULTIPLIED alpha" {
     if (comptime builtin.os.tag != .windows) return;
 
     // Create a hidden window for the swap chain.
@@ -402,24 +404,49 @@ test "SwapChain: HWND surface uses SCALING_NONE" {
         }
     };
 
-    const class_name = std.unicode.utf8ToUtf16LeStringLiteral("GhosttyTestClass");
+    const class_name = std.unicode.utf8ToUtf16LeStringLiteral("GhosttyDCompTestClass");
     const wc = WNDCLASSEXW{ .lpfnWndProc = user32.defWindowProc, .lpszClassName = class_name };
     _ = user32.RegisterClassExW(&wc);
 
     const hwnd = user32.CreateWindowExW(
-        0, class_name, null, 0, // WS_OVERLAPPED
+        0, class_name, null, 0,
         0, 0, 100, 100, null, null, null, null,
-    ) orelse return; // Skip if window creation fails (e.g. headless CI).
+    ) orelse return;
     defer _ = user32.DestroyWindow(hwnd);
 
-    // Init the full Device with an HWND surface.
     var device = Device.init(.{ .hwnd = hwnd }, 100, 100) catch return;
     defer device.deinit();
 
-    // Query the swap chain descriptor and verify scaling.
-    // Guards against regression to STRETCH (PR #76).
+    // HWND path now uses DirectComposition: dcomp objects must be non-null.
+    try std.testing.expect(device.dcomp_device != null);
+    try std.testing.expect(device.dcomp_target != null);
+    try std.testing.expect(device.dcomp_visual != null);
+
+    // Swap chain uses composition path: STRETCH scaling, premultiplied alpha.
     var desc: dxgi.DXGI_SWAP_CHAIN_DESC1 = undefined;
     const hr = device.swap_chain.?.GetDesc1(&desc);
     try std.testing.expect(!com.FAILED(hr));
-    try std.testing.expectEqual(desc.Scaling, .NONE);
+    try std.testing.expectEqual(desc.Scaling, .STRETCH);
+    try std.testing.expectEqual(desc.AlphaMode, .PREMULTIPLIED);
+
+    // Present should succeed (includes dcomp Commit).
+    try device.present();
+}
+
+test "Device: shared texture mode has no dcomp objects" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    const HANDLE = std.os.windows.HANDLE;
+    var shared_handle: ?HANDLE = null;
+
+    var device = Device.init(.{ .shared_texture = .{
+        .handle_out = &shared_handle,
+        .width = 640,
+        .height = 480,
+    } }, 640, 480) catch return;
+    defer device.deinit();
+
+    try std.testing.expectEqual(device.dcomp_device, null);
+    try std.testing.expectEqual(device.dcomp_target, null);
+    try std.testing.expectEqual(device.dcomp_visual, null);
 }


### PR DESCRIPTION
## Summary

Replaces `CreateSwapChainForHwnd` with DirectComposition + `CreateSwapChainForComposition` for the HWND surface path. This gives HWND consumers per-pixel transparency support and independent flip (when opaque) without changing the embedder API.

- New `dcomp.zig` with COM bindings for IDCompositionDevice, IDCompositionTarget, IDCompositionVisual
- HWND branch in Device now creates a dcomp visual tree and uses `CreateSwapChainForComposition` with `PREMULTIPLIED` alpha and `STRETCH` scaling
- `present()` calls `IDCompositionDevice::Commit()` after swap chain `Present()` so DWM sees each frame
- `deinit()` releases dcomp objects in reverse creation order
- XAML (SwapChainPanel) and shared texture paths unchanged

Foundation layer for #93 (progressive adaptive composition strategy). Presentation optimizations (dirty rects, scroll rects, VRR) deferred to follow-up.

IMPORTANT: This is part of the DX11 renderer stack. Previous PRs: #92 (shared texture), #86 (composition swap chain), #76 (smooth resize).

## What I Learnt

**Composition vs swap chain**: A swap chain is the buffer infrastructure (back buffers, present semantics). Composition is how those buffers get attached to a window and displayed by DWM. `CreateSwapChainForHwnd` ties both together -- DWM manages the swap chain presentation directly on the window. `CreateSwapChainForComposition` decouples them -- you create a DirectComposition visual tree and attach the swap chain as content, giving you control over how DWM composites (transparency, independent flip, layering).

**Why DirectComposition for HWND**: `CreateSwapChainForHwnd` ignores the alpha channel -- DWM treats the window as fully opaque. DirectComposition lets DWM composite the swap chain properly, so per-pixel transparency works. When the content is fully opaque, DWM is smart enough to use independent flip (direct scanout, no extra copy). This is the same approach Windows Terminal uses.

**dcomp.dll availability**: DirectComposition is available on Windows 8.1+. Every supported Windows version (10+) has it, so no fallback to `CreateSwapChainForHwnd` is needed.

## Test plan

- [x] Build compiles clean (`zig build -Dapp-runtime=none -Drenderer=directx11`)
- [x] All 49 DX11 unit tests pass
- [x] New test: HWND surface creates dcomp objects and uses PREMULTIPLIED alpha
- [x] New test: shared texture surface has null dcomp objects
- [x] C Win32 example builds and links against updated DLL