### PR TITLE
renderer: DX12 wire all 5 render pipelines end-to-end

### DIFF
--- a/example/c-win32-terminal/README.md
+++ b/example/c-win32-terminal/README.md
@@ -1,7 +1,7 @@
 # Example: Win32 Terminal (C)
 
 Minimal C program that embeds libghostty in a Win32 window.
-Uses the ghostty C API to create an app and surface with DX11
+Uses the ghostty C API to create an app and surface with DX12
 rendering. Creates the window, initializes ghostty, and forwards
 keyboard, mouse, resize, focus, and DPI events to the surface.
 

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -1,7 +1,7 @@
 // example/c-win32-terminal/src/main.c
 //
 // Minimal Win32 host for libghostty. Creates an HWND and passes it to
-// ghostty which creates a surface with DX11 rendering and ConPTY.
+// ghostty which creates a surface with DX12 rendering and ConPTY.
 // Forwards keyboard, mouse, resize, focus, and DPI events to ghostty.
 
 #define WIN32_LEAN_AND_MEAN

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -48,9 +48,8 @@ pub const descriptor_heap = @import("directx12/descriptor_heap.zig");
 pub const device = @import("directx12/device.zig");
 pub const dxgi = @import("directx12/dxgi.zig");
 
-// TODO: custom shaders not yet supported on DX12. Using .glsl as placeholder;
-// DX12 will need its own shadertoy.Target variant (.hlsl) when custom shaders
-// are implemented. Can't add it without modifying upstream shadertoy.zig.
+// Custom shaders not yet supported on DX12. Using .glsl as placeholder;
+// DX12 will need its own shadertoy.Target variant (.hlsl) -- see #129.
 pub const custom_shader_target: shadertoy.Target = .glsl;
 
 /// DX12 uses top-left origin, same as Metal and DX11.
@@ -334,8 +333,7 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     dev_ptr.command_queue.ExecuteCommandLists(1, &lists);
 
     // Present the swap chain.
