### PR TITLE
feat(windows): taskbar progress coordinator with per-tab cycling

### DIFF
--- a/windows/Ghostty.Core/Panes/IPaneHost.cs
+++ b/windows/Ghostty.Core/Panes/IPaneHost.cs
@@ -1,4 +1,5 @@
 using System;
+using Ghostty.Core.Tabs;
 
 namespace Ghostty.Core.Panes;
 
@@ -25,6 +26,13 @@ internal interface IPaneHost
 
     /// <summary>Raised when the last leaf in the tree closes.</summary>
     event EventHandler? LastLeafClosed;
+
+    /// <summary>Raised when the active leaf reports a progress state
+    /// change via OSC 9;4. Only the active leaf's progress is
+    /// forwarded — background panes update their own
+    /// <c>TerminalControl.CurrentProgress</c> but do not drive the
+    /// tab-level indicator.</summary>
+    event EventHandler<TabProgressState>? ProgressChanged;
 
     /// <summary>Close the currently active pane.</summary>
     void CloseActive();

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -98,6 +98,8 @@ internal sealed class TabManager
 
         tab.PaneHost.LeafFocused -= OnLeafFocused;
         tab.PropertyChanged -= OnTabPropertyChanged;
+        tab.OnClose?.Invoke();
+        tab.OnClose = null;
         tab.PaneHost.DisposeAllLeaves();
 
         _tabs.RemoveAt(index);
@@ -171,6 +173,12 @@ internal sealed class TabManager
         var host = _paneHostFactory();
         var tab = new TabModel(host);
         host.LeafFocused += OnLeafFocused;
+        // Forward the active-leaf's progress onto the tab model. The
+        // handler is captured as a local so CloseTab can unsubscribe
+        // without needing a shared dictionary.
+        EventHandler<TabProgressState> progressHandler = (_, state) => tab.Progress = state;
+        host.ProgressChanged += progressHandler;
+        tab.OnClose = () => host.ProgressChanged -= progressHandler;
         tab.PropertyChanged += OnTabPropertyChanged;
         return tab;
     }

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -70,6 +70,14 @@ internal sealed class TabModel : INotifyPropertyChanged
         PaneHost = paneHost;
     }
 
+    /// <summary>
+    /// Disposer assigned by <see cref="TabManager.CreateTab"/> so
+    /// <see cref="TabManager.CloseTab"/> can unwire the per-tab
+    /// <c>IPaneHost.ProgressChanged</c> handler captured as a local
+    /// closure, without maintaining a side dictionary.
+    /// </summary>
+    internal Action? OnClose { get; set; }
+
     public event PropertyChangedEventHandler? PropertyChanged;
     private void Raise([CallerMemberName] string? name = null) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));

--- a/windows/Ghostty.Core/Taskbar/ITaskbarProgressSink.cs
+++ b/windows/Ghostty.Core/Taskbar/ITaskbarProgressSink.cs
@@ -1,0 +1,22 @@
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Core.Taskbar;
+
+/// <summary>
+/// Narrow surface the <see cref="TaskbarProgressCoordinator"/>
+/// writes to. Implemented in the WinUI project by a facade that
+/// forwards to <c>ITaskbarList3::SetProgressValue</c> and
+/// <c>SetProgressState</c>. Tests implement it with a recording fake.
+///
+/// Pure Ghostty.Core — no WinUI types in the surface so the
+/// coordinator can be unit-tested without dragging WinAppSDK in.
+/// </summary>
+internal interface ITaskbarProgressSink
+{
+    /// <summary>Reflect the given state+percent onto the taskbar.
+    /// State == <see cref="TabProgressState.Kind.None"/> clears the
+    /// progress indicator. The sink is expected to be idempotent —
+    /// the coordinator may call this with the same value multiple
+    /// times.</summary>
+    void Write(TabProgressState state);
+}

--- a/windows/Ghostty.Core/Taskbar/TaskbarProgressCoordinator.cs
+++ b/windows/Ghostty.Core/Taskbar/TaskbarProgressCoordinator.cs
@@ -26,7 +26,7 @@ namespace Ghostty.Core.Taskbar;
 /// <c>DispatcherQueueTimer</c> to drive <see cref="Tick"/> on a
 /// 2-second cadence.
 /// </summary>
-internal sealed class TaskbarProgressCoordinator
+internal sealed class TaskbarProgressCoordinator : IDisposable
 {
     private const double SlotDurationMs = 2000.0;
 
@@ -34,19 +34,30 @@ internal sealed class TaskbarProgressCoordinator
     private readonly ITaskbarProgressSink _sink;
     private readonly Func<DateTime> _nowProvider;
     private readonly List<TabModel> _active = new();
+    private readonly EventHandler<TabModel> _onTabAdded;
+    private readonly EventHandler<TabModel> _onTabRemoved;
     private int _currentIndex = -1;
     private DateTime _slotStart;
     private bool _paused;
+    private bool _disposed;
 
     public TaskbarProgressCoordinator(TabManager manager, ITaskbarProgressSink sink, Func<DateTime> nowProvider)
     {
+        ArgumentNullException.ThrowIfNull(manager);
+        ArgumentNullException.ThrowIfNull(sink);
+        ArgumentNullException.ThrowIfNull(nowProvider);
+
         _manager = manager;
         _sink = sink;
         _nowProvider = nowProvider;
+        _slotStart = nowProvider();
+
+        _onTabAdded = (_, t) => Subscribe(t);
+        _onTabRemoved = (_, t) => { Unsubscribe(t); ForceRemove(t); };
 
         foreach (var t in _manager.Tabs) Subscribe(t);
-        _manager.TabAdded += (_, t) => Subscribe(t);
-        _manager.TabRemoved += (_, t) => { Unsubscribe(t); HandleProgressChange(t); };
+        _manager.TabAdded += _onTabAdded;
+        _manager.TabRemoved += _onTabRemoved;
     }
 
     public void Pause() => _paused = true;
@@ -74,6 +85,16 @@ internal sealed class TaskbarProgressCoordinator
         _sink.Write(_active[_currentIndex].Progress);
     }
 
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _manager.TabAdded -= _onTabAdded;
+        _manager.TabRemoved -= _onTabRemoved;
+        foreach (var t in _manager.Tabs) Unsubscribe(t);
+        _active.Clear();
+    }
+
     private void Subscribe(TabModel tab) => tab.PropertyChanged += OnTabPropertyChanged;
 
     private void Unsubscribe(TabModel tab) => tab.PropertyChanged -= OnTabPropertyChanged;
