### PR TITLE
renderer: DX12 upgrade root signature to v1.1

### DIFF
--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -122,7 +122,7 @@ pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignat
     };
 
     const desc = d3d12.D3D12_VERSIONED_ROOT_SIGNATURE_DESC{
-        .Version = 2, // D3D_ROOT_SIGNATURE_VERSION_1_1
+        .Version = .VERSION_1_1,
         .u = .{ .Desc_1_1 = .{
             .NumParameters = root_params.len,
             .pParameters = &root_params,

--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -67,30 +67,37 @@ pub const root_param_sampler_table: u32 = 2;
 ///   [2] Descriptor table: 1 sampler at s0
 pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignature {
     // SRV range: t0..t2 (textures and structured buffers).
-    const srv_range = d3d12.D3D12_DESCRIPTOR_RANGE{
+    // DATA_STATIC: atlas textures are uploaded once and don't change
+    // within a command list execution.
+    const srv_range = d3d12.D3D12_DESCRIPTOR_RANGE1{
         .RangeType = .SRV,
         .NumDescriptors = srv_table_size,
         .BaseShaderRegister = 0,
         .RegisterSpace = 0,
+        .Flags = .DATA_STATIC,
         .OffsetInDescriptorsFromTableStart = 0,
     };
 
     // Sampler range: s0.
-    const sampler_range = d3d12.D3D12_DESCRIPTOR_RANGE{
+    // NONE: default for v1.1 samplers is static descriptors.
+    const sampler_range = d3d12.D3D12_DESCRIPTOR_RANGE1{
         .RangeType = .SAMPLER,
         .NumDescriptors = 1,
         .BaseShaderRegister = 0,
         .RegisterSpace = 0,
+        .Flags = .NONE,
         .OffsetInDescriptorsFromTableStart = 0,
     };
 
-    const root_params = [_]d3d12.D3D12_ROOT_PARAMETER{
+    const root_params = [_]d3d12.D3D12_ROOT_PARAMETER1{
         // [0] Inline CBV at b0 -- binds with SetGraphicsRootConstantBufferView.
+        // DATA_VOLATILE: uniform buffer changes every frame.
         .{
             .ParameterType = .CBV,
             .u = .{ .Descriptor = .{
                 .ShaderRegister = 0,
                 .RegisterSpace = 0,
+                .Flags = .DATA_VOLATILE,
             } },
             .ShaderVisibility = .ALL,
         },
@@ -114,23 +121,22 @@ pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignat
         },
     };
 
-    const desc = d3d12.D3D12_ROOT_SIGNATURE_DESC{
-        .NumParameters = root_params.len,
-        .pParameters = &root_params,
-        .NumStaticSamplers = 0,
-        .pStaticSamplers = null,
-        .Flags = .ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
+    const desc = d3d12.D3D12_VERSIONED_ROOT_SIGNATURE_DESC{
+        .Version = 2, // D3D_ROOT_SIGNATURE_VERSION_1_1
+        .u = .{ .Desc_1_1 = .{
+            .NumParameters = root_params.len,
+            .pParameters = &root_params,
+            .NumStaticSamplers = 0,
+            .pStaticSamplers = null,
+            .Flags = .ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
+        } },
     };
 
-    // Serialize the root signature to a blob.
+    // Serialize the versioned root signature to a blob.
     var blob: ?*d3d12.ID3DBlob = null;
     var error_blob: ?*d3d12.ID3DBlob = null;
-    // TODO(#127): upgrade to D3D_ROOT_SIGNATURE_VERSION_1_1 for DATA_STATIC /
-    // DESCRIPTORS_VOLATILE flags -- allows driver to optimize descriptor
-    // access for our workload (static atlas textures, per-frame uniforms).
-    var hr = d3d12.D3D12SerializeRootSignature(
+    var hr = d3d12.D3D12SerializeVersionedRootSignature(
         &desc,
-        1, // D3D_ROOT_SIGNATURE_VERSION_1
         &blob,
         &error_blob,
     );

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -605,6 +605,13 @@ pub const D3D12_ROOT_SIGNATURE_DESC = extern struct {
     Flags: D3D12_ROOT_SIGNATURE_FLAGS,
 };
 
+// --- Root Signature versioning ---
+
+pub const D3D_ROOT_SIGNATURE_VERSION = enum(u32) {
+    VERSION_1_0 = 1,
+    VERSION_1_1 = 2,
+};
+
 // --- Root Signature v1.1 types ---
 
 pub const D3D12_DESCRIPTOR_RANGE_FLAGS = enum(u32) {
@@ -664,7 +671,7 @@ pub const D3D12_ROOT_SIGNATURE_DESC1 = extern struct {
 };
 
 pub const D3D12_VERSIONED_ROOT_SIGNATURE_DESC = extern struct {
-    Version: u32,
+    Version: D3D_ROOT_SIGNATURE_VERSION,
     u: extern union {
         Desc_1_0: D3D12_ROOT_SIGNATURE_DESC,
         Desc_1_1: D3D12_ROOT_SIGNATURE_DESC1,
@@ -1466,13 +1473,6 @@ pub extern "d3d12" fn D3D12GetDebugInterface(
     ppvDebug: *?*anyopaque,
 ) callconv(.winapi) HRESULT;
 
-pub extern "d3d12" fn D3D12SerializeRootSignature(
-    pRootSignature: *const D3D12_ROOT_SIGNATURE_DESC,
-    Version: u32,
-    ppBlob: *?*ID3DBlob,
-    ppErrorBlob: *?*ID3DBlob,
-) callconv(.winapi) HRESULT;
-
 pub extern "d3d12" fn D3D12SerializeVersionedRootSignature(
     pRootSignature: *const D3D12_VERSIONED_ROOT_SIGNATURE_DESC,
     ppBlob: *?*ID3DBlob,
@@ -1517,18 +1517,13 @@ test "D3D12 struct sizes" {
     try std.testing.expectEqual(32, @sizeOf(D3D12_RESOURCE_BARRIER));
     try std.testing.expectEqual(32, @sizeOf(D3D12_ROOT_PARAMETER));
     try std.testing.expectEqual(656, @sizeOf(D3D12_GRAPHICS_PIPELINE_STATE_DESC));
-}
 
-test "D3D12_DESCRIPTOR_RANGE1 size" {
+    // v1.1 root signature types
     try std.testing.expectEqual(24, @sizeOf(D3D12_DESCRIPTOR_RANGE1));
-}
-
-test "D3D12_ROOT_DESCRIPTOR1 size" {
     try std.testing.expectEqual(12, @sizeOf(D3D12_ROOT_DESCRIPTOR1));
-}
-
-test "D3D12_ROOT_PARAMETER1 size" {
     try std.testing.expectEqual(32, @sizeOf(D3D12_ROOT_PARAMETER1));
+    try std.testing.expectEqual(40, @sizeOf(D3D12_ROOT_SIGNATURE_DESC1));
+    try std.testing.expectEqual(48, @sizeOf(D3D12_VERSIONED_ROOT_SIGNATURE_DESC));
 }
 
 test "D3D12 GUID constants" {

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -605,6 +605,72 @@ pub const D3D12_ROOT_SIGNATURE_DESC = extern struct {
     Flags: D3D12_ROOT_SIGNATURE_FLAGS,
 };
 
+// --- Root Signature v1.1 types ---
+
+pub const D3D12_DESCRIPTOR_RANGE_FLAGS = enum(u32) {
+    NONE = 0,
+    DESCRIPTORS_VOLATILE = 0x1,
+    DATA_VOLATILE = 0x2,
+    DATA_STATIC_WHILE_SET_AT_EXECUTE = 0x4,
+    DATA_STATIC = 0x8,
+    DESCRIPTORS_STATIC_KEEPING_BUFFER_BOUNDS_CHECKS = 0x10000,
+    _,
+};
+
+pub const D3D12_DESCRIPTOR_RANGE1 = extern struct {
+    RangeType: D3D12_DESCRIPTOR_RANGE_TYPE,
+    NumDescriptors: u32,
+    BaseShaderRegister: u32,
+    RegisterSpace: u32,
+    Flags: D3D12_DESCRIPTOR_RANGE_FLAGS,
+    OffsetInDescriptorsFromTableStart: u32,
+};
+
+pub const D3D12_ROOT_DESCRIPTOR_TABLE1 = extern struct {
+    NumDescriptorRanges: u32,
+    pDescriptorRanges: ?[*]const D3D12_DESCRIPTOR_RANGE1,
+};
+
+pub const D3D12_ROOT_DESCRIPTOR_FLAGS = enum(u32) {
+    NONE = 0,
+    DATA_VOLATILE = 0x2,
+    DATA_STATIC_WHILE_SET_AT_EXECUTE = 0x4,
+    DATA_STATIC = 0x8,
+    _,
+};
+
+pub const D3D12_ROOT_DESCRIPTOR1 = extern struct {
+    ShaderRegister: u32,
+    RegisterSpace: u32,
+    Flags: D3D12_ROOT_DESCRIPTOR_FLAGS,
+};
+
+pub const D3D12_ROOT_PARAMETER1 = extern struct {
+    ParameterType: D3D12_ROOT_PARAMETER_TYPE,
+    u: extern union {
+        DescriptorTable: D3D12_ROOT_DESCRIPTOR_TABLE1,
+        Constants: D3D12_ROOT_CONSTANTS,
+        Descriptor: D3D12_ROOT_DESCRIPTOR1,
+    },
+    ShaderVisibility: D3D12_SHADER_VISIBILITY,
+};
+
+pub const D3D12_ROOT_SIGNATURE_DESC1 = extern struct {
+    NumParameters: u32,
+    pParameters: ?[*]const D3D12_ROOT_PARAMETER1,
+    NumStaticSamplers: u32,
+    pStaticSamplers: ?[*]const D3D12_STATIC_SAMPLER_DESC,
+    Flags: D3D12_ROOT_SIGNATURE_FLAGS,
+};
+
+pub const D3D12_VERSIONED_ROOT_SIGNATURE_DESC = extern struct {
+    Version: u32,
+    u: extern union {
+        Desc_1_0: D3D12_ROOT_SIGNATURE_DESC,
+        Desc_1_1: D3D12_ROOT_SIGNATURE_DESC1,
+    },
+};
+
 pub const D3D12_SUBRESOURCE_FOOTPRINT = extern struct {
     Format: DXGI_FORMAT,
     Width: u32,
@@ -1407,6 +1473,12 @@ pub extern "d3d12" fn D3D12SerializeRootSignature(
     ppErrorBlob: *?*ID3DBlob,
 ) callconv(.winapi) HRESULT;
 
+pub extern "d3d12" fn D3D12SerializeVersionedRootSignature(
+    pRootSignature: *const D3D12_VERSIONED_ROOT_SIGNATURE_DESC,
+    ppBlob: *?*ID3DBlob,
+    ppErrorBlob: *?*ID3DBlob,
+) callconv(.winapi) HRESULT;
+
 // --- Kernel32 helpers for fence synchronization ---
 
 pub extern "kernel32" fn CreateEventW(
@@ -1445,6 +1517,18 @@ test "D3D12 struct sizes" {
     try std.testing.expectEqual(32, @sizeOf(D3D12_RESOURCE_BARRIER));
     try std.testing.expectEqual(32, @sizeOf(D3D12_ROOT_PARAMETER));
     try std.testing.expectEqual(656, @sizeOf(D3D12_GRAPHICS_PIPELINE_STATE_DESC));
+}
+
+test "D3D12_DESCRIPTOR_RANGE1 size" {
+    try std.testing.expectEqual(24, @sizeOf(D3D12_DESCRIPTOR_RANGE1));
+}
+
+test "D3D12_ROOT_DESCRIPTOR1 size" {
+    try std.testing.expectEqual(12, @sizeOf(D3D12_ROOT_DESCRIPTOR1));
+}
+
+test "D3D12_ROOT_PARAMETER1 size" {
+    try std.testing.expectEqual(32, @sizeOf(D3D12_ROOT_PARAMETER1));
 }
 
 test "D3D12 GUID constants" {


### PR DESCRIPTION
Fixes #127.

Upgrades the root signature from v1.0 to v1.1, adding descriptor range flags that let the driver optimize descriptor access:
- SRV range (atlas textures): `DATA_STATIC` -- textures don't change within a command list
- Sampler range: `NONE` (default static for v1.1)
- CBV root descriptor (uniforms): `DATA_VOLATILE` -- changes per frame

Changes:
- `d3d12.zig`: add v1.1 types (`D3D12_DESCRIPTOR_RANGE1`, `D3D12_ROOT_PARAMETER1`, etc.) and `D3D12SerializeVersionedRootSignature`
- `Pipeline.zig`: rewrite `createRootSignature()` to use v1.1 types with Version=2