### PR TITLE
fix: Win32 Ctrl+C does not interrupt child process via ConPTY

### DIFF
--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -21,6 +21,16 @@ static WCHAR g_high_surrogate = 0;
 
 static LRESULT CALLBACK wnd_proc(HWND, UINT, WPARAM, LPARAM);
 
+// Custom console ctrl handler. Returns TRUE to prevent the default
+// handler from terminating the process on Ctrl+C. Unlike
+// SetConsoleCtrlHandler(NULL, TRUE), a custom handler is NOT
+// inherited by child processes, so ConPTY children still receive
+// CTRL_C_EVENT normally.
+static BOOL WINAPI ctrl_handler(DWORD type) {
+    (void)type;
+    return TRUE;  // handled -- don't kill us
+}
+
 // --- Runtime callbacks ---
 // ghostty calls wakeup from background threads when the app needs to tick.
 // We post a message to the main thread's message loop.
@@ -334,9 +344,18 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdLine, int show) {
     (void)hPrev; (void)cmdLine;
 
     // Attach to parent console or allocate one so we can see stderr/stdout.
+    // A console is required for Ctrl+C keystrokes to reach the GUI window.
     if (!AttachConsole(ATTACH_PARENT_PROCESS)) AllocConsole();
     freopen("CONOUT$", "w", stdout);
     freopen("CONOUT$", "w", stderr);
+
+    // Install a custom handler that prevents Ctrl+C from killing
+    // this process. The default handler calls ExitProcess; our
+    // handler returns TRUE ("handled") so the keystroke reaches
+    // the GUI window's WM_KEYDOWN instead. A custom handler is
+    // NOT inherited by child processes (unlike NULL/TRUE), so
+    // ConPTY children still receive CTRL_C_EVENT normally.
+    SetConsoleCtrlHandler(ctrl_handler, TRUE);
 
     // 1. Register window class
     WNDCLASSEX wc = {

--- a/example/c-win32-terminal/src/main.c
+++ b/example/c-win32-terminal/src/main.c
@@ -21,14 +21,10 @@ static WCHAR g_high_surrogate = 0;
 
 static LRESULT CALLBACK wnd_proc(HWND, UINT, WPARAM, LPARAM);
 
-// Custom console ctrl handler. Returns TRUE to prevent the default
-// handler from terminating the process on Ctrl+C. Unlike
-// SetConsoleCtrlHandler(NULL, TRUE), a custom handler is NOT
-// inherited by child processes, so ConPTY children still receive
-// CTRL_C_EVENT normally.
+// Prevent default Ctrl+C handler from killing us. Custom handlers
+// (unlike NULL) are not inherited by child processes.
 static BOOL WINAPI ctrl_handler(DWORD type) {
-    (void)type;
-    return TRUE;  // handled -- don't kill us
+    return type == CTRL_C_EVENT || type == CTRL_BREAK_EVENT;
 }
 
 // --- Runtime callbacks ---
@@ -349,12 +345,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR cmdLine, int show) {
     freopen("CONOUT$", "w", stdout);
     freopen("CONOUT$", "w", stderr);
 
-    // Install a custom handler that prevents Ctrl+C from killing
-    // this process. The default handler calls ExitProcess; our
-    // handler returns TRUE ("handled") so the keystroke reaches
-    // the GUI window's WM_KEYDOWN instead. A custom handler is
-    // NOT inherited by child processes (unlike NULL/TRUE), so
-    // ConPTY children still receive CTRL_C_EVENT normally.
+    // Prevent Ctrl+C from killing this process. A custom handler
+    // (unlike NULL) is not inherited by child processes.
     SetConsoleCtrlHandler(ctrl_handler, TRUE);
 
     // 1. Register window class

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1985,15 +1985,10 @@ pub const CAPI = struct {
             if (surface.pending_key) |*pending| {
                 const text = ptr[0..len];
 
-                // Don't attach C0 control characters as text. Windows
-                // WM_CHAR delivers the control byte directly (e.g. 0x03
-                // for Ctrl+C) but the key encoder expects the printable
-                // character and derives the control byte from the logical
-                // key and modifier. Passing the raw control byte causes
-                // ctrlSeq to miss its switch match and fall through to
-                // CSI u, which ConPTY cannot translate into CTRL_C_EVENT.
-                // This matches GTK, which filters cp < 0x20 from IM text.
-                // We also filter 0x7F (DEL) since it has no printable form.
+                // Don't attach C0 control characters as text. WM_CHAR
+                // delivers the raw byte (e.g. 0x03 for Ctrl+C) but the
+                // key encoder expects the printable character. Matches
+                // GTK filtering (surface.zig:1390).
                 const is_c0 = text.len == 1 and (text[0] < 0x20 or text[0] == 0x7f);
 
                 var event = pending.event;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1984,19 +1984,33 @@ pub const CAPI = struct {
         if (comptime builtin.os.tag == .windows) {
             if (surface.pending_key) |*pending| {
                 const text = ptr[0..len];
-                const copy_len: usize = @min(text.len, surface.pending_key_text.len - 1);
 
-                // Copy text into the Surface-level buffer (not
-                // inside the optional) so it survives clearing
-                // pending_key. Zig poisons optional payloads in
-                // debug mode when set to null.
-                @memcpy(surface.pending_key_text[0..copy_len], text[0..copy_len]);
-                surface.pending_key_text[copy_len] = 0; // null-terminate
+                // Don't attach C0 control characters as text. Windows
+                // WM_CHAR delivers the control byte directly (e.g. 0x03
+                // for Ctrl+C) but the key encoder expects the printable
+                // character and derives the control byte from the logical
+                // key and modifier. Passing the raw control byte causes
+                // ctrlSeq to miss its switch match and fall through to
+                // CSI u, which ConPTY cannot translate into CTRL_C_EVENT.
+                // This matches GTK, which filters cp < 0x20 from IM text.
+                // We also filter 0x7F (DEL) since it has no printable form.
+                const is_c0 = text.len == 1 and (text[0] < 0x20 or text[0] == 0x7f);
 
-                // Rebuild the event with text attached and dispatch
-                // through key encoding, not the paste path.
                 var event = pending.event;
-                event.text = surface.pending_key_text[0..copy_len :0];
+
+                if (!is_c0) {
+                    const copy_len: usize = @min(text.len, surface.pending_key_text.len - 1);
+
+                    // Copy text into the Surface-level buffer (not
+                    // inside the optional) so it survives clearing
+                    // pending_key. Zig poisons optional payloads in
+                    // debug mode when set to null.
+                    @memcpy(surface.pending_key_text[0..copy_len], text[0..copy_len]);
+                    surface.pending_key_text[copy_len] = 0; // null-terminate
+
+                    event.text = surface.pending_key_text[0..copy_len :0];
+                }
+
                 surface.pending_key = null;
                 _ = surface.dispatchKey(event);
                 return;

--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -2444,3 +2444,10 @@ test "ctrlseq: ctrl c with no text uses logical key" {
     const seq = ctrlSeq(.key_c, "", 'c', .{ .ctrl = true });
     try testing.expectEqual(@as(u8, 0x03), seq.?);
 }
+
+test "ctrlseq: DEL byte in text returns null" {
+    // If 0x7F (DEL) leaks through as text, ctrlSeq can't map it.
+    // The embedded apprt filters this before it reaches the encoder.
+    const seq = ctrlSeq(.backspace, "\x7f", 0x7f, .{ .ctrl = true });
+    try testing.expect(seq == null);
+}

--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -2019,9 +2019,6 @@ test "legacy: ctrl+c" {
 }
 
 test "legacy: ctrl+c no text" {
-    // On Windows, C0 text from WM_CHAR is filtered so the encoder
-    // receives empty text. It should still produce 0x03 via the
-    // logical key fallback in ctrlSeq.
     var buf: [128]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
     try legacy(&writer, .{
@@ -2439,15 +2436,7 @@ test "ctrlseq: right ctrl c" {
 }
 
 test "ctrlseq: ctrl c with no text uses logical key" {
-    // When text is empty (e.g. C0 filtered on Windows), ctrlSeq falls
-    // through to the logical key path and still produces 0x03.
     const seq = ctrlSeq(.key_c, "", 'c', .{ .ctrl = true });
     try testing.expectEqual(@as(u8, 0x03), seq.?);
 }
 
-test "ctrlseq: DEL byte in text returns null" {
-    // If 0x7F (DEL) leaks through as text, ctrlSeq can't map it.
-    // The embedded apprt filters this before it reaches the encoder.
-    const seq = ctrlSeq(.backspace, "\x7f", 0x7f, .{ .ctrl = true });
-    try testing.expect(seq == null);
-}

--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -2018,6 +2018,21 @@ test "legacy: ctrl+c" {
     try testing.expectEqualStrings("\x03", writer.buffered());
 }
 
+test "legacy: ctrl+c no text" {
+    // On Windows, C0 text from WM_CHAR is filtered so the encoder
+    // receives empty text. It should still produce 0x03 via the
+    // logical key fallback in ctrlSeq.
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try legacy(&writer, .{
+        .key = .key_c,
+        .mods = .{ .ctrl = true },
+        .utf8 = "",
+        .unshifted_codepoint = 'c',
+    }, .{});
+    try testing.expectEqualStrings("\x03", writer.buffered());
+}
+
 test "legacy: ctrl+space" {
     var buf: [128]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
@@ -2420,5 +2435,12 @@ test "ctrlseq: right ctrl c" {
         .ctrl = true,
         .sides = .{ .ctrl = .right },
     });
+    try testing.expectEqual(@as(u8, 0x03), seq.?);
+}
+
+test "ctrlseq: ctrl c with no text uses logical key" {
+    // When text is empty (e.g. C0 filtered on Windows), ctrlSeq falls
+    // through to the logical key path and still produces 0x03.
+    const seq = ctrlSeq(.key_c, "", 'c', .{ .ctrl = true });
     try testing.expectEqual(@as(u8, 0x03), seq.?);
 }


### PR DESCRIPTION
## Summary

- Filter C0 control characters from WM_CHAR text in the Windows pending key combining path so the key encoder produces raw control bytes instead of CSI u sequences
- Add custom console ctrl handler in the Win32 example to prevent Ctrl+C from killing the host process

Closes #152

## Problem

On Windows, `TranslateMessage` produces `WM_CHAR` with the control byte directly (e.g. `0x03` for Ctrl+C). The embedded apprt's pending key mechanism attached this byte as text on the key event. In `ctrlSeq`, `utf8[0]` was `0x03` which doesn't match `'c' => 3` in the lookup switch, so the encoder fell through to CSI u encoding (`\x1B[3;5u`). ConPTY cannot translate CSI u sequences into `CTRL_C_EVENT` for the child process.

On GTK, control characters (`< 0x20`) are explicitly filtered from IM text (`src/apprt/gtk/class/surface.zig:1390`), so the encoder receives empty text and uses the logical key's codepoint instead.

## Fix

**C0 text filtering:** When the WM_CHAR text is a single C0 control character (`< 0x20` or `0x7F`), don't attach it as text to the pending key event. With empty text, `ctrlSeq` falls through to the logical key path (`key_c` -> codepoint `'c'` -> `3`) and writes the raw `0x03` byte to the ConPTY input pipe, which ConPTY translates into `CTRL_C_EVENT`.

This affects all Ctrl+key combinations (Ctrl+C, Ctrl+Z, Ctrl+D, etc.) on Windows.

**Console ctrl handler:** The Win32 example's console default handler would kill the process on Ctrl+C before it reaches the GUI window. A custom `SetConsoleCtrlHandler` callback returns TRUE to prevent this. Unlike `SetConsoleCtrlHandler(NULL, TRUE)`, a custom handler is not inherited by child processes, so ConPTY children still receive `CTRL_C_EVENT` normally.

## Known limitation

When the Win32 example is launched from a non-console parent (where `AttachConsole(ATTACH_PARENT_PROCESS)` fails and `AllocConsole()` is used), ConPTY does not translate the raw `0x03` byte into `CTRL_C_EVENT`. Ctrl+C works correctly when launched from cmd.exe. Tracked in # 155.

## Test plan

- [x] New unit tests for `ctrlSeq` and `legacy` encoder with empty text + logical key
- [x] New test for DEL (0x7F) byte filtering
- [x] `zig build test` passes
- [x] Manual: launch from cmd.exe, run `ping -t 8.8.8.8`, press Ctrl+C -- stops ping
- [ ] Manual: verify Ctrl+Z, Ctrl+D also work from cmd.exe