@@ -82,6 +103,39 @@ internal sealed class TaskbarProgressCoordinator
     {
         if (e.PropertyName != nameof(TabModel.Progress)) return;
         if (sender is TabModel t) HandleProgressChange(t);
+    }
+
+    /// <summary>
+    /// Called when a tab is removed from the manager. If the tab was
+    /// currently in the active list we force a "no progress" transition
+    /// so the state machine drops it cleanly — we can't trust
+    /// <see cref="TabModel.Progress"/> here because the closing tab may
+    /// still be mid-report.
+    /// </summary>
+    private void ForceRemove(TabModel tab)
+    {
+        if (!_active.Contains(tab)) return;
+        var wasCurrent = _active[_currentIndex] == tab;
+        _active.Remove(tab);
+
+        if (_active.Count == 0)
+        {
+            _currentIndex = -1;
+            _sink.Write(TabProgressState.None);
+            return;
+        }
+
+        if (_currentIndex >= _active.Count) _currentIndex = 0;
+
+        if (_active.Count == 1)
+        {
+            _currentIndex = 0;
+            _sink.Write(_active[0].Progress);
+            return;
+        }
+
+        if (wasCurrent)
+            _sink.Write(_active[_currentIndex].Progress);
     }
 
     private void HandleProgressChange(TabModel tab)
@@ -111,31 +165,7 @@ internal sealed class TaskbarProgressCoordinator
 
         if (!hasProgress && inList)
         {
-            var wasCurrent = _active[_currentIndex] == tab;
-            _active.Remove(tab);
-
-            if (_active.Count == 0)
-            {
-                _currentIndex = -1;
-                _sink.Write(TabProgressState.None);
-                return;
-            }
-
-            // Fix up _currentIndex so it still points at a valid slot.
-            if (_currentIndex >= _active.Count) _currentIndex = 0;
-
-            if (_active.Count == 1)
-            {
-                // Cycling -> Single. Emit the remaining tab's state.
-                _currentIndex = 0;
-                _sink.Write(_active[0].Progress);
-                return;
-            }
-
-            // Still Cycling with 2+ left. Only emit if the current
-            // slot was the one that dropped out.
-            if (wasCurrent)
-                _sink.Write(_active[_currentIndex].Progress);
+            ForceRemove(tab);
             return;
         }
 

