### PR TITLE
fix(windows): WinUI 3 shell focus, input topology, and action plumbing

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -1,26 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    IsTabStop must stay False on the outer UserControl. If both it and
-    the inner SwapChainPanel are tab stops, keyboard focus flaps between
-    them on Tab/Shift+Tab, which the apprt sees as a rapid focus on/off
-    cycle and libghostty interprets as losing focus for one tick between
-    keystrokes.
+    Focus, keyboard, and IME handlers live on the UserControl, not on
+    the inner SwapChainPanel. SwapChainPanel inherits from Grid (not
+    Control) and is not designed to be a focusable input sink: when it
+    is made tab-stop and has CharacterReceived/KeyDown handlers,
+    transient focus grabs from the TSF/IME input scope (or from the
+    composition visual tree itself) cause a continuous GotFocus/
+    LostFocus ping-pong. Keep all input on the root UserControl and
+    leave only SizeChanged + CompositionScaleChanged on the
+    SwapChainPanel.
 -->
 <UserControl
     x:Class="Ghostty.Controls.TerminalControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    IsTabStop="False"
+    IsTabStop="True"
+    TabNavigation="Cycle"
     HorizontalAlignment="Stretch"
     VerticalAlignment="Stretch"
     HorizontalContentAlignment="Stretch"
     VerticalContentAlignment="Stretch"
     Loaded="OnLoaded"
-    Unloaded="OnUnloaded">
+    Unloaded="OnUnloaded"
+    GotFocus="OnGotFocus"
+    LostFocus="OnLostFocus"
+    KeyDown="OnKeyDown"
+    KeyUp="OnKeyUp"
+    CharacterReceived="OnCharacterReceived">
 
     <SwapChainPanel
         x:Name="Panel"
-        IsTabStop="True"
+        IsTabStop="False"
         HorizontalAlignment="Stretch"
         VerticalAlignment="Stretch"
         SizeChanged="OnSizeChanged"
@@ -28,10 +38,5 @@
         PointerPressed="OnPointerPressed"
         PointerMoved="OnPointerMoved"
         PointerReleased="OnPointerReleased"
-        PointerWheelChanged="OnPointerWheelChanged"
-        KeyDown="OnKeyDown"
-        KeyUp="OnKeyUp"
-        CharacterReceived="OnCharacterReceived"
-        GotFocus="OnGotFocus"
-        LostFocus="OnLostFocus" />
+        PointerWheelChanged="OnPointerWheelChanged" />
 </UserControl>

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    IsTabStop must stay False on the outer UserControl. If both it and
+    the inner SwapChainPanel are tab stops, keyboard focus flaps between
+    them on Tab/Shift+Tab, which the apprt sees as a rapid focus on/off
+    cycle and libghostty interprets as losing focus for one tick between
+    keystrokes.
+-->
 <UserControl
     x:Class="Ghostty.Controls.TerminalControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -42,6 +42,14 @@ public sealed partial class TerminalControl : UserControl
     private GhosttyWriteClipboardCb? _writeClipboardCb;
     private GhosttyCloseSurfaceCb? _closeSurfaceCb;
 
