### PR TITLE
feat(windows): DX12 swap chain resize + Target double-free fix

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -131,16 +131,24 @@ init_command_list: ?*d3d12.ID3D12GraphicsCommandList = null,
 /// Must be saved here because GetCurrentBackBufferIndex advances after Present.
 pending_frame_index: u32 = 0,
 
-/// Cached surface dimensions, updated by setTargetSize and seeded in init.
+/// Desired surface dimensions, updated by setTargetSize.
 ///
 /// DX12 uses composition swap chains for all surface types (HWND via
 /// DirectComposition, SwapChainPanel via XAML). Unlike DX11's GetClientRect
 /// path, there is no way to query the actual window size from within the
-/// renderer -- the apprt must forward it via setTargetSize. The GetDesc1
-/// fallback returns buffer dimensions which lag behind until ResizeBuffers
-/// is called, so this cache is the primary source of truth.
-cached_width: u32 = 0,
-cached_height: u32 = 0,
+/// renderer -- the apprt must forward it via setTargetSize.
+///
+/// These are atomics because setTargetSize is invoked synchronously from
+/// ghostty_surface_set_size on the apprt thread (the C# UI thread for the
+/// WinUI 3 shell), while the renderer thread reads them in beginFrame to
+/// drive ResizeBuffers. The renderer thread tracks what it has actually
+/// applied in `applied_width` / `applied_height` -- if the desired and
+/// applied values differ at the start of beginFrame, it resizes the swap
+/// chain there (the only thread allowed to touch back_buffers/RTVs/fence).
+desired_width: std.atomic.Value(u32) = .init(0),
+desired_height: std.atomic.Value(u32) = .init(0),
+applied_width: u32 = 0,
+applied_height: u32 = 0,
 
 // --- GraphicsAPI contract: functions ---
 
@@ -329,8 +337,10 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         result.pending_command_list = init_cl;
     }
 
-    result.cached_width = size.width;
-    result.cached_height = size.height;
+    result.desired_width.store(size.width, .monotonic);
+    result.desired_height.store(size.height, .monotonic);
+    result.applied_width = size.width;
+    result.applied_height = size.height;
 
     return result;
 }
