### PR TITLE
renderer: DX12 Target (RTV + barriers) and RenderPass (command recording)

### DIFF
--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -134,8 +134,17 @@ pub fn renderPass(
     self: *Frame,
     attachments: []const RenderPass.Options.Attachment,
 ) RenderPass {
+    const cl = self.command_list orelse {
+        // Frame not initialized (stub path) -- return a no-op RenderPass.
+        // begin/step/complete will be no-ops without a command list.
+        return .{
+            .command_list = null,
+            .attachments = attachments,
+            .step_number = 0,
+        };
+    };
     return RenderPass.begin(.{
-        .command_list = self.command_list,
+        .command_list = cl,
         .attachments = attachments,
     });
 }

--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -134,10 +134,10 @@ pub fn renderPass(
     self: *Frame,
     attachments: []const RenderPass.Options.Attachment,
 ) RenderPass {
-    _ = self;
-    _ = attachments;
-    // Will wire to command list recording in a later PR.
-    return .{};
+    return RenderPass.begin(.{
+        .command_list = self.command_list,
+        .attachments = attachments,
+    });
 }
 
 /// Close the command list and report frame health.

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -60,6 +60,16 @@ step_number: usize,
 pub fn begin(opts: Options) RenderPass {
     const cl = opts.command_list;
 
+    // Collect all RTV handles so we can set them with a single
+    // OMSetRenderTargets call (per-attachment calls would silently
+    // overwrite, leaving only the last target bound).
+    var rtv_handles: [8]d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = undefined;
+    var rtv_count: u32 = 0;
+
+    // Track viewport dimensions from the first valid target.
+    var vp_width: usize = 0;
+    var vp_height: usize = 0;
+
     for (opts.attachments) |at| {
         switch (at.target) {
             .target => |t| {
@@ -74,33 +84,19 @@ pub fn begin(opts: Options) RenderPass {
                     d3d12.D3D12_RESOURCE_STATE_RENDER_TARGET,
                 );
 
-                // Set the render target on the command list.
-                cl.OMSetRenderTargets(
-                    1,
-                    @ptrCast(&t.rtv_handle),
-                    0, // FALSE
-                    null,
-                );
+                // Collect RTV handle.
+                if (rtv_count < rtv_handles.len) {
+                    rtv_handles[rtv_count] = t.rtv_handle;
+                    rtv_count += 1;
+                }
 
-                // Set viewport and scissor to cover the full target.
-                const viewport = d3d12.D3D12_VIEWPORT{
-                    .TopLeftX = 0,
-                    .TopLeftY = 0,
-                    .Width = @floatFromInt(t.width),
-                    .Height = @floatFromInt(t.height),
-                    .MinDepth = 0.0,
-                    .MaxDepth = 1.0,
-                };
-                cl.RSSetViewports(1, @ptrCast(&viewport));
+                // Use the first valid target for viewport dimensions.
+                if (rtv_count == 1) {
+                    vp_width = t.width;
+                    vp_height = t.height;
+                }
 
-                const scissor = d3d12.D3D12_RECT{
-                    .left = 0,
-                    .top = 0,
-                    .right = @intCast(t.width),
-                    .bottom = @intCast(t.height),
-                };
-                cl.RSSetScissorRects(1, @ptrCast(&scissor));
-
+                // Clear if requested.
                 if (at.clear_color) |c| {
                     const color = [4]f32{
                         @floatCast(c[0]),
@@ -116,6 +112,35 @@ pub fn begin(opts: Options) RenderPass {
                 // a real GPU resource implementation.
             },
         }
+    }
+
+    if (rtv_count > 0) {
+        // Bind all render targets at once.
+        cl.OMSetRenderTargets(
+            rtv_count,
+            &rtv_handles,
+            0, // FALSE -- handles are individual, not contiguous
+            null,
+        );
+
+        // Set viewport and scissor once from the first target.
+        const viewport = d3d12.D3D12_VIEWPORT{
+            .TopLeftX = 0,
+            .TopLeftY = 0,
+            .Width = @floatFromInt(vp_width),
+            .Height = @floatFromInt(vp_height),
+            .MinDepth = 0.0,
+            .MaxDepth = 1.0,
+        };
+        cl.RSSetViewports(1, @ptrCast(&viewport));
+
+        const scissor = d3d12.D3D12_RECT{
+            .left = 0,
+            .top = 0,
+            .right = @intCast(vp_width),
+            .bottom = @intCast(vp_height),
+        };
+        cl.RSSetScissorRects(1, @ptrCast(&scissor));
     }
 
     return .{

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -8,6 +8,7 @@
 const RenderPass = @This();
 
 const d3d12 = @import("d3d12.zig");
+const ResourceStates = d3d12.D3D12_RESOURCE_STATES;
 
 const Pipeline = @import("Pipeline.zig");
 const Sampler = @import("Sampler.zig");
@@ -53,7 +54,7 @@ pub const Step = struct {
     };
 };
 
-command_list: *d3d12.ID3D12GraphicsCommandList,
+command_list: ?*d3d12.ID3D12GraphicsCommandList,
 attachments: []const Options.Attachment,
 step_number: usize,
 
@@ -63,25 +64,25 @@ pub fn begin(opts: Options) RenderPass {
     // Collect all RTV handles so we can set them with a single
     // OMSetRenderTargets call (per-attachment calls would silently
     // overwrite, leaving only the last target bound).
-    var rtv_handles: [8]d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = undefined;
+    const max_rtvs = 8; // D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT
+    var rtv_handles: [max_rtvs]d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = undefined;
     var rtv_count: u32 = 0;
 
     // Track viewport dimensions from the first valid target.
     var vp_width: usize = 0;
     var vp_height: usize = 0;
 
-    for (opts.attachments) |at| {
+    for (opts.attachments) |*at| {
         switch (at.target) {
-            .target => |t| {
+            .target => |*t| {
                 // Skip if this target has no GPU resource yet (stub).
                 if (t.resource == null) continue;
 
                 // Transition PRESENT -> RENDER_TARGET.
-                Target.transitionBarrier(
-                    t.resource,
+                t.transitionBarrier(
                     cl,
-                    d3d12.D3D12_RESOURCE_STATE_PRESENT,
-                    d3d12.D3D12_RESOURCE_STATE_RENDER_TARGET,
+                    ResourceStates.PRESENT,
+                    ResourceStates.RENDER_TARGET,
                 );
 
                 // Collect RTV handle.
@@ -151,7 +152,9 @@ pub fn begin(opts: Options) RenderPass {
 }
 
 /// Add a step to this render pass.
+/// No-op if the render pass has no command list (stub path).
 pub fn step(self: *RenderPass, s: Step) void {
+    if (self.command_list == null) return;
     if (s.draw.instance_count == 0) return;
 
     // Pipeline, buffer bindings, texture/sampler bindings will be
@@ -162,16 +165,17 @@ pub fn step(self: *RenderPass, s: Step) void {
 }
 
 /// Complete the render pass. Transitions targets back to PRESENT.
+/// No-op if the render pass has no command list (stub path).
 pub fn complete(self: *const RenderPass) void {
-    for (self.attachments) |at| {
+    const cl = self.command_list orelse return;
+    for (self.attachments) |*at| {
         switch (at.target) {
-            .target => |t| {
+            .target => |*t| {
                 if (t.resource == null) continue;
-                Target.transitionBarrier(
-                    t.resource,
-                    self.command_list,
-                    d3d12.D3D12_RESOURCE_STATE_RENDER_TARGET,
-                    d3d12.D3D12_RESOURCE_STATE_PRESENT,
+                t.transitionBarrier(
+                    cl,
+                    ResourceStates.RENDER_TARGET,
+                    ResourceStates.PRESENT,
                 );
             },
             .texture => {},

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -1,7 +1,14 @@
-//! DX12 render pass stub.
+//! DX12 render pass -- records draw commands into an
+//! ID3D12GraphicsCommandList for a single render pass.
 //!
-//! Will be replaced with a real implementation that records draw commands
-//! into an ID3D12GraphicsCommandList.
+//! Follows the same begin/step/complete pattern as Metal and OpenGL.
+//! begin() transitions the target to RENDER_TARGET, sets viewport and
+//! scissor, and optionally clears. step() binds pipeline state and
+//! issues draw calls. complete() transitions the target back to PRESENT.
+const RenderPass = @This();
+
+const d3d12 = @import("d3d12.zig");
+
 const Pipeline = @import("Pipeline.zig");
 const Sampler = @import("Sampler.zig");
 const Target = @import("Target.zig");
@@ -11,6 +18,9 @@ const RawBuffer = bufferpkg.RawBuffer;
 
 /// Options for beginning a render pass.
 pub const Options = struct {
+    /// The command list to record into.
+    command_list: *d3d12.ID3D12GraphicsCommandList,
+    /// Color attachments for this render pass.
     attachments: []const Attachment,
 
     pub const Attachment = struct {
@@ -43,16 +53,124 @@ pub const Step = struct {
     };
 };
 
-pub fn begin(opts: Options) @This() {
-    _ = opts;
-    return .{};
+command_list: *d3d12.ID3D12GraphicsCommandList,
+attachments: []const Options.Attachment,
+step_number: usize,
+
+pub fn begin(opts: Options) RenderPass {
+    const cl = opts.command_list;
+
+    for (opts.attachments) |at| {
+        switch (at.target) {
+            .target => |t| {
+                // Skip if this target has no GPU resource yet (stub).
+                if (t.resource == null) continue;
+
+                // Transition PRESENT -> RENDER_TARGET.
+                Target.transitionBarrier(
+                    t.resource,
+                    cl,
+                    d3d12.D3D12_RESOURCE_STATE_PRESENT,
+                    d3d12.D3D12_RESOURCE_STATE_RENDER_TARGET,
+                );
+
+                // Set the render target on the command list.
+                cl.OMSetRenderTargets(
+                    1,
+                    @ptrCast(&t.rtv_handle),
+                    0, // FALSE
+                    null,
+                );
+
+                // Set viewport and scissor to cover the full target.
+                const viewport = d3d12.D3D12_VIEWPORT{
+                    .TopLeftX = 0,
+                    .TopLeftY = 0,
+                    .Width = @floatFromInt(t.width),
+                    .Height = @floatFromInt(t.height),
+                    .MinDepth = 0.0,
+                    .MaxDepth = 1.0,
+                };
+                cl.RSSetViewports(1, @ptrCast(&viewport));
+
+                const scissor = d3d12.D3D12_RECT{
+                    .left = 0,
+                    .top = 0,
+                    .right = @intCast(t.width),
+                    .bottom = @intCast(t.height),
+                };
+                cl.RSSetScissorRects(1, @ptrCast(&scissor));
+
+                if (at.clear_color) |c| {
+                    const color = [4]f32{
+                        @floatCast(c[0]),
+                        @floatCast(c[1]),
+                        @floatCast(c[2]),
+                        @floatCast(c[3]),
+                    };
+                    cl.ClearRenderTargetView(t.rtv_handle, &color, 0, null);
+                }
+            },
+            .texture => {
+                // Texture targets will be handled when Texture.zig gets
+                // a real GPU resource implementation.
+            },
+        }
+    }
+
+    return .{
+        .command_list = cl,
+        .attachments = opts.attachments,
+        .step_number = 0,
+    };
 }
 
-pub fn step(self: *@This(), s: Step) void {
-    _ = self;
-    _ = s;
+/// Add a step to this render pass.
+pub fn step(self: *RenderPass, s: Step) void {
+    if (s.draw.instance_count == 0) return;
+
+    // Pipeline, buffer bindings, texture/sampler bindings will be
+    // wired when Pipeline.zig, buffer.zig, Texture.zig, and
+    // Sampler.zig get their real implementations.
+
+    self.step_number += 1;
 }
 
-pub fn complete(self: *const @This()) void {
-    _ = self;
+/// Complete the render pass. Transitions targets back to PRESENT.
+pub fn complete(self: *const RenderPass) void {
+    for (self.attachments) |at| {
+        switch (at.target) {
+            .target => |t| {
+                if (t.resource == null) continue;
+                Target.transitionBarrier(
+                    t.resource,
+                    self.command_list,
+                    d3d12.D3D12_RESOURCE_STATE_RENDER_TARGET,
+                    d3d12.D3D12_RESOURCE_STATE_PRESENT,
+                );
+            },
+            .texture => {},
+        }
+    }
+}
+
+// --- Tests ---
+
+const std = @import("std");
+
+test "RenderPass struct fields" {
+    try std.testing.expect(@hasField(RenderPass, "command_list"));
+    try std.testing.expect(@hasField(RenderPass, "attachments"));
+    try std.testing.expect(@hasField(RenderPass, "step_number"));
+}
+
+test "RenderPass has required methods" {
+    try std.testing.expect(@TypeOf(RenderPass.begin) != void);
+    try std.testing.expect(@TypeOf(RenderPass.step) != void);
+    try std.testing.expect(@TypeOf(RenderPass.complete) != void);
+}
+
+test "Step DrawType values" {
+    try std.testing.expectEqual(@as(u1, 0), @intFromEnum(Step.DrawType.triangle));
+    try std.testing.expectEqual(@as(u1, 1), @intFromEnum(Step.DrawType.triangle_strip));
 }

--- a/src/renderer/directx12/Target.zig
+++ b/src/renderer/directx12/Target.zig
@@ -23,17 +23,18 @@ height: usize = 0,
 
 pub fn deinit(self: *Target) void {
     if (self.resource) |r| _ = r.Release();
+    self.resource = null;
 }
 
 /// Record a transition barrier on the given command list.
 /// No-op if resource is null (stub target without a GPU resource).
 pub fn transitionBarrier(
-    resource: ?*d3d12.ID3D12Resource,
+    self: *const Target,
     command_list: *d3d12.ID3D12GraphicsCommandList,
     state_before: d3d12.D3D12_RESOURCE_STATES,
     state_after: d3d12.D3D12_RESOURCE_STATES,
 ) void {
-    const res = resource orelse return;
+    const res = self.resource orelse return;
     const barrier = d3d12.D3D12_RESOURCE_BARRIER{
         .Type = .TRANSITION,
         .Flags = .NONE,

--- a/src/renderer/directx12/Target.zig
+++ b/src/renderer/directx12/Target.zig
@@ -1,11 +1,66 @@
-//! DX12 render target stub.
+//! DX12 render target -- wraps a swap chain back buffer (or offscreen
+//! resource) with its RTV descriptor handle.
 //!
-//! Will be replaced with a real implementation wrapping D3D12 render
-//! targets (RTV descriptors pointing at swap chain or offscreen buffers).
+//! Barrier transitions are handled by RenderPass, which knows the
+//! expected state cycle (PRESENT -> RENDER_TARGET -> PRESENT).
+const Target = @This();
 
+const d3d12 = @import("d3d12.zig");
+
+/// The underlying GPU resource (swap chain back buffer or offscreen texture).
+/// Null until device wiring is done.
+resource: ?*d3d12.ID3D12Resource = null,
+
+/// CPU descriptor handle for the render target view.
+/// Zero-initialized until device wiring is done.
+rtv_handle: d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = .{ .ptr = 0 },
+
+/// Width of this target in pixels.
 width: usize = 0,
+
+/// Height of this target in pixels.
 height: usize = 0,
 
-pub fn deinit(self: *@This()) void {
-    _ = self;
+pub fn deinit(self: *Target) void {
+    if (self.resource) |r| _ = r.Release();
+}
+
+/// Record a transition barrier on the given command list.
+/// No-op if resource is null (stub target without a GPU resource).
+pub fn transitionBarrier(
+    resource: ?*d3d12.ID3D12Resource,
+    command_list: *d3d12.ID3D12GraphicsCommandList,
+    state_before: d3d12.D3D12_RESOURCE_STATES,
+    state_after: d3d12.D3D12_RESOURCE_STATES,
+) void {
+    const res = resource orelse return;
+    const barrier = d3d12.D3D12_RESOURCE_BARRIER{
+        .Type = .TRANSITION,
+        .Flags = .NONE,
+        .u = .{
+            .Transition = .{
+                .pResource = res,
+                .Subresource = 0xFFFFFFFF, // D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES
+                .StateBefore = state_before,
+                .StateAfter = state_after,
+            },
+        },
+    };
+    command_list.ResourceBarrier(1, @ptrCast(&barrier));
+}
+
+// --- Tests ---
+
+const std = @import("std");
+
+test "Target struct fields" {
+    try std.testing.expect(@hasField(Target, "resource"));
+    try std.testing.expect(@hasField(Target, "rtv_handle"));
+    try std.testing.expect(@hasField(Target, "width"));
+    try std.testing.expect(@hasField(Target, "height"));
+}
+
+test "Target has required methods" {
+    try std.testing.expect(@TypeOf(Target.deinit) != void);
+    try std.testing.expect(@TypeOf(Target.transitionBarrier) != void);
 }


### PR DESCRIPTION
> **IMPORTANT:** This is PR 8 of 15 in the DX12 pivot stack. Based on pivotdx12-007/frame-command-list (# 116).

## Summary

- Replace Target.zig stub with real implementation wrapping a swap chain back buffer resource, RTV descriptor handle, and barrier transition helper
- Replace RenderPass.zig stub with command list recording following the same begin/step/complete pattern as Metal and OpenGL
- Wire Frame.renderPass() to create a RenderPass with the frame's command list

Target tracks the GPU resource and its RTV handle. RenderPass handles the PRESENT to RENDER_TARGET barrier transition at begin, sets viewport/scissor/clear, and transitions back at complete. Draw step bindings are stubbed until Pipeline, buffer, Texture, and Sampler get their real implementations.