### PR TITLE
renderer: DX12 multi-buffer binding for cell_text pipeline

### DIFF
--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -58,6 +58,7 @@ pub const srv_table_size: u32 = 3;
 pub const root_param_cbv: u32 = 0;
 pub const root_param_srv_table: u32 = 1;
 pub const root_param_sampler_table: u32 = 2;
+pub const root_param_buffer_srv: u32 = 3;
 
 /// Create the shared root signature used by all pipelines.
 ///
@@ -65,6 +66,7 @@ pub const root_param_sampler_table: u32 = 2;
 ///   [0] CBV at b0 (inline root CBV -- just a GPU virtual address)
 ///   [1] Descriptor table: 3 SRVs at t0, t1, t2
 ///   [2] Descriptor table: 1 sampler at s0
+///   [3] Inline SRV at t3 (structured buffer data, e.g. cells_bg)
 pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignature {
     // SRV range: t0..t2 (textures and structured buffers).
     // DATA_STATIC: atlas textures are uploaded once and don't change
@@ -116,6 +118,17 @@ pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignat
             .u = .{ .DescriptorTable = .{
                 .NumDescriptorRanges = 1,
                 .pDescriptorRanges = @ptrCast(&sampler_range),
+            } },
+            .ShaderVisibility = .ALL,
+        },
+        // [3] Inline SRV for structured buffer data (cells_bg).
+        // Binds with SetGraphicsRootShaderResourceView -- the GPU virtual
+        // address is passed directly, no descriptor heap slot needed.
+        .{
+            .ParameterType = .SRV,
+            .u = .{ .Descriptor = .{
+                .ShaderRegister = 3,
+                .RegisterSpace = 0,
             } },
             .ShaderVisibility = .ALL,
         },
@@ -308,6 +321,10 @@ test "root parameter indices" {
     try std.testing.expectEqual(@as(u32, 0), root_param_cbv);
     try std.testing.expectEqual(@as(u32, 1), root_param_srv_table);
     try std.testing.expectEqual(@as(u32, 2), root_param_sampler_table);
+}
+
+test "root_param_buffer_srv index" {
+    try std.testing.expectEqual(@as(u32, 3), root_param_buffer_srv);
 }
 
 test "srv_table_size covers t0..t2" {

--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -5,8 +5,9 @@
 //! layout that all pipelines share:
 //!
 //!   Param 0: CBV at b0 (Uniforms constant buffer)
-//!   Param 1: Descriptor table for SRVs at t0..t2 (textures, structured buffers)
+//!   Param 1: Descriptor table for SRVs at t0..t2 (atlas textures)
 //!   Param 2: Descriptor table for samplers at s0
+//!   Param 3: Inline SRV at t3 (structured buffer, e.g. cells_bg)
 //!
 //! This matches the HLSL register layout in shaders.hlsl. All five
 //! pipelines (bg_color, cell_bg, cell_text, image, bg_image) share the
@@ -124,11 +125,13 @@ pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignat
         // [3] Inline SRV for structured buffer data (cells_bg).
         // Binds with SetGraphicsRootShaderResourceView -- the GPU virtual
         // address is passed directly, no descriptor heap slot needed.
+        // DATA_VOLATILE: the buffer binding changes per draw call.
         .{
             .ParameterType = .SRV,
             .u = .{ .Descriptor = .{
                 .ShaderRegister = 3,
                 .RegisterSpace = 0,
+                .Flags = .DATA_VOLATILE,
             } },
             .ShaderVisibility = .ALL,
         },

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -252,8 +252,8 @@ pub fn step(self: *RenderPass, s: Step) void {
         }
     }
 