+    // Events raised from the runtime action callback. They always fire
+    // on the UI thread: the callback itself runs on libghostty's thread
+    // and uses DispatcherQueue.TryEnqueue before invoking these.
+    //
+    // MainWindow subscribes to update the window chrome.
+    public event EventHandler<string>? TitleChanged;
+    public event EventHandler? CloseRequested;
+
     public TerminalControl()
     {
         InitializeComponent();
@@ -155,6 +163,11 @@ public sealed partial class TerminalControl : UserControl
         _commandUtf8 = IntPtr.Zero;
         _initialInputUtf8 = IntPtr.Zero;
         _initialized = false;
+
+        // Drop subscribers so MainWindow is not rooted via these events
+        // after the control tears down.
+        TitleChanged = null;
+        CloseRequested = null;
     }
 
     private static IntPtr AllocEmptyUtf8()

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -268,7 +268,6 @@ public sealed partial class TerminalControl : UserControl
     // Size / scale -------------------------------------------------------
 
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _resizeTimer;
-    private Windows.Foundation.Size _pendingSize;
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
     {
@@ -280,7 +279,6 @@ public sealed partial class TerminalControl : UserControl
         // during a drag. The fix is in the renderer: ResizeBuffers instead
         // of full recreate. Until that lands, debounce here. Drop this
         // entire timer once the renderer is idempotent.
-        _pendingSize = e.NewSize;
         if (_resizeTimer is null)
         {
             _resizeTimer = DispatcherQueue.CreateTimer();
@@ -295,10 +293,17 @@ public sealed partial class TerminalControl : UserControl
     {
         sender.Stop();
         if (_surface.Handle == IntPtr.Zero) return;
+
+        // Read the panel's own layout bounds rather than the
+        // SizeChangedEventArgs value. DPI rounding and any padding in
+        // the visual tree can make the two differ by a pixel, which
+        // manifests as letterboxing: the DX12 swap chain sizes off one
+        // value while the compositor stretches the panel to its own
+        // bounds, leaving a gap at the edges.
         var sx = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1.0;
         var sy = Panel.CompositionScaleY > 0 ? Panel.CompositionScaleY : 1.0;
-        var w = (uint)Math.Max(1, _pendingSize.Width * sx);
-        var h = (uint)Math.Max(1, _pendingSize.Height * sy);
+        var w = (uint)Math.Max(1, Panel.ActualWidth * sx);
+        var h = (uint)Math.Max(1, Panel.ActualHeight * sy);
         NativeMethods.SurfaceSetSize(_surface, w, h);
     }
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -131,8 +131,38 @@ public sealed partial class TerminalControl : UserControl
         // Drop our ref to the panel: libghostty did not retain it.
         SwapChainPanelInterop.Release(panelPtr);
 
+        // Prime the initial size when layout is actually settled.
+        // SwapChainPanel.SizeChanged fires during the first layout pass,
+        // which happens BEFORE Loaded, so by the time the surface exists
+        // no further SizeChanged is queued until the user resizes the
+        // window. Reading Panel.ActualWidth/Height here directly is
+        // also unsafe: CompositionScaleX/Y is frequently reported as 1.0
+        // until a later CompositionScaleChanged fires. Wait for
+        // LayoutUpdated - the first one after the surface exists
+        // guarantees ActualWidth/Height and the composition scale are
+        // both valid - then revoke the handler.
+        Panel.LayoutUpdated += OnFirstLayoutUpdated;
+
         // Request focus so keyboard input starts flowing immediately.
-        Panel.Focus(FocusState.Programmatic);
+        // Focus lives on the UserControl now, not the panel.
+        this.Focus(FocusState.Programmatic);
+    }
+
+    private void OnFirstLayoutUpdated(object? sender, object e)
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        var w = Panel.ActualWidth;
+        var h = Panel.ActualHeight;
+        if (w <= 0 || h <= 0) return;  // still not settled, wait for next tick
+        Panel.LayoutUpdated -= OnFirstLayoutUpdated;
+
+        var sx = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1f;
+        var sy = Panel.CompositionScaleY > 0 ? Panel.CompositionScaleY : 1f;
+        NativeMethods.SurfaceSetContentScale(_surface, sx, sy);
+        NativeMethods.SurfaceSetSize(
+            _surface,
+            (uint)Math.Max(1, w * sx),
+            (uint)Math.Max(1, h * sy));
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -272,7 +302,11 @@ public sealed partial class TerminalControl : UserControl
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
     {
         if (_surface.Handle == IntPtr.Zero) return;
+        KickResizeDebounce();
+    }
 
+    private void KickResizeDebounce()
+    {
         // FIXME: the DX12 renderer recreates the swap chain on every
         // set_size, which tears down GPU resources faster than the
         // compositor can follow when WinUI 3 fires SizeChanged per pixel
@@ -310,30 +344,45 @@ public sealed partial class TerminalControl : UserControl
     private void OnCompositionScaleChanged(SwapChainPanel sender, object args)
     {
         if (_surface.Handle == IntPtr.Zero) return;
+        // Push the new scale to libghostty, then re-kick the debounced
+        // resize path so the pixel dimensions get recomputed with the
+        // new scale. DPI change (e.g. moving the window between monitors)
+        // changes the pixel size even though the DIP size is unchanged.
         NativeMethods.SurfaceSetContentScale(_surface, sender.CompositionScaleX, sender.CompositionScaleY);
+        KickResizeDebounce();
     }
 
     // Focus --------------------------------------------------------------
+    //
+    // Focus is owned by the outer UserControl, not the SwapChainPanel -
+    // see the comment in the XAML for the full reasoning. These
+    // handlers fire off the UserControl's GotFocus/LostFocus routed
+    // events. We still dedupe on state change as a belt-and-braces
+    // guard so libghostty never sees a redundant focus event.
 
-    private void OnGotFocus(object sender, RoutedEventArgs e)
-    {
-        if (_surface.Handle == IntPtr.Zero) return;
-        NativeMethods.SurfaceSetFocus(_surface, true);
-        if (_app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(_app, true);
-    }
+    private bool _focused;
 
-    private void OnLostFocus(object sender, RoutedEventArgs e)
+    private void OnGotFocus(object sender, RoutedEventArgs e) => SetFocusState(true);
+
+    private void OnLostFocus(object sender, RoutedEventArgs e) => SetFocusState(false);
+
+    private void SetFocusState(bool focused)
     {
+        if (_focused == focused) return;
+        _focused = focused;
         if (_surface.Handle == IntPtr.Zero) return;
-        NativeMethods.SurfaceSetFocus(_surface, false);
-        if (_app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(_app, false);
+        NativeMethods.SurfaceSetFocus(_surface, focused);
+        if (_app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(_app, focused);
     }
 
     // Mouse --------------------------------------------------------------
 
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
-        Panel.Focus(FocusState.Pointer);
+        // Take focus on the UserControl, not the panel. Guard with the
+        // current focus state to avoid generating a Lost+Got pair when
+        // we already have focus.
+        if (!_focused) this.Focus(FocusState.Pointer);
         SendMouseButton(e, GhosttyMouseState.Press);
     }
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -203,10 +203,61 @@ public sealed partial class TerminalControl : UserControl
 
     private bool OnAction(GhosttyApp app, IntPtr targetPtr, IntPtr actionPtr)
     {
-        // Real decode lands in a follow-up step. For now preserve existing
-        // behavior: return false so the core falls back to its defaults
-        // for every action.
-        return false;
+        // ghostty_action_s layout:
+        //   { int32 tag; <union> action; }
+        // The union is 8-byte aligned on x64 so it starts at offset 8.
+        // We read the tag first and only touch the union for variants we
+        // actually handle. Returning false for an unhandled tag lets the
+        // core fall back to its default behavior.
+        if (actionPtr == IntPtr.Zero) return false;
+        var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
+
+        switch (tag)
+        {
+            case GhosttyActionTag.SetTitle:
+            {
+                // set_title_s is { const char* title }, so the first
+                // pointer-sized word of the union is the UTF-8 title.
+                var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
+                var title = PtrToStringUtf8(titlePtr) ?? string.Empty;
+                var dq = DispatcherQueue;
+                if (dq is null) return true;
+                dq.TryEnqueue(() => TitleChanged?.Invoke(this, title));
+                return true;
+            }
+
+            case GhosttyActionTag.RingBell:
+            {
+                // MessageBeep is thread-safe; no dispatcher hop needed.
+                NativeMethods.MessageBeep(NativeMethods.MB_OK);
+                return true;
+            }
+
+            case GhosttyActionTag.CloseWindow:
+            {
+                var dq = DispatcherQueue;
+                if (dq is null) return true;
+                dq.TryEnqueue(() => CloseRequested?.Invoke(this, EventArgs.Empty));
+                return true;
+            }
+
+            default:
+                // Everything else falls back to libghostty defaults.
+                return false;
+        }
+    }
+
+    private static string? PtrToStringUtf8(IntPtr p)
+    {
+        if (p == IntPtr.Zero) return null;
+        // Walk to the null terminator. UTF-8 strings from libghostty are
+        // always null-terminated.
+        int len = 0;
+        while (Marshal.ReadByte(p, len) != 0) len++;
+        if (len == 0) return string.Empty;
+        var bytes = new byte[len];
+        Marshal.Copy(p, bytes, 0, len);
+        return Encoding.UTF8.GetString(bytes);
     }
 
     private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -188,10 +188,11 @@ public sealed partial class TerminalControl : UserControl
         });
     }
 
-    private bool OnAction(GhosttyApp app, GhosttyTarget target, IntPtr actionPtr)
+    private bool OnAction(GhosttyApp app, IntPtr targetPtr, IntPtr actionPtr)
     {
-        // false = not handled, fall back to libghostty default. Per-action
-        // dispatch lands when the shell starts wiring real handlers.
+        // Real decode lands in a follow-up step. For now preserve existing
+        // behavior: return false so the core falls back to its defaults
+        // for every action.
         return false;
     }
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -71,9 +71,9 @@ public sealed partial class TerminalControl : UserControl
         NativeMethods.ConfigLoadDefaultFiles(_config);
         NativeMethods.ConfigFinalize(_config);
 
-        // 3) Runtime config. The Zig side requires non-null callbacks even
-        //    if they are no-ops; storing each delegate in a field prevents
-        //    GC from freeing it while libghostty still holds the pointer.
+        // The Zig side requires non-null callbacks even if they are no-ops;
+        // storing each delegate in a field prevents GC from freeing it while
+        // libghostty still holds the pointer.
         _wakeupCb = OnWakeup;
         _actionCb = OnAction;
         _readClipboardCb = OnReadClipboard;
@@ -95,7 +95,7 @@ public sealed partial class TerminalControl : UserControl
 
         _app = NativeMethods.AppNew(runtime, _config);
 
-        // 4) Surface config. swap_chain_panel takes an ISwapChainPanelNative*
+        // Surface config. swap_chain_panel takes an ISwapChainPanelNative*
         //    which libghostty's DX12 device init uses synchronously (it calls
         //    SetSwapChain once and never stores it - see
         //    src/renderer/directx12/device.zig). We Release the COM ptr right
@@ -167,6 +167,11 @@ public sealed partial class TerminalControl : UserControl
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
+        // Drop the one-shot LayoutUpdated handler in case the initial size
+        // never settled (zero ActualWidth/Height): otherwise it would keep
+        // firing after teardown and pin the control via the closure.
+        Panel.LayoutUpdated -= OnFirstLayoutUpdated;
+
         // Stop and detach the resize timer first so a pending tick cannot
         // observe a half-freed surface. The timer holds a strong reference
         // to this control via OnResizeTick, so leaving it pending across
@@ -231,14 +236,17 @@ public sealed partial class TerminalControl : UserControl
         });
     }
 
