### PR TITLE
DX12 pivot: backend enum + stub DirectX12.zig

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1721,34 +1721,40 @@ pub const CAPI = struct {
         surface.draw();
     }
 
-    /// Return the ID3D11Device pointer that ghostty uses for rendering.
+    /// Return the GPU device pointer used by the renderer. For DX11 this
+    /// is the ID3D11Device; for DX12 it will be the ID3D12Device.
     /// Shared texture consumers should open the DXGI shared handle on
     /// this same device to avoid cross-device synchronization issues.
-    /// Returns null on non-DX11 builds or if the device is not initialized.
+    /// Returns null if the renderer backend has no device yet.
     export fn ghostty_surface_get_d3d11_device(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
-        const dev = surface.core_surface.renderer.api.device orelse return null;
+        const api = surface.core_surface.renderer.api;
+        if (comptime !@hasField(@TypeOf(api), "device")) return null;
+        const dev = api.device orelse return null;
         return @ptrCast(dev.device);
     }
 
-    /// Return the ID3D11DeviceContext pointer that ghostty uses for
-    /// rendering. Consumers need this to call CopyResource from the
-    /// shared texture. Enable multithread protection on the context
-    /// when accessing from a non-render thread.
-    /// Returns null on non-DX11 builds or if the device is not initialized.
+    /// Return the device context pointer used for rendering. For DX11
+    /// this is the ID3D11DeviceContext. DX12 does not have this concept
+    /// (uses command lists instead) so it returns null.
+    /// Returns null if not applicable or if the device is not initialized.
     export fn ghostty_surface_get_d3d11_context(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
-        const dev = surface.core_surface.renderer.api.device orelse return null;
+        const api = surface.core_surface.renderer.api;
+        if (comptime !@hasField(@TypeOf(api), "device")) return null;
+        const dev = api.device orelse return null;
         return @ptrCast(dev.context);
     }
 
-    /// Return the ID3D11Texture2D pointer that ghostty renders to in
+    /// Return the shared texture pointer that ghostty renders to in
     /// shared texture mode. Same-process consumers can CopyResource
     /// directly from this pointer using ghostty's device context.
-    /// Returns null on non-DX11 builds or if not in shared texture mode.
+    /// Returns null if not in shared texture mode or not applicable.
     export fn ghostty_surface_get_d3d11_texture(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
-        const st = surface.core_surface.renderer.api.shared_target orelse return null;
+        const api = surface.core_surface.renderer.api;
+        if (comptime !@hasField(@TypeOf(api), "shared_target")) return null;
+        const st = api.shared_target orelse return null;
         return @ptrCast(st.texture orelse return null);
     }
 

--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -134,11 +134,11 @@ pub fn initShared(
         lib.linkSystemLibrary("libucrt");
     }
 
-    // Link DirectX 11 libraries on Windows when using the directx11 renderer.
+    // Link DirectX 12 libraries on Windows when using the directx12 renderer.
     if (deps.config.target.result.os.tag == .windows and
-        deps.config.renderer == .directx11)
+        deps.config.renderer == .directx12)
     {
-        lib.linkSystemLibrary("d3d11");
+        lib.linkSystemLibrary("d3d12");
         lib.linkSystemLibrary("dxgi");
     }
 

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -18,7 +18,7 @@ pub const GenericRenderer = @import("renderer/generic.zig").Renderer;
 pub const Metal = @import("renderer/Metal.zig");
 pub const OpenGL = @import("renderer/OpenGL.zig");
 pub const WebGL = @import("renderer/WebGL.zig");
-pub const DirectX11 = if (build_config.renderer == .directx11) @import("renderer/DirectX11.zig") else struct {};
+pub const DirectX12 = if (build_config.renderer == .directx12) @import("renderer/DirectX12.zig") else struct {};
 pub const Options = @import("renderer/Options.zig");
 pub const Overlay = @import("renderer/Overlay.zig");
 pub const Thread = @import("renderer/Thread.zig");