--- a/windows/Ghostty.Core/Taskbar/TaskbarProgressCoordinator.cs
+++ b/windows/Ghostty.Core/Taskbar/TaskbarProgressCoordinator.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Core.Taskbar;
+
+/// <summary>
+/// Cycles the Windows taskbar progress indicator across tabs that
+/// are reporting OSC 9;4 progress. Pure-logic state machine; the
+/// WinUI-side facade writes to <c>ITaskbarList3</c>.
+///
+/// State model (implicit in _active list length):
+///   Clear:    _active.Count == 0. Sink is told None.
+///   Single:   _active.Count == 1. Live updates to that tab pass
+///             through immediately.
+///   Cycling:  _active.Count >= 2. A <see cref="Tick"/> call
+///             advances <see cref="_currentIndex"/> and emits the
+///             new current tab's state. Live updates to the
+///             currently displayed tab pass through; updates to
+///             other tabs update <see cref="TabModel.Progress"/>
+///             but do not touch the sink.
+///
+/// Time is injected via the <c>nowProvider</c> so tests can control
+/// it. Real call site uses <see cref="DateTime.UtcNow"/> and a
+/// <c>DispatcherQueueTimer</c> to drive <see cref="Tick"/> on a
+/// 2-second cadence.
+/// </summary>
+internal sealed class TaskbarProgressCoordinator
+{
+    private const double SlotDurationMs = 2000.0;
+
+    private readonly TabManager _manager;
+    private readonly ITaskbarProgressSink _sink;
+    private readonly Func<DateTime> _nowProvider;
+    private readonly List<TabModel> _active = new();
+    private int _currentIndex = -1;
+    private DateTime _slotStart;
+    private bool _paused;
+
+    public TaskbarProgressCoordinator(TabManager manager, ITaskbarProgressSink sink, Func<DateTime> nowProvider)
+    {
+        _manager = manager;
+        _sink = sink;
+        _nowProvider = nowProvider;
+
+        foreach (var t in _manager.Tabs) Subscribe(t);
+        _manager.TabAdded += (_, t) => Subscribe(t);
+        _manager.TabRemoved += (_, t) => { Unsubscribe(t); HandleProgressChange(t); };
+    }
+
+    public void Pause() => _paused = true;
+
+    public void Resume()
+    {
+        _paused = false;
+        _slotStart = _nowProvider();
+    }
+
+    /// <summary>
+    /// Driven by a DispatcherQueueTimer at ~2 seconds in production;
+    /// tests call manually after advancing their clock.
+    /// </summary>
+    public void Tick()
+    {
+        if (_paused) return;
+        if (_active.Count < 2) return;
+
+        var elapsed = (_nowProvider() - _slotStart).TotalMilliseconds;
+        if (elapsed < SlotDurationMs) return;
+
+        _currentIndex = (_currentIndex + 1) % _active.Count;
+        _slotStart = _nowProvider();
+        _sink.Write(_active[_currentIndex].Progress);
+    }
+
+    private void Subscribe(TabModel tab) => tab.PropertyChanged += OnTabPropertyChanged;
+
+    private void Unsubscribe(TabModel tab) => tab.PropertyChanged -= OnTabPropertyChanged;
+
+    private void OnTabPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(TabModel.Progress)) return;
+        if (sender is TabModel t) HandleProgressChange(t);
+    }
+
+    private void HandleProgressChange(TabModel tab)
+    {
+        var inList = _active.Contains(tab);
+        var hasProgress = tab.Progress.State != TabProgressState.Kind.None;
+
+        if (hasProgress && !inList)
+        {
+            _active.Add(tab);
+            if (_active.Count == 1)
+            {
+                _currentIndex = 0;
+                _slotStart = _nowProvider();
+                _sink.Write(tab.Progress); // Clear -> Single
+            }
+            else if (_active.Count == 2)
+            {
+                // Single -> Cycling. Emit the currently displayed
+                // tab's state to re-sync the sink (idempotent in the
+                // common case where Single was already showing it).
+                _sink.Write(_active[_currentIndex].Progress);
+            }
+            // 3+ joining just sits in the list until its slot comes.
+            return;
+        }
+
+        if (!hasProgress && inList)
+        {
+            var wasCurrent = _active[_currentIndex] == tab;
+            _active.Remove(tab);
+
+            if (_active.Count == 0)
+            {
+                _currentIndex = -1;
+                _sink.Write(TabProgressState.None);
+                return;
+            }
+
+            // Fix up _currentIndex so it still points at a valid slot.
+            if (_currentIndex >= _active.Count) _currentIndex = 0;
+
+            if (_active.Count == 1)
+            {
+                // Cycling -> Single. Emit the remaining tab's state.
+                _currentIndex = 0;
+                _sink.Write(_active[0].Progress);
+                return;
+            }
+
+            // Still Cycling with 2+ left. Only emit if the current
+            // slot was the one that dropped out.
+            if (wasCurrent)
+                _sink.Write(_active[_currentIndex].Progress);
+            return;
+        }
+
+        if (hasProgress && inList)
+        {
+            // Live update. Pass through only if this IS the current
+            // displayed tab in Single or the current-slot tab in
+            // Cycling.
+            if (_active.Count == 1 || _active[_currentIndex] == tab)
+                _sink.Write(tab.Progress);
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
+++ b/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
@@ -1,5 +1,6 @@
 using System;
 using Ghostty.Core.Panes;
+using Ghostty.Core.Tabs;
 
 namespace Ghostty.Tests.Tabs;
 
@@ -22,6 +23,10 @@ internal sealed class FakePaneHost : IPaneHost
 
     public event EventHandler<LeafPane>? LeafFocused;
     public event EventHandler? LastLeafClosed;
+    public event EventHandler<TabProgressState>? ProgressChanged;
+
+    public void RaiseProgressChanged(TabProgressState state)
+        => ProgressChanged?.Invoke(this, state);
 
     public void CloseActive()
     {

--- a/windows/Ghostty.Tests/Tabs/TabManagerTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerTests.cs
@@ -20,6 +20,26 @@ public class TabManagerTests
     }
 
     [Fact]
+    public void PaneHost_progress_forwards_to_TabModel_and_stops_after_close()
+    {
+        var mgr = NewManager(out var hosts);
+        var tab = mgr.Tabs[0];
+        var host = hosts[0];
+
+        host.RaiseProgressChanged(TabProgressState.Normal(50));
+        Assert.Equal(TabProgressState.Normal(50), tab.Progress);
+
+        host.RaiseProgressChanged(TabProgressState.Error(75));
+        Assert.Equal(TabProgressState.Error(75), tab.Progress);
+
+        // After CloseTab the forwarding handler must be unhooked.
+        mgr.NewTab(); // CloseTab refuses to close the last tab
+        mgr.CloseTab(tab);
+        host.RaiseProgressChanged(TabProgressState.Normal(99));
+        Assert.NotEqual(TabProgressState.Normal(99), tab.Progress);
+    }
+
+    [Fact]
     public void Construction_creates_one_tab_and_activates_it()
     {
         var mgr = NewManager(out var hosts);

--- a/windows/Ghostty.Tests/Taskbar/FakeTaskbarProgressSink.cs
+++ b/windows/Ghostty.Tests/Taskbar/FakeTaskbarProgressSink.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Ghostty.Core.Tabs;
 using Ghostty.Core.Taskbar;
@@ -12,7 +13,15 @@ namespace Ghostty.Tests.Taskbar;
 internal sealed class FakeTaskbarProgressSink : ITaskbarProgressSink
 {
     public List<TabProgressState> Writes { get; } = new();
-    public TabProgressState Last => Writes.Count == 0 ? TabProgressState.None : Writes[^1];
+
+    /// <summary>Last recorded write. Throws if nothing has been
+    /// written yet so callers can't silently conflate "no writes"
+    /// with "wrote None".</summary>
+    public TabProgressState Last =>
+        Writes.Count == 0
+            ? throw new InvalidOperationException("No writes recorded yet.")
+            : Writes[^1];
+
     public void Write(TabProgressState state) => Writes.Add(state);
     public void Reset() => Writes.Clear();
 }

--- a/windows/Ghostty.Tests/Taskbar/FakeTaskbarProgressSink.cs
+++ b/windows/Ghostty.Tests/Taskbar/FakeTaskbarProgressSink.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Ghostty.Core.Taskbar;
+
+namespace Ghostty.Tests.Taskbar;
+
+/// <summary>
+/// Recording fake for <see cref="ITaskbarProgressSink"/>. Stores
+/// every <see cref="Write"/> call in order so tests can assert
+/// the full sequence the coordinator emitted.
+/// </summary>
+internal sealed class FakeTaskbarProgressSink : ITaskbarProgressSink
+{
+    public List<TabProgressState> Writes { get; } = new();
+    public TabProgressState Last => Writes.Count == 0 ? TabProgressState.None : Writes[^1];
+    public void Write(TabProgressState state) => Writes.Add(state);
+    public void Reset() => Writes.Clear();
+}

--- a/windows/Ghostty.Tests/Taskbar/TaskbarProgressCoordinatorTests.cs
+++ b/windows/Ghostty.Tests/Taskbar/TaskbarProgressCoordinatorTests.cs
@@ -157,6 +157,47 @@ public class TaskbarProgressCoordinatorTests
     }
 
     [Fact]
+    public void Tab_removed_while_cycling_drops_from_active_list()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
+        mgr.NewTab();
+        mgr.Tabs[1].Progress = TabProgressState.Normal(60);
+        sink.Reset();
+
+        // Close the non-current tab mid-cycle — state machine should
+        // fall back to Single(tab0) and emit tab 0's state.
+        mgr.CloseTab(mgr.Tabs[1]);
+
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.Normal(30), sink.Last);
+
+        // Further ticks must not revisit the removed tab.
+        clock.Advance(TimeSpan.FromSeconds(10));
+        coord.Tick();
+        Assert.Single(sink.Writes);
+    }
+
+    [Fact]
+    public void Dispose_unsubscribes_from_manager_and_tabs()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        coord.Dispose();
+
+        // After dispose, progress changes must not reach the sink.
+        mgr.Tabs[0].Progress = TabProgressState.Normal(42);
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
     public void Pause_freezes_ticks_resume_restarts_slot()
     {
         var (mgr, _) = NewManager();

--- a/windows/Ghostty.Tests/Taskbar/TaskbarProgressCoordinatorTests.cs
+++ b/windows/Ghostty.Tests/Taskbar/TaskbarProgressCoordinatorTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Ghostty.Core.Taskbar;
+using Ghostty.Tests.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Taskbar;
+
+public class TaskbarProgressCoordinatorTests
+{
+    private static (TabManager mgr, List<FakePaneHost> hosts) NewManager()
+    {
+        var hostList = new List<FakePaneHost>();
+        var mgr = new TabManager(() =>
+        {
+            var h = new FakePaneHost();
+            hostList.Add(h);
+            return h;
+        });
+        return (mgr, hostList);
+    }
+
+    /// <summary>
+    /// Test-controllable clock. Tests advance time manually and then
+    /// call Tick(); the real implementation uses DateTime.UtcNow and
+    /// a DispatcherQueueTimer.
+    /// </summary>
+    private sealed class TestClock
+    {
+        public DateTime Now { get; set; } = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public void Advance(TimeSpan t) => Now += t;
+    }
+
+    [Fact]
+    public void Clear_on_construction()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        // No progress reported yet.
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
+    public void First_progress_goes_to_Single_live()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(42);
+
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.Normal(42), sink.Last);
+    }
+
+    [Fact]
+    public void Second_tab_progress_starts_Cycling()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
+        mgr.NewTab();
+        sink.Reset();
+        mgr.Tabs[1].Progress = TabProgressState.Normal(60);
+
+        // On entering Cycling, the coordinator emits the currently
+        // displayed tab's state (tab 0, the one that was already
+        // showing). Subsequent ticks advance to the newly added tab.
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.Normal(30), sink.Last);
+    }
+
+    [Fact]
+    public void Cycling_tick_advances_to_next_tab()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
+        mgr.NewTab();
+        mgr.Tabs[1].Progress = TabProgressState.Normal(60);
+        sink.Reset();
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        coord.Tick();
+
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.Normal(60), sink.Last);
+    }
+
+    [Fact]
+    public void Live_update_to_current_slot_passes_through()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
+        mgr.NewTab();
+        mgr.Tabs[1].Progress = TabProgressState.Normal(60);
+        sink.Reset();
+
+        // Still showing tab 0 as the cycling index. Live update to
+        // tab 0 should pass through; update to tab 1 should not.
+        mgr.Tabs[0].Progress = TabProgressState.Normal(40);
+        mgr.Tabs[1].Progress = TabProgressState.Normal(70);
+
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.Normal(40), sink.Last);
+    }
+
+    [Fact]
+    public void Tab_clears_progress_while_cycling_falls_back_to_single()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
+        mgr.NewTab();
+        mgr.Tabs[1].Progress = TabProgressState.Normal(60);
+        sink.Reset();
+
+        // Tab 1 clears. Falls back to Single(tab0), writes tab 0's state.
+        mgr.Tabs[1].Progress = TabProgressState.None;
+
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.Normal(30), sink.Last);
+    }
+
+    [Fact]
+    public void All_tabs_clear_emits_None()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
+        sink.Reset();
+        mgr.Tabs[0].Progress = TabProgressState.None;
+
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.None, sink.Last);
+    }
+
+    [Fact]
+    public void Pause_freezes_ticks_resume_restarts_slot()
+    {
+        var (mgr, _) = NewManager();
+        var sink = new FakeTaskbarProgressSink();
+        var clock = new TestClock();
+        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
+
+        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
+        mgr.NewTab();
+        mgr.Tabs[1].Progress = TabProgressState.Normal(60);
+        sink.Reset();
+
+        coord.Pause();
+
+        // While paused, ticks are ignored.
+        clock.Advance(TimeSpan.FromSeconds(10));
+        coord.Tick();
+        Assert.Empty(sink.Writes);
+
+        coord.Resume();
+        // Resume starts a fresh slot at the current index (still 0).
+        // Nothing written yet until the next Tick.
+        Assert.Empty(sink.Writes);
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        coord.Tick();
+        Assert.Single(sink.Writes);
+        Assert.Equal(TabProgressState.Normal(60), sink.Last); // advanced to tab 1
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -86,6 +86,15 @@ public sealed partial class TerminalControl : UserControl
         TitleChanged?.Invoke(this, title);
     }
     internal void RaiseCloseRequested() => CloseRequested?.Invoke(this, EventArgs.Empty);