-    private bool OnAction(GhosttyApp app, IntPtr targetPtr, IntPtr actionPtr)
+    private bool OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr)
     {
         // ghostty_action_s layout:
         //   { int32 tag; <union> action; }
         // The union is 8-byte aligned on x64 so it starts at offset 8.
         // We read the tag first and only touch the union for variants we
         // actually handle. Returning false for an unhandled tag lets the
-        // core fall back to its default behavior.
+        // core fall back to its default behavior. We also return false on
+        // any path that fails to actually invoke the handler (null pointer,
+        // null dispatcher) so the core never thinks we handled an action
+        // we silently dropped.
         if (actionPtr == IntPtr.Zero) return false;
         var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
 
@@ -249,9 +257,9 @@ public sealed partial class TerminalControl : UserControl
                 // set_title_s is { const char* title }, so the first
                 // pointer-sized word of the union is the UTF-8 title.
                 var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
-                var title = PtrToStringUtf8(titlePtr) ?? string.Empty;
+                var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
                 var dq = DispatcherQueue;
-                if (dq is null) return true;
+                if (dq is null) return false;
                 dq.TryEnqueue(() => TitleChanged?.Invoke(this, title));
                 return true;
             }
@@ -266,7 +274,7 @@ public sealed partial class TerminalControl : UserControl
             case GhosttyActionTag.CloseWindow:
             {
                 var dq = DispatcherQueue;
-                if (dq is null) return true;
+                if (dq is null) return false;
                 dq.TryEnqueue(() => CloseRequested?.Invoke(this, EventArgs.Empty));
                 return true;
             }
