### PR TITLE
renderer: DX12 Texture (DEFAULT heap + staging) and Sampler (descriptor)

### DIFF
--- a/src/renderer/directx12/Sampler.zig
+++ b/src/renderer/directx12/Sampler.zig
@@ -1,19 +1,80 @@
-//! DX12 texture sampler stub.
+//! DX12 texture sampler backed by a descriptor in the sampler heap.
 //!
-//! Will be replaced with a real implementation using a sampler descriptor
-//! in a GPU-visible descriptor heap.
+//! In DX12, samplers are not standalone objects -- they are descriptors
+//! written into a GPU-visible sampler heap. This struct tracks the
+//! descriptor index and handles so the sampler can be bound via
+//! SetGraphicsRootDescriptorTable.
+const Sampler = @This();
 
-pub const Options = struct {};
+const std = @import("std");
+
+const d3d12 = @import("d3d12.zig");
+const com = @import("com.zig");
+const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
+
+const log = std.log.scoped(.directx12);
+
+pub const Options = struct {
+    device: ?*d3d12.ID3D12Device = null,
+    sampler_heap: ?*DescriptorHeap = null,
+    filter: d3d12.D3D12_FILTER = .MIN_MAG_MIP_LINEAR,
+    address_mode_u: d3d12.D3D12_TEXTURE_ADDRESS_MODE = .CLAMP,
+    address_mode_v: d3d12.D3D12_TEXTURE_ADDRESS_MODE = .CLAMP,
+};
 
 pub const Error = error{
     SamplerCreateFailed,
 };
 
-pub fn init(opts: Options) Error!@This() {
-    _ = opts;
-    return .{};
+/// Descriptor handle for binding this sampler to the pipeline.
+descriptor: DescriptorHeap.Descriptor = .{
+    .cpu = .{ .ptr = 0 },
+    .gpu = .{ .ptr = 0 },
+    .index = 0,
+},
+
+pub fn init(opts: Options) Error!Sampler {
+    const device = opts.device orelse return error.SamplerCreateFailed;
+    const sampler_heap = opts.sampler_heap orelse return error.SamplerCreateFailed;
+
+    const desc = sampler_heap.allocate() catch return error.SamplerCreateFailed;
+
+    const sampler_desc = d3d12.D3D12_SAMPLER_DESC{
+        .Filter = opts.filter,
+        .AddressU = opts.address_mode_u,
+        .AddressV = opts.address_mode_v,
+        .AddressW = .CLAMP,
+        .MipLODBias = 0.0,
+        .MaxAnisotropy = 1,
+        .ComparisonFunc = .NEVER,
+        .BorderColor = .{ 0.0, 0.0, 0.0, 0.0 },
+        .MinLOD = 0.0,
+        .MaxLOD = 0.0,
+    };
+    device.CreateSampler(&sampler_desc, desc.cpu);
+
+    return .{
+        .descriptor = desc,
+    };
 }
 
-pub fn deinit(self: @This()) void {
+pub fn deinit(self: Sampler) void {
+    // Sampler descriptors are owned by the heap's linear allocator --
+    // freed when the heap is destroyed.
     _ = self;
+}
+
+// --- Tests ---
+
+test "Sampler struct fields" {
+    try std.testing.expect(@hasField(Sampler, "descriptor"));
+}
+
+test "Sampler.Options defaults" {
+    const opts = Options{};
+    try std.testing.expect(opts.device == null);
+    try std.testing.expect(opts.sampler_heap == null);
+    try std.testing.expectEqual(d3d12.D3D12_FILTER.MIN_MAG_MIP_LINEAR, opts.filter);
+    try std.testing.expectEqual(d3d12.D3D12_TEXTURE_ADDRESS_MODE.CLAMP, opts.address_mode_u);
+    try std.testing.expectEqual(d3d12.D3D12_TEXTURE_ADDRESS_MODE.CLAMP, opts.address_mode_v);
 }

--- a/src/renderer/directx12/Sampler.zig
+++ b/src/renderer/directx12/Sampler.zig
@@ -9,7 +9,6 @@ const Sampler = @This();
 const std = @import("std");
 
 const d3d12 = @import("d3d12.zig");
-const com = @import("com.zig");
 const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
 
 const log = std.log.scoped(.directx12);

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -51,7 +51,7 @@ device: ?*d3d12.ID3D12Device = null,
 /// Cached command list for replaceRegion uploads.
 command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
 /// Current resource state for barrier tracking.
-state: d3d12.D3D12_RESOURCE_STATES = d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+state: d3d12.D3D12_RESOURCE_STATES = d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE,
 
 const TEXTURE_DATA_PITCH_ALIGNMENT: u32 = 256;
 
@@ -67,6 +67,8 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
     errdefer _ = resource.Release();
 
     // Allocate SRV descriptor.
+    // Note: the linear allocator has no individual free, so a failed init()
+    // after this point permanently consumes one descriptor slot.
     const srv = srv_heap.allocate() catch return error.TextureCreateFailed;
 
     // Create the SRV.
@@ -97,7 +99,7 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
         .command_list = opts.command_list,
         // Texture starts in COPY_DEST so the initial upload (if any) can proceed
         // without a barrier. After the upload we transition to PIXEL_SHADER_RESOURCE.
-        .state = d3d12.D3D12_RESOURCE_STATE_COPY_DEST,
+        .state = d3d12.D3D12_RESOURCE_STATES.COPY_DEST,
     };
 
     // Upload initial data if provided.
@@ -106,7 +108,7 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
     }
     // Transition to shader-readable. The texture was created in COPY_DEST
     // so the initial upload (if any) could proceed without a barrier.
