### PR TITLE
refactor(windows): hoist libghostty config/app ownership to MainWindow

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using Ghostty.Hosting;
 using Ghostty.Interop;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
@@ -15,32 +16,37 @@ namespace Ghostty.Controls;
 /// SwapChainPanel composition path (null HWND). Matches how macOS's
 /// Ghostty.Surface.swift owns one ghostty_surface_t per SwiftUI view.
 ///
-/// This first pass owns the whole ghostty_app_t lifetime too; when we add
-/// tabs/splits the app handle will move up to MainWindow and each control
-/// will only own its surface.
+/// Config and app handle ownership lives in <see cref="Ghostty.Hosting.GhosttyHost"/>,
+/// which is constructed by MainWindow and assigned via the Host property before load.
 /// </summary>
 public sealed partial class TerminalControl : UserControl
 {
     // Handles ------------------------------------------------------------
 
-    private GhosttyConfig _config;
-    private GhosttyApp _app;
     private GhosttySurface _surface;
     private IntPtr _workingDirectoryUtf8;
     private IntPtr _commandUtf8;
     private IntPtr _initialInputUtf8;
     private bool _initialized;
 
-    // Keep delegates alive for as long as the runtime config references
-    // them. P/Invoke marshals the managed delegate to a native function
-    // pointer that the GC has no way of tracking, so a dropped field here
-    // would crash the Zig side on the first wakeup.
-    private GhosttyWakeupCb? _wakeupCb;
-    private GhosttyActionCb? _actionCb;
-    private GhosttyReadClipboardCb? _readClipboardCb;
-    private GhosttyConfirmReadClipboardCb? _confirmReadClipboardCb;
-    private GhosttyWriteClipboardCb? _writeClipboardCb;
-    private GhosttyCloseSurfaceCb? _closeSurfaceCb;
+    // Pinned managed handle to `this`, passed to libghostty as the
+    // per-surface userdata. Per-surface callbacks (close_surface_cb,
+    // read/write clipboard) receive this pointer back so GhosttyHost can
+    // resolve a callback to the owning TerminalControl without scanning
+    // the surface map. Allocated immediately before SurfaceNew, freed in
+    // OnUnloaded after SurfaceFree so the GC cannot move or collect this
+    // control while libghostty still holds a reference.
+    private GCHandle _selfHandle;
+
+    /// <summary>
+    /// The per-window libghostty host that owns the config and app
+    /// handles. Must be assigned before the control loads.
+    /// </summary>
+    internal GhosttyHost? Host { get; set; }
+
+    // Raisers invoked by GhosttyHost after routing an action to this leaf.
+    internal void RaiseTitleChanged(string title) => TitleChanged?.Invoke(this, title);
+    internal void RaiseCloseRequested() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
     // Events raised from the runtime action callback. They always fire
     // on the UI thread: the callback itself runs on libghostty's thread
@@ -62,38 +68,11 @@ public sealed partial class TerminalControl : UserControl
         if (_initialized) return;
         _initialized = true;
 
-        // ghostty_init is documented safe to call repeatedly.
-        NativeMethods.Init(UIntPtr.Zero, IntPtr.Zero);
+        if (Host is null)
+            throw new InvalidOperationException(
+                "TerminalControl.Host must be set before the control loads.");
 
-        // Skip CLI args: WinUI 3's entry point swallows them before we get
-        // here. Default config files are loaded from the standard locations.
-        _config = NativeMethods.ConfigNew();
-        NativeMethods.ConfigLoadDefaultFiles(_config);
-        NativeMethods.ConfigFinalize(_config);
-
-        // The Zig side requires non-null callbacks even if they are no-ops;
-        // storing each delegate in a field prevents GC from freeing it while
-        // libghostty still holds the pointer.
-        _wakeupCb = OnWakeup;
-        _actionCb = OnAction;
-        _readClipboardCb = OnReadClipboard;
-        _confirmReadClipboardCb = OnConfirmReadClipboard;
-        _writeClipboardCb = OnWriteClipboard;
-        _closeSurfaceCb = OnCloseSurface;
-
-        var runtime = new GhosttyRuntimeConfig
-        {
-            Userdata = IntPtr.Zero,
-            SupportsSelectionClipboard = false,
-            WakeupCb = Marshal.GetFunctionPointerForDelegate(_wakeupCb),
-            ActionCb = Marshal.GetFunctionPointerForDelegate(_actionCb),
-            ReadClipboardCb = Marshal.GetFunctionPointerForDelegate(_readClipboardCb),
-            ConfirmReadClipboardCb = Marshal.GetFunctionPointerForDelegate(_confirmReadClipboardCb),
-            WriteClipboardCb = Marshal.GetFunctionPointerForDelegate(_writeClipboardCb),
-            CloseSurfaceCb = Marshal.GetFunctionPointerForDelegate(_closeSurfaceCb),
-        };
-
-        _app = NativeMethods.AppNew(runtime, _config);
+        var app = Host.App;
 
         // Surface config. swap_chain_panel takes an ISwapChainPanelNative*
         //    which libghostty's DX12 device init uses synchronously (it calls
@@ -127,9 +106,19 @@ public sealed partial class TerminalControl : UserControl
         surfaceConfig.Command = _commandUtf8;
         surfaceConfig.InitialInput = _initialInputUtf8;
 
-        _surface = NativeMethods.SurfaceNew(_app, surfaceConfig);
+        // Pin a managed handle to `this` and pass it as per-surface userdata.
+        // libghostty echoes this pointer back through close_surface_cb and the
+        // clipboard callbacks; GhosttyHost decodes it via GCHandle.FromIntPtr
+        // to dispatch the callback to the right control. Use Normal (not
+        // Pinned) - we are not pinning bytes, only preventing GC collection
+        // of the managed object behind the IntPtr.
+        _selfHandle = GCHandle.Alloc(this, GCHandleType.Normal);
+        surfaceConfig.Userdata = GCHandle.ToIntPtr(_selfHandle);
+
+        _surface = NativeMethods.SurfaceNew(app, surfaceConfig);
         // Drop our ref to the panel: libghostty did not retain it.
         SwapChainPanelInterop.Release(panelPtr);
+        Host.Register(_surface, this);
 
         // Prime the initial size when layout is actually settled.
         // SwapChainPanel.SizeChanged fires during the first layout pass,
@@ -195,17 +184,20 @@ public sealed partial class TerminalControl : UserControl
         // firing after teardown and pin the control via the closure.
         Panel.LayoutUpdated -= OnFirstLayoutUpdated;
 
-        // Tear down in reverse order. Each free is a no-op on a zero handle.
-        if (_surface.Handle != IntPtr.Zero) NativeMethods.SurfaceFree(_surface);
-        if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
-        if (_config.Handle != IntPtr.Zero) NativeMethods.ConfigFree(_config);
+        if (_surface.Handle != IntPtr.Zero)
+        {
+            Host?.Unregister(_surface);
+            NativeMethods.SurfaceFree(_surface);
+        }
+        // Free the GCHandle AFTER SurfaceFree: libghostty may still touch
+        // userdata during teardown (e.g. emitting a final event). Once
+        // SurfaceFree returns, no callback can fire on this surface.
+        if (_selfHandle.IsAllocated) _selfHandle.Free();
         if (_workingDirectoryUtf8 != IntPtr.Zero) Marshal.FreeHGlobal(_workingDirectoryUtf8);
         if (_commandUtf8 != IntPtr.Zero) Marshal.FreeHGlobal(_commandUtf8);
         if (_initialInputUtf8 != IntPtr.Zero) Marshal.FreeHGlobal(_initialInputUtf8);
 
         _surface = default;
-        _app = default;
-        _config = default;
         _workingDirectoryUtf8 = IntPtr.Zero;
         _commandUtf8 = IntPtr.Zero;
         _initialInputUtf8 = IntPtr.Zero;
@@ -223,84 +215,6 @@ public sealed partial class TerminalControl : UserControl
         Marshal.WriteByte(p, 0);
         return p;
     }
