### PR TITLE
feat(windows): scaffold WinUI 3 app shell consuming libghostty

### DIFF
--- a/justfile
+++ b/justfile
@@ -83,6 +83,17 @@ _test-examples-cmake:
 build-dll:
     zig build -Dapp-runtime=none
 
+# === WinUI 3 app shell ===
+
+# Build the WinUI 3 app shell (expects ghostty.dll at zig-out/bin/).
+build-win:
+    dotnet build windows/Ghostty/Ghostty.sln
+
+# Build the DLL and the shell, then launch it.
+run-win: build-dll build-win
+    #!/usr/bin/env bash
+    exec ./windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/Ghostty.exe
+
 # === Upstream Sync ===
 
 # Fetch upstream and rebase windows branch

--- a/windows/Ghostty/.gitignore
+++ b/windows/Ghostty/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.user

--- a/windows/Ghostty/App.xaml
+++ b/windows/Ghostty/App.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="Ghostty.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</Application>

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Xaml;
+
+namespace Ghostty;
+
+/// <summary>
+/// Application entry point. Keeps a strong reference to the main window so
+/// it is not collected while the message loop is running.
+/// </summary>
+public partial class App : Application
+{
+    private Window? _window;
+
+    static App()
+    {
+        // libghostty.dll lives in a `native/` subdirectory next to this
+        // assembly so its filename (ghostty.dll) does not collide with our
+        // own managed Ghostty.dll on case-insensitive filesystems. The
+        // DllImport entries use "ghostty" so we resolve that name here.
+        NativeLibrary.SetDllImportResolver(
+            typeof(Interop.NativeMethods).Assembly,
+            (name, assembly, path) =>
+            {
+                if (!string.Equals(name, "ghostty", StringComparison.OrdinalIgnoreCase))
+                    return IntPtr.Zero;
+                var baseDir = Path.GetDirectoryName(assembly.Location) ?? AppContext.BaseDirectory;
+                var candidate = Path.Combine(baseDir, "native", "ghostty.dll");
+                return NativeLibrary.Load(candidate);
+            });
+    }
+
+    public App()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        _window = new MainWindow();
+        _window.Activate();
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -25,7 +25,12 @@ public partial class App : Application
             {
                 if (!string.Equals(name, "ghostty", StringComparison.OrdinalIgnoreCase))
                     return IntPtr.Zero;
-                var baseDir = Path.GetDirectoryName(assembly.Location) ?? AppContext.BaseDirectory;
+                // Prefer AppContext.BaseDirectory: assembly.Location is empty
+                // under single-file publish and Native AOT, which is where
+                // this shell will eventually run.
+                var baseDir = AppContext.BaseDirectory;
+                if (string.IsNullOrEmpty(baseDir))
+                    baseDir = Path.GetDirectoryName(assembly.Location) ?? string.Empty;
                 var candidate = Path.Combine(baseDir, "native", "ghostty.dll");
                 return NativeLibrary.Load(candidate);
             });

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Controls.TerminalControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    IsTabStop="False"
+    HorizontalAlignment="Stretch"
+    VerticalAlignment="Stretch"
+    HorizontalContentAlignment="Stretch"
+    VerticalContentAlignment="Stretch"
+    Loaded="OnLoaded"
+    Unloaded="OnUnloaded">
+
+    <SwapChainPanel
+        x:Name="Panel"
+        IsTabStop="True"
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Stretch"
+        SizeChanged="OnSizeChanged"
+        CompositionScaleChanged="OnCompositionScaleChanged"
+        PointerPressed="OnPointerPressed"
+        PointerMoved="OnPointerMoved"
+        PointerReleased="OnPointerReleased"
+        PointerWheelChanged="OnPointerWheelChanged"
+        KeyDown="OnKeyDown"
+        KeyUp="OnKeyUp"
+        CharacterReceived="OnCharacterReceived"
+        GotFocus="OnGotFocus"
+        LostFocus="OnLostFocus" />
+</UserControl>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -54,13 +54,11 @@ public sealed partial class TerminalControl : UserControl
         if (_initialized) return;
         _initialized = true;
 
-        // 1) ghostty_init — one-time per process, but calling multiple
-        //    times is documented as safe.
-        _ = NativeMethods.Init(UIntPtr.Zero, IntPtr.Zero);
+        // ghostty_init is documented safe to call repeatedly.
+        NativeMethods.Init(UIntPtr.Zero, IntPtr.Zero);
 
-        // 2) Build the global config. Default files are loaded from the
-        //    standard locations; we skip CLI args because WinUI 3's entry
-        //    point swallows them before we get here.
+        // Skip CLI args: WinUI 3's entry point swallows them before we get
+        // here. Default config files are loaded from the standard locations.
         _config = NativeMethods.ConfigNew();
         NativeMethods.ConfigLoadDefaultFiles(_config);
         NativeMethods.ConfigFinalize(_config);
@@ -131,8 +129,18 @@ public sealed partial class TerminalControl : UserControl
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
-        // Tear down in reverse order. Each free is a no-op on a zero
-        // handle so we do not need to guard individually.
+        // Stop and detach the resize timer first so a pending tick cannot
+        // observe a half-freed surface. The timer holds a strong reference
+        // to this control via OnResizeTick, so leaving it pending across
+        // an Unloaded would also leak.
+        if (_resizeTimer is not null)
+        {
+            _resizeTimer.Stop();
+            _resizeTimer.Tick -= OnResizeTick;
+            _resizeTimer = null;
+        }
+
+        // Tear down in reverse order. Each free is a no-op on a zero handle.
         if (_surface.Handle != IntPtr.Zero) NativeMethods.SurfaceFree(_surface);
         if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
         if (_config.Handle != IntPtr.Zero) NativeMethods.ConfigFree(_config);
@@ -165,34 +173,25 @@ public sealed partial class TerminalControl : UserControl
 
     private void OnWakeup(IntPtr userdata)
     {
-        // libghostty is asking us to pump its event loop. We do it on the
-        // UI thread so any resulting draws land on the right dispatcher.
+        // Fires on libghostty's thread. Hop to the UI dispatcher so the
+        // tick (and any resulting draws) lands on the right queue.
         //
-        // This fires on libghostty's thread. The control may already be
-        // unloaded - DispatcherQueue becomes null once the visual tree
-        // detaches - so guard the enqueue. We also capture the app handle
-        // into a local so the lambda does not race with OnUnloaded zeroing
-        // the field between enqueue and dispatch.
+        // OnUnloaded also runs on the UI thread, so the dispatched lambda
+        // and the teardown are serialized: either Unloaded ran first and
+        // the lambda sees a zero handle, or the lambda ran first and
+        // Unloaded waits its turn. No lock needed.
         var dq = DispatcherQueue;
         if (dq is null) return;
-        var app = _app;
-        if (app.Handle == IntPtr.Zero) return;
         dq.TryEnqueue(() =>
         {
-            // Re-read the field on the UI thread: if Unloaded ran meanwhile
-            // the captured handle is stale and calling tick would use-after
-            // -free.
-            if (_app.Handle == app.Handle) NativeMethods.AppTick(app);
+            if (_app.Handle != IntPtr.Zero) NativeMethods.AppTick(_app);
         });
     }
 
     private bool OnAction(GhosttyApp app, GhosttyTarget target, IntPtr actionPtr)
     {
-        // Return false = "not handled, fall back to libghostty default".
-        // Returning true silently swallows actions (ring bell, open config,
-        // close surface, etc.) which hides behavior from the core. As the
-        // shell wires up real action handling these will become per-case
-        // returns.
+        // false = not handled, fall back to libghostty default. Per-action
+        // dispatch lands when the shell starts wiring real handlers.
         return false;
     }
 
