### PR TITLE
renderer: DX12 clear-to-color through real device + command list

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -2,13 +2,18 @@
 //!
 //! This module provides the GraphicsAPI contract required by GenericRenderer,
 //! mirroring the structure of Metal.zig, OpenGL.zig, and the previous
-//! DirectX11.zig. All functions are stubs that will be replaced as the
-//! DX12 backend is built out in subsequent PRs.
+//! DirectX11.zig.
+//!
+//! Current status: device init, swap chain, command queue, fence sync,
+//! clear render target, and present are functional. The window clears
+//! to the background color via the real DX12 pipeline.
 pub const DirectX12 = @This();
 
+const builtin = @import("builtin");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+const apprt = @import("../apprt.zig");
 const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
 const rendererpkg = @import("../renderer.zig");
@@ -31,6 +36,15 @@ pub const Buffer = bufferpkg.Buffer;
 
 pub const shaders = @import("directx12/shaders.zig");
 
+// --- Sub-module re-exports: low-level D3D12/DXGI/COM bindings ---
+
+pub const com = @import("directx12/com.zig");
+pub const d3d12 = @import("directx12/d3d12.zig");
+pub const dcomp = @import("directx12/dcomp.zig");
+pub const descriptor_heap = @import("directx12/descriptor_heap.zig");
+pub const device = @import("directx12/device.zig");
+pub const dxgi = @import("directx12/dxgi.zig");
+
 // TODO: custom shaders not yet supported on DX12. Using .glsl as placeholder;
 // DX12 will need its own shadertoy.Target variant (.hlsl) when custom shaders
 // are implemented. Can't add it without modifying upstream shadertoy.zig.
@@ -52,31 +66,196 @@ pub const ImageTextureFormat = enum {
     bgra,
 };
 
-// --- Sub-module re-exports: low-level D3D12/DXGI/COM bindings ---
-
-pub const com = @import("directx12/com.zig");
-pub const d3d12 = @import("directx12/d3d12.zig");
-pub const dcomp = @import("directx12/dcomp.zig");
-pub const descriptor_heap = @import("directx12/descriptor_heap.zig");
-pub const device = @import("directx12/device.zig");
-pub const dxgi = @import("directx12/dxgi.zig");
-
 // --- GraphicsAPI contract: mutable state ---
 
 /// Runtime blending mode, set by GenericRenderer when config changes.
 blending: configpkg.Config.AlphaBlending = .native,
 