+    internal void RaiseProgressChanged(Ghostty.Core.Tabs.TabProgressState state)
+    {
+        CurrentProgress = state;
+        ProgressChanged?.Invoke(this, state);
+    }
+
+    /// <summary>Most recent OSC 9;4 state reported for this leaf.</summary>
+    internal Ghostty.Core.Tabs.TabProgressState CurrentProgress { get; private set; }
+        = Ghostty.Core.Tabs.TabProgressState.None;
 
     // Events raised from the runtime action callback. They always fire
     // on the UI thread: the callback itself runs on libghostty's thread
@@ -94,6 +103,7 @@ public sealed partial class TerminalControl : UserControl
     // MainWindow subscribes to update the window chrome.
     public event EventHandler<string>? TitleChanged;
     public event EventHandler? CloseRequested;
+    internal event EventHandler<Ghostty.Core.Tabs.TabProgressState>? ProgressChanged;
 
     public TerminalControl()
     {

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -208,9 +208,12 @@ internal sealed class GhosttyHost : IDisposable
                 // inside ghostty_action_s. Layout:
                 //   int32 state  @ +8
                 //   int8  prog   @ +12  (-1 sentinel when no percent)
-                var state = (GhosttyProgressState)Marshal.ReadInt32(actionPtr, 8);
-                var rawPct = (sbyte)Marshal.ReadByte(actionPtr, 12);
-                int pct = rawPct < 0 ? 0 : rawPct;
+                // Decode at the union offset via a pinned struct rather
+                // than manual offset math; keeps us honest if the upstream
+                // field order ever shifts.
+                var report = Marshal.PtrToStructure<GhosttyActionProgressReport>(actionPtr + 8);
+                var state = (GhosttyProgressState)report.State;
+                int pct = report.Progress < 0 ? 0 : report.Progress;
                 var tabState = state switch
                 {
                     GhosttyProgressState.Remove        => Ghostty.Core.Tabs.TabProgressState.None,

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -202,6 +202,32 @@ internal sealed class GhosttyHost : IDisposable
                 return true;
             }
 
+            case GhosttyActionTag.ProgressReport:
+            {
+                // ghostty_action_progress_report_s sits at union offset 8
+                // inside ghostty_action_s. Layout:
+                //   int32 state  @ +8
+                //   int8  prog   @ +12  (-1 sentinel when no percent)
+                var state = (GhosttyProgressState)Marshal.ReadInt32(actionPtr, 8);
+                var rawPct = (sbyte)Marshal.ReadByte(actionPtr, 12);
+                int pct = rawPct < 0 ? 0 : rawPct;
+                var tabState = state switch
+                {
+                    GhosttyProgressState.Remove        => Ghostty.Core.Tabs.TabProgressState.None,
+                    GhosttyProgressState.Set           => Ghostty.Core.Tabs.TabProgressState.Normal(pct),
+                    GhosttyProgressState.Error         => Ghostty.Core.Tabs.TabProgressState.Error(pct),
+                    GhosttyProgressState.Indeterminate => Ghostty.Core.Tabs.TabProgressState.Indeterminate,
+                    GhosttyProgressState.Pause         => Ghostty.Core.Tabs.TabProgressState.Paused(pct),
+                    _ => Ghostty.Core.Tabs.TabProgressState.None,
+                };
+                _dispatcher.TryEnqueue(() =>
+                {
+                    if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                        c.RaiseProgressChanged(tabState);
+                });
+                return true;
+            }
+
             default:
                 return false;
         }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -232,6 +232,30 @@ internal enum GhosttyActionTag
     SetTitle = 32,
     CloseWindow = 49,
     RingBell = 50,