@@ -210,13 +209,12 @@ public sealed partial class TerminalControl : UserControl
     {
         if (_surface.Handle == IntPtr.Zero) return;
 
-        // Debounce: WinUI 3 fires SizeChanged per pixel during a drag and
-        // libghostty's DX12 renderer currently recreates the swap chain on
-        // every set_size, which tears down GPU resources faster than the
-        // compositor can follow. Coalesce to a single resize ~30ms after
-        // the last event fires. TODO: the proper fix is to make the DX12
-        // renderer's resize path cheap/idempotent (ResizeBuffers instead of
-        // full recreate); once that lands, drop this debounce.
+        // FIXME: the DX12 renderer recreates the swap chain on every
+        // set_size, which tears down GPU resources faster than the
+        // compositor can follow when WinUI 3 fires SizeChanged per pixel
+        // during a drag. The fix is in the renderer: ResizeBuffers instead
+        // of full recreate. Until that lands, debounce here. Drop this
+        // entire timer once the renderer is idempotent.
         _pendingSize = e.NewSize;
         if (_resizeTimer is null)
         {
@@ -275,12 +273,12 @@ public sealed partial class TerminalControl : UserControl
     private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
     {
         if (_surface.Handle == IntPtr.Zero) return;
+        // ghostty_surface_mouse_pos expects unscaled coordinates (DIPs):
+        // src/apprt/embedded.zig cursorPosCallback runs the input through
+        // cursorPosToPixels using the surface's content scale. Multiplying
+        // by CompositionScaleX/Y here would double-scale on high DPI.
         var pt = e.GetCurrentPoint(Panel).Position;
-        NativeMethods.SurfaceMousePos(
-            _surface,
-            pt.X * Panel.CompositionScaleX,
-            pt.Y * Panel.CompositionScaleY,
-            CurrentMods());
+        NativeMethods.SurfaceMousePos(_surface, pt.X, pt.Y, CurrentMods());
     }
 
     private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Ghostty.Interop;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+
+namespace Ghostty.Controls;
+
+/// <summary>
+/// Single libghostty-backed terminal surface, hosted via the WinUI 3
+/// SwapChainPanel composition path (null HWND). Matches how macOS's
+/// Ghostty.Surface.swift owns one ghostty_surface_t per SwiftUI view.
+///
+/// This first pass owns the whole ghostty_app_t lifetime too; when we add
+/// tabs/splits the app handle will move up to MainWindow and each control
+/// will only own its surface.
+/// </summary>
+public sealed partial class TerminalControl : UserControl
+{
+    // Handles ------------------------------------------------------------
+
+    private GhosttyConfig _config;
+    private GhosttyApp _app;
+    private GhosttySurface _surface;
+    private IntPtr _emptyCString;
+    private bool _initialized;
+
+    // Keep delegates alive for as long as the runtime config references
+    // them. P/Invoke marshals the managed delegate to a native function
+    // pointer that the GC has no way of tracking, so a dropped field here
+    // would crash the Zig side on the first wakeup.
+    private GhosttyWakeupCb? _wakeupCb;
+    private GhosttyActionCb? _actionCb;
+    private GhosttyReadClipboardCb? _readClipboardCb;
+    private GhosttyConfirmReadClipboardCb? _confirmReadClipboardCb;
+    private GhosttyWriteClipboardCb? _writeClipboardCb;
+    private GhosttyCloseSurfaceCb? _closeSurfaceCb;
+
+    public TerminalControl()
+    {
+        InitializeComponent();
+    }
+
+    // Lifecycle ----------------------------------------------------------
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_initialized) return;
+        _initialized = true;
+
+        // 1) ghostty_init — one-time per process, but calling multiple
+        //    times is documented as safe.
+        _ = NativeMethods.Init(UIntPtr.Zero, IntPtr.Zero);
+
+        // 2) Build the global config. Default files are loaded from the
+        //    standard locations; we skip CLI args because WinUI 3's entry
+        //    point swallows them before we get here.
+        _config = NativeMethods.ConfigNew();
+        NativeMethods.ConfigLoadDefaultFiles(_config);
+        NativeMethods.ConfigFinalize(_config);
+
+        // 3) Runtime config. The Zig side requires non-null callbacks even
+        //    if they are no-ops; storing each delegate in a field prevents
+        //    GC from freeing it while libghostty still holds the pointer.
+        _wakeupCb = OnWakeup;
+        _actionCb = OnAction;
+        _readClipboardCb = OnReadClipboard;
+        _confirmReadClipboardCb = OnConfirmReadClipboard;
+        _writeClipboardCb = OnWriteClipboard;
+        _closeSurfaceCb = OnCloseSurface;
+
+        var runtime = new GhosttyRuntimeConfig
+        {
+            Userdata = IntPtr.Zero,
+            SupportsSelectionClipboard = false,
+            WakeupCb = Marshal.GetFunctionPointerForDelegate(_wakeupCb),
+            ActionCb = Marshal.GetFunctionPointerForDelegate(_actionCb),
+            ReadClipboardCb = Marshal.GetFunctionPointerForDelegate(_readClipboardCb),
+            ConfirmReadClipboardCb = Marshal.GetFunctionPointerForDelegate(_confirmReadClipboardCb),
+            WriteClipboardCb = Marshal.GetFunctionPointerForDelegate(_writeClipboardCb),
+            CloseSurfaceCb = Marshal.GetFunctionPointerForDelegate(_closeSurfaceCb),
+        };
+
+        _app = NativeMethods.AppNew(runtime, _config);
+
+        // 4) Surface config. swap_chain_panel takes the panel's IUnknown
+        //    pointer; libghostty QIs for ISwapChainPanelNative internally.
+        //    The string fields (working_directory, command, initial_input)
+        //    must be non-null: Zig dereferences them unconditionally. The
+        //    macOS side passes empty C strings via withCString; we do the
+        //    same by allocating a single null-terminated byte and pointing
+        //    all three at it. These live until the surface is freed.
+        var surfaceConfig = NativeMethods.SurfaceConfigNew();
+        surfaceConfig.PlatformTag = GhosttyPlatform.Windows;
+        surfaceConfig.Platform.Windows = new GhosttyPlatformWindows
+        {
+            Hwnd = IntPtr.Zero,
+            SwapChainPanel = SwapChainPanelInterop.QueryInterface(Panel),
+            SharedTextureOut = IntPtr.Zero,
+            TextureWidth = 0,
+            TextureHeight = 0,
+        };
+        surfaceConfig.ScaleFactor = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1.0;
+        surfaceConfig.Context = GhosttySurfaceContext.Window;
+
+        _emptyCString = Marshal.AllocHGlobal(1);
+        Marshal.WriteByte(_emptyCString, 0);
+        surfaceConfig.WorkingDirectory = _emptyCString;
+        surfaceConfig.Command = _emptyCString;
+        surfaceConfig.InitialInput = _emptyCString;
+
+        _surface = NativeMethods.SurfaceNew(_app, surfaceConfig);
+
+        // Request focus so keyboard input starts flowing immediately.
+        Panel.Focus(FocusState.Programmatic);
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        // Tear down in reverse order. Each free is a no-op on a zero
+        // handle so we do not need to guard individually.
+        if (_surface.Handle != IntPtr.Zero) NativeMethods.SurfaceFree(_surface);
+        if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
+        if (_config.Handle != IntPtr.Zero) NativeMethods.ConfigFree(_config);
+        if (_emptyCString != IntPtr.Zero) Marshal.FreeHGlobal(_emptyCString);
+
+        _surface = default;
+        _app = default;
+        _config = default;
+        _emptyCString = IntPtr.Zero;
+        _initialized = false;
+    }
+
+    // Runtime callbacks --------------------------------------------------
+    //
+    // These fire on libghostty's thread. For this first pass we implement
+    // the minimum required to avoid null-deref on the Zig side. Marshaling
+    // back to the UI thread for things like clipboard and actions will be
+    // added when those features are wired.
+
+    private void OnWakeup(IntPtr userdata)
+    {
+        // libghostty is asking us to pump its event loop. We do it on the
+        // UI thread so any resulting draws land on the right dispatcher.
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_app.Handle != IntPtr.Zero) NativeMethods.AppTick(_app);
+        });
+    }
+
+    private bool OnAction(GhosttyApp app, GhosttyTarget target, IntPtr actionPtr)
+    {
+        // Actions dispatch is not wired yet. Returning true tells ghostty
+        // the action was handled so it does not fall back to a default
+        // that we do not implement.
+        return true;
+    }
+
+    private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;
+    private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest req) { }
+    private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm) { }
+    private void OnCloseSurface(IntPtr userdata, bool processAlive) { }
+
+    // Size / scale -------------------------------------------------------
+
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _resizeTimer;
+    private Windows.Foundation.Size _pendingSize;
+
+    private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+
+        // Debounce: WinUI 3 fires SizeChanged per pixel during a drag.
+        // libghostty's DX12 renderer recreates the swap chain on every
+        // set_size, which crashes under that kind of storm. Coalesce to a
+        // single resize ~30ms after the last event fires.
+        _pendingSize = e.NewSize;
+        _resizeTimer ??= DispatcherQueue.CreateTimer();
+        _resizeTimer.Interval = TimeSpan.FromMilliseconds(30);
+        _resizeTimer.IsRepeating = false;
+        _resizeTimer.Tick -= OnResizeTick;
+        _resizeTimer.Tick += OnResizeTick;
+        _resizeTimer.Start();
+    }
+
+    private void OnResizeTick(Microsoft.UI.Dispatching.DispatcherQueueTimer sender, object args)
+    {
+        sender.Stop();
+        if (_surface.Handle == IntPtr.Zero) return;
+        var sx = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1.0;
+        var sy = Panel.CompositionScaleY > 0 ? Panel.CompositionScaleY : 1.0;
+        var w = (uint)Math.Max(1, _pendingSize.Width * sx);
+        var h = (uint)Math.Max(1, _pendingSize.Height * sy);
+        NativeMethods.SurfaceSetSize(_surface, w, h);
+    }
+
+    private void OnCompositionScaleChanged(SwapChainPanel sender, object args)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        NativeMethods.SurfaceSetContentScale(_surface, sender.CompositionScaleX, sender.CompositionScaleY);
+    }
+
+    // Focus --------------------------------------------------------------
+
+    private void OnGotFocus(object sender, RoutedEventArgs e)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        NativeMethods.SurfaceSetFocus(_surface, true);
+        if (_app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(_app, true);
+    }
+
+    private void OnLostFocus(object sender, RoutedEventArgs e)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        NativeMethods.SurfaceSetFocus(_surface, false);
+        if (_app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(_app, false);
+    }
+
+    // Mouse --------------------------------------------------------------
+
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        Panel.Focus(FocusState.Pointer);
+        SendMouseButton(e, GhosttyMouseState.Press);
+    }
+
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e) =>
+        SendMouseButton(e, GhosttyMouseState.Release);
+
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        var pt = e.GetCurrentPoint(Panel).Position;
+        NativeMethods.SurfaceMousePos(
+            _surface,
+            pt.X * Panel.CompositionScaleX,
+            pt.Y * Panel.CompositionScaleY,
+            CurrentMods());
+    }
+
+    private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        var pt = e.GetCurrentPoint(Panel);
+        var delta = pt.Properties.MouseWheelDelta / 120.0;  // 120 = one notch
+        var isHorizontal = pt.Properties.IsHorizontalMouseWheel;
+        NativeMethods.SurfaceMouseScroll(
+            _surface,
+            isHorizontal ? delta : 0.0,
+            isHorizontal ? 0.0 : delta,
+            0);  // scroll mods packed bitfield - wire when we need them
+    }
+
+    private void SendMouseButton(PointerRoutedEventArgs e, GhosttyMouseState state)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        var props = e.GetCurrentPoint(Panel).Properties;
+        GhosttyMouseButton btn = GhosttyMouseButton.Unknown;
+        // Pick whichever button changed in this event. For Press/Release
+        // only one bit flips, so "IsLeftButtonPressed == (state == Press)"
+        // is the right test; but we can shortcut using PointerUpdateKind.
+        btn = props.PointerUpdateKind switch
+        {
+            PointerUpdateKind.LeftButtonPressed or
+            PointerUpdateKind.LeftButtonReleased => GhosttyMouseButton.Left,
+            PointerUpdateKind.RightButtonPressed or
+            PointerUpdateKind.RightButtonReleased => GhosttyMouseButton.Right,
+            PointerUpdateKind.MiddleButtonPressed or
+            PointerUpdateKind.MiddleButtonReleased => GhosttyMouseButton.Middle,
+            _ => GhosttyMouseButton.Unknown,
+        };
+        if (btn == GhosttyMouseButton.Unknown) return;
+        NativeMethods.SurfaceMouseButton(_surface, state, btn, CurrentMods());
+    }
+
+    // Keyboard -----------------------------------------------------------
+
+    private void OnKeyDown(object sender, KeyRoutedEventArgs e) =>
+        SendKey(e, GhosttyInputAction.Press);
+
+    private void OnKeyUp(object sender, KeyRoutedEventArgs e) =>
+        SendKey(e, GhosttyInputAction.Release);
+
+    private void SendKey(KeyRoutedEventArgs e, GhosttyInputAction action)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+
+        // First-pass key routing mirrors the WM_CHAR-combining fix landed
+        // in the Win32 example: we send the key event itself here, and the
+        // CharacterReceived handler below sends the translated text when
+        // it arrives. GhosttyKey mapping is intentionally skipped for now
+        // because ghostty can accept a bare keycode (Keycode field) with
+        // text filled in from CharacterReceived separately.
+        var key = new GhosttyInputKey
+        {
+            Action = action,
+            Mods = CurrentMods(),
+            ConsumedMods = GhosttyMods.None,
+            Keycode = (uint)e.OriginalKey,
+            Text = IntPtr.Zero,
+            UnshiftedCodepoint = 0,
+            Composing = false,
+        };
+        var handled = NativeMethods.SurfaceKey(_surface, key);
+        if (handled) e.Handled = true;
+    }
+
+    private void OnCharacterReceived(UIElement sender, CharacterReceivedRoutedEventArgs e)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+
+        // Filter C0 control chars: these are already produced by the key
+        // event path (Ctrl+C, Backspace, etc). Mirrors the fix in
+        // 8dde86df5 for the Win32 example.
+        var ch = e.Character;
+        if (ch < 0x20 || ch == 0x7F) return;
+
+        Span<byte> buf = stackalloc byte[4];
+        var len = new Rune(ch).EncodeToUtf8(buf);
+        unsafe
+        {
+            fixed (byte* p = buf)
+            {
+                NativeMethods.SurfaceText(_surface, (IntPtr)p, (UIntPtr)len);
+            }
+        }
+    }
+
+    // Mods helper --------------------------------------------------------
+
+    private static GhosttyMods CurrentMods()
+    {
+        // Use Win32 GetKeyState directly. WinUI 3's InputKeyboardSource
+        // surface has moved several times between releases; Win32 is
+        // stable and cheap (reads a thread-local state table).
+        var mods = GhosttyMods.None;
+        if ((GetKeyState(VK_SHIFT) & 0x8000) != 0) mods |= GhosttyMods.Shift;
+        if ((GetKeyState(VK_CONTROL) & 0x8000) != 0) mods |= GhosttyMods.Ctrl;
+        if ((GetKeyState(VK_MENU) & 0x8000) != 0) mods |= GhosttyMods.Alt;
+        if ((GetKeyState(VK_LWIN) & 0x8000) != 0) mods |= GhosttyMods.Super;
+        if ((GetKeyState(VK_RWIN) & 0x8000) != 0) mods |= GhosttyMods.Super;
+        return mods;
+    }
+
+    private const int VK_SHIFT = 0x10;
+    private const int VK_CONTROL = 0x11;
+    private const int VK_MENU = 0x12;  // Alt
+    private const int VK_LWIN = 0x5B;
+    private const int VK_RWIN = 0x5C;
+
+    [DllImport("user32.dll")]
+    private static extern short GetKeyState(int vKey);
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -26,7 +26,9 @@ public sealed partial class TerminalControl : UserControl
     private GhosttyConfig _config;
     private GhosttyApp _app;
     private GhosttySurface _surface;
