### PR TITLE
renderer: DX12 TDR detection (DXGI_ERROR_DEVICE_REMOVED)

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -84,8 +84,9 @@ const sampler_heap_capacity: u32 = 16;
 /// Runtime blending mode, set by GenericRenderer when config changes.
 blending: configpkg.Config.AlphaBlending = .native,
 
-/// Set to true when DXGI_ERROR_DEVICE_REMOVED is detected.
-/// Prevents further GPU submissions until device recovery.
+/// Set to true when a device-loss error is detected (DEVICE_REMOVED,
+/// DEVICE_HUNG, or DEVICE_RESET). Prevents further GPU submissions
+/// until device recovery.
 device_lost: bool = false,
 
 /// DX12 device owning command queue, fence, and swap chain.
@@ -350,8 +351,9 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     // Present the swap chain and check for device-removed errors.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
-        if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_RESET) {
+        if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_HUNG or hr == com.DXGI_ERROR_DEVICE_RESET) {
             self.handleDeviceRemoved();
+            // Fence signal is intentionally skipped -- the device is gone.
             return;
         }
         if (com.FAILED(hr)) {
@@ -478,7 +480,7 @@ pub fn presentLastTarget(self: *DirectX12) !void {
     // valid and the next beginFrame will wait correctly.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
-        if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_RESET) {
+        if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_HUNG or hr == com.DXGI_ERROR_DEVICE_RESET) {
             self.handleDeviceRemoved();
             return error.PresentFailed;
         }
@@ -605,5 +607,23 @@ test "DirectX12 has device_lost field" {
 
 test "DirectX12 default device_lost is false" {
     const api: DirectX12 = .{};
-    try std.testing.expect(!api.device_lost)
+    try std.testing.expect(!api.device_lost);
+}
+
+test "device_lost flag gates further rendering" {
+    var api: DirectX12 = .{};
+    try std.testing.expect(!api.device_lost);
+    // Simulate what handleDeviceRemoved does to the flag.
+    api.device_lost = true;
+    try std.testing.expect(api.device_lost);
+}
+
+test "device_lost flag is independent of device presence" {
+    var api: DirectX12 = .{};
+    // device_lost can be set regardless of whether dev is populated,
+    // matching the guard in beginFrame which checks device_lost before
+    // accessing dev.
+    try std.testing.expect(api.dev == null);
+    api.device_lost = true;
+    try std.testing.expect(api.device_lost);
 }

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -84,6 +84,10 @@ const sampler_heap_capacity: u32 = 16;
 /// Runtime blending mode, set by GenericRenderer when config changes.
 blending: configpkg.Config.AlphaBlending = .native,
 
+/// Set to true when DXGI_ERROR_DEVICE_REMOVED is detected.
+/// Prevents further GPU submissions until device recovery.
+device_lost: bool = false,
+
 /// DX12 device owning command queue, fence, and swap chain.
 dev: ?device.Device = null,
 
@@ -343,10 +347,13 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     const lists = [_]*d3d12.ID3D12GraphicsCommandList{cl};
     dev_ptr.command_queue.ExecuteCommandLists(1, &lists);
 
-    // Present the swap chain.
-    // Does not yet check for DXGI_ERROR_DEVICE_REMOVED -- see #130.
+    // Present the swap chain and check for device-removed errors.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
+        if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_RESET) {
+            self.handleDeviceRemoved();
+            return;
+        }
         if (com.FAILED(hr)) {
             log.err("Present failed: 0x{x}", .{@as(u32, @bitCast(hr))});
         }
@@ -427,6 +434,7 @@ pub inline fn beginFrame(
     // as DX11.
     _ = self;
     const api: *DirectX12 = &renderer.api;
+    if (api.device_lost) return error.DeviceLost;
     // SharedTexture surfaces have no swap chain; they need a separate
     // submission path that is not yet implemented.
     const sc3 = api.swap_chain3 orelse return error.NoSwapChain;
@@ -470,10 +478,24 @@ pub fn presentLastTarget(self: *DirectX12) !void {
     // valid and the next beginFrame will wait correctly.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
+        if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_RESET) {
+            self.handleDeviceRemoved();
+            return error.PresentFailed;
+        }
         if (com.FAILED(hr)) {
             log.err("presentLastTarget failed: 0x{x}", .{@as(u32, @bitCast(hr))});
             return error.PresentFailed;
         }
+    }
+}
+
+fn handleDeviceRemoved(self: *DirectX12) void {
+    self.device_lost = true;
+    if (self.dev) |*dev_ptr| {
+        const reason = dev_ptr.device.GetDeviceRemovedReason();
+        log.err("GPU device removed, reason: 0x{x}", .{@as(u32, @bitCast(reason))});
+    } else {
+        log.err("GPU device removed, no device available for reason query", .{});
     }
 }
 