@@ -40,7 +40,7 @@ pub const Renderer = switch (build_config.renderer) {
     .metal => GenericRenderer(Metal),
     .opengl => GenericRenderer(OpenGL),
     .webgl => WebGL,
-    .directx11 => GenericRenderer(DirectX11),
+    .directx12 => GenericRenderer(DirectX12),
 };
 
 /// The health status of a renderer. These must be shared across all

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -1,0 +1,182 @@
+//! Graphics API wrapper for DirectX 12.
+//!
+//! This module provides the GraphicsAPI contract required by GenericRenderer,
+//! mirroring the structure of Metal.zig, OpenGL.zig, and the previous
+//! DirectX11.zig. All functions are stubs that will be replaced as the
+//! DX12 backend is built out in subsequent PRs.
+pub const DirectX12 = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const configpkg = @import("../config.zig");
+const font = @import("../font/main.zig");
+const rendererpkg = @import("../renderer.zig");
+const Renderer = rendererpkg.GenericRenderer(DirectX12);
+const shadertoy = @import("shadertoy.zig");
+const log = std.log.scoped(.directx12);
+
+// --- GraphicsAPI contract: types ---
+
+pub const GraphicsAPI = DirectX12;
+pub const Target = @import("directx12/Target.zig");
+pub const Frame = @import("directx12/Frame.zig");
+pub const RenderPass = @import("directx12/RenderPass.zig");
+pub const Pipeline = @import("directx12/Pipeline.zig");
+pub const Sampler = @import("directx12/Sampler.zig");
+pub const Texture = @import("directx12/Texture.zig");
+
+const bufferpkg = @import("directx12/buffer.zig");
+pub const Buffer = bufferpkg.Buffer;
+
+pub const shaders = @import("directx12/shaders.zig");
+
+// TODO: custom shaders not yet supported on DX12. Using .glsl as placeholder;
+// DX12 will need its own shadertoy.Target variant (.hlsl) when custom shaders
+// are implemented. Can't add it without modifying upstream shadertoy.zig.
+pub const custom_shader_target: shadertoy.Target = .glsl;
+
+/// DX12 uses top-left origin, same as Metal and DX11.
+pub const custom_shader_y_is_down = true;
+
+/// Triple buffering for DX12, matching Metal's swap chain depth.
+pub const swap_chain_count = 3;
+
+/// Pixel format for image texture options.
+pub const ImageTextureFormat = enum {
+    /// 1 byte per pixel grayscale.
+    gray,
+    /// 4 bytes per pixel RGBA.
+    rgba,
+    /// 4 bytes per pixel BGRA.
+    bgra,
+};
+
+// --- Sub-module re-exports: low-level D3D12/DXGI/COM bindings ---
+
+pub const com = @import("directx12/com.zig");
+pub const dxgi = @import("directx12/dxgi.zig");
+
+// --- GraphicsAPI contract: mutable state ---
+
+/// Runtime blending mode, set by GenericRenderer when config changes.
+blending: configpkg.Config.AlphaBlending = .native,
+
+// --- GraphicsAPI contract: functions ---
+
+pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
+    _ = alloc;
+    _ = opts;
+    log.warn("DX12 backend is a stub -- no GPU output yet", .{});
+    return .{};
+}
+
+pub fn deinit(self: *DirectX12) void {
+    _ = self;
+}
+
+pub fn drawFrameStart(self: *DirectX12) void {
+    _ = self;
+}
+
+pub fn drawFrameEnd(self: *DirectX12) void {
+    _ = self;
+}
+
+pub fn initShaders(
+    self: *const DirectX12,
+    alloc: Allocator,
+    custom_shaders: []const [:0]const u8,
+) !shaders.Shaders {
+    _ = self;
+    _ = alloc;
+    _ = custom_shaders;
+    return .{};
+}
+
+pub fn setTargetSize(self: *DirectX12, width: u32, height: u32) void {
+    _ = self;
+    _ = width;
+    _ = height;
+}
+
+pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
+    _ = self;
+    return .{ .width = 0, .height = 0 };
+}
+
+pub fn initTarget(self: *const DirectX12, width: usize, height: usize) !Target {
+    _ = self;
+    return .{ .width = width, .height = height };
+}
+
+pub inline fn beginFrame(
+    self: *const DirectX12,
+    renderer: *Renderer,
+    target: *Target,
+) !Frame {
+    _ = self;
+    return .{
+        .renderer = renderer,
+        .target = target,
+    };
+}
+
+pub fn presentLastTarget(self: *DirectX12) !void {
+    _ = self;
+}
+
+pub inline fn bufferOptions(self: DirectX12) bufferpkg.Options {
+    _ = self;
+    return .{};
+}
+
+pub const instanceBufferOptions = bufferOptions;
+pub const fgBufferOptions = bufferOptions;
+pub const imageBufferOptions = bufferOptions;
+pub const bgImageBufferOptions = bufferOptions;
+
+pub inline fn bgBufferOptions(self: DirectX12) bufferpkg.Options {
+    _ = self;
+    return .{};
+}
+
+pub inline fn uniformBufferOptions(self: DirectX12) bufferpkg.Options {
+    _ = self;
+    return .{};
+}
+
+pub inline fn textureOptions(self: DirectX12) Texture.Options {
+    _ = self;
+    return .{};
+}
+
+pub inline fn samplerOptions(self: DirectX12) Sampler.Options {
+    _ = self;
+    return .{};
+}
+
+pub inline fn imageTextureOptions(
+    self: DirectX12,
+    format: ImageTextureFormat,
+    srgb: bool,
+) Texture.Options {
+    _ = self;
+    _ = format;
+    _ = srgb;
+    return .{};
+}
+
+pub fn initAtlasTexture(
+    self: *const DirectX12,
+    atlas: *const font.Atlas,
+) Texture.Error!Texture {
+    _ = self;
+    return .{ .width = @intCast(atlas.size) };
+}
+
+test {
+    _ = com;
+    _ = @import("directx12/dcomp.zig");
+    _ = dxgi;
+}