-    private IntPtr _emptyCString;
+    private IntPtr _workingDirectoryUtf8;
+    private IntPtr _commandUtf8;
+    private IntPtr _initialInputUtf8;
     private bool _initialized;
 
     // Keep delegates alive for as long as the runtime config references
@@ -87,33 +89,41 @@ public sealed partial class TerminalControl : UserControl
 
         _app = NativeMethods.AppNew(runtime, _config);
 
-        // 4) Surface config. swap_chain_panel takes the panel's IUnknown
-        //    pointer; libghostty QIs for ISwapChainPanelNative internally.
+        // 4) Surface config. swap_chain_panel takes an ISwapChainPanelNative*
+        //    which libghostty's DX12 device init uses synchronously (it calls
+        //    SetSwapChain once and never stores it - see
+        //    src/renderer/directx12/device.zig). We Release the COM ptr right
+        //    after SurfaceNew returns to avoid leaking a ref per open/close.
+        //
         //    The string fields (working_directory, command, initial_input)
-        //    must be non-null: Zig dereferences them unconditionally. The
-        //    macOS side passes empty C strings via withCString; we do the
-        //    same by allocating a single null-terminated byte and pointing
-        //    all three at it. These live until the surface is freed.
+        //    must be non-null: Zig dereferences them unconditionally. We
+        //    allocate three independent UTF-8 empty strings rather than
+        //    aliasing one buffer - aliasing was a footgun if Zig ever wrote
+        //    through any of them. These live until the surface is freed.
+        _workingDirectoryUtf8 = AllocEmptyUtf8();
+        _commandUtf8 = AllocEmptyUtf8();
+        _initialInputUtf8 = AllocEmptyUtf8();
+
         var surfaceConfig = NativeMethods.SurfaceConfigNew();
         surfaceConfig.PlatformTag = GhosttyPlatform.Windows;