-
-    // Runtime callbacks --------------------------------------------------
-    //
-    // These fire on libghostty's thread. For this first pass we implement
-    // the minimum required to avoid null-deref on the Zig side. Marshaling
-    // back to the UI thread for things like clipboard and actions will be
-    // added when those features are wired.
-
-    private void OnWakeup(IntPtr userdata)
-    {
-        // Fires on libghostty's thread. Hop to the UI dispatcher so the
-        // tick (and any resulting draws) lands on the right queue.
-        //
-        // OnUnloaded also runs on the UI thread, so the dispatched lambda
-        // and the teardown are serialized: either Unloaded ran first and
-        // the lambda sees a zero handle, or the lambda ran first and
-        // Unloaded waits its turn. No lock needed.
-        var dq = DispatcherQueue;
-        if (dq is null) return;
-        dq.TryEnqueue(() =>
-        {
-            if (_app.Handle != IntPtr.Zero) NativeMethods.AppTick(_app);
-        });
-    }
-
-    private bool OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr)
-    {
-        // ghostty_action_s layout:
-        //   { int32 tag; <union> action; }
-        // The union is 8-byte aligned on x64 so it starts at offset 8.
-        // We read the tag first and only touch the union for variants we
-        // actually handle. Returning false for an unhandled tag lets the
-        // core fall back to its default behavior. We also return false on
-        // any path that fails to actually invoke the handler (null pointer,
-        // null dispatcher) so the core never thinks we handled an action
-        // we silently dropped.
-        if (actionPtr == IntPtr.Zero) return false;
-        var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
-
-        switch (tag)
-        {
-            case GhosttyActionTag.SetTitle:
-            {
-                // set_title_s is { const char* title }, so the first
-                // pointer-sized word of the union is the UTF-8 title.
-                var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
-                var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
-                var dq = DispatcherQueue;
-                if (dq is null) return false;
-                dq.TryEnqueue(() => TitleChanged?.Invoke(this, title));
-                return true;
-            }
-
-            case GhosttyActionTag.RingBell:
-            {
-                // MessageBeep is thread-safe; no dispatcher hop needed.
-                NativeMethods.MessageBeep(NativeMethods.MB_OK);
-                return true;
-            }
-
-            case GhosttyActionTag.CloseWindow:
-            {
-                var dq = DispatcherQueue;
-                if (dq is null) return false;
-                dq.TryEnqueue(() => CloseRequested?.Invoke(this, EventArgs.Empty));
-                return true;
-            }
-
-            default:
-                // Everything else falls back to libghostty defaults.
-                return false;
-        }
-    }
-
-    private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;
-    private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest req) { }
-    private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm) { }
-    private void OnCloseSurface(IntPtr userdata, bool processAlive) { }
 
     // Size / scale -------------------------------------------------------
 
