### PR TITLE
chore: update progress bars (MVWT 85%, MVT 0%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 > **Status:** DX12 renderer in progress (3 surface modes + DirectComposition), shared infrastructure from DX11 carried forward
 >
 > **MVWT** Minimum Viewable Windows Terminal
-> `[██████████░░░░░░░░░░] 54%`
+> `[█████████████████░░░] 85%`
 >
 > **MVT** Moonshot Viable Terminal ([#26](https://github.com/deblasis/ghostty/issues/26))
 > `[░░░░░░░░░░░░░░░░░░░░]  0%`


### PR DESCRIPTION
Updates the two progress trackers in the fork README. MVWT jumps from 54% to 85% to reflect work landed since the last snapshot.

## What changed since the last update

- DX11 to DX12 pivot complete. 15 stacked PRs merged into windows. Three surface modes (HWND, SwapChainPanel composition, shared texture) all wired through the DX12 backend.
- WinUI 3 shell scaffolded with C# + WinUI 3 + DirectComposition via SwapChainPanel (PRs 156 to 159 merged).
- libghostty config and app ownership hoisted to a per-window GhosttyHost (PR 161 merged).
- Multi-pane splits in draft (PR 163): binary tree of LeafPane/SplitPane, hand-rolled splitter, KeyBindings registry, active-pane highlight overlay.
- DirectWrite font discovery, fallback chain, ClearType tuning all landed.
- ConPTY shell spawning works with the Ctrl+C interrupt fix from PR 154.
- Keyboard input including text combining and chord bindings.

## MVWT chunk breakdown

| Chunk                          | Weight | Done | Score |
|--------------------------------|-------:|-----:|------:|
| Build infra                    |   15%  | 100% | 15.0% |
| DX12 renderer infra            |   15%  | 100% | 15.0% |
| App scaffold                   |   10%  |  95% |  9.5% |
| Cell rendering                 |   20%  |  85% | 17.0% |
| DirectWrite font backend       |   15%  |  90% | 13.5% |
| ConPTY shell spawning          |   10%  |  95% |  9.5% |
| Keyboard, mouse, clipboard     |   10%  |  75% |  7.5% |
| DPI and dark/light theming     |    5%  |  60% |  3.0% |
| **Total**                      |        |      | **90.0%** |

Rounded down to 85% to be honest about residual rendering bugs that keep popping up (PR 149 fixed three linked DX12 init issues recently) and the parts that still need work: clipboard not wired, light theme not done, splits still in draft.

## MVT

Stays at 0% because issue 26's checkbox list has zero items ticked. Splits in draft will bump it once merged and the issue is updated.