-    tex.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    tex.transition(d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE);
 
     return tex;
 }
@@ -120,26 +122,41 @@ pub fn deinit(self: Texture) void {
 }
 
 /// Upload pixel data to a sub-region of this texture.
-/// The staging buffer is recorded on the command list; the caller
-/// must execute and wait before the staging memory becomes invalid.
+///
+/// Precondition: the command list must be executed and the GPU must
+/// finish before this texture is used for rendering. In practice,
+/// GenericRenderer calls waitForGpu() after each frame which satisfies
+/// this requirement.
+///
+/// Returns error{}!void for API compatibility with Metal's replaceRegion
+/// which cannot fail. DX12 upload failures are logged but not propagated.
 pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
     // Transition to COPY_DEST if needed.
-    if (self.state != d3d12.D3D12_RESOURCE_STATE_COPY_DEST) {
-        self.transition(d3d12.D3D12_RESOURCE_STATE_COPY_DEST);
+    if (self.state != d3d12.D3D12_RESOURCE_STATES.COPY_DEST) {
+        self.transition(d3d12.D3D12_RESOURCE_STATES.COPY_DEST);
     }
 
     self.uploadRegion(@intCast(x), @intCast(y), @intCast(width), @intCast(height), data);
 
     // Transition back to shader-readable.
-    self.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    self.transition(d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE);
 }
 
 // --- Internal helpers ---
 
 fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: []const u8) void {
-    const device = self.device orelse return;
-    const cmd_list = self.command_list orelse return;
-    const texture = self.resource orelse return;
+    const device = self.device orelse {
+        log.err("uploadRegion called with null device", .{});
+        return;
+    };
+    const cmd_list = self.command_list orelse {
+        log.err("uploadRegion called with null command_list", .{});
+        return;
+    };
+    const texture = self.resource orelse {
+        log.err("uploadRegion called with null resource", .{});
+        return;
+    };
 
     const region_aligned_pitch = alignPitch(width * self.bpp);
     const staging_size: u64 = @as(u64, region_aligned_pitch) * @as(u64, height);
@@ -208,10 +225,10 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
 
     cmd_list.CopyTextureRegion(&dst_loc, x, y, 0, &src_loc, &src_box);
 
-    // Release staging buffer. The copy command has been recorded; the GPU
-    // will read from this memory when the command list executes. This is
-    // safe because we release the COM reference AFTER recording -- the
-    // runtime keeps the resource alive until the GPU finishes the copy.
+    // Release staging buffer. DX12 does NOT extend resource lifetimes for
+    // recorded commands (unlike D3D11). This Release is only safe because
+    // the caller ensures the command list is executed and the GPU finishes
+    // before the texture is used again (GenericRenderer.waitForGpu).
     _ = staging.Release();
 }
 