@@ -367,7 +281,8 @@ public sealed partial class TerminalControl : UserControl
         if (_surface.Handle == IntPtr.Zero) return;
         _focused = focused;
         NativeMethods.SurfaceSetFocus(_surface, focused);
-        if (_app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(_app, focused);
+        var app = Host?.App ?? default;
+        if (app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(app, focused);
     }
 
     // Mouse --------------------------------------------------------------

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Ghostty.Controls;
 using Ghostty.Interop;
@@ -33,7 +34,10 @@ internal sealed class GhosttyHost : IDisposable
     private GhosttyWriteClipboardCb? _writeClipboardCb;
     private GhosttyCloseSurfaceCb? _closeSurfaceCb;
 
-    private readonly Dictionary<IntPtr, TerminalControl> _surfaces = new();
+    // ConcurrentDictionary: Register/Unregister run on the UI thread but
+    // lookups happen on libghostty's callback thread in OnAction and
+    // OnCloseSurface. A plain Dictionary would race here.
+    private readonly ConcurrentDictionary<IntPtr, TerminalControl> _surfaces = new();
     private readonly DispatcherQueue _dispatcher;
 
     public GhosttyApp App => _app;
@@ -73,17 +77,20 @@ internal sealed class GhosttyHost : IDisposable
     public void Register(GhosttySurface surface, TerminalControl control)
     {
         if (surface.Handle == IntPtr.Zero) return;
-        _surfaces[surface.Handle] = control;
+        var added = _surfaces.TryAdd(surface.Handle, control);
+        Debug.Assert(added, "surface handle collision in GhosttyHost registry");
     }
 
     public void Unregister(GhosttySurface surface)
     {
         if (surface.Handle == IntPtr.Zero) return;
-        _surfaces.Remove(surface.Handle);
+        _surfaces.TryRemove(surface.Handle, out _);
     }
 
     public void Dispose()
     {
+        // Clear before AppFree so any late callbacks libghostty emits during
+        // teardown miss the lookup and become harmless no-ops.
         _surfaces.Clear();
         if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
         if (_config.Handle != IntPtr.Zero) NativeMethods.ConfigFree(_config);
@@ -151,7 +158,14 @@ internal sealed class GhosttyHost : IDisposable
             {
                 var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
                 var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
-                _dispatcher.TryEnqueue(() => control.RaiseTitleChanged(title));
+                // Capture the surface handle, not `control`: by the time the
+                // dispatched lambda runs the control may have unregistered
+                // and torn down. Re-check the dictionary on the UI thread.
+                _dispatcher.TryEnqueue(() =>
+                {
+                    if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                        c.RaiseTitleChanged(title);
+                });
                 return true;
             }
 
@@ -163,7 +177,11 @@ internal sealed class GhosttyHost : IDisposable
 
             case GhosttyActionTag.CloseWindow:
             {
-                _dispatcher.TryEnqueue(() => control.RaiseCloseRequested());
+                _dispatcher.TryEnqueue(() =>
+                {
+                    if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                        c.RaiseCloseRequested();
+                });
                 return true;
             }
 
@@ -193,8 +211,25 @@ internal sealed class GhosttyHost : IDisposable
         // at the libghostty layer and only invokes us once the user has
         // already agreed (or wait_after_command was off).
         if (userdata == IntPtr.Zero) return;
+
+        // Decode the GCHandle, then confirm the resulting control is still
+        // registered. If Unregister already ran on the UI thread the surface
+        // is being torn down and this callback is a late arrival we drop.
+        // Using the thread-safe ConcurrentDictionary lookup avoids a race
+        // with a GCHandle that has been freed by OnUnloaded.
         var control = GCHandle.FromIntPtr(userdata).Target as TerminalControl;
         if (control is null) return;
-        _dispatcher.TryEnqueue(() => control.RaiseCloseRequested());
+        if (!IsRegistered(control)) return;
+        _dispatcher.TryEnqueue(() =>
+        {
+            if (IsRegistered(control)) control.RaiseCloseRequested();
+        });
+    }
+
+    private bool IsRegistered(TerminalControl control)
+    {
+        foreach (var c in _surfaces.Values)
+            if (ReferenceEquals(c, control)) return true;
+        return false;
     }
 }

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -97,11 +97,104 @@ internal sealed class GhosttyHost : IDisposable
         _closeSurfaceCb = null;
     }
 
