### PR TITLE
lib: restore ghostty_type_json() in vt/types.h

### DIFF
--- a/include/ghostty/vt/types.h
+++ b/include/ghostty/vt/types.h
@@ -83,4 +83,39 @@ typedef struct {
 #define GHOSTTY_INIT_SIZED(type) \
   ((type){ .size = sizeof(type) })
 
+/**
+ * Return a pointer to a null-terminated JSON string describing the
+ * layout of every C API struct for the current target.
+ *
+ * This is primarily useful for language bindings that can't easily
+ * set C struct fields and need to do so via byte offsets. For example,
+ * WebAssembly modules can't share struct definitions with the host.
+ *
+ * Example (abbreviated):
+ * @code{.json}
+ * {
+ *   "GhosttyMouseEncoderSize": {
+ *     "size": 40,
+ *     "align": 8,
+ *     "fields": {
+ *       "size":           { "offset": 0,  "size": 8, "type": "u64" },
+ *       "screen_width":   { "offset": 8,  "size": 4, "type": "u32" },
+ *       "screen_height":  { "offset": 12, "size": 4, "type": "u32" },
+ *       "cell_width":     { "offset": 16, "size": 4, "type": "u32" },
+ *       "cell_height":    { "offset": 20, "size": 4, "type": "u32" },
+ *       "padding_top":    { "offset": 24, "size": 4, "type": "u32" },
+ *       "padding_bottom": { "offset": 28, "size": 4, "type": "u32" },
+ *       "padding_right":  { "offset": 32, "size": 4, "type": "u32" },
+ *       "padding_left":   { "offset": 36, "size": 4, "type": "u32" }
+ *     }
+ *   }
+ * }
+ * @endcode
+ *
+ * The returned pointer is valid for the lifetime of the process.
+ *
+ * @return Pointer to the null-terminated JSON string.
+ */
+GHOSTTY_API const char *ghostty_type_json(void);
+
 #endif /* GHOSTTY_VT_TYPES_H */


### PR DESCRIPTION
## Summary

- Restore `ghostty_type_json()` declaration and documentation in `include/ghostty/vt/types.h`

Same rebase artifact as the GHOSTTY_EXPORT rename (PR # 99). The fork's PR # 84 commit predates upstream adding this function, so rebasing silently dropped it. After this fix, all VT headers match upstream exactly.

## Test plan

- [x] `just test-lib-vt` passes (declaration only, no behavior change)
- [x] `diff <(git show upstream/main:include/ghostty/vt/types.h) include/ghostty/vt/types.h` is empty