@@ -265,9 +282,9 @@ fn createTextureResource(device: *d3d12.ID3D12Device, width: u32, height: u32, f
         &heap_props,
         0,
         &desc,
-        d3d12.D3D12_RESOURCE_STATE_COPY_DEST,
+        d3d12.D3D12_RESOURCE_STATES.COPY_DEST,
         null,
-        &d3d12.IID_ID3D12Resource,
+        &d3d12.ID3D12Resource.IID,
         @ptrCast(&resource),
     );
     if (com.FAILED(hr)) {
@@ -304,9 +321,9 @@ fn createStagingBuffer(device: *d3d12.ID3D12Device, size: u64) ?*d3d12.ID3D12Res
         &heap_props,
         0,
         &desc,
-        d3d12.D3D12_RESOURCE_STATE_GENERIC_READ,
+        d3d12.D3D12_RESOURCE_STATES.GENERIC_READ,
         null,
-        &d3d12.IID_ID3D12Resource,
+        &d3d12.ID3D12Resource.IID,
         @ptrCast(&resource),
     );
     if (com.FAILED(hr)) {
@@ -325,8 +342,8 @@ fn bppForFormat(format: dxgi.DXGI_FORMAT) u32 {
         .R8_UNORM => 1,
         .R8G8B8A8_UNORM, .B8G8R8A8_UNORM => 4,
         else => {
-            log.warn("unhandled pixel format in bppForFormat, defaulting to 4 bpp", .{});
-            break :switch 4;
+            log.err("unhandled pixel format in bppForFormat, defaulting to 4 bpp", .{});
+            return 4;
         },
     };
 }

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -103,12 +103,10 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
     // Upload initial data if provided.
     if (data) |pixels| {
         tex.uploadRegion(0, 0, @intCast(width), @intCast(height), pixels);
-        // Transition to shader-readable after the initial upload.
-        tex.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-    } else {
-        // No initial data -- transition to shader-readable immediately.
-        tex.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     }
+    // Transition to shader-readable. The texture was created in COPY_DEST
+    // so the initial upload (if any) could proceed without a barrier.
+    tex.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
     return tex;
 }
@@ -147,7 +145,10 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
     const staging_size: u64 = @as(u64, region_aligned_pitch) * @as(u64, height);
 
     // Create a temporary upload buffer for staging.
-    const staging = createStagingBuffer(device, staging_size) orelse return;
+    const staging = createStagingBuffer(device, staging_size) orelse {
+        log.err("failed to create staging buffer for texture upload (size={d})", .{staging_size});
+        return;
+    };
     // The staging buffer will be released after the command list executes.
     // For now we rely on the caller to manage staging lifetime via GPU sync.
     // In practice, GenericRenderer calls waitForGpu() after each frame.
@@ -157,6 +158,7 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
     const read_range = d3d12.D3D12_RANGE{ .Begin = 0, .End = 0 };
     const map_hr = staging.Map(0, &read_range, &mapped);
     if (com.FAILED(map_hr) or mapped == null) {
+        log.err("Map for staging buffer failed: 0x{x}", .{@as(u32, @bitCast(map_hr))});
         _ = staging.Release();
         return;
     }
