### PR TITLE
fix: Win32 example keyboard input by combining key events with text

### DIFF
--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -91,6 +91,19 @@ static ghostty_input_mods_e current_mods(void) {
     return mods;
 }
 
+// Get the unshifted codepoint for a virtual key. This gives ghostty the
+// base character without Shift applied, matching what GTK provides via
+// gdk_keyval_to_unicode on the unshifted keyval.
+static uint32_t unshifted_codepoint_from_vk(WPARAM vk) {
+    // MapVirtualKeyW with MAPVK_VK_TO_CHAR returns the unshifted character
+    // for the key. Bit 31 is set for dead keys -- mask it off.
+    UINT ch = MapVirtualKeyW((UINT)vk, MAPVK_VK_TO_CHAR) & 0x7FFFFFFF;
+    // The result is an uppercase letter for A-Z; lowercase it to match
+    // the unshifted interpretation (physical key without Shift).
+    if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 'a';
+    return (uint32_t)ch;
+}
+
 // --- Window procedure ---
 
 static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
@@ -108,8 +121,8 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             .consumed_mods = GHOSTTY_MODS_NONE,
             .keycode = scancode_from_lparam(lp),
             .text = NULL,
+            .unshifted_codepoint = unshifted_codepoint_from_vk(wp),
             .composing = false,
-            .unshifted_codepoint = 0,
         };
         ghostty_surface_key(g_surface, key);
         return 0;
@@ -124,25 +137,64 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             .consumed_mods = GHOSTTY_MODS_NONE,
             .keycode = scancode_from_lparam(lp),
             .text = NULL,
+            .unshifted_codepoint = unshifted_codepoint_from_vk(wp),
             .composing = false,
-            .unshifted_codepoint = 0,
         };
         ghostty_surface_key(g_surface, key);
         return 0;
     }
 
