### PR TITLE
feat(windows): jump list + AUMID for taskbar right-click menu

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -1,0 +1,17 @@
+namespace Ghostty.Core;
+
+/// <summary>
+/// Stable identifiers for the Ghostty Windows application. Shared across
+/// the shell (AUMID for SetCurrentProcessExplicitAppUserModelID, jump
+/// list, taskbar progress, toast notifications) and tests so nobody has
+/// to duplicate the string literal.
+/// </summary>
+internal static class AppIdentity
+{
+    /// <summary>
+    /// Explicit AppUserModelID for the process. Must be set before any
+    /// Shell interop call (jump list, taskbar, toasts) — the Shell
+    /// caches the process-to-AUMID association on first use.
+    /// </summary>
+    public const string AumId = "com.deblasis.ghostty";
+}

--- a/windows/Ghostty.Core/JumpList/ICustomDestinationListFacade.cs
+++ b/windows/Ghostty.Core/JumpList/ICustomDestinationListFacade.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.JumpList;
+
+/// <summary>
+/// Narrow facade over <see cref="Ghostty.Interop.ShellInterop.ICustomDestinationList"/>.
+/// Exposes only the operations <see cref="JumpListBuilder"/> uses
+/// so tests can substitute a recording fake without touching COM.
+/// </summary>
+internal interface ICustomDestinationListFacade
+{
+    /// <summary>Set the AppUserModelID this list is associated with.</summary>
+    void SetAppId(string appId);
+
+    /// <summary>Begin a new list cycle. Returns the max slots.</summary>
+    uint BeginList();
+
+    /// <summary>Add a "Tasks" entry: a shell link with path + args + title.</summary>
+    void AddTask(string exePath, string arguments, string title);
+
+    /// <summary>Add a custom category with its own entries.</summary>
+    void AddCategory(string categoryName, IReadOnlyList<(string exePath, string args, string title)> entries);
+
+    /// <summary>Commit the list to the shell.</summary>
+    void Commit();
+}

--- a/windows/Ghostty.Core/JumpList/JumpListBuilder.cs
+++ b/windows/Ghostty.Core/JumpList/JumpListBuilder.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.JumpList;
+
+/// <summary>
+/// Builds the Windows jump list for Ghostty. Consumes an
+/// <see cref="ICustomDestinationListFacade"/> so tests can
+/// substitute a recording fake; the real call site in
+/// <c>App.xaml.cs</c> passes <see cref="CustomDestinationListFacade"/>.
+///
+/// Tasks: "New Window" and "New Tab in Current Window" are static
+/// and always present.
+///
+/// Pinned profiles: sourced from the <see cref="_profilesProvider"/>
+/// factory, which is currently always empty behind a
+/// <c>TODO(config)</c> marker. When profiles exist, each becomes
+/// an entry in a "Pinned Profiles" custom category with the
+/// profile's display name as the title and its shell command as
+/// the invocation argument.
+/// </summary>
+internal sealed class JumpListBuilder
+{
+    private readonly ICustomDestinationListFacade _facade;
+    private readonly Func<IReadOnlyList<ProfileEntry>> _profilesProvider;
+    private readonly string _exePath;
+    private readonly string _appId;
+
+    public JumpListBuilder(
+        ICustomDestinationListFacade facade,
+        Func<IReadOnlyList<ProfileEntry>> profilesProvider,
+        string exePath,
+        string appId)
+    {
+        _facade = facade;
+        _profilesProvider = profilesProvider;
+        _exePath = exePath;
+        _appId = appId;
+    }
+
+    public void Build()
+    {
+        _facade.SetAppId(_appId);
+        _facade.BeginList();
+
+        // Static tasks. These always appear. The CLI argument shape
+        // is a placeholder: real wiring happens when libghostty's
+        // --action / --jumplist-action plumbing is defined.
+        // TODO(jumplist): finalise the CLI arg contract with libghostty
+        _facade.AddTask(_exePath, "--jumplist-action=new-window", "New Window");
+        _facade.AddTask(_exePath, "--jumplist-action=new-tab", "New Tab in Current Window");
+
+        // Pinned profiles category. Empty today; TODO(config): profiles
+        var profiles = _profilesProvider();
+        if (profiles.Count > 0)
+        {
+            var entries = new List<(string exePath, string args, string title)>(profiles.Count);
+            foreach (var p in profiles)
+            {
+                entries.Add((
+                    exePath: _exePath,
+                    args: $"--jumplist-profile={p.Id}",
+                    title: p.DisplayName));
+            }
+            _facade.AddCategory("Pinned Profiles", entries);
+        }
+
+        _facade.Commit();
+    }
+}