+    ProgressReport = 56,
+}
+
+// ghostty_action_progress_report_state_e ordinal values, matching
+// the enum in include/ghostty.h around line 850. Do not reorder —
+// these are read by value out of the action payload.
+internal enum GhosttyProgressState
+{
+    Remove = 0,
+    Set = 1,
+    Error = 2,
+    Indeterminate = 3,
+    Pause = 4,
+}
+
+// ghostty_action_progress_report_s:
+//   { int32 state; int8 progress; /* -1 if none, else 0..100 */ }
+// Marshalled manually in GhosttyHost since the action union layout
+// places this at a known offset inside the larger action struct.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionProgressReport
+{
+    public int State;
+    public sbyte Progress;
 }
 
 // ghostty_action_set_title_s { const char* title; }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -251,11 +251,13 @@ internal enum GhosttyProgressState
 //   { int32 state; int8 progress; /* -1 if none, else 0..100 */ }
 // Marshalled manually in GhosttyHost since the action union layout
 // places this at a known offset inside the larger action struct.
-[StructLayout(LayoutKind.Sequential)]
+// Pinned offsets rather than LayoutKind.Sequential so any future
+// upstream reorder fails at build time rather than silently misreading.
+[StructLayout(LayoutKind.Explicit, Size = 8)]
 internal struct GhosttyActionProgressReport
 {
-    public int State;
-    public sbyte Progress;
+    [FieldOffset(0)] public int State;
+    [FieldOffset(4)] public sbyte Progress;
 }
 
 // ghostty_action_set_title_s { const char* title; }

