### PR TITLE
renderer: DX12 shader loading from embedded DXIL bytecode

### DIFF
--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -199,12 +199,8 @@ test "Frame reset error set includes expected errors" {
     }
 }
 
-test "Frame.complete is safe with null command list" {
-    // Verifies the stub path (command_list = null) does not crash.
-    // We can't construct a real Frame without a GPU device, but we
-    // can verify the type is optional at compile time.
-    comptime {
-        try std.testing.expect(@TypeOf(Frame.command_list) == ?*d3d12.ID3D12GraphicsCommandList);
-        try std.testing.expect(@TypeOf(Frame.command_allocator) == ?*d3d12.ID3D12CommandAllocator);
-    }
+test "Frame has expected optional fields" {
+    try std.testing.expect(@hasField(Frame, "command_list"));
+    try std.testing.expect(@hasField(Frame, "command_allocator"));
+    try std.testing.expect(@hasField(Frame, "fence_value"));
 }

--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -199,7 +199,7 @@ test "Frame reset error set includes expected errors" {
     }
 }
 
-test "Frame has expected optional fields" {
+test "Frame has expected fields" {
     try std.testing.expect(@hasField(Frame, "command_list"));
     try std.testing.expect(@hasField(Frame, "command_allocator"));
     try std.testing.expect(@hasField(Frame, "fence_value"));

--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -245,26 +245,7 @@ pub fn init(opts: Options) !Pipeline {
             .ForcedSampleCount = 0,
             .ConservativeRaster = 0,
         },
-        .DepthStencilState = .{
-            .DepthEnable = 0,
-            .DepthWriteMask = 0,
-            .DepthFunc = 0,
-            .StencilEnable = 0,
-            .StencilReadMask = 0,
-            .StencilWriteMask = 0,
-            .FrontFace = .{
-                .StencilFailOp = 0,
-                .StencilDepthFailOp = 0,
-                .StencilPassOp = 0,
-                .StencilFunc = 0,
-            },
-            .BackFace = .{
-                .StencilFailOp = 0,
-                .StencilDepthFailOp = 0,
-                .StencilPassOp = 0,
-                .StencilFunc = 0,
-            },
-        },
+        .DepthStencilState = std.mem.zeroes(d3d12.D3D12_DEPTH_STENCIL_DESC),
         .InputLayout = .{
             .pInputElementDescs = if (opts.input_layout) |il| il.ptr else null,
             .NumElements = if (opts.input_layout) |il| @intCast(il.len) else 0,
@@ -332,4 +313,14 @@ test "BlendMode values" {
 test "deinit on default pipeline is safe" {
     const p: Pipeline = .{};
     p.deinit();
+}
+
+test "deinit does not touch root_signature" {
+    // Shaders owns the shared root signature and releases it in
+    // Shaders.deinit. Pipeline.deinit must only release the PSO.
+    // If deinit tried to Release the root_signature this would crash
+    // on the bogus pointer, failing the test.
+    const sentinel: *d3d12.ID3D12RootSignature = @ptrFromInt(0xDEAD_BEF0);
+    const p: Pipeline = .{ .pso = null, .root_signature = sentinel };
+    p.deinit(); // must not dereference root_signature
 }

--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -125,6 +125,9 @@ pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignat
     // Serialize the root signature to a blob.
     var blob: ?*d3d12.ID3DBlob = null;
     var error_blob: ?*d3d12.ID3DBlob = null;
+    // TODO(#127): upgrade to D3D_ROOT_SIGNATURE_VERSION_1_1 for DATA_STATIC /
+    // DESCRIPTORS_VOLATILE flags -- allows driver to optimize descriptor
+    // access for our workload (static atlas textures, per-frame uniforms).
     var hr = d3d12.D3D12SerializeRootSignature(
         &desc,
         1, // D3D_ROOT_SIGNATURE_VERSION_1

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -1,8 +1,9 @@
-//! Shader management and GPU data structs for DX12.
+//! Shader management for DX12.
 //!
-//! Re-exports the shared GPU data structs from gpu_data.zig and provides
-//! a stub Shaders type that satisfies the GenericRenderer contract.
+//! Loads DXIL bytecode via @embedFile and defines input element descriptions
+//! for all 5 pipelines. GPU data structs are imported from gpu_data.zig.
 const std = @import("std");
+const builtin = @import("builtin");
 
 const d3d12 = @import("d3d12.zig");
 const gpu_data = @import("gpu_data.zig");
@@ -13,6 +14,172 @@ pub const CellText = gpu_data.CellText;
 pub const CellBg = gpu_data.CellBg;
 pub const Image = gpu_data.Image;
 pub const BgImage = gpu_data.BgImage;
+
+/// Embedded shader bytecode -- compiled at build time by HlslStep.zig.
+/// On non-Windows these are empty slices so the module still compiles.
+const shader_bytecode = if (builtin.os.tag == .windows) struct {
+    const bg_color_vs = @embedFile("ghostty_hlsl_bg_color_vs");
+    const bg_color_ps = @embedFile("ghostty_hlsl_bg_color_ps");
+    const cell_bg_ps = @embedFile("ghostty_hlsl_cell_bg_ps");
+    const cell_text_vs = @embedFile("ghostty_hlsl_cell_text_vs");
+    const cell_text_ps = @embedFile("ghostty_hlsl_cell_text_ps");
+    const image_vs = @embedFile("ghostty_hlsl_image_vs");
+    const image_ps = @embedFile("ghostty_hlsl_image_ps");
+    const bg_image_vs = @embedFile("ghostty_hlsl_bg_image_vs");
+    const bg_image_ps = @embedFile("ghostty_hlsl_bg_image_ps");
+} else struct {
+    const bg_color_vs: []const u8 = &.{};
+    const bg_color_ps: []const u8 = &.{};
+    const cell_bg_ps: []const u8 = &.{};
+    const cell_text_vs: []const u8 = &.{};
+    const cell_text_ps: []const u8 = &.{};
+    const image_vs: []const u8 = &.{};
+    const image_ps: []const u8 = &.{};
+    const bg_image_vs: []const u8 = &.{};
+    const bg_image_ps: []const u8 = &.{};
+};
+
+// --- Input element descriptions for instanced pipelines ---
+const PER_INSTANCE = d3d12.D3D12_INPUT_CLASSIFICATION.PER_INSTANCE_DATA;
+
+/// Input layout for CellText instances (32 bytes per instance).
+const cell_text_input_elements = [_]d3d12.D3D12_INPUT_ELEMENT_DESC{
+    .{ // glyph_pos: [2]u32
+        .SemanticName = "GLYPH_POS",
+        .SemanticIndex = 0,
+        .Format = .R32G32_UINT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 0,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // glyph_size: [2]u32
+        .SemanticName = "GLYPH_SIZE",
+        .SemanticIndex = 0,
+        .Format = .R32G32_UINT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 8,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // bearings: [2]i16
+        .SemanticName = "BEARINGS",
+        .SemanticIndex = 0,
+        .Format = .R16G16_SINT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 16,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // grid_pos: [2]u16
+        .SemanticName = "GRID_POS",
+        .SemanticIndex = 0,
+        .Format = .R16G16_UINT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 20,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // color: [4]u8
+        .SemanticName = "COLOR",
+        .SemanticIndex = 0,
+        .Format = .R8G8B8A8_UNORM,
+        .InputSlot = 0,
+        .AlignedByteOffset = 24,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // atlas: Atlas (u8)
+        .SemanticName = "ATLAS",
+        .SemanticIndex = 0,
+        .Format = .R8_UINT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 28,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // bools: packed struct(u8)
+        .SemanticName = "BOOLS",
+        .SemanticIndex = 0,
+        .Format = .R8_UINT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 29,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+};
+
+/// Input layout for Image instances (40 bytes per instance).
+const image_input_elements = [_]d3d12.D3D12_INPUT_ELEMENT_DESC{
+    .{ // grid_pos: [2]f32
+        .SemanticName = "GRID_POS",
+        .SemanticIndex = 0,
+        .Format = .R32G32_FLOAT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 0,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // cell_offset: [2]f32
+        .SemanticName = "CELL_OFFSET",
+        .SemanticIndex = 0,
+        .Format = .R32G32_FLOAT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 8,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // source_rect: [4]f32
+        .SemanticName = "SOURCE_RECT",
+        .SemanticIndex = 0,
+        .Format = .R32G32B32A32_FLOAT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 16,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // dest_size: [2]f32
+        .SemanticName = "DEST_SIZE",
+        .SemanticIndex = 0,
+        .Format = .R32G32_FLOAT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 32,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+};
+
+/// Input layout for BgImage instances (8 bytes per instance).
+const bg_image_input_elements = [_]d3d12.D3D12_INPUT_ELEMENT_DESC{
+    .{ // opacity: f32
+        .SemanticName = "OPACITY",
+        .SemanticIndex = 0,
+        .Format = .R32_FLOAT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 0,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+    .{ // info: packed struct(u8)
+        .SemanticName = "INFO",
+        .SemanticIndex = 0,
+        .Format = .R8_UINT,
+        .InputSlot = 0,
+        .AlignedByteOffset = 4,
+        .InputSlotClass = PER_INSTANCE,
+        .InstanceDataStepRate = 1,
+    },
+};
+
+// Verify input layouts match GPU data struct sizes and offsets.
+comptime {
+    std.debug.assert(@sizeOf(CellText) == 32);
+    std.debug.assert(@offsetOf(CellText, "bools") == 29);
+    std.debug.assert(@sizeOf(Image) == 40);
+    std.debug.assert(@offsetOf(Image, "dest_size") == 32);
+    std.debug.assert(@sizeOf(BgImage) == 8);
+    std.debug.assert(@offsetOf(BgImage, "info") == 4);
+}
 
 /// Shader management for DX12.
 pub const Shaders = struct {
@@ -31,6 +198,68 @@ pub const Shaders = struct {
         bg_image: Pipeline = .{},
     };
 
+    pub const InitError = error{
+        RootSignatureSerializeFailed,
+        RootSignatureCreationFailed,
+        PipelineStateCreationFailed,
+    };
+
+    /// Initialize all 5 pipelines from embedded DXIL bytecode.
+    /// On non-Windows, returns default-initialized (empty) pipelines.
+    pub fn init(device: ?*d3d12.ID3D12Device) InitError!Shaders {
+        const dev = device orelse return .{};
+
+        // All pipelines share a single root signature.
+        const root_sig = Pipeline.createRootSignature(dev) catch |err| return err;
+
+        return .{
+            .pipelines = .{
+                // bg_color: full-screen VS, no input layout, no blending.
+                .bg_color = try Pipeline.init(.{
+                    .device = dev,
+                    .root_signature = root_sig,
+                    .vs_bytecode = shader_bytecode.bg_color_vs,
+                    .ps_bytecode = shader_bytecode.bg_color_ps,
+                }),
+                // cell_bg: same full-screen VS, blended.
+                .cell_bg = try Pipeline.init(.{
+                    .device = dev,
+                    .root_signature = root_sig,
+                    .vs_bytecode = shader_bytecode.bg_color_vs,
+                    .ps_bytecode = shader_bytecode.cell_bg_ps,
+                    .blend = .premultiplied_alpha,
+                }),
+                // cell_text: instanced with CellText input layout, blended.
+                .cell_text = try Pipeline.init(.{
+                    .device = dev,
+                    .root_signature = root_sig,
+                    .vs_bytecode = shader_bytecode.cell_text_vs,
+                    .ps_bytecode = shader_bytecode.cell_text_ps,
+                    .input_layout = &cell_text_input_elements,
+                    .blend = .premultiplied_alpha,
+                }),
+                // image: instanced with Image input layout, blended.
+                .image = try Pipeline.init(.{
+                    .device = dev,
+                    .root_signature = root_sig,
+                    .vs_bytecode = shader_bytecode.image_vs,
+                    .ps_bytecode = shader_bytecode.image_ps,
+                    .input_layout = &image_input_elements,
+                    .blend = .premultiplied_alpha,
+                }),
+                // bg_image: instanced with BgImage input layout, blended.
+                .bg_image = try Pipeline.init(.{
+                    .device = dev,
+                    .root_signature = root_sig,
+                    .vs_bytecode = shader_bytecode.bg_image_vs,
+                    .ps_bytecode = shader_bytecode.bg_image_ps,
+                    .input_layout = &bg_image_input_elements,
+                    .blend = .premultiplied_alpha,
+                }),
+            },
+        };
+    }
+
     pub fn deinit(self: *Shaders, alloc: std.mem.Allocator) void {
         for (self.post_pipelines) |p| {
             p.deinit();
@@ -39,6 +268,10 @@ pub const Shaders = struct {
             alloc.free(self.post_pipelines);
         }
         self.post_pipelines = &.{};
+
+        // Release the shared root signature via bg_color (which owns it).
+        // Other pipelines just reference it, so only release PSOs for them.
+        if (self.pipelines.bg_color.root_signature) |rs| _ = rs.Release();
 
         self.pipelines.bg_color.deinit();
         self.pipelines.cell_bg.deinit();
@@ -51,3 +284,90 @@ pub const Shaders = struct {
         self.root_signature = null;
     }
 };
+
+// --- Tests ---
+
+test "shader bytecode fields exist" {
+    // Verify all expected bytecode fields are present.
+    _ = shader_bytecode.bg_color_vs;
+    _ = shader_bytecode.bg_color_ps;
+    _ = shader_bytecode.cell_bg_ps;
+    _ = shader_bytecode.cell_text_vs;
+    _ = shader_bytecode.cell_text_ps;
+    _ = shader_bytecode.image_vs;
+    _ = shader_bytecode.image_ps;
+    _ = shader_bytecode.bg_image_vs;
+    _ = shader_bytecode.bg_image_ps;
+}
+
+test "cell_text_input_elements count matches CellText fields" {
+    // 7 elements: glyph_pos, glyph_size, bearings, grid_pos, color, atlas, bools
+    try std.testing.expectEqual(@as(usize, 7), cell_text_input_elements.len);
+}
+
+test "image_input_elements count matches Image fields" {
+    // 4 elements: grid_pos, cell_offset, source_rect, dest_size
+    try std.testing.expectEqual(@as(usize, 4), image_input_elements.len);
+}
+
+test "bg_image_input_elements count matches BgImage fields" {
+    // 2 elements: opacity, info
+    try std.testing.expectEqual(@as(usize, 2), bg_image_input_elements.len);
+}
+
+test "cell_text byte offsets match struct layout" {
+    // Last element (bools) at offset 29 matches @offsetOf(CellText, "bools")
+    try std.testing.expectEqual(@as(u32, 29), cell_text_input_elements[6].AlignedByteOffset);
+    try std.testing.expectEqual(@as(u32, 28), cell_text_input_elements[5].AlignedByteOffset);
+    try std.testing.expectEqual(@as(u32, 24), cell_text_input_elements[4].AlignedByteOffset);
+}
+
+test "image byte offsets match struct layout" {
+    try std.testing.expectEqual(@as(u32, 32), image_input_elements[3].AlignedByteOffset);
+    try std.testing.expectEqual(@as(u32, 16), image_input_elements[2].AlignedByteOffset);
+}
+
+test "bg_image byte offsets match struct layout" {
+    try std.testing.expectEqual(@as(u32, 4), bg_image_input_elements[1].AlignedByteOffset);
+    try std.testing.expectEqual(@as(u32, 0), bg_image_input_elements[0].AlignedByteOffset);
+}
+
+test "Shaders struct fields" {
+    try std.testing.expect(@hasField(Shaders, "pipelines"));
+    try std.testing.expect(@hasField(Shaders, "post_pipelines"));
+    try std.testing.expect(@hasField(Shaders, "defunct"));
+}
+
+test "Shaders default is empty" {
+    const s: Shaders = .{};
+    try std.testing.expect(s.pipelines.bg_color.pso == null);
+    try std.testing.expect(s.pipelines.cell_text.pso == null);
+    try std.testing.expect(s.post_pipelines.len == 0);
+    try std.testing.expect(!s.defunct);
+}
+
+test "Shaders.init returns default on null device" {
+    const s = try Shaders.init(null);
+    try std.testing.expect(s.pipelines.bg_color.pso == null);
+    try std.testing.expect(s.pipelines.cell_text.pso == null);
+}
+
+test "Pipelines has all 5 fields" {
+    try std.testing.expect(@hasField(Shaders.Pipelines, "bg_color"));
+    try std.testing.expect(@hasField(Shaders.Pipelines, "cell_bg"));
+    try std.testing.expect(@hasField(Shaders.Pipelines, "cell_text"));
+    try std.testing.expect(@hasField(Shaders.Pipelines, "image"));
+    try std.testing.expect(@hasField(Shaders.Pipelines, "bg_image"));
+}
+
+test "all input elements use PER_INSTANCE_DATA" {
+    for (&cell_text_input_elements) |elem| {
+        try std.testing.expectEqual(PER_INSTANCE, elem.InputSlotClass);
+    }
+    for (&image_input_elements) |elem| {
+        try std.testing.expectEqual(PER_INSTANCE, elem.InputSlotClass);
+    }
+    for (&bg_image_input_elements) |elem| {
+        try std.testing.expectEqual(PER_INSTANCE, elem.InputSlotClass);
+    }
+}

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -171,14 +171,26 @@ const bg_image_input_elements = [_]d3d12.D3D12_INPUT_ELEMENT_DESC{
     },
 };
 
-// Verify input layouts match GPU data struct sizes and offsets.
+// Cross-reference input layout byte offsets against GPU data struct offsets.
+// gpu_data.zig already asserts struct sizes; these verify the input element
+// descriptions stay in sync with the struct layout.
 comptime {
-    std.debug.assert(@sizeOf(CellText) == 32);
-    std.debug.assert(@offsetOf(CellText, "bools") == 29);
-    std.debug.assert(@sizeOf(Image) == 40);
-    std.debug.assert(@offsetOf(Image, "dest_size") == 32);
-    std.debug.assert(@sizeOf(BgImage) == 8);
-    std.debug.assert(@offsetOf(BgImage, "info") == 4);
+    // CellText: last element (bools) must match struct offset
+    std.debug.assert(cell_text_input_elements[0].AlignedByteOffset == @offsetOf(CellText, "glyph_pos"));
+    std.debug.assert(cell_text_input_elements[1].AlignedByteOffset == @offsetOf(CellText, "glyph_size"));
+    std.debug.assert(cell_text_input_elements[2].AlignedByteOffset == @offsetOf(CellText, "bearings"));
+    std.debug.assert(cell_text_input_elements[3].AlignedByteOffset == @offsetOf(CellText, "grid_pos"));
+    std.debug.assert(cell_text_input_elements[4].AlignedByteOffset == @offsetOf(CellText, "color"));
+    std.debug.assert(cell_text_input_elements[5].AlignedByteOffset == @offsetOf(CellText, "atlas"));
+    std.debug.assert(cell_text_input_elements[6].AlignedByteOffset == @offsetOf(CellText, "bools"));
+    // Image: last element (dest_size) must match struct offset
+    std.debug.assert(image_input_elements[0].AlignedByteOffset == @offsetOf(Image, "grid_pos"));
+    std.debug.assert(image_input_elements[1].AlignedByteOffset == @offsetOf(Image, "cell_offset"));
+    std.debug.assert(image_input_elements[2].AlignedByteOffset == @offsetOf(Image, "source_rect"));
+    std.debug.assert(image_input_elements[3].AlignedByteOffset == @offsetOf(Image, "dest_size"));
+    // BgImage: info element must match struct offset
+    std.debug.assert(bg_image_input_elements[0].AlignedByteOffset == @offsetOf(BgImage, "opacity"));
+    std.debug.assert(bg_image_input_elements[1].AlignedByteOffset == @offsetOf(BgImage, "info"));
 }
 
 /// Shader management for DX12.
@@ -277,13 +289,13 @@ pub const Shaders = struct {
         }
         self.post_pipelines = &.{};
 
-        if (self.root_signature) |rs| _ = rs.Release();
-        self.root_signature = null;
-
         inline for (@typeInfo(Pipelines).@"struct".fields) |field| {
             @field(self.pipelines, field.name).deinit();
         }
         self.pipelines = .{};
+
+        if (self.root_signature) |rs| _ = rs.Release();
+        self.root_signature = null;
     }
 };
 

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -183,8 +183,8 @@ comptime {
 
 /// Shader management for DX12.
 pub const Shaders = struct {
-    /// Shared root signature owned by this Shaders instance.
-    /// All pipelines reference it but only Shaders releases it.
+    /// Shared root signature owned by this struct. Pipelines reference it
+    /// for draw-time binding but do not own it -- deinit releases it here.
     root_signature: ?*d3d12.ID3D12RootSignature = null,
     pipelines: Pipelines = .{},
     post_pipelines: []const Pipeline = &.{},
@@ -204,6 +204,14 @@ pub const Shaders = struct {
         PipelineStateCreationFailed,
     };
 
+    /// Release all PSOs that have been created so far.
+    /// Used as errdefer cleanup during init.
+    fn releasePipelines(pipelines: *Pipelines) void {
+        inline for (@typeInfo(Pipelines).@"struct".fields) |field| {
+            @field(pipelines, field.name).deinit();
+        }
+    }
+
     /// Initialize all 5 pipelines from embedded DXIL bytecode.
     /// On non-Windows, returns default-initialized (empty) pipelines.
     pub fn init(device: ?*d3d12.ID3D12Device) InitError!Shaders {
@@ -211,52 +219,52 @@ pub const Shaders = struct {
 
         // All pipelines share a single root signature.
         const root_sig = Pipeline.createRootSignature(dev) catch |err| return err;
+        errdefer _ = root_sig.Release();
+
+        var pipelines: Pipelines = .{};
+        errdefer releasePipelines(&pipelines);
+
+        pipelines.bg_color = try Pipeline.init(.{
+            .device = dev,
+            .root_signature = root_sig,
+            .vs_bytecode = shader_bytecode.bg_color_vs,
+            .ps_bytecode = shader_bytecode.bg_color_ps,
+        });
+        pipelines.cell_bg = try Pipeline.init(.{
+            .device = dev,
+            .root_signature = root_sig,
+            .vs_bytecode = shader_bytecode.bg_color_vs,
+            .ps_bytecode = shader_bytecode.cell_bg_ps,
+            .blend = .premultiplied_alpha,
+        });
+        pipelines.cell_text = try Pipeline.init(.{
+            .device = dev,
+            .root_signature = root_sig,
+            .vs_bytecode = shader_bytecode.cell_text_vs,
+            .ps_bytecode = shader_bytecode.cell_text_ps,
+            .input_layout = &cell_text_input_elements,
+            .blend = .premultiplied_alpha,
+        });
+        pipelines.image = try Pipeline.init(.{
+            .device = dev,
+            .root_signature = root_sig,
+            .vs_bytecode = shader_bytecode.image_vs,
+            .ps_bytecode = shader_bytecode.image_ps,
+            .input_layout = &image_input_elements,
+            .blend = .premultiplied_alpha,
+        });
+        pipelines.bg_image = try Pipeline.init(.{
+            .device = dev,
+            .root_signature = root_sig,
+            .vs_bytecode = shader_bytecode.bg_image_vs,
+            .ps_bytecode = shader_bytecode.bg_image_ps,
+            .input_layout = &bg_image_input_elements,
+            .blend = .premultiplied_alpha,
+        });
 
         return .{
-            .pipelines = .{
-                // bg_color: full-screen VS, no input layout, no blending.
-                .bg_color = try Pipeline.init(.{
-                    .device = dev,
-                    .root_signature = root_sig,
-                    .vs_bytecode = shader_bytecode.bg_color_vs,
-                    .ps_bytecode = shader_bytecode.bg_color_ps,
-                }),
-                // cell_bg: same full-screen VS, blended.
-                .cell_bg = try Pipeline.init(.{
-                    .device = dev,
-                    .root_signature = root_sig,
-                    .vs_bytecode = shader_bytecode.bg_color_vs,
-                    .ps_bytecode = shader_bytecode.cell_bg_ps,
-                    .blend = .premultiplied_alpha,
-                }),
-                // cell_text: instanced with CellText input layout, blended.
-                .cell_text = try Pipeline.init(.{
-                    .device = dev,
-                    .root_signature = root_sig,
-                    .vs_bytecode = shader_bytecode.cell_text_vs,
-                    .ps_bytecode = shader_bytecode.cell_text_ps,
-                    .input_layout = &cell_text_input_elements,
-                    .blend = .premultiplied_alpha,
-                }),
-                // image: instanced with Image input layout, blended.
-                .image = try Pipeline.init(.{
-                    .device = dev,
-                    .root_signature = root_sig,
-                    .vs_bytecode = shader_bytecode.image_vs,
-                    .ps_bytecode = shader_bytecode.image_ps,
-                    .input_layout = &image_input_elements,
-                    .blend = .premultiplied_alpha,
-                }),
-                // bg_image: instanced with BgImage input layout, blended.
-                .bg_image = try Pipeline.init(.{
-                    .device = dev,
-                    .root_signature = root_sig,
-                    .vs_bytecode = shader_bytecode.bg_image_vs,
-                    .ps_bytecode = shader_bytecode.bg_image_ps,
-                    .input_layout = &bg_image_input_elements,
-                    .blend = .premultiplied_alpha,
-                }),
-            },
+            .root_signature = root_sig,
+            .pipelines = pipelines,
         };
     }
 
@@ -269,19 +277,13 @@ pub const Shaders = struct {
         }
         self.post_pipelines = &.{};
 
-        // Release the shared root signature via bg_color (which owns it).
-        // Other pipelines just reference it, so only release PSOs for them.
-        if (self.pipelines.bg_color.root_signature) |rs| _ = rs.Release();
-
-        self.pipelines.bg_color.deinit();
-        self.pipelines.cell_bg.deinit();
-        self.pipelines.cell_text.deinit();
-        self.pipelines.image.deinit();
-        self.pipelines.bg_image.deinit();
-        self.pipelines = .{};
-
         if (self.root_signature) |rs| _ = rs.Release();
         self.root_signature = null;
+
+        inline for (@typeInfo(Pipelines).@"struct".fields) |field| {
+            @field(self.pipelines, field.name).deinit();
+        }
+        self.pipelines = .{};
     }
 };
 
@@ -300,39 +302,20 @@ test "shader bytecode fields exist" {
     _ = shader_bytecode.bg_image_ps;
 }
 
-test "cell_text_input_elements count matches CellText fields" {
-    // 7 elements: glyph_pos, glyph_size, bearings, grid_pos, color, atlas, bools
+test "cell_text_input_elements count" {
     try std.testing.expectEqual(@as(usize, 7), cell_text_input_elements.len);
 }
 
-test "image_input_elements count matches Image fields" {
-    // 4 elements: grid_pos, cell_offset, source_rect, dest_size
+test "image_input_elements count" {
     try std.testing.expectEqual(@as(usize, 4), image_input_elements.len);
 }
 
-test "bg_image_input_elements count matches BgImage fields" {
-    // 2 elements: opacity, info
+test "bg_image_input_elements count" {
     try std.testing.expectEqual(@as(usize, 2), bg_image_input_elements.len);
 }
 
-test "cell_text byte offsets match struct layout" {
-    // Last element (bools) at offset 29 matches @offsetOf(CellText, "bools")
-    try std.testing.expectEqual(@as(u32, 29), cell_text_input_elements[6].AlignedByteOffset);
-    try std.testing.expectEqual(@as(u32, 28), cell_text_input_elements[5].AlignedByteOffset);
-    try std.testing.expectEqual(@as(u32, 24), cell_text_input_elements[4].AlignedByteOffset);
-}
-
-test "image byte offsets match struct layout" {
-    try std.testing.expectEqual(@as(u32, 32), image_input_elements[3].AlignedByteOffset);
-    try std.testing.expectEqual(@as(u32, 16), image_input_elements[2].AlignedByteOffset);
-}
-
-test "bg_image byte offsets match struct layout" {
-    try std.testing.expectEqual(@as(u32, 4), bg_image_input_elements[1].AlignedByteOffset);
-    try std.testing.expectEqual(@as(u32, 0), bg_image_input_elements[0].AlignedByteOffset);
-}
-
 test "Shaders struct fields" {
+    try std.testing.expect(@hasField(Shaders, "root_signature"));
     try std.testing.expect(@hasField(Shaders, "pipelines"));
     try std.testing.expect(@hasField(Shaders, "post_pipelines"));
     try std.testing.expect(@hasField(Shaders, "defunct"));
@@ -340,6 +323,7 @@ test "Shaders struct fields" {
 
 test "Shaders default is empty" {
     const s: Shaders = .{};
+    try std.testing.expect(s.root_signature == null);
     try std.testing.expect(s.pipelines.bg_color.pso == null);
     try std.testing.expect(s.pipelines.cell_text.pso == null);
     try std.testing.expect(s.post_pipelines.len == 0);
@@ -348,6 +332,7 @@ test "Shaders default is empty" {
 
 test "Shaders.init returns default on null device" {
     const s = try Shaders.init(null);
+    try std.testing.expect(s.root_signature == null);
     try std.testing.expect(s.pipelines.bg_color.pso == null);
     try std.testing.expect(s.pipelines.cell_text.pso == null);
 }

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -345,6 +345,25 @@ test "Pipelines has all 5 fields" {
     try std.testing.expect(@hasField(Shaders.Pipelines, "bg_image"));
 }
 
+test "pipeline deinit loop does not touch root_signature" {
+    // Shaders.deinit releases root_signature separately, after calling
+    // deinit on each pipeline. If Pipeline.deinit ever started releasing
+    // root_signature, the second release in Shaders.deinit would
+    // double-free. This test catches that by setting a bogus
+    // root_signature that would crash if dereferenced.
+    const sentinel: *d3d12.ID3D12RootSignature = @ptrFromInt(0xDEAD_BEF0);
+    var pipelines: Shaders.Pipelines = .{};
+
+    inline for (@typeInfo(Shaders.Pipelines).@"struct".fields) |field| {
+        @field(pipelines, field.name).root_signature = sentinel;
+    }
+
+    // Same loop as Shaders.deinit -- must not dereference root_signature.
+    inline for (@typeInfo(Shaders.Pipelines).@"struct".fields) |field| {
+        @field(pipelines, field.name).deinit();
+    }
+}
+
 test "all input elements use PER_INSTANCE_DATA" {
     for (&cell_text_input_elements) |elem| {
         try std.testing.expectEqual(PER_INSTANCE, elem.InputSlotClass);


### PR DESCRIPTION
## Summary

- Replace shaders.zig stub with DXIL bytecode loading via `@embedFile` for all 9 shader blobs (5 VS + 4 PS, cell_bg shares bg_color VS)
- Input element descriptions for 3 instanced pipelines: cell_text (7 elements), image (4 elements), bg_image (2 elements)
- `Shaders.init()` creates shared root signature + all 5 PSOs with correct blend modes
- Comptime assertions verify struct sizes/offsets match input layouts

> **IMPORTANT:** This is PR 13 of a 15-PR stacked series for the DX12 pivot.
> Each PR targets its parent branch. GitHub auto-retargets when the parent merges.
>
> Stack: #107 -> #108 -> #109 -> #110 -> #113 -> #114 -> #116 -> #117 -> #118 -> #119 -> #126 -> #121 -> **this PR**

## Test plan

- [x] `zig build -Dapp-runtime=none` compiles clean
- [ ] Unit tests pass (bytecode fields, element counts, byte offsets, null-device init)