### PR TITLE
font: add Segoe UI Emoji as Windows fallback font

### DIFF
--- a/src/font/Collection.zig
+++ b/src/font/Collection.zig
@@ -1438,6 +1438,7 @@ test "face metrics" {
         .cell_width = switch (options.backend) {
             .freetype,
             .fontconfig_freetype,
+            .directwrite_freetype,
             .coretext_freetype,
             => 8.0,
             .coretext,
@@ -1458,6 +1459,7 @@ test "face metrics" {
         .ascii_height = switch (options.backend) {
             .freetype,
             .fontconfig_freetype,
+            .directwrite_freetype,
             .coretext_freetype,
             => 18.0625,
             .coretext,
@@ -1472,6 +1474,7 @@ test "face metrics" {
         .cell_width = switch (options.backend) {
             .freetype,
             .fontconfig_freetype,
+            .directwrite_freetype,
             .coretext_freetype,
             => 10.0,
             .coretext,
@@ -1492,6 +1495,7 @@ test "face metrics" {
         .ascii_height = switch (options.backend) {
             .freetype,
             .fontconfig_freetype,
+            .directwrite_freetype,
             .coretext_freetype,
             => 16.0,
             .coretext,

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -606,3 +606,31 @@ test "coretext" {
     defer face.deinit();
     try testing.expect(face.glyphIndex(' ') != null);
 }
+
+test "directwrite" {
+    if (options.backend != .directwrite_freetype) return error.SkipZigTest;
+
+    const discovery_mod = @import("main.zig").discovery;
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var lib = try Library.init(alloc);
+    defer lib.deinit();
+
+    var def = def: {
+        var dw = discovery_mod.DirectWrite.init();
+        defer dw.deinit();
+        var it = try dw.discover(alloc, .{ .family = "Consolas", .size = 12 });
+        defer it.deinit();
+        break :def (try it.next()).?;
+    };
+    defer def.deinit();
+
+    var buf_dw: [1024]u8 = undefined;
+    const n_dw = try def.name(&buf_dw);
+    try testing.expect(n_dw.len > 0);
+
+    var face_dw = try def.load(lib, .{ .size = .{ .points = 12 } });
+    defer face_dw.deinit();
+    try testing.expect(face_dw.glyphIndex(' ') != null);
+}

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -87,7 +87,7 @@ pub const WebCanvas = struct {
 pub fn deinit(self: *DeferredFace) void {
     switch (options.backend) {
         .fontconfig_freetype => if (self.fc) |*fc| fc.deinit(),
-        .freetype => {},
+        .freetype, .directwrite_freetype => {},
         .web_canvas => if (self.wc) |*wc| wc.deinit(),
         .coretext,
         .coretext_freetype,
@@ -101,7 +101,7 @@ pub fn deinit(self: *DeferredFace) void {
 /// Returns the family name of the font.
 pub fn familyName(self: DeferredFace, buf: []u8) ![]const u8 {
     switch (options.backend) {
-        .freetype => {},
+        .freetype, .directwrite_freetype => {},
 
         .fontconfig_freetype => if (self.fc) |fc|
             return (try fc.pattern.get(.family, 0)).string,
@@ -129,7 +129,7 @@ pub fn familyName(self: DeferredFace, buf: []u8) ![]const u8 {
 /// face so it doesn't have to be freed.
 pub fn name(self: DeferredFace, buf: []u8) ![]const u8 {
     switch (options.backend) {
-        .freetype => {},
+        .freetype, .directwrite_freetype => {},
 
         .fontconfig_freetype => if (self.fc) |fc|
             return (try fc.pattern.get(.fullname, 0)).string,
@@ -170,7 +170,7 @@ pub fn load(
 
         // Unreachable because we must be already loaded or have the
         // proper configuration for one of the other deferred mechanisms.
-        .freetype => unreachable,
+        .freetype, .directwrite_freetype => unreachable,
     };
 }
 
@@ -344,7 +344,7 @@ pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
             return face.glyphIndex(cp) != null;
         },
 
-        .freetype => {},
+        .freetype, .directwrite_freetype => {},
     }
 
     // This is unreachable because discovery mechanisms terminate, and

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const fontconfig = @import("fontconfig");
 const macos = @import("macos");
+const dwrite = @import("directwrite.zig");
 const font = @import("main.zig");
 const options = @import("main.zig").options;
 const Library = @import("main.zig").Library;
@@ -29,6 +30,10 @@ ct: if (font.Discover == font.discovery.CoreText) ?CoreText else void =
 /// Canvas
 wc: if (options.backend == .web_canvas) ?WebCanvas else void =
     if (options.backend == .web_canvas) null else {},
+
+/// DirectWrite
+dw: if (options.backend == .directwrite_freetype) ?DirectWrite else void =
+    if (options.backend == .directwrite_freetype) null else {},
 
 /// Fontconfig specific data. This is only present if building with fontconfig.
 pub const Fontconfig = struct {
@@ -84,10 +89,21 @@ pub const WebCanvas = struct {
     }
 };
 
+pub const DirectWrite = struct {
+    font: *dwrite.IDWriteFont,
+    variations: []const font.face.Variation,
+
+    pub fn deinit(self: *DirectWrite) void {
+        _ = self.font.Release();
+        self.* = undefined;
+    }
+};
+
 pub fn deinit(self: *DeferredFace) void {
     switch (options.backend) {
         .fontconfig_freetype => if (self.fc) |*fc| fc.deinit(),
-        .freetype, .directwrite_freetype => {},
+        .freetype => {},
+        .directwrite_freetype => if (self.dw) |*dw_| dw_.deinit(),
         .web_canvas => if (self.wc) |*wc| wc.deinit(),
         .coretext,
         .coretext_freetype,
@@ -101,7 +117,20 @@ pub fn deinit(self: *DeferredFace) void {
 /// Returns the family name of the font.
 pub fn familyName(self: DeferredFace, buf: []u8) ![]const u8 {
     switch (options.backend) {
-        .freetype, .directwrite_freetype => {},
+        .freetype => {},
+
+        .directwrite_freetype => if (self.dw) |dw_| {
+            var names: ?*dwrite.IDWriteLocalizedStrings = null;
+            var str_exists: i32 = 0;
+            const hr = dw_.font.GetInformationalStrings(.WIN32_FAMILY_NAMES, &names, &str_exists);
+            if (dwrite.SUCCEEDED(hr) and str_exists != 0) {
+                if (names) |n| {
+                    defer _ = n.Release();
+                    return dwrite.getLocalizedString(n, buf);
+                }
+            }
+            return "";
+        },
 
         .fontconfig_freetype => if (self.fc) |fc|
             return (try fc.pattern.get(.family, 0)).string,
@@ -129,7 +158,30 @@ pub fn familyName(self: DeferredFace, buf: []u8) ![]const u8 {
 /// face so it doesn't have to be freed.
 pub fn name(self: DeferredFace, buf: []u8) ![]const u8 {
     switch (options.backend) {
-        .freetype, .directwrite_freetype => {},
+        .freetype => {},
+
+        .directwrite_freetype => if (self.dw) |dw_| {
+            // Try full name first
+            var names: ?*dwrite.IDWriteLocalizedStrings = null;
+            var str_exists: i32 = 0;
+            var hr = dw_.font.GetInformationalStrings(.FULL_NAME, &names, &str_exists);
+            if (dwrite.SUCCEEDED(hr) and str_exists != 0) {
+                if (names) |n| {
+                    defer _ = n.Release();
+                    return dwrite.getLocalizedString(n, buf);
+                }
+            }
+            // Fall back to face names
+            var face_names: ?*dwrite.IDWriteLocalizedStrings = null;
+            hr = dw_.font.GetFaceNames(&face_names);
+            if (dwrite.SUCCEEDED(hr)) {
+                if (face_names) |n| {
+                    defer _ = n.Release();
+                    return dwrite.getLocalizedString(n, buf);
+                }
+            }
+            return "";
+        },
 
         .fontconfig_freetype => if (self.fc) |fc|
             return (try fc.pattern.get(.fullname, 0)).string,
@@ -164,13 +216,14 @@ pub fn load(
 ) !Face {
     return switch (options.backend) {
         .fontconfig_freetype => try self.loadFontconfig(lib, opts),
+        .directwrite_freetype => try self.loadDirectWrite(lib, opts),
         .coretext, .coretext_harfbuzz, .coretext_noshape => try self.loadCoreText(lib, opts),
         .coretext_freetype => try self.loadCoreTextFreetype(lib, opts),
         .web_canvas => try self.loadWebCanvas(opts),
 
         // Unreachable because we must be already loaded or have the
         // proper configuration for one of the other deferred mechanisms.
-        .freetype, .directwrite_freetype => unreachable,
+        .freetype => unreachable,
     };
 }
 
@@ -256,6 +309,85 @@ fn loadWebCanvas(
     return try .initNamed(wc.alloc, wc.font_str, opts, wc.presentation);
 }
 
+fn loadDirectWrite(self: *DeferredFace, lib: Library, opts: font.face.Options) !Face {
+    const dw_ = self.dw.?;
+
+    var dw_face: ?*dwrite.IDWriteFontFace = null;
+    var hr = dw_.font.CreateFontFace(&dw_face);
+    if (dwrite.FAILED(hr)) return error.DirectWriteError;
+    defer _ = dw_face.?.Release();
+
+    // Get file count
+    var num_files: u32 = 0;
+    hr = dw_face.?.GetFiles(&num_files, null);
+    if (dwrite.FAILED(hr) or num_files == 0) return error.FontHasNoFile;
+
+    // Get first font file
+    var font_file: ?*dwrite.IDWriteFontFile = null;
+    var one: u32 = 1;
+    hr = dw_face.?.GetFiles(&one, @ptrCast(&font_file));
+    if (dwrite.FAILED(hr)) return error.FontHasNoFile;
+    defer _ = font_file.?.Release();
+
+    // Get reference key
+    var key: ?*const anyopaque = null;
+    var key_size: u32 = 0;
+    hr = font_file.?.GetReferenceKey(&key, &key_size);
+    if (dwrite.FAILED(hr)) return error.FontHasNoFile;
+
+    // Get loader and QI to local loader
+    var loader: ?*dwrite.IDWriteFontFileLoader = null;
+    hr = font_file.?.GetLoader(&loader);
+    if (dwrite.FAILED(hr)) return error.FontHasNoFile;
+    defer _ = loader.?.Release();
+
+    var local_loader_raw: ?*anyopaque = null;
+    hr = loader.?.QueryInterface(&dwrite.IDWriteLocalFontFileLoader.IID, &local_loader_raw);
+    if (dwrite.FAILED(hr)) return error.FontHasNoFile;
+    const local_loader: *dwrite.IDWriteLocalFontFileLoader = @ptrCast(@alignCast(local_loader_raw.?));
+    defer _ = local_loader.Release();
+
+    // Get file path length then path
+    var path_len: u32 = 0;
+    hr = local_loader.GetFilePathLengthFromKey(key.?, key_size, &path_len);
+    if (dwrite.FAILED(hr)) return error.FontHasNoFile;
+
+    var wpath_buf: [512]u16 = undefined;
+    if (path_len + 1 > wpath_buf.len) return error.FontPathCantDecode;
+    hr = local_loader.GetFilePathFromKey(key.?, key_size, &wpath_buf, path_len + 1);
+    if (dwrite.FAILED(hr)) return error.FontHasNoFile;
+
+    // Convert UTF-16 to UTF-8
+    var path_buf: [1024]u8 = undefined;
+    var utf8_len: usize = 0;
+    for (wpath_buf[0..path_len]) |wc| {
+        if (utf8_len + 3 > path_buf.len - 1) return error.FontPathCantDecode;
+        const c: u21 = @intCast(wc);
+        if (c < 0x80) {
+            path_buf[utf8_len] = @intCast(c);
+            utf8_len += 1;
+        } else if (c < 0x800) {
+            path_buf[utf8_len] = @intCast(0xC0 | (c >> 6));
+            path_buf[utf8_len + 1] = @intCast(0x80 | (c & 0x3F));
+            utf8_len += 2;
+        } else {
+            path_buf[utf8_len] = @intCast(0xE0 | (c >> 12));
+            path_buf[utf8_len + 1] = @intCast(0x80 | ((c >> 6) & 0x3F));
+            path_buf[utf8_len + 2] = @intCast(0x80 | (c & 0x3F));
+            utf8_len += 3;
+        }
+    }
+    path_buf[utf8_len] = 0;
+    const path: [:0]const u8 = path_buf[0..utf8_len :0];
+
+    const face_index: i32 = @intCast(dw_face.?.GetIndex());
+
+    var face = try Face.initFile(lib, path, face_index, opts);
+    errdefer face.deinit();
+    try face.setVariations(dw_.variations, opts);
+    return face;
+}
+
 /// Returns true if this face can satisfy the given codepoint and
 /// presentation. If presentation is null, then it just checks if the
 /// codepoint is present at all.
@@ -319,6 +451,19 @@ pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
 
         // Canvas always has the codepoint because we have no way of
         // really checking and we let the browser handle it.
+        .directwrite_freetype => {
+            if (self.dw) |dw_| {
+                if (p) |desired_p| {
+                    const is_color = dw_.font.IsColorFont() != 0;
+                    const actual_p: Presentation = if (is_color) .emoji else .text;
+                    if (actual_p != desired_p) return false;
+                }
+                var cp_exists: i32 = 0;
+                const hr = dw_.font.HasCharacter(cp, &cp_exists);
+                return dwrite.SUCCEEDED(hr) and cp_exists != 0;
+            }
+        },
+
         .web_canvas => if (self.wc) |wc| {
             // Fast-path if we have a specific presentation and we
             // don't match, then it is definitely not this face.
@@ -344,7 +489,7 @@ pub fn hasCodepoint(self: DeferredFace, cp: u32, p: ?Presentation) bool {
             return face.glyphIndex(cp) != null;
         },
 
-        .freetype, .directwrite_freetype => {},
+        .freetype => {},
     }
 
     // This is unreachable because discovery mechanisms terminate, and

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -357,26 +357,10 @@ fn loadDirectWrite(self: *DeferredFace, lib: Library, opts: font.face.Options) !
     hr = local_loader.GetFilePathFromKey(key.?, key_size, &wpath_buf, path_len + 1);
     if (dwrite.FAILED(hr)) return error.FontHasNoFile;
 
-    // Convert UTF-16 to UTF-8
+    // Convert UTF-16 path to null-terminated UTF-8 for FreeType
     var path_buf: [1024]u8 = undefined;
-    var utf8_len: usize = 0;
-    for (wpath_buf[0..path_len]) |wc| {
-        if (utf8_len + 3 > path_buf.len - 1) return error.FontPathCantDecode;
-        const c: u21 = @intCast(wc);
-        if (c < 0x80) {
-            path_buf[utf8_len] = @intCast(c);
-            utf8_len += 1;
-        } else if (c < 0x800) {
-            path_buf[utf8_len] = @intCast(0xC0 | (c >> 6));
-            path_buf[utf8_len + 1] = @intCast(0x80 | (c & 0x3F));
-            utf8_len += 2;
-        } else {
-            path_buf[utf8_len] = @intCast(0xE0 | (c >> 12));
-            path_buf[utf8_len + 1] = @intCast(0x80 | ((c >> 6) & 0x3F));
-            path_buf[utf8_len + 2] = @intCast(0x80 | (c & 0x3F));
-            utf8_len += 3;
-        }
-    }
+    const utf8_len = std.unicode.utf16LeToUtf8(path_buf[0 .. path_buf.len - 1], wpath_buf[0..path_len]) catch
+        return error.FontPathCantDecode;
     path_buf[utf8_len] = 0;
     const path: [:0]const u8 = path_buf[0..utf8_len :0];
 

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -353,9 +353,27 @@ fn collection(
         }
     }
 
-    // Emoji fallback. We don't include this on Mac since Mac is expected
-    // to always have the Apple Emoji available on the system.
-    if (comptime !builtin.target.os.tag.isDarwin() or Discover == void) {
+    // On Windows, prefer "Segoe UI Emoji" for native emoji rendering.
+    // Ships with Windows 10+, same floor as DirectWrite.
+    if (comptime builtin.target.os.tag == .windows and Discover != void) windows_emoji: {
+        const disco = try self.discover() orelse break :windows_emoji;
+        var disco_it = try disco.discover(self.alloc, .{
+            .family = "Segoe UI Emoji",
+        });
+        defer disco_it.deinit();
+        if (try disco_it.next()) |face| {
+            _ = try c.addDeferred(self.alloc, face, .{
+                .style = .regular,
+                .fallback = true,
+                // No size adjustment for emojis.
+                .size_adjustment = .none,
+            });
+        }
+    }
+
+    // Emoji fallback. We don't include this on Mac or Windows since both
+    // are expected to have system emoji fonts available.
+    if (comptime (!builtin.target.os.tag.isDarwin() and builtin.target.os.tag != .windows) or Discover == void) {
         _ = try c.add(
             self.alloc,
             try .init(

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -353,8 +353,11 @@ fn collection(
         }
     }
 
-    // On Windows, prefer "Segoe UI Emoji" for native emoji rendering.
-    // Ships with Windows 10+, same floor as DirectWrite.
+    // On Windows, always search for and add the Segoe UI Emoji font
+    // as our preferred emoji font for fallback. We do this in case
+    // people add other emoji fonts to their system, we always want to
+    // prefer the official one. Users can override this by explicitly
+    // specifying a font-family for emoji.
     if (comptime builtin.target.os.tag == .windows and Discover != void) windows_emoji: {
         const disco = try self.discover() orelse break :windows_emoji;
         var disco_it = try disco.discover(self.alloc, .{
@@ -371,9 +374,10 @@ fn collection(
         }
     }
 
-    // Emoji fallback. We don't include this on Mac or Windows since both
-    // are expected to have system emoji fonts available.
-    if (comptime (!builtin.target.os.tag.isDarwin() and builtin.target.os.tag != .windows) or Discover == void) {
+    // Embedded emoji fallback for platforms without a system emoji font.
+    // macOS and Windows use their native emoji fonts (added above) when
+    // discovery is available.
+    if (comptime !(builtin.target.os.tag.isDarwin() or builtin.target.os.tag == .windows) or Discover == void) {
         _ = try c.add(
             self.alloc,
             try .init(

--- a/src/font/backend.zig
+++ b/src/font/backend.zig
@@ -22,6 +22,10 @@ pub const Backend = enum {
     /// CoreText for font discovery and rendering, no shaping.
     coretext_noshape,
 
+    /// DirectWrite for font discovery, FreeType for rendering,
+    /// and HarfBuzz for shaping (Windows).
+    directwrite_freetype,
+
     /// Use the browser font system and the Canvas API (wasm). This limits
     /// the available fonts to browser fonts (anything Canvas natively
     /// supports).
@@ -41,11 +45,7 @@ pub const Backend = enum {
         }
 
         if (target.os.tag == .windows) {
-            // Avoid fontconfig on Windows because its libxml2 dependency
-            // may not unpack due to symlinks. Use plain freetype for now
-            // which means no font discovery. Full solution would likely use
-            // DirectWrite which has its own discovery API.
-            return .freetype;
+            return .directwrite_freetype;
         }
 
         // macOS also supports "coretext_freetype" but there is no scenario
@@ -61,6 +61,7 @@ pub const Backend = enum {
         return switch (self) {
             .freetype,
             .fontconfig_freetype,
+            .directwrite_freetype,
             .coretext_freetype,
             => true,
 
@@ -82,6 +83,7 @@ pub const Backend = enum {
 
             .freetype,
             .fontconfig_freetype,
+            .directwrite_freetype,
             .web_canvas,
             => false,
         };
@@ -92,6 +94,7 @@ pub const Backend = enum {
             .fontconfig_freetype => true,
 
             .freetype,
+            .directwrite_freetype,
             .coretext,
             .coretext_freetype,
             .coretext_harfbuzz,
@@ -105,11 +108,26 @@ pub const Backend = enum {
         return switch (self) {
             .freetype,
             .fontconfig_freetype,
+            .directwrite_freetype,
             .coretext_freetype,
             .coretext_harfbuzz,
             => true,
 
             .coretext,
+            .coretext_noshape,
+            .web_canvas,
+            => false,
+        };
+    }
+
+    pub fn hasDirectwrite(self: Backend) bool {
+        return switch (self) {
+            .directwrite_freetype => true,
+            .freetype,
+            .fontconfig_freetype,
+            .coretext,
+            .coretext_freetype,
+            .coretext_harfbuzz,
             .coretext_noshape,
             .web_canvas,
             => false,

--- a/src/font/directwrite.zig
+++ b/src/font/directwrite.zig
@@ -1,0 +1,917 @@
+const std = @import("std");
+const com = @import("../os/windows_com.zig");
+
+pub const GUID = com.GUID;
+pub const HRESULT = com.HRESULT;
+pub const SUCCEEDED = com.SUCCEEDED;
+pub const FAILED = com.FAILED;
+pub const S_OK = com.S_OK;
+pub const E_NOINTERFACE = com.E_NOINTERFACE;
+pub const IUnknown = com.IUnknown;
+pub const Reserved = com.Reserved;
+
+const BOOL = i32;
+const WCHAR = u16;
+const UINT32 = u32;
+const UINT16 = u16;
+const FLOAT = f32;
+
+// --- Enums ---
+
+pub const DWRITE_FACTORY_TYPE = enum(u32) {
+    SHARED = 0,
+    ISOLATED = 1,
+};
+
+pub const DWRITE_FONT_WEIGHT = enum(u32) {
+    THIN = 100,
+    EXTRA_LIGHT = 200,
+    LIGHT = 300,
+    SEMI_LIGHT = 350,
+    NORMAL = 400,
+    MEDIUM = 500,
+    SEMI_BOLD = 600,
+    BOLD = 700,
+    EXTRA_BOLD = 800,
+    BLACK = 900,
+    EXTRA_BLACK = 950,
+    _,
+};
+
+pub const DWRITE_FONT_STYLE = enum(u32) {
+    NORMAL = 0,
+    OBLIQUE = 1,
+    ITALIC = 2,
+};
+
+pub const DWRITE_FONT_STRETCH = enum(u32) {
+    UNDEFINED = 0,
+    ULTRA_CONDENSED = 1,
+    EXTRA_CONDENSED = 2,
+    CONDENSED = 3,
+    SEMI_CONDENSED = 4,
+    NORMAL = 5,
+    SEMI_EXPANDED = 6,
+    EXPANDED = 7,
+    EXTRA_EXPANDED = 8,
+    ULTRA_EXPANDED = 9,
+};
+
+pub const DWRITE_FONT_SIMULATIONS = enum(u32) {
+    NONE = 0,
+    BOLD = 1,
+    OBLIQUE = 2,
+    _,
+};
+
+pub const DWRITE_INFORMATIONAL_STRING_ID = enum(u32) {
+    NONE = 0,
+    COPYRIGHT_NOTICE = 1,
+    VERSION_STRINGS = 2,
+    TRADEMARK = 3,
+    MANUFACTURER = 4,
+    DESIGNER = 5,
+    DESIGNER_URL = 6,
+    DESCRIPTION = 7,
+    FONT_VENDOR_URL = 8,
+    LICENSE_DESCRIPTION = 9,
+    LICENSE_INFO_URL = 10,
+    WIN32_FAMILY_NAMES = 11,
+    WIN32_SUBFAMILY_NAMES = 12,
+    TYPOGRAPHIC_FAMILY_NAMES = 13,
+    TYPOGRAPHIC_SUBFAMILY_NAMES = 14,
+    SAMPLE_TEXT = 15,
+    FULL_NAME = 16,
+    POSTSCRIPT_NAME = 17,
+    POSTSCRIPT_CID_NAME = 18,
+};
+
+pub const DWRITE_READING_DIRECTION = enum(u32) {
+    LEFT_TO_RIGHT = 0,
+    RIGHT_TO_LEFT = 1,
+};
+
+// --- Structs ---
+
+pub const DWRITE_UNICODE_RANGE = extern struct {
+    first: UINT32,
+    last: UINT32,
+};
+
+// --- COM Interfaces ---
+
+// IDWriteNumberSubstitution -- IUnknown only, no extra methods.
+pub const IDWriteNumberSubstitution = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDWriteNumberSubstitution, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDWriteNumberSubstitution) callconv(.winapi) u32,
+        Release: *const fn (*IDWriteNumberSubstitution) callconv(.winapi) u32,
+    };
+
+    pub inline fn Release(self: *IDWriteNumberSubstitution) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// IDWriteLocalizedStrings
+// Slots: GetCount(3), FindLocaleName(4), [5-6 Reserved], GetStringLength(7), GetString(8)
+pub const IDWriteLocalizedStrings = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteLocalizedStrings) callconv(.winapi) u32,
+        // IDWriteLocalizedStrings (slots 3-8)
+        GetCount: *const fn (*IDWriteLocalizedStrings) callconv(.winapi) UINT32,
+        FindLocaleName: *const fn (
+            *IDWriteLocalizedStrings,
+            localeName: [*:0]const WCHAR,
+            index: *UINT32,
+            exists: *BOOL,
+        ) callconv(.winapi) HRESULT,
+        GetLocaleNameLength: Reserved,
+        GetLocaleName: Reserved,
+        GetStringLength: *const fn (
+            *IDWriteLocalizedStrings,
+            index: UINT32,
+            length: *UINT32,
+        ) callconv(.winapi) HRESULT,
+        GetString: *const fn (
+            *IDWriteLocalizedStrings,
+            index: UINT32,
+            stringBuffer: [*]WCHAR,
+            size: UINT32,
+        ) callconv(.winapi) HRESULT,
+    };
+
+    pub inline fn Release(self: *IDWriteLocalizedStrings) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetCount(self: *IDWriteLocalizedStrings) UINT32 {
+        return self.vtable.GetCount(self);
+    }
+
+    pub inline fn FindLocaleName(
+        self: *IDWriteLocalizedStrings,
+        localeName: [*:0]const WCHAR,
+        index: *UINT32,
+        exists: *BOOL,
+    ) HRESULT {
+        return self.vtable.FindLocaleName(self, localeName, index, exists);
+    }
+
+    pub inline fn GetStringLength(self: *IDWriteLocalizedStrings, index: UINT32, length: *UINT32) HRESULT {
+        return self.vtable.GetStringLength(self, index, length);
+    }
+
+    pub inline fn GetString(self: *IDWriteLocalizedStrings, index: UINT32, stringBuffer: [*]WCHAR, size: UINT32) HRESULT {
+        return self.vtable.GetString(self, index, stringBuffer, size);
+    }
+};
+
+// IDWriteFontFace
+// Slots: [3 Reserved], GetFiles(4), GetIndex(5), [6-17 Reserved]
+pub const IDWriteFontFace = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFontFace) callconv(.winapi) u32,
+        // IDWriteFontFace (slots 3-17)
+        GetType: Reserved,
+        GetFiles: *const fn (
+            *IDWriteFontFace,
+            numberOfFiles: *UINT32,
+            fontFiles: ?[*]?*IDWriteFontFile,
+        ) callconv(.winapi) HRESULT,
+        GetIndex: *const fn (*IDWriteFontFace) callconv(.winapi) UINT32,
+        GetSimulations: Reserved,
+        IsSymbolFont: Reserved,
+        GetMetrics: Reserved,
+        GetGlyphCount: Reserved,
+        GetDesignGlyphMetrics: Reserved,
+        GetGlyphIndices: Reserved,
+        TryGetFontTable: Reserved,
+        ReleaseFontTable: Reserved,
+        GetGlyphRunOutline: Reserved,
+        GetRecommendedRenderingMode: Reserved,
+        GetGdiCompatibleMetrics: Reserved,
+        GetGdiCompatibleGlyphMetrics: Reserved,
+    };
+
+    pub inline fn Release(self: *IDWriteFontFace) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetFiles(
+        self: *IDWriteFontFace,
+        numberOfFiles: *UINT32,
+        fontFiles: ?[*]?*IDWriteFontFile,
+    ) HRESULT {
+        return self.vtable.GetFiles(self, numberOfFiles, fontFiles);
+    }
+
+    pub inline fn GetIndex(self: *IDWriteFontFace) UINT32 {
+        return self.vtable.GetIndex(self);
+    }
+};
+
+// IDWriteFontFileLoader (IID needed to QI to IDWriteLocalFontFileLoader)
+pub const IDWriteFontFileLoader = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0x727cad4e,
+        .data2 = 0xd6af,
+        .data3 = 0x4c9e,
+        .data4 = .{ 0x8a, 0x08, 0xd6, 0x95, 0xb1, 0x1c, 0xaa, 0x49 },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDWriteFontFileLoader, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDWriteFontFileLoader) callconv(.winapi) u32,
+        Release: *const fn (*IDWriteFontFileLoader) callconv(.winapi) u32,
+        // IDWriteFontFileLoader (slot 3)
+        CreateStreamFromKey: Reserved,
+    };
+
+    pub inline fn QueryInterface(self: *IDWriteFontFileLoader, riid: *const GUID, ppv: *?*anyopaque) HRESULT {
+        return self.vtable.QueryInterface(self, riid, ppv);
+    }
+
+    pub inline fn Release(self: *IDWriteFontFileLoader) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
+// IDWriteLocalFontFileLoader
+pub const IDWriteLocalFontFileLoader = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0xb2d9f3ec,
+        .data2 = 0xc9fe,
+        .data3 = 0x4a11,
+        .data4 = .{ 0xa2, 0xec, 0xd8, 0x62, 0x08, 0xf7, 0xc0, 0xa2 },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteLocalFontFileLoader) callconv(.winapi) u32,
+        // IDWriteFontFileLoader (slot 3)
+        CreateStreamFromKey: Reserved,
+        // IDWriteLocalFontFileLoader (slots 4-6)
+        GetFilePathLengthFromKey: *const fn (
+            *IDWriteLocalFontFileLoader,
+            fontFileReferenceKey: *const anyopaque,
+            fontFileReferenceKeySize: UINT32,
+            filePathLength: *UINT32,
+        ) callconv(.winapi) HRESULT,
+        GetFilePathFromKey: *const fn (
+            *IDWriteLocalFontFileLoader,
+            fontFileReferenceKey: *const anyopaque,
+            fontFileReferenceKeySize: UINT32,
+            filePath: [*]WCHAR,
+            filePathSize: UINT32,
+        ) callconv(.winapi) HRESULT,
+        GetLastWriteTimeFromKey: Reserved,
+    };
+
+    pub inline fn Release(self: *IDWriteLocalFontFileLoader) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetFilePathLengthFromKey(
+        self: *IDWriteLocalFontFileLoader,
+        key: *const anyopaque,
+        key_size: UINT32,
+        path_len: *UINT32,
+    ) HRESULT {
+        return self.vtable.GetFilePathLengthFromKey(self, key, key_size, path_len);
+    }
+
+    pub inline fn GetFilePathFromKey(
+        self: *IDWriteLocalFontFileLoader,
+        key: *const anyopaque,
+        key_size: UINT32,
+        path: [*]WCHAR,
+        path_size: UINT32,
+    ) HRESULT {
+        return self.vtable.GetFilePathFromKey(self, key, key_size, path, path_size);
+    }
+};
+
+// IDWriteFontFile
+// Slots: GetReferenceKey(3), GetLoader(4), [5 Reserved]
+pub const IDWriteFontFile = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFontFile) callconv(.winapi) u32,
+        // IDWriteFontFile (slots 3-5)
+        GetReferenceKey: *const fn (
+            *IDWriteFontFile,
+            fontFileReferenceKey: *?*const anyopaque,
+            fontFileReferenceKeySize: *UINT32,
+        ) callconv(.winapi) HRESULT,
+        GetLoader: *const fn (
+            *IDWriteFontFile,
+            fontFileLoader: *?*IDWriteFontFileLoader,
+        ) callconv(.winapi) HRESULT,
+        Analyze: Reserved,
+    };
+
+    pub inline fn Release(self: *IDWriteFontFile) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetReferenceKey(
+        self: *IDWriteFontFile,
+        key: *?*const anyopaque,
+        key_size: *UINT32,
+    ) HRESULT {
+        return self.vtable.GetReferenceKey(self, key, key_size);
+    }
+
+    pub inline fn GetLoader(self: *IDWriteFontFile, loader: *?*IDWriteFontFileLoader) HRESULT {
+        return self.vtable.GetLoader(self, loader);
+    }
+};
+
+// IDWriteTextAnalysisSource -- callback interface we implement.
+// DWrite calls our methods through this vtable.
+pub const IDWriteTextAnalysisSource = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDWriteTextAnalysisSource, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDWriteTextAnalysisSource) callconv(.winapi) u32,
+        Release: *const fn (*IDWriteTextAnalysisSource) callconv(.winapi) u32,
+        // IDWriteTextAnalysisSource (slots 3-7)
+        GetTextAtPosition: *const fn (
+            *IDWriteTextAnalysisSource,
+            textPosition: UINT32,
+            textString: *?[*]const WCHAR,
+            textLength: *UINT32,
+        ) callconv(.winapi) HRESULT,
+        GetTextBeforePosition: *const fn (
+            *IDWriteTextAnalysisSource,
+            textPosition: UINT32,
+            textString: *?[*]const WCHAR,
+            textLength: *UINT32,
+        ) callconv(.winapi) HRESULT,
+        GetParagraphReadingDirection: *const fn (
+            *IDWriteTextAnalysisSource,
+        ) callconv(.winapi) DWRITE_READING_DIRECTION,
+        GetLocaleName: *const fn (
+            *IDWriteTextAnalysisSource,
+            textPosition: UINT32,
+            textLength: *UINT32,
+            localeName: *?[*:0]const WCHAR,
+        ) callconv(.winapi) HRESULT,
+        GetNumberSubstitution: *const fn (
+            *IDWriteTextAnalysisSource,
+            textPosition: UINT32,
+            textLength: *UINT32,
+            numberSubstitution: *?*IDWriteNumberSubstitution,
+        ) callconv(.winapi) HRESULT,
+    };
+};
+
+// IDWriteFontFallback
+// Slot 3: MapCharacters
+pub const IDWriteFontFallback = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFontFallback) callconv(.winapi) u32,
+        // IDWriteFontFallback (slot 3)
+        MapCharacters: *const fn (
+            *IDWriteFontFallback,
+            analysisSource: *IDWriteTextAnalysisSource,
+            textPosition: UINT32,
+            textLength: UINT32,
+            baseFontCollection: ?*IDWriteFontCollection,
+            baseFamilyName: ?[*:0]const WCHAR,
+            baseWeight: DWRITE_FONT_WEIGHT,
+            baseStyle: DWRITE_FONT_STYLE,
+            baseStretch: DWRITE_FONT_STRETCH,
+            mappedLength: *UINT32,
+            mappedFont: *?*IDWriteFont,
+            scale: *FLOAT,
+        ) callconv(.winapi) HRESULT,
+    };
+
+    pub inline fn Release(self: *IDWriteFontFallback) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn MapCharacters(
+        self: *IDWriteFontFallback,
+        analysisSource: *IDWriteTextAnalysisSource,
+        textPosition: UINT32,
+        textLength: UINT32,
+        baseFontCollection: ?*IDWriteFontCollection,
+        baseFamilyName: ?[*:0]const WCHAR,
+        baseWeight: DWRITE_FONT_WEIGHT,
+        baseStyle: DWRITE_FONT_STYLE,
+        baseStretch: DWRITE_FONT_STRETCH,
+        mappedLength: *UINT32,
+        mappedFont: *?*IDWriteFont,
+        scale: *FLOAT,
+    ) HRESULT {
+        return self.vtable.MapCharacters(
+            self,
+            analysisSource,
+            textPosition,
+            textLength,
+            baseFontCollection,
+            baseFamilyName,
+            baseWeight,
+            baseStyle,
+            baseStretch,
+            mappedLength,
+            mappedFont,
+            scale,
+        );
+    }
+};
+
+// IDWriteFont (through IDWriteFont2 for IsColorFont)
+// Slots: GetFontFamily(3), GetWeight(4), GetStretch(5), GetStyle(6), IsSymbolFont(7),
+//        GetFaceNames(8), GetInformationalStrings(9), GetSimulations(10),
+//        GetMetrics(11), HasCharacter(12), CreateFontFace(13),
+//        IDWriteFont1 slots 14-17, IsColorFont(18 IDWriteFont2)
+pub const IDWriteFont = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFont) callconv(.winapi) u32,
+        // IDWriteFont (slots 3-13)
+        GetFontFamily: Reserved,
+        GetWeight: *const fn (*IDWriteFont) callconv(.winapi) DWRITE_FONT_WEIGHT,
+        GetStretch: *const fn (*IDWriteFont) callconv(.winapi) DWRITE_FONT_STRETCH,
+        GetStyle: *const fn (*IDWriteFont) callconv(.winapi) DWRITE_FONT_STYLE,
+        IsSymbolFont: Reserved,
+        GetFaceNames: *const fn (*IDWriteFont, names: *?*IDWriteLocalizedStrings) callconv(.winapi) HRESULT,
+        GetInformationalStrings: *const fn (
+            *IDWriteFont,
+            informationalStringID: DWRITE_INFORMATIONAL_STRING_ID,
+            informationalStrings: *?*IDWriteLocalizedStrings,
+            exists: *BOOL,
+        ) callconv(.winapi) HRESULT,
+        GetSimulations: *const fn (*IDWriteFont) callconv(.winapi) DWRITE_FONT_SIMULATIONS,
+        GetMetrics: Reserved,
+        HasCharacter: *const fn (*IDWriteFont, unicodeValue: UINT32, exists: *BOOL) callconv(.winapi) HRESULT,
+        CreateFontFace: *const fn (*IDWriteFont, fontFace: *?*IDWriteFontFace) callconv(.winapi) HRESULT,
+        // IDWriteFont1 (slots 14-17)
+        _slot14: Reserved,
+        _slot15: Reserved,
+        _slot16: Reserved,
+        _slot17: Reserved,
+        // IDWriteFont2 (slot 18)
+        IsColorFont: *const fn (*IDWriteFont) callconv(.winapi) BOOL,
+    };
+
+    pub inline fn Release(self: *IDWriteFont) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetWeight(self: *IDWriteFont) DWRITE_FONT_WEIGHT {
+        return self.vtable.GetWeight(self);
+    }
+
+    pub inline fn GetStretch(self: *IDWriteFont) DWRITE_FONT_STRETCH {
+        return self.vtable.GetStretch(self);
+    }
+
+    pub inline fn GetStyle(self: *IDWriteFont) DWRITE_FONT_STYLE {
+        return self.vtable.GetStyle(self);
+    }
+
+    pub inline fn GetFaceNames(self: *IDWriteFont, names: *?*IDWriteLocalizedStrings) HRESULT {
+        return self.vtable.GetFaceNames(self, names);
+    }
+
+    pub inline fn GetInformationalStrings(
+        self: *IDWriteFont,
+        id: DWRITE_INFORMATIONAL_STRING_ID,
+        strings: *?*IDWriteLocalizedStrings,
+        exists: *BOOL,
+    ) HRESULT {
+        return self.vtable.GetInformationalStrings(self, id, strings, exists);
+    }
+
+    pub inline fn GetSimulations(self: *IDWriteFont) DWRITE_FONT_SIMULATIONS {
+        return self.vtable.GetSimulations(self);
+    }
+
+    pub inline fn HasCharacter(self: *IDWriteFont, unicodeValue: UINT32, exists: *BOOL) HRESULT {
+        return self.vtable.HasCharacter(self, unicodeValue, exists);
+    }
+
+    pub inline fn CreateFontFace(self: *IDWriteFont, fontFace: *?*IDWriteFontFace) HRESULT {
+        return self.vtable.CreateFontFace(self, fontFace);
+    }
+
+    pub inline fn IsColorFont(self: *IDWriteFont) BOOL {
+        return self.vtable.IsColorFont(self);
+    }
+};
+
+// IDWriteFontFamily (extends IDWriteFontList)
+// IDWriteFontList slots 3-5: [3 Reserved], GetFontCount(4), GetFont(5)
+// IDWriteFontFamily slots 6-7: GetFamilyNames(6), [7 Reserved]
+pub const IDWriteFontFamily = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFontFamily) callconv(.winapi) u32,
+        // IDWriteFontList (slots 3-5)
+        GetFontCollection: Reserved,
+        GetFontCount: *const fn (*IDWriteFontFamily) callconv(.winapi) UINT32,
+        GetFont: *const fn (*IDWriteFontFamily, index: UINT32, font: *?*IDWriteFont) callconv(.winapi) HRESULT,
+        // IDWriteFontFamily (slots 6-7)
+        GetFamilyNames: *const fn (*IDWriteFontFamily, names: *?*IDWriteLocalizedStrings) callconv(.winapi) HRESULT,
+        MatchClosestFont: Reserved,
+    };
+
+    pub inline fn Release(self: *IDWriteFontFamily) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetFontCount(self: *IDWriteFontFamily) UINT32 {
+        return self.vtable.GetFontCount(self);
+    }
+
+    pub inline fn GetFont(self: *IDWriteFontFamily, index: UINT32, font: *?*IDWriteFont) HRESULT {
+        return self.vtable.GetFont(self, index, font);
+    }
+
+    pub inline fn GetFamilyNames(self: *IDWriteFontFamily, names: *?*IDWriteLocalizedStrings) HRESULT {
+        return self.vtable.GetFamilyNames(self, names);
+    }
+};
+
+// IDWriteFontCollection
+// Slots: GetFontFamilyCount(3), GetFontFamily(4), FindFamilyName(5), GetFontFromFontFace(6)
+pub const IDWriteFontCollection = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFontCollection) callconv(.winapi) u32,
+        // IDWriteFontCollection (slots 3-6)
+        GetFontFamilyCount: *const fn (*IDWriteFontCollection) callconv(.winapi) UINT32,
+        GetFontFamily: *const fn (
+            *IDWriteFontCollection,
+            index: UINT32,
+            fontFamily: *?*IDWriteFontFamily,
+        ) callconv(.winapi) HRESULT,
+        FindFamilyName: *const fn (
+            *IDWriteFontCollection,
+            familyName: [*:0]const WCHAR,
+            index: *UINT32,
+            exists: *BOOL,
+        ) callconv(.winapi) HRESULT,
+        GetFontFromFontFace: Reserved,
+    };
+
+    pub inline fn Release(self: *IDWriteFontCollection) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetFontFamilyCount(self: *IDWriteFontCollection) UINT32 {
+        return self.vtable.GetFontFamilyCount(self);
+    }
+
+    pub inline fn GetFontFamily(self: *IDWriteFontCollection, index: UINT32, fontFamily: *?*IDWriteFontFamily) HRESULT {
+        return self.vtable.GetFontFamily(self, index, fontFamily);
+    }
+
+    pub inline fn FindFamilyName(
+        self: *IDWriteFontCollection,
+        familyName: [*:0]const WCHAR,
+        index: *UINT32,
+        exists: *BOOL,
+    ) HRESULT {
+        return self.vtable.FindFamilyName(self, familyName, index, exists);
+    }
+};
+
+// IDWriteFontCollection1 (extends IDWriteFontCollection)
+// Adds slots 7-8 (all Reserved for our purposes)
+pub const IDWriteFontCollection1 = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFontCollection1) callconv(.winapi) u32,
+        // IDWriteFontCollection (slots 3-6)
+        GetFontFamilyCount: *const fn (*IDWriteFontCollection1) callconv(.winapi) UINT32,
+        GetFontFamily: *const fn (
+            *IDWriteFontCollection1,
+            index: UINT32,
+            fontFamily: *?*IDWriteFontFamily,
+        ) callconv(.winapi) HRESULT,
+        FindFamilyName: *const fn (
+            *IDWriteFontCollection1,
+            familyName: [*:0]const WCHAR,
+            index: *UINT32,
+            exists: *BOOL,
+        ) callconv(.winapi) HRESULT,
+        GetFontFromFontFace: Reserved,
+        // IDWriteFontCollection1 (slots 7-8)
+        _slot7: Reserved,
+        _slot8: Reserved,
+    };
+
+    pub inline fn Release(self: *IDWriteFontCollection1) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetFontFamilyCount(self: *IDWriteFontCollection1) UINT32 {
+        return self.vtable.GetFontFamilyCount(self);
+    }
+
+    pub inline fn GetFontFamily(self: *IDWriteFontCollection1, index: UINT32, fontFamily: *?*IDWriteFontFamily) HRESULT {
+        return self.vtable.GetFontFamily(self, index, fontFamily);
+    }
+
+    pub inline fn FindFamilyName(
+        self: *IDWriteFontCollection1,
+        familyName: [*:0]const WCHAR,
+        index: *UINT32,
+        exists: *BOOL,
+    ) HRESULT {
+        return self.vtable.FindFamilyName(self, familyName, index, exists);
+    }
+};
+
+// IDWriteFactory3
+// IUnknown slots 0-2
+// IDWriteFactory slots 3-23: GetSystemFontCollection(3), ..., CreateNumberSubstitution(22), CreateGlyphRunAnalysis(23)
+// IDWriteFactory1 slots 24-25: all Reserved
+// IDWriteFactory2 slots 26-30: GetSystemFontFallback(26), [27-30 Reserved]
+// IDWriteFactory3 slots 31-39: [31-37 Reserved], GetSystemFontCollection1(38), [39 Reserved]
+pub const IDWriteFactory3 = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0x9A1B41C3,
+        .data2 = 0xD3BB,
+        .data3 = 0x466A,
+        .data4 = .{ 0x87, 0xFC, 0xFE, 0x67, 0x55, 0x6A, 0x3B, 0x65 },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: Reserved,
+        AddRef: Reserved,
+        Release: *const fn (*IDWriteFactory3) callconv(.winapi) u32,
+        // IDWriteFactory (slots 3-23)
+        GetSystemFontCollection: *const fn (
+            *IDWriteFactory3,
+            fontCollection: *?*IDWriteFontCollection,
+            checkForUpdates: BOOL,
+        ) callconv(.winapi) HRESULT,
+        CreateCustomFontCollection: Reserved,
+        RegisterFontCollectionLoader: Reserved,
+        UnregisterFontCollectionLoader: Reserved,
+        CreateFontFileReference: Reserved,
+        CreateCustomFontFileReference: Reserved,
+        CreateFontFace: Reserved,
+        CreateRenderingParams: Reserved,
+        CreateMonitorRenderingParams: Reserved,
+        CreateCustomRenderingParams: Reserved,
+        RegisterFontFileLoader: Reserved,
+        UnregisterFontFileLoader: Reserved,
+        CreateTextFormat: Reserved,
+        CreateTypography: Reserved,
+        GetGdiInterop: Reserved,
+        CreateTextLayout: Reserved,
+        CreateGdiCompatibleTextLayout: Reserved,
+        CreateEllipsisTrimmingSign: Reserved,
+        CreateTextAnalyzer: Reserved,
+        CreateNumberSubstitution: *const fn (
+            *IDWriteFactory3,
+            method: u32,
+            localeName: ?[*:0]const WCHAR,
+            ignoreUserOverride: BOOL,
+            numberSubstitution: *?*IDWriteNumberSubstitution,
+        ) callconv(.winapi) HRESULT,
+        CreateGlyphRunAnalysis: Reserved,
+        // IDWriteFactory1 (slots 24-25)
+        _slot24: Reserved,
+        _slot25: Reserved,
+        // IDWriteFactory2 (slots 26-30)
+        GetSystemFontFallback: *const fn (
+            *IDWriteFactory3,
+            fontFallback: *?*IDWriteFontFallback,
+        ) callconv(.winapi) HRESULT,
+        _slot27: Reserved,
+        _slot28: Reserved,
+        _slot29: Reserved,
+        _slot30: Reserved,
+        // IDWriteFactory3 (slots 31-39)
+        _slot31: Reserved,
+        _slot32: Reserved,
+        _slot33: Reserved,
+        _slot34: Reserved,
+        _slot35: Reserved,
+        _slot36: Reserved,
+        _slot37: Reserved,
+        GetSystemFontCollection1: *const fn (
+            *IDWriteFactory3,
+            includeDownloadableFonts: BOOL,
+            fontCollection: *?*IDWriteFontCollection1,
+            checkForUpdates: BOOL,
+        ) callconv(.winapi) HRESULT,
+        _slot39: Reserved,
+    };
+
+    pub inline fn Release(self: *IDWriteFactory3) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn GetSystemFontCollection(
+        self: *IDWriteFactory3,
+        fontCollection: *?*IDWriteFontCollection,
+        checkForUpdates: BOOL,
+    ) HRESULT {
+        return self.vtable.GetSystemFontCollection(self, fontCollection, checkForUpdates);
+    }
+
+    pub inline fn CreateNumberSubstitution(
+        self: *IDWriteFactory3,
+        method: u32,
+        localeName: ?[*:0]const WCHAR,
+        ignoreUserOverride: BOOL,
+        numberSubstitution: *?*IDWriteNumberSubstitution,
+    ) HRESULT {
+        return self.vtable.CreateNumberSubstitution(self, method, localeName, ignoreUserOverride, numberSubstitution);
+    }
+
+    pub inline fn GetSystemFontFallback(
+        self: *IDWriteFactory3,
+        fontFallback: *?*IDWriteFontFallback,
+    ) HRESULT {
+        return self.vtable.GetSystemFontFallback(self, fontFallback);
+    }
+
+    pub inline fn GetSystemFontCollection1(
+        self: *IDWriteFactory3,
+        includeDownloadableFonts: BOOL,
+        fontCollection: *?*IDWriteFontCollection1,
+        checkForUpdates: BOOL,
+    ) HRESULT {
+        return self.vtable.GetSystemFontCollection1(self, includeDownloadableFonts, fontCollection, checkForUpdates);
+    }
+};
+
+// --- Helper Functions ---
+
+pub const DWriteCreateFactoryFn = *const fn (
+    DWRITE_FACTORY_TYPE,
+    *const GUID,
+    *?*anyopaque,
+) callconv(.winapi) HRESULT;
+
+pub fn loadDWriteCreateFactory() !DWriteCreateFactoryFn {
+    const dwrite_dll = std.os.windows.kernel32.LoadLibraryW(
+        std.unicode.utf8ToUtf16LeStringLiteral("dwrite.dll"),
+    ) orelse return error.DWriteNotAvailable;
+
+    const proc = std.os.windows.kernel32.GetProcAddress(
+        dwrite_dll,
+        "DWriteCreateFactory",
+    ) orelse return error.DWriteCreateFactoryNotFound;
+
+    return @ptrCast(proc);
+}
+
+/// Read the string at index 0 from an IDWriteLocalizedStrings into a
+/// UTF-8 slice backed by the provided buffer.
+///
+/// Covers all BMP characters, which includes every practical font name.
+/// Surrogate pairs (non-BMP) are replaced with U+FFFD.
+pub fn getLocalizedString(
+    strings: *IDWriteLocalizedStrings,
+    buf: []u8,
+) ![]const u8 {
+    // Get the length of the string at index 0 (in WCHARs, not including null).
+    var wide_len: UINT32 = 0;
+    const hr = strings.GetStringLength(0, &wide_len);
+    if (FAILED(hr)) return error.GetStringLengthFailed;
+
+    // Stack-allocate a wide buffer (512 WCHAR max).
+    var wide_buf: [512]WCHAR = undefined;
+    if (wide_len + 1 > wide_buf.len) return error.StringTooLong;
+
+    const hr2 = strings.GetString(0, &wide_buf, wide_len + 1);
+    if (FAILED(hr2)) return error.GetStringFailed;
+
+    // Convert UTF-16LE to UTF-8 manually, handling BMP characters.
+    var out_pos: usize = 0;
+    var i: usize = 0;
+    while (i < wide_len) : (i += 1) {
+        const wc = wide_buf[i];
+        const codepoint: u21 = if (wc >= 0xD800 and wc <= 0xDFFF)
+            // Surrogate -- replace with U+FFFD (we only handle BMP).
+            0xFFFD
+        else
+            wc;
+
+        // Encode codepoint as UTF-8.
+        if (codepoint < 0x80) {
+            if (out_pos >= buf.len) return error.BufferTooSmall;
+            buf[out_pos] = @intCast(codepoint);
+            out_pos += 1;
+        } else if (codepoint < 0x800) {
+            if (out_pos + 1 >= buf.len) return error.BufferTooSmall;
+            buf[out_pos] = @intCast(0xC0 | (codepoint >> 6));
+            buf[out_pos + 1] = @intCast(0x80 | (codepoint & 0x3F));
+            out_pos += 2;
+        } else {
+            if (out_pos + 2 >= buf.len) return error.BufferTooSmall;
+            buf[out_pos] = @intCast(0xE0 | (codepoint >> 12));
+            buf[out_pos + 1] = @intCast(0x80 | ((codepoint >> 6) & 0x3F));
+            buf[out_pos + 2] = @intCast(0x80 | (codepoint & 0x3F));
+            out_pos += 3;
+        }
+    }
+
+    return buf[0..out_pos];
+}
+
+// --- Tests ---
+
+test "vtable pointer sizes" {
+    const ptr_size = @sizeOf(*anyopaque);
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFactory3));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFontCollection));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFontCollection1));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFontFamily));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFont));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFontFace));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFontFile));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFontFileLoader));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteLocalFontFileLoader));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteFontFallback));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteLocalizedStrings));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteNumberSubstitution));
+    try std.testing.expectEqual(ptr_size, @sizeOf(IDWriteTextAnalysisSource));
+}
+
+test "IID values" {
+    // IDWriteFactory3: 9A1B41C3-D3BB-466A-87FC-FE67556A3B65
+    try std.testing.expectEqual(IDWriteFactory3.IID.data1, 0x9A1B41C3);
+    try std.testing.expectEqual(IDWriteFactory3.IID.data2, 0xD3BB);
+    try std.testing.expectEqual(IDWriteFactory3.IID.data3, 0x466A);
+    try std.testing.expectEqualSlices(u8, &IDWriteFactory3.IID.data4, &[8]u8{ 0x87, 0xFC, 0xFE, 0x67, 0x55, 0x6A, 0x3B, 0x65 });
+
+    // IDWriteLocalFontFileLoader: b2d9f3ec-c9fe-4a11-a2ec-d86208f7c0a2
+    try std.testing.expectEqual(IDWriteLocalFontFileLoader.IID.data1, 0xb2d9f3ec);
+    try std.testing.expectEqual(IDWriteLocalFontFileLoader.IID.data2, 0xc9fe);
+    try std.testing.expectEqual(IDWriteLocalFontFileLoader.IID.data3, 0x4a11);
+    try std.testing.expectEqualSlices(u8, &IDWriteLocalFontFileLoader.IID.data4, &[8]u8{ 0xa2, 0xec, 0xd8, 0x62, 0x08, 0xf7, 0xc0, 0xa2 });
+}
+
+test "enum values" {
+    try std.testing.expectEqual(@intFromEnum(DWRITE_FONT_WEIGHT.NORMAL), 400);
+    try std.testing.expectEqual(@intFromEnum(DWRITE_FONT_WEIGHT.BOLD), 700);
+    try std.testing.expectEqual(@intFromEnum(DWRITE_FONT_STYLE.NORMAL), 0);
+    try std.testing.expectEqual(@intFromEnum(DWRITE_FONT_STYLE.ITALIC), 2);
+}
+
+test "DWRITE_UNICODE_RANGE size" {
+    try std.testing.expectEqual(@sizeOf(DWRITE_UNICODE_RANGE), 8);
+}

