### PR TITLE
font: verify variable font variations through DirectWrite

### DIFF
--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -1461,6 +1461,6 @@ test "directwrite variations" {
     // at load time (via FreeType's setVarDesignCoordinates).
     var face = (try it.next()) orelse return;
     defer face.deinit();
-    try testing.expectEqual(@as(usize, 1), face.dw.?.variations.len);
-    try testing.expectEqual(@as(u32, @bitCast(Variation.Id.init("wght"))), @as(u32, @bitCast(face.dw.?.variations[0].id)));
+    try testing.expectEqual(1, face.dw.?.variations.len);
+    try testing.expectEqual(Variation.Id.init("wght"), face.dw.?.variations[0].id);
 }

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -523,6 +523,11 @@ pub const DirectWrite = struct {
         return @ptrCast(buf[0..len :0].ptr);
     }
 
+    // Variation axes are not used for scoring because DirectWrite's
+    // GetWeight/GetStyle already return instance-level values. Variations
+    // are passed through to DeferredFace and applied when the font is
+    // loaded via FreeType (see DeferredFace.loadDirectWrite).
+
     pub const DiscoverIterator = struct {
         fonts: []*dwrite.IDWriteFont,
         alloc: Allocator,
@@ -1431,4 +1436,31 @@ test "directwrite fallback" {
         defer f_mut.deinit();
         try testing.expect(f_mut.hasCodepoint(0x1F600, null));
     }
+}
+
+test "directwrite variations" {
+    if (options.backend != .directwrite_freetype) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const variations = [_]Variation{
+        .{ .id = Variation.Id.init("wght"), .value = 300 },
+    };
+
+    var dw = DirectWrite.init();
+    defer dw.deinit();
+    var it = try dw.discover(alloc, .{
+        .family = "Cascadia Code",
+        .variations = &variations,
+        .size = 12,
+    });
+    defer it.deinit();
+
+    // Variations are carried through to DeferredFace for application
+    // at load time (via FreeType's setVarDesignCoordinates).
+    var face = (try it.next()) orelse return;
+    defer face.deinit();
+    try testing.expectEqual(@as(usize, 1), face.dw.?.variations.len);
+    try testing.expectEqual(@as(u32, @bitCast(Variation.Id.init("wght"))), @as(u32, @bitCast(face.dw.?.variations[0].id)));
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR** -- review in order:
> 1. #101 -- DirectWrite font discovery backend
> 2. #102 -- Segoe UI Emoji as Windows fallback font
> 3. #104 -- ClearType rendering tuning
> 4. **#105 -- This PR: Variable font axis verification**

## Summary

- Add test confirming font-variation axes (e.g. `wght=300`) flow through DirectWrite discovery into DeferredFace
- Document that DirectWrite does not need CoreText-style variation axis scoring because `GetWeight`/`GetStyle` already return instance-level values
- Variations are applied at load time via FreeType's `setVarDesignCoordinates`

## Test plan

- [x] `zig build test -Dtest-filter="directwrite"` -- all 5 DirectWrite tests pass (76/76 total)
- [ ] Visual check: `font-variation = "wght=300"` with Cascadia Code produces lighter text