@@ -488,14 +498,110 @@ pub fn initShaders(
 /// Called by the apprt (via generic.zig) when the surface is resized.
 /// This is the only resize signal DX12 gets -- composition swap chains
 /// have no equivalent of DX11's GetClientRect-based windowSize().
+///
+/// IMPORTANT: this is invoked synchronously from `ghostty_surface_set_size`,
+/// which the WinUI 3 shell calls on the C# UI thread for every SizeChanged
+/// event. We must NOT touch any GPU state here -- back_buffers, fences,
+/// command lists, and the descriptor heaps all belong to the renderer
+/// thread. Just record the desired size atomically; `beginFrame` (running
+/// on the renderer thread) will pick it up and call `resizeSwapChain` at
+/// a safe point before any command-list work for the next frame.
 pub fn setTargetSize(self: *DirectX12, width: u32, height: u32) void {
-    self.cached_width = width;
-    self.cached_height = height;
+    if (width == 0 or height == 0) return;
+    self.desired_width.store(width, .monotonic);
+    self.desired_height.store(height, .monotonic);
+}
+
+/// Resize the swap chain back buffers in place via IDXGISwapChain1::ResizeBuffers.
+///
+/// DXGI requires every reference to the existing back buffers (including
+/// RTVs implicitly via the resource) to be released before ResizeBuffers,
+/// and the GPU must be idle so it isn't still reading them.
+fn resizeSwapChain(self: *DirectX12, width: u32, height: u32) !void {
+    const dev_ptr = &(self.dev orelse return);
+    const sc3 = self.swap_chain3 orelse return;
+
+    // Drain in-flight frames so back_buffers[*] aren't being read by the GPU.
+    dev_ptr.waitForGpu() catch |err| {
+        log.err("waitForGpu before ResizeBuffers failed: {}", .{err});
+        return error.WaitForGpuFailed;
+    };
+
+    // Drop our references to the existing back buffers. DXGI keeps the
+    // underlying allocations alive and rebinds them to the resized buffers
+    // on the next GetBuffer call.
+    for (&self.back_buffers) |*bb| {
+        if (bb.*) |r| {
+            _ = r.Release();
+            bb.* = null;
+        }
+    }
+
+    // UNKNOWN format and 0 flags preserve whatever the swap chain was
+    // created with -- the same values device.zig used at creation time.
+    // ResizeBuffers lives on IDXGISwapChain1; cast our SwapChain3 down.
+    const sc1: *dxgi.IDXGISwapChain1 = @ptrCast(sc3);
+    const hr = sc1.ResizeBuffers(
+        device.Device.frame_count,
+        width,
+        height,
+        .UNKNOWN,
+        0,
+    );
+    if (hr == com.DXGI_ERROR_DEVICE_REMOVED or
+        hr == com.DXGI_ERROR_DEVICE_HUNG or
+        hr == com.DXGI_ERROR_DEVICE_RESET)
+    {
+        self.handleDeviceRemoved();
+        return error.DeviceRemoved;
+    }
+    if (com.FAILED(hr)) {
+        log.err("ResizeBuffers failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+        return error.ResizeBuffersFailed;
+    }
+
+    // Re-acquire back buffers and recreate RTVs at the same descriptor
+    // slots. Mirrors the loop in init() so the rtv_handles array stays
+    // valid for beginFrame.
+    const rtv_heap = &(self.rtv_heap orelse return error.NoRtvHeap);
+    for (0..device.Device.frame_count) |i| {
+        var resource: ?*d3d12.ID3D12Resource = null;
+        const get_hr = sc3.GetBuffer(
+            @intCast(i),
+            &d3d12.ID3D12Resource.IID,
+            @ptrCast(&resource),
+        );
+        if (com.FAILED(get_hr)) {
+            log.err("GetBuffer({}) after resize failed: 0x{x}", .{ i, @as(u32, @bitCast(get_hr)) });
+            return error.GetBufferFailed;
+        }
+        self.back_buffers[i] = resource;
+
+        const rtv_handle = rtv_heap.cpuHandle(@intCast(i));
+        dev_ptr.device.CreateRenderTargetView(resource, null, rtv_handle);
+        self.rtv_handles[i] = rtv_handle;
+    }
+
+    // waitForGpu drained everything, so any fence value the per-frame slots
+    // were waiting on is already complete. Reset to 0 so beginFrame doesn't
+    // burn an event wait on a stale value (and so a future fence_value
+    // wraparound corner case can't trip on a leftover signal).
+    for (&self.gpu_frames) |*gf| {
+        if (gf.*) |*f| f.fence_value = 0;
+    }
+
+    // Record what we just applied so beginFrame doesn't loop on the same
+    // resize. Stored on the renderer thread; only the renderer thread reads
+    // it, so a plain field is fine (no atomic needed).
+    self.applied_width = width;
+    self.applied_height = height;
 }
 
 pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
-    if (self.cached_width != 0 and self.cached_height != 0) {
-        return .{ .width = self.cached_width, .height = self.cached_height };
+    const w = self.desired_width.load(.monotonic);
+    const h = self.desired_height.load(.monotonic);
+    if (w != 0 and h != 0) {
+        return .{ .width = w, .height = h };
     }
 
     // Fallback: query swap chain buffer dimensions via GetDesc1.
@@ -540,6 +646,23 @@ pub inline fn beginFrame(
     const sc3 = api.swap_chain3 orelse return error.NoSwapChain;
     const dev_ptr = &(api.dev orelse return error.NoDevice);
 
+    // If the apprt asked for a new surface size since the last frame,
+    // resize the swap chain now -- on the renderer thread, before any
+    // command list work. setTargetSize only records the desired size;
+    // it cannot touch GPU state because it runs on the apprt thread.
+    {
+        const want_w = api.desired_width.load(.monotonic);
+        const want_h = api.desired_height.load(.monotonic);
+        if (want_w != 0 and want_h != 0 and
+            (want_w != api.applied_width or want_h != api.applied_height))
+        {
+            api.resizeSwapChain(want_w, want_h) catch |err| {
+                log.err("DX12 swap chain resize failed: {}", .{err});
+                return error.ResizeFailed;
+            };
+        }
+    }
+
     // Which back buffer does the swap chain want us to render to?
     const frame_idx = sc3.GetCurrentBackBufferIndex();
 
@@ -573,6 +696,7 @@ pub inline fn beginFrame(
 }
 
 pub fn presentLastTarget(self: *DirectX12) !void {
+    log.info("presentLastTarget", .{});
     // Called when no redraw is needed -- re-present the current frame.
     // No new GPU work is submitted, so the existing fence values remain
     // valid and the next beginFrame will wait correctly.
@@ -695,15 +819,19 @@ test "DirectX12 does not have frame_fence_values" {
     try std.testing.expect(!@hasField(DirectX12, "frame_fence_values"));
 }
 
-test "DirectX12 has cached size fields" {
-    try std.testing.expect(@hasField(DirectX12, "cached_width"));
-    try std.testing.expect(@hasField(DirectX12, "cached_height"));
+test "DirectX12 has desired/applied size fields" {
+    try std.testing.expect(@hasField(DirectX12, "desired_width"));
+    try std.testing.expect(@hasField(DirectX12, "desired_height"));
+    try std.testing.expect(@hasField(DirectX12, "applied_width"));
+    try std.testing.expect(@hasField(DirectX12, "applied_height"));
 }
 
-test "DirectX12 default cached size is zero" {
+test "DirectX12 default size is zero" {
     const api: DirectX12 = .{};
-    try std.testing.expectEqual(@as(u32, 0), api.cached_width);
-    try std.testing.expectEqual(@as(u32, 0), api.cached_height);
+    try std.testing.expectEqual(@as(u32, 0), api.desired_width.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 0), api.desired_height.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 0), api.applied_width);
+    try std.testing.expectEqual(@as(u32, 0), api.applied_height);
 }
 
 test "DirectX12 has device_lost field" {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -138,17 +138,32 @@ pending_frame_index: u32 = 0,
 /// path, there is no way to query the actual window size from within the
 /// renderer -- the apprt must forward it via setTargetSize.
 ///
-/// These are atomics because setTargetSize is invoked synchronously from
-/// ghostty_surface_set_size on the apprt thread (the C# UI thread for the
-/// WinUI 3 shell), while the renderer thread reads them in beginFrame to
-/// drive ResizeBuffers. The renderer thread tracks what it has actually
-/// applied in `applied_width` / `applied_height` -- if the desired and
-/// applied values differ at the start of beginFrame, it resizes the swap
-/// chain there (the only thread allowed to touch back_buffers/RTVs/fence).
-desired_width: std.atomic.Value(u32) = .init(0),
-desired_height: std.atomic.Value(u32) = .init(0),
+/// Width and height are packed into a single u64 (high 32 = width, low 32
+/// = height) so we can store/load both atomically. setTargetSize is invoked
+/// synchronously from ghostty_surface_set_size on the apprt thread (the C#
+/// UI thread for the WinUI 3 shell), while the renderer thread reads it
+/// in beginFrame to drive ResizeBuffers. Two separate atomics would tear
+/// during a drag: a resize that updates only width before the renderer
+/// reads height would briefly show a mismatched back buffer. The renderer
+/// thread tracks what it has actually applied in `applied_width` /
+/// `applied_height` -- if the desired and applied values differ at the
+/// start of beginFrame, it resizes the swap chain there (the only thread
+/// allowed to touch back_buffers/RTVs/fence).
+desired_size: std.atomic.Value(u64) = .init(0),
 applied_width: u32 = 0,
 applied_height: u32 = 0,
+
+/// Pack/unpack helpers for desired_size. Width in the high 32 bits so a
+/// hexdump reads naturally as WWWWWWWW_HHHHHHHH.
+inline fn packSize(width: u32, height: u32) u64 {
+    return (@as(u64, width) << 32) | @as(u64, height);
+}
+inline fn unpackSize(packed_size: u64) struct { width: u32, height: u32 } {
+    return .{
+        .width = @intCast(packed_size >> 32),
+        .height = @intCast(packed_size & 0xFFFFFFFF),
+    };
+}
 
 // --- GraphicsAPI contract: functions ---
 
@@ -337,8 +352,7 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         result.pending_command_list = init_cl;
     }
 
-    result.desired_width.store(size.width, .monotonic);
-    result.desired_height.store(size.height, .monotonic);
+    result.desired_size.store(packSize(size.width, size.height), .monotonic);
     result.applied_width = size.width;
     result.applied_height = size.height;
 
@@ -507,9 +521,9 @@ pub fn initShaders(
 /// on the renderer thread) will pick it up and call `resizeSwapChain` at
 /// a safe point before any command-list work for the next frame.
 pub fn setTargetSize(self: *DirectX12, width: u32, height: u32) void {
+    // Guard against transient 0x0 reports during WinUI 3 layout passes.
     if (width == 0 or height == 0) return;
-    self.desired_width.store(width, .monotonic);
-    self.desired_height.store(height, .monotonic);
+    self.desired_size.store(packSize(width, height), .monotonic);
 }
 
 /// Resize the swap chain back buffers in place via IDXGISwapChain1::ResizeBuffers.
@@ -518,8 +532,12 @@ pub fn setTargetSize(self: *DirectX12, width: u32, height: u32) void {
 /// RTVs implicitly via the resource) to be released before ResizeBuffers,
 /// and the GPU must be idle so it isn't still reading them.
 fn resizeSwapChain(self: *DirectX12, width: u32, height: u32) !void {
-    const dev_ptr = &(self.dev orelse return);
-    const sc3 = self.swap_chain3 orelse return;
+    // Reaching this path without a device or swap chain is a programming
+    // error: beginFrame on the renderer thread already short-circuited on
+    // both. Return real errors so the caller logs and we never silently
+    // loop on the same desired size forever (applied_* would never advance).
+    const dev_ptr = &(self.dev orelse return error.NoDevice);
+    const sc3 = self.swap_chain3 orelse return error.NoSwapChain;
 
     // Drain in-flight frames so back_buffers[*] aren't being read by the GPU.
     dev_ptr.waitForGpu() catch |err| {
@@ -539,7 +557,10 @@ fn resizeSwapChain(self: *DirectX12, width: u32, height: u32) !void {
 
     // UNKNOWN format and 0 flags preserve whatever the swap chain was
     // created with -- the same values device.zig used at creation time.
-    // ResizeBuffers lives on IDXGISwapChain1; cast our SwapChain3 down.
+    // ResizeBuffers lives on IDXGISwapChain1. IDXGISwapChain3 inherits
+    // from IDXGISwapChain1 in COM, so the v-table prefix is identical and
+    // a pointer reinterpret is safe; we use it instead of QueryInterface
+    // to avoid an AddRef/Release pair on every resize.
     const sc1: *dxgi.IDXGISwapChain1 = @ptrCast(sc3);
     const hr = sc1.ResizeBuffers(
         device.Device.frame_count,
@@ -598,10 +619,9 @@ fn resizeSwapChain(self: *DirectX12, width: u32, height: u32) !void {
 }
 
 pub fn surfaceSize(self: *const DirectX12) !struct { width: u32, height: u32 } {
-    const w = self.desired_width.load(.monotonic);
-    const h = self.desired_height.load(.monotonic);
-    if (w != 0 and h != 0) {
-        return .{ .width = w, .height = h };
+    const sz = unpackSize(self.desired_size.load(.monotonic));
+    if (sz.width != 0 and sz.height != 0) {
+        return .{ .width = sz.width, .height = sz.height };
     }
 
     // Fallback: query swap chain buffer dimensions via GetDesc1.
@@ -651,12 +671,11 @@ pub inline fn beginFrame(
     // command list work. setTargetSize only records the desired size;
     // it cannot touch GPU state because it runs on the apprt thread.
     {
-        const want_w = api.desired_width.load(.monotonic);
-        const want_h = api.desired_height.load(.monotonic);
-        if (want_w != 0 and want_h != 0 and
-            (want_w != api.applied_width or want_h != api.applied_height))
+        const want = unpackSize(api.desired_size.load(.monotonic));
+        if (want.width != 0 and want.height != 0 and
+            (want.width != api.applied_width or want.height != api.applied_height))
         {
-            api.resizeSwapChain(want_w, want_h) catch |err| {
+            api.resizeSwapChain(want.width, want.height) catch |err| {
                 log.err("DX12 swap chain resize failed: {}", .{err});
                 return error.ResizeFailed;
             };
@@ -696,7 +715,6 @@ pub inline fn beginFrame(
 }
 
 pub fn presentLastTarget(self: *DirectX12) !void {
-    log.info("presentLastTarget", .{});
     // Called when no redraw is needed -- re-present the current frame.
     // No new GPU work is submitted, so the existing fence values remain
     // valid and the next beginFrame will wait correctly.
@@ -820,18 +838,23 @@ test "DirectX12 does not have frame_fence_values" {
 }
 
 test "DirectX12 has desired/applied size fields" {
-    try std.testing.expect(@hasField(DirectX12, "desired_width"));
-    try std.testing.expect(@hasField(DirectX12, "desired_height"));
+    try std.testing.expect(@hasField(DirectX12, "desired_size"));
     try std.testing.expect(@hasField(DirectX12, "applied_width"));
     try std.testing.expect(@hasField(DirectX12, "applied_height"));
 }
 
 test "DirectX12 default size is zero" {
     const api: DirectX12 = .{};
-    try std.testing.expectEqual(@as(u32, 0), api.desired_width.load(.monotonic));
-    try std.testing.expectEqual(@as(u32, 0), api.desired_height.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 0), api.desired_size.load(.monotonic));
     try std.testing.expectEqual(@as(u32, 0), api.applied_width);
     try std.testing.expectEqual(@as(u32, 0), api.applied_height);
+}
+
+test "DirectX12 packSize/unpackSize roundtrip" {
+    const packed_size = DirectX12.packSize(1920, 1080);
+    const sz = DirectX12.unpackSize(packed_size);
+    try std.testing.expectEqual(@as(u32, 1920), sz.width);
+    try std.testing.expectEqual(@as(u32, 1080), sz.height);
 }
 
 test "DirectX12 has device_lost field" {

--- a/src/renderer/directx12/Target.zig
+++ b/src/renderer/directx12/Target.zig
@@ -7,8 +7,14 @@ const Target = @This();
 
 const d3d12 = @import("d3d12.zig");
 
-/// The underlying GPU resource (swap chain back buffer or offscreen texture).
-/// Null until device wiring is done.
+/// The underlying GPU resource. This is a BORROWED reference -- it points
+/// at one of the API's `back_buffers[*]` slots and is rebound by every
+/// `beginFrame`. Target does NOT AddRef on assign and MUST NOT Release on
+/// deinit, otherwise after a swap chain ResizeBuffers (which releases the
+/// back buffers and re-acquires them) the old pointer here is dangling and
+/// Release on it is a use-after-free.
+///
+/// Null until `beginFrame` wires it up.
 resource: ?*d3d12.ID3D12Resource = null,
 
 /// CPU descriptor handle for the render target view.
@@ -22,8 +28,7 @@ width: usize = 0,
 height: usize = 0,
 
 pub fn deinit(self: *Target) void {
-    if (self.resource) |r| _ = r.Release();
-
+    // resource is a borrowed reference (see field doc) -- do NOT Release.
     self.* = undefined;
 }
 

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -39,6 +39,48 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
+
+        // Surface unhandled exceptions to stderr before the process dies.
+        // Without this, a managed exception on the UI thread silently exits
+        // with a non-descriptive code and we have nothing to debug from.
+        // Stays enabled in Debug builds only -- in Release we want WER to
+        // capture a real crash dump instead.
+#if DEBUG
+        UnhandledException += (s, e) =>
+        {
+            try
+            {
+                Console.Error.WriteLine("[Ghostty] UNHANDLED EXCEPTION on UI thread:");
+                Console.Error.WriteLine(e.Exception.ToString());
+                Console.Error.Flush();
+            }
+            catch { /* logging must not throw */ }
+            // Leave Handled=false so the runtime still tears the app down --
+            // we just wanted to see the exception first.
+        };
+
+        AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+        {
+            try
+            {
+                Console.Error.WriteLine("[Ghostty] UNHANDLED EXCEPTION (AppDomain):");
+                Console.Error.WriteLine(e.ExceptionObject?.ToString() ?? "(null)");
+                Console.Error.Flush();
+            }
+            catch { /* logging must not throw */ }
+        };
+
+        System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (s, e) =>
+        {
+            try
+            {
+                Console.Error.WriteLine("[Ghostty] UNOBSERVED TASK EXCEPTION:");
+                Console.Error.WriteLine(e.Exception.ToString());
+                Console.Error.Flush();
+            }
+            catch { /* logging must not throw */ }
+        };
+#endif
     }
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -172,17 +172,6 @@ public sealed partial class TerminalControl : UserControl
         // firing after teardown and pin the control via the closure.
         Panel.LayoutUpdated -= OnFirstLayoutUpdated;
 
-        // Stop and detach the resize timer first so a pending tick cannot
-        // observe a half-freed surface. The timer holds a strong reference
-        // to this control via OnResizeTick, so leaving it pending across
-        // an Unloaded would also leak.
-        if (_resizeTimer is not null)
-        {
-            _resizeTimer.Stop();
-            _resizeTimer.Tick -= OnResizeTick;
-            _resizeTimer = null;
-        }
-
         // Tear down in reverse order. Each free is a no-op on a zero handle.
         if (_surface.Handle != IntPtr.Zero) NativeMethods.SurfaceFree(_surface);
         if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
@@ -292,43 +281,25 @@ public sealed partial class TerminalControl : UserControl
 
     // Size / scale -------------------------------------------------------
 
-    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _resizeTimer;
-
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
     {
         if (_surface.Handle == IntPtr.Zero) return;
-        KickResizeDebounce();
+        PushSurfaceSize();
     }
 
-    private void KickResizeDebounce()
+    private void PushSurfaceSize()
     {
-        // FIXME: the DX12 renderer recreates the swap chain on every
-        // set_size, which tears down GPU resources faster than the
-        // compositor can follow when WinUI 3 fires SizeChanged per pixel
-        // during a drag. The fix is in the renderer: ResizeBuffers instead
-        // of full recreate. Until that lands, debounce here. Drop this
-        // entire timer once the renderer is idempotent.
-        if (_resizeTimer is null)
-        {
-            _resizeTimer = DispatcherQueue.CreateTimer();
-            _resizeTimer.Interval = TimeSpan.FromMilliseconds(30);
-            _resizeTimer.IsRepeating = false;
-            _resizeTimer.Tick += OnResizeTick;
-        }
-        _resizeTimer.Start();
-    }
-
-    private void OnResizeTick(Microsoft.UI.Dispatching.DispatcherQueueTimer sender, object args)
-    {
-        sender.Stop();
-        if (_surface.Handle == IntPtr.Zero) return;
-
         // Read the panel's own layout bounds rather than the
         // SizeChangedEventArgs value. DPI rounding and any padding in
         // the visual tree can make the two differ by a pixel, which
         // manifests as letterboxing: the DX12 swap chain sizes off one
         // value while the compositor stretches the panel to its own
         // bounds, leaving a gap at the edges.
+        //
+        // No debounce: the renderer's setTargetSize records the desired
+        // dimensions atomically and the actual ResizeBuffers happens at
+        // the top of the next beginFrame, so per-pixel SizeChanged spam
+        // costs us only an atomic store each.
         var sx = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1.0;
         var sy = Panel.CompositionScaleY > 0 ? Panel.CompositionScaleY : 1.0;
         var w = (uint)Math.Max(1, Panel.ActualWidth * sx);
@@ -339,12 +310,12 @@ public sealed partial class TerminalControl : UserControl
     private void OnCompositionScaleChanged(SwapChainPanel sender, object args)
     {
         if (_surface.Handle == IntPtr.Zero) return;
-        // Push the new scale to libghostty, then re-kick the debounced
-        // resize path so the pixel dimensions get recomputed with the
-        // new scale. DPI change (e.g. moving the window between monitors)
-        // changes the pixel size even though the DIP size is unchanged.
+        // Push the new scale to libghostty, then recompute pixel
+        // dimensions: a DPI change (e.g. moving the window between
+        // monitors) shifts the pixel size even though the DIP size is
+        // unchanged.
         NativeMethods.SurfaceSetContentScale(_surface, sender.CompositionScaleX, sender.CompositionScaleY);
-        KickResizeDebounce();
+        PushSurfaceSize();
     }
 
     // Focus --------------------------------------------------------------

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -6,7 +6,16 @@
     xmlns:controls="using:Ghostty.Controls"
     Title="Ghostty">
 
-    <Grid x:Name="RootGrid">
+    <!--
+        RootGrid background matches a typical terminal background (Windows
+        Terminal's default #0C0C0C). Without this, the Window's default
+        white content background bleeds through during a resize: WinUI 3
+        grows the SwapChainPanel before DX12 finishes ResizeBuffers and
+        re-renders, leaving a visible white frame around the still-old
+        swap chain contents. A dark fill makes that gap effectively
+        invisible against any dark color scheme.
+    -->
+    <Grid x:Name="RootGrid" Background="#0C0C0C">
         <controls:TerminalControl
             x:Name="Terminal"
             HorizontalAlignment="Stretch"

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1,14 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
+using WinRT.Interop;
 
 namespace Ghostty;
 
 public sealed partial class MainWindow : Window
 {
+    // Win32 interop for the window class background brush. WinUI 3 hosts
+    // the XAML island inside a Win32 HWND whose WNDCLASS hbrBackground
+    // defaults to white. During an interactive drag-resize, DWM paints
+    // any uncovered window pixels with that brush BEFORE WinUI 3 gets a
+    // chance to extend its XAML content into the new area, producing a
+    // visible white flash at the leading edge of the drag. Replacing the
+    // class brush with a dark solid brush makes the flash invisible
+    // against any dark color scheme.
+    private const int GCLP_HBRBACKGROUND = -10;
+
+    [DllImport("user32.dll", EntryPoint = "SetClassLongPtrW", SetLastError = true)]
+    private static extern IntPtr SetClassLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateSolidBrush(uint crColor);
+
     public MainWindow()
     {
         InitializeComponent();
+
+        // Match the RootGrid background (#0C0C0C). Win32 COLORREF is 0x00BBGGRR.
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var brush = CreateSolidBrush(0x000C0C0Cu);
+        SetClassLongPtr(hwnd, GCLP_HBRBACKGROUND, brush);
 
         // Mica is only available on Windows 11 22H1+ with a supported GPU.
         // Our TargetPlatformMinVersion is still 19041 (Windows 10), so a


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR. Order:
> 1. #156 feat/winui3-shell -> windows
> 2. #157 feat/winui3-shell-followup -> feat/winui3-shell
> 3. **this PR** feat/winui3-shell-dx12-fixes -> feat/winui3-shell-followup

Two bugs from the followup backlog. They surfaced together but had separate root causes.

## Target.deinit double-free

`Target.resource` is set in `beginFrame` to one of `DirectX12.back_buffers[i]` without an AddRef -- it is a borrowed reference owned by the API. `Target.deinit` was Releasing it anyway. The previous no-op `setTargetSize` masked this because the back buffers were never released, so the dangling pointer was never used. As soon as `ResizeBuffers` releases a back buffer, the next `frame.resize` hits `Target.deinit` on the dangling pointer and the process dies silently (no Zig panic, no managed exception).

Fix: document `Target.resource` as borrowed and stop releasing it in `deinit`.

## DX12 swap chain resize

`setTargetSize` only cached the requested dimensions. The back buffers stayed at the initial size for the lifetime of the surface and DXGI composition stretched the small buffer onto the larger SwapChainPanel, which is why the terminal looked smaller and blurry.

`setTargetSize` runs synchronously from `ghostty_surface_set_size` on the C# UI thread, so it cannot touch GPU state. It now stores the desired dims as atomics. `beginFrame` runs on the renderer thread (the only thread allowed near back buffers, fences, and RTVs) and compares desired vs applied at the top -- if they differ it calls a new `resizeSwapChain`:

- drain the GPU via `waitForGpu`
- release the three back buffers
- `IDXGISwapChain1::ResizeBuffers(frame_count, w, h, UNKNOWN, 0)`
- re-acquire back buffers and recreate RTVs at the same descriptor slots
- reset per-frame fence values

`UNKNOWN` format and `0` flags preserve creation values. Device-removed HRESULTs route through the existing `handleDeviceRemoved` path. Guarded against zero/no-op sizes so the C# 30ms debounce drops identical calls cheaply.

## Debug-only unhandled-exception logger

The crash here was masked by the C# host silently exiting on an unhandled managed exception with no diagnostic. Added a Debug-only hook on the three exception entry points (UI dispatcher, AppDomain, task scheduler) that writes the exception to stderr. Release builds leave this off so WER can capture a real crash dump.

## Test plan

- [x] `zig build -Dapp-runtime=none` clean
- [x] `dotnet build windows/Ghostty/Ghostty.sln` clean
- [x] `just run-win`, drag-resize aggressively across many sizes, run `dir`, close window. No crash, no DX12 debug-layer warnings, terminal grid fills the panel pixel-perfect.