--- a/windows/Ghostty/Interop/TaskbarInterop.cs
+++ b/windows/Ghostty/Interop/TaskbarInterop.cs
@@ -10,8 +10,8 @@ namespace Ghostty.Interop;
 /// </summary>
 internal static class TaskbarInterop
 {
-    public static Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
-    public static Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
+    public static readonly Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
+    public static readonly Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
 
     [ComImport]
     [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
@@ -31,7 +31,8 @@ internal static class TaskbarInterop
         void SetProgressState(IntPtr hwnd, TBPFLAG tbpFlags);
     }
 
-    [Flags]
+    // Not [Flags] — ITaskbarList3::SetProgressState takes exactly one
+    // of these values per call, not a combination.
     public enum TBPFLAG
     {
         NOPROGRESS    = 0,

--- a/windows/Ghostty/Interop/TaskbarInterop.cs
+++ b/windows/Ghostty/Interop/TaskbarInterop.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Interop;
+
+/// <summary>
+/// ComImport + CLSIDs / IIDs for <c>ITaskbarList3</c>. Sibling of
+/// <see cref="ShellInterop"/>. Kept narrow to the methods the
+/// progress facade actually invokes.
+/// </summary>
+internal static class TaskbarInterop
+{
+    public static Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
+    public static Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
+
+    [ComImport]
+    [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface ITaskbarList3
+    {
+        // ITaskbarList
+        void HrInit();
+        void AddTab(IntPtr hwnd);
+        void DeleteTab(IntPtr hwnd);
+        void ActivateTab(IntPtr hwnd);
+        void SetActiveAlt(IntPtr hwnd);
+        // ITaskbarList2
+        void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
+        // ITaskbarList3 — only SetProgressValue/SetProgressState used
+        void SetProgressValue(IntPtr hwnd, ulong ullCompleted, ulong ullTotal);
+        void SetProgressState(IntPtr hwnd, TBPFLAG tbpFlags);
+    }
+
+    [Flags]
+    public enum TBPFLAG
+    {
+        NOPROGRESS    = 0,
+        INDETERMINATE = 0x1,
+        NORMAL        = 0x2,
+        ERROR         = 0x4,
+        PAUSED        = 0x8,
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -113,44 +113,75 @@ public sealed partial class MainWindow : Window
 
         // Taskbar progress: wire a TaskbarProgressCoordinator through
         // a real ITaskbarList3 facade, driven by a 2s DispatcherQueueTimer.
-        // Wrapped in try/catch because a COM failure here must not
-        // block window construction — the taskbar indicator is a
-        // nice-to-have.
+        //
+        // Narrow try/catch on COMException only: if CoCreateInstance /
+        // HrInit genuinely fails (explorer down, session 0, etc.) the
+        // indicator is a nice-to-have and we keep the window alive.
+        // Any other exception (NRE, OOM, arg errors) is a real bug and
+        // we let it propagate so it is visible in debug and telemetry.
         try
         {
-            var taskbarHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            _taskbarFacade = new TaskbarList3Facade(taskbarHwnd);
-            _taskbarCoordinator = new TaskbarProgressCoordinator(
+            // Reuse the HWND resolved for the class-brush fix above.
+            var facade = new TaskbarList3Facade(hwnd);
+            var coord = new TaskbarProgressCoordinator(
                 _tabManager,
-                _taskbarFacade,
-                () => System.DateTime.UtcNow);
-            _taskbarTickTimer = DispatcherQueue.CreateTimer();
-            _taskbarTickTimer.Interval = System.TimeSpan.FromSeconds(2);
-            _taskbarTickTimer.IsRepeating = true;
-            _taskbarTickTimer.Tick += (_, _) => _taskbarCoordinator!.Tick();
-            _taskbarTickTimer.Start();
+                facade,
+                () => DateTime.UtcNow);
+            var timer = DispatcherQueue.CreateTimer();
+            timer.Interval = TimeSpan.FromSeconds(2);
+            timer.IsRepeating = true;
+            // Capture the coordinator locally rather than dereferencing
+            // the field via `!`, so a partially-torn-down state cannot
+            // NRE here.
+            timer.Tick += (_, _) => coord.Tick();
+            timer.Start();
+
+            _taskbarFacade = facade;
+            _taskbarCoordinator = coord;
+            _taskbarTickTimer = timer;
 
             // Pause cycling when minimized so the taskbar does not
             // churn while the window is hidden. AppWindow.Changed
-            // fires on presenter state transitions.
-            this.AppWindow.Changed += (_, _) =>
+            // fires on presenter state transitions. Store the handler
+            // so Closed can detach it.
+            _appWindowChanged = (_, _) =>
             {
                 if (this.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter op)
                 {
                     if (op.State == Microsoft.UI.Windowing.OverlappedPresenterState.Minimized)
-                        _taskbarCoordinator?.Pause();
+                        coord.Pause();
                     else
-                        _taskbarCoordinator?.Resume();
+                        coord.Resume();
                 }
             };
+            this.AppWindow.Changed += _appWindowChanged;
         }
-        catch (System.Exception ex)
+        catch (COMException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Taskbar progress wiring failed: {ex.Message}");
+            // Log loudly in debug; in release the taskbar indicator is
+            // simply absent for this window's lifetime.
+            System.Diagnostics.Debug.WriteLine(
+                $"Taskbar progress wiring failed: 0x{ex.HResult:X8} {ex.Message}");
+            System.Diagnostics.Debug.Fail("Taskbar progress wiring failed", ex.ToString());
         }
 
         Closed += (_, _) =>
         {
+            // Tear down the taskbar chain before disposing the host.
+            // Order: stop timer, detach window state handler, dispose
+            // coordinator (unhooks TabManager), dispose facade (releases
+            // the ITaskbarList3 RCW).
+            _taskbarTickTimer?.Stop();
+            if (_appWindowChanged is not null)
+            {
+                this.AppWindow.Changed -= _appWindowChanged;
+                _appWindowChanged = null;
+            }
+            _taskbarCoordinator?.Dispose();
+            _taskbarCoordinator = null;
+            _taskbarFacade?.Dispose();
+            _taskbarFacade = null;
+
             // Surface lifetime is decoupled from Loaded/Unloaded
             // (see TerminalControl.DisposeSurface), so we have to
             // free every leaf in every tab explicitly before tearing

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3,6 +3,8 @@ using System.Runtime.InteropServices;
 using Ghostty.Controls;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Tabs;
+using Ghostty.Core.Taskbar;
+using Ghostty.Taskbar;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Panes;
@@ -23,6 +25,9 @@ public sealed partial class MainWindow : Window
     private readonly GhosttyHost _host;
     private readonly PaneHostFactory _factory;
     private readonly TabManager _tabManager;
+    private TaskbarList3Facade? _taskbarFacade;
+    private TaskbarProgressCoordinator? _taskbarCoordinator;
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _taskbarTickTimer;
     private readonly ITabHost _tabHost;
     private LeafPane? _activeLeaf;
 
@@ -105,6 +110,44 @@ public sealed partial class MainWindow : Window
         HookActiveTabTitle();
 
         _tabManager.LastTabClosed += (_, _) => Close();
+
+        // Taskbar progress: wire a TaskbarProgressCoordinator through
+        // a real ITaskbarList3 facade, driven by a 2s DispatcherQueueTimer.
+        // Wrapped in try/catch because a COM failure here must not
+        // block window construction — the taskbar indicator is a
+        // nice-to-have.
+        try
+        {
+            var taskbarHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            _taskbarFacade = new TaskbarList3Facade(taskbarHwnd);
+            _taskbarCoordinator = new TaskbarProgressCoordinator(
+                _tabManager,
+                _taskbarFacade,
+                () => System.DateTime.UtcNow);
+            _taskbarTickTimer = DispatcherQueue.CreateTimer();
+            _taskbarTickTimer.Interval = System.TimeSpan.FromSeconds(2);
+            _taskbarTickTimer.IsRepeating = true;
+            _taskbarTickTimer.Tick += (_, _) => _taskbarCoordinator!.Tick();
+            _taskbarTickTimer.Start();
+
+            // Pause cycling when minimized so the taskbar does not
+            // churn while the window is hidden. AppWindow.Changed
+            // fires on presenter state transitions.
+            this.AppWindow.Changed += (_, _) =>
+            {
+                if (this.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter op)
+                {
+                    if (op.State == Microsoft.UI.Windowing.OverlappedPresenterState.Minimized)
+                        _taskbarCoordinator?.Pause();
+                    else
+                        _taskbarCoordinator?.Resume();
+                }
+            };
+        }
+        catch (System.Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Taskbar progress wiring failed: {ex.Message}");
+        }
 
         Closed += (_, _) =>
         {

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -87,6 +87,35 @@ internal sealed class PaneHost : UserControl, IPaneHost
     public event EventHandler<LeafPane>? LeafFocused;
 
     /// <summary>
+    /// Raised when the active leaf's <c>TerminalControl</c> reports a
+    /// new OSC 9;4 state. Rewires across leaf-focus changes so only
+    /// the currently active leaf drives the tab-level indicator.
+    /// </summary>
+    public event EventHandler<Ghostty.Core.Tabs.TabProgressState>? ProgressChanged;
+
+    // The leaf whose terminal we are currently subscribed to for
+    // progress updates. Swapped in BindActiveLeafProgress whenever
+    // the active leaf changes.
+    private TerminalControl? _progressBoundTerminal;
+
+    private void BindActiveLeafProgress()
+    {
+        var next = _activeLeaf.Terminal();
+        if (ReferenceEquals(next, _progressBoundTerminal)) return;
+        if (_progressBoundTerminal is not null)
+            _progressBoundTerminal.ProgressChanged -= OnActiveLeafProgressChanged;
+        _progressBoundTerminal = next;
+        next.ProgressChanged += OnActiveLeafProgressChanged;
+        // Re-emit the new leaf's last known state so subscribers see
+        // a correct value immediately after a focus change — without
+        // this the tab would stay stuck on the previous leaf's progress.
+        ProgressChanged?.Invoke(this, next.CurrentProgress);
+    }
+
+    private void OnActiveLeafProgressChanged(object? sender, Ghostty.Core.Tabs.TabProgressState state)
+        => ProgressChanged?.Invoke(this, state);
+
+    /// <summary>
     /// Raised when the last leaf in the tree closes. Subscribers should
     /// close the window.
     /// </summary>
@@ -174,7 +203,13 @@ internal sealed class PaneHost : UserControl, IPaneHost
 
         // Defer the first LeafFocused so subscribers (MainWindow) can
         // wire up before the event fires.
-        Loaded += (_, _) => LeafFocused?.Invoke(this, _activeLeaf);
+        Loaded += (_, _) =>
+        {
+            BindActiveLeafProgress();
+            LeafFocused?.Invoke(this, _activeLeaf);
+        };
+        // Rebind progress whenever the active leaf changes later.
+        LeafFocused += (_, _) => BindActiveLeafProgress();
     }
 
     // Public operations -------------------------------------------------

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -51,9 +51,27 @@ internal sealed partial class TabHost : UserControl, ITabHost
         paneHost.Visibility = Visibility.Collapsed;
         PaneHostContainer.Children.Add(paneHost);
 
+        // Header is a StackPanel with a TextBlock for the title and a
+        // 2px ProgressBar stacked below. Both update from TabModel's
+        // INPC notifications — TabModel raises EffectiveTitle on title
+        // changes and Progress on OSC 9;4 state changes.
+        var headerText = new TextBlock { Text = tab.EffectiveTitle };
+        var headerBar = new ProgressBar
+        {
+            Height = 2,
+            Minimum = 0,
+            Maximum = 100,
+            Visibility = Visibility.Collapsed,
+            IsIndeterminate = false,
+            Margin = new Thickness(0, 1, 0, 0),
+        };
+        var headerPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 0 };
+        headerPanel.Children.Add(headerText);
+        headerPanel.Children.Add(headerBar);
+
         var item = new TabViewItem
         {
-            Header = tab.EffectiveTitle,
+            Header = headerPanel,
             Content = null,
             ContextFlyout = TabContextMenuBuilder.Build(_manager, tab, RequestCloseTabAsync),
             DataContext = tab,
@@ -62,7 +80,25 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // Named handler retained in a dictionary so RemoveItem can
         // unhook it. A lambda captured inline would be unreachable
         // and leak the TabViewItem.
-        PropertyChangedEventHandler handler = (_, _) => RefreshHeader(item, tab);
+        PropertyChangedEventHandler handler = (_, e) =>
+        {
+            if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
+                e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
+                e.PropertyName == nameof(TabModel.UserOverrideTitle))
+            {
+                headerText.Text = tab.EffectiveTitle;
+            }
+            else if (e.PropertyName == nameof(TabModel.Progress))
+            {
+                var p = tab.Progress;
+                headerBar.Visibility = p.State == TabProgressState.Kind.None
+                    ? Visibility.Collapsed
+                    : Visibility.Visible;
+                headerBar.IsIndeterminate = p.State == TabProgressState.Kind.Indeterminate;
+                if (p.State != TabProgressState.Kind.Indeterminate)
+                    headerBar.Value = p.Percent;
+            }
+        };
         tab.PropertyChanged += handler;
         _headerHandlers[tab] = handler;
 
@@ -112,11 +148,6 @@ internal sealed partial class TabHost : UserControl, ITabHost
         _suppressSelectionEvent = true;
         TabViewControl.SelectedItem = item;
         _suppressSelectionEvent = false;
-    }
-
-    private void RefreshHeader(TabViewItem item, TabModel tab)
-    {
-        item.Header = tab.EffectiveTitle;
     }
 
     private void OnAddTabButtonClick(TabView sender, object args) => _manager.NewTab();

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -6,6 +6,8 @@ using Ghostty.Core.Tabs;
 using Ghostty.Panes;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
 
 namespace Ghostty.Tabs;
 
@@ -97,6 +99,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 headerBar.IsIndeterminate = p.State == TabProgressState.Kind.Indeterminate;
                 if (p.State != TabProgressState.Kind.Indeterminate)
                     headerBar.Value = p.Percent;
+                // Mirror the taskbar indicator's coloring so the inline
+                // bar and the taskbar agree on Paused/Error.
+                headerBar.Foreground = p.State switch
+                {
+                    TabProgressState.Kind.Error  => new SolidColorBrush(Colors.Red),
+                    TabProgressState.Kind.Paused => new SolidColorBrush(Colors.Goldenrod),
+                    _ => (Brush)Application.Current.Resources["SystemAccentColorBrush"],
+                };
             }
         };
         tab.PropertyChanged += handler;

--- a/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
@@ -1,0 +1,62 @@
+using System;
+using Ghostty.Core.Tabs;
+using Ghostty.Core.Taskbar;
+using Ghostty.Interop;
+
+namespace Ghostty.Taskbar;
+
+/// <summary>
+/// Real implementation of <see cref="ITaskbarProgressSink"/>.
+/// CoCreates an <see cref="TaskbarInterop.ITaskbarList3"/>, calls
+/// HrInit once, and forwards sink writes to SetProgressValue and
+/// SetProgressState against the window's HWND.
+///
+/// One facade per window. MainWindow constructs it with its HWND.
+/// </summary>
+internal sealed class TaskbarList3Facade : ITaskbarProgressSink
+{
+    private readonly IntPtr _hwnd;
+    private readonly TaskbarInterop.ITaskbarList3 _taskbar;
+
+    public TaskbarList3Facade(IntPtr hwnd)
+    {
+        _hwnd = hwnd;
+        var clsid = TaskbarInterop.CLSID_TaskbarList;
+        var iid = TaskbarInterop.IID_ITaskbarList3;
+        ShellInterop.CoCreateInstance(
+            ref clsid,
+            IntPtr.Zero,
+            ShellInterop.CLSCTX_INPROC_SERVER,
+            ref iid,
+            out var obj);
+        _taskbar = (TaskbarInterop.ITaskbarList3)obj;
+        _taskbar.HrInit();
+    }
+
+    public void Write(TabProgressState state)
+    {
+        switch (state.State)
+        {
+            case TabProgressState.Kind.None:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NOPROGRESS);
+                return;
+            case TabProgressState.Kind.Indeterminate:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.INDETERMINATE);
+                return;
+            case TabProgressState.Kind.Normal:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NORMAL);
+                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
+                return;
+            case TabProgressState.Kind.Paused:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.PAUSED);
+                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
+                return;
+            case TabProgressState.Kind.Error:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.ERROR);
+                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
+                return;
+        }
+    }
+
+    private static int Clamp(int v) => v < 0 ? 0 : v > 100 ? 100 : v;
+}

