### PR TITLE
renderer: DX12 custom shader support (.hlsl shadertoy target)

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -48,9 +48,9 @@ pub const descriptor_heap = @import("directx12/descriptor_heap.zig");
 pub const device = @import("directx12/device.zig");
 pub const dxgi = @import("directx12/dxgi.zig");
 
-// Custom shaders not yet supported on DX12. Using .glsl as placeholder;
-// DX12 will need its own shadertoy.Target variant (.hlsl) -- see #129.
-pub const custom_shader_target: shadertoy.Target = .glsl;
+// Custom shaders use HLSL for DX12, cross-compiled from GLSL via
+// SPIR-V -> SPIRV-Cross (HLSL backend) -> Shader Model 6.0.
+pub const custom_shader_target: shadertoy.Target = .hlsl;
 
 /// DX12 uses top-left origin, same as Metal and DX11.
 pub const custom_shader_y_is_down = true;

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -48,8 +48,6 @@ pub const descriptor_heap = @import("directx12/descriptor_heap.zig");
 pub const device = @import("directx12/device.zig");
 pub const dxgi = @import("directx12/dxgi.zig");
 
-// Custom shaders use HLSL for DX12, cross-compiled from GLSL via
-// SPIR-V -> SPIRV-Cross (HLSL backend) -> Shader Model 6.0.
 pub const custom_shader_target: shadertoy.Target = .hlsl;
 
 /// DX12 uses top-left origin, same as Metal and DX11.

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -40,7 +40,7 @@ pub const Uniforms = extern struct {
 };
 
 /// The target to load shaders for.
-pub const Target = enum { glsl, msl };
+pub const Target = enum { glsl, msl, hlsl };
 
 /// Load a set of shaders from files and convert them to the target
 /// format. The shader order is preserved.
@@ -135,6 +135,7 @@ pub fn loadFromFile(
         // is the final result that will be returned to the caller.
         .glsl => try glslFromSpv(alloc_gpa, spirv),
         .msl => try mslFromSpv(alloc_gpa, spirv),
+        .hlsl => try hlslFromSpv(alloc_gpa, spirv),
     };
 }
 
@@ -248,6 +249,23 @@ pub fn mslFromSpv(alloc: Allocator, spv: []const u8) ![:0]const u8 {
                 options,
                 c.SPVC_COMPILER_OPTION_MSL_ENABLE_DECORATION_BINDING,
                 c.SPVC_TRUE,
+            ) != c.SPVC_SUCCESS) {
+                return error.SpvcFailed;
+            }
+        }
+    }).setOptions);
+}
+
+/// Convert SPIR-V binary to HLSL.
+pub fn hlslFromSpv(alloc: Allocator, spv: []const u8) ![:0]const u8 {
+    const c = spvcross.c;
+    return try spvCross(alloc, c.SPVC_BACKEND_HLSL, spv, (struct {
+        fn setOptions(options: c.spvc_compiler_options) error{SpvcFailed}!void {
+            // Target Shader Model 6.0 for broad DX12 hardware support.
+            if (c.spvc_compiler_options_set_uint(
+                options,
+                c.SPVC_COMPILER_OPTION_HLSL_SHADER_MODEL,
+                60,
             ) != c.SPVC_SUCCESS) {
                 return error.SpvcFailed;
             }
@@ -420,6 +438,26 @@ test "shadertoy to glsl" {
     defer alloc.free(glsl);
 
     // log.warn("glsl={s}", .{glsl});
+}
+
+test "shadertoy to hlsl" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const src = try testGlslZ(alloc, test_crt);
+    defer alloc.free(src);
+
+    var buf: std.Io.Writer.Allocating = .init(alloc);
+    defer buf.deinit();
+    try spirvFromGlsl(&buf.writer, null, src);
+
+    // TODO: Replace this with an aligned version of Writer.Allocating
+    var spvlist: std.ArrayListAligned(u8, .of(u32)) = .empty;
+    defer spvlist.deinit(alloc);
+    try spvlist.appendSlice(alloc, buf.written());
+
+    const hlsl = try hlslFromSpv(alloc, spvlist.items);
+    defer alloc.free(hlsl);
 }
 
 const test_crt = @embedFile("shaders/test_shadertoy_crt.glsl");


### PR DESCRIPTION
Fixes #129.

Adds `.hlsl` variant to `shadertoy.Target` and a SPIR-V to HLSL cross-compilation function using SPIRV-Cross's HLSL backend (`SPVC_BACKEND_HLSL`) targeting Shader Model 6.0. Wires `DirectX12.custom_shader_target` to `.hlsl`.

This gives us the cross-compilation pipeline (GLSL -> SPIR-V -> HLSL). Runtime DXC compilation of the resulting HLSL to DXIL bytecode for PSO creation is a follow-up.

Changes:
- `shadertoy.zig`: add `.hlsl` to Target enum, add `hlslFromSpv()` function, add `.hlsl` case in switch
- `DirectX12.zig`: change `custom_shader_target` from `.glsl` to `.hlsl`