--- a/windows/Ghostty.Core/JumpList/ProfileEntry.cs
+++ b/windows/Ghostty.Core/JumpList/ProfileEntry.cs
@@ -1,0 +1,26 @@
+namespace Ghostty.Core.JumpList;
+
+/// <summary>
+/// Stub data type for a jump-list profile entry. The shape drives
+/// what the config layer will need to produce once it lands; for
+/// this PR every instance comes from an empty list and none of
+/// these fields are read.
+///
+/// <see cref="Id"/> is the stable identifier the jump list invokes
+/// back (e.g. "pwsh", "cmd", "wsl-ubuntu"). <see cref="DisplayName"/>
+/// is the human text shown in the menu. <see cref="IconPath"/> is a
+/// .exe or .ico file the Shell will rasterise; null means the
+/// default Ghostty icon. <see cref="ShellCommand"/> and
+/// <see cref="WorkingDirectory"/> are forwarded to the spawned
+/// process when the entry is clicked.
+///
+/// TODO(config): replace the Array.Empty pathway in
+/// <see cref="JumpListBuilder"/> with real profiles once the
+/// config layer exists.
+/// </summary>
+internal sealed record ProfileEntry(
+    string Id,
+    string DisplayName,
+    string? IconPath,
+    string? ShellCommand,
+    string? WorkingDirectory);

--- a/windows/Ghostty.Tests/JumpList/FakeCustomDestinationList.cs
+++ b/windows/Ghostty.Tests/JumpList/FakeCustomDestinationList.cs
@@ -17,10 +17,18 @@ internal sealed class FakeCustomDestinationList : ICustomDestinationListFacade
 
     public void SetAppId(string appId) => AppId = appId;
 
+    /// <summary>
+    /// Max slots returned from <see cref="BeginList"/>. Defaults to
+    /// <see cref="uint.MaxValue"/> ("no limit") so current tests don't
+    /// accidentally exercise a clamping path that doesn't exist yet;
+    /// future tests can override this to cover slot-limit behaviour.
+    /// </summary>
+    public uint MaxSlots { get; set; } = uint.MaxValue;
+
     public uint BeginList()
     {
         BeginListCalls++;
-        return 10; // max slots; arbitrary for fake
+        return MaxSlots;
     }
 
     public void AddTask(string exePath, string arguments, string title)