-    // Runtime callbacks - implemented in Task 2.
-    private void OnWakeup(IntPtr userdata) { }
-    private bool OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr) => false;
+    private void OnWakeup(IntPtr userdata)
+    {
+        // Fires on libghostty's thread. Hop to the UI dispatcher so the
+        // tick (and any resulting draws) lands on the right queue.
+        _dispatcher.TryEnqueue(() =>
+        {
+            if (_app.Handle != IntPtr.Zero) NativeMethods.AppTick(_app);
+        });
+    }
+
+    // ghostty_target_s tag values, mirroring ghostty.h ghostty_target_tag_e.
+    private const int GhosttyTargetApp = 0;
+    private const int GhosttyTargetSurface = 1;
+
+    private bool OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr)
+    {
+        // ABI note: ghostty_runtime_action_cb is declared as
+        //
+        //   bool action_cb(ghostty_app_t, ghostty_target_s, ghostty_action_s);
+        //
+        // Both target and action are passed BY VALUE in C, but on the Windows
+        // x64 calling convention any struct larger than 8 bytes is passed via
+        // a hidden pointer to a caller-allocated copy. ghostty_target_s is
+        // 16 bytes:
+        //
+        //   struct ghostty_target_s {
+        //     ghostty_target_tag_e tag;   // int32 at offset 0
+        //     // 4 bytes padding
+        //     union {                     // 8-byte aligned
+        //       ghostty_surface_t surface; // pointer at offset 8
+        //     } target;
+        //   };
+        //
+        // ghostty_action_s is similarly oversized. The C# delegate therefore
+        // declares both as IntPtr - the actual pointers we receive point at
+        // ephemeral stack copies of the structs and must be DEREFERENCED to
+        // get at their contents. Treating targetPtr as if it were the surface
+        // handle silently misses every dictionary lookup.
+        if (actionPtr == IntPtr.Zero || targetPtr == IntPtr.Zero) return false;
+
+        var targetTag = Marshal.ReadInt32(targetPtr);
+        if (targetTag != GhosttyTargetSurface) return false;
+        var surfaceHandle = Marshal.ReadIntPtr(targetPtr, 8);
+        if (!_surfaces.TryGetValue(surfaceHandle, out var control)) return false;
+
+        // ghostty_action_s layout: { int32 tag; <union> action; }
+        // Union starts at offset 8 (8-byte aligned on x64).
+        var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
+        switch (tag)
+        {
+            case GhosttyActionTag.SetTitle:
+            {
+                var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
+                var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
+                _dispatcher.TryEnqueue(() => control.RaiseTitleChanged(title));
+                return true;
+            }
+
+            case GhosttyActionTag.RingBell:
+            {
+                NativeMethods.MessageBeep(NativeMethods.MB_OK);
+                return true;
+            }
+
+            case GhosttyActionTag.CloseWindow:
+            {
+                _dispatcher.TryEnqueue(() => control.RaiseCloseRequested());
+                return true;
+            }
+
+            default:
+                return false;
+        }
+    }
+
     private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;