@@ -275,19 +283,6 @@ public sealed partial class TerminalControl : UserControl
                 // Everything else falls back to libghostty defaults.
                 return false;
         }
-    }
-
-    private static string? PtrToStringUtf8(IntPtr p)
-    {
-        if (p == IntPtr.Zero) return null;
-        // Walk to the null terminator. UTF-8 strings from libghostty are
-        // always null-terminated.
-        int len = 0;
-        while (Marshal.ReadByte(p, len) != 0) len++;
-        if (len == 0) return string.Empty;
-        var bytes = new byte[len];
-        Marshal.Copy(p, bytes, 0, len);
-        return Encoding.UTF8.GetString(bytes);
     }
 
     private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;
@@ -369,8 +364,11 @@ public sealed partial class TerminalControl : UserControl
     private void SetFocusState(bool focused)
     {
         if (_focused == focused) return;
-        _focused = focused;
+        // Don't flip _focused before we know we can actually push the new
+        // state to the surface: otherwise the next focus change after the
+        // surface is recreated would be deduped against a stale value.
         if (_surface.Handle == IntPtr.Zero) return;
+        _focused = focused;
         NativeMethods.SurfaceSetFocus(_surface, focused);
         if (_app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(_app, focused);
     }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -218,78 +218,20 @@ internal struct GhosttyTarget
     [FieldOffset(8)] public IntPtr Surface;
 }
 