-    case WM_CHAR: {
+    case WM_UNICHAR: {
+        if (wp == UNICODE_NOCHAR) return TRUE;
         if (!g_surface) break;
-        // wp is a UTF-16 code unit. Characters outside the BMP arrive as
-        // two WM_CHAR messages (high surrogate then low surrogate).
+
+        uint32_t cp = (uint32_t)wp;
+
+        char utf8[8] = {0};
+        int len = 0;
+        if (cp < 0x80) {
+            utf8[0] = (char)cp;
+            len = 1;
+        } else if (cp < 0x800) {
+            utf8[0] = (char)(0xC0 | (cp >> 6));
+            utf8[1] = (char)(0x80 | (cp & 0x3F));
+            len = 2;
+        } else if (cp < 0x10000) {
+            utf8[0] = (char)(0xE0 | (cp >> 12));
+            utf8[1] = (char)(0x80 | ((cp >> 6) & 0x3F));
+            utf8[2] = (char)(0x80 | (cp & 0x3F));
+            len = 3;
+        } else if (cp < 0x110000) {
+            utf8[0] = (char)(0xF0 | (cp >> 18));
+            utf8[1] = (char)(0x80 | ((cp >> 12) & 0x3F));
+            utf8[2] = (char)(0x80 | ((cp >> 6) & 0x3F));
+            utf8[3] = (char)(0x80 | (cp & 0x3F));
+            len = 4;
+        }
+        if (len <= 0) return 0;
+        utf8[len] = '\0';
+
+        ghostty_surface_text(g_surface, utf8, (uintptr_t)len);
+        return 0;
+    }
+
+    case WM_DEADCHAR:
+    case WM_SYSDEADCHAR:
+        return 0;
+
+    case WM_CHAR:
+    case WM_SYSCHAR: {
+        if (!g_surface) break;
+
         WCHAR wc = (WCHAR)wp;
-        wchar_t wc_buf[3] = {0};
-        int count;
 
         if (IS_HIGH_SURROGATE(wc)) {
             g_high_surrogate = wc;
             return 0;
         }
+
+        wchar_t wc_buf[3] = {0};
+        int count;
         if (IS_LOW_SURROGATE(wc)) {
             if (g_high_surrogate) {
                 wc_buf[0] = g_high_surrogate;
@@ -150,7 +202,7 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
                 g_high_surrogate = 0;
                 count = 2;
             } else {
-                return 0;  // orphaned low surrogate
+                return 0;
             }
         } else {
             g_high_surrogate = 0;
@@ -159,11 +211,12 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         }
 
         char utf8[8] = {0};
-        int len = WideCharToMultiByte(CP_UTF8, 0, wc_buf, count, utf8, sizeof(utf8) - 1, NULL, NULL);
-        if (len > 0) {
-            utf8[len] = '\0';
-            ghostty_surface_text(g_surface, utf8, (uintptr_t)len);
-        }
+        int len = WideCharToMultiByte(CP_UTF8, 0, wc_buf, count,
+                                       utf8, sizeof(utf8) - 1, NULL, NULL);
+        if (len <= 0) return 0;
+        utf8[len] = '\0';
+
+        ghostty_surface_text(g_surface, utf8, (uintptr_t)len);
         return 0;
     }
 

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -91,19 +91,6 @@ static ghostty_input_mods_e current_mods(void) {
     return mods;
 }
 
-// Get the unshifted codepoint for a virtual key. This gives ghostty the
-// base character without Shift applied, matching what GTK provides via
-// gdk_keyval_to_unicode on the unshifted keyval.
-static uint32_t unshifted_codepoint_from_vk(WPARAM vk) {
-    // MapVirtualKeyW with MAPVK_VK_TO_CHAR returns the unshifted character
-    // for the key. Bit 31 is set for dead keys -- mask it off.
-    UINT ch = MapVirtualKeyW((UINT)vk, MAPVK_VK_TO_CHAR) & 0x7FFFFFFF;
-    // The result is an uppercase letter for A-Z; lowercase it to match
-    // the unshifted interpretation (physical key without Shift).
-    if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 'a';
-    return (uint32_t)ch;
-}
-
 // --- Window procedure ---
 
 static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
@@ -121,7 +108,7 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             .consumed_mods = GHOSTTY_MODS_NONE,
             .keycode = scancode_from_lparam(lp),
             .text = NULL,
-            .unshifted_codepoint = unshifted_codepoint_from_vk(wp),
+            .unshifted_codepoint = 0,
             .composing = false,
         };
         ghostty_surface_key(g_surface, key);
@@ -137,7 +124,7 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             .consumed_mods = GHOSTTY_MODS_NONE,
             .keycode = scancode_from_lparam(lp),
             .text = NULL,
-            .unshifted_codepoint = unshifted_codepoint_from_vk(wp),
+            .unshifted_codepoint = 0,
             .composing = false,
         };
         ghostty_surface_key(g_surface, key);

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -144,33 +144,31 @@ static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         return 0;
     }
 