-    private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest req) { }
+    private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest request) { }
     private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm) { }
-    private void OnCloseSurface(IntPtr userdata, bool processAlive) { }
+
+    private void OnCloseSurface(IntPtr userdata, bool processAlive)
+    {
+        // userdata is the GCHandle.ToIntPtr value the owning TerminalControl
+        // pinned for itself before SurfaceNew. Decode it back to the managed
+        // control and raise CloseRequested on the UI thread; MainWindow's
+        // CloseRequested handler is what actually closes the window.
+        //
+        // This callback fires from libghostty's thread on two paths today:
+        // (1) the user typed `exit` in the shell and then pressed any key,
+        //     which makes Surface.zig encode the keystroke, notice
+        //     child_exited, and call self.close().
+        // (2) a binding action ran .close_surface or .close_window.
+        //
+        // We deliberately ignore processAlive here. Confirm-on-close lives
+        // at the libghostty layer and only invokes us once the user has
+        // already agreed (or wait_after_command was off).
+        if (userdata == IntPtr.Zero) return;
+        var control = GCHandle.FromIntPtr(userdata).Target as TerminalControl;
+        if (control is null) return;
+        _dispatcher.TryEnqueue(() => control.RaiseCloseRequested());
+    }
 }

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Ghostty.Controls;
+using Ghostty.Interop;
+using Microsoft.UI.Dispatching;
+
+namespace Ghostty.Hosting;
+
+/// <summary>
+/// Per-window owner of the libghostty config + app handles and the
+/// runtime callback surface. Holds a dictionary mapping
+/// <see cref="GhosttySurface"/> handles to the <see cref="TerminalControl"/>
+/// that owns them so action-callback <c>target</c> arguments can be routed
+/// to the correct leaf.
+///
+/// Lifetime: created once by <see cref="MainWindow"/> before any terminal
+/// surface is constructed, disposed when the window closes. The app handle
+/// is passed to each <see cref="TerminalControl"/> via its
+/// <see cref="TerminalControl.Host"/> property before it is loaded.
+/// </summary>
+internal sealed class GhosttyHost : IDisposable
+{
+    private GhosttyConfig _config;
+    private GhosttyApp _app;
+
+    // Delegates must be retained as fields; P/Invoke hands out native
+    // function pointers the GC cannot track.
+    private GhosttyWakeupCb? _wakeupCb;
+    private GhosttyActionCb? _actionCb;
+    private GhosttyReadClipboardCb? _readClipboardCb;
+    private GhosttyConfirmReadClipboardCb? _confirmReadClipboardCb;
+    private GhosttyWriteClipboardCb? _writeClipboardCb;
+    private GhosttyCloseSurfaceCb? _closeSurfaceCb;
+
+    private readonly Dictionary<IntPtr, TerminalControl> _surfaces = new();
+    private readonly DispatcherQueue _dispatcher;
+
+    public GhosttyApp App => _app;
+
+    public GhosttyHost(DispatcherQueue dispatcher)
+    {
+        _dispatcher = dispatcher;
+
+        NativeMethods.Init(UIntPtr.Zero, IntPtr.Zero);
+
+        _config = NativeMethods.ConfigNew();
+        NativeMethods.ConfigLoadDefaultFiles(_config);
+        NativeMethods.ConfigFinalize(_config);
+
+        _wakeupCb = OnWakeup;
+        _actionCb = OnAction;
+        _readClipboardCb = OnReadClipboard;
+        _confirmReadClipboardCb = OnConfirmReadClipboard;
+        _writeClipboardCb = OnWriteClipboard;
+        _closeSurfaceCb = OnCloseSurface;
+
+        var runtime = new GhosttyRuntimeConfig
+        {
+            Userdata = IntPtr.Zero,
+            SupportsSelectionClipboard = false,
+            WakeupCb = Marshal.GetFunctionPointerForDelegate(_wakeupCb),
+            ActionCb = Marshal.GetFunctionPointerForDelegate(_actionCb),
+            ReadClipboardCb = Marshal.GetFunctionPointerForDelegate(_readClipboardCb),
+            ConfirmReadClipboardCb = Marshal.GetFunctionPointerForDelegate(_confirmReadClipboardCb),
+            WriteClipboardCb = Marshal.GetFunctionPointerForDelegate(_writeClipboardCb),
+            CloseSurfaceCb = Marshal.GetFunctionPointerForDelegate(_closeSurfaceCb),
+        };
+
+        _app = NativeMethods.AppNew(runtime, _config);
+    }
+
+    public void Register(GhosttySurface surface, TerminalControl control)
+    {
+        if (surface.Handle == IntPtr.Zero) return;
+        _surfaces[surface.Handle] = control;
+    }
+
+    public void Unregister(GhosttySurface surface)
+    {
+        if (surface.Handle == IntPtr.Zero) return;
+        _surfaces.Remove(surface.Handle);
+    }
+
+    public void Dispose()
+    {
+        _surfaces.Clear();
+        if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
+        if (_config.Handle != IntPtr.Zero) NativeMethods.ConfigFree(_config);
+        _app = default;
+        _config = default;
+        _wakeupCb = null;
+        _actionCb = null;
+        _readClipboardCb = null;
+        _confirmReadClipboardCb = null;
+        _writeClipboardCb = null;
+        _closeSurfaceCb = null;
+    }
+
+    // Runtime callbacks - implemented in Task 2.
+    private void OnWakeup(IntPtr userdata) { }
+    private bool OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr) => false;
+    private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;
+    private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest req) { }
+    private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm) { }
+    private void OnCloseSurface(IntPtr userdata, bool processAlive) { }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using Ghostty.Controls;
+using Ghostty.Hosting;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
@@ -9,6 +11,8 @@ namespace Ghostty;
 
 public sealed partial class MainWindow : Window
 {
+    private readonly GhosttyHost _host;
+
     // Win32 interop for the window class background brush. WinUI 3 hosts
     // the XAML island inside a Win32 HWND whose WNDCLASS hbrBackground
     // defaults to white. During an interactive drag-resize, DWM paints
@@ -28,6 +32,9 @@ public sealed partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+
+        _host = new GhosttyHost(DispatcherQueue);
+        Terminal.Host = _host;
 
         // Match the RootGrid background (#0C0C0C). Win32 COLORREF is 0x00BBGGRR.
         var hwnd = WindowNative.GetWindowHandle(this);
@@ -50,6 +57,33 @@ public sealed partial class MainWindow : Window
         // runtime action callback to the window chrome. Both events
         // are raised on the UI thread by TerminalControl.
         Terminal.TitleChanged += (_, title) => Title = title;
-        Terminal.CloseRequested += (_, _) => Close();
+        Terminal.CloseRequested += (sender, _) => RequestCloseLeaf((TerminalControl)sender!);
+        Closed += (_, _) => _host.Dispose();
+    }
+
+    /// <summary>
+    /// Handle a close request from a single terminal leaf.
+    ///
+    /// This is the close cascade entry point. The cascade runs:
+    ///
+    ///     leaf -> pane -> tab -> window
+    ///
+    /// In the multi-pane PR (next stacked) the leaf will be removed from
+    /// its parent split, focus will move to the sibling subtree, and the
+    /// window only closes when the last leaf goes away. With tabs (a
+    /// later PR) the same logic runs at the tab level: closing the last
+    /// leaf in a tab closes the tab; closing the last tab closes the
+    /// window.
+    ///
+    /// PR 1 has exactly one leaf per window, so the cascade collapses to
+    /// "close the window". The shape of this method is intentional - it
+    /// is the single point that future code will extend, mirroring
+    /// macOS's BaseTerminalController.closeSurface(_).
+    /// </summary>
+    private void RequestCloseLeaf(TerminalControl leaf)
+    {
+        // Today the only leaf is `Terminal`. When the surface tree exists,
+        // this becomes: tree.remove(leaf); if (tree.IsEmpty) Close();
+        if (leaf == Terminal) Close();
     }
 }


