### PR TITLE
renderer: DX12 Buffer with upload heap and persistent mapping

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -403,8 +403,9 @@ pub fn presentLastTarget(self: *DirectX12) !void {
 }
 
 pub inline fn bufferOptions(self: DirectX12) bufferpkg.Options {
-    _ = self;
-    return .{};
+    return .{
+        .device = if (self.dev) |*d| d.device else null,
+    };
 }
 
 pub const instanceBufferOptions = bufferOptions;
@@ -413,13 +414,11 @@ pub const imageBufferOptions = bufferOptions;
 pub const bgImageBufferOptions = bufferOptions;
 
 pub inline fn bgBufferOptions(self: DirectX12) bufferpkg.Options {
-    _ = self;
-    return .{};
+    return self.bufferOptions();
 }
 
 pub inline fn uniformBufferOptions(self: DirectX12) bufferpkg.Options {
-    _ = self;
-    return .{};
+    return self.bufferOptions();
 }
 
 pub inline fn textureOptions(self: DirectX12) Texture.Options {

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -26,7 +26,7 @@ pub const Options = struct {
 /// Holds the GPU virtual address and size needed for binding.
 pub const RawBuffer = struct {
     gpu_address: u64 = 0,
-    size: u32 = 0,
+    size: u64 = 0,
 };
 
 /// DX12 GPU data buffer for a set of equal-typed elements.
@@ -54,6 +54,7 @@ pub fn Buffer(comptime T: type) type {
 
         pub fn init(opts: Options, len: usize) !Self {
             var self = Self{ .opts = opts };
+            errdefer self.release();
             if (len > 0) {
                 try self.allocate(len);
             }
@@ -63,9 +64,10 @@ pub fn Buffer(comptime T: type) type {
         /// Init the buffer filled with the given data.
         pub fn initFill(opts: Options, data: []const T) !Self {
             var self = Self{ .opts = opts };
+            errdefer self.release();
             if (data.len > 0) {
                 try self.allocate(data.len);
-                self.copy(data);
+                try self.copy(data);
             }
             return self;
         }
@@ -86,7 +88,7 @@ pub fn Buffer(comptime T: type) type {
                 try self.allocate(data.len * 2);
             }
 
-            self.copy(data);
+            try self.copy(data);
         }
 
         /// Sync from multiple ArrayListUnmanaged(T), returning total count.
@@ -103,7 +105,10 @@ pub fn Buffer(comptime T: type) type {
                 try self.allocate(total * 2);
             }
 
-            const dst = self.mapped orelse return error.BufferNotMapped;
+            const dst = self.mapped orelse {
+                log.warn("buffer mapped pointer is null", .{});
+                return error.BufferMapFailed;
+            };
             var offset: usize = 0;
             for (lists) |list| {
                 const bytes = list.items.len * @sizeOf(T);
@@ -121,6 +126,8 @@ pub fn Buffer(comptime T: type) type {
             const device = self.opts.device orelse return error.NoDevice;
             const byte_size = len * @sizeOf(T);
 
+            // CPUPageProperty, MemoryPoolPreference, and node masks are
+            // ignored by the runtime when Type is not CUSTOM.
             const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
                 .Type = .UPLOAD,
                 .CPUPageProperty = 0,
@@ -175,7 +182,7 @@ pub fn Buffer(comptime T: type) type {
             self.len = len;
             self.buffer = .{
                 .gpu_address = res.GetGPUVirtualAddress(),
-                .size = @intCast(byte_size),
+                .size = byte_size,
             };
         }
 
@@ -189,8 +196,11 @@ pub fn Buffer(comptime T: type) type {
             self.buffer = .{};
         }
 
-        fn copy(self: *Self, data: []const T) void {
-            const dst = self.mapped orelse return;
+        fn copy(self: *Self, data: []const T) !void {
+            const dst = self.mapped orelse {
+                log.warn("buffer mapped pointer is null", .{});
+                return error.BufferMapFailed;
+            };
             const bytes = data.len * @sizeOf(T);
             const src: [*]const u8 = @ptrCast(data.ptr);
             @memcpy(dst[0..bytes], src[0..bytes]);

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -11,7 +11,6 @@
 const std = @import("std");
 
 const d3d12 = @import("d3d12.zig");
-const dxgi = @import("dxgi.zig");
 const com = @import("com.zig");
 
 const log = std.log.scoped(.directx12);
@@ -156,9 +155,9 @@ pub fn Buffer(comptime T: type) type {
                 &heap_props,
                 0, // no heap flags
                 &desc,
-                d3d12.D3D12_RESOURCE_STATE_GENERIC_READ,
+                d3d12.D3D12_RESOURCE_STATES.GENERIC_READ,
                 null, // no optimized clear
-                &d3d12.IID_ID3D12Resource,
+                &d3d12.ID3D12Resource.IID,
                 @ptrCast(&resource),
             );
             if (com.FAILED(hr)) {

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -1,54 +1,199 @@
-//! DX12 GPU buffer stub.
+//! DX12 GPU buffer backed by an upload heap with persistent mapping.
 //!
-//! Will be replaced with a real implementation using upload heaps
-//! (ring buffer or per-frame allocators) for CPU-to-GPU data transfer.
+//! Each Buffer(T) owns a single ID3D12Resource in D3D12_HEAP_TYPE.UPLOAD,
+//! mapped once at creation and never unmapped until deinit. Writes go
+//! through the mapped pointer via @memcpy -- zero-copy from the CPU side.
+//!
+//! Per-frame isolation is handled one layer up by GenericRenderer's
+//! FrameState, which maintains separate Buffer instances per in-flight
+//! frame. This keeps the buffer implementation simple: no ring buffer
+//! segmentation needed.
 const std = @import("std");
 
-/// Type-erased buffer handle for passing to RenderPass.Step.
-pub const RawBuffer = struct {};
+const d3d12 = @import("d3d12.zig");
+const dxgi = @import("dxgi.zig");
+const com = @import("com.zig");
 
-/// Options for initializing a buffer.
-pub const Options = struct {};
+const log = std.log.scoped(.directx12);
+
+/// Options for creating a DX12 buffer. Passed from DirectX12.zig's
+/// bufferOptions() / uniformBufferOptions() / bgBufferOptions().
+pub const Options = struct {
+    device: ?*d3d12.ID3D12Device = null,
+};
+
+/// Type-erased buffer handle for passing to RenderPass.Step.
+/// Holds the GPU virtual address and size needed for binding.
+pub const RawBuffer = struct {
+    gpu_address: u64 = 0,
+    size: u32 = 0,
+};
 
 /// DX12 GPU data buffer for a set of equal-typed elements.
+///
+/// Wraps an upload heap resource with persistent CPU mapping.
+/// Regrows automatically (2x) when sync data exceeds capacity.
 pub fn Buffer(comptime T: type) type {
     return struct {
         const Self = @This();
 
-        /// The type-erased handle passed into RenderPass steps.
+        opts: Options,
+
+        /// The underlying upload heap resource, null if zero-length.
+        resource: ?*d3d12.ID3D12Resource = null,
+
+        /// Persistently mapped pointer to the upload heap. Valid for
+        /// the lifetime of the resource (Map at creation, no Unmap).
+        mapped: ?[*]u8 = null,
+
+        /// Allocated capacity in number of T elements.
+        len: usize = 0,
+
+        /// Type-erased handle for RenderPass binding.
         buffer: RawBuffer = .{},
 
         pub fn init(opts: Options, len: usize) !Self {
-            _ = opts;
-            _ = len;
-            return .{};
+            var self = Self{ .opts = opts };
+            if (len > 0) {
+                try self.allocate(len);
+            }
+            return self;
         }
 
         /// Init the buffer filled with the given data.
         pub fn initFill(opts: Options, data: []const T) !Self {
-            _ = opts;
-            _ = data;
-            return .{};
+            var self = Self{ .opts = opts };
+            if (data.len > 0) {
+                try self.allocate(data.len);
+                self.copy(data);
+            }
+            return self;
         }
 
         pub fn deinit(self: *const Self) void {
-            _ = self;
+            if (self.resource) |res| {
+                _ = res.Release();
+            }
         }
 
         /// Sync the buffer contents with the given data slice.
+        /// If the data exceeds capacity, the buffer is reallocated at 2x.
         pub fn sync(self: *Self, data: []const T) !void {
-            _ = self;
-            _ = data;
+            if (data.len == 0) return;
+
+            if (data.len > self.len) {
+                self.release();
+                try self.allocate(data.len * 2);
+            }
+
+            self.copy(data);
         }
 
         /// Sync from multiple ArrayListUnmanaged(T), returning total count.
         pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
-            _ = self;
             var total: usize = 0;
             for (lists) |list| {
                 total += list.items.len;
             }
+
+            if (total == 0) return 0;
+
+            if (total > self.len) {
+                self.release();
+                try self.allocate(total * 2);
+            }
+
+            const dst = self.mapped orelse return error.BufferNotMapped;
+            var offset: usize = 0;
+            for (lists) |list| {
+                const bytes = list.items.len * @sizeOf(T);
+                const src: [*]const u8 = @ptrCast(list.items.ptr);
+                @memcpy(dst[offset..][0..bytes], src[0..bytes]);
+                offset += bytes;
+            }
+
             return total;
+        }
+
+        // -- internal helpers --
+
+        fn allocate(self: *Self, len: usize) !void {
+            const device = self.opts.device orelse return error.NoDevice;
+            const byte_size = len * @sizeOf(T);
+
+            const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
+                .Type = .UPLOAD,
+                .CPUPageProperty = 0,
+                .MemoryPoolPreference = 0,
+                .CreationNodeMask = 0,
+                .VisibleNodeMask = 0,
+            };
+
+            const desc = d3d12.D3D12_RESOURCE_DESC{
+                .Dimension = .BUFFER,
+                .Alignment = 0,
+                .Width = byte_size,
+                .Height = 1,
+                .DepthOrArraySize = 1,
+                .MipLevels = 1,
+                .Format = .UNKNOWN,
+                .SampleDesc = .{ .Count = 1, .Quality = 0 },
+                .Layout = .ROW_MAJOR,
+                .Flags = .NONE,
+            };
+
+            var resource: ?*d3d12.ID3D12Resource = null;
+            const hr = device.CreateCommittedResource(
+                &heap_props,
+                0, // no heap flags
+                &desc,
+                d3d12.D3D12_RESOURCE_STATE_GENERIC_READ,
+                null, // no optimized clear
+                &d3d12.IID_ID3D12Resource,
+                @ptrCast(&resource),
+            );
+            if (com.FAILED(hr)) {
+                log.err("CreateCommittedResource for upload buffer failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.BufferCreationFailed;
+            }
+
+            const res = resource orelse return error.BufferCreationFailed;
+
+            // Persistently map the upload heap. Read range is empty because
+            // the CPU never reads back from this buffer.
+            var mapped: ?*anyopaque = null;
+            const read_range = d3d12.D3D12_RANGE{ .Begin = 0, .End = 0 };
+            const map_hr = res.Map(0, &read_range, &mapped);
+            if (com.FAILED(map_hr) or mapped == null) {
+                log.err("Map for upload buffer failed: 0x{x}", .{@as(u32, @bitCast(map_hr))});
+                _ = res.Release();
+                return error.BufferMapFailed;
+            }
+
+            self.resource = res;
+            self.mapped = @ptrCast(mapped.?);
+            self.len = len;
+            self.buffer = .{
+                .gpu_address = res.GetGPUVirtualAddress(),
+                .size = @intCast(byte_size),
+            };
+        }
+
+        fn release(self: *Self) void {
+            if (self.resource) |res| {
+                _ = res.Release();
+            }
+            self.resource = null;
+            self.mapped = null;
+            self.len = 0;
+            self.buffer = .{};
+        }
+
+        fn copy(self: *Self, data: []const T) void {
+            const dst = self.mapped orelse return;
+            const bytes = data.len * @sizeOf(T);
+            const src: [*]const u8 = @ptrCast(data.ptr);
+            @memcpy(dst[0..bytes], src[0..bytes]);
         }
     };
 }

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -73,9 +73,11 @@ pub fn Buffer(comptime T: type) type {
         }
 
         pub fn deinit(self: *const Self) void {
-            if (self.resource) |res| {
-                _ = res.Release();
-            }
+            // Delegate to release() for full cleanup. @constCast is safe
+            // because deinit is the owner and this matches Metal's pattern
+            // of calling release through a *const Self.
+            const mutable = @constCast(self);
+            mutable.release();
         }
 
         /// Sync the buffer contents with the given data slice.


### PR DESCRIPTION
> **IMPORTANT:** This is PR 10 of 15 in the DX12 pivot stack.
> Full stack: #107 -> #108 -> #109 -> #110 -> #113 -> #114 -> #116 -> #117 -> #118 -> **this PR** -> ...

## Summary

- Replace buffer.zig stub with real upload heap implementation
- Buffer(T) creates a committed resource in D3D12_HEAP_TYPE_UPLOAD, persistently mapped at creation
- Regrows at 2x capacity when sync data exceeds current allocation
- bufferOptions() now passes the D3D12 device through to buffer creation

Per-frame isolation is already handled by GenericRenderer's FrameState (separate Buffer instances per in-flight frame), so no ring buffer segmentation needed here.