-    // Bind additional buffers as root SRV descriptors.
-    // buffers[0] is bound as a vertex buffer above. buffers[1..] are
+    // Bind buffers[1] as a root SRV descriptor (e.g. cells_bg).
+    // buffers[0] is bound as a vertex buffer above. buffers[1] is
     // structured buffer data accessed via SRV in the pixel/vertex shader.
     if (s.buffers.len > 1) {
         if (s.buffers[1]) |buf| {

--- a/src/renderer/directx12/RenderPass.zig
+++ b/src/renderer/directx12/RenderPass.zig
@@ -238,8 +238,6 @@ pub fn step(self: *RenderPass, s: Step) void {
 
     // Bind the first buffer as the instance vertex buffer.
     // Only the first non-null buffer with a stride is bound as a VB.
-    // Multi-buffer pipelines (e.g. cell_text) will need root descriptor
-    // table entries for storage buffers -- see #128.
     for (s.buffers) |b| {
         if (b) |buf| {
             if (buf.gpu_address != 0 and buf.size > 0 and buf.stride > 0) {
@@ -250,6 +248,20 @@ pub fn step(self: *RenderPass, s: Step) void {
                 };
                 cl.IASetVertexBuffers(0, 1, @ptrCast(&vbv));
                 break;
+            }
+        }
+    }
+
+    // Bind additional buffers as root SRV descriptors.
+    // buffers[0] is bound as a vertex buffer above. buffers[1..] are
+    // structured buffer data accessed via SRV in the pixel/vertex shader.
+    if (s.buffers.len > 1) {
+        if (s.buffers[1]) |buf| {
+            if (buf.gpu_address != 0) {
+                cl.SetGraphicsRootShaderResourceView(
+                    Pipeline.root_param_buffer_srv,
+                    buf.gpu_address,
+                );
             }
         }
     }
@@ -300,6 +312,16 @@ test "RenderPass has required methods" {
     try std.testing.expect(@TypeOf(RenderPass.begin) != void);
     try std.testing.expect(@TypeOf(RenderPass.step) != void);
     try std.testing.expect(@TypeOf(RenderPass.complete) != void);
+}
+
+test "Step supports multiple buffers" {
+    const s = Step{
+        .buffers = &.{
+            RawBuffer{ .gpu_address = 0x1000, .size = 256, .stride = 32 },
+            RawBuffer{ .gpu_address = 0x2000, .size = 128, .stride = 4 },
+        },
+    };
+    try std.testing.expectEqual(@as(usize, 2), s.buffers.len);
 }
 
 test "Step DrawType values" {

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -1194,7 +1194,7 @@ pub const ID3D12GraphicsCommandList = extern struct {
         // slot 39
         SetComputeRootShaderResourceView: Reserved,
         // slot 40
-        SetGraphicsRootShaderResourceView: Reserved,
+        SetGraphicsRootShaderResourceView: *const fn (*ID3D12GraphicsCommandList, RootParameterIndex: u32, BufferLocation: u64) callconv(.winapi) void,
         // slot 41
         SetComputeRootUnorderedAccessView: Reserved,
         // slot 42
@@ -1293,6 +1293,10 @@ pub const ID3D12GraphicsCommandList = extern struct {
 
     pub inline fn SetGraphicsRootConstantBufferView(self: *ID3D12GraphicsCommandList, index: u32, buffer_location: u64) void {
         self.vtable.SetGraphicsRootConstantBufferView(self, index, buffer_location);
+    }
+
+    pub inline fn SetGraphicsRootShaderResourceView(self: *ID3D12GraphicsCommandList, index: u32, buffer_location: u64) void {
+        self.vtable.SetGraphicsRootShaderResourceView(self, index, buffer_location);
     }
 
     pub inline fn CopyBufferRegion(self: *ID3D12GraphicsCommandList, dst: *ID3D12Resource, dst_offset: u64, src: *ID3D12Resource, src_offset: u64, num_bytes: u64) void {

--- a/src/renderer/shaders/hlsl/shaders.hlsl
+++ b/src/renderer/shaders/hlsl/shaders.hlsl
@@ -199,10 +199,10 @@ float4 BgColorPS(FullScreenVSOut input) : SV_TARGET
 //
 // The CPU side binds an array of packed RGBA u32 values indexed by grid
 // position (row-major: index = y * grid_width + x).
-// This is a StructuredBuffer<uint> at t0.
+// This is a StructuredBuffer<uint> at t3 (root SRV, not in the descriptor table).
 // ===========================================================================
 
-StructuredBuffer<uint> cell_bg_colors : register(t0);
+StructuredBuffer<uint> cell_bg_colors : register(t3);
 
 float4 CellBgPS(FullScreenVSOut input) : SV_TARGET
 {
@@ -263,12 +263,12 @@ float4 CellBgPS(FullScreenVSOut input) : SV_TARGET
 // Texture bindings:
 //   t0 = grayscale atlas (Texture2D<float4>)
 //   t1 = color atlas     (Texture2D<float4>)
-//   t2 = cell bg colors  (StructuredBuffer<uint>)
+//   t3 = cell bg colors  (StructuredBuffer<uint>, root SRV)
 // ===========================================================================
 
 Texture2D<float4>  ct_atlas_grayscale   : register(t0);
 Texture2D<float4>  ct_atlas_color       : register(t1);
-StructuredBuffer<uint> ct_cell_bg_colors: register(t2);
+StructuredBuffer<uint> ct_cell_bg_colors: register(t3);
 
 struct CellTextVSIn
 {


### PR DESCRIPTION
Fixes #128.

Adds a root SRV descriptor (param 3, register t3) for the cells_bg structured buffer. This avoids descriptor heap layout coordination between textures and buffers. RenderPass.step() binds buffers[1] via SetGraphicsRootShaderResourceView when present.

Changes:
- `d3d12.zig`: un-reserve `SetGraphicsRootShaderResourceView` (slot 40), add inline wrapper
- `Pipeline.zig`: add `root_param_buffer_srv = 3`, add 4th root parameter (inline SRV at t3)
- `shaders.hlsl`: move both StructuredBuffer declarations from t0/t2 to t3
- `RenderPass.zig`: bind buffers[1] as root SRV when present