### PR DESCRIPTION
Prerequisite refactor for multi-pane support. No user-visible change in single-pane mode.

Moves `GhosttyConfig` and `GhosttyApp` ownership from `TerminalControl` up to a new `GhosttyHost` owned by `MainWindow`. Runtime callbacks (wakeup, action, clipboard, close-surface) now live on `GhosttyHost`. Two routing dictionaries:

- The action callback dereferences its `ghostty_target_s` argument (16-byte struct passed by hidden pointer on Win x64), reads the surface handle out of the union, and looks up the owning `TerminalControl` in a `Dictionary<IntPtr, TerminalControl>`.
- The close-surface callback decodes a `GCHandle` from per-surface userdata that each `TerminalControl` pins for itself before `SurfaceNew`.

`TerminalControl` is now a thin surface host: receives a `Host` property, creates and registers its surface on Loaded, frees and unregisters on Unloaded. It no longer touches the app or config.

`MainWindow.RequestCloseLeaf` is the single entry point for the future leaf -> pane -> tab -> window close cascade. PR 1 has one leaf per window, so it just calls `Close()`. The shape mirrors macOS's `BaseTerminalController.closeSurface(_)`.

IMPORTANT: stacked PR 1 of 2. PR 2 (the actual multi-pane splits) stacks on top.

Verified manually on Windows 11: launch, prompt, typing, ``title Hello``, ``exit``, X button, drag-resize.