### PR TITLE
renderer: DX12 init command list and staging buffer lifetime fix

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -113,7 +113,18 @@ rtv_handles: [device.Device.frame_count]d3d12.D3D12_CPU_DESCRIPTOR_HANDLE =
     .{ .{ .ptr = 0 }, .{ .ptr = 0 }, .{ .ptr = 0 } },
 
 /// Command list from the current beginFrame, executed in drawFrameEnd.
+/// Also temporarily set to the init command list during init() so that
+/// initAtlasTexture can record resource barriers for placeholder textures.
 pending_command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
+
+/// Temporary command allocator for init-time GPU work (texture barriers).
+/// Created in init(), released by flushInitCommands().
+init_command_allocator: ?*d3d12.ID3D12CommandAllocator = null,
+
+/// Temporary command list for init-time GPU work.
+/// Set as pending_command_list during init so initAtlasTexture picks it
+/// up through the existing textureOptions path without signature changes.
+init_command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
 
 /// Back buffer index from the current beginFrame, used in drawFrameEnd
 /// to record the fence value against the correct frame slot.
@@ -280,6 +291,44 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         }
     }
 
+    // Create a one-shot command list for init-time texture work.
+    // initAtlasTexture (called from SwapChain.init) needs a command list
+    // to record COPY_DEST -> PIXEL_SHADER_RESOURCE barriers on placeholder
+    // textures. Per-frame command lists aren't available until beginFrame,
+    // so we create a dedicated one here and flush it after SwapChain.init.
+    {
+        var init_alloc: ?*d3d12.ID3D12CommandAllocator = null;
+        const alloc_hr = dev_ptr.device.CreateCommandAllocator(
+            .DIRECT,
+            &d3d12.ID3D12CommandAllocator.IID,
+            @ptrCast(&init_alloc),
+        );
+        if (com.FAILED(alloc_hr)) {
+            log.err("CreateCommandAllocator for init failed: 0x{x}", .{@as(u32, @bitCast(alloc_hr))});
+            return error.CommandAllocatorCreationFailed;
+        }
+        errdefer _ = init_alloc.?.Release();
+
+        var init_cl: ?*d3d12.ID3D12GraphicsCommandList = null;
+        const cl_hr = dev_ptr.device.CreateCommandList(
+            0,
+            .DIRECT,
+            init_alloc.?,
+            null,
+            &d3d12.ID3D12GraphicsCommandList.IID,
+            @ptrCast(&init_cl),
+        );
+        if (com.FAILED(cl_hr)) {
+            log.err("CreateCommandList for init failed: 0x{x}", .{@as(u32, @bitCast(cl_hr))});
+            return error.CommandListCreationFailed;
+        }
+        errdefer _ = init_cl.?.Release();
+
+        result.init_command_allocator = init_alloc;
+        result.init_command_list = init_cl;
+        result.pending_command_list = init_cl;
+    }
+
     result.cached_width = size.width;
     result.cached_height = size.height;
 
@@ -290,6 +339,16 @@ pub fn deinit(self: *DirectX12) void {
     // Wait for GPU to finish before releasing anything.
     if (self.dev) |*dev_ptr| {
         dev_ptr.waitForGpu() catch {};
+    }
+
+    // Release init command list if never flushed (error during init).
+    if (self.init_command_list) |cl| {
+        _ = cl.Release();
+        self.init_command_list = null;
+    }
+    if (self.init_command_allocator) |alloc| {
+        _ = alloc.Release();
+        self.init_command_allocator = null;
     }
 
     for (&self.gpu_frames) |*gf| {
@@ -330,6 +389,41 @@ pub fn deinit(self: *DirectX12) void {
         dev_ptr.deinit();
         self.dev = null;
     }
+}
+
+/// Execute and release the one-shot init command list.
+/// Called from GenericRenderer.init after SwapChain.init creates the
+/// initial atlas textures. Submits the recorded resource barriers
+/// (COPY_DEST -> PIXEL_SHADER_RESOURCE) and waits for the GPU to
+/// finish before the first render frame.
+pub fn flushInitCommands(self: *DirectX12) void {
+    const dev_ptr = &(self.dev orelse return);
+
+    if (self.init_command_list) |cl| {
+        const close_hr = cl.Close();
+        if (!com.FAILED(close_hr)) {
+            const lists = [_]*d3d12.ID3D12GraphicsCommandList{cl};
+            dev_ptr.command_queue.ExecuteCommandLists(1, &lists);
+
+            dev_ptr.waitForGpu() catch |err| {
+                log.err("waitForGpu after init commands failed: {}", .{err});
+            };
+        } else {
+            log.err("init command list Close failed: 0x{x}", .{@as(u32, @bitCast(close_hr))});
+        }
+
+        _ = cl.Release();
+        self.init_command_list = null;
+    }
+
+    if (self.init_command_allocator) |alloc| {
+        _ = alloc.Release();
+        self.init_command_allocator = null;
+    }
+
+    // Clear so it doesn't point to the now-released init command list.
+    // beginFrame will set it to the per-frame command list.
+    self.pending_command_list = null;
 }
 
 pub fn drawFrameStart(self: *DirectX12) void {
@@ -574,6 +668,13 @@ pub fn initAtlasTexture(
     }, size, size, null);
 }
 