+        var panelPtr = SwapChainPanelInterop.QueryInterface(Panel);
         surfaceConfig.Platform.Windows = new GhosttyPlatformWindows
         {
             Hwnd = IntPtr.Zero,
-            SwapChainPanel = SwapChainPanelInterop.QueryInterface(Panel),
+            SwapChainPanel = panelPtr,
             SharedTextureOut = IntPtr.Zero,
             TextureWidth = 0,
             TextureHeight = 0,
         };
         surfaceConfig.ScaleFactor = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1.0;
         surfaceConfig.Context = GhosttySurfaceContext.Window;
-
-        _emptyCString = Marshal.AllocHGlobal(1);
-        Marshal.WriteByte(_emptyCString, 0);
-        surfaceConfig.WorkingDirectory = _emptyCString;
-        surfaceConfig.Command = _emptyCString;
-        surfaceConfig.InitialInput = _emptyCString;
+        surfaceConfig.WorkingDirectory = _workingDirectoryUtf8;
+        surfaceConfig.Command = _commandUtf8;
+        surfaceConfig.InitialInput = _initialInputUtf8;
 
         _surface = NativeMethods.SurfaceNew(_app, surfaceConfig);
+        // Drop our ref to the panel: libghostty did not retain it.
+        SwapChainPanelInterop.Release(panelPtr);
 
         // Request focus so keyboard input starts flowing immediately.
         Panel.Focus(FocusState.Programmatic);
@@ -126,13 +136,24 @@ public sealed partial class TerminalControl : UserControl
         if (_surface.Handle != IntPtr.Zero) NativeMethods.SurfaceFree(_surface);
         if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
         if (_config.Handle != IntPtr.Zero) NativeMethods.ConfigFree(_config);
-        if (_emptyCString != IntPtr.Zero) Marshal.FreeHGlobal(_emptyCString);
+        if (_workingDirectoryUtf8 != IntPtr.Zero) Marshal.FreeHGlobal(_workingDirectoryUtf8);
+        if (_commandUtf8 != IntPtr.Zero) Marshal.FreeHGlobal(_commandUtf8);
+        if (_initialInputUtf8 != IntPtr.Zero) Marshal.FreeHGlobal(_initialInputUtf8);
 
         _surface = default;
         _app = default;
         _config = default;
-        _emptyCString = IntPtr.Zero;
+        _workingDirectoryUtf8 = IntPtr.Zero;
+        _commandUtf8 = IntPtr.Zero;
+        _initialInputUtf8 = IntPtr.Zero;
         _initialized = false;
+    }
+
+    private static IntPtr AllocEmptyUtf8()
+    {
+        var p = Marshal.AllocHGlobal(1);
+        Marshal.WriteByte(p, 0);
+        return p;
     }
 
     // Runtime callbacks --------------------------------------------------