--- a/src/renderer/backend.zig
+++ b/src/renderer/backend.zig
@@ -6,7 +6,7 @@ pub const Backend = enum {
     opengl,
     metal,
     webgl,
-    directx11,
+    directx12,
 
     pub fn default(
         target: std.Target,
@@ -19,7 +19,7 @@ pub const Backend = enum {
         }
 
         if (target.os.tag.isDarwin()) return .metal;
-        if (target.os.tag == .windows) return .directx11;
+        if (target.os.tag == .windows) return .directx12;
         return .opengl;
     }
 };

--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -1,0 +1,26 @@
+//! DX12 frame context stub.
+//!
+//! Will be replaced with a real implementation managing command allocators,
+//! command lists, and fence synchronization for each in-flight frame.
+const DirectX12 = @import("../DirectX12.zig");
+const Renderer = @import("../generic.zig").Renderer(DirectX12);
+const Target = @import("Target.zig");
+const RenderPass = @import("RenderPass.zig");
+const Health = @import("../../renderer.zig").Health;
+
+renderer: *Renderer,
+target: *Target,
+
+pub fn renderPass(
+    self: *@This(),
+    attachments: []const RenderPass.Options.Attachment,
+) RenderPass {
+    _ = self;
+    _ = attachments;
+    return .{};
+}
+
+pub fn complete(self: *@This(), sync: bool) void {
+    _ = sync;
+    self.renderer.frameCompleted(.healthy);
+}

--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -1,0 +1,8 @@
+//! DX12 render pipeline stub.
+//!
+//! Will be replaced with a real implementation wrapping a root signature
+//! and ID3D12PipelineState (PSO).
+
+pub fn deinit(self: @This()) void {
+    _ = self;
+}

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -1,0 +1,58 @@
+//! DX12 render pass stub.
+//!
+//! Will be replaced with a real implementation that records draw commands
+//! into an ID3D12GraphicsCommandList.
+const Pipeline = @import("Pipeline.zig");
+const Sampler = @import("Sampler.zig");
+const Target = @import("Target.zig");
+const Texture = @import("Texture.zig");
+const bufferpkg = @import("buffer.zig");
+const RawBuffer = bufferpkg.RawBuffer;
+
+/// Options for beginning a render pass.
+pub const Options = struct {
+    attachments: []const Attachment,
+
+    pub const Attachment = struct {
+        target: union(enum) {
+            texture: Texture,
+            target: Target,
+        },
+        clear_color: ?[4]f64 = null,
+    };
+};
+
+/// A single step in a render pass.
+pub const Step = struct {
+    pipeline: Pipeline = .{},
+    uniforms: ?RawBuffer = null,
+    buffers: []const ?RawBuffer = &.{},
+    textures: []const ?Texture = &.{},
+    samplers: []const ?Sampler = &.{},
+    draw: Draw = .{},
+
+    pub const Draw = struct {
+        type: DrawType = .triangle,
+        vertex_count: usize = 0,
+        instance_count: usize = 1,
+    };
+
+    pub const DrawType = enum {
+        triangle,
+        triangle_strip,
+    };
+};
+
+pub fn begin(opts: Options) @This() {
+    _ = opts;
+    return .{};
+}
+
+pub fn step(self: *@This(), s: Step) void {
+    _ = self;
+    _ = s;
+}
+
+pub fn complete(self: *const @This()) void {
+    _ = self;
+}

