### PR TITLE
font: fix review findings in DirectWrite backend

### DIFF
--- a/src/font/directwrite.zig
+++ b/src/font/directwrite.zig
@@ -843,37 +843,10 @@ pub fn getLocalizedString(
     const hr2 = strings.GetString(0, &wide_buf, wide_len + 1);
     if (FAILED(hr2)) return error.GetStringFailed;
 
-    // Convert UTF-16LE to UTF-8 manually, handling BMP characters.
-    var out_pos: usize = 0;
-    var i: usize = 0;
-    while (i < wide_len) : (i += 1) {
-        const wc = wide_buf[i];
-        const codepoint: u21 = if (wc >= 0xD800 and wc <= 0xDFFF)
-            // Surrogate -- replace with U+FFFD (we only handle BMP).
-            0xFFFD
-        else
-            wc;
+    const out_len = std.unicode.utf16LeToUtf8(buf, wide_buf[0..wide_len]) catch
+        return error.BufferTooSmall;
 
-        // Encode codepoint as UTF-8.
-        if (codepoint < 0x80) {
-            if (out_pos >= buf.len) return error.BufferTooSmall;
-            buf[out_pos] = @intCast(codepoint);
-            out_pos += 1;
-        } else if (codepoint < 0x800) {
-            if (out_pos + 1 >= buf.len) return error.BufferTooSmall;
-            buf[out_pos] = @intCast(0xC0 | (codepoint >> 6));
-            buf[out_pos + 1] = @intCast(0x80 | (codepoint & 0x3F));
-            out_pos += 2;
-        } else {
-            if (out_pos + 2 >= buf.len) return error.BufferTooSmall;
-            buf[out_pos] = @intCast(0xE0 | (codepoint >> 12));
-            buf[out_pos + 1] = @intCast(0x80 | ((codepoint >> 6) & 0x3F));
-            buf[out_pos + 2] = @intCast(0x80 | (codepoint & 0x3F));
-            out_pos += 3;
-        }
-    }
-
-    return buf[0..out_pos];
+    return buf[0..out_len];
 }
 
 // --- Tests ---

--- a/src/font/directwrite.zig
+++ b/src/font/directwrite.zig
@@ -824,9 +824,6 @@ pub fn loadDWriteCreateFactory() !DWriteCreateFactoryFn {
 
 /// Read the string at index 0 from an IDWriteLocalizedStrings into a
 /// UTF-8 slice backed by the provided buffer.
-///
-/// Covers all BMP characters, which includes every practical font name.
-/// Surrogate pairs (non-BMP) are replaced with U+FFFD.
 pub fn getLocalizedString(
     strings: *IDWriteLocalizedStrings,
     buf: []u8,

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -289,7 +289,7 @@ pub const DirectWrite = struct {
     pub fn discover(self: *const DirectWrite, alloc: Allocator, desc: Descriptor) !DiscoverIterator {
         const family = desc.family orelse return DiscoverIterator.empty(alloc, desc.variations);
 
-        // Convert family name to UTF-16 (ASCII fast path for font names)
+        // Convert family name to UTF-16 for DirectWrite APIs
         var wfamily_buf: [128]u16 = undefined;
         const wfamily = utf8ToUtf16Le(&wfamily_buf, family) orelse
             return DiscoverIterator.empty(alloc, desc.variations);
@@ -1425,7 +1425,9 @@ test "directwrite fallback" {
     var dw = DirectWrite.init();
     defer dw.deinit();
 
-    // U+1F600 = grinning face emoji -- should find a fallback font
+    // U+1F600 = grinning face emoji -- should find a fallback font.
+    // DirectWrite.discoverFallback ignores the collection parameter
+    // (uses its own system collection), so undefined is safe here.
     var dummy_collection: Collection = undefined;
     var it = try dw.discoverFallback(alloc, &dummy_collection, .{ .codepoint = 0x1F600, .size = 12 });
     defer it.deinit();


### PR DESCRIPTION
## Summary

Cleanup from code review of the DirectWrite font stack (PRs #101-#105).

- Replace hand-rolled UTF-16-to-UTF-8 encoder in `getLocalizedString` with `std.unicode.utf16LeToUtf8` -- the old code only handled BMP and replaced surrogate pairs with U+FFFD
- Fix stale "ASCII fast path" comment that no longer matched the implementation
- Document why `undefined` Collection is safe in the fallback test (the parameter is explicitly ignored)

Note: the review also flagged `DWRITE_NUMBER_SUBSTITUTION_METHOD_NONE = 2` as wrong, but 2 is correct per the Windows SDK enum (`FROM_CULTURE=0, CONTEXTUAL=1, NONE=2`).

## Test plan

- [x] `zig build test -Dtest-filter="directwrite"` -- 76/76 tests passed