--- a/windows/Ghostty.Tests/JumpList/FakeCustomDestinationList.cs
+++ b/windows/Ghostty.Tests/JumpList/FakeCustomDestinationList.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Ghostty.Core.JumpList;
+
+namespace Ghostty.Tests.JumpList;
+
+/// <summary>
+/// Recording fake for <see cref="ICustomDestinationListFacade"/>.
+/// Stores every call in order so tests can assert sequences.
+/// </summary>
+internal sealed class FakeCustomDestinationList : ICustomDestinationListFacade
+{
+    public string? AppId { get; private set; }
+    public int BeginListCalls { get; private set; }
+    public int CommitCalls { get; private set; }
+    public List<(string exe, string args, string title)> Tasks { get; } = new();
+    public List<(string category, List<(string exe, string args, string title)> entries)> Categories { get; } = new();
+
+    public void SetAppId(string appId) => AppId = appId;
+
+    public uint BeginList()
+    {
+        BeginListCalls++;
+        return 10; // max slots; arbitrary for fake
+    }
+
+    public void AddTask(string exePath, string arguments, string title)
+        => Tasks.Add((exePath, arguments, title));
+
+    public void AddCategory(string categoryName, IReadOnlyList<(string exePath, string args, string title)> entries)
+    {
+        var copy = new List<(string, string, string)>();
+        foreach (var e in entries) copy.Add((e.exePath, e.args, e.title));
+        Categories.Add((categoryName, copy));
+    }
+
+    public void Commit() => CommitCalls++;
+}

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.JumpList;
+using Xunit;
+
+namespace Ghostty.Tests.JumpList;
+
+public class JumpListBuilderTests
+{
+    private const string TestExe = @"C:\fake\Ghostty.exe";
+    private const string TestAppId = "com.deblasis.ghostty";
+
+    [Fact]
+    public void Build_sets_app_id()
+    {
+        var fake = new FakeCustomDestinationList();
+        var builder = new JumpListBuilder(fake, () => Array.Empty<ProfileEntry>(), TestExe, TestAppId);
+
+        builder.Build();
+
+        Assert.Equal(TestAppId, fake.AppId);
+    }
+
+    [Fact]
+    public void Build_begins_and_commits_exactly_once()
+    {
+        var fake = new FakeCustomDestinationList();
+        var builder = new JumpListBuilder(fake, () => Array.Empty<ProfileEntry>(), TestExe, TestAppId);
+
+        builder.Build();
+
+        Assert.Equal(1, fake.BeginListCalls);
+        Assert.Equal(1, fake.CommitCalls);
+    }
+
+    [Fact]
+    public void Build_adds_static_tasks_new_window_and_new_tab()
+    {
+        var fake = new FakeCustomDestinationList();
+        var builder = new JumpListBuilder(fake, () => Array.Empty<ProfileEntry>(), TestExe, TestAppId);
+
+        builder.Build();
+
+        Assert.Equal(2, fake.Tasks.Count);
+        Assert.Contains(fake.Tasks, t => t.title == "New Window");
+        Assert.Contains(fake.Tasks, t => t.title == "New Tab in Current Window");
+        Assert.All(fake.Tasks, t => Assert.Equal(TestExe, t.exe));
+    }
+
+    [Fact]
+    public void Build_with_empty_profiles_does_not_add_pinned_category()
+    {
+        var fake = new FakeCustomDestinationList();
+        var builder = new JumpListBuilder(fake, () => Array.Empty<ProfileEntry>(), TestExe, TestAppId);
+
+        builder.Build();
+
+        Assert.Empty(fake.Categories);
+    }
+
+    [Fact]
+    public void Build_with_nonempty_profiles_adds_pinned_category()
+    {
+        var fake = new FakeCustomDestinationList();
+        var profiles = new List<ProfileEntry>
+        {
+            new("pwsh", "PowerShell", null, "pwsh.exe", null),
+            new("cmd", "Command Prompt", null, "cmd.exe", null),
+        };
+        var builder = new JumpListBuilder(fake, () => profiles, TestExe, TestAppId);
+
+        builder.Build();
+
+        Assert.Single(fake.Categories);
+        var (categoryName, entries) = fake.Categories[0];
+        Assert.Equal("Pinned Profiles", categoryName);
+        Assert.Equal(2, entries.Count);
+        Assert.Contains(entries, e => e.title == "PowerShell");
+        Assert.Contains(entries, e => e.title == "Command Prompt");
+    }
+}

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -8,7 +8,7 @@ namespace Ghostty.Tests.JumpList;
 public class JumpListBuilderTests
 {
     private const string TestExe = @"C:\fake\Ghostty.exe";
-    private const string TestAppId = "com.deblasis.ghostty";
+    private const string TestAppId = Ghostty.Core.AppIdentity.AumId;
 
     [Fact]
     public void Build_sets_app_id()

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -85,6 +85,50 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
+        // Set the explicit AppUserModelID. This MUST happen before
+        // any shell interop call (jump list registration, taskbar
+        // icon operations, toast notifications) — the Shell caches
+        // the process-to-AUMID association on first use and reads
+        // the jump list from a per-AUMID store. Without this, the
+        // jump list silently no-ops on unpackaged exes.
+        const string AppUserModelId = "com.deblasis.ghostty";
+        try
+        {
+            Ghostty.Interop.ShellInterop.SetCurrentProcessExplicitAppUserModelID(AppUserModelId);
+        }
+        catch (System.Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to set AUMID: {ex.Message}");
+            // Continue anyway; app still functions, just without jump list.
+        }
+
+        // Build the jump list once at startup. Rebuilds happen when
+        // the profile list changes (TODO(config): hook a config event).
+        try
+        {
+            // Environment.ProcessPath points to the apphost .exe, which
+            // is what we want the shell to invoke from the jump list.
+            // Assembly.GetEntryAssembly().Location returns the managed
+            // .dll on single-file apphost layouts, so prefer ProcessPath.
+            var exePath = System.Environment.ProcessPath ?? string.Empty;
+            if (!string.IsNullOrEmpty(exePath))
+            {
+                var facade = new Ghostty.JumpList.CustomDestinationListFacade();
+                var builder = new Ghostty.Core.JumpList.JumpListBuilder(
+                    facade,
+                    // TODO(config): profiles — swap for config-driven list
+                    profilesProvider: () => System.Array.Empty<Ghostty.Core.JumpList.ProfileEntry>(),
+                    exePath: exePath,
+                    appId: AppUserModelId);
+                builder.Build();
+            }
+        }
+        catch (System.Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to build jump list: {ex.Message}");
+            // Jump list is nice-to-have; failure here does not block startup.
+        }
+
         _window = new MainWindow();
         _window.Activate();
     }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -91,14 +91,15 @@ public partial class App : Application
         // the process-to-AUMID association on first use and reads
         // the jump list from a per-AUMID store. Without this, the
         // jump list silently no-ops on unpackaged exes.
-        const string AppUserModelId = "com.deblasis.ghostty";
         try
         {
-            Ghostty.Interop.ShellInterop.SetCurrentProcessExplicitAppUserModelID(AppUserModelId);
+            Ghostty.Interop.ShellInterop.SetCurrentProcessExplicitAppUserModelID(Ghostty.Core.AppIdentity.AumId);
         }