+/// DX12 device owning command queue, fence, and swap chain.
+dev: ?device.Device = null,
+
+/// SwapChain3 interface for GetCurrentBackBufferIndex.
+/// Obtained by QueryInterface from the SwapChain1 in dev.
+swap_chain3: ?*dxgi.IDXGISwapChain3 = null,
+
+/// RTV descriptor heap for swap chain back buffers.
+rtv_heap: ?descriptor_heap.DescriptorHeap = null,
+
+/// Per-frame command recording contexts (triple buffered).
+gpu_frames: [device.Device.frame_count]?Frame = .{ null, null, null },
+
+/// Back buffer resources from the swap chain.
+back_buffers: [device.Device.frame_count]?*d3d12.ID3D12Resource = .{ null, null, null },
+
+/// RTV handles for each back buffer.
+rtv_handles: [device.Device.frame_count]d3d12.D3D12_CPU_DESCRIPTOR_HANDLE =
+    .{ .{ .ptr = 0 }, .{ .ptr = 0 }, .{ .ptr = 0 } },
+
+/// Fence values per frame for CPU/GPU sync.
+frame_fence_values: [device.Device.frame_count]u64 = .{ 0, 0, 0 },
+
+/// Command list from the current beginFrame, executed in drawFrameEnd.
+pending_command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
+
+/// Back buffer index from the current beginFrame, used in drawFrameEnd
+/// to record the fence value against the correct frame slot.
+/// Must be saved here because GetCurrentBackBufferIndex advances after Present.
+pending_frame_index: u32 = 0,
+
 // --- GraphicsAPI contract: functions ---
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     _ = alloc;
-    _ = opts;
-    log.warn("DX12 backend is a stub -- no GPU output yet", .{});
-    return .{};
+
+    var result = DirectX12{};
+
+    if (comptime builtin.os.tag != .windows) {
+        return result;
+    }
+
+    const surface_pkg = @import("directx12/surface.zig");
+    const w = opts.rt_surface.platform.windows;
+
+    const surface: surface_pkg.Surface = if (w.hwnd) |hwnd|
+        .{ .hwnd = hwnd }
+    else if (w.swap_chain_panel) |panel|
+        .{ .swap_chain_panel = @ptrCast(@alignCast(panel)) }
+    else if (w.shared_texture_out) |out_ptr|
+        .{ .shared_texture = .{
+            .handle_out = @ptrCast(@alignCast(out_ptr)),
+            .width = w.texture_width,
+            .height = w.texture_height,
+        } }
+    else
+        @panic("Windows surface requires hwnd, swap_chain_panel, or shared_texture_out");
+
+    const size = opts.size.screen;
+    result.dev = device.Device.init(surface, .{
+        .width = size.width,
+        .height = size.height,
+    }) catch |err| {
+        log.err("DX12 device init failed: {}", .{err});
+        return error.DeviceInitFailed;
+    };
+    errdefer {
+        result.dev.?.deinit();
+        result.dev = null;
+    }
+
+    const dev_ptr = &result.dev.?;
+
+    // Get SwapChain3 for GetCurrentBackBufferIndex.
+    if (dev_ptr.swap_chain) |sc| {
+        var sc3: ?*dxgi.IDXGISwapChain3 = null;
+        const hr = sc.vtable.QueryInterface(
+            @ptrCast(sc),
+            &dxgi.IDXGISwapChain3.IID,
+            @ptrCast(&sc3),
+        );
+        if (com.FAILED(hr)) {
+            log.err("QueryInterface for IDXGISwapChain3 failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return error.SwapChain3QueryFailed;
+        }
+        result.swap_chain3 = sc3;
+    }
+    errdefer if (result.swap_chain3) |sc3| {
+        _ = sc3.Release();
+    };
+
+    // Create RTV descriptor heap for back buffers.
+    result.rtv_heap = descriptor_heap.DescriptorHeap.init(
+        dev_ptr.device,
+        .RTV,
+        device.Device.frame_count,
+        false,
+    ) catch |err| {
+        log.err("RTV descriptor heap creation failed: {}", .{err});
+        return error.DescriptorHeapCreationFailed;
+    };
+    errdefer {
+        result.rtv_heap.?.deinit();
+        result.rtv_heap = null;
+    }
+
+    // Get back buffer resources and create RTVs.
+    if (result.swap_chain3) |sc3| {
+        for (0..device.Device.frame_count) |i| {
+            var resource: ?*d3d12.ID3D12Resource = null;
+            const hr = sc3.GetBuffer(
+                @intCast(i),
+                &d3d12.IID_ID3D12Resource,
+                @ptrCast(&resource),
+            );
+            if (com.FAILED(hr)) {
+                log.err("GetBuffer({}) failed: 0x{x}", .{ i, @as(u32, @bitCast(hr)) });
+                return error.GetBufferFailed;
+            }
+            result.back_buffers[i] = resource;
+
+            const rtv_handle = result.rtv_heap.?.cpuHandle(@intCast(i));
+            dev_ptr.device.CreateRenderTargetView(resource, null, rtv_handle);
+            result.rtv_handles[i] = rtv_handle;
+        }
+    }
+    errdefer {
+        for (&result.back_buffers) |*bb| {
+            if (bb.*) |r| {
+                _ = r.Release();
+                bb.* = null;
+            }
+        }
+    }
+
+    // Create per-frame command allocators and command lists.
+    for (&result.gpu_frames) |*gf| {
+        gf.* = Frame.init(dev_ptr.device) catch |err| {
+            log.err("Frame init failed: {}", .{err});
+            return error.FrameInitFailed;
+        };
+    }
+    errdefer {
+        for (&result.gpu_frames) |*gf| {
+            if (gf.*) |*f| f.deinit();
+        }
+    }
+
+    return result;
 }
 
 pub fn deinit(self: *DirectX12) void {
-    _ = self;
+    // Wait for GPU to finish before releasing anything.
+    if (self.dev) |*dev_ptr| {
+        dev_ptr.waitForGpu() catch {};
+    }
+
+    for (&self.gpu_frames) |*gf| {
+        if (gf.*) |*f| {
+            f.deinit();
+            gf.* = null;
+        }
+    }
+
+    for (&self.back_buffers) |*bb| {
+        if (bb.*) |r| {
+            _ = r.Release();
+            bb.* = null;
+        }
+    }
+
+    if (self.rtv_heap) |*h| {
+        h.deinit();
+        self.rtv_heap = null;
+    }
+
+    if (self.swap_chain3) |sc3| {
+        _ = sc3.Release();
+        self.swap_chain3 = null;
+    }
+
+    if (self.dev) |*dev_ptr| {
+        dev_ptr.deinit();
+        self.dev = null;
+    }
 }
 
 pub fn drawFrameStart(self: *DirectX12) void {
@@ -84,7 +263,32 @@ pub fn drawFrameStart(self: *DirectX12) void {
 }
 
 pub fn drawFrameEnd(self: *DirectX12) void {
-    _ = self;
+    const dev_ptr = &(self.dev orelse return);
+    const cl = self.pending_command_list orelse return;
+    self.pending_command_list = null;
+
+    // Execute the command list.
+    const lists = [_]*d3d12.ID3D12GraphicsCommandList{cl};
+    dev_ptr.command_queue.ExecuteCommandLists(1, &lists);
+
+    // Present the swap chain.
+    if (self.swap_chain3) |sc3| {
+        const hr = sc3.Present(1, 0);
+        if (com.FAILED(hr)) {
+            log.err("Present failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+        }
+    }
+
+    // Signal the fence so we know when this frame is done.
+    // Use the saved index, not GetCurrentBackBufferIndex, because
+    // Present may have already advanced the current back buffer.
+    const frame_idx = self.pending_frame_index;
+    dev_ptr.fence_value += 1;
+    self.frame_fence_values[frame_idx] = dev_ptr.fence_value;
+    const hr = dev_ptr.command_queue.Signal(dev_ptr.fence, dev_ptr.fence_value);
+    if (com.FAILED(hr)) {
+        log.err("fence Signal failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+    }
 }
 
 pub fn initShaders(
@@ -102,15 +306,33 @@ pub fn setTargetSize(self: *DirectX12, width: u32, height: u32) void {
     _ = self;
     _ = width;
     _ = height;
+    // TODO: for composition surfaces, store the target size so
+    // surfaceSize() can return it (no HWND to query).
 }
 
 pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
-    _ = self;
+    const dev_ptr = self.dev orelse return .{ .width = 0, .height = 0 };
+
+    if (dev_ptr.swap_chain) |sc| {
+        // Query the swap chain's current buffer dimensions.
+        // TODO: for HWND surfaces, store the HWND on Device and query
+        // the client rect directly, so resize is detected before the
+        // swap chain is resized. For now, the swap chain desc gives us
+        // correct dimensions after creation and after ResizeBuffers.
+        var desc: dxgi.DXGI_SWAP_CHAIN_DESC1 = undefined;
+        const hr = sc.GetDesc1(&desc);
+        if (com.SUCCEEDED(hr)) {
+            return .{ .width = desc.Width, .height = desc.Height };
+        }
+    }
+
     return .{ .width = 0, .height = 0 };
 }
 
 pub fn initTarget(self: *const DirectX12, width: usize, height: usize) !Target {
     _ = self;
+    // Target resource and RTV handle are set in beginFrame when we know
+    // which back buffer is current. Start with the dimensions only.
     return .{ .width = width, .height = height };
 }
 
@@ -119,20 +341,47 @@ pub inline fn beginFrame(
     renderer: *Renderer,
     target: *Target,
 ) !Frame {
-    _ = self;
-    // Stub frame: D3D objects are null so complete()/reset() guard against
-    // them safely. Real init happens once device wiring lands (PR 13).
-    return .{
-        .command_allocator = null,
-        .command_list = null,
-        .fence_value = 0,
-        .renderer = renderer,
-        .target = target,
-    };
+    const mutable_self = @constCast(self);
+    const sc3 = self.swap_chain3 orelse return error.PresentFailed;
+    const dev_ptr = &(mutable_self.dev orelse return error.PresentFailed);
+
+    // Which back buffer does the swap chain want us to render to?
+    const frame_idx = sc3.GetCurrentBackBufferIndex();
+
+    // Wait for this frame slot's previous GPU work to finish.
+    const wait_value = self.frame_fence_values[frame_idx];
+    if (dev_ptr.fence.GetCompletedValue() < wait_value) {
+        const hr = dev_ptr.fence.SetEventOnCompletion(wait_value, dev_ptr.fence_event);
+        if (com.FAILED(hr)) return error.PresentFailed;
+        _ = d3d12.WaitForSingleObject(dev_ptr.fence_event, d3d12.INFINITE);
+    }
+
+    // Point the target at this back buffer.
+    target.resource = self.back_buffers[frame_idx];
+    target.rtv_handle = self.rtv_handles[frame_idx];
+
+    // Reset and open the command list for recording.
+    var frame = self.gpu_frames[frame_idx] orelse return error.PresentFailed;
+    try frame.reset();
+    frame.renderer = renderer;
+    frame.target = target;
+
+    // Save state for drawFrameEnd to execute and signal.
+    mutable_self.pending_command_list = frame.command_list;
+    mutable_self.pending_frame_index = frame_idx;
+
+    return frame;
 }
 
 pub fn presentLastTarget(self: *DirectX12) !void {
-    _ = self;
+    // Called when no redraw is needed. Re-present the current frame.
+    if (self.swap_chain3) |sc3| {
+        const hr = sc3.Present(1, 0);
+        if (com.FAILED(hr)) {
+            log.err("presentLastTarget failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return error.PresentFailed;
+        }
+    }
 }
 
 pub inline fn bufferOptions(self: DirectX12) bufferpkg.Options {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -105,7 +105,7 @@ pending_frame_index: u32 = 0,
 // --- GraphicsAPI contract: functions ---
 
 pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
-    _ = alloc;
+    _ = alloc; // DX12 uses COM-based allocation; Zig allocator unused for now.
 
     var result = DirectX12{};
 
@@ -119,15 +119,17 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     const surface: surface_pkg.Surface = if (w.hwnd) |hwnd|
         .{ .hwnd = hwnd }
     else if (w.swap_chain_panel) |panel|
+        // panel is an opaque COM-compatible pointer from apprt; alignment is guaranteed.
         .{ .swap_chain_panel = @ptrCast(@alignCast(panel)) }
     else if (w.shared_texture_out) |out_ptr|
+        // out_ptr is an opaque pointer from apprt; alignment is guaranteed.
         .{ .shared_texture = .{
             .handle_out = @ptrCast(@alignCast(out_ptr)),
             .width = w.texture_width,
             .height = w.texture_height,
         } }
     else
-        @panic("Windows surface requires hwnd, swap_chain_panel, or shared_texture_out");
+        return error.NoWindowsSurface;
 
     const size = opts.size.screen;
     result.dev = device.Device.init(surface, .{
@@ -282,6 +284,7 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     // Signal the fence so we know when this frame is done.
     // Use the saved index, not GetCurrentBackBufferIndex, because
     // Present may have already advanced the current back buffer.
+    // Safe without sync because rendering is single-threaded per surface.
     const frame_idx = self.pending_frame_index;
     dev_ptr.fence_value += 1;
     self.frame_fence_values[frame_idx] = dev_ptr.fence_value;
@@ -315,10 +318,10 @@ pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
 
     if (dev_ptr.swap_chain) |sc| {
         // Query the swap chain's current buffer dimensions.
-        // TODO: for HWND surfaces, store the HWND on Device and query
-        // the client rect directly, so resize is detected before the
-        // swap chain is resized. For now, the swap chain desc gives us
-        // correct dimensions after creation and after ResizeBuffers.
+        // TODO: GetDesc1 is called every frame -- cache the dimensions and
+        // only re-query on resize. For HWND surfaces, store the HWND on
+        // Device and query the client rect directly, so resize is detected
+        // before the swap chain is resized.
         var desc: dxgi.DXGI_SWAP_CHAIN_DESC1 = undefined;
         const hr = sc.GetDesc1(&desc);
         if (com.SUCCEEDED(hr)) {
@@ -341,34 +344,38 @@ pub inline fn beginFrame(
     renderer: *Renderer,
     target: *Target,
 ) !Frame {
-    const mutable_self = @constCast(self);
-    const sc3 = self.swap_chain3 orelse return error.PresentFailed;
-    const dev_ptr = &(mutable_self.dev orelse return error.PresentFailed);
+    // self is *const to match the GraphicsAPI contract (Metal, OpenGL, DX11
+    // all use *const). Mutable access goes through renderer.api, same pattern
+    // as DX11.
+    _ = self;
+    const api: *DirectX12 = &renderer.api;
+    const sc3 = api.swap_chain3 orelse return error.NoSwapChain;
+    const dev_ptr = &(api.dev orelse return error.NoDevice);
 
     // Which back buffer does the swap chain want us to render to?
     const frame_idx = sc3.GetCurrentBackBufferIndex();
 
     // Wait for this frame slot's previous GPU work to finish.
-    const wait_value = self.frame_fence_values[frame_idx];
+    const wait_value = api.frame_fence_values[frame_idx];
     if (dev_ptr.fence.GetCompletedValue() < wait_value) {
         const hr = dev_ptr.fence.SetEventOnCompletion(wait_value, dev_ptr.fence_event);
-        if (com.FAILED(hr)) return error.PresentFailed;
+        if (com.FAILED(hr)) return error.FrameSyncFailed;
         _ = d3d12.WaitForSingleObject(dev_ptr.fence_event, d3d12.INFINITE);
     }
 
     // Point the target at this back buffer.
-    target.resource = self.back_buffers[frame_idx];
-    target.rtv_handle = self.rtv_handles[frame_idx];
+    target.resource = api.back_buffers[frame_idx];
+    target.rtv_handle = api.rtv_handles[frame_idx];
 
     // Reset and open the command list for recording.
-    var frame = self.gpu_frames[frame_idx] orelse return error.PresentFailed;
+    var frame = api.gpu_frames[frame_idx] orelse return error.FrameNotReady;
     try frame.reset();
     frame.renderer = renderer;
     frame.target = target;
 
     // Save state for drawFrameEnd to execute and signal.
-    mutable_self.pending_command_list = frame.command_list;
-    mutable_self.pending_frame_index = frame_idx;
+    api.pending_command_list = frame.command_list;
+    api.pending_frame_index = frame_idx;
 
     return frame;
 }

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -13,7 +13,6 @@ const builtin = @import("builtin");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const apprt = @import("../apprt.zig");
 const configpkg = @import("../config.zig");
 const font = @import("../font/main.zig");
 const rendererpkg = @import("../renderer.zig");
@@ -185,7 +184,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
             var resource: ?*d3d12.ID3D12Resource = null;
             const hr = sc3.GetBuffer(
                 @intCast(i),
-                &d3d12.IID_ID3D12Resource,
+                &d3d12.ID3D12Resource.IID,
                 @ptrCast(&resource),
             );
             if (com.FAILED(hr)) {
@@ -274,6 +273,8 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     dev_ptr.command_queue.ExecuteCommandLists(1, &lists);
 
     // Present the swap chain.
+    // TODO: check for DXGI_ERROR_DEVICE_REMOVED and trigger TDR recovery
+    // once device-lost handling is implemented.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
         if (com.FAILED(hr)) {
@@ -327,8 +328,10 @@ pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
         if (com.SUCCEEDED(hr)) {
             return .{ .width = desc.Width, .height = desc.Height };
         }
+        log.warn("GetDesc1 failed: 0x{x}", .{@as(u32, @bitCast(hr))});
     }
 
+    // No swap chain (SharedTexture surface) or query failed.
     return .{ .width = 0, .height = 0 };
 }
 
@@ -349,6 +352,8 @@ pub inline fn beginFrame(
     // as DX11.
     _ = self;
     const api: *DirectX12 = &renderer.api;
+    // SharedTexture surfaces have no swap chain; they need a separate
+    // submission path that is not yet implemented.
     const sc3 = api.swap_chain3 orelse return error.NoSwapChain;
     const dev_ptr = &(api.dev orelse return error.NoDevice);
 
@@ -373,6 +378,10 @@ pub inline fn beginFrame(
     frame.renderer = renderer;
     frame.target = target;
 
+    // Write back so the stored copy stays current (the local is a value copy
+    // from the optional, not a reference).
+    api.gpu_frames[frame_idx] = frame;
+
     // Save state for drawFrameEnd to execute and signal.
     api.pending_command_list = frame.command_list;
     api.pending_frame_index = frame_idx;
@@ -381,7 +390,9 @@ pub inline fn beginFrame(
 }
 
 pub fn presentLastTarget(self: *DirectX12) !void {
-    // Called when no redraw is needed. Re-present the current frame.
+    // Called when no redraw is needed -- re-present the current frame.
+    // No new GPU work is submitted, so the existing fence values remain
+    // valid and the next beginFrame will wait correctly.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
         if (com.FAILED(hr)) {

--- a/src/renderer/directx12/descriptor_heap.zig
+++ b/src/renderer/directx12/descriptor_heap.zig
@@ -9,7 +9,7 @@
 //! - CBV/SRV/UAV (shader-visible): constant buffers, textures
 //! - Sampler (shader-visible): texture samplers
 //! - RTV (non-shader-visible): render target views
-const DescriptorHeap = @This();
+pub const DescriptorHeap = @This();
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -8,7 +8,7 @@
 //! - HWND: standalone windows, uses DirectComposition
 //! - SwapChainPanel: WinUI 3 / XAML hosts
 //! - SharedTexture: offscreen / game engine embedding (no swap chain)
-const Device = @This();
+pub const Device = @This();
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/src/renderer/directx12/dxgi.zig
+++ b/src/renderer/directx12/dxgi.zig
@@ -335,6 +335,82 @@ pub const IDXGISwapChain2 = extern struct {
     }
 };
 
+// IDXGISwapChain3
+// Slot we call: GetCurrentBackBufferIndex (36)
+pub const IDXGISwapChain3 = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0x94d99bdb,
+        .data2 = 0xf1f8,
+        .data3 = 0x4ab0,
+        .data4 = .{ 0xb2, 0x36, 0x7d, 0xa0, 0x17, 0x0e, 0xda, 0xb1 },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown (slots 0-2)
+        QueryInterface: *const fn (*IDXGISwapChain3, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDXGISwapChain3) callconv(.winapi) u32,
+        Release: *const fn (*IDXGISwapChain3) callconv(.winapi) u32,
+        // IDXGIObject (slots 3-6)
+        SetPrivateData: Reserved,
+        SetPrivateDataInterface: Reserved,
+        GetPrivateData: Reserved,
+        GetParent: Reserved,
+        // IDXGIDeviceSubObject (slot 7)
+        GetDevice: Reserved,
+        // IDXGISwapChain (slots 8-17)
+        Present: *const fn (*IDXGISwapChain3, u32, u32) callconv(.winapi) HRESULT,
+        GetBuffer: *const fn (*IDXGISwapChain3, u32, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        SetFullscreenState: Reserved,
+        GetFullscreenState: Reserved,
+        GetDesc: Reserved,
+        ResizeBuffers: Reserved,
+        ResizeTarget: Reserved,
+        GetContainingOutput: Reserved,
+        GetFrameStatistics: Reserved,
+        GetLastPresentCount: Reserved,
+        // IDXGISwapChain1 (slots 18-28)
+        GetDesc1: Reserved,
+        GetFullscreenDesc: Reserved,
+        GetHwnd: Reserved,
+        GetCoreWindow: Reserved,
+        Present1: Reserved,
+        IsTemporaryMonoSupported: Reserved,
+        GetRestrictToOutput: Reserved,
+        SetBackgroundColor: Reserved,
+        GetBackgroundColor: Reserved,
+        SetRotation: Reserved,
+        GetRotation: Reserved,
+        // IDXGISwapChain2 (slots 29-35)
+        SetSourceSize: Reserved,
+        GetSourceSize: Reserved,
+        SetMaximumFrameLatency: Reserved,
+        GetMaximumFrameLatency: Reserved,
+        GetFrameLatencyWaitableObject: Reserved,
+        SetMatrixTransform: Reserved,
+        GetMatrixTransform: Reserved,
+        // IDXGISwapChain3 (slot 36)
+        GetCurrentBackBufferIndex: *const fn (*IDXGISwapChain3) callconv(.winapi) u32,
+    };
+
+    pub inline fn Present(self: *IDXGISwapChain3, sync_interval: u32, flags: u32) HRESULT {
+        return self.vtable.Present(self, sync_interval, flags);
+    }
+
+    pub inline fn GetBuffer(self: *IDXGISwapChain3, buffer: u32, riid: *const GUID, surface: *?*anyopaque) HRESULT {
+        return self.vtable.GetBuffer(self, buffer, riid, surface);
+    }
+
+    pub inline fn GetCurrentBackBufferIndex(self: *IDXGISwapChain3) u32 {
+        return self.vtable.GetCurrentBackBufferIndex(self);
+    }
+
+    pub inline fn Release(self: *IDXGISwapChain3) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
 // IDXGIDevice
 // Slot we call: GetAdapter (slot 7)
 pub const IDXGIDevice = extern struct {


### PR DESCRIPTION
> **IMPORTANT:** This is PR 9 of the DX12 pivot stack. Full order:
> #107 -> #108 -> #109 -> #110 -> #113 -> #114 -> #116 -> #117 -> this PR

## Summary

- Wire DirectX12.zig stubs to real GPU init and rendering
- init() creates Device (d3d12 device, command queue, fence, swap chain via DirectComposition), QIs to SwapChain3, creates RTV descriptor heap, gets back buffer resources, creates render target views, creates per-frame command allocators and command lists
- beginFrame() waits on per-frame fence, sets target to current back buffer, resets command allocator and command list
- drawFrameEnd() executes the command list, presents the swap chain, signals the fence
- surfaceSize() queries swap chain desc for buffer dimensions
- Add IDXGISwapChain3 binding for GetCurrentBackBufferIndex
- Make Device and DescriptorHeap types pub for use from DirectX12.zig

## Test plan

- [x] `zig build -Dapp-runtime=none` compiles clean
- [x] `zig build test -Dapp-runtime=none` passes
- [x] `zig build test -Dapp-runtime=none -Dtest-filter="directx12"` passes