--- a/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Ghostty.Core.Tabs;
 using Ghostty.Core.Taskbar;
 using Ghostty.Interop;
@@ -11,12 +13,16 @@ namespace Ghostty.Taskbar;
 /// HrInit once, and forwards sink writes to SetProgressValue and
 /// SetProgressState against the window's HWND.
 ///
-/// One facade per window. MainWindow constructs it with its HWND.
+/// One facade per window. MainWindow constructs it with its HWND
+/// and disposes it on Closed so the RCW is released deterministically
+/// rather than waiting on GC.
 /// </summary>
-internal sealed class TaskbarList3Facade : ITaskbarProgressSink
+internal sealed class TaskbarList3Facade : ITaskbarProgressSink, IDisposable
 {
+    private const ulong ProgressTotal = 100UL;
+
     private readonly IntPtr _hwnd;
-    private readonly TaskbarInterop.ITaskbarList3 _taskbar;
+    private TaskbarInterop.ITaskbarList3? _taskbar;
 
     public TaskbarList3Facade(IntPtr hwnd)
     {
@@ -35,27 +41,73 @@ internal sealed class TaskbarList3Facade : ITaskbarProgressSink
 
     public void Write(TabProgressState state)
     {
-        switch (state.State)
+        var taskbar = _taskbar;
+        if (taskbar is null) return;
+
+        // COM RPC can fail at any time (explorer restart, desktop switch,
+        // taskbar in a transient state). The taskbar indicator is a
+        // nice-to-have, so swallow + log rather than take the window
+        // down through the PropertyChanged chain that reaches us.
+        try
         {
-            case TabProgressState.Kind.None:
-                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NOPROGRESS);
-                return;
-            case TabProgressState.Kind.Indeterminate:
-                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.INDETERMINATE);
-                return;
-            case TabProgressState.Kind.Normal:
-                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NORMAL);
-                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
-                return;
-            case TabProgressState.Kind.Paused:
-                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.PAUSED);
-                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
-                return;
-            case TabProgressState.Kind.Error:
-                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.ERROR);
-                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
-                return;
+            switch (state.State)
+            {
+                case TabProgressState.Kind.None:
+                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NOPROGRESS);
+                    return;
+                case TabProgressState.Kind.Indeterminate:
+                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.INDETERMINATE);
+                    return;
+                case TabProgressState.Kind.Normal:
+                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NORMAL);
+                    taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), ProgressTotal);
+                    return;
+                case TabProgressState.Kind.Paused:
+                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.PAUSED);
+                    taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), ProgressTotal);
+                    return;
+                case TabProgressState.Kind.Error:
+                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.ERROR);
+                    taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), ProgressTotal);
+                    return;
+                default:
+                    Debug.Fail($"Unknown TabProgressState.Kind: {state.State}");
+                    return;
+            }
         }