-        catch (System.Exception ex)
+        catch (System.Runtime.InteropServices.COMException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Failed to set AUMID: {ex.Message}");
+            // Visible in Release too — Trace goes to attached debuggers
+            // and the process's default trace listeners, unlike Debug.
+            System.Diagnostics.Trace.TraceWarning("Ghostty: failed to set AUMID: 0x{0:x8} {1}", ex.HResult, ex.Message);
             // Continue anyway; app still functions, just without jump list.
         }
 
@@ -113,19 +114,19 @@ public partial class App : Application
             var exePath = System.Environment.ProcessPath ?? string.Empty;
             if (!string.IsNullOrEmpty(exePath))
             {
-                var facade = new Ghostty.JumpList.CustomDestinationListFacade();
+                using var facade = new Ghostty.JumpList.CustomDestinationListFacade();
                 var builder = new Ghostty.Core.JumpList.JumpListBuilder(
                     facade,
                     // TODO(config): profiles — swap for config-driven list
                     profilesProvider: () => System.Array.Empty<Ghostty.Core.JumpList.ProfileEntry>(),
                     exePath: exePath,
-                    appId: AppUserModelId);
+                    appId: Ghostty.Core.AppIdentity.AumId);
                 builder.Build();
             }
         }
-        catch (System.Exception ex)
+        catch (System.Runtime.InteropServices.COMException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Failed to build jump list: {ex.Message}");
+            System.Diagnostics.Trace.TraceWarning("Ghostty: failed to build jump list: 0x{0:x8} {1}", ex.HResult, ex.Message);
             // Jump list is nice-to-have; failure here does not block startup.
         }
 

--- a/windows/Ghostty/Interop/ShellInterop.cs
+++ b/windows/Ghostty/Interop/ShellInterop.cs
@@ -14,14 +14,26 @@ namespace Ghostty.Interop;
 /// PROPVARIANT helpers needed to set System.Title on a shell link.
 ///
 /// P/Invoke: SetCurrentProcessExplicitAppUserModelID from shell32.
+///
+/// TODO(aot): these declarations use classic [ComImport] + [DllImport]
+/// which pull in runtime marshalling and are incompatible with
+/// [assembly: DisableRuntimeMarshalling] and NativeAOT. When the rest
+/// of the Windows shell flips to AOT, migrate this file to
+/// [GeneratedComInterface]/[LibraryImport] — or, preferably, replace
+/// it entirely with CsWin32-generated bindings (ICustomDestinationList,
+/// IShellLinkW, IPropertyStore, PROPVARIANT, CoCreateInstance and
+/// SetCurrentProcessExplicitAppUserModelID are all in Win32 metadata).
 /// </summary>