--- a/src/font/directwrite.zig
+++ b/src/font/directwrite.zig
@@ -466,7 +466,7 @@ pub const IDWriteFont = extern struct {
     pub const VTable = extern struct {
         // IUnknown (slots 0-2)
         QueryInterface: Reserved,
-        AddRef: Reserved,
+        AddRef: *const fn (*IDWriteFont) callconv(.winapi) u32,
         Release: *const fn (*IDWriteFont) callconv(.winapi) u32,
         // IDWriteFont (slots 3-13)
         GetFontFamily: Reserved,
@@ -493,6 +493,10 @@ pub const IDWriteFont = extern struct {
         // IDWriteFont2 (slot 18)
         IsColorFont: *const fn (*IDWriteFont) callconv(.winapi) BOOL,
     };
+
+    pub inline fn AddRef(self: *IDWriteFont) u32 {
+        return self.vtable.AddRef(self);
+    }
 
     pub inline fn Release(self: *IDWriteFont) u32 {
         return self.vtable.Release(self);

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -264,8 +264,11 @@ pub const DirectWrite = struct {
         hr = factory.GetSystemFontFallback(&fallback);
         if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to get system font fallback");
 
+        // DWRITE_NUMBER_SUBSTITUTION_METHOD_NONE = 2
+        // We don't need number substitution for font discovery, but
+        // IDWriteTextAnalysisSource requires one for MapCharacters.
         var number_sub: ?*dwrite.IDWriteNumberSubstitution = null;
-        hr = factory.CreateNumberSubstitution(0, null, 0, &number_sub);
+        hr = factory.CreateNumberSubstitution(2, null, 0, &number_sub);
         if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to create number substitution");
 
         return .{
@@ -1357,5 +1360,80 @@ test "coretext sorting" {
         var buf: [1024]u8 = undefined;
         const name = try res.name(&buf);
         try testing.expectEqualStrings("SF Pro Bold Italic", name);
+    }
+}
+
+test "directwrite" {
+    if (options.backend != .directwrite_freetype) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var dw = DirectWrite.init();
+    defer dw.deinit();
+    var it = try dw.discover(alloc, .{ .family = "Consolas", .size = 12 });
+    defer it.deinit();
+    var count: usize = 0;
+    while (try it.next()) |_| {
+        count += 1;
+    }
+    try testing.expect(count > 0);
+}
+
+test "directwrite codepoint" {
+    if (options.backend != .directwrite_freetype) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var dw = DirectWrite.init();
+    defer dw.deinit();
+    var it = try dw.discover(alloc, .{ .family = "Consolas", .codepoint = 'A', .size = 12 });
+    defer it.deinit();
+
+    var face = (try it.next()).?;
+    defer face.deinit();
+    try testing.expect(face.hasCodepoint('A', null));
+    try testing.expect(face.hasCodepoint('B', null));
+}
+
+test "directwrite bold" {
+    if (options.backend != .directwrite_freetype) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var dw = DirectWrite.init();
+    defer dw.deinit();
+    var it = try dw.discover(alloc, .{ .family = "Consolas", .bold = true, .size = 12 });
+    defer it.deinit();
+
+    var face = (try it.next()).?;
+    defer face.deinit();
+
+    var buf: [1024]u8 = undefined;
+    const name = try face.name(&buf);
+    try testing.expect(name.len > 0);
+}
+
+test "directwrite fallback" {
+    if (options.backend != .directwrite_freetype) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var dw = DirectWrite.init();
+    defer dw.deinit();
+
+    // U+1F600 = grinning face emoji -- should find a fallback font
+    var dummy_collection: Collection = undefined;
+    var it = try dw.discoverFallback(alloc, &dummy_collection, .{ .codepoint = 0x1F600, .size = 12 });
+    defer it.deinit();
+
+    // It's OK if no emoji font is found on headless CI
+    if (try it.next()) |f| {
+        var f_mut = f;
+        defer f_mut.deinit();
+        try testing.expect(f_mut.hasCodepoint(0x1F600, null));
     }
 }

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -4,6 +4,7 @@ const assert = @import("../quirks.zig").inlineAssert;
 const fontconfig = @import("fontconfig");
 const macos = @import("macos");
 const opentype = @import("opentype.zig");
+const dwrite = @import("directwrite.zig");
 const options = @import("main.zig").options;
 const Collection = @import("main.zig").Collection;
 const DeferredFace = @import("main.zig").DeferredFace;
@@ -13,9 +14,8 @@ const log = std.log.scoped(.discovery);
 
 /// Discover implementation for the compile options.
 pub const Discover = switch (options.backend) {
-    .freetype,
-    .directwrite_freetype,
-    => void, // no discovery (DirectWrite discovery implementation comes later)
+    .freetype => void, // no discovery
+    .directwrite_freetype => DirectWrite,
     .fontconfig_freetype => Fontconfig,
     .web_canvas => void, // no discovery
     .coretext,
@@ -239,6 +239,316 @@ pub const Descriptor = struct {
 
         return try macos.text.FontDescriptor.createWithAttributes(@ptrCast(attrs));
     }
+};
+
+pub const DirectWrite = struct {
+    factory: *dwrite.IDWriteFactory3,
+    collection: *dwrite.IDWriteFontCollection,
+    fallback: *dwrite.IDWriteFontFallback,
+    number_sub: *dwrite.IDWriteNumberSubstitution,
+
+    pub fn init() DirectWrite {
+        const createFactory = dwrite.loadDWriteCreateFactory() catch
+            @panic("DirectWrite: failed to load DWriteCreateFactory");
+
+        var factory_raw: ?*anyopaque = null;
+        var hr = createFactory(.SHARED, &dwrite.IDWriteFactory3.IID, &factory_raw);
+        if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to create factory");
+        const factory: *dwrite.IDWriteFactory3 = @ptrCast(@alignCast(factory_raw.?));
+
+        var collection: ?*dwrite.IDWriteFontCollection = null;
+        hr = factory.GetSystemFontCollection(&collection, 0);
+        if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to get system font collection");
+
+        var fallback: ?*dwrite.IDWriteFontFallback = null;
+        hr = factory.GetSystemFontFallback(&fallback);
+        if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to get system font fallback");
+
+        var number_sub: ?*dwrite.IDWriteNumberSubstitution = null;
+        hr = factory.CreateNumberSubstitution(0, null, 0, &number_sub);
+        if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to create number substitution");
+
+        return .{
+            .factory = factory,
+            .collection = collection.?,
+            .fallback = fallback.?,
+            .number_sub = number_sub.?,
+        };
+    }
+
+    pub fn deinit(self: *DirectWrite) void {
+        _ = self.number_sub.Release();
+        _ = self.fallback.Release();
+        _ = self.collection.Release();
+        _ = self.factory.Release();
+    }
+
+    pub fn discover(self: *const DirectWrite, alloc: Allocator, desc: Descriptor) !DiscoverIterator {
+        const family = desc.family orelse return DiscoverIterator.empty(alloc, desc.variations);
+
+        // Convert family name to UTF-16 (ASCII fast path for font names)
+        var wfamily_buf: [128]u16 = undefined;
+        const wfamily = utf8ToUtf16Le(&wfamily_buf, family) orelse
+            return DiscoverIterator.empty(alloc, desc.variations);
+
+        var family_index: u32 = 0;
+        var exists: i32 = 0;
+        var hr = self.collection.FindFamilyName(wfamily, &family_index, &exists);
+        if (dwrite.FAILED(hr) or exists == 0)
+            return DiscoverIterator.empty(alloc, desc.variations);
+
+        var dw_family: ?*dwrite.IDWriteFontFamily = null;
+        hr = self.collection.GetFontFamily(family_index, &dw_family);
+        if (dwrite.FAILED(hr)) return error.DirectWriteError;
+        defer _ = dw_family.?.Release();
+
+        const font_count = dw_family.?.GetFontCount();
+        var fonts = try alloc.alloc(ScoredFont, font_count);
+        var valid_count: usize = 0;
+
+        for (0..font_count) |i| {
+            var dw_font: ?*dwrite.IDWriteFont = null;
+            hr = dw_family.?.GetFont(@intCast(i), &dw_font);
+            if (dwrite.FAILED(hr)) continue;
+
+            if (dw_font.?.GetSimulations() != .NONE) {
+                _ = dw_font.?.Release();
+                continue;
+            }
+
+            fonts[valid_count] = .{ .font = dw_font.?, .score = scoreFont(&desc, dw_font.?) };
+            valid_count += 1;
+        }
+
+        const scored = fonts[0..valid_count];
+        std.mem.sortUnstable(ScoredFont, scored, {}, struct {
+            fn lessThan(_: void, a: ScoredFont, b: ScoredFont) bool {
+                return a.score.int() > b.score.int();
+            }
+        }.lessThan);
+
+        var result = try alloc.alloc(*dwrite.IDWriteFont, valid_count);
+        for (scored, 0..) |sf, j| result[j] = sf.font;
+        alloc.free(fonts);
+
+        return DiscoverIterator{
+            .fonts = result,
+            .alloc = alloc,
+            .variations = desc.variations,
+            .i = 0,
+        };
+    }
+
+    pub fn discoverFallback(
+        self: *const DirectWrite,
+        alloc: Allocator,
+        collection: *Collection,
+        desc: Descriptor,
+    ) !DiscoverIterator {
+        _ = collection;
+        if (desc.codepoint == 0) return try self.discover(alloc, desc);
+
+        var utf16_buf: [2]u16 = undefined;
+        const utf16_len: u32 = if (desc.codepoint > 0xFFFF) blk: {
+            const cp = desc.codepoint - 0x10000;
+            utf16_buf[0] = @intCast(0xD800 + (cp >> 10));
+            utf16_buf[1] = @intCast(0xDC00 + (cp & 0x3FF));
+            break :blk 2;
+        } else blk: {
+            utf16_buf[0] = @intCast(desc.codepoint);
+            break :blk 1;
+        };
+
+        var source = TextAnalysisSource{
+            .vtable = &TextAnalysisSource.static_vtable,
+            .text = &utf16_buf,
+            .text_len = utf16_len,
+            .number_sub = self.number_sub,
+        };
+
+        var mapped_length: u32 = 0;
+        var mapped_font: ?*dwrite.IDWriteFont = null;
+        var scale: f32 = 0;
+
+        const base_weight: dwrite.DWRITE_FONT_WEIGHT = if (desc.bold) .BOLD else .NORMAL;
+        const base_style: dwrite.DWRITE_FONT_STYLE = if (desc.italic) .ITALIC else .NORMAL;
+
+        const fb_hr = self.fallback.MapCharacters(
+            @ptrCast(&source),
+            0,
+            utf16_len,
+            self.collection,
+            null,
+            base_weight,
+            base_style,
+            .NORMAL,
+            &mapped_length,
+            &mapped_font,
+            &scale,
+        );
+
+        if (dwrite.SUCCEEDED(fb_hr)) {
+            if (mapped_font) |font| {
+                var result = try alloc.alloc(*dwrite.IDWriteFont, 1);
+                result[0] = font;
+                return DiscoverIterator{
+                    .fonts = result,
+                    .alloc = alloc,
+                    .variations = desc.variations,
+                    .i = 0,
+                };
+            }
+        }
+
+        return try self.discover(alloc, desc);
+    }
+
+    // Scoring
+
+    const Score = packed struct {
+        const Backing = @typeInfo(@This()).@"struct".backing_integer.?;
+        glyph_count: u16 = 0,
+        bold: bool = false,
+        italic: bool = false,
+        normal_stretch: bool = false,
+        codepoint: bool = false,
+
+        pub fn int(self: Score) Backing {
+            return @bitCast(self);
+        }
+    };
+
+    const ScoredFont = struct {
+        font: *dwrite.IDWriteFont,
+        score: Score,
+    };
+
+    fn scoreFont(desc: *const Descriptor, font: *dwrite.IDWriteFont) Score {
+        var score: Score = .{};
+
+        const weight = font.GetWeight();
+        const style = font.GetStyle();
+        const stretch = font.GetStretch();
+
+        const is_bold = @intFromEnum(weight) >= @intFromEnum(dwrite.DWRITE_FONT_WEIGHT.SEMI_BOLD);
+        score.bold = desc.bold == is_bold;
+
+        const is_italic = (style == .ITALIC or style == .OBLIQUE);
+        score.italic = desc.italic == is_italic;
+
+        score.normal_stretch = (stretch == .NORMAL);
+
+        if (desc.codepoint > 0) {
+            var cp_exists: i32 = 0;
+            const cp_hr = font.HasCharacter(desc.codepoint, &cp_exists);
+            if (dwrite.SUCCEEDED(cp_hr) and cp_exists != 0) score.codepoint = true;
+        }
+
+        return score;
+    }
+
+    // TextAnalysisSource -- minimal implementation for IDWriteFontFallback::MapCharacters
+
+    const TextAnalysisSource = extern struct {
+        vtable: *const dwrite.IDWriteTextAnalysisSource.VTable,
+        text: *const [2]u16,
+        text_len: u32,
+        number_sub: *dwrite.IDWriteNumberSubstitution,
+
+        const static_vtable = dwrite.IDWriteTextAnalysisSource.VTable{
+            .QueryInterface = @ptrCast(&queryInterface),
+            .AddRef = @ptrCast(&addRef),
+            .Release = @ptrCast(&release),
+            .GetTextAtPosition = @ptrCast(&getTextAtPosition),
+            .GetTextBeforePosition = @ptrCast(&getTextBeforePosition),
+            .GetParagraphReadingDirection = @ptrCast(&getParagraphReadingDirection),
+            .GetLocaleName = @ptrCast(&getLocaleName),
+            .GetNumberSubstitution = @ptrCast(&getNumberSubstitution),
+        };
+
+        fn queryInterface(_: *TextAnalysisSource, _: *const dwrite.GUID, _: *?*anyopaque) callconv(.winapi) dwrite.HRESULT {
+            return dwrite.E_NOINTERFACE;
+        }
+        fn addRef(_: *TextAnalysisSource) callconv(.winapi) u32 { return 1; }
+        fn release(_: *TextAnalysisSource) callconv(.winapi) u32 { return 1; }
+
+        fn getTextAtPosition(self: *TextAnalysisSource, pos: u32, text_out: *?[*]const u16, len_out: *u32) callconv(.winapi) dwrite.HRESULT {
+            if (pos >= self.text_len) {
+                text_out.* = null;
+                len_out.* = 0;
+            } else {
+                text_out.* = @as([*]const u16, self.text) + pos;
+                len_out.* = self.text_len - pos;
+            }
+            return dwrite.S_OK;
+        }
+
+        fn getTextBeforePosition(self: *TextAnalysisSource, pos: u32, text_out: *?[*]const u16, len_out: *u32) callconv(.winapi) dwrite.HRESULT {
+            if (pos == 0 or pos > self.text_len) {
+                text_out.* = null;
+                len_out.* = 0;
+            } else {
+                text_out.* = @as([*]const u16, self.text);
+                len_out.* = pos;
+            }
+            return dwrite.S_OK;
+        }
+
+        fn getParagraphReadingDirection(_: *TextAnalysisSource) callconv(.winapi) dwrite.DWRITE_READING_DIRECTION {
+            return .LEFT_TO_RIGHT;
+        }
+
+        fn getLocaleName(_: *TextAnalysisSource, _: u32, text_len: *u32, locale: *?[*:0]const u16) callconv(.winapi) dwrite.HRESULT {
+            const empty: [*:0]const u16 = &[_:0]u16{};
+            locale.* = empty;
+            text_len.* = 0;
+            return dwrite.S_OK;
+        }
+
+        fn getNumberSubstitution(self: *TextAnalysisSource, _: u32, text_len: *u32, sub: *?*dwrite.IDWriteNumberSubstitution) callconv(.winapi) dwrite.HRESULT {
+            sub.* = self.number_sub;
+            text_len.* = self.text_len;
+            return dwrite.S_OK;
+        }
+    };
+
+    // UTF-8 to UTF-16 helper (ASCII fast path, sufficient for font family names)
+
+    fn utf8ToUtf16Le(buf: []u16, utf8: []const u8) ?[*:0]const u16 {
+        var i: usize = 0;
+        for (utf8) |byte| {
+            if (i >= buf.len - 1) return null;
+            buf[i] = @intCast(byte);
+            i += 1;
+        }
+        buf[i] = 0;
+        return @ptrCast(buf[0..i :0].ptr);
+    }
+
+    pub const DiscoverIterator = struct {
+        fonts: []*dwrite.IDWriteFont,
+        alloc: Allocator,
+        variations: []const Variation,
+        i: usize,
+
+        pub fn empty(alloc: Allocator, variations: []const Variation) DiscoverIterator {
+            return .{ .fonts = &.{}, .alloc = alloc, .variations = variations, .i = 0 };
+        }
+
+        pub fn deinit(self: *DiscoverIterator) void {
+            for (self.fonts) |font| _ = font.Release();
+            if (self.fonts.len > 0) self.alloc.free(self.fonts);
+            self.* = undefined;
+        }
+
+        pub fn next(self: *DiscoverIterator) !?DeferredFace {
+            if (self.i >= self.fonts.len) return null;
+            const font = self.fonts[self.i];
+            _ = font.AddRef();
+            defer self.i += 1;
+            return DeferredFace{ .dw = .{ .font = font, .variations = self.variations } };
+        }
+    };
 };
 
 pub const Fontconfig = struct {

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -13,7 +13,9 @@ const log = std.log.scoped(.discovery);
 
 /// Discover implementation for the compile options.
 pub const Discover = switch (options.backend) {
-    .freetype => void, // no discovery
+    .freetype,
+    .directwrite_freetype,
+    => void, // no discovery (DirectWrite discovery implementation comes later)
     .fontconfig_freetype => Fontconfig,
     .web_canvas => void, // no discovery
     .coretext,

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -264,11 +264,11 @@ pub const DirectWrite = struct {
         hr = factory.GetSystemFontFallback(&fallback);
         if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to get system font fallback");
 
-        // DWRITE_NUMBER_SUBSTITUTION_METHOD_NONE = 2
         // We don't need number substitution for font discovery, but
         // IDWriteTextAnalysisSource requires one for MapCharacters.
+        const DWRITE_NUMBER_SUBSTITUTION_METHOD_NONE: u32 = 2;
         var number_sub: ?*dwrite.IDWriteNumberSubstitution = null;
-        hr = factory.CreateNumberSubstitution(2, null, 0, &number_sub);
+        hr = factory.CreateNumberSubstitution(DWRITE_NUMBER_SUBSTITUTION_METHOD_NONE, null, 0, &number_sub);
         if (dwrite.FAILED(hr)) @panic("DirectWrite: failed to create number substitution");
 
         return .{
@@ -515,17 +515,12 @@ pub const DirectWrite = struct {
         }
     };
 
-    // UTF-8 to UTF-16 helper (ASCII fast path, sufficient for font family names)
+    // UTF-8 to null-terminated UTF-16LE for DirectWrite APIs.
 
     fn utf8ToUtf16Le(buf: []u16, utf8: []const u8) ?[*:0]const u16 {
-        var i: usize = 0;
-        for (utf8) |byte| {
-            if (i >= buf.len - 1) return null;
-            buf[i] = @intCast(byte);
-            i += 1;
-        }
-        buf[i] = 0;
-        return @ptrCast(buf[0..i :0].ptr);
+        const len = std.unicode.utf8ToUtf16Le(buf[0 .. buf.len - 1], utf8) catch return null;
+        buf[len] = 0;
+        return @ptrCast(buf[0..len :0].ptr);
     }
 
     pub const DiscoverIterator = struct {

--- a/src/font/face.zig
+++ b/src/font/face.zig
@@ -12,6 +12,7 @@ pub const web_canvas = @import("face/web_canvas.zig");
 pub const Face = switch (options.backend) {
     .freetype,
     .fontconfig_freetype,
+    .directwrite_freetype,
     .coretext_freetype,
     => freetype.Face,
 

--- a/src/font/library.zig
+++ b/src/font/library.zig
@@ -11,6 +11,7 @@ pub const Library = switch (options.backend) {
     // Freetype requires a state library
     .freetype,
     .fontconfig_freetype,
+    .directwrite_freetype,
     .coretext_freetype,
     => FreetypeLibrary,
 

--- a/src/font/main.zig
+++ b/src/font/main.zig
@@ -25,6 +25,7 @@ pub const SharedGridSet = @import("SharedGridSet.zig");
 pub const sprite = @import("sprite.zig");
 pub const Sprite = sprite.Sprite;
 pub const SpriteFace = sprite.Face;
+pub const directwrite = if (options.backend.hasDirectwrite()) @import("directwrite.zig") else struct {};
 pub const Descriptor = discovery.Descriptor;
 pub const Discover = discovery.Discover;
 pub const Library = library.Library;

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -20,6 +20,7 @@ pub const default_features = feature.default_features;
 pub const Shaper = switch (options.backend) {
     .freetype,
     .fontconfig_freetype,
+    .directwrite_freetype,
     .coretext_freetype,
     .coretext_harfbuzz,
     => harfbuzz.Shaper,

--- a/src/os/windows_com.zig
+++ b/src/os/windows_com.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+
+/// COM GUID (Globally Unique Identifier).
+pub const GUID = extern struct {
+    data1: u32,
+    data2: u16,
+    data3: u16,
+    data4: [8]u8,
+};
+
+/// COM HRESULT return type.
+pub const HRESULT = i32;
+
+/// Returns true if the HRESULT indicates success (non-negative).
+pub inline fn SUCCEEDED(hr: HRESULT) bool {
+    return hr >= 0;
+}
+
+/// Returns true if the HRESULT indicates failure (negative).
+pub inline fn FAILED(hr: HRESULT) bool {
+    return hr < 0;
+}
+
+pub const S_OK: HRESULT = 0;
+pub const E_NOINTERFACE: HRESULT = @bitCast(@as(u32, 0x80004002));
+pub const E_FAIL: HRESULT = @bitCast(@as(u32, 0x80004005));
+
+/// IUnknown - base COM interface that all COM objects implement.
+pub const IUnknown = extern struct {
+    vtable: *const VTable,
+
+    pub const VTable = extern struct {
+        QueryInterface: *const fn (
+            self: *IUnknown,
+            riid: *const GUID,
+            ppvObject: *?*anyopaque,
+        ) callconv(.winapi) HRESULT,
+        AddRef: *const fn (self: *IUnknown) callconv(.winapi) u32,
+        Release: *const fn (self: *IUnknown) callconv(.winapi) u32,
+    };
+
+    pub inline fn Release(self: *IUnknown) u32 {
+        return self.vtable.Release(self);
+    }
+
+    pub inline fn AddRef(self: *IUnknown) u32 {
+        return self.vtable.AddRef(self);
+    }
+
+    pub inline fn QueryInterface(
+        self: *IUnknown,
+        riid: *const GUID,
+        ppvObject: *?*anyopaque,
+    ) HRESULT {
+        return self.vtable.QueryInterface(self, riid, ppvObject);
+    }
+};
+
+/// Stub vtable entry for COM methods not yet wrapped.
+pub const Reserved = *const fn () callconv(.winapi) void;
+
+test "GUID size and alignment" {
+    try std.testing.expectEqual(@sizeOf(GUID), 16);
+    try std.testing.expectEqual(@alignOf(GUID), 4);
+}
+
+test "HRESULT helpers" {
+    try std.testing.expect(SUCCEEDED(S_OK));
+    try std.testing.expect(!FAILED(S_OK));
+    try std.testing.expect(FAILED(E_FAIL));
+    try std.testing.expect(!SUCCEEDED(E_FAIL));
+    try std.testing.expect(FAILED(E_NOINTERFACE));
+}
+
+test "IUnknown vtable pointer size" {
+    try std.testing.expectEqual(@sizeOf(IUnknown), @sizeOf(*anyopaque));
+}
+
+test "Reserved size" {
+    try std.testing.expectEqual(@sizeOf(Reserved), @sizeOf(*anyopaque));
+}

--- a/src/renderer/directx11/com.zig
+++ b/src/renderer/directx11/com.zig
@@ -1,64 +1,18 @@
-const std = @import("std");
+const windows_com = @import("../../os/windows_com.zig");
 
-/// COM GUID (Globally Unique Identifier).
-pub const GUID = extern struct {
-    data1: u32,
-    data2: u16,
-    data3: u16,
-    data4: [8]u8,
-};
+// Re-export shared COM primitives so all existing imports are unchanged.
+pub const GUID = windows_com.GUID;
+pub const HRESULT = windows_com.HRESULT;
+pub const SUCCEEDED = windows_com.SUCCEEDED;
+pub const FAILED = windows_com.FAILED;
+pub const S_OK = windows_com.S_OK;
+pub const E_NOINTERFACE = windows_com.E_NOINTERFACE;
+pub const E_FAIL = windows_com.E_FAIL;
+pub const IUnknown = windows_com.IUnknown;
+pub const Reserved = windows_com.Reserved;
 
-/// COM HRESULT return type.
-pub const HRESULT = i32;
-
-/// Returns true if the HRESULT indicates success (non-negative).
-pub inline fn SUCCEEDED(hr: HRESULT) bool {
-    return hr >= 0;
-}
-
-/// Returns true if the HRESULT indicates failure (negative).
-pub inline fn FAILED(hr: HRESULT) bool {
-    return hr < 0;
-}
-
-pub const S_OK: HRESULT = 0;
-pub const E_NOINTERFACE: HRESULT = @bitCast(@as(u32, 0x80004002));
-pub const E_FAIL: HRESULT = @bitCast(@as(u32, 0x80004005));
+// DX11-specific HRESULT code; not a general COM primitive.
 pub const DXGI_ERROR_DEVICE_REMOVED: HRESULT = @bitCast(@as(u32, 0x887A0005));
-
-/// IUnknown - base COM interface that all COM objects implement.
-pub const IUnknown = extern struct {
-    vtable: *const VTable,
-
-    pub const VTable = extern struct {
-        QueryInterface: *const fn (
-            self: *IUnknown,
-            riid: *const GUID,
-            ppvObject: *?*anyopaque,
-        ) callconv(.winapi) HRESULT,
-        AddRef: *const fn (self: *IUnknown) callconv(.winapi) u32,
-        Release: *const fn (self: *IUnknown) callconv(.winapi) u32,
-    };
-
-    pub inline fn Release(self: *IUnknown) u32 {
-        return self.vtable.Release(self);
-    }
-
-    pub inline fn AddRef(self: *IUnknown) u32 {
-        return self.vtable.AddRef(self);
-    }
-
-    pub inline fn QueryInterface(
-        self: *IUnknown,
-        riid: *const GUID,
-        ppvObject: *?*anyopaque,
-    ) HRESULT {
-        return self.vtable.QueryInterface(self, riid, ppvObject);
-    }
-};
-
-/// Stub vtable entry for COM methods not yet wrapped.
-pub const Reserved = *const fn () callconv(.winapi) void;
 
 test {
     _ = @import("com_test.zig");

--- a/src/renderer/directx11/com_test.zig
+++ b/src/renderer/directx11/com_test.zig
@@ -3,29 +3,6 @@ const com = @import("com.zig");
 const dxgi = @import("dxgi.zig");
 const d3d11 = @import("d3d11.zig");
 
-// Verify COM GUID byte layout matches the Windows SDK definitions.
-// GUIDs are stored as { u32, u16, u16, [8]u8 } in little-endian.
-
-test "IUnknown GUID has no definition" {
-    // IUnknown doesn't define its own IID in our bindings (it's accessed
-    // via derived interfaces), so verify the base struct layout instead.
-    try std.testing.expectEqual(@sizeOf(com.GUID), 16);
-    try std.testing.expectEqual(@alignOf(com.GUID), 4);
-}
-
-test "HRESULT helpers" {
-    try std.testing.expect(com.SUCCEEDED(com.S_OK));
-    try std.testing.expect(!com.FAILED(com.S_OK));
-    try std.testing.expect(com.FAILED(com.E_FAIL));
-    try std.testing.expect(!com.SUCCEEDED(com.E_FAIL));
-    try std.testing.expect(com.FAILED(com.E_NOINTERFACE));
-    try std.testing.expect(com.FAILED(com.DXGI_ERROR_DEVICE_REMOVED));
-}
-
-test "Reserved type is function pointer sized" {
-    try std.testing.expectEqual(@sizeOf(com.Reserved), @sizeOf(*anyopaque));
-}
-
 // Verify struct sizes match the C ABI (these are extern structs that
 // cross the COM boundary, so size mismatches cause runtime crashes).
 


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR: #101 -> **this PR**
> Review the incremental diff only.

## Summary

- Discover "Segoe UI Emoji" via DirectWrite and add as preferred emoji fallback on Windows
- Mirror the macOS "Apple Color Emoji" pattern exactly
- Skip embedded Noto Color Emoji on Windows when DirectWrite discovery is available

## What changed

In `SharedGridSet.zig`:
- Added Windows emoji block after the existing macOS block, using the same discover -> addDeferred pattern
- Updated embedded emoji guard to exclude Windows (alongside macOS) when discovery is available

Fallback behavior:
- macOS: Apple Color Emoji (system), no embedded
- Windows: Segoe UI Emoji (system), no embedded
- Linux: embedded Noto Color Emoji
- Any platform without discovery (`Discover == void`): embedded fallback loads

## Testing

- Build passes with `directwrite_freetype` backend
- Full test suite passes (`zig build test -Dfont-backend=directwrite_freetype`)
- "Segoe UI Emoji" ships with Windows 10+, same floor as DirectWrite