+        catch (COMException ex)
+        {
+            // Explorer restarts, DWM transitions and remote-session
+            // teardown can all kill the live ITaskbarList3 instance.
+            // We don't want to take the window down because the
+            // taskbar indicator stopped responding — but we DO want
+            // debug builds to fail loudly so real bugs are not hidden.
+            // Release builds log to the debug stream and the sink
+            // becomes a no-op for the rest of the window's lifetime.
+            _taskbar = null;
+            Debug.WriteLine($"[TaskbarList3Facade] SetProgress* failed: 0x{ex.HResult:X8} {ex.Message}");
+            Debug.Fail("ITaskbarList3 call failed", ex.ToString());
+        }
+    }
+
+    public void Dispose()
+    {
+        var taskbar = _taskbar;
+        _taskbar = null;
+        if (taskbar is null) return;
+        try
+        {
+            // Best-effort clear so the indicator does not linger after
+            // the window closes.
+            taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NOPROGRESS);
+        }
+        catch (COMException ex)
+        {
+            // Tearing down; the RCW is still released below. Log so
+            // a recurring teardown failure is visible in debug builds.
+            Debug.WriteLine($"[TaskbarList3Facade] teardown clear failed: 0x{ex.HResult:X8} {ex.Message}");
+        }
+        Marshal.FinalReleaseComObject(taskbar);
     }
 
     private static int Clamp(int v) => v < 0 ? 0 : v > 100 ? 100 : v;


### PR DESCRIPTION
> IMPORTANT: part 3 of 3 in a stacked PR chain.
> Stack order:
> 1. #167 windows-tabs-vertical -> windows
> 2. #168 windows-tabs-jumplist -> windows-tabs-vertical
> 3. windows-tabs-taskbar-progress (this PR) -> windows-tabs-jumplist
>
> GitHub will auto-retarget this PR as parent PRs merge.

## Summary
Wires OSC 9;4 progress reports end-to-end: libghostty action -> TerminalControl event -> PaneHost (active-leaf only) -> TabManager -> TabModel.Progress -> taskbar via ITaskbarList3 and a new per-tab inline progress bar under each tab title. Multi-tab sessions cycle the taskbar indicator across active tabs every two seconds while each tab keeps rendering its own live state inline.

The cycling state machine (TaskbarProgressCoordinator) lives in Ghostty.Core as pure-logic, driven by an injectable clock and eight xunit facts that cover Clear/Single/Cycling transitions, live passthrough on the current slot, mid-cycle clears, all-clear, and Pause/Resume. The real ITaskbarList3 path sits behind an ITaskbarProgressSink facade so tests never touch COM. MainWindow runs a 2 second DispatcherQueueTimer against the coordinator and pauses it when the window minimizes.

The libghostty side maps ghostty_action_progress_report_s onto TabProgressState: state is read at union offset +8 and the int8 percent at +12 inside the action payload, translated into None/Normal/Error/Indeterminate/Paused.

The per-tab inline bar that plan 1 had to stub out is back as a StackPanel header on each TabViewItem, reacting to TabModel INPC events.

Manual verification confirmed cycling alternates cleanly every ~2s between two tabs running PowerShell Write-Progress loops (with \`\$PSStyle.Progress.UseOSCIndicator = \$true\`).

## Test plan
- [ ] dotnet test passes the eight new TaskbarProgressCoordinatorTests
- [ ] Single tab with Write-Progress shows both inline bar and taskbar bar advancing in sync
- [ ] Two tabs running Write-Progress: taskbar alternates between them every ~2s, inline bars stay live
- [ ] Minimize pauses cycling, restore resumes from a fresh slot
- [ ] Raw OSC state 2/4 show red error and yellow paused respectively