-internal static class ShellInterop
+internal static partial class ShellInterop
 {
     // P/Invoke ---------------------------------------------------
 
-    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
-    public static extern void SetCurrentProcessExplicitAppUserModelID(
-        [MarshalAs(UnmanagedType.LPWStr)] string AppID);
+    // SetCurrentProcessExplicitAppUserModelID is a plain void(LPCWSTR)
+    // export with no runtime-marshalling surface worth speaking of, so
+    // it's already AOT-friendly via LibraryImport.
+    [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16)]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+    public static partial void SetCurrentProcessExplicitAppUserModelID(string AppID);
 
     [DllImport("ole32.dll", PreserveSig = false)]
     public static extern void CoCreateInstance(
@@ -35,17 +47,17 @@ internal static class ShellInterop
 
     // CLSIDs -----------------------------------------------------
 
-    public static Guid CLSID_DestinationList = new("77f10cf0-3db5-4966-b520-b7c54fd35ed6");
-    public static Guid CLSID_EnumerableObjectCollection = new("2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
-    public static Guid CLSID_ShellLink = new("00021401-0000-0000-c000-000000000046");
+    public static readonly Guid CLSID_DestinationList = new("77f10cf0-3db5-4966-b520-b7c54fd35ed6");
+    public static readonly Guid CLSID_EnumerableObjectCollection = new("2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
+    public static readonly Guid CLSID_ShellLink = new("00021401-0000-0000-c000-000000000046");
 
     // Interface IIDs ---------------------------------------------
 
-    public static Guid IID_ICustomDestinationList = new("6332debf-87b5-4670-90c0-5e57b408a49e");
-    public static Guid IID_IObjectCollection = new("5632b1a4-e38a-400a-928a-d4cd63230295");
-    public static Guid IID_IObjectArray = new("92ca9dcd-5622-4bba-a805-5e9f541bd8c9");
-    public static Guid IID_IShellLinkW = new("000214f9-0000-0000-c000-000000000046");
-    public static Guid IID_IPropertyStore = new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
+    public static readonly Guid IID_ICustomDestinationList = new("6332debf-87b5-4670-90c0-5e57b408a49e");
+    public static readonly Guid IID_IObjectCollection = new("5632b1a4-e38a-400a-928a-d4cd63230295");
+    public static readonly Guid IID_IObjectArray = new("92ca9dcd-5622-4bba-a805-5e9f541bd8c9");
+    public static readonly Guid IID_IShellLinkW = new("000214f9-0000-0000-c000-000000000046");
+    public static readonly Guid IID_IPropertyStore = new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
 
     // ICustomDestinationList ------------------------------------
 
@@ -144,12 +156,20 @@ internal static class ShellInterop
     }
 
     /// <summary>System.Title: PKEY used to set the display name on a shell link for jump list entries.</summary>
-    public static PROPERTYKEY PKEY_Title = new(new Guid("f29f85e0-4ff9-1068-ab91-08002b27b3d9"), 2);
+    public static readonly PROPERTYKEY PKEY_Title = new(new Guid("f29f85e0-4ff9-1068-ab91-08002b27b3d9"), 2);
 
     // PROPVARIANT for VT_LPWSTR strings. Only the vt + union pointer
     // fields are used; the rest is padding. Caller is responsible for
     // allocating/freeing the string (CoTaskMemAlloc / PropVariantClear).
-    [StructLayout(LayoutKind.Explicit)]
+    //
+    // Size is pinned explicitly: the native PROPVARIANT is 16 bytes on
+    // x86 and 24 bytes on x64 (8-byte header + 16-byte union — the
+    // largest union member being BLOB { ULONG cbSize; BYTE* pBlobData; }
+    // or CA* caXxx, both of which pad to 16 on x64). Without Size, the
+    // marshaller sizes the struct at max(offset+size)=16 and
+    // IPropertyStore::SetValue — which does a full-sized PropVariantCopy
+    // internally — would read 8 bytes past our managed storage on x64.
+    [StructLayout(LayoutKind.Explicit, Size = 24)]
     public struct PROPVARIANT
     {
         [FieldOffset(0)] public ushort vt;

--- a/windows/Ghostty/Interop/ShellInterop.cs
+++ b/windows/Ghostty/Interop/ShellInterop.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Interop;
+
+/// <summary>
+/// ComImport declarations and P/Invoke for the Windows Shell APIs
+/// this project needs. Kept in one file so the ABI surface is easy
+/// to audit.
+///
+/// Interfaces: ICustomDestinationList (jump list), IObjectCollection
+/// (category content), IObjectArray (read-only views), IShellLinkW
+/// (entries), IPropertyStore (link titles), plus the PROPERTYKEY /
+/// PROPVARIANT helpers needed to set System.Title on a shell link.
+///
+/// P/Invoke: SetCurrentProcessExplicitAppUserModelID from shell32.
+/// </summary>
+internal static class ShellInterop
+{
+    // P/Invoke ---------------------------------------------------
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    public static extern void SetCurrentProcessExplicitAppUserModelID(
+        [MarshalAs(UnmanagedType.LPWStr)] string AppID);
+
+    [DllImport("ole32.dll", PreserveSig = false)]
+    public static extern void CoCreateInstance(
+        [In] ref Guid rclsid,
+        IntPtr pUnkOuter,
+        uint dwClsContext,
+        [In] ref Guid riid,
+        [MarshalAs(UnmanagedType.Interface)] out object ppv);
+
+    public const uint CLSCTX_INPROC_SERVER = 0x1;
+
+    // CLSIDs -----------------------------------------------------
+
+    public static Guid CLSID_DestinationList = new("77f10cf0-3db5-4966-b520-b7c54fd35ed6");
+    public static Guid CLSID_EnumerableObjectCollection = new("2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
+    public static Guid CLSID_ShellLink = new("00021401-0000-0000-c000-000000000046");
+
+    // Interface IIDs ---------------------------------------------
+
+    public static Guid IID_ICustomDestinationList = new("6332debf-87b5-4670-90c0-5e57b408a49e");
+    public static Guid IID_IObjectCollection = new("5632b1a4-e38a-400a-928a-d4cd63230295");
+    public static Guid IID_IObjectArray = new("92ca9dcd-5622-4bba-a805-5e9f541bd8c9");
+    public static Guid IID_IShellLinkW = new("000214f9-0000-0000-c000-000000000046");
+    public static Guid IID_IPropertyStore = new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
+
+    // ICustomDestinationList ------------------------------------
+
+    [ComImport]
+    [Guid("6332debf-87b5-4670-90c0-5e57b408a49e")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface ICustomDestinationList
+    {
+        void SetAppID([MarshalAs(UnmanagedType.LPWStr)] string pszAppID);
+        void BeginList(out uint pcMaxSlots, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+        void AppendCategory([MarshalAs(UnmanagedType.LPWStr)] string pszCategory, [MarshalAs(UnmanagedType.Interface)] IObjectArray poa);
+        void AppendKnownCategory(int category);
+        void AddUserTasks([MarshalAs(UnmanagedType.Interface)] IObjectArray poa);
+        void CommitList();
+        void GetRemovedDestinations([In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+        void DeleteList([MarshalAs(UnmanagedType.LPWStr)] string pszAppID);
+        void AbortList();
+    }
+
+    // IObjectCollection (extends IObjectArray) -------------------
+
+    [ComImport]
+    [Guid("5632b1a4-e38a-400a-928a-d4cd63230295")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IObjectCollection
+    {
+        // IObjectArray methods (this interface inherits from it)
+        void GetCount(out uint pcObjects);
+        void GetAt(uint uiIndex, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+        // IObjectCollection additions
+        void AddObject([MarshalAs(UnmanagedType.IUnknown)] object punk);
+        void AddFromArray([MarshalAs(UnmanagedType.Interface)] IObjectArray poaSource);
+        void RemoveObjectAt(uint uiIndex);
+        void Clear();
+    }
+
+    [ComImport]
+    [Guid("92ca9dcd-5622-4bba-a805-5e9f541bd8c9")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IObjectArray
+    {
+        void GetCount(out uint pcObjects);
+        void GetAt(uint uiIndex, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+    }
+
+    // IShellLinkW -------------------------------------------------
+
+    [ComImport]
+    [Guid("000214f9-0000-0000-c000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IShellLinkW
+    {
+        void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszFile, int cch, IntPtr pfd, uint fFlags);
+        void GetIDList(out IntPtr ppidl);
+        void SetIDList(IntPtr pidl);
+        void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszName, int cch);
+        void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+        void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszDir, int cch);
+        void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+        void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszArgs, int cch);
+        void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+        void GetHotkey(out ushort pwHotkey);
+        void SetHotkey(ushort wHotkey);
+        void GetShowCmd(out int piShowCmd);
+        void SetShowCmd(int iShowCmd);
+        void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszIconPath, int cch, out int piIcon);
+        void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+        void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
+        void Resolve(IntPtr hwnd, uint fFlags);
+        void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+    }
+
+    // IPropertyStore ---------------------------------------------
+
+    [ComImport]
+    [Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IPropertyStore
+    {
+        void GetCount(out uint cProps);
+        void GetAt(uint iProp, out PROPERTYKEY pkey);
+        void GetValue([In] ref PROPERTYKEY key, out PROPVARIANT pv);
+        void SetValue([In] ref PROPERTYKEY key, [In] ref PROPVARIANT pv);
+        void Commit();
+    }
+
+    // PROPERTYKEY and PROPVARIANT helpers ------------------------
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct PROPERTYKEY
+    {
+        public Guid fmtid;
+        public uint pid;
+
+        public PROPERTYKEY(Guid g, uint p) { fmtid = g; pid = p; }
+    }
+
+    /// <summary>System.Title: PKEY used to set the display name on a shell link for jump list entries.</summary>
+    public static PROPERTYKEY PKEY_Title = new(new Guid("f29f85e0-4ff9-1068-ab91-08002b27b3d9"), 2);
+
+    // PROPVARIANT for VT_LPWSTR strings. Only the vt + union pointer
+    // fields are used; the rest is padding. Caller is responsible for
+    // allocating/freeing the string (CoTaskMemAlloc / PropVariantClear).
+    [StructLayout(LayoutKind.Explicit)]
+    public struct PROPVARIANT
+    {
+        [FieldOffset(0)] public ushort vt;
+        [FieldOffset(8)] public IntPtr pointerValue;
+    }
+
+    public const ushort VT_LPWSTR = 31;
+
+    [DllImport("ole32.dll")]
+    public static extern int PropVariantClear(ref PROPVARIANT pvar);
+
+    /// <summary>
+    /// Helper: populate a shell link's System.Title so the jump list
+    /// shows a nice display string. Allocates the string via
+    /// CoTaskMemAlloc and transfers ownership to the property store.
+    /// </summary>
+    public static void SetShellLinkTitle(IShellLinkW link, string title)
+    {
+        var store = (IPropertyStore)link;
+        var pv = new PROPVARIANT
+        {
+            vt = VT_LPWSTR,
+            pointerValue = Marshal.StringToCoTaskMemUni(title),
+        };
+        try
+        {
+            store.SetValue(ref PKEY_Title, ref pv);
+            store.Commit();
+        }
+        finally
+        {
+            PropVariantClear(ref pv);
+        }
+    }
+}

--- a/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
+++ b/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.JumpList;
+using Ghostty.Interop;
+
+namespace Ghostty.JumpList;
+
+/// <summary>
+/// Real implementation of <see cref="ICustomDestinationListFacade"/>.
+/// Creates the underlying <see cref="ShellInterop.ICustomDestinationList"/>
+/// COM object via <see cref="ShellInterop.CoCreateInstance"/> on
+/// construction and forwards every facade call to it.
+///
+/// One instance per process is typical; <see cref="JumpListBuilder"/>
+/// calls <see cref="BeginList"/> and <see cref="Commit"/> in pairs
+/// to replace the list wholesale.
+/// </summary>
+internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
+{
+    private readonly ShellInterop.ICustomDestinationList _list;
+    // AddUserTasks on ICustomDestinationList is a one-shot call per
+    // BeginList/Commit cycle — it creates the Tasks slot in the shell
+    // store and a second invocation returns 0x800700B7 ALREADY_EXISTS.
+    // So we buffer every AddTask call and flush a single AddUserTasks
+    // in Commit.
+    private readonly List<(string exe, string args, string title)> _pendingTasks = new();
+
+    public CustomDestinationListFacade()
+    {
+        var clsid = ShellInterop.CLSID_DestinationList;
+        var iid = ShellInterop.IID_ICustomDestinationList;
+        ShellInterop.CoCreateInstance(
+            ref clsid,
+            IntPtr.Zero,
+            ShellInterop.CLSCTX_INPROC_SERVER,
+            ref iid,
+            out var obj);
+        _list = (ShellInterop.ICustomDestinationList)obj;
+    }
+
+    public void SetAppId(string appId) => _list.SetAppID(appId);
+
+    public uint BeginList()
+    {
+        var iid = ShellInterop.IID_IObjectArray;
+        _list.BeginList(out var maxSlots, ref iid, out _);
+        return maxSlots;
+    }
+
+    public void AddTask(string exePath, string arguments, string title)
+        => _pendingTasks.Add((exePath, arguments, title));
+
+    public void AddCategory(string categoryName, IReadOnlyList<(string exePath, string args, string title)> entries)
+    {
+        var collection = CreateCollection();
+        foreach (var e in entries)
+        {
+            var link = CreateShellLink(e.exePath, e.args, e.title);
+            collection.AddObject(link);
+        }
+        var array = (ShellInterop.IObjectArray)collection;
+        _list.AppendCategory(categoryName, array);
+    }
+
+    public void Commit()
+    {
+        if (_pendingTasks.Count > 0)
+        {
+            var collection = CreateCollection();
+            foreach (var t in _pendingTasks)
+            {
+                var link = CreateShellLink(t.exe, t.args, t.title);
+                collection.AddObject(link);
+            }
+            _list.AddUserTasks((ShellInterop.IObjectArray)collection);
+            _pendingTasks.Clear();
+        }
+        _list.CommitList();
+    }
+
+    private static ShellInterop.IShellLinkW CreateShellLink(string exePath, string arguments, string title)
+    {
+        var clsid = ShellInterop.CLSID_ShellLink;
+        var iid = ShellInterop.IID_IShellLinkW;
+        ShellInterop.CoCreateInstance(
+            ref clsid,
+            IntPtr.Zero,
+            ShellInterop.CLSCTX_INPROC_SERVER,
+            ref iid,
+            out var obj);
+        var link = (ShellInterop.IShellLinkW)obj;
+        link.SetPath(exePath);
+        link.SetArguments(arguments);
+        link.SetDescription(title);
+        // Title shown in the jump list comes from System.Title, not
+        // the description. Set it via the IPropertyStore side of the
+        // same object.
+        ShellInterop.SetShellLinkTitle(link, title);
+        return link;
+    }
+
+    private static ShellInterop.IObjectCollection CreateCollection()
+    {
+        var clsid = ShellInterop.CLSID_EnumerableObjectCollection;
+        var iid = ShellInterop.IID_IObjectCollection;
+        ShellInterop.CoCreateInstance(
+            ref clsid,
+            IntPtr.Zero,
+            ShellInterop.CLSCTX_INPROC_SERVER,
+            ref iid,
+            out var obj);
+        return (ShellInterop.IObjectCollection)obj;
+    }
+}

--- a/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
+++ b/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Ghostty.Core.JumpList;
 using Ghostty.Interop;
 
@@ -11,11 +12,12 @@ namespace Ghostty.JumpList;
 /// COM object via <see cref="ShellInterop.CoCreateInstance"/> on
 /// construction and forwards every facade call to it.
 ///
-/// One instance per process is typical; <see cref="JumpListBuilder"/>
-/// calls <see cref="BeginList"/> and <see cref="Commit"/> in pairs
-/// to replace the list wholesale.
+/// The instance is single-use: one BeginList/Commit cycle per facade.
+/// Dispose after Commit to release the underlying STA RCW deterministically
+/// instead of waiting for the finalizer queue. Callers in App.xaml.cs
+/// wrap the facade in a <c>using</c> block.
 /// </summary>
-internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
+internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade, IDisposable
 {
     private readonly ShellInterop.ICustomDestinationList _list;
     // AddUserTasks on ICustomDestinationList is a one-shot call per
@@ -58,24 +60,43 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
             var link = CreateShellLink(e.exePath, e.args, e.title);
             collection.AddObject(link);
         }
+        // QI cast: IObjectCollection inherits IObjectArray at the COM
+        // level but not in the C# type system (classic ComImport doesn't
+        // chain vtables), so this cast goes through the RCW's
+        // QueryInterface rather than a type-system coercion.
         var array = (ShellInterop.IObjectArray)collection;
         _list.AppendCategory(categoryName, array);
     }
 
     public void Commit()
     {
-        if (_pendingTasks.Count > 0)
+        try
         {
-            var collection = CreateCollection();
-            foreach (var t in _pendingTasks)
+            if (_pendingTasks.Count > 0)
             {
-                var link = CreateShellLink(t.exe, t.args, t.title);
-                collection.AddObject(link);
+                var collection = CreateCollection();
+                foreach (var t in _pendingTasks)
+                {
+                    var link = CreateShellLink(t.exe, t.args, t.title);
+                    collection.AddObject(link);
+                }
+                _list.AddUserTasks((ShellInterop.IObjectArray)collection);
             }
-            _list.AddUserTasks((ShellInterop.IObjectArray)collection);
+            _list.CommitList();
+        }
+        finally
+        {
+            // Always drop pending state, even on failure, so a retried
+            // Commit() on the same facade doesn't replay stale tasks.
             _pendingTasks.Clear();
         }
-        _list.CommitList();
+    }
+
+    public void Dispose()
+    {
+        // Deterministically release the STA RCW so the underlying
+        // ICustomDestinationList doesn't sit on the finalizer queue.
+        Marshal.FinalReleaseComObject(_list);
     }
 
     private static ShellInterop.IShellLinkW CreateShellLink(string exePath, string arguments, string title)
@@ -91,10 +112,9 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
         var link = (ShellInterop.IShellLinkW)obj;
         link.SetPath(exePath);
         link.SetArguments(arguments);
-        link.SetDescription(title);
-        // Title shown in the jump list comes from System.Title, not
-        // the description. Set it via the IPropertyStore side of the
-        // same object.
+        // Title shown in the jump list comes from System.Title on the
+        // IPropertyStore side of this object — IShellLinkW.SetDescription
+        // is ignored by the Shell jump list UI on Win10+. Skip it.
         ShellInterop.SetShellLinkTitle(link, title);
         return link;
     }


### PR DESCRIPTION
> IMPORTANT: part 2 of 3 in a stacked PR chain.
> Stack order:
> 1. #167 windows-tabs-vertical -> windows
> 2. windows-tabs-jumplist (this PR) -> windows-tabs-vertical
> 3. windows-tabs-taskbar-progress -> windows-tabs-jumplist
>
> GitHub will auto-retarget this PR to windows once part 1 merges.

## Summary
Sets an explicit AppUserModelID (com.deblasis.ghostty) on the process at app startup and registers a Windows jump list with two static tasks (New Window, New Tab in Current Window). Right-clicking the taskbar icon now shows a Tasks section.

The jump list pipeline is split across the two assemblies so tests can exercise the real builder: ProfileEntry, ICustomDestinationListFacade, and JumpListBuilder are pure-logic types in Ghostty.Core with five xunit facts against a recording fake. The COM-backed CustomDestinationListFacade lives in the WinUI project and buffers AddTask calls to flush a single AddUserTasks invocation on Commit. The one-shot semantics of ICustomDestinationList.AddUserTasks was a real trap here: calling it per-task returns 0x800700B7 ALREADY_EXISTS and the whole list silently no-ops.

A "Pinned Profiles" category is stubbed behind a TODO(config) marker and stays empty until the config layer exists. The CLI args the jump list entries pass (--jumplist-action=new-window etc.) are placeholders and libghostty does not parse them yet.

## Test plan
- [ ] Right-click the Ghostty taskbar icon on a running instance
- [ ] Tasks section shows New Window and New Tab in Current Window
- [ ] No Pinned Profiles category (empty stub list)
- [ ] dotnet test passes the five JumpListBuilderTests