+    // WM_UNICHAR is sent by some IME frameworks (e.g. IBUS on Wine) and
+    // accessibility tools that bypass TranslateMessage. Unlike WM_CHAR
+    // which delivers UTF-16, WM_UNICHAR carries a full UTF-32 codepoint.
     case WM_UNICHAR: {
         if (wp == UNICODE_NOCHAR) return TRUE;
         if (!g_surface) break;
 
+        // Convert the UTF-32 codepoint to a surrogate pair (or single
+        // wchar_t) so we can use WideCharToMultiByte like WM_CHAR.
         uint32_t cp = (uint32_t)wp;
+        wchar_t wc_buf[3] = {0};
+        int count;
+        if (cp >= 0x10000 && cp < 0x110000) {
+            cp -= 0x10000;
+            wc_buf[0] = (wchar_t)(0xD800 | (cp >> 10));
+            wc_buf[1] = (wchar_t)(0xDC00 | (cp & 0x3FF));
+            count = 2;
+        } else {
+            wc_buf[0] = (wchar_t)cp;
+            count = 1;
+        }
 
         char utf8[8] = {0};
-        int len = 0;
-        if (cp < 0x80) {
-            utf8[0] = (char)cp;
-            len = 1;
-        } else if (cp < 0x800) {
-            utf8[0] = (char)(0xC0 | (cp >> 6));
-            utf8[1] = (char)(0x80 | (cp & 0x3F));
-            len = 2;
-        } else if (cp < 0x10000) {
-            utf8[0] = (char)(0xE0 | (cp >> 12));
-            utf8[1] = (char)(0x80 | ((cp >> 6) & 0x3F));
-            utf8[2] = (char)(0x80 | (cp & 0x3F));
-            len = 3;
-        } else if (cp < 0x110000) {
-            utf8[0] = (char)(0xF0 | (cp >> 18));
-            utf8[1] = (char)(0x80 | ((cp >> 12) & 0x3F));
-            utf8[2] = (char)(0x80 | ((cp >> 6) & 0x3F));
-            utf8[3] = (char)(0x80 | (cp & 0x3F));
-            len = 4;
-        }
+        int len = WideCharToMultiByte(CP_UTF8, 0, wc_buf, count,
+                                       utf8, sizeof(utf8) - 1, NULL, NULL);
         if (len <= 0) return 0;
         utf8[len] = '\0';
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -463,11 +463,12 @@ pub const Surface = struct {
     /// Text buffer for Windows key event combining. Lives outside the
     /// pending_key optional so it doesn't get poisoned when the optional
     /// is set to null in debug builds. The event.text pointer references
-    /// this buffer during dispatch.
+    /// this buffer during dispatch. Sized to match GTK's im_buf (128)
+    /// so IME compositions aren't silently truncated.
     pending_key_text: if (builtin.os.tag == .windows)
-        [16]u8
+        [128]u8
     else
-        void = if (builtin.os.tag == .windows) .{0} ** 16 else {},
+        void = if (builtin.os.tag == .windows) .{0} ** 128 else {},
 
     const PendingKey = struct {
         event: App.KeyEvent,
@@ -983,6 +984,11 @@ pub const Surface = struct {
     }
 
     pub fn focusCallback(self: *Surface, focused: bool) void {
+        // Flush any buffered key event on focus loss so it isn't
+        // silently dropped (e.g. user presses a key then Alt-Tabs
+        // before WM_CHAR arrives).
+        if (!focused) self.flushPendingKey();
+
         self.core_surface.focusCallback(focused) catch |err| {
             log.err("error in focus callback err={}", .{err});
             return;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -450,6 +450,29 @@ pub const Surface = struct {
     /// that getTitle works without the implementer needing to save it.
     title: ?[:0]const u8 = null,
 
+    /// Windows key event buffering. WM_KEYDOWN and WM_CHAR arrive as
+    /// separate messages on Windows. We buffer the keydown here and
+    /// attach text from the following ghostty_surface_text call before
+    /// dispatching through key encoding. On non-Windows this is void
+    /// and eliminated by comptime.
+    pending_key: if (builtin.os.tag == .windows)
+        ?PendingKey
+    else
+        void = if (builtin.os.tag == .windows) null else {},
+
+    /// Text buffer for Windows key event combining. Lives outside the
+    /// pending_key optional so it doesn't get poisoned when the optional
+    /// is set to null in debug builds. The event.text pointer references
+    /// this buffer during dispatch.
+    pending_key_text: if (builtin.os.tag == .windows)
+        [16]u8
+    else
+        void = if (builtin.os.tag == .windows) .{0} ** 16 else {},
+
+    const PendingKey = struct {
+        event: App.KeyEvent,
+    };
+
     /// Surface initialization options.
     pub const Options = extern struct {
         /// The platform that this surface is being initialized for and
@@ -932,6 +955,31 @@ pub const Surface = struct {
             log.err("error in key callback err={}", .{err});
             return;
         };
+    }
+
+    /// Dispatch a key event through the core key handling path.
+    /// Extracted from ghostty_surface_key to share between the
+    /// immediate dispatch and pending key flush paths.
+    fn dispatchKey(self: *Surface, event: App.KeyEvent) bool {
+        return self.app.keyEvent(
+            .{ .surface = self },
+            event,
+        ) catch |err| {
+            log.warn("error processing key event err={}", .{err});
+            return false;
+        };
+    }
+
+    /// Flush any pending key event that was buffered by
+    /// ghostty_surface_key on Windows. Called before buffering a
+    /// new key or when a key release arrives. On non-Windows this
+    /// is a no-op eliminated by comptime.
+    fn flushPendingKey(self: *Surface) void {
+        if (comptime builtin.os.tag != .windows) return;
+        if (self.pending_key) |pending| {
+            self.pending_key = null;
+            _ = self.dispatchKey(pending.event);
+        }
     }
 
     pub fn focusCallback(self: *Surface, focused: bool) void {
@@ -1831,17 +1879,37 @@ pub const CAPI = struct {
     /// Send this for raw keypresses (i.e. the keyDown event on macOS).
     /// This will handle the keymap translation and send the appropriate
     /// key and char events.
+    ///
+    /// On Windows, if this is a press/repeat with no text, the event
+    /// is buffered. A following ghostty_surface_text call will attach
+    /// text and dispatch through key encoding. This handles the split
+    /// WM_KEYDOWN / WM_CHAR message pattern so embedders don't need
+    /// to combine them manually.
     export fn ghostty_surface_key(
         surface: *Surface,
         event: KeyEvent,
     ) bool {
-        return surface.app.keyEvent(
-            .{ .surface = surface },
-            event.keyEvent(),
-        ) catch |err| {
-            log.warn("error processing key event err={}", .{err});
-            return false;
-        };
+        const key_event = event.keyEvent();
+
+        if (comptime builtin.os.tag == .windows) {
+            // Flush any previous pending key that never got text
+            // (e.g. arrow keys, function keys, backspace).
+            surface.flushPendingKey();
+
+            // If this is a press/repeat with no text, buffer it --
+            // a ghostty_surface_text call may follow with the character.
+            if (key_event.text == null and key_event.action != .release) {
+                surface.pending_key = .{ .event = key_event };
+                return false;
+            }
+
+            // Has text already (caller did combining) or is a release --
+            // dispatch immediately.
+            return surface.dispatchKey(key_event);
+        }
+
+        // Non-Windows: straight passthrough, unchanged.
+        return surface.dispatchKey(key_event);
     }
 
     /// Returns true if the given key event would trigger a binding
@@ -1865,14 +1933,39 @@ pub const CAPI = struct {
         return true;
     }
 
-    /// Send raw text to the terminal. This is treated like a paste
-    /// so this isn't useful for sending escape sequences. For that,
-    /// individual key input should be used.
+    /// Send raw text to the terminal. On non-Windows (or when there is
+    /// no pending key event), this is treated like a paste. On Windows,
+    /// if there is a pending key event from ghostty_surface_key, the
+    /// text is attached to that key and dispatched through key encoding
+    /// instead -- this handles the WM_CHAR message that follows WM_KEYDOWN.
     export fn ghostty_surface_text(
         surface: *Surface,
         ptr: [*]const u8,
         len: usize,
     ) void {
+        if (comptime builtin.os.tag == .windows) {
+            if (surface.pending_key) |*pending| {
+                const text = ptr[0..len];
+                const copy_len: u8 = @intCast(@min(text.len, surface.pending_key_text.len - 1));
+
+                // Copy text into the Surface-level buffer (not
+                // inside the optional) so it survives clearing
+                // pending_key. Zig poisons optional payloads in
+                // debug mode when set to null.
+                @memcpy(surface.pending_key_text[0..copy_len], text[0..copy_len]);
+                surface.pending_key_text[copy_len] = 0; // null-terminate
+
+                // Rebuild the event with text attached and dispatch
+                // through key encoding, not the paste path.
+                var event = pending.event;
+                event.text = surface.pending_key_text[0..copy_len :0];
+                surface.pending_key = null;
+                _ = surface.dispatchKey(event);
+                return;
+            }
+        }
+
+        // No pending key (or non-Windows): paste path, unchanged.
         surface.textCallback(ptr[0..len]);
     }
 

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1984,7 +1984,7 @@ pub const CAPI = struct {
         if (comptime builtin.os.tag == .windows) {
             if (surface.pending_key) |*pending| {
                 const text = ptr[0..len];
-                const copy_len: u8 = @intCast(@min(text.len, surface.pending_key_text.len - 1));
+                const copy_len: usize = @min(text.len, surface.pending_key_text.len - 1);
 
                 // Copy text into the Surface-level buffer (not
                 // inside the optional) so it survives clearing

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1351,9 +1351,41 @@ pub const CAPI = struct {
                 )),
                 .keycode = self.keycode,
                 .text = if (self.text) |ptr| std.mem.sliceTo(ptr, 0) else null,
-                .unshifted_codepoint = self.unshifted_codepoint,
+                .unshifted_codepoint = if (self.unshifted_codepoint != 0)
+                    self.unshifted_codepoint
+                else
+                    unshiftedCodepointFromKeycode(self.keycode),
                 .composing = self.composing,
             };
+        }
+
+        /// Derive the unshifted codepoint from a Win32 scancode so
+        /// embedders don't need to provide it themselves. Uses
+        /// MapVirtualKeyW to go scancode -> VK -> base character,
+        /// matching what the C example does with MAPVK_VK_TO_CHAR.
+        /// On non-Windows this returns 0 (no-op).
+        fn unshiftedCodepointFromKeycode(keycode: u32) u32 {
+            if (comptime builtin.os.tag != .windows) return 0;
+
+            const win32 = struct {
+                const MAPVK_VSC_TO_VK_EX = 3;
+                const MAPVK_VK_TO_CHAR = 2;
+                extern "user32" fn MapVirtualKeyW(uCode: u32, uMapType: u32) callconv(.winapi) u32;
+            };
+
+            // Extended keys have 0xE000 prefix in our scancode
+            // encoding. MapVirtualKeyW expects the raw scancode
+            // with the extended bit in the high byte (0xE0xx).
+            const vk = win32.MapVirtualKeyW(keycode, win32.MAPVK_VSC_TO_VK_EX);
+            if (vk == 0) return 0;
+
+            // Bit 31 set means dead key -- mask it off.
+            var ch = win32.MapVirtualKeyW(vk, win32.MAPVK_VK_TO_CHAR) & 0x7FFFFFFF;
+
+            // Lowercase A-Z to match the unshifted physical key.
+            if (ch >= 'A' and ch <= 'Z') ch = ch - 'A' + 'a';
+
+            return ch;
         }
     };
 


### PR DESCRIPTION
## Summary

- WM_KEYDOWN and WM_CHAR were sent as separate ghostty API calls, but ghostty expects them combined in a single `ghostty_surface_key` call with the text field populated (matching how GTK sends key+text together)
- The split caused printable keys to be double-processed and control keys like backspace to have C0 chars leak through as invalid text
- Buffer WM_KEYDOWN as pending, PeekMessage to detect following WM_CHAR, attach UTF-8 text before flushing
- Filter C0 control characters from WM_CHAR, convert Ctrl+letter C0 chars back to base letters for the key encoder

Closes #147

## Test plan

- [x] Backspace reliably deletes characters
- [x] Regular typing (letters, numbers, symbols) works correctly
- [x] Enter submits commands
- [x] Arrow keys work
- [x] Builds clean with zig cc (only pre-existing freopen warnings)