### PR TITLE
fix(windows): WinUI 3 shell DX12 reliability and input fixes

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1850,8 +1850,14 @@ pub const CAPI = struct {
         surface.updateSize(w, h);
         // For composition surfaces (no HWND), the renderer cannot query
         // the window size via GetClientRect. Forward the desired dimensions
-        // so the resize detection loop in drawFrame picks up the change.
+        // so the resize detection loop in beginFrame picks up the change.
         surface.core_surface.renderer.setTargetSize(w, h);
+        // Wake the renderer thread so it picks up the new desired_size
+        // immediately rather than waiting for its next natural draw-timer
+        // tick (~8 ms). Cheap (single futex op) and safe to call from any
+        // thread. The 120 Hz draw timer is the backstop if the wakeup is
+        // ever coalesced; in either path beginFrame applies the size.
+        surface.core_surface.renderer_thread.wakeup.notify() catch {};
     }
 
     /// Return the size information a surface has.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -471,6 +471,13 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     dev_ptr.command_queue.ExecuteCommandLists(1, &lists);
 
     // Present the swap chain and check for device-removed errors.
+    // Sync interval 1 paces to vblank without tearing against the
+    // compositor. Interactive resize relies on setTargetSize waking the
+    // renderer thread (see embedded.zig) plus the existing 120 Hz draw
+    // timer as a backstop -- both routes hit beginFrame, which compares
+    // desired_size against applied_width/height and calls ResizeBuffers
+    // before any new GPU work. The renderer thread owns Present
+    // exclusively; the apprt UI thread does no GPU work during resize.
     if (self.swap_chain3) |sc3| {
         const hr = sc3.Present(1, 0);
         if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_HUNG or hr == com.DXGI_ERROR_DEVICE_RESET) {
@@ -719,6 +726,7 @@ pub fn presentLastTarget(self: *DirectX12) !void {
     // No new GPU work is submitted, so the existing fence values remain
     // valid and the next beginFrame will wait correctly.
     if (self.swap_chain3) |sc3| {
+        // Sync interval 1: see drawFrameEnd for the rationale.
         const hr = sc3.Present(1, 0);
         if (hr == com.DXGI_ERROR_DEVICE_REMOVED or hr == com.DXGI_ERROR_DEVICE_HUNG or hr == com.DXGI_ERROR_DEVICE_RESET) {
             self.handleDeviceRemoved();

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -285,6 +285,16 @@ fn createCompositionSwapChain(
         .SampleDesc = .{ .Count = 1, .Quality = 0 },
         .BufferUsage = dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
         .BufferCount = frame_count,
+        // STRETCH causes DirectComposition to interpolate stale content
+        // into the bigger area for one frame, which is preferable to
+        // the black bar NONE produces with the
+        // CreateSwapChainForComposition path. The bounded one-frame
+        // stretch artifact is acceptable: setTargetSize wakes the
+        // renderer thread immediately, and the 120 Hz draw timer is a
+        // backstop, so the renderer typically converges within one
+        // frame. If the renderer thread ever stalls (TDR recovery, slow
+        // GPU) the stretch becomes a visible smear -- accept that as a
+        // graceful degradation rather than a black bar.
         .Scaling = .STRETCH,
         .SwapEffect = .FLIP_DISCARD,
         .AlphaMode = .PREMULTIPLIED,

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -2,13 +2,21 @@
 <!--
     Focus, keyboard, and IME handlers live on the UserControl, not on
     the inner SwapChainPanel. SwapChainPanel inherits from Grid (not
-    Control) and is not designed to be a focusable input sink: when it
-    is made tab-stop and has CharacterReceived/KeyDown handlers,
-    transient focus grabs from the TSF/IME input scope (or from the
-    composition visual tree itself) cause a continuous GotFocus/
-    LostFocus ping-pong. Keep all input on the root UserControl and
-    leave only SizeChanged + CompositionScaleChanged on the
-    SwapChainPanel.
+    Control) and is not designed to be a focusable input sink.
+
+    Even with the panel set IsTabStop="False", clicking the SwapChainPanel
+    triggered a continuous GotFocus / LostFocus ping-pong: WinUI 3
+    implicitly hosts a Microsoft.UI.Xaml.Controls.ScrollViewer somewhere
+    above our content (likely the framework's XAML host for the Window),
+    and on every pointer click the framework focused that ScrollViewer
+    first; OnPointerPressed then bounced focus back to this UserControl,
+    generating a focused=false / focused=true pair on every click.
+
+    The fix is in TerminalControl.xaml.cs DisableAncestorScrollViewerTabStop,
+    which walks the visual tree at Loaded time and sets IsTabStop=false on
+    any ancestor ScrollViewer. This removes the parasitic ScrollViewer from
+    the focus chain at the source: no per-event handler, no global
+    FocusManager subscription, no fragile type-check filter.
 -->
 <UserControl
     x:Class="Ghostty.Controls.TerminalControl"

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -454,12 +454,44 @@ public sealed partial class TerminalControl : UserControl
         // VirtualKey). embedded.zig matches it against keycodes.entries
         // where the native column is the Win32 scancode, and derives
         // unshifted_codepoint via MapVirtualKeyW when we pass 0.
+        //
+        // Two scancode adjustments are required to match what the C
+        // example/c-win32-terminal/src/main.c (the canonical Win32
+        // embedder) computes from raw lParam:
+        //
+        //  1. Extended keys (arrows, navigation cluster, numpad enter,
+        //     right-side modifiers) need the 0xE000 prefix or'd in.
+        //     PhysicalKeyStatus.ScanCode only returns the low byte;
+        //     IsExtendedKey tells us whether to set the prefix.
+        //     Without this, Up/Down/Left/Right/Home/End/PgUp/PgDn never
+        //     find a match in input.keycodes.entries (the table uses
+        //     0xE048 etc on the Windows column) and the dispatch returns
+        //     .ignored.
+        //
+        //  2. WinUI 3 strips ScanCode entirely for some keys that the
+        //     framework treats as "navigation" (most notably Tab),
+        //     reporting 0 even on the press path. Fall back to
+        //     MapVirtualKey(VK, MAPVK_VK_TO_VSC) using e.Key as the
+        //     virtual-key when ScanCode is 0, so the apprt sees the
+        //     real scancode.
+        uint scancode = e.KeyStatus.ScanCode;
+        if (scancode == 0)
+        {
+            // Recover the OEM scancode from the VirtualKey. This handles
+            // Tab and any other key WinUI 3 strips ScanCode for.
+            scancode = NativeMethods.MapVirtualKeyW((uint)e.Key, NativeMethods.MAPVK_VK_TO_VSC);
+        }
+        if (e.KeyStatus.IsExtendedKey)
+        {
+            scancode |= 0xE000;
+        }
+
         var key = new GhosttyInputKey
         {
             Action = action,
             Mods = CurrentMods(),
             ConsumedMods = GhosttyMods.None,
-            Keycode = e.KeyStatus.ScanCode,
+            Keycode = scancode,
             Text = IntPtr.Zero,
             UnshiftedCodepoint = 0,
             Composing = false,

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -146,6 +146,29 @@ public sealed partial class TerminalControl : UserControl
         // Request focus so keyboard input starts flowing immediately.
         // Focus lives on the UserControl now, not the panel.
         this.Focus(FocusState.Programmatic);
+
+        // Walk our visual ancestors and disable IsTabStop on any
+        // ScrollViewer we find. WinUI 3 implicitly inserts a
+        // Microsoft.UI.Xaml.Controls.ScrollViewer above our content
+        // (likely from the Window's XAML host); without this, every
+        // pointer click on the SwapChainPanel routes through the
+        // framework's hit-test focus path -> ScrollViewer, gets bounced
+        // back by OnPointerPressed -> UserControl, and surfaces to
+        // libghostty as a focused=false / focused=true pair on every
+        // click. Removing the ScrollViewer from the focus chain at
+        // load time prevents the storm at the source, with no per-event
+        // cost and no global FocusManager subscription.
+        DisableAncestorScrollViewerTabStop();
+    }
+
+    private void DisableAncestorScrollViewerTabStop()
+    {
+        DependencyObject? node = this;
+        while (node is not null)
+        {
+            node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+            if (node is ScrollViewer sv) sv.IsTabStop = false;
+        }
     }
 
     private void OnFirstLayoutUpdated(object? sender, object e)
@@ -295,15 +318,18 @@ public sealed partial class TerminalControl : UserControl
         // manifests as letterboxing: the DX12 swap chain sizes off one
         // value while the compositor stretches the panel to its own
         // bounds, leaving a gap at the edges.
-        //
-        // No debounce: the renderer's setTargetSize records the desired
-        // dimensions atomically and the actual ResizeBuffers happens at
-        // the top of the next beginFrame, so per-pixel SizeChanged spam
-        // costs us only an atomic store each.
         var sx = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1.0;
         var sy = Panel.CompositionScaleY > 0 ? Panel.CompositionScaleY : 1.0;
         var w = (uint)Math.Max(1, Panel.ActualWidth * sx);
         var h = (uint)Math.Max(1, Panel.ActualHeight * sy);
+
+        // Fire-and-forget. ghostty_surface_set_size records the desired
+        // dimensions in an atomic and wakes the renderer thread; the
+        // next beginFrame on that thread (within one wakeup hop or, at
+        // worst, one ~8 ms draw-timer tick) compares desired_size to
+        // applied_width/height and calls ResizeBuffers before the next
+        // Present. We never block here, never touch draw_mutex, and
+        // never do GPU work on the UI thread.
         NativeMethods.SurfaceSetSize(_surface, w, h);
     }
 

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -323,6 +323,12 @@ internal static class NativeMethods
     [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_set_size")]
     internal static extern void SurfaceSetSize(GhosttySurface surface, uint width, uint height);
 
+    // MapVirtualKeyW for the keycode ScanCode==0 fallback in TerminalControl.
+    // Win32 user32, not WinRT - bypasses any WinUI framework filtering.
+    internal const uint MAPVK_VK_TO_VSC = 0;
+    [DllImport("user32.dll", EntryPoint = "MapVirtualKeyW")]
+    internal static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
+
     [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_set_content_scale")]
     internal static extern void SurfaceSetContentScale(GhosttySurface surface, double x, double y);
 


### PR DESCRIPTION
Three Windows-only fixes against the WinUI 3 shell + DX12 renderer that surfaced as the shell got real interactive use.

## What this fixes

1. **Interactive resize latency.** `ghostty_surface_set_size` only stored the desired dimensions in an atomic; the renderer thread picked them up at its next natural draw-timer tick (~8 ms worst case), which made drags feel stair-stepped. Add `wakeup.notify()` so the renderer thread is woken immediately after the atomic store. The 120 Hz draw timer is the backstop if the wakeup is ever coalesced. UI thread does no GPU work, never holds `draw_mutex`.

2. **Focus ping-pong on click.** WinUI 3 implicitly hosts a `Microsoft.UI.Xaml.Controls.ScrollViewer` above our content (likely from the Window's XAML host); on every click the framework focused that ScrollViewer first and `OnPointerPressed` bounced focus back, generating a `focused=false` / `focused=true` storm in libghostty on every click. Walk the visual tree at `Loaded` time and set `IsTabStop=false` on any ancestor ScrollViewer found. No per-event handler, no global FocusManager subscription.

3. **Up arrow / Tab silently dropped.** `PhysicalKeyStatus.ScanCode` returns only the low byte of the OEM scancode and never the 0xE000 extended-key prefix that `input.keycodes.entries` expects for navigation cluster keys. WinUI 3 also reports `ScanCode=0` for some keys it treats as framework navigation (most notably Tab). Fall back to `MapVirtualKey(VK, MAPVK_VK_TO_VSC)` for the `ScanCode=0` case and OR in 0xE000 when `IsExtendedKey` is set. Matches what `example/c-win32-terminal/src/main.c` computes from raw lParam. `MapVirtualKeyW` lives in `NativeMethods.cs` alongside the rest of the P/Invoke surface.

## Cross-platform impact

Zero. All Zig changes are Windows-only paths or `@hasDecl`-gated. macOS Swift, GTK, and GLFW apprts are untouched.

## Test plan

- [x] Slow + fast window drag, no crash, smooth
- [x] Heavy resize storm under `yes` output, no crash
- [x] Click in/out of window 5+ times, no focus storm in log
- [x] Type 50+ characters, all delivered
- [x] Up arrow recalls previous shell command in cmd.exe
- [x] Tab triggers cmd.exe completion
- [x] Renderer + IO threads shut down cleanly on close
- [x] DirectX12 size-field tests pass