-// ghostty_action_tag_e from ghostty.h. Keep this in sync on rebase:
-// grep for "ghostty_action_tag_e" in include/ghostty.h. New variants
-// added upstream land at the end of the enum; any tag we do not
-// explicitly handle falls through to "return false" in the callback,
-// so drift is safe - at worst a new action is ignored until wired.
+// Subset of ghostty_action_tag_e from include/ghostty.h that we actually
+// dispatch on. Indices are pinned explicitly to the upstream values so a
+// reorder upstream cannot silently misroute one tag to another handler -
+// any tag we don't list falls through to "return false" in the action
+// callback and the core uses its default behavior.
+//
+// Synced against include/ghostty.h @ 2598bef60. To verify after a rebase:
+//   grep -n GHOSTTY_ACTION_ include/ghostty.h | grep -nE 'SET_TITLE|CLOSE_WINDOW|RING_BELL'
+// and confirm the ordinal positions still match the values below.
 internal enum GhosttyActionTag
 {
-    Quit = 0,
-    NewWindow,
-    NewTab,
-    CloseTab,
-    NewSplit,
-    CloseAllWindows,
-    ToggleMaximize,
-    ToggleFullscreen,
-    ToggleTabOverview,
-    ToggleWindowDecorations,
-    ToggleQuickTerminal,
-    ToggleCommandPalette,
-    ToggleVisibility,
-    ToggleBackgroundOpacity,
-    MoveTab,
-    GotoTab,
-    GotoSplit,
-    GotoWindow,
-    ResizeSplit,
-    EqualizeSplits,
-    ToggleSplitZoom,
-    PresentTerminal,
-    SizeLimit,
-    ResetWindowSize,
-    InitialSize,
-    CellSize,
-    Scrollbar,
-    Render,
-    Inspector,
-    ShowGtkInspector,
-    RenderInspector,
-    DesktopNotification,
-    SetTitle,
-    SetTabTitle,
-    PromptTitle,
-    Pwd,
-    MouseShape,
-    MouseVisibility,
-    MouseOverLink,
-    RendererHealth,
-    OpenConfig,
-    QuitTimer,
-    FloatWindow,
-    SecureInput,
-    KeySequence,
-    KeyTable,
-    ColorChange,
-    ReloadConfig,
-    ConfigChange,
-    CloseWindow,
-    RingBell,
-    Undo,
-    Redo,
-    CheckForUpdates,
-    OpenUrl,
-    ShowChildExited,
-    ProgressReport,
-    ShowOnScreenKeyboard,
-    CommandFinished,
-    StartSearch,
-    EndSearch,
-    SearchTotal,
-    SearchSelected,
-    Readonly,
-    CopyTitleToClipboard,
+    SetTitle = 32,
+    CloseWindow = 49,
+    RingBell = 50,
 }
 
 // ghostty_action_set_title_s { const char* title; }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -218,6 +218,88 @@ internal struct GhosttyTarget
     [FieldOffset(8)] public IntPtr Surface;
 }
 