-    // TODO: check for DXGI_ERROR_DEVICE_REMOVED and trigger TDR recovery
-    // once device-lost handling is implemented.
+    // Does not yet check for DXGI_ERROR_DEVICE_REMOVED -- see #130.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
         if (com.FAILED(hr)) {
@@ -371,8 +369,7 @@ pub fn setTargetSize(self: *DirectX12, width: u32, height: u32) void {
     _ = self;
     _ = width;
     _ = height;
-    // TODO: for composition surfaces, store the target size so
-    // surfaceSize() can return it (no HWND to query).
+    // Composition surfaces should store the target size -- see #131.
 }
 
 pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
@@ -380,10 +377,8 @@ pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
 
     if (dev_ptr.swap_chain) |sc| {
         // Query the swap chain's current buffer dimensions.
-        // TODO: GetDesc1 is called every frame -- cache the dimensions and
-        // only re-query on resize. For HWND surfaces, store the HWND on
-        // Device and query the client rect directly, so resize is detected
-        // before the swap chain is resized.
+        // GetDesc1 is called every frame -- should cache and re-query
+        // only on resize. See #131.
         var desc: dxgi.DXGI_SWAP_CHAIN_DESC1 = undefined;
         const hr = sc.GetDesc1(&desc);
         if (com.SUCCEEDED(hr)) {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -4,9 +4,11 @@
 //! mirroring the structure of Metal.zig, OpenGL.zig, and the previous
 //! DirectX11.zig.
 //!
-//! Current status: device init, swap chain, command queue, fence sync,
-//! clear render target, and present are functional. The window clears
-//! to the background color via the real DX12 pipeline.
+//! Current status: all 5 render pipelines (bg_color, cell_bg, cell_text,
+//! image, bg_image) are wired end-to-end. Shader-visible descriptor heaps
+//! for SRV and sampler binding are created at init. RenderPass.step()
+//! binds PSO, root signature, uniforms, textures, samplers, and instance
+//! buffers, then issues DrawInstanced calls.
 pub const DirectX12 = @This();
 
 const builtin = @import("builtin");
@@ -34,6 +36,8 @@ const bufferpkg = @import("directx12/buffer.zig");
 pub const Buffer = bufferpkg.Buffer;
 
 pub const shaders = @import("directx12/shaders.zig");
+
+const DescriptorHeap = @import("directx12/descriptor_heap.zig").DescriptorHeap;
 
 // --- Sub-module re-exports: low-level D3D12/DXGI/COM bindings ---
 
@@ -78,7 +82,13 @@ dev: ?device.Device = null,
 swap_chain3: ?*dxgi.IDXGISwapChain3 = null,
 
 /// RTV descriptor heap for swap chain back buffers.
-rtv_heap: ?descriptor_heap.DescriptorHeap = null,
+rtv_heap: ?DescriptorHeap = null,
+
+/// Shader-visible CBV/SRV/UAV descriptor heap for textures and buffers.
+srv_heap: ?DescriptorHeap = null,
+
+/// Shader-visible sampler descriptor heap.
+sampler_heap: ?DescriptorHeap = null,
 
 /// Per-frame command recording contexts (triple buffered).
 gpu_frames: [device.Device.frame_count]?Frame = .{ null, null, null },
@@ -164,7 +174,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     };
 
     // Create RTV descriptor heap for back buffers.
-    result.rtv_heap = descriptor_heap.DescriptorHeap.init(
+    result.rtv_heap = DescriptorHeap.init(
         dev_ptr.device,
         .RTV,
         device.Device.frame_count,
@@ -176,6 +186,37 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     errdefer {
         result.rtv_heap.?.deinit();
         result.rtv_heap = null;
+    }
+
+    // Shader-visible CBV/SRV/UAV heap for texture SRVs.
+    // 64 slots is enough for atlas textures + custom shader textures.
+    result.srv_heap = DescriptorHeap.init(
+        dev_ptr.device,
+        .CBV_SRV_UAV,
+        64,
+        true,
+    ) catch |err| {
+        log.err("SRV descriptor heap creation failed: {}", .{err});
+        return error.DescriptorHeapCreationFailed;
+    };
+    errdefer {
+        result.srv_heap.?.deinit();
+        result.srv_heap = null;
+    }
+
+    // Shader-visible sampler heap for texture sampling.
+    result.sampler_heap = DescriptorHeap.init(
+        dev_ptr.device,
+        .SAMPLER,
+        16,
+        true,
+    ) catch |err| {
+        log.err("Sampler descriptor heap creation failed: {}", .{err});
+        return error.DescriptorHeapCreationFailed;
+    };
+    errdefer {
+        result.sampler_heap.?.deinit();
+        result.sampler_heap = null;
     }
 
     // Get back buffer resources and create RTVs.
@@ -243,6 +284,16 @@ pub fn deinit(self: *DirectX12) void {
         }
     }
 
+    if (self.sampler_heap) |*h| {
+        h.deinit();
+        self.sampler_heap = null;
+    }
+
+    if (self.srv_heap) |*h| {
+        h.deinit();
+        self.srv_heap = null;
+    }
+
     if (self.rtv_heap) |*h| {
         h.deinit();
         self.rtv_heap = null;
@@ -300,10 +351,10 @@ pub fn initShaders(
     alloc: Allocator,
     custom_shaders: []const [:0]const u8,
 ) !shaders.Shaders {
-    _ = self;
     _ = alloc;
     _ = custom_shaders;
-    return .{};
+    const dev_device = if (self.dev) |*d| d.device else null;
+    return shaders.Shaders.init(dev_device);
 }
 
 pub fn setTargetSize(self: *DirectX12, width: u32, height: u32) void {
@@ -422,13 +473,18 @@ pub inline fn uniformBufferOptions(self: DirectX12) bufferpkg.Options {
 }
 
 pub inline fn textureOptions(self: DirectX12) Texture.Options {
-    _ = self;
-    return .{};
+    return .{
+        .device = if (self.dev) |*d| d.device else null,
+        .command_list = self.pending_command_list,
+        .srv_heap = if (self.srv_heap) |*h| @constCast(h) else null,
+    };
 }
 
 pub inline fn samplerOptions(self: DirectX12) Sampler.Options {
-    _ = self;
-    return .{};
+    return .{
+        .device = if (self.dev) |*d| d.device else null,
+        .sampler_heap = if (self.sampler_heap) |*h| @constCast(h) else null,
+    };
 }
 
 pub inline fn imageTextureOptions(
@@ -436,18 +492,37 @@ pub inline fn imageTextureOptions(
     format: ImageTextureFormat,
     srgb: bool,
 ) Texture.Options {
-    _ = self;
-    _ = format;
-    _ = srgb;
-    return .{};
+    _ = srgb; // DX12 sRGB handled by the render target format, not texture views.
+    return .{
+        .device = if (self.dev) |*d| d.device else null,
+        .command_list = self.pending_command_list,
+        .srv_heap = if (self.srv_heap) |*h| @constCast(h) else null,
+        .pixel_format = switch (format) {
+            .gray => .R8_UNORM,
+            .rgba => .R8G8B8A8_UNORM,
+            .bgra => .B8G8R8A8_UNORM,
+        },
+    };
 }
 
 pub fn initAtlasTexture(
     self: *const DirectX12,
     atlas: *const font.Atlas,
 ) Texture.Error!Texture {
-    _ = self;
-    return .{ .width = @intCast(atlas.size) };
+    const size: usize = @intCast(atlas.size);
+    const pixel_format: dxgi.DXGI_FORMAT = switch (atlas.format) {
+        .grayscale => .R8_UNORM,
+        .bgra => .B8G8R8A8_UNORM,
+        // BGR has no direct DXGI format; use BGRA and let the atlas
+        // handle depth conversion when uploading.
+        .bgr => .B8G8R8A8_UNORM,
+    };
+    return Texture.init(.{
+        .device = if (self.dev) |*d| d.device else null,
+        .command_list = self.pending_command_list,
+        .srv_heap = if (self.srv_heap) |*h| @constCast(h) else null,
+        .pixel_format = pixel_format,
+    }, size, size, null);
 }
 
 test {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -69,6 +69,17 @@ pub const ImageTextureFormat = enum {
     bgra,
 };
 
+
+/// Number of CBV/SRV/UAV descriptors in the shader-visible heap.
+/// Covers: font atlas (grayscale + color), grid texture, image textures,
+/// and up to ~50 custom shader textures. Will need tuning if custom
+/// shaders exceed this.
+const srv_heap_capacity: u32 = 64;
+
+/// Number of sampler descriptors in the shader-visible heap.
+/// Covers: default point/linear samplers + per-pipeline overrides.
+const sampler_heap_capacity: u32 = 16;
+
 // --- GraphicsAPI contract: mutable state ---
 
 /// Runtime blending mode, set by GenericRenderer when config changes.
@@ -189,11 +200,10 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     }
 
     // Shader-visible CBV/SRV/UAV heap for texture SRVs.
-    // 64 slots is enough for atlas textures + custom shader textures.
     result.srv_heap = DescriptorHeap.init(
         dev_ptr.device,
         .CBV_SRV_UAV,
-        64,
+        srv_heap_capacity,
         true,
     ) catch |err| {
         log.err("SRV descriptor heap creation failed: {}", .{err});
@@ -208,7 +218,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     result.sampler_heap = DescriptorHeap.init(
         dev_ptr.device,
         .SAMPLER,
-        16,
+        sampler_heap_capacity,
         true,
     ) catch |err| {
         log.err("Sampler descriptor heap creation failed: {}", .{err});
@@ -476,6 +486,7 @@ pub inline fn textureOptions(self: DirectX12) Texture.Options {
     return .{
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,
+        // @constCast is safe: DescriptorHeap wraps a COM object on the heap.
         .srv_heap = if (self.srv_heap) |*h| @constCast(h) else null,
     };
 }
@@ -483,6 +494,7 @@ pub inline fn textureOptions(self: DirectX12) Texture.Options {
 pub inline fn samplerOptions(self: DirectX12) Sampler.Options {
     return .{
         .device = if (self.dev) |*d| d.device else null,
+        // @constCast is safe: DescriptorHeap wraps a COM object on the heap.
         .sampler_heap = if (self.sampler_heap) |*h| @constCast(h) else null,
     };
 }
@@ -496,6 +508,7 @@ pub inline fn imageTextureOptions(
     return .{
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,
+        // @constCast is safe: DescriptorHeap wraps a COM object on the heap.
         .srv_heap = if (self.srv_heap) |*h| @constCast(h) else null,
         .pixel_format = switch (format) {
             .gray => .R8_UNORM,
@@ -520,6 +533,7 @@ pub fn initAtlasTexture(
     return Texture.init(.{
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,
+        // @constCast is safe: DescriptorHeap wraps a COM object on the heap.
         .srv_heap = if (self.srv_heap) |*h| @constCast(h) else null,
         .pixel_format = pixel_format,
     }, size, size, null);

--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -139,12 +139,19 @@ pub fn renderPass(
         // begin/step/complete will be no-ops without a command list.
         return .{
             .command_list = null,
+            .srv_heap = null,
+            .sampler_heap = null,
             .attachments = attachments,
             .step_number = 0,
         };
     };
+    // Pass GPU-visible descriptor heaps from the DirectX12 API so
+    // RenderPass.step() can bind SRV and sampler tables.
+    const api = &self.renderer.api;
     return RenderPass.begin(.{
         .command_list = cl,
+        .srv_heap = if (api.srv_heap) |*h| @constCast(h) else null,
+        .sampler_heap = if (api.sampler_heap) |*h| @constCast(h) else null,
         .attachments = attachments,
     });
 }

--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -39,8 +39,7 @@ fn hrFmt(hr: HRESULT) u32 {
 command_allocator: ?*d3d12.ID3D12CommandAllocator,
 command_list: ?*d3d12.ID3D12GraphicsCommandList,
 /// Fence value for GPU synchronization.
-/// TODO: fence wait is the caller's responsibility -- will be wired
-/// when the frame pool lands in a later PR.
+/// Caller must wait on this before reusing the frame -- see #132.
 fence_value: u64,
 
 renderer: *Renderer,

--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -146,7 +146,8 @@ pub fn renderPass(
         };
     };
     // Pass GPU-visible descriptor heaps from the DirectX12 API so
-    // RenderPass.step() can bind SRV and sampler tables.
+    // RenderPass.begin() can bind them via SetDescriptorHeaps before
+    // any root descriptor table calls.
     const api = &self.renderer.api;
     return RenderPass.begin(.{
         .command_list = cl,

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -237,10 +237,9 @@ pub fn step(self: *RenderPass, s: Step) void {
     }
 
     // Bind the first buffer as the instance vertex buffer.
-    // TODO: Metal binds buffers[0] as vertex+fragment at index 0, then
-    // buffers[1..] at index 2+. OpenGL uses SSBOs for the rest. DX12
-    // will need root descriptor table entries for storage buffers when
-    // pipelines that use multiple buffers (e.g. cell_text) are wired.
+    // Only the first non-null buffer with a stride is bound as a VB.
+    // Multi-buffer pipelines (e.g. cell_text) will need root descriptor
+    // table entries for storage buffers -- see #128.
     for (s.buffers) |b| {
         if (b) |buf| {
             if (buf.gpu_address != 0 and buf.size > 0 and buf.stride > 0) {

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -10,6 +10,7 @@ const RenderPass = @This();
 const d3d12 = @import("d3d12.zig");
 const ResourceStates = d3d12.D3D12_RESOURCE_STATES;
 
+const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
 const Pipeline = @import("Pipeline.zig");
 const Sampler = @import("Sampler.zig");
 const Target = @import("Target.zig");
@@ -21,6 +22,10 @@ const RawBuffer = bufferpkg.RawBuffer;
 pub const Options = struct {
     /// The command list to record into.
     command_list: *d3d12.ID3D12GraphicsCommandList,
+    /// Shader-visible CBV/SRV/UAV descriptor heap.
+    srv_heap: ?*DescriptorHeap = null,
+    /// Shader-visible sampler descriptor heap.
+    sampler_heap: ?*DescriptorHeap = null,
     /// Color attachments for this render pass.
     attachments: []const Attachment,
 
@@ -55,6 +60,8 @@ pub const Step = struct {
 };
 
 command_list: ?*d3d12.ID3D12GraphicsCommandList,
+srv_heap: ?*DescriptorHeap,
+sampler_heap: ?*DescriptorHeap,
 attachments: []const Options.Attachment,
 step_number: usize,
 
@@ -144,22 +151,110 @@ pub fn begin(opts: Options) RenderPass {
         cl.RSSetScissorRects(1, @ptrCast(&scissor));
     }
 
+    // Bind GPU-visible descriptor heaps for the duration of this pass.
+    // DX12 requires SetDescriptorHeaps before any SetGraphicsRootDescriptorTable.
+    var heap_count: u32 = 0;
+    var heaps: [2]*d3d12.ID3D12DescriptorHeap = undefined;
+    if (opts.srv_heap) |h| {
+        heaps[heap_count] = h.heap;
+        heap_count += 1;
+    }
+    if (opts.sampler_heap) |h| {
+        heaps[heap_count] = h.heap;
+        heap_count += 1;
+    }
+    if (heap_count > 0) {
+        cl.SetDescriptorHeaps(heap_count, &heaps);
+    }
+
     return .{
         .command_list = cl,
+        .srv_heap = opts.srv_heap,
+        .sampler_heap = opts.sampler_heap,
         .attachments = opts.attachments,
         .step_number = 0,
     };
 }
 
-/// Add a step to this render pass.
+/// Add a step to this render pass. Binds the pipeline, resources,
+/// and issues a DrawInstanced call.
 /// No-op if the render pass has no command list (stub path).
 pub fn step(self: *RenderPass, s: Step) void {
-    if (self.command_list == null) return;
+    const cl = self.command_list orelse return;
     if (s.draw.instance_count == 0) return;
+    const pso = s.pipeline.pso orelse return;
+    const root_sig = s.pipeline.root_signature orelse return;
 
-    // Pipeline, buffer bindings, texture/sampler bindings will be
-    // wired when Pipeline.zig, buffer.zig, Texture.zig, and
-    // Sampler.zig get their real implementations.
+    // Bind pipeline state and root signature.
+    cl.SetPipelineState(pso);
+    cl.SetGraphicsRootSignature(root_sig);
+
+    // Set primitive topology.
+    cl.IASetPrimitiveTopology(switch (s.draw.type) {
+        .triangle => .TRIANGLELIST,
+        .triangle_strip => .TRIANGLESTRIP,
+    });
+
+    // Bind uniforms as inline CBV at root parameter 0.
+    if (s.uniforms) |buf| {
+        if (buf.gpu_address != 0) {
+            cl.SetGraphicsRootConstantBufferView(
+                Pipeline.root_param_cbv,
+                buf.gpu_address,
+            );
+        }
+    }
+
+    // Bind textures via the SRV descriptor table at root parameter 1.
+    // Use the GPU handle of the first texture's SRV descriptor.
+    for (s.textures) |t| {
+        if (t) |tex| {
+            if (tex.srv.gpu.ptr != 0) {
+                cl.SetGraphicsRootDescriptorTable(
+                    Pipeline.root_param_srv_table,
+                    tex.srv.gpu,
+                );
+                break;
+            }
+        }
+    }
+
+    // Bind samplers via the sampler descriptor table at root parameter 2.
+    for (s.samplers) |samp| {
+        if (samp) |sampler| {
+            if (sampler.descriptor.gpu.ptr != 0) {
+                cl.SetGraphicsRootDescriptorTable(
+                    Pipeline.root_param_sampler_table,
+                    sampler.descriptor.gpu,
+                );
+                break;
+            }
+        }
+    }
+
+    // Set vertex buffer view for instance data (first non-null buffer
+    // with a non-zero stride, which indicates it carries per-instance data).
+    for (s.buffers) |b| {
+        if (b) |buf| {
+            if (buf.gpu_address != 0 and buf.size > 0 and buf.stride > 0) {
+                const vbv = d3d12.D3D12_VERTEX_BUFFER_VIEW{
+                    .BufferLocation = buf.gpu_address,
+                    .SizeInBytes = buf.size,
+                    .StrideInBytes = buf.stride,
+                };
+                cl.IASetVertexBuffers(0, 1, @ptrCast(&vbv));
+                break;
+            }
+        }
+    }
+
+    // Issue the draw call.
+    cl.DrawInstanced(
+        @intCast(s.draw.vertex_count),
+        @intCast(s.draw.instance_count),
+        0,
+        0,
+    );
 
     self.step_number += 1;
 }
@@ -189,6 +284,8 @@ const std = @import("std");
 
 test "RenderPass struct fields" {
     try std.testing.expect(@hasField(RenderPass, "command_list"));
+    try std.testing.expect(@hasField(RenderPass, "srv_heap"));
+    try std.testing.expect(@hasField(RenderPass, "sampler_heap"));
     try std.testing.expect(@hasField(RenderPass, "attachments"));
     try std.testing.expect(@hasField(RenderPass, "step_number"));
 }

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -205,8 +205,11 @@ pub fn step(self: *RenderPass, s: Step) void {
         }
     }
 
-    // Bind textures via the SRV descriptor table at root parameter 1.
-    // Use the GPU handle of the first texture's SRV descriptor.
+    // Bind the SRV descriptor table at root parameter 1.
+    // The root signature declares a contiguous range of srv_table_size (3)
+    // descriptors. Unlike Metal which binds textures individually at indices,
+    // DX12 binds the whole table from one base GPU handle. Textures must be
+    // allocated contiguously in the SRV heap so the range covers all slots.
     for (s.textures) |t| {
         if (t) |tex| {
             if (tex.srv.gpu.ptr != 0) {
@@ -219,7 +222,8 @@ pub fn step(self: *RenderPass, s: Step) void {
         }
     }
 
-    // Bind samplers via the sampler descriptor table at root parameter 2.
+    // Bind the sampler descriptor table at root parameter 2.
+    // Same table-based binding as textures -- one call covers s0.
     for (s.samplers) |samp| {
         if (samp) |sampler| {
             if (sampler.descriptor.gpu.ptr != 0) {
@@ -232,8 +236,11 @@ pub fn step(self: *RenderPass, s: Step) void {
         }
     }
 
-    // Set vertex buffer view for instance data (first non-null buffer
-    // with a non-zero stride, which indicates it carries per-instance data).
+    // Bind the first buffer as the instance vertex buffer.
+    // TODO: Metal binds buffers[0] as vertex+fragment at index 0, then
+    // buffers[1..] at index 2+. OpenGL uses SSBOs for the rest. DX12
+    // will need root descriptor table entries for storage buffers when
+    // pipelines that use multiple buffers (e.g. cell_text) are wired.
     for (s.buffers) |b| {
         if (b) |buf| {
             if (buf.gpu_address != 0 and buf.size > 0 and buf.stride > 0) {

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -24,6 +24,9 @@ pub const Options = struct {
 /// Type-erased buffer handle for passing to RenderPass.Step.
 /// Holds the GPU virtual address, total size, and per-element stride
 /// needed for vertex buffer view binding.
+/// Both size and stride are u32 to match D3D12_VERTEX_BUFFER_VIEW's
+/// SizeInBytes/StrideInBytes fields (UINT). Terminal buffers are well
+/// under the 4GB limit so @intCast from usize is always safe here.
 pub const RawBuffer = struct {
     gpu_address: u64 = 0,
     size: u32 = 0,

--- a/src/renderer/directx12/buffer.zig
+++ b/src/renderer/directx12/buffer.zig
@@ -22,10 +22,12 @@ pub const Options = struct {
 };
 
 /// Type-erased buffer handle for passing to RenderPass.Step.
-/// Holds the GPU virtual address and size needed for binding.
+/// Holds the GPU virtual address, total size, and per-element stride
+/// needed for vertex buffer view binding.
 pub const RawBuffer = struct {
     gpu_address: u64 = 0,
-    size: u64 = 0,
+    size: u32 = 0,
+    stride: u32 = 0,
 };
 
 /// DX12 GPU data buffer for a set of equal-typed elements.
@@ -183,7 +185,8 @@ pub fn Buffer(comptime T: type) type {
             self.len = len;
             self.buffer = .{
                 .gpu_address = res.GetGPUVirtualAddress(),
-                .size = byte_size,
+                .size = @intCast(byte_size),
+                .stride = @sizeOf(T),
             };
         }
 


### PR DESCRIPTION
> **IMPORTANT:** This is PR 14/15 in the DX12 pivot stack.
> Full stack: #107 > #108 > #109 > #110 > #113 > #114 > #116 > #117 > #118 > #119 > #126 > #121 > #122 > this PR > PR 15 (gpu_test)

## Summary

- RenderPass.step() binds PSO, root signature, uniforms, textures, samplers, and instance buffers, then issues DrawInstanced
- Shader-visible CBV/SRV/UAV (64 slots) and sampler (16 slots) descriptor heaps created at init
- initShaders() creates the 5 PSOs (bg_color, cell_bg, cell_text, image, bg_image) via Shaders.init()
- Texture/sampler/image options wired with device and heap pointers so atlas textures get real SRV descriptors
- RawBuffer gains a stride field for vertex buffer view binding

## Test plan

- [x] `zig build -Dapp-runtime=none` compiles
- [x] `zig build test -Dapp-runtime=none` passes
- [ ] Visual verification with Win32 example -- blocked on #133 (pre-existing surface creation crash)