@@ -174,7 +176,7 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
     // Record the copy command.
     const src_loc = d3d12.D3D12_TEXTURE_COPY_LOCATION{
         .pResource = staging,
-        .Type = 1, // D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT
+        .Type = .PLACED_FOOTPRINT,
         .u = .{
             .PlacedFootprint = .{
                 .Offset = 0,
@@ -191,7 +193,7 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
 
     const dst_loc = d3d12.D3D12_TEXTURE_COPY_LOCATION{
         .pResource = texture,
-        .Type = 0, // D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX
+        .Type = .SUBRESOURCE_INDEX,
         .u = .{ .SubresourceIndex = 0 },
     };
 
@@ -322,7 +324,10 @@ fn bppForFormat(format: dxgi.DXGI_FORMAT) u32 {
     return switch (format) {
         .R8_UNORM => 1,
         .R8G8B8A8_UNORM, .B8G8R8A8_UNORM => 4,
-        else => 4,
+        else => {
+            log.warn("unhandled pixel format in bppForFormat, defaulting to 4 bpp", .{});
+            break :switch 4;
+        },
     };
 }
 

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -1,9 +1,28 @@
-//! DX12 GPU texture stub.
+//! DX12 GPU texture backed by a committed resource in DEFAULT heap.
 //!
-//! Will be replaced with a real implementation wrapping an
-//! ID3D12Resource (committed texture) and SRV descriptor.
+//! GPU-only memory (D3D12_HEAP_TYPE_DEFAULT). Uploads go through a
+//! staging buffer in UPLOAD heap, copied via CopyTextureRegion on the
+//! provided command list. The caller is responsible for executing the
+//! command list and waiting for the GPU before releasing the staging buffer.
+//!
+//! Each texture owns an SRV descriptor allocated from the CBV/SRV/UAV heap.
+const Texture = @This();
 
-pub const Options = struct {};
+const std = @import("std");
+
+const d3d12 = @import("d3d12.zig");
+const dxgi = @import("dxgi.zig");
+const com = @import("com.zig");
+const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
+
+const log = std.log.scoped(.directx12);
+
+pub const Options = struct {
+    device: ?*d3d12.ID3D12Device = null,
+    command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
+    srv_heap: ?*DescriptorHeap = null,
+    pixel_format: dxgi.DXGI_FORMAT = .R8_UNORM,
+};
 
 pub const Error = error{
     TextureCreateFailed,
@@ -11,24 +30,330 @@ pub const Error = error{
 
 /// Width of this texture in pixels.
 width: usize = 0,
+/// Height of this texture in pixels.
+height: usize = 0,
+/// Bytes per pixel, derived from the pixel format.
+bpp: u32 = 1,
+/// The GPU texture resource (DEFAULT heap).
+resource: ?*d3d12.ID3D12Resource = null,
+/// SRV descriptor for shader binding.
+srv: DescriptorHeap.Descriptor = .{
+    .cpu = .{ .ptr = 0 },
+    .gpu = .{ .ptr = 0 },
+    .index = 0,
+},
+/// Row pitch aligned to D3D12_TEXTURE_DATA_PITCH_ALIGNMENT (256 bytes).
+aligned_row_pitch: u32 = 0,
+/// Pixel format of this texture.
+format: dxgi.DXGI_FORMAT = .R8_UNORM,
+/// Cached device pointer for replaceRegion uploads.
+device: ?*d3d12.ID3D12Device = null,
+/// Cached command list for replaceRegion uploads.
+command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
+/// Current resource state for barrier tracking.
+state: d3d12.D3D12_RESOURCE_STATES = d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
 
-pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error!@This() {
-    _ = opts;
-    _ = height;
-    _ = data;
-    return .{ .width = width };
+const TEXTURE_DATA_PITCH_ALIGNMENT: u32 = 256;
+
+pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error!Texture {
+    const device = opts.device orelse return error.TextureCreateFailed;
+    const srv_heap = opts.srv_heap orelse return error.TextureCreateFailed;
+
+    const bpp: u32 = bppForFormat(opts.pixel_format);
+    const aligned_row_pitch = alignPitch(@intCast(width * bpp));
+
+    // Create the GPU-only texture resource.
+    const resource = createTextureResource(device, @intCast(width), @intCast(height), opts.pixel_format) orelse return error.TextureCreateFailed;
+    errdefer _ = resource.Release();
+
+    // Allocate SRV descriptor.
+    const srv = srv_heap.allocate() catch return error.TextureCreateFailed;
+
+    // Create the SRV.
+    const srv_desc = d3d12.D3D12_SHADER_RESOURCE_VIEW_DESC{
+        .Format = opts.pixel_format,
+        .ViewDimension = .TEXTURE2D,
+        .Shader4ComponentMapping = d3d12.D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+        .u = .{
+            .Texture2D = .{
+                .MostDetailedMip = 0,
+                .MipLevels = 1,
+                .PlaneSlice = 0,
+                .ResourceMinLODClamp = 0.0,
+            },
+        },
+    };
+    device.CreateShaderResourceView(resource, &srv_desc, srv.cpu);
+
+    var tex = Texture{
+        .width = width,
+        .height = height,
+        .bpp = bpp,
+        .resource = resource,
+        .srv = srv,
+        .aligned_row_pitch = aligned_row_pitch,
+        .format = opts.pixel_format,
+        .device = device,
+        .command_list = opts.command_list,
+        // Texture starts in COPY_DEST so the initial upload (if any) can proceed
+        // without a barrier. After the upload we transition to PIXEL_SHADER_RESOURCE.
+        .state = d3d12.D3D12_RESOURCE_STATE_COPY_DEST,
+    };
+
+    // Upload initial data if provided.
+    if (data) |pixels| {
+        tex.uploadRegion(0, 0, @intCast(width), @intCast(height), pixels);
+        // Transition to shader-readable after the initial upload.
+        tex.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    } else {
+        // No initial data -- transition to shader-readable immediately.
+        tex.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    }
+
+    return tex;
 }
 
-pub fn deinit(self: @This()) void {
-    _ = self;
+pub fn deinit(self: Texture) void {
+    if (self.resource) |res| {
+        _ = res.Release();
+    }
+    // SRV descriptor is owned by the heap's linear allocator --
+    // it gets freed when the heap itself is destroyed.
 }
 
 /// Upload pixel data to a sub-region of this texture.
-pub fn replaceRegion(self: *@This(), x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
-    _ = self;
-    _ = x;
-    _ = y;
-    _ = width;
-    _ = height;
-    _ = data;
+/// The staging buffer is recorded on the command list; the caller
+/// must execute and wait before the staging memory becomes invalid.
+pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
+    // Transition to COPY_DEST if needed.
+    if (self.state != d3d12.D3D12_RESOURCE_STATE_COPY_DEST) {
+        self.transition(d3d12.D3D12_RESOURCE_STATE_COPY_DEST);
+    }
+
+    self.uploadRegion(@intCast(x), @intCast(y), @intCast(width), @intCast(height), data);
+
+    // Transition back to shader-readable.
+    self.transition(d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+}
+
+// --- Internal helpers ---
+
+fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: []const u8) void {
+    const device = self.device orelse return;
+    const cmd_list = self.command_list orelse return;
+    const texture = self.resource orelse return;
+
+    const region_aligned_pitch = alignPitch(width * self.bpp);
+    const staging_size: u64 = @as(u64, region_aligned_pitch) * @as(u64, height);
+
+    // Create a temporary upload buffer for staging.
+    const staging = createStagingBuffer(device, staging_size) orelse return;
+    // The staging buffer will be released after the command list executes.
+    // For now we rely on the caller to manage staging lifetime via GPU sync.
+    // In practice, GenericRenderer calls waitForGpu() after each frame.
+
+    // Map and copy row-by-row with pitch alignment.
+    var mapped: ?*anyopaque = null;
+    const read_range = d3d12.D3D12_RANGE{ .Begin = 0, .End = 0 };
+    const map_hr = staging.Map(0, &read_range, &mapped);
+    if (com.FAILED(map_hr) or mapped == null) {
+        _ = staging.Release();
+        return;
+    }
+
+    const dst: [*]u8 = @ptrCast(mapped.?);
+    const src_row_bytes = width * self.bpp;
+    for (0..height) |row| {
+        const dst_offset = row * @as(usize, region_aligned_pitch);
+        const src_offset = row * @as(usize, src_row_bytes);
+        @memcpy(dst[dst_offset..][0..src_row_bytes], data[src_offset..][0..src_row_bytes]);
+    }
+
+    staging.Unmap(0, null);
+
+    // Record the copy command.
+    const src_loc = d3d12.D3D12_TEXTURE_COPY_LOCATION{
+        .pResource = staging,
+        .Type = 1, // D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT
+        .u = .{
+            .PlacedFootprint = .{
+                .Offset = 0,
+                .Footprint = .{
+                    .Format = self.format,
+                    .Width = width,
+                    .Height = height,
+                    .Depth = 1,
+                    .RowPitch = region_aligned_pitch,
+                },
+            },
+        },
+    };
+
+    const dst_loc = d3d12.D3D12_TEXTURE_COPY_LOCATION{
+        .pResource = texture,
+        .Type = 0, // D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX
+        .u = .{ .SubresourceIndex = 0 },
+    };
+
+    const src_box = d3d12.D3D12_BOX{
+        .left = 0,
+        .top = 0,
+        .front = 0,
+        .right = width,
+        .bottom = height,
+        .back = 1,
+    };
+
+    cmd_list.CopyTextureRegion(&dst_loc, x, y, 0, &src_loc, &src_box);
+
+    // Release staging buffer. The copy command has been recorded; the GPU
+    // will read from this memory when the command list executes. This is
+    // safe because we release the COM reference AFTER recording -- the
+    // runtime keeps the resource alive until the GPU finishes the copy.
+    _ = staging.Release();
+}
+
+fn transition(self: *Texture, new_state: d3d12.D3D12_RESOURCE_STATES) void {
+    const cmd_list = self.command_list orelse return;
+    const resource = self.resource orelse return;
+
+    if (self.state == new_state) return;
+
+    const barrier = d3d12.D3D12_RESOURCE_BARRIER{
+        .Type = .TRANSITION,
+        .Flags = .NONE,
+        .u = .{
+            .Transition = .{
+                .pResource = resource,
+                .Subresource = 0xFFFFFFFF, // D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES
+                .StateBefore = self.state,
+                .StateAfter = new_state,
+            },
+        },
+    };
+    cmd_list.ResourceBarrier(1, @ptrCast(&barrier));
+    self.state = new_state;
+}
+
+fn createTextureResource(device: *d3d12.ID3D12Device, width: u32, height: u32, format: dxgi.DXGI_FORMAT) ?*d3d12.ID3D12Resource {
+    const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
+        .Type = .DEFAULT,
+        .CPUPageProperty = 0,
+        .MemoryPoolPreference = 0,
+        .CreationNodeMask = 0,
+        .VisibleNodeMask = 0,
+    };
+
+    const desc = d3d12.D3D12_RESOURCE_DESC{
+        .Dimension = .TEXTURE2D,
+        .Alignment = 0,
+        .Width = width,
+        .Height = height,
+        .DepthOrArraySize = 1,
+        .MipLevels = 1,
+        .Format = format,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .Layout = .UNKNOWN,
+        .Flags = .NONE,
+    };
+
+    var resource: ?*d3d12.ID3D12Resource = null;
+    // Texture starts in COPY_DEST state so we can upload initial data.
+    const hr = device.CreateCommittedResource(
+        &heap_props,
+        0,
+        &desc,
+        d3d12.D3D12_RESOURCE_STATE_COPY_DEST,
+        null,
+        &d3d12.IID_ID3D12Resource,
+        @ptrCast(&resource),
+    );
+    if (com.FAILED(hr)) {
+        log.err("CreateCommittedResource for texture failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+        return null;
+    }
+    return resource;
+}
+
+fn createStagingBuffer(device: *d3d12.ID3D12Device, size: u64) ?*d3d12.ID3D12Resource {
+    const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
+        .Type = .UPLOAD,
+        .CPUPageProperty = 0,
+        .MemoryPoolPreference = 0,
+        .CreationNodeMask = 0,
+        .VisibleNodeMask = 0,
+    };
+
+    const desc = d3d12.D3D12_RESOURCE_DESC{
+        .Dimension = .BUFFER,
+        .Alignment = 0,
+        .Width = size,
+        .Height = 1,
+        .DepthOrArraySize = 1,
+        .MipLevels = 1,
+        .Format = .UNKNOWN,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .Layout = .ROW_MAJOR,
+        .Flags = .NONE,
+    };
+
+    var resource: ?*d3d12.ID3D12Resource = null;
+    const hr = device.CreateCommittedResource(
+        &heap_props,
+        0,
+        &desc,
+        d3d12.D3D12_RESOURCE_STATE_GENERIC_READ,
+        null,
+        &d3d12.IID_ID3D12Resource,
+        @ptrCast(&resource),
+    );
+    if (com.FAILED(hr)) {
+        log.err("CreateCommittedResource for staging buffer failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+        return null;
+    }
+    return resource;
+}
+
+fn alignPitch(row_bytes: u32) u32 {
+    return (row_bytes + TEXTURE_DATA_PITCH_ALIGNMENT - 1) & ~(TEXTURE_DATA_PITCH_ALIGNMENT - 1);
+}
+
+fn bppForFormat(format: dxgi.DXGI_FORMAT) u32 {
+    return switch (format) {
+        .R8_UNORM => 1,
+        .R8G8B8A8_UNORM, .B8G8R8A8_UNORM => 4,
+        else => 4,
+    };
+}
+
+// --- Tests ---
+
+test "alignPitch rounds up to 256" {
+    try std.testing.expectEqual(@as(u32, 256), alignPitch(1));
+    try std.testing.expectEqual(@as(u32, 256), alignPitch(256));
+    try std.testing.expectEqual(@as(u32, 512), alignPitch(257));
+    try std.testing.expectEqual(@as(u32, 1024), alignPitch(1000));
+}
+
+test "bppForFormat returns correct bytes per pixel" {
+    try std.testing.expectEqual(@as(u32, 1), bppForFormat(.R8_UNORM));
+    try std.testing.expectEqual(@as(u32, 4), bppForFormat(.R8G8B8A8_UNORM));
+    try std.testing.expectEqual(@as(u32, 4), bppForFormat(.B8G8R8A8_UNORM));
+}
+
+test "Texture struct fields" {
+    try std.testing.expect(@hasField(Texture, "width"));
+    try std.testing.expect(@hasField(Texture, "height"));
+    try std.testing.expect(@hasField(Texture, "resource"));
+    try std.testing.expect(@hasField(Texture, "srv"));
+    try std.testing.expect(@hasField(Texture, "aligned_row_pitch"));
+    try std.testing.expect(@hasField(Texture, "state"));
+}
+
+test "Texture.Options defaults" {
+    const opts = Options{};
+    try std.testing.expect(opts.device == null);
+    try std.testing.expect(opts.command_list == null);
+    try std.testing.expect(opts.srv_heap == null);
+    try std.testing.expectEqual(dxgi.DXGI_FORMAT.R8_UNORM, opts.pixel_format);
 }

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -618,9 +618,14 @@ pub const D3D12_PLACED_SUBRESOURCE_FOOTPRINT = extern struct {
     Footprint: D3D12_SUBRESOURCE_FOOTPRINT,
 };
 
+pub const D3D12_TEXTURE_COPY_TYPE = enum(u32) {
+    SUBRESOURCE_INDEX = 0,
+    PLACED_FOOTPRINT = 1,
+};
+
 pub const D3D12_TEXTURE_COPY_LOCATION = extern struct {
     pResource: *ID3D12Resource,
-    Type: u32, // D3D12_TEXTURE_COPY_TYPE
+    Type: D3D12_TEXTURE_COPY_TYPE,
     u: extern union {
         PlacedFootprint: D3D12_PLACED_SUBRESOURCE_FOOTPRINT,
         SubresourceIndex: u32,

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -274,6 +274,53 @@ pub const D3D12_STATIC_BORDER_COLOR = enum(u32) {
     OPAQUE_WHITE = 2,
 };
 
+pub const D3D12_SRV_DIMENSION = enum(u32) {
+    UNKNOWN = 0,
+    BUFFER = 1,
+    TEXTURE1D = 2,
+    TEXTURE1DARRAY = 3,
+    TEXTURE2D = 4,
+    TEXTURE2DARRAY = 5,
+    TEXTURE2DMS = 6,
+    TEXTURE2DMSARRAY = 7,
+    TEXTURE3D = 8,
+    TEXTURECUBE = 9,
+    TEXTURECUBEARRAY = 10,
+    RAYTRACING_ACCELERATION_STRUCTURE = 11,
+};
+
+pub const D3D12_TEX2D_SRV = extern struct {
+    MostDetailedMip: u32,
+    MipLevels: u32,
+    PlaneSlice: u32,
+    ResourceMinLODClamp: f32,
+};
+
+pub const D3D12_SHADER_RESOURCE_VIEW_DESC = extern struct {
+    Format: DXGI_FORMAT,
+    ViewDimension: D3D12_SRV_DIMENSION,
+    Shader4ComponentMapping: u32,
+    u: extern union {
+        Texture2D: D3D12_TEX2D_SRV,
+    },
+};
+
+/// Default component mapping: identity (RGBA -> RGBA).
+pub const D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING: u32 = 0x00001688;
+
+pub const D3D12_SAMPLER_DESC = extern struct {
+    Filter: D3D12_FILTER,
+    AddressU: D3D12_TEXTURE_ADDRESS_MODE,
+    AddressV: D3D12_TEXTURE_ADDRESS_MODE,
+    AddressW: D3D12_TEXTURE_ADDRESS_MODE,
+    MipLODBias: f32,
+    MaxAnisotropy: u32,
+    ComparisonFunc: D3D12_COMPARISON_FUNC,
+    BorderColor: [4]f32,
+    MinLOD: f32,
+    MaxLOD: f32,
+};
+
 pub const D3D12_COLOR_WRITE_ENABLE = enum(u32) {
     RED = 1,
     GREEN = 2,
@@ -1228,7 +1275,7 @@ pub const ID3D12Device = extern struct {
         // slot 17
         CreateConstantBufferView: Reserved,
         // slot 18
-        CreateShaderResourceView: Reserved,
+        CreateShaderResourceView: *const fn (*ID3D12Device, pResource: ?*ID3D12Resource, pDesc: ?*const D3D12_SHADER_RESOURCE_VIEW_DESC, DestDescriptor: D3D12_CPU_DESCRIPTOR_HANDLE) callconv(.winapi) void,
         // slot 19
         CreateUnorderedAccessView: Reserved,
         // slot 20
@@ -1236,7 +1283,7 @@ pub const ID3D12Device = extern struct {
         // slot 21
         CreateDepthStencilView: Reserved,
         // slot 22
-        CreateSampler: Reserved,
+        CreateSampler: *const fn (*ID3D12Device, pDesc: *const D3D12_SAMPLER_DESC, DestDescriptor: D3D12_CPU_DESCRIPTOR_HANDLE) callconv(.winapi) void,
         // slot 23
         CopyDescriptors: Reserved,
         // slot 24
@@ -1307,6 +1354,14 @@ pub const ID3D12Device = extern struct {
 
     pub inline fn CreateRootSignature(self: *ID3D12Device, node_mask: u32, blob: *const anyopaque, blob_len: usize, riid: *const GUID, pp: *?*anyopaque) HRESULT {
         return self.vtable.CreateRootSignature(self, node_mask, blob, blob_len, riid, pp);
+    }
+
+    pub inline fn CreateShaderResourceView(self: *ID3D12Device, resource: ?*ID3D12Resource, desc: ?*const D3D12_SHADER_RESOURCE_VIEW_DESC, dest: D3D12_CPU_DESCRIPTOR_HANDLE) void {
+        self.vtable.CreateShaderResourceView(self, resource, desc, dest);
+    }
+
+    pub inline fn CreateSampler(self: *ID3D12Device, desc: *const D3D12_SAMPLER_DESC, dest: D3D12_CPU_DESCRIPTOR_HANDLE) void {
+        self.vtable.CreateSampler(self, desc, dest);
     }
 
     pub inline fn CreateRenderTargetView(self: *ID3D12Device, resource: ?*ID3D12Resource, desc: ?*const anyopaque, dest: D3D12_CPU_DESCRIPTOR_HANDLE) void {


### PR DESCRIPTION
> **IMPORTANT**: This is PR 11 of 15 in the DX12 pivot stack.
> Full stack: #107 -> #108 -> #109 -> #110 -> #113 -> #114 -> #116 -> #117 -> #118 -> #119 -> this PR

## Summary

- Texture uses a committed resource in DEFAULT heap (GPU-only). Uploads go through a staging buffer + CopyTextureRegion on the command list. Each texture owns an SRV descriptor from the CBV/SRV/UAV heap.
- Sampler is a descriptor written into the sampler heap -- DX12 samplers are not standalone objects.
- Added COM bindings for CreateShaderResourceView and CreateSampler on ID3D12Device, plus SRV and sampler descriptor types.

Replaces #120, which was closed when its base branch was deleted during squash merge.

## Test plan

- [x] `zig build` compiles clean
- [x] `zig build test -Dtest-filter=alignPitch` passes
- [x] `zig build test -Dtest-filter=bppForFormat` passes
- [x] `zig build test -Dtest-filter=Texture` passes (struct field, Options defaults)
- [x] `zig build test -Dtest-filter=Sampler` passes (struct field, Options defaults)