@@ -146,18 +167,33 @@ public sealed partial class TerminalControl : UserControl
     {
         // libghostty is asking us to pump its event loop. We do it on the
         // UI thread so any resulting draws land on the right dispatcher.
-        DispatcherQueue.TryEnqueue(() =>
+        //
+        // This fires on libghostty's thread. The control may already be
+        // unloaded - DispatcherQueue becomes null once the visual tree
+        // detaches - so guard the enqueue. We also capture the app handle
+        // into a local so the lambda does not race with OnUnloaded zeroing
+        // the field between enqueue and dispatch.
+        var dq = DispatcherQueue;
+        if (dq is null) return;
+        var app = _app;
+        if (app.Handle == IntPtr.Zero) return;
+        dq.TryEnqueue(() =>
         {
-            if (_app.Handle != IntPtr.Zero) NativeMethods.AppTick(_app);
+            // Re-read the field on the UI thread: if Unloaded ran meanwhile
+            // the captured handle is stale and calling tick would use-after
+            // -free.
+            if (_app.Handle == app.Handle) NativeMethods.AppTick(app);
         });
     }
 
     private bool OnAction(GhosttyApp app, GhosttyTarget target, IntPtr actionPtr)
     {
-        // Actions dispatch is not wired yet. Returning true tells ghostty
-        // the action was handled so it does not fall back to a default
-        // that we do not implement.
-        return true;
+        // Return false = "not handled, fall back to libghostty default".
+        // Returning true silently swallows actions (ring bell, open config,
+        // close surface, etc.) which hides behavior from the core. As the
+        // shell wires up real action handling these will become per-case
+        // returns.
+        return false;
     }
 
     private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;
@@ -174,16 +210,21 @@ public sealed partial class TerminalControl : UserControl
     {
         if (_surface.Handle == IntPtr.Zero) return;
 
-        // Debounce: WinUI 3 fires SizeChanged per pixel during a drag.
-        // libghostty's DX12 renderer recreates the swap chain on every
-        // set_size, which crashes under that kind of storm. Coalesce to a
-        // single resize ~30ms after the last event fires.
+        // Debounce: WinUI 3 fires SizeChanged per pixel during a drag and
+        // libghostty's DX12 renderer currently recreates the swap chain on
+        // every set_size, which tears down GPU resources faster than the
+        // compositor can follow. Coalesce to a single resize ~30ms after
+        // the last event fires. TODO: the proper fix is to make the DX12
+        // renderer's resize path cheap/idempotent (ResizeBuffers instead of
+        // full recreate); once that lands, drop this debounce.
         _pendingSize = e.NewSize;
-        _resizeTimer ??= DispatcherQueue.CreateTimer();
-        _resizeTimer.Interval = TimeSpan.FromMilliseconds(30);
-        _resizeTimer.IsRepeating = false;
-        _resizeTimer.Tick -= OnResizeTick;
-        _resizeTimer.Tick += OnResizeTick;
+        if (_resizeTimer is null)
+        {
+            _resizeTimer = DispatcherQueue.CreateTimer();
+            _resizeTimer.Interval = TimeSpan.FromMilliseconds(30);
+            _resizeTimer.IsRepeating = false;
+            _resizeTimer.Tick += OnResizeTick;
+        }
         _resizeTimer.Start();
     }
 
@@ -289,18 +330,24 @@ public sealed partial class TerminalControl : UserControl
     {
         if (_surface.Handle == IntPtr.Zero) return;
 
-        // First-pass key routing mirrors the WM_CHAR-combining fix landed
-        // in the Win32 example: we send the key event itself here, and the
-        // CharacterReceived handler below sends the translated text when
-        // it arrives. GhosttyKey mapping is intentionally skipped for now
-        // because ghostty can accept a bare keycode (Keycode field) with
-        // text filled in from CharacterReceived separately.
+        // The embedded apprt (src/apprt/embedded.zig) implements key+text
+        // combining on Windows at comptime: ghostty_surface_key buffers a
+        // keydown with no text, and the next ghostty_surface_text attaches
+        // the text and dispatches through the full key encoding pipeline.
+        // We just forward WM_KEYDOWN/WM_KEYUP here and forward WM_CHAR from
+        // OnCharacterReceived - embedders do not implement the combining
+        // themselves.
+        //
+        // The Keycode field carries the native Windows *scancode* (not a
+        // VirtualKey). embedded.zig matches it against keycodes.entries
+        // where the native column is the Win32 scancode, and derives
+        // unshifted_codepoint via MapVirtualKeyW when we pass 0.
         var key = new GhosttyInputKey
         {
             Action = action,
             Mods = CurrentMods(),
             ConsumedMods = GhosttyMods.None,
-            Keycode = (uint)e.OriginalKey,
+            Keycode = e.KeyStatus.ScanCode,
             Text = IntPtr.Zero,
             UnshiftedCodepoint = 0,
             Composing = false,
@@ -313,12 +360,12 @@ public sealed partial class TerminalControl : UserControl
     {
         if (_surface.Handle == IntPtr.Zero) return;
 
-        // Filter C0 control chars: these are already produced by the key
-        // event path (Ctrl+C, Backspace, etc). Mirrors the fix in
-        // 8dde86df5 for the Win32 example.
+        // Forward WM_CHAR unchanged. The embedded apprt's key+text combining
+        // handles C0 control filtering on its side: the preceding key event
+        // already produced Ctrl+C / Backspace / etc via the key encoder, and
+        // the apprt drops the duplicated WM_CHAR text. Filtering here would
+        // also clobber legitimate U+007F / U+001B text the core might want.
         var ch = e.Character;
-        if (ch < 0x20 || ch == 0x7F) return;
-
         Span<byte> buf = stackalloc byte[4];
         var len = new Rune(ch).EncodeToUtf8(buf);
         unsafe
@@ -337,20 +384,34 @@ public sealed partial class TerminalControl : UserControl
         // Use Win32 GetKeyState directly. WinUI 3's InputKeyboardSource
         // surface has moved several times between releases; Win32 is
         // stable and cheap (reads a thread-local state table).
+        //
+        // We query the left/right variants individually so the *Right
+        // flags in ghostty_mods_e are set correctly - these matter for
+        // keybinds that distinguish "right alt" (AltGr) from "left alt".
         var mods = GhosttyMods.None;
-        if ((GetKeyState(VK_SHIFT) & 0x8000) != 0) mods |= GhosttyMods.Shift;
-        if ((GetKeyState(VK_CONTROL) & 0x8000) != 0) mods |= GhosttyMods.Ctrl;
-        if ((GetKeyState(VK_MENU) & 0x8000) != 0) mods |= GhosttyMods.Alt;
+        if ((GetKeyState(VK_LSHIFT) & 0x8000) != 0) mods |= GhosttyMods.Shift;
+        if ((GetKeyState(VK_RSHIFT) & 0x8000) != 0) mods |= GhosttyMods.Shift | GhosttyMods.ShiftRight;
+        if ((GetKeyState(VK_LCONTROL) & 0x8000) != 0) mods |= GhosttyMods.Ctrl;
+        if ((GetKeyState(VK_RCONTROL) & 0x8000) != 0) mods |= GhosttyMods.Ctrl | GhosttyMods.CtrlRight;
+        if ((GetKeyState(VK_LMENU) & 0x8000) != 0) mods |= GhosttyMods.Alt;
+        if ((GetKeyState(VK_RMENU) & 0x8000) != 0) mods |= GhosttyMods.Alt | GhosttyMods.AltRight;
         if ((GetKeyState(VK_LWIN) & 0x8000) != 0) mods |= GhosttyMods.Super;
-        if ((GetKeyState(VK_RWIN) & 0x8000) != 0) mods |= GhosttyMods.Super;
+        if ((GetKeyState(VK_RWIN) & 0x8000) != 0) mods |= GhosttyMods.Super | GhosttyMods.SuperRight;
+        if ((GetKeyState(VK_CAPITAL) & 0x0001) != 0) mods |= GhosttyMods.Caps;
+        if ((GetKeyState(VK_NUMLOCK) & 0x0001) != 0) mods |= GhosttyMods.Num;
         return mods;
     }
 
-    private const int VK_SHIFT = 0x10;
-    private const int VK_CONTROL = 0x11;
-    private const int VK_MENU = 0x12;  // Alt
+    private const int VK_LSHIFT = 0xA0;
+    private const int VK_RSHIFT = 0xA1;
+    private const int VK_LCONTROL = 0xA2;
+    private const int VK_RCONTROL = 0xA3;
+    private const int VK_LMENU = 0xA4; // left Alt
+    private const int VK_RMENU = 0xA5; // right Alt / AltGr
     private const int VK_LWIN = 0x5B;
     private const int VK_RWIN = 0x5C;
+    private const int VK_CAPITAL = 0x14;
+    private const int VK_NUMLOCK = 0x90;
 
     [DllImport("user32.dll")]
     private static extern short GetKeyState(int vKey);

--- a/windows/Ghostty/Directory.Build.props
+++ b/windows/Ghostty/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+  <!--
+    'dotnet build' resolves AppxMSBuildToolsPath to the SDK directory which
+    lacks the PRI/Appx task DLLs. These ship with Visual Studio Build Tools.
+    Redirect when missing. See WindowsAppSDK#3997.
+  -->
+  <PropertyGroup Condition="!Exists('$(AppxMSBuildToolsPath)Microsoft.Build.Packaging.Pri.Tasks.dll')">
+    <AppxMSBuildToolsPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio\18\BuildTools\MSBuild\Microsoft\VisualStudio\v18.0\AppxPackage\</AppxMSBuildToolsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="!Exists('$(AppxMSBuildToolsPath)Microsoft.Build.Packaging.Pri.Tasks.dll')">
+    <AppxMSBuildToolsPath>$(ProgramW6432)\Microsoft Visual Studio\18\Community\MSBuild\Microsoft\VisualStudio\v18.0\AppxPackage\</AppxMSBuildToolsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="!Exists('$(AppxMSBuildToolsPath)Microsoft.Build.Packaging.Pri.Tasks.dll')">
+    <AppxMSBuildToolsPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VisualStudio\v17.0\AppxPackage\</AppxMSBuildToolsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="!Exists('$(AppxMSBuildToolsPath)Microsoft.Build.Packaging.Pri.Tasks.dll')">
+    <AppxMSBuildToolsPath>$(ProgramW6432)\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VisualStudio\v17.0\AppxPackage\</AppxMSBuildToolsPath>
+  </PropertyGroup>
+</Project>

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>Ghostty</RootNamespace>
+    <AssemblyName>Ghostty</AssemblyName>
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250602001" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+  </ItemGroup>
+
+  <!--
+    Copy libghostty.dll from the zig-out install dir produced by
+    `zig build -Dapp-runtime=none`. This mirrors how macos/Ghostty.xcodeproj
+    consumes the xcframework from zig-out. Zig installs shared libs to
+    zig-out/lib on Windows (not zig-out/bin). The path is relative to this csproj.
+  -->
+  <ItemGroup>
+    <None Include="..\..\zig-out\lib\ghostty.dll" Condition="Exists('..\..\zig-out\lib\ghostty.dll')">
+      <Link>native\ghostty.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <Target Name="WarnIfNoLibghostty" BeforeTargets="Build"
+          Condition="!Exists('..\..\zig-out\lib\ghostty.dll')">
+    <Warning Text="ghostty.dll not found at ..\..\zig-out\lib\. Run 'zig build -Dapp-runtime=none' from the repo root first, or the app will fail to start." />
+  </Target>
+</Project>

--- a/windows/Ghostty/Ghostty.sln
+++ b/windows/Ghostty/Ghostty.sln
@@ -1,0 +1,22 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ghostty", "Ghostty.csproj", "{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+		Debug|ARM64 = Debug|ARM64
+		Release|ARM64 = Release|ARM64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Release|x64.Build.0 = Release|x64
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Debug|ARM64.Build.0 = Debug|ARM64
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Release|ARM64.ActiveCfg = Release|ARM64
+		{A1B2C3D4-E5F6-4789-ABCD-1234567890AB}.Release|ARM64.Build.0 = Release|ARM64
+	EndGlobalSection
+EndGlobal

--- a/windows/Ghostty/Interop/ISwapChainPanelNative.cs
+++ b/windows/Ghostty/Interop/ISwapChainPanelNative.cs
@@ -1,0 +1,56 @@
+// COM interop for Microsoft.UI.Xaml.Controls.SwapChainPanel. The managed
+// SwapChainPanel type does not expose a way to attach a native swap chain
+// directly, so we QueryInterface for ISwapChainPanelNative and call
+// SetSwapChain(IDXGISwapChain*) manually.
+//
+// libghostty's Windows renderer lives inside ghostty.dll and uses the panel
+// handle we pass via ghostty_surface_config_s.platform.windows.swap_chain_panel.
+// We hand it the IUnknown* of the panel (which is QI-able to
+// ISwapChainPanelNative), so nothing on the C# side actually calls
+// SetSwapChain - but we keep the interface here for any case where the
+// shell needs to present its own swap chain (overlays, inspector, etc).
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using WinRT;
+
+namespace Ghostty.Interop;
+
+[ComImport]
+[Guid("63aad0b8-7c24-40ff-85a8-640d944cc325")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface ISwapChainPanelNative
+{
+    [PreserveSig]
+    int SetSwapChain(IntPtr swapChain); // IDXGISwapChain*
+}
+
+internal static class SwapChainPanelInterop
+{
+    private static readonly Guid IID_ISwapChainPanelNative =
+        new("63aad0b8-7c24-40ff-85a8-640d944cc325");
+
+    /// <summary>
+    /// QueryInterfaces a WinUI 3 SwapChainPanel for ISwapChainPanelNative
+    /// and returns the raw interface pointer. libghostty's DX12 renderer
+    /// calls SetSwapChain (v-table slot 3) directly on the pointer we
+    /// pass, so it must already be the ISwapChainPanelNative v-table, not
+    /// the IUnknown of the WinRT projection.
+    /// </summary>
+    /// <remarks>
+    /// This returns an AddRef'd pointer. libghostty is expected to Release
+    /// it when the surface is destroyed. The managed SwapChainPanel still
+    /// holds its own reference so nothing leaks if lifetimes line up.
+    /// </remarks>
+    public static IntPtr QueryInterface(Microsoft.UI.Xaml.Controls.SwapChainPanel panel)
+    {
+        var objRef = ((IWinRTObject)panel).NativeObject;
+        var iid = IID_ISwapChainPanelNative;
+        var hr = Marshal.QueryInterface(objRef.ThisPtr, in iid, out var ppv);
+        if (hr < 0 || ppv == IntPtr.Zero)
+            throw new InvalidOperationException(
+                $"QueryInterface for ISwapChainPanelNative failed: 0x{hr:X8}");
+        return ppv;
+    }
+}

--- a/windows/Ghostty/Interop/ISwapChainPanelNative.cs
+++ b/windows/Ghostty/Interop/ISwapChainPanelNative.cs
@@ -39,9 +39,13 @@ internal static class SwapChainPanelInterop
     /// the IUnknown of the WinRT projection.
     /// </summary>
     /// <remarks>
-    /// This returns an AddRef'd pointer. libghostty is expected to Release
-    /// it when the surface is destroyed. The managed SwapChainPanel still
-    /// holds its own reference so nothing leaks if lifetimes line up.
+    /// Returns an AddRef'd pointer. libghostty's DX12 device init only uses
+    /// the pointer synchronously during ghostty_surface_new (it calls
+    /// ISwapChainPanelNative::SetSwapChain once and never stores it), so the
+    /// caller MUST Release this pointer immediately after SurfaceNew returns.
+    /// Confirmed in src/renderer/directx12/device.zig (swap_chain_panel
+    /// branch only calls SetSwapChain, no field retention). The managed
+    /// SwapChainPanel keeps composition alive via its own ref.
     /// </remarks>
     public static IntPtr QueryInterface(Microsoft.UI.Xaml.Controls.SwapChainPanel panel)
     {
@@ -52,5 +56,14 @@ internal static class SwapChainPanelInterop
             throw new InvalidOperationException(
                 $"QueryInterface for ISwapChainPanelNative failed: 0x{hr:X8}");
         return ppv;
+    }
+
+    /// <summary>
+    /// Release a pointer obtained from <see cref="QueryInterface"/>. Safe on
+    /// IntPtr.Zero.
+    /// </summary>
+    public static void Release(IntPtr ppv)
+    {
+        if (ppv != IntPtr.Zero) Marshal.Release(ppv);
     }
 }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -96,16 +96,6 @@ internal enum GhosttyInputAction
     Repeat = 2,
 }
 
-// ghostty_input_key_e. Values matter because they cross the FFI boundary;
-// keep in sync with include/ghostty.h § "Writing System Keys" onward.
-internal enum GhosttyKey
-{
-    Unidentified = 0,
-    // Only the entries the shell currently maps are listed; the enum is
-    // backed by int so unmapped values round-trip fine.
-    // See include/ghostty.h for the full list.
-}
-
 [StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyInputKey
 {

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -198,13 +198,19 @@ internal delegate void GhosttyCloseSurfaceCb(
     IntPtr userdata,
     [MarshalAs(UnmanagedType.I1)] bool processAlive);
 
-[StructLayout(LayoutKind.Sequential)]
+// Mirrors ghostty_target_s in include/ghostty.h:
+//   typedef struct { ghostty_target_tag_e tag; ghostty_target_u target; }
+// On x64 the enum is 4 bytes, the union is one 8-byte pointer aligned to 8,
+// giving a 4-byte tail pad after the tag. We pin the offsets explicitly so
+// this layout cannot drift if the union ever gains a wider variant — we
+// would notice via a build failure rather than a silent ABI mismatch.
+[StructLayout(LayoutKind.Explicit, Size = 16)]
 internal struct GhosttyTarget
 {
     // tag: 0 = app, 1 = surface
-    public int Tag;
-    // union: only surface is non-empty in practice
-    public IntPtr Surface;
+    [FieldOffset(0)] public int Tag;
+    // union: only the surface variant is populated today
+    [FieldOffset(8)] public IntPtr Surface;
 }
 
 [StructLayout(LayoutKind.Sequential)]

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -1,0 +1,347 @@
+// P/Invoke layer for libghostty (ghostty.dll).
+//
+// This mirrors include/ghostty.h. It is intentionally incremental: the shell
+// only needs a subset of the C API (init, config, app lifecycle, surface
+// lifecycle, input, size, focus) to bring up the first window. Additional
+// functions will be added as features land. Keep this file sorted in the
+// same order as ghostty.h so drift is easy to spot on rebases.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Interop;
+
+// Opaque handle typedefs from ghostty.h. We use IntPtr so no marshaling
+// gymnastics are needed; the C side sees these as void*.
+internal readonly record struct GhosttyApp(IntPtr Handle);
+internal readonly record struct GhosttyConfig(IntPtr Handle);
+internal readonly record struct GhosttySurface(IntPtr Handle);
+
+internal enum GhosttyPlatform
+{
+    Invalid = 0,
+    MacOS = 1,
+    IOS = 2,
+    Windows = 3,
+}
+
+internal enum GhosttySurfaceContext
+{
+    Window = 0,
+    Tab = 1,
+    Split = 2,
+}
+
+internal enum GhosttyClipboard
+{
+    Standard = 0,
+    Selection = 1,
+}
+
+internal enum GhosttyClipboardRequest
+{
+    Paste = 0,
+    Osc52Read = 1,
+    Osc52Write = 2,
+}
+
+internal enum GhosttyMouseState
+{
+    Release = 0,
+    Press = 1,
+}
+
+internal enum GhosttyMouseButton
+{
+    Unknown = 0,
+    Left = 1,
+    Right = 2,
+    Middle = 3,
+    Four = 4,
+    Five = 5,
+    Six = 6,
+    Seven = 7,
+    Eight = 8,
+    Nine = 9,
+    Ten = 10,
+    Eleven = 11,
+}
+
+internal enum GhosttyColorScheme
+{
+    Light = 0,
+    Dark = 1,
+}
+
+[Flags]
+internal enum GhosttyMods
+{
+    None = 0,
+    Shift = 1 << 0,
+    Ctrl = 1 << 1,
+    Alt = 1 << 2,
+    Super = 1 << 3,
+    Caps = 1 << 4,
+    Num = 1 << 5,
+    ShiftRight = 1 << 6,
+    CtrlRight = 1 << 7,
+    AltRight = 1 << 8,
+    SuperRight = 1 << 9,
+}
+
+internal enum GhosttyInputAction
+{
+    Release = 0,
+    Press = 1,
+    Repeat = 2,
+}
+
+// ghostty_input_key_e. Values matter because they cross the FFI boundary;
+// keep in sync with include/ghostty.h § "Writing System Keys" onward.
+internal enum GhosttyKey
+{
+    Unidentified = 0,
+    // Only the entries the shell currently maps are listed; the enum is
+    // backed by int so unmapped values round-trip fine.
+    // See include/ghostty.h for the full list.
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyInputKey
+{
+    public GhosttyInputAction Action;
+    public GhosttyMods Mods;
+    public GhosttyMods ConsumedMods;
+    public uint Keycode;
+    public IntPtr Text;              // const char*
+    public uint UnshiftedCodepoint;
+    [MarshalAs(UnmanagedType.I1)]
+    public bool Composing;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyPlatformWindows
+{
+    public IntPtr Hwnd;               // null for composition mode
+    public IntPtr SwapChainPanel;     // ISwapChainPanelNative*
+    public IntPtr SharedTextureOut;   // OUT: HANDLE
+    public uint TextureWidth;
+    public uint TextureHeight;
+}
+
+// ghostty_platform_u — explicit layout so all three variants share memory.
+// Windows variant is the widest, so size the struct to match it.
+[StructLayout(LayoutKind.Explicit)]
+internal struct GhosttyPlatformUnion
+{
+    [FieldOffset(0)] public IntPtr MacosNsView;     // macos variant
+    [FieldOffset(0)] public IntPtr IosUiView;       // ios variant
+    [FieldOffset(0)] public GhosttyPlatformWindows Windows;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyEnvVar
+{
+    public IntPtr Key;    // const char*
+    public IntPtr Value;  // const char*
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttySurfaceConfig
+{
+    public GhosttyPlatform PlatformTag;
+    public GhosttyPlatformUnion Platform;
+    public IntPtr Userdata;
+    public double ScaleFactor;
+    public float FontSize;
+    public IntPtr WorkingDirectory; // const char*
+    public IntPtr Command;          // const char*
+    public IntPtr EnvVars;          // ghostty_env_var_s*
+    public UIntPtr EnvVarCount;
+    public IntPtr InitialInput;     // const char*
+    [MarshalAs(UnmanagedType.I1)]
+    public bool WaitAfterCommand;
+    public GhosttySurfaceContext Context;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttySurfaceSize
+{
+    public ushort Columns;
+    public ushort Rows;
+    public uint WidthPx;
+    public uint HeightPx;
+    public uint CellWidthPx;
+    public uint CellHeightPx;
+}
+
+// Runtime callback delegates. These are called from the Zig side on its
+// own thread; marshal to the UI dispatcher before touching XAML.
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void GhosttyWakeupCb(IntPtr userdata);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+[return: MarshalAs(UnmanagedType.I1)]
+internal delegate bool GhosttyActionCb(GhosttyApp app, GhosttyTarget target, IntPtr actionPtr);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+[return: MarshalAs(UnmanagedType.I1)]
+internal delegate bool GhosttyReadClipboardCb(IntPtr userdata, GhosttyClipboard kind, IntPtr state);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void GhosttyConfirmReadClipboardCb(
+    IntPtr userdata,
+    IntPtr str,
+    IntPtr state,
+    GhosttyClipboardRequest request);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void GhosttyWriteClipboardCb(
+    IntPtr userdata,
+    GhosttyClipboard kind,
+    IntPtr content,  // const ghostty_clipboard_content_s*
+    UIntPtr count,
+    [MarshalAs(UnmanagedType.I1)] bool confirm);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void GhosttyCloseSurfaceCb(
+    IntPtr userdata,
+    [MarshalAs(UnmanagedType.I1)] bool processAlive);
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyTarget
+{
+    // tag: 0 = app, 1 = surface
+    public int Tag;
+    // union: only surface is non-empty in practice
+    public IntPtr Surface;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyRuntimeConfig
+{
+    public IntPtr Userdata;
+    [MarshalAs(UnmanagedType.I1)]
+    public bool SupportsSelectionClipboard;
+    public IntPtr WakeupCb;              // function pointers held as IntPtr
+    public IntPtr ActionCb;              // so we control the lifetime of the
+    public IntPtr ReadClipboardCb;       // managed delegates they point at.
+    public IntPtr ConfirmReadClipboardCb;
+    public IntPtr WriteClipboardCb;
+    public IntPtr CloseSurfaceCb;
+}
+
+internal static class NativeMethods
+{
+    // Name only, no extension or path. .NET's native loader handles the
+    // platform-specific suffix and searches the app base directory first,
+    // so the copy-on-build from zig-out in the csproj lands it where we
+    // need it. Users who want to point at a debug build can set
+    // DllImportResolver in App.xaml.cs.
+    private const string Dll = "ghostty";
+
+    // ---- init ----------------------------------------------------------
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_init")]
+    internal static extern int Init(UIntPtr argc, IntPtr argv);
+
+    // ---- config --------------------------------------------------------
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_config_new")]
+    internal static extern GhosttyConfig ConfigNew();
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_config_free")]
+    internal static extern void ConfigFree(GhosttyConfig config);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_config_load_default_files")]
+    internal static extern void ConfigLoadDefaultFiles(GhosttyConfig config);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_config_finalize")]
+    internal static extern void ConfigFinalize(GhosttyConfig config);
+
+    // ---- app -----------------------------------------------------------
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_app_new")]
+    internal static extern GhosttyApp AppNew(in GhosttyRuntimeConfig runtime, GhosttyConfig config);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_app_free")]
+    internal static extern void AppFree(GhosttyApp app);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_app_tick")]
+    internal static extern void AppTick(GhosttyApp app);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_app_set_focus")]
+    internal static extern void AppSetFocus(GhosttyApp app, [MarshalAs(UnmanagedType.I1)] bool focused);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_app_set_color_scheme")]
+    internal static extern void AppSetColorScheme(GhosttyApp app, GhosttyColorScheme scheme);
+
+    // ---- surface lifecycle ---------------------------------------------
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_config_new")]
+    internal static extern GhosttySurfaceConfig SurfaceConfigNew();
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_new")]
+    internal static extern GhosttySurface SurfaceNew(GhosttyApp app, in GhosttySurfaceConfig config);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_free")]
+    internal static extern void SurfaceFree(GhosttySurface surface);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_refresh")]
+    internal static extern void SurfaceRefresh(GhosttySurface surface);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_draw")]
+    internal static extern void SurfaceDraw(GhosttySurface surface);
+
+    // ---- surface size / scale / focus ----------------------------------
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_set_size")]
+    internal static extern void SurfaceSetSize(GhosttySurface surface, uint width, uint height);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_set_content_scale")]
+    internal static extern void SurfaceSetContentScale(GhosttySurface surface, double x, double y);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_set_focus")]
+    internal static extern void SurfaceSetFocus(GhosttySurface surface, [MarshalAs(UnmanagedType.I1)] bool focused);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_set_occlusion")]
+    internal static extern void SurfaceSetOcclusion(GhosttySurface surface, [MarshalAs(UnmanagedType.I1)] bool occluded);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_size")]
+    internal static extern GhosttySurfaceSize SurfaceSize(GhosttySurface surface);
+
+    // ---- surface input -------------------------------------------------
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_key")]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool SurfaceKey(GhosttySurface surface, GhosttyInputKey key);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_text")]
+    internal static extern void SurfaceText(GhosttySurface surface, IntPtr utf8, UIntPtr len);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_preedit")]
+    internal static extern void SurfacePreedit(GhosttySurface surface, IntPtr utf8, UIntPtr len);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_mouse_button")]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool SurfaceMouseButton(
+        GhosttySurface surface,
+        GhosttyMouseState state,
+        GhosttyMouseButton button,
+        GhosttyMods mods);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_mouse_pos")]
+    internal static extern void SurfaceMousePos(GhosttySurface surface, double x, double y, GhosttyMods mods);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_mouse_scroll")]
+    internal static extern void SurfaceMouseScroll(GhosttySurface surface, double x, double y, int scrollMods);
+
+    // ---- surface misc --------------------------------------------------
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_request_close")]
+    internal static extern void SurfaceRequestClose(GhosttySurface surface);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_process_exited")]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool SurfaceProcessExited(GhosttySurface surface);
+}

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="Ghostty.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Ghostty.Controls"
+    Title="Ghostty">
+
+    <Grid x:Name="RootGrid">
+        <controls:TerminalControl
+            x:Name="Terminal"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch" />
+    </Grid>
+</Window>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 
@@ -9,10 +10,16 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
 
-        // Mica backdrop. Keep the default Windows title bar for the first
-        // shell pass; custom title bar with ExtendsContentIntoTitleBar
-        // comes in a follow-up PR so we can focus on the terminal plumbing
-        // here.
-        SystemBackdrop = new MicaBackdrop();
+        // Mica is only available on Windows 11 22H1+ with a supported GPU.
+        // Our TargetPlatformMinVersion is still 19041 (Windows 10), so a
+        // bare `new MicaBackdrop()` would silently fail on older systems
+        // and leave the window with a transparent black backdrop. Probe
+        // MicaController.IsSupported() and skip the backdrop on unsupported
+        // hosts; XAML's default Window background takes over.
+        //
+        // Custom title bar with ExtendsContentIntoTitleBar comes in a
+        // follow-up PR so we can focus on the terminal plumbing here.
+        if (MicaController.IsSupported())
+            SystemBackdrop = new MicaBackdrop();
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1,0 +1,18 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty;
+
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        // Mica backdrop. Keep the default Windows title bar for the first
+        // shell pass; custom title bar with ExtendsContentIntoTitleBar
+        // comes in a follow-up PR so we can focus on the terminal plumbing
+        // here.
+        SystemBackdrop = new MicaBackdrop();
+    }
+}

--- a/windows/Ghostty/app.manifest
+++ b/windows/Ghostty/app.manifest
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Ghostty.app" />
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/windows/Ghostty/global.json
+++ b/windows/Ghostty/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.312",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
First pass at a native Windows shell for Ghostty, mirroring how macos/ consumes libghostty. Adds windows/Ghostty/ as a WinUI 3 unpackaged desktop app that hosts a single libghostty surface via the DX12 composition path (SwapChainPanel, null HWND).

## What's in place

- **Ghostty.sln + Ghostty.csproj** — net9.0-windows, unpackaged. Copies ghostty.dll from zig-out/lib into a native/ subdirectory to avoid collision with the managed Ghostty.dll on case-insensitive filesystems. NativeLibrary.SetDllImportResolver loads it at startup.
- **Directory.Build.props** — redirects AppxMSBuildToolsPath to VS Build Tools so dotnet build from the CLI can find the PRI task DLL (WindowsAppSDK#3997).
- **global.json** — pins .NET 9 SDK. .NET 10 is installed and breaks the WinUI 3 build targets.
- **app.manifest** — PerMonitorV2 DPI, longPathAware, UTF-8 code page.
- **Interop/NativeMethods.cs** — P/Invoke covering init, config lifecycle, app lifecycle, surface lifecycle, size/scale/focus, key/text/mouse. Incremental subset of ghostty.h sorted in header order for easy drift detection on rebases. Runtime config callbacks held in fields so the GC does not free them while libghostty holds the function pointers.
- **Interop/ISwapChainPanelNative.cs** — COM interop. QueryInterface on the WinUI 3 SwapChainPanel returns the ISwapChainPanelNative v-table pointer, which is what libghostty's DX12 renderer calls SetSwapChain on (slot 3). Passing the raw IUnknown crashes inside the renderer.
- **App.xaml, MainWindow.xaml** — Mica backdrop, default title bar (custom title bar is a follow-up PR).
- **Controls/TerminalControl.xaml(.cs)** — SwapChainPanel + input routing. Fills working_directory/command/initial_input with an empty C string (not null) because Zig crashes in surface_new otherwise. Resize is debounced on a 30ms DispatcherQueueTimer because the DX12 renderer recreates the swap chain on every set_size, which can't keep up with WinUI 3's per-pixel drag events. CharacterReceived filters C0 control chars so Ctrl+key combinations don't double up (same fix as the Win32 example in 8dde86df5).

## just recipes

- \`just build-win\` — dotnet build the shell alone.
- \`just run-win\` — zig build the DLL, dotnet build the shell, launch it.

## First-boot status

Opens a Mica window, creates the surface, spawns cmd.exe, DX12 renders, title updates, resize no longer crashes.

Known issues to address in follow-up stacked PRs:

- [ ] Focus flaps between the UserControl and the inner SwapChainPanel
- [ ] Terminal does not pixel-perfect fill the window (swap chain is sized correctly, visual clipping to investigate)
- [ ] VirtualKey is passed as the raw Keycode instead of a translated GhosttyKey

## Not included yet (intentional)

Tabs, splits, custom title bar, settings UI, clipboard, bell, shell integration, dispatcher for ghostty_action callbacks, full VirtualKey -> GhosttyKey mapping, and about 70 of the 88 functions in ghostty.h. Each unlocks its own small PR.