@@ -575,4 +597,13 @@ test "DirectX12 default cached size is zero" {
     const api: DirectX12 = .{};
     try std.testing.expectEqual(@as(u32, 0), api.cached_width);
     try std.testing.expectEqual(@as(u32, 0), api.cached_height);
+}
+
+test "DirectX12 has device_lost field" {
+    try std.testing.expect(@hasField(DirectX12, "device_lost"));
+}
+
+test "DirectX12 default device_lost is false" {
+    const api: DirectX12 = .{};
+    try std.testing.expect(!api.device_lost)
 }

--- a/src/renderer/directx12/com.zig
+++ b/src/renderer/directx12/com.zig
@@ -13,6 +13,7 @@ pub const Reserved = windows_com.Reserved;
 
 // DXGI error code used for device-lost / TDR recovery.
 pub const DXGI_ERROR_DEVICE_REMOVED: HRESULT = @bitCast(@as(u32, 0x887A0005));
+pub const DXGI_ERROR_DEVICE_RESET: HRESULT = @bitCast(@as(u32, 0x887A0007));
 
 test {
     _ = @import("com_test.zig");

--- a/src/renderer/directx12/com.zig
+++ b/src/renderer/directx12/com.zig
@@ -13,6 +13,7 @@ pub const Reserved = windows_com.Reserved;
 
 // DXGI error code used for device-lost / TDR recovery.
 pub const DXGI_ERROR_DEVICE_REMOVED: HRESULT = @bitCast(@as(u32, 0x887A0005));
+pub const DXGI_ERROR_DEVICE_HUNG: HRESULT = @bitCast(@as(u32, 0x887A0006));
 pub const DXGI_ERROR_DEVICE_RESET: HRESULT = @bitCast(@as(u32, 0x887A0007));
 
 test {

--- a/src/renderer/directx12/com_test.zig
+++ b/src/renderer/directx12/com_test.zig
@@ -51,6 +51,34 @@ test "ISwapChainPanelNative IID" {
     try std.testing.expectEqualSlices(u8, &iid.data4, &[_]u8{ 0xa2, 0x0c, 0xf6, 0xf1, 0xea, 0x90, 0x55, 0x4b });
 }
 
+// Verify DXGI error constants match the Windows SDK values.
+// These are HRESULT codes that cross the COM boundary, so wrong
+// values would silently miss device-loss events.
+
+test "DXGI_ERROR_DEVICE_REMOVED value" {
+    try std.testing.expectEqual(@as(u32, 0x887A0005), @as(u32, @bitCast(com.DXGI_ERROR_DEVICE_REMOVED)));
+}
+
+test "DXGI_ERROR_DEVICE_HUNG value" {
+    try std.testing.expectEqual(@as(u32, 0x887A0006), @as(u32, @bitCast(com.DXGI_ERROR_DEVICE_HUNG)));
+}
+
+test "DXGI_ERROR_DEVICE_RESET value" {
+    try std.testing.expectEqual(@as(u32, 0x887A0007), @as(u32, @bitCast(com.DXGI_ERROR_DEVICE_RESET)));
+}
+
+test "DXGI device-loss error codes are distinct" {
+    try std.testing.expect(com.DXGI_ERROR_DEVICE_REMOVED != com.DXGI_ERROR_DEVICE_HUNG);
+    try std.testing.expect(com.DXGI_ERROR_DEVICE_HUNG != com.DXGI_ERROR_DEVICE_RESET);
+    try std.testing.expect(com.DXGI_ERROR_DEVICE_REMOVED != com.DXGI_ERROR_DEVICE_RESET);
+}
+
+test "DXGI device-loss error codes are all failures" {
+    try std.testing.expect(com.FAILED(com.DXGI_ERROR_DEVICE_REMOVED));
+    try std.testing.expect(com.FAILED(com.DXGI_ERROR_DEVICE_HUNG));
+    try std.testing.expect(com.FAILED(com.DXGI_ERROR_DEVICE_RESET));
+}
+
 test "Buffer type instantiation compiles" {
     const buffer_mod = @import("buffer.zig");
     _ = buffer_mod.Buffer(f32);

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -1391,7 +1391,7 @@ pub const ID3D12Device = extern struct {
         // slot 36
         CreateFence: *const fn (*ID3D12Device, InitialValue: u64, Flags: D3D12_FENCE_FLAGS, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         // slot 37
-        GetDeviceRemovedReason: Reserved,
+        GetDeviceRemovedReason: *const fn (*ID3D12Device) callconv(.winapi) HRESULT,
         // slot 38
         GetCopyableFootprints: Reserved,
         // slot 39
@@ -1452,6 +1452,10 @@ pub const ID3D12Device = extern struct {
 
     pub inline fn CreateFence(self: *ID3D12Device, initial_value: u64, flags: D3D12_FENCE_FLAGS, riid: *const GUID, pp: *?*anyopaque) HRESULT {
         return self.vtable.CreateFence(self, initial_value, flags, riid, pp);
+    }
+
+    pub inline fn GetDeviceRemovedReason(self: *ID3D12Device) HRESULT {
+        return self.vtable.GetDeviceRemovedReason(self);
     }
 
     pub inline fn Release(self: *ID3D12Device) u32 {

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -767,3 +767,16 @@ test "Fence: execute empty command list and wait" {
     // Fence value should match what we signaled.
     try std.testing.expect(dev.fence.GetCompletedValue() >= dev.fence_value);
 }
+
+// ---- Device removed reason test ----
+
+test "Device: GetDeviceRemovedReason returns S_OK on healthy device" {
+    if (comptime builtin.os.tag != .windows) return;
+    var dev = createTestDevice() catch return;
+    defer dev.deinit();
+    _ = dev.command_list.Close();
+
+    // A healthy device should return S_OK (0) for GetDeviceRemovedReason.
+    const hr = dev.device.GetDeviceRemovedReason();
+    try std.testing.expectEqual(@as(com.HRESULT, 0), hr);
+}


### PR DESCRIPTION
Fixes #130.

Adds detection-only handling for GPU device removal (TDR). Checks the `Present()` return value for `DXGI_ERROR_DEVICE_REMOVED` and `DXGI_ERROR_DEVICE_RESET`, logs the reason via `GetDeviceRemovedReason()`, and gates future frames with a `device_lost` flag. Full device recovery is deferred to a follow-up.

Changes:
- `d3d12.zig`: un-reserve `GetDeviceRemovedReason` (vtable slot 37), add inline wrapper
- `com.zig`: add `DXGI_ERROR_DEVICE_RESET` constant
- `DirectX12.zig`: add `device_lost` field, `handleDeviceRemoved()` helper, check Present() in `drawFrameEnd()` and `presentLastTarget()`, early-return in `beginFrame()`
- `gpu_test.zig`: test `GetDeviceRemovedReason` returns S_OK on healthy device