### PR TITLE
fix(directx11): add D3D11_BIND_SHADER_RESOURCE to shared texture

### DIFF
--- a/src/renderer/directx11/Target.zig
+++ b/src/renderer/directx11/Target.zig
@@ -104,7 +104,7 @@ fn createSharedTextureResources(
         .Format = .B8G8R8A8_UNORM,
         .SampleDesc = .{ .Count = 1, .Quality = 0 },
         .Usage = .DEFAULT,
-        .BindFlags = d3d11.D3D11_BIND_RENDER_TARGET,
+        .BindFlags = d3d11.D3D11_BIND_RENDER_TARGET | d3d11.D3D11_BIND_SHADER_RESOURCE,
         .CPUAccessFlags = 0,
         .MiscFlags = d3d11.D3D11_RESOURCE_MISC_SHARED,
     };


### PR DESCRIPTION
## Summary

- Adds `D3D11_BIND_SHADER_RESOURCE` to the bind flags of the shared DXGI texture created for cross-process texture sharing on Windows.

## Problem

Shared textures created for embedded/interop use only had `D3D11_BIND_RENDER_TARGET`. This prevents consumers from creating an SRV directly on the shared texture handle obtained via `OpenSharedResource`. Every consumer is forced to create an intermediate copy texture and `CopyResource` each frame, adding unnecessary GPU overhead.

## Fix

Add `D3D11_BIND_SHADER_RESOURCE` alongside the existing `D3D11_BIND_RENDER_TARGET`. Both bind flags on a single texture is standard D3D11 practice. This allows consumers to create an SRV directly on the shared texture, enabling zero-copy texture sharing.

## Testing

- Verified with Unity-Bridge: `CreateShaderResourceView` now succeeds on the shared texture (previously returned `E_INVALIDARG`)
- Unity-Direct example continues to work unchanged