### PR TITLE
fix: D3D12 SRV desc struct size test and SPIRV-Cross HLSL backend

### DIFF
--- a/pkg/spirv-cross/build.zig
+++ b/pkg/spirv-cross/build.zig
@@ -75,6 +75,7 @@ fn buildSpirvCross(
     defer flags.deinit(b.allocator);
     try flags.appendSlice(b.allocator, &.{
         "-DSPIRV_CROSS_C_API_GLSL=1",
+        "-DSPIRV_CROSS_C_API_HLSL=1",
         "-DSPIRV_CROSS_C_API_MSL=1",
 
         "-fno-sanitize=undefined",
@@ -103,6 +104,9 @@ fn buildSpirvCross(
 
                 // GLSL
                 "spirv_glsl.cpp",
+
+                // HLSL
+                "spirv_hlsl.cpp",
 
                 // MSL
                 "spirv_msl.cpp",

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -1553,9 +1553,10 @@ test "D3D12 struct sizes" {
     try std.testing.expectEqual(32, @sizeOf(D3D12_ROOT_PARAMETER));
     try std.testing.expectEqual(656, @sizeOf(D3D12_GRAPHICS_PIPELINE_STATE_DESC));
 
-    // SRV desc must match MSVC size (union sized to largest member: D3D12_BUFFER_SRV at 24 bytes).
-    // A too-small struct causes the D3D12 runtime to read past the end, triggering DEVICE_REMOVED.
-    try std.testing.expectEqual(36, @sizeOf(D3D12_SHADER_RESOURCE_VIEW_DESC));
+    // SRV desc must match MSVC ABI size. The union contains D3D12_BUFFER_SRV which starts
+    // with a u64, giving the union 8-byte alignment. After three u32 fields (12 bytes),
+    // 4 bytes of padding are inserted before the union: 12 + 4(pad) + 24(union) = 40.
+    try std.testing.expectEqual(40, @sizeOf(D3D12_SHADER_RESOURCE_VIEW_DESC));
     try std.testing.expectEqual(24, @sizeOf(D3D12_BUFFER_SRV));
     try std.testing.expectEqual(16, @sizeOf(D3D12_TEX2D_SRV));
 


### PR DESCRIPTION
## Summary

Fixes two pre-existing Windows test failures (# 146):

- **D3D12 struct size test**: Expected 36 bytes for `D3D12_SHADER_RESOURCE_VIEW_DESC` but the correct MSVC ABI size is 40. The union has 8-byte alignment from `D3D12_BUFFER_SRV`'s `u64` field, so 4 bytes of padding are inserted after the three `u32` fields.

- **Shadertoy HLSL test**: SPIRV-Cross was built without the HLSL backend. Added `SPIRV_CROSS_C_API_HLSL=1` define and `spirv_hlsl.cpp` to the build.

The hostname test (third item in # 146) passes independently -- it was collateral, not an actual bug.

## Test plan

- [x] `zig build test -Dapp-runtime=none -Drenderer=directx12 -Dtest-filter="D3D12 struct sizes"` passes
- [x] `zig build test -Dapp-runtime=none -Drenderer=directx12 -Dtest-filter="shadertoy to hlsl"` passes
- [x] Full test suite passes (0 failures)

Closes #146