+// ghostty_action_tag_e from ghostty.h. Keep this in sync on rebase:
+// grep for "ghostty_action_tag_e" in include/ghostty.h. New variants
+// added upstream land at the end of the enum; any tag we do not
+// explicitly handle falls through to "return false" in the callback,
+// so drift is safe - at worst a new action is ignored until wired.
+internal enum GhosttyActionTag
+{
+    Quit = 0,
+    NewWindow,
+    NewTab,
+    CloseTab,
+    NewSplit,
+    CloseAllWindows,
+    ToggleMaximize,
+    ToggleFullscreen,
+    ToggleTabOverview,
+    ToggleWindowDecorations,
+    ToggleQuickTerminal,
+    ToggleCommandPalette,
+    ToggleVisibility,
+    ToggleBackgroundOpacity,
+    MoveTab,
+    GotoTab,
+    GotoSplit,
+    GotoWindow,
+    ResizeSplit,
+    EqualizeSplits,
+    ToggleSplitZoom,
+    PresentTerminal,
+    SizeLimit,
+    ResetWindowSize,
+    InitialSize,
+    CellSize,
+    Scrollbar,
+    Render,
+    Inspector,
+    ShowGtkInspector,
+    RenderInspector,
+    DesktopNotification,
+    SetTitle,
+    SetTabTitle,
+    PromptTitle,
+    Pwd,
+    MouseShape,
+    MouseVisibility,
+    MouseOverLink,
+    RendererHealth,
+    OpenConfig,
+    QuitTimer,
+    FloatWindow,
+    SecureInput,
+    KeySequence,
+    KeyTable,
+    ColorChange,
+    ReloadConfig,
+    ConfigChange,
+    CloseWindow,
+    RingBell,
+    Undo,
+    Redo,
+    CheckForUpdates,
+    OpenUrl,
+    ShowChildExited,
+    ProgressReport,
+    ShowOnScreenKeyboard,
+    CommandFinished,
+    StartSearch,
+    EndSearch,
+    SearchTotal,
+    SearchSelected,
+    Readonly,
+    CopyTitleToClipboard,
+}
+
+// ghostty_action_set_title_s { const char* title; }
+// We only read .title; the struct is declared so the offset is explicit.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionSetTitle
+{
+    public IntPtr Title;
+}
+
 [StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyRuntimeConfig
 {
@@ -345,4 +427,15 @@ internal static class NativeMethods
     [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_process_exited")]
     [return: MarshalAs(UnmanagedType.I1)]
     internal static extern bool SurfaceProcessExited(GhosttySurface surface);
+
+    // ---- user32 --------------------------------------------------------
+
+    // MessageBeep is thread-safe and minimal-dependency. Used by the
+    // action callback for RING_BELL without any dispatcher hop.
+    // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-messagebeep
+    internal const uint MB_OK = 0x00000000;
+
+    [DllImport("user32.dll", CallingConvention = CallingConvention.Winapi)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool MessageBeep(uint uType);
 }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -170,9 +170,14 @@ internal struct GhosttySurfaceSize
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 internal delegate void GhosttyWakeupCb(IntPtr userdata);
 
+// C signature: bool (*)(ghostty_app_t, ghostty_target_s, ghostty_action_s)
+// Both ghostty_target_s (16 bytes) and ghostty_action_s (hundreds of bytes)
+// are larger than 8 bytes, so on the Windows x64 ABI they are passed by
+// hidden pointer. We take both as IntPtr and decode the fields we need
+// with Marshal.PtrToStructure / Marshal.ReadIntPtr.
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 [return: MarshalAs(UnmanagedType.I1)]
-internal delegate bool GhosttyActionCb(GhosttyApp app, GhosttyTarget target, IntPtr actionPtr);
+internal delegate bool GhosttyActionCb(GhosttyApp app, IntPtr targetPtr, IntPtr actionPtr);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 [return: MarshalAs(UnmanagedType.I1)]

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -21,5 +21,11 @@ public sealed partial class MainWindow : Window
         // follow-up PR so we can focus on the terminal plumbing here.
         if (MicaController.IsSupported())
             SystemBackdrop = new MicaBackdrop();
+
+        // Route title updates and close requests from the terminal's
+        // runtime action callback to the window chrome. Both events
+        // are raised on the UI thread by TerminalControl.
+        Terminal.TitleChanged += (_, title) => Title = title;
+        Terminal.CloseRequested += (_, _) => Close();
     }
 }


### PR DESCRIPTION
> **IMPORTANT**: Stacked PR — depends on #156. Merge order: # 156 first, then this. The next stacked branch (`feat/winui3-shell-dx12-fixes`) will address the remaining DX12 renderer issues.

Follow-up fixes on top of the WinUI 3 shell scaffold. Three areas:

**Action callback plumbing**
- Fix the `GhosttyActionCb` P/Invoke signature: `ghostty_target_s` and `ghostty_action_s` are passed by hidden pointer on Windows x64, not by value.
- Decode `ghostty_action_s` and dispatch `SET_TITLE`, `RING_BELL`, `CLOSE_WINDOW`. Everything else falls through to core defaults.
- New `TitleChanged` and `CloseRequested` events on `TerminalControl`; `MainWindow` subscribes to update the chrome.
- `MessageBeep(MB_OK)` for the bell.

**Focus and input topology**
- Move `GotFocus`/`LostFocus`/`KeyDown`/`KeyUp`/`CharacterReceived` from the `SwapChainPanel` to the outer `UserControl`. SwapChainPanel inherits from Grid, not Control, so it cannot hold keyboard focus directly — `Panel.Focus(...)` was a silent no-op. Subscribing `CharacterReceived` to a SwapChainPanel also inserts a TSF input scope that thrashes focus on every layout pass.
- Dedupe focus state forwarding so libghostty never sees redundant focus events.
- Pointer-press now calls `this.Focus(FocusState.Pointer)` only when not already focused.

**Resize and initial sizing**
- Replace the `OnLoaded` `TryEnqueue` retry loop with a one-shot `Panel.LayoutUpdated` subscription so the initial size is primed once layout is settled and `CompositionScaleX/Y` is valid.
- `OnCompositionScaleChanged` now re-kicks the resize debounce so pixel dimensions are recomputed when DPI changes.
- Extracted `KickResizeDebounce` helper to avoid duplicating the timer init.

**Out of scope (deferred to next stacked PR `feat/winui3-shell-dx12-fixes`)**
- Pixel-perfect fill: panel dims match the window but the rendered terminal still appears smaller. Lives in the Zig DX12 renderer.
- Resize crash: dragging crashes the process. Memory note from # 156 already flagged this — DX12 renderer recreates the swap chain on every set_size. Real fix is in the Zig renderer.
- VirtualKey translation table (~130 entries) and the remaining ~70 ghostty.h bindings stay deferred as scaffold-PR memory called out.

Target: `feat/winui3-shell`