--- a/src/renderer/directx12/Sampler.zig
+++ b/src/renderer/directx12/Sampler.zig
@@ -1,0 +1,19 @@
+//! DX12 texture sampler stub.
+//!
+//! Will be replaced with a real implementation using a sampler descriptor
+//! in a GPU-visible descriptor heap.
+
+pub const Options = struct {};
+
+pub const Error = error{
+    SamplerCreateFailed,
+};
+
+pub fn init(opts: Options) Error!@This() {
+    _ = opts;
+    return .{};
+}
+
+pub fn deinit(self: @This()) void {
+    _ = self;
+}

--- a/src/renderer/directx12/Target.zig
+++ b/src/renderer/directx12/Target.zig
@@ -1,0 +1,11 @@
+//! DX12 render target stub.
+//!
+//! Will be replaced with a real implementation wrapping D3D12 render
+//! targets (RTV descriptors pointing at swap chain or offscreen buffers).
+
+width: usize = 0,
+height: usize = 0,
+
+pub fn deinit(self: *@This()) void {
+    _ = self;
+}

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -1,0 +1,34 @@
+//! DX12 GPU texture stub.
+//!
+//! Will be replaced with a real implementation wrapping an
+//! ID3D12Resource (committed texture) and SRV descriptor.
+
+pub const Options = struct {};
+
+pub const Error = error{
+    TextureCreateFailed,
+};
+
+/// Width of this texture in pixels.
+width: usize = 0,
+
+pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error!@This() {
+    _ = opts;
+    _ = height;
+    _ = data;
+    return .{ .width = width };
+}
+
+pub fn deinit(self: @This()) void {
+    _ = self;
+}
+
+/// Upload pixel data to a sub-region of this texture.
+pub fn replaceRegion(self: *@This(), x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
+    _ = self;
+    _ = x;
+    _ = y;
+    _ = width;
+    _ = height;
+    _ = data;
+}

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -1,0 +1,54 @@
+//! DX12 GPU buffer stub.
+//!
+//! Will be replaced with a real implementation using upload heaps
+//! (ring buffer or per-frame allocators) for CPU-to-GPU data transfer.
+const std = @import("std");
+
+/// Type-erased buffer handle for passing to RenderPass.Step.
+pub const RawBuffer = struct {};
+
+/// Options for initializing a buffer.
+pub const Options = struct {};
+
+/// DX12 GPU data buffer for a set of equal-typed elements.
+pub fn Buffer(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        /// The type-erased handle passed into RenderPass steps.
+        buffer: RawBuffer = .{},
+
+        pub fn init(opts: Options, len: usize) !Self {
+            _ = opts;
+            _ = len;
+            return .{};
+        }
+
+        /// Init the buffer filled with the given data.
+        pub fn initFill(opts: Options, data: []const T) !Self {
+            _ = opts;
+            _ = data;
+            return .{};
+        }
+
+        pub fn deinit(self: *const Self) void {
+            _ = self;
+        }
+
+        /// Sync the buffer contents with the given data slice.
+        pub fn sync(self: *Self, data: []const T) !void {
+            _ = self;
+            _ = data;
+        }
+
+        /// Sync from multiple ArrayListUnmanaged(T), returning total count.
+        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+            _ = self;
+            var total: usize = 0;
+            for (lists) |list| {
+                total += list.items.len;
+            }
+            return total;
+        }
+    };
+}

--- a/src/renderer/directx12/com_test.zig
+++ b/src/renderer/directx12/com_test.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const com = @import("com.zig");
 const dxgi = @import("dxgi.zig");
