### PR TITLE
renderer: add deinit poisoning to DX12 types

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -330,6 +330,8 @@ pub fn deinit(self: *DirectX12) void {
         dev_ptr.deinit();
         self.dev = null;
     }
+
+    self.* = undefined;
 }
 
 pub fn drawFrameStart(self: *DirectX12) void {

--- a/src/renderer/directx12/Frame.zig
+++ b/src/renderer/directx12/Frame.zig
@@ -104,6 +104,8 @@ pub fn deinit(self: *Frame) void {
     if (self.command_allocator) |ca| {
         _ = ca.Release();
     }
+
+    self.* = undefined;
 }
 
 // --- Per-frame operations ---

--- a/src/renderer/directx12/Target.zig
+++ b/src/renderer/directx12/Target.zig
@@ -23,7 +23,8 @@ height: usize = 0,
 
 pub fn deinit(self: *Target) void {
     if (self.resource) |r| _ = r.Release();
-    self.resource = null;
+
+    self.* = undefined;
 }
 
 /// Record a transition barrier on the given command list.

--- a/src/renderer/directx12/descriptor_heap.zig
+++ b/src/renderer/directx12/descriptor_heap.zig
@@ -80,6 +80,8 @@ pub fn init(
 
 pub fn deinit(self: *DescriptorHeap) void {
     _ = self.heap.Release();
+
+    self.* = undefined;
 }
 
 /// Reset the allocator so all slots can be reused. Does not invalidate

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -229,6 +229,8 @@ pub fn deinit(self: *Device) void {
     if (self.swap_chain) |sc| _ = sc.Release();
 
     _ = self.device.Release();
+
+    self.* = undefined;
 }
 
 /// Signal the fence from the command queue and block until the GPU catches up.

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -296,6 +296,8 @@ pub const Shaders = struct {
 
         if (self.root_signature) |rs| _ = rs.Release();
         self.root_signature = null;
+
+        self.* = undefined;
     }
 };
 


### PR DESCRIPTION
## Summary

- Add `self.* = undefined` at the end of every pointer-taking `deinit` in the DX12 renderer module
- Matches the pattern used by `OpenGL.zig` and `generic.zig`
- Catches double-deinit and use-after-deinit in debug builds by poisoning the struct with 0xaa

Covers: DirectX12, Device, Frame, Target, DescriptorHeap, Shaders.