+/// Update an atlas texture's command list to the current frame's.
+/// DX12 rotates command lists across triple-buffered frames, so textures
+/// must not use a stale command list from a different frame slot.
+pub fn updateTextureCommandList(self: DirectX12, texture: *Texture) void {
+    texture.setCommandList(self.pending_command_list);
+}
+
 test {
     _ = com;
     _ = d3d12;
@@ -600,6 +701,17 @@ test "DirectX12 default cached size is zero" {
 
 test "DirectX12 has device_lost field" {
     try std.testing.expect(@hasField(DirectX12, "device_lost"));
+}
+
+test "DirectX12 has init command list fields" {
+    try std.testing.expect(@hasField(DirectX12, "init_command_allocator"));
+    try std.testing.expect(@hasField(DirectX12, "init_command_list"));
+}
+
+test "DirectX12 init command list defaults to null" {
+    const api: DirectX12 = .{};
+    try std.testing.expect(api.init_command_allocator == null);
+    try std.testing.expect(api.init_command_list == null);
 }
 
 test "DirectX12 default device_lost is false" {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -409,6 +409,11 @@ pub fn flushInitCommands(self: *DirectX12) void {
                 log.err("waitForGpu after init commands failed: {}", .{err});
             };
         } else {
+            // Close failed -- the recorded barriers won't reach the GPU.
+            // Texture.state already reads PIXEL_SHADER_RESOURCE but the
+            // GPU-side state is still COPY_DEST, so the first render frame
+            // will likely hit a resource state mismatch. This typically
+            // means the device is already in a bad state.
             log.err("init command list Close failed: 0x{x}", .{@as(u32, @bitCast(close_hr))});
         }
 

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -52,6 +52,12 @@ device: ?*d3d12.ID3D12Device = null,
 command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
 /// Current resource state for barrier tracking.
 state: d3d12.D3D12_RESOURCE_STATES = d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE,
+/// Staging buffer from the most recent upload, kept alive until the GPU
+/// finishes executing the CopyTextureRegion that reads from it.
+/// D3D12 does NOT extend resource lifetimes for recorded commands, so
+/// the staging buffer must outlive the command list execution.
+/// Released at the start of the next replaceRegion or in deinit.
+pending_staging: ?*d3d12.ID3D12Resource = null,
 
 const TEXTURE_DATA_PITCH_ALIGNMENT: u32 = 256;
 
@@ -114,6 +120,9 @@ pub fn init(opts: Options, width: usize, height: usize, data: ?[]const u8) Error
 }
 
 pub fn deinit(self: Texture) void {
+    if (self.pending_staging) |staging| {
+        _ = staging.Release();
+    }
     if (self.resource) |res| {
         _ = res.Release();
     }
@@ -121,16 +130,33 @@ pub fn deinit(self: Texture) void {
     // it gets freed when the heap itself is destroyed.
 }
 
+/// Update the cached command list to the current frame's.
+/// DX12 uses triple-buffered command lists that rotate each frame;
+/// the texture must use the current frame's list, not a stale one
+/// from init or a different frame slot.
+pub fn setCommandList(self: *Texture, cl: ?*d3d12.ID3D12GraphicsCommandList) void {
+    self.command_list = cl;
+}
+
 /// Upload pixel data to a sub-region of this texture.
 ///
-/// Precondition: the command list must be executed and the GPU must
-/// finish before this texture is used for rendering. In practice,
-/// GenericRenderer calls waitForGpu() after each frame which satisfies
-/// this requirement.
+/// The staging buffer is kept alive until the next replaceRegion call or
+/// deinit, because D3D12 does not extend resource lifetimes for recorded
+/// commands. The previous staging buffer is safe to release here because
+/// the frame's fence wait in beginFrame guarantees the GPU finished
+/// executing the prior CopyTextureRegion.
 ///
 /// Returns error{}!void for API compatibility with Metal's replaceRegion
 /// which cannot fail. DX12 upload failures are logged but not propagated.
 pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: usize, data: []const u8) error{}!void {
+    // Release the staging buffer from the previous upload. Safe because
+    // beginFrame waited on the fence for this frame slot, so the GPU
+    // has finished reading from it.
+    if (self.pending_staging) |prev| {
+        _ = prev.Release();
+        self.pending_staging = null;
+    }
+
     // Transition to COPY_DEST if needed.
     if (self.state != d3d12.D3D12_RESOURCE_STATES.COPY_DEST) {
         self.transition(d3d12.D3D12_RESOURCE_STATES.COPY_DEST);
@@ -225,11 +251,9 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
 
     cmd_list.CopyTextureRegion(&dst_loc, x, y, 0, &src_loc, &src_box);
 
-    // Release staging buffer. DX12 does NOT extend resource lifetimes for
-    // recorded commands (unlike D3D11). This Release is only safe because
-    // the caller ensures the command list is executed and the GPU finishes
-    // before the texture is used again (GenericRenderer.waitForGpu).
-    _ = staging.Release();
+    // Keep the staging buffer alive until the GPU finishes the copy.
+    // Released at the start of the next replaceRegion or in deinit.
+    self.pending_staging = staging;
 }
 
 fn transition(self: *Texture, new_state: d3d12.D3D12_RESOURCE_STATES) void {
@@ -370,6 +394,12 @@ test "Texture struct fields" {
     try std.testing.expect(@hasField(Texture, "srv"));
     try std.testing.expect(@hasField(Texture, "aligned_row_pitch"));
     try std.testing.expect(@hasField(Texture, "state"));
+    try std.testing.expect(@hasField(Texture, "pending_staging"));
+}
+
+test "Texture pending_staging defaults to null" {
+    const tex = Texture{};
+    try std.testing.expect(tex.pending_staging == null);
 }
 
 test "Texture.Options defaults" {
@@ -378,4 +408,15 @@ test "Texture.Options defaults" {
     try std.testing.expect(opts.command_list == null);
     try std.testing.expect(opts.srv_heap == null);
     try std.testing.expectEqual(dxgi.DXGI_FORMAT.R8_UNORM, opts.pixel_format);
+}
+
+test "setCommandList updates cached command list" {
+    var tex = Texture{};
+    try std.testing.expect(tex.command_list == null);
+    // Use a sentinel to verify the field is written without a real device.
+    const sentinel: *d3d12.ID3D12GraphicsCommandList = @ptrFromInt(0xDEAD0);
+    tex.setCommandList(sentinel);
+    try std.testing.expect(tex.command_list == sentinel);
+    tex.setCommandList(null);
+    try std.testing.expect(tex.command_list == null);
 }

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -192,9 +192,9 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
         log.err("failed to create staging buffer for texture upload (size={d})", .{staging_size});
         return;
     };
-    // The staging buffer will be released after the command list executes.
-    // For now we rely on the caller to manage staging lifetime via GPU sync.
-    // In practice, GenericRenderer calls waitForGpu() after each frame.
+    // Staging buffer is saved to self.pending_staging after the copy is
+    // recorded, and released at the start of the next replaceRegion or
+    // in deinit (after the GPU has finished reading from it).
 
     // Map and copy row-by-row with pitch alignment.
     var mapped: ?*anyopaque = null;

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -671,6 +671,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             );
             errdefer swap_chain.deinit();
 
+            // Flush any init-time GPU commands (e.g., DX12 texture barriers).
+            // SwapChain.init creates placeholder atlas textures that may need
+            // resource state transitions submitted to the GPU before rendering.
+            if (@hasDecl(GraphicsAPI, "flushInitCommands")) {
+                api.flushInitCommands();
+            }
+
             // Create the font shaper.
             var font_shaper = try font.Shaper.init(alloc, .{
                 .features = options.config.font_features.items,
@@ -1576,7 +1583,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 frame.bg_image_buffer_modified = self.bg_image_buffer_modified;
             }
 
-            // If our font atlas changed, sync the texture data
+            // Get a frame context from the graphics API.
+            // This must happen before atlas sync because DX12 texture uploads
+            // (CopyTextureRegion) require the frame's command list, which is
+            // only available after beginFrame. Metal and OpenGL use immediate
+            // CPU-to-GPU copies so this ordering is transparent to them.
+            var frame_ctx = try self.api.beginFrame(self, &frame.target);
+            defer frame_ctx.complete(sync);
+
+            // If our font atlas changed, sync the texture data.
+            // Placed after beginFrame so the DX12 command list is available.
             texture: {
                 const modified = self.font_grid.atlas_grayscale.modified.load(.monotonic);
                 if (modified <= frame.grayscale_modified) break :texture;
@@ -1593,10 +1609,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 frame.color_modified = self.font_grid.atlas_color.modified.load(.monotonic);
                 try self.syncAtlasTexture(&self.font_grid.atlas_color, &frame.color);
             }
-
-            // Get a frame context from the graphics API.
-            var frame_ctx = try self.api.beginFrame(self, &frame.target);
-            defer frame_ctx.complete(sync);
 
             {
                 var pass = frame_ctx.renderPass(&.{.{
@@ -3369,6 +3381,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             atlas: *const font.Atlas,
             texture: *Texture,
         ) !void {
+            // DX12 rotates command lists across triple-buffered frames.
+            // Update the texture to use the current frame's command list
+            // before any upload or resize operation. Metal and OpenGL use
+            // immediate uploads so they don't need this.
+            if (@hasDecl(GraphicsAPI, "updateTextureCommandList")) {
+                self.api.updateTextureCommandList(texture);
+            }
+
             if (atlas.size > texture.width) {
                 // Free our old texture
                 texture.*.deinit();


### PR DESCRIPTION
## Summary

Fixes #144.

- Create a one-shot command list for init-time texture barriers, flushed after SwapChain.init
- Move beginFrame before atlas sync so DX12 texture uploads use the frame's command list
- Add updateTextureCommandList to refresh stale command list refs across triple-buffered frames
- Defer staging buffer release until next replaceRegion/deinit to fix use-after-free