-const d3d11 = @import("d3d11.zig");
 
 // Verify struct sizes match the C ABI (these are extern structs that
 // cross the COM boundary, so size mismatches cause runtime crashes).
@@ -15,59 +14,6 @@ test "DXGI_SAMPLE_DESC size" {
     try std.testing.expectEqual(@sizeOf(dxgi.DXGI_SAMPLE_DESC), 8);
 }
 
-test "D3D11_VIEWPORT size" {
-    // D3D11_VIEWPORT is 6 floats = 24 bytes.
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_VIEWPORT), 24);
-}
-
-test "D3D11_BUFFER_DESC size" {
-    // D3D11_BUFFER_DESC is 24 bytes (6 u32 fields).
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_BUFFER_DESC), 24);
-}
-
-test "D3D11_INPUT_ELEMENT_DESC size" {
-    // D3D11_INPUT_ELEMENT_DESC: ptr + u32 + enum + enum + u32 + u32 + enum = 32 bytes on 64-bit.
-    const expected: usize = if (@sizeOf(*anyopaque) == 8) 32 else 24;
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_INPUT_ELEMENT_DESC), expected);
-}
-
-test "D3D11_MAPPED_SUBRESOURCE size" {
-    // D3D11_MAPPED_SUBRESOURCE: ptr + u32 + u32.
-    const expected: usize = if (@sizeOf(*anyopaque) == 8) 16 else 12;
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_MAPPED_SUBRESOURCE), expected);
-}
-
-test "D3D11_TEXTURE2D_DESC size" {
-    // D3D11_TEXTURE2D_DESC: 4 u32s + DXGI_FORMAT(u32) + DXGI_SAMPLE_DESC(8) + D3D11_USAGE(u32) + 3 u32s = 44 bytes.
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_TEXTURE2D_DESC), 44);
-}
-
-test "D3D11_SHADER_RESOURCE_VIEW_DESC size" {
-    // Format(4) + ViewDimension(4) + union(16) = 24 bytes.
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_SHADER_RESOURCE_VIEW_DESC), 24);
-}
-
-test "D3D11_SAMPLER_DESC size" {
-    // Filter(4) + 3 AddressMode(4 each) + MipLODBias(4) + MaxAnisotropy(4) + ComparisonFunc(4) + BorderColor(16) + MinLOD(4) + MaxLOD(4) = 52 bytes.
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_SAMPLER_DESC), 52);
-}
-
-test "D3D11_BOX size" {
-    // 6 u32s = 24 bytes.
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_BOX), 24);
-}
-
-test "D3D11_BLEND_DESC size" {
-    // AlphaToCoverageEnable(4) + IndependentBlendEnable(4) + 8 * D3D11_RENDER_TARGET_BLEND_DESC(32) = 264 bytes.
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_BLEND_DESC), 264);
-}
-
-test "D3D11_RENDER_TARGET_BLEND_DESC size" {
-    // BlendEnable(4) + SrcBlend(4) + DestBlend(4) + BlendOp(4) + SrcBlendAlpha(4)
-    // + DestBlendAlpha(4) + BlendOpAlpha(4) + RenderTargetWriteMask(1) + padding(3) = 32 bytes.
-    try std.testing.expectEqual(@sizeOf(d3d11.D3D11_RENDER_TARGET_BLEND_DESC), 32);
-}
-
 // Verify vtable pointer layout - COM objects are a single pointer to a vtable.
 
 test "IDXGIDevice is a single vtable pointer" {
@@ -76,14 +22,6 @@ test "IDXGIDevice is a single vtable pointer" {
 
 test "IDXGISwapChain1 is a single vtable pointer" {
     try std.testing.expectEqual(@sizeOf(dxgi.IDXGISwapChain1), @sizeOf(*anyopaque));
-}
-
-test "ID3D11Device is a single vtable pointer" {
-    try std.testing.expectEqual(@sizeOf(d3d11.ID3D11Device), @sizeOf(*anyopaque));
-}
-
-test "ID3D11DeviceContext is a single vtable pointer" {
-    try std.testing.expectEqual(@sizeOf(d3d11.ID3D11DeviceContext), @sizeOf(*anyopaque));
 }
 
 // Verify GUID constants are the right values (cross-referenced with
@@ -113,35 +51,9 @@ test "ISwapChainPanelNative IID" {
     try std.testing.expectEqualSlices(u8, &iid.data4, &[_]u8{ 0xa2, 0x0c, 0xf6, 0xf1, 0xea, 0x90, 0x55, 0x4b });
 }
 
-test "ID3D11Texture2D IID" {
-    const iid = d3d11.ID3D11Texture2D.IID;
-    try std.testing.expectEqual(iid.data1, 0x6f15aaf2);
-    try std.testing.expectEqual(iid.data2, 0xd208);
-    try std.testing.expectEqual(iid.data3, 0x4e89);
-}
-
-test "Buffer Options has device and context fields" {
-    const BufferOpts = @import("buffer.zig").Options;
-    try std.testing.expect(@hasField(BufferOpts, "device"));
-    try std.testing.expect(@hasField(BufferOpts, "context"));
-    try std.testing.expect(@hasField(BufferOpts, "bind_flags"));
-}
-
 test "Buffer type instantiation compiles" {
     const buffer_mod = @import("buffer.zig");
     _ = buffer_mod.Buffer(f32);
     _ = buffer_mod.Buffer(extern struct { x: f32, y: f32 });
     _ = buffer_mod.Buffer(u8);
-}
-
-test "Texture Options has expected fields" {
-    const Texture = @import("Texture.zig");
-    try std.testing.expect(@hasField(Texture.Options, "device"));
-    try std.testing.expect(@hasField(Texture.Options, "context"));
-    try std.testing.expect(@hasField(Texture.Options, "format"));
-}
-
-test "Sampler Options has device field" {
-    const Sampler = @import("Sampler.zig");
-    try std.testing.expect(@hasField(Sampler.Options, "device"));
 }

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -1,0 +1,46 @@
+//! Shader management and GPU data structs for DX12.
+//!
+//! Re-exports the shared GPU data structs from gpu_data.zig and provides
+//! a stub Shaders type that satisfies the GenericRenderer contract.
+const std = @import("std");
+
+const gpu_data = @import("gpu_data.zig");
+const Pipeline = @import("Pipeline.zig");
+
+pub const Uniforms = gpu_data.Uniforms;
+pub const CellText = gpu_data.CellText;
+pub const CellBg = gpu_data.CellBg;
+pub const Image = gpu_data.Image;
+pub const BgImage = gpu_data.BgImage;
+
+/// Shader management for DX12.
+pub const Shaders = struct {
+    pipelines: Pipelines = .{},
+    post_pipelines: []const Pipeline = &.{},
+    defunct: bool = false,
+
+    pub const Pipelines = struct {
+        bg_color: Pipeline = .{},
+        cell_bg: Pipeline = .{},
+        cell_text: Pipeline = .{},
+        image: Pipeline = .{},
+        bg_image: Pipeline = .{},
+    };
+
+    pub fn deinit(self: *Shaders, alloc: std.mem.Allocator) void {
+        for (self.post_pipelines) |p| {
+            p.deinit();
+        }
+        if (self.post_pipelines.len > 0) {
+            alloc.free(self.post_pipelines);
+        }
+        self.post_pipelines = &.{};
+
+        self.pipelines.bg_color.deinit();
+        self.pipelines.cell_bg.deinit();
+        self.pipelines.cell_text.deinit();
+        self.pipelines.image.deinit();
+        self.pipelines.bg_image.deinit();
+        self.pipelines = .{};
+    }
+};


### PR DESCRIPTION
## Summary

- Update backend.zig: `directx11` -> `directx12` enum variant
- Update renderer.zig: DirectX12 import and switch arm
- Update GhosttyLib.zig: link d3d12 instead of d3d11
- Create stub DirectX12.zig satisfying the full GenericRenderer contract
- Create stub type files: Target, Frame, RenderPass, Pipeline, Sampler, Texture, Buffer, Shaders
- Guard DX11-specific C API exports in embedded.zig with `@hasField` checks
- Clean up com_test.zig (remove D3D11-specific struct size tests)

Build compiles with `zig build -Dapp-runtime=none`. All stubs return defaults/no-ops.

> **IMPORTANT:** This is PR 2 of 15 in the `pivotdx12` stack. Base: `pivotdx12-001/rename-cleanup`.