### PR TITLE
feat(windows): runtime switch between horizontal and vertical tabs

### DIFF
--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -17,13 +17,4 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
-  <!-- InternalsVisibleTo as MSBuild items rather than [assembly: ...]
-       attributes in a source file: the attribute form relies on a
-       specific file staying in the project and on usings preceding
-       namespaces, both of which rot silently. -->
-  <ItemGroup>
-    <InternalsVisibleTo Include="Ghostty" />
-    <InternalsVisibleTo Include="Ghostty.Tests" />
-  </ItemGroup>
 </Project>

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -1,3 +1,8 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Ghostty")]
+[assembly: InternalsVisibleTo("Ghostty.Tests")]
+
 namespace Ghostty.Core.Panes;
 
 internal abstract class PaneNode { }

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -30,15 +30,13 @@ internal sealed class TabManager
 {
     private readonly Func<IPaneHost> _paneHostFactory;
     private readonly ObservableCollection<TabModel> _tabs = new();
-    private readonly ReadOnlyObservableCollection<TabModel> _tabsView;
     private TabModel _activeTab = null!;
 
-    // Exposed as a ReadOnlyObservableCollection so WinUI can still bind
-    // ItemsSource directly (INotifyCollectionChanged is forwarded) but
-    // view code cannot mutate the collection out of band and bypass
-    // TabManager bookkeeping. Tests only use Count / indexer, which
-    // the read-only view exposes.
-    public ReadOnlyObservableCollection<TabModel> Tabs => _tabsView;
+    // Exposed as the concrete ObservableCollection so WinUI can bind
+    // ItemsSource directly and pick up INotifyCollectionChanged for
+    // free. Tests only depend on IReadOnlyList surface (Count, indexer),
+    // which ObservableCollection satisfies.
+    public ObservableCollection<TabModel> Tabs => _tabs;
     public TabModel ActiveTab => _activeTab;
 
     /// <summary>
@@ -59,7 +57,6 @@ internal sealed class TabManager
     public TabManager(Func<IPaneHost> paneHostFactory)
     {
         _paneHostFactory = paneHostFactory;
-        _tabsView = new ReadOnlyObservableCollection<TabModel>(_tabs);
         var first = CreateTab();
         _tabs.Add(first);
         _activeTab = first;

--- a/windows/Ghostty.Core/Taskbar/TaskbarProgressCoordinator.cs
+++ b/windows/Ghostty.Core/Taskbar/TaskbarProgressCoordinator.cs
@@ -26,7 +26,7 @@ namespace Ghostty.Core.Taskbar;
 /// <c>DispatcherQueueTimer</c> to drive <see cref="Tick"/> on a
 /// 2-second cadence.
 /// </summary>
-internal sealed class TaskbarProgressCoordinator : IDisposable
+internal sealed class TaskbarProgressCoordinator
 {
     private const double SlotDurationMs = 2000.0;
 
@@ -34,30 +34,19 @@ internal sealed class TaskbarProgressCoordinator : IDisposable
     private readonly ITaskbarProgressSink _sink;
     private readonly Func<DateTime> _nowProvider;
     private readonly List<TabModel> _active = new();
-    private readonly EventHandler<TabModel> _onTabAdded;
-    private readonly EventHandler<TabModel> _onTabRemoved;
     private int _currentIndex = -1;
     private DateTime _slotStart;
     private bool _paused;
-    private bool _disposed;
 
     public TaskbarProgressCoordinator(TabManager manager, ITaskbarProgressSink sink, Func<DateTime> nowProvider)
     {
-        ArgumentNullException.ThrowIfNull(manager);
-        ArgumentNullException.ThrowIfNull(sink);
-        ArgumentNullException.ThrowIfNull(nowProvider);
-
         _manager = manager;
         _sink = sink;
         _nowProvider = nowProvider;
-        _slotStart = nowProvider();
-
-        _onTabAdded = (_, t) => Subscribe(t);
-        _onTabRemoved = (_, t) => { Unsubscribe(t); ForceRemove(t); };
 
         foreach (var t in _manager.Tabs) Subscribe(t);
-        _manager.TabAdded += _onTabAdded;
-        _manager.TabRemoved += _onTabRemoved;
+        _manager.TabAdded += (_, t) => Subscribe(t);
+        _manager.TabRemoved += (_, t) => { Unsubscribe(t); HandleProgressChange(t); };
     }
 
     public void Pause() => _paused = true;
@@ -85,16 +74,6 @@ internal sealed class TaskbarProgressCoordinator : IDisposable
         _sink.Write(_active[_currentIndex].Progress);
     }
 
-    public void Dispose()
-    {
-        if (_disposed) return;
-        _disposed = true;
-        _manager.TabAdded -= _onTabAdded;
-        _manager.TabRemoved -= _onTabRemoved;
-        foreach (var t in _manager.Tabs) Unsubscribe(t);
-        _active.Clear();
-    }
-
     private void Subscribe(TabModel tab) => tab.PropertyChanged += OnTabPropertyChanged;
 
     private void Unsubscribe(TabModel tab) => tab.PropertyChanged -= OnTabPropertyChanged;
@@ -103,39 +82,6 @@ internal sealed class TaskbarProgressCoordinator : IDisposable
     {
         if (e.PropertyName != nameof(TabModel.Progress)) return;
         if (sender is TabModel t) HandleProgressChange(t);
-    }
-
-    /// <summary>
-    /// Called when a tab is removed from the manager. If the tab was
-    /// currently in the active list we force a "no progress" transition
-    /// so the state machine drops it cleanly — we can't trust
-    /// <see cref="TabModel.Progress"/> here because the closing tab may
-    /// still be mid-report.
-    /// </summary>
-    private void ForceRemove(TabModel tab)
-    {
-        if (!_active.Contains(tab)) return;
-        var wasCurrent = _active[_currentIndex] == tab;
-        _active.Remove(tab);
-
-        if (_active.Count == 0)
-        {
-            _currentIndex = -1;
-            _sink.Write(TabProgressState.None);
-            return;
-        }
-
-        if (_currentIndex >= _active.Count) _currentIndex = 0;
-
-        if (_active.Count == 1)
-        {
-            _currentIndex = 0;
-            _sink.Write(_active[0].Progress);
-            return;
-        }
-
-        if (wasCurrent)
-            _sink.Write(_active[_currentIndex].Progress);
     }
 
     private void HandleProgressChange(TabModel tab)
@@ -165,7 +111,31 @@ internal sealed class TaskbarProgressCoordinator : IDisposable
 
         if (!hasProgress && inList)
         {
-            ForceRemove(tab);
+            var wasCurrent = _active[_currentIndex] == tab;
+            _active.Remove(tab);
+
+            if (_active.Count == 0)
+            {
+                _currentIndex = -1;
+                _sink.Write(TabProgressState.None);
+                return;
+            }
+
+            // Fix up _currentIndex so it still points at a valid slot.
+            if (_currentIndex >= _active.Count) _currentIndex = 0;
+
+            if (_active.Count == 1)
+            {
+                // Cycling -> Single. Emit the remaining tab's state.
+                _currentIndex = 0;
+                _sink.Write(_active[0].Progress);
+                return;
+            }
+
+            // Still Cycling with 2+ left. Only emit if the current
+            // slot was the one that dropped out.
+            if (wasCurrent)
+                _sink.Write(_active[_currentIndex].Progress);
             return;
         }
 

--- a/windows/Ghostty.Tests/JumpList/FakeCustomDestinationList.cs
+++ b/windows/Ghostty.Tests/JumpList/FakeCustomDestinationList.cs
@@ -17,18 +17,10 @@ internal sealed class FakeCustomDestinationList : ICustomDestinationListFacade
 
     public void SetAppId(string appId) => AppId = appId;
 
-    /// <summary>
-    /// Max slots returned from <see cref="BeginList"/>. Defaults to
-    /// <see cref="uint.MaxValue"/> ("no limit") so current tests don't
-    /// accidentally exercise a clamping path that doesn't exist yet;
-    /// future tests can override this to cover slot-limit behaviour.
-    /// </summary>
-    public uint MaxSlots { get; set; } = uint.MaxValue;
-
     public uint BeginList()
     {
         BeginListCalls++;
-        return MaxSlots;
+        return 10; // max slots; arbitrary for fake
     }
 
     public void AddTask(string exePath, string arguments, string title)

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -8,7 +8,7 @@ namespace Ghostty.Tests.JumpList;
 public class JumpListBuilderTests
 {
     private const string TestExe = @"C:\fake\Ghostty.exe";
-    private const string TestAppId = Ghostty.Core.AppIdentity.AumId;
+    private const string TestAppId = "com.deblasis.ghostty";
 
     [Fact]
     public void Build_sets_app_id()

--- a/windows/Ghostty.Tests/Tabs/TabManagerTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerTests.cs
@@ -20,26 +20,6 @@ public class TabManagerTests
     }
 
     [Fact]
-    public void PaneHost_progress_forwards_to_TabModel_and_stops_after_close()
-    {
-        var mgr = NewManager(out var hosts);
-        var tab = mgr.Tabs[0];
-        var host = hosts[0];
-
-        host.RaiseProgressChanged(TabProgressState.Normal(50));
-        Assert.Equal(TabProgressState.Normal(50), tab.Progress);
-
-        host.RaiseProgressChanged(TabProgressState.Error(75));
-        Assert.Equal(TabProgressState.Error(75), tab.Progress);
-
-        // After CloseTab the forwarding handler must be unhooked.
-        mgr.NewTab(); // CloseTab refuses to close the last tab
-        mgr.CloseTab(tab);
-        host.RaiseProgressChanged(TabProgressState.Normal(99));
-        Assert.NotEqual(TabProgressState.Normal(99), tab.Progress);
-    }
-
-    [Fact]
     public void Construction_creates_one_tab_and_activates_it()
     {
         var mgr = NewManager(out var hosts);

--- a/windows/Ghostty.Tests/Taskbar/FakeTaskbarProgressSink.cs
+++ b/windows/Ghostty.Tests/Taskbar/FakeTaskbarProgressSink.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Ghostty.Core.Tabs;
 using Ghostty.Core.Taskbar;
@@ -13,15 +12,7 @@ namespace Ghostty.Tests.Taskbar;
 internal sealed class FakeTaskbarProgressSink : ITaskbarProgressSink
 {
     public List<TabProgressState> Writes { get; } = new();
-
-    /// <summary>Last recorded write. Throws if nothing has been
-    /// written yet so callers can't silently conflate "no writes"
-    /// with "wrote None".</summary>
-    public TabProgressState Last =>
-        Writes.Count == 0
-            ? throw new InvalidOperationException("No writes recorded yet.")
-            : Writes[^1];
-
+    public TabProgressState Last => Writes.Count == 0 ? TabProgressState.None : Writes[^1];
     public void Write(TabProgressState state) => Writes.Add(state);
     public void Reset() => Writes.Clear();
 }

--- a/windows/Ghostty.Tests/Taskbar/TaskbarProgressCoordinatorTests.cs
+++ b/windows/Ghostty.Tests/Taskbar/TaskbarProgressCoordinatorTests.cs
@@ -157,47 +157,6 @@ public class TaskbarProgressCoordinatorTests
     }
 
     [Fact]
-    public void Tab_removed_while_cycling_drops_from_active_list()
-    {
-        var (mgr, _) = NewManager();
-        var sink = new FakeTaskbarProgressSink();
-        var clock = new TestClock();
-        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
-
-        mgr.Tabs[0].Progress = TabProgressState.Normal(30);
-        mgr.NewTab();
-        mgr.Tabs[1].Progress = TabProgressState.Normal(60);
-        sink.Reset();
-
-        // Close the non-current tab mid-cycle — state machine should
-        // fall back to Single(tab0) and emit tab 0's state.
-        mgr.CloseTab(mgr.Tabs[1]);
-
-        Assert.Single(sink.Writes);
-        Assert.Equal(TabProgressState.Normal(30), sink.Last);
-
-        // Further ticks must not revisit the removed tab.
-        clock.Advance(TimeSpan.FromSeconds(10));
-        coord.Tick();
-        Assert.Single(sink.Writes);
-    }
-
-    [Fact]
-    public void Dispose_unsubscribes_from_manager_and_tabs()
-    {
-        var (mgr, _) = NewManager();
-        var sink = new FakeTaskbarProgressSink();
-        var clock = new TestClock();
-        var coord = new TaskbarProgressCoordinator(mgr, sink, () => clock.Now);
-
-        coord.Dispose();
-
-        // After dispose, progress changes must not reach the sink.
-        mgr.Tabs[0].Progress = TabProgressState.Normal(42);
-        Assert.Empty(sink.Writes);
-    }
-
-    [Fact]
     public void Pause_freezes_ticks_resume_restarts_slot()
     {
         var (mgr, _) = NewManager();

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -91,15 +91,14 @@ public partial class App : Application
         // the process-to-AUMID association on first use and reads
         // the jump list from a per-AUMID store. Without this, the
         // jump list silently no-ops on unpackaged exes.
+        const string AppUserModelId = "com.deblasis.ghostty";
         try
         {
-            Ghostty.Interop.ShellInterop.SetCurrentProcessExplicitAppUserModelID(Ghostty.Core.AppIdentity.AumId);
+            Ghostty.Interop.ShellInterop.SetCurrentProcessExplicitAppUserModelID(AppUserModelId);
         }
-        catch (System.Runtime.InteropServices.COMException ex)
+        catch (System.Exception ex)
         {
-            // Visible in Release too — Trace goes to attached debuggers
-            // and the process's default trace listeners, unlike Debug.
-            System.Diagnostics.Trace.TraceWarning("Ghostty: failed to set AUMID: 0x{0:x8} {1}", ex.HResult, ex.Message);
+            System.Diagnostics.Debug.WriteLine($"Failed to set AUMID: {ex.Message}");
             // Continue anyway; app still functions, just without jump list.
         }
 
@@ -114,19 +113,19 @@ public partial class App : Application
             var exePath = System.Environment.ProcessPath ?? string.Empty;
             if (!string.IsNullOrEmpty(exePath))
             {
-                using var facade = new Ghostty.JumpList.CustomDestinationListFacade();
+                var facade = new Ghostty.JumpList.CustomDestinationListFacade();
                 var builder = new Ghostty.Core.JumpList.JumpListBuilder(
                     facade,
                     // TODO(config): profiles — swap for config-driven list
                     profilesProvider: () => System.Array.Empty<Ghostty.Core.JumpList.ProfileEntry>(),
                     exePath: exePath,
-                    appId: Ghostty.Core.AppIdentity.AumId);
+                    appId: AppUserModelId);
                 builder.Build();
             }
         }
-        catch (System.Runtime.InteropServices.COMException ex)
+        catch (System.Exception ex)
         {
-            System.Diagnostics.Trace.TraceWarning("Ghostty: failed to build jump list: 0x{0:x8} {1}", ex.HResult, ex.Message);
+            System.Diagnostics.Debug.WriteLine($"Failed to build jump list: {ex.Message}");
             // Jump list is nice-to-have; failure here does not block startup.
         }
 

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -94,7 +94,8 @@ public partial class App : Application
         const string AppUserModelId = "com.deblasis.ghostty";
         try
         {
-            Ghostty.Interop.ShellInterop.SetCurrentProcessExplicitAppUserModelID(AppUserModelId);
+            System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(
+                Ghostty.Interop.ShellInterop.SetCurrentProcessExplicitAppUserModelID(AppUserModelId));
         }
         catch (System.Exception ex)
         {

--- a/windows/Ghostty/Dialogs/DialogTracker.cs
+++ b/windows/Ghostty/Dialogs/DialogTracker.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Dialogs;
+
+/// <summary>
+/// Registers every in-flight <see cref="ContentDialog"/> so
+/// <c>MainWindow.Closed</c> can wait for them to dismiss before
+/// tearing down the libghostty host. Shutting down while a dialog is
+/// still on-screen races the XAML data-binding teardown and throws
+/// <c>COMException</c> out of the runtime — see
+/// files-community/Files #17363 for the well-known reproducer.
+///
+/// Usage:
+///   using (tracker.Track(dialog))
+///   {
+///       var result = await dialog.ShowAsync();
+///   }
+///
+/// The token disposes the tracker entry when the dialog's own
+/// <see cref="ContentDialog.ShowAsync"/> completes, whether the user
+/// confirmed, cancelled, or the runtime forced it to close.
+/// </summary>
+internal sealed class DialogTracker
+{
+    private readonly HashSet<TaskCompletionSource> _pending = new();
+    private readonly object _lock = new();
+
+    public int PendingCount
+    {
+        get { lock (_lock) return _pending.Count; }
+    }
+
+    /// <summary>
+    /// Register a dialog as open. Returns a disposable token whose
+    /// Dispose() marks the entry as complete. Callers wrap their
+    /// <c>await dialog.ShowAsync()</c> in a <c>using</c>.
+    /// </summary>
+    public System.IDisposable Track(ContentDialog dialog)
+    {
+        var tcs = new TaskCompletionSource();
+        lock (_lock) _pending.Add(tcs);
+        return new Token(this, tcs, dialog);
+    }
+
+    /// <summary>
+    /// Await every dialog currently tracked. Safe to call multiple
+    /// times; if nothing is pending, completes immediately.
+    /// </summary>
+    public Task WhenAllClosedAsync()
+    {
+        Task[] tasks;
+        lock (_lock)
+        {
+            if (_pending.Count == 0) return Task.CompletedTask;
+            tasks = new Task[_pending.Count];
+            int i = 0;
+            foreach (var t in _pending) tasks[i++] = t.Task;
+        }
+        return Task.WhenAll(tasks);
+    }
+
+    private void Release(TaskCompletionSource tcs)
+    {
+        lock (_lock) _pending.Remove(tcs);
+        tcs.TrySetResult();
+    }
+
+    private sealed class Token : System.IDisposable
+    {
+        private readonly DialogTracker _tracker;
+        private readonly TaskCompletionSource _tcs;
+        private readonly ContentDialog _dialog;
+        private bool _disposed;
+
+        public Token(DialogTracker tracker, TaskCompletionSource tcs, ContentDialog dialog)
+        {
+            _tracker = tracker;
+            _tcs = tcs;
+            _dialog = dialog;
+            // If the window is closing while the dialog is showing,
+            // MainWindow hides the dialog explicitly; we still need
+            // the Closed handler to release the TCS even when the
+            // caller's await is abandoned.
+            _dialog.Closed += OnClosed;
+        }
+
+        private void OnClosed(ContentDialog sender, ContentDialogClosedEventArgs args)
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _dialog.Closed -= OnClosed;
+            _tracker.Release(_tcs);
+        }
+    }
+}

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -23,6 +23,14 @@
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <!--
+      Allow [GeneratedComInterface] types to interop with the few
+      remaining [ComImport] surfaces (e.g. WinRT projections, the
+      ISwapChainPanelNative shim) during the transition to fully
+      AOT-safe COM. The interop shim is on by default in .NET 9 but
+      we set it explicitly so the contract is documented in the csproj.
+    -->
+    <EnableGeneratedComInterfaceComImportInterop>true</EnableGeneratedComInterfaceComImportInterop>
   </PropertyGroup>
 
   <ItemGroup>

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -26,21 +26,16 @@ internal sealed class GhosttyHost : IDisposable
     private GhosttyApp _app;
 
     /// <summary>
-    /// Monotonic millisecond tick of the most recent key event seen by
-    /// any <see cref="Ghostty.Controls.TerminalControl"/> bound to this
-    /// host. Read by <see cref="Tabs.VerticalTabHost"/>'s hover-expand
-    /// suppression to decide whether the user is mid-typing (popping
-    /// the sidebar in that case would feel jarring and could interfere
-    /// with an IME composition).
-    ///
-    /// <see cref="Environment.TickCount64"/> rather than
-    /// <see cref="DateTime.UtcNow"/>: monotonic, immune to NTP / DST
-    /// jumps, and a single read instead of a DateTime allocation on
-    /// every keystroke.
+    /// UTC timestamp of the most recent key event seen by any
+    /// <see cref="Ghostty.Controls.TerminalControl"/> bound to this
+    /// host. Read by <see cref="Tabs.VerticalTabHost"/>'s
+    /// hover-expand suppression to decide whether the user is
+    /// mid-typing (popping the sidebar in that case would feel
+    /// jarring and could interfere with an IME composition).
     /// </summary>
-    public long LastKeystrokeTick { get; private set; } = long.MinValue / 2;
+    public DateTime LastKeystrokeTimestamp { get; private set; } = DateTime.MinValue;
 
-    internal void NoteKeystroke() => LastKeystrokeTick = Environment.TickCount64;
+    internal void NoteKeystroke() => LastKeystrokeTimestamp = DateTime.UtcNow;
 
     // Delegates must be retained as fields; P/Invoke hands out native
     // function pointers the GC cannot track.
@@ -208,12 +203,9 @@ internal sealed class GhosttyHost : IDisposable
                 // inside ghostty_action_s. Layout:
                 //   int32 state  @ +8
                 //   int8  prog   @ +12  (-1 sentinel when no percent)
-                // Decode at the union offset via a pinned struct rather
-                // than manual offset math; keeps us honest if the upstream
-                // field order ever shifts.
-                var report = Marshal.PtrToStructure<GhosttyActionProgressReport>(actionPtr + 8);
-                var state = (GhosttyProgressState)report.State;
-                int pct = report.Progress < 0 ? 0 : report.Progress;
+                var state = (GhosttyProgressState)Marshal.ReadInt32(actionPtr, 8);
+                var rawPct = (sbyte)Marshal.ReadByte(actionPtr, 12);
+                int pct = rawPct < 0 ? 0 : rawPct;
                 var tabState = state switch
                 {
                     GhosttyProgressState.Remove        => Ghostty.Core.Tabs.TabProgressState.None,

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text;
 using Windows.System;
 
 namespace Ghostty.Input;
@@ -52,6 +53,29 @@ internal sealed class KeyBindings
     /// config-driven loader lands with 50+ bindings, switch to a
     /// Dictionary&lt;(mods,key), action&gt; built once in the ctor.
     /// </summary>
+    /// <summary>
+    /// Render the binding for <paramref name="action"/> as a
+    /// human-readable chord (e.g. <c>Ctrl+Shift+Alt+V</c>), or
+    /// <c>null</c> if no binding exists. Used for tooltips so the
+    /// chord text and the KeyboardAccelerator are sourced from the
+    /// same place.
+    /// </summary>
+    public string? Label(PaneAction action)
+    {
+        foreach (var b in _bindings)
+        {
+            if (b.Action != action) continue;
+            var sb = new StringBuilder();
+            if ((b.Modifiers & VirtualKeyModifiers.Control) != 0) sb.Append("Ctrl+");
+            if ((b.Modifiers & VirtualKeyModifiers.Shift) != 0)   sb.Append("Shift+");
+            if ((b.Modifiers & VirtualKeyModifiers.Menu) != 0)    sb.Append("Alt+");
+            if ((b.Modifiers & VirtualKeyModifiers.Windows) != 0) sb.Append("Win+");
+            sb.Append(b.Key);
+            return sb.ToString();
+        }
+        return null;
+    }
+
     public PaneAction? Match(VirtualKeyModifiers modifiers, VirtualKey key)
     {
         foreach (var b in _bindings)

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -97,5 +97,7 @@ internal sealed class KeyBindings
         // is enabled; PaneActionRouter no-ops if the host is not a
         // VerticalTabHost.
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Space, PaneAction.ToggleVerticalTabsPinned),
+        // Runtime switch between horizontal and vertical tab layouts.
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift | VirtualKeyModifiers.Menu, VirtualKey.V, PaneAction.ToggleTabLayout),
     });
 }

--- a/windows/Ghostty/Input/PaneAction.cs
+++ b/windows/Ghostty/Input/PaneAction.cs
@@ -31,4 +31,5 @@ internal enum PaneAction
     MoveTabRight,
     MoveTabLeft,
     ToggleVerticalTabsPinned,
+    ToggleTabLayout,
 }

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -17,12 +17,47 @@ namespace Ghostty.Input;
 /// full-tab close is needed, the router raises
 /// <see cref="TabCloseRequestedFromKeyboard"/> so MainWindow can show
 /// the multi-pane confirmation dialog from a context with an XamlRoot.
+///
+/// Instance-scoped: one <see cref="PaneActionRouter"/> per
+/// <see cref="TabManager"/>, owned by <c>MainWindow</c>. The earlier
+/// version exposed static events which kept MainWindow rooted past
+/// close and would leak once the shell supported multiple windows.
 /// </summary>
-internal static class PaneActionRouter
+internal sealed class PaneActionRouter
 {
-    public static void Invoke(PaneAction action, TabManager tabs)
+    private readonly TabManager _tabs;
+
+    public PaneActionRouter(TabManager tabs)
     {
-        var pane = tabs.ActiveTab.PaneHost;
+        _tabs = tabs;
+    }
+
+    public TabManager Tabs => _tabs;
+
+    /// <summary>
+    /// Raised when the Ctrl+Shift+Space chord fires. MainWindow
+    /// listens and calls <c>VerticalTabHost.TogglePinnedFromKeyboard</c>
+    /// if the current <see cref="Tabs.ITabHost"/> is a VerticalTabHost.
+    /// </summary>
+    public event EventHandler? ToggleVerticalTabsPinnedRequested;
+
+    /// <summary>
+    /// Raised when the Ctrl+Shift+Alt+V chord — or the title-bar
+    /// icon, or the context-menu item — fires. MainWindow listens
+    /// and runs its animated layout switch.
+    /// </summary>
+    public event EventHandler? ToggleTabLayoutRequested;
+
+    /// <summary>
+    /// Raised when the keyboard close chord targets a full-tab close.
+    /// MainWindow listens and shows the confirmation dialog (if needed)
+    /// before calling <see cref="TabManager.CloseTab"/>.
+    /// </summary>
+    public event EventHandler? TabCloseRequestedFromKeyboard;
+
+    public void Invoke(PaneAction action)
+    {
+        var pane = _tabs.ActiveTab.PaneHost;
         var concrete = (PaneHost)pane;
         switch (action)
         {
@@ -36,44 +71,36 @@ internal static class PaneActionRouter
             case PaneAction.FocusDown:       concrete.FocusDirection(FocusDirection.Down); break;
 
             // Tabs
-            case PaneAction.NewTab: tabs.NewTab(); break;
-            case PaneAction.CloseActiveProgressive: HandleProgressiveClose(tabs); break;
-            case PaneAction.NextTab: tabs.Next(); break;
-            case PaneAction.PrevTab: tabs.Prev(); break;
-            case PaneAction.JumpTab1: tabs.JumpTo(0); break;
-            case PaneAction.JumpTab2: tabs.JumpTo(1); break;
-            case PaneAction.JumpTab3: tabs.JumpTo(2); break;
-            case PaneAction.JumpTab4: tabs.JumpTo(3); break;
-            case PaneAction.JumpTab5: tabs.JumpTo(4); break;
-            case PaneAction.JumpTab6: tabs.JumpTo(5); break;
-            case PaneAction.JumpTab7: tabs.JumpTo(6); break;
-            case PaneAction.JumpTab8: tabs.JumpTo(7); break;
-            case PaneAction.JumpTabLast: tabs.JumpToLast(); break;
+            case PaneAction.NewTab: _tabs.NewTab(); break;
+            case PaneAction.CloseActiveProgressive: HandleProgressiveClose(); break;
+            case PaneAction.NextTab: _tabs.Next(); break;
+            case PaneAction.PrevTab: _tabs.Prev(); break;
+            case PaneAction.JumpTab1: _tabs.JumpTo(0); break;
+            case PaneAction.JumpTab2: _tabs.JumpTo(1); break;
+            case PaneAction.JumpTab3: _tabs.JumpTo(2); break;
+            case PaneAction.JumpTab4: _tabs.JumpTo(3); break;
+            case PaneAction.JumpTab5: _tabs.JumpTo(4); break;
+            case PaneAction.JumpTab6: _tabs.JumpTo(5); break;
+            case PaneAction.JumpTab7: _tabs.JumpTo(6); break;
+            case PaneAction.JumpTab8: _tabs.JumpTo(7); break;
+            case PaneAction.JumpTabLast: _tabs.JumpToLast(); break;
             case PaneAction.MoveTabRight:
             {
-                var i = tabs.IndexOf(tabs.ActiveTab);
-                if (i >= 0 && i < tabs.Tabs.Count - 1) tabs.Move(i, i + 1);
+                var i = _tabs.IndexOf(_tabs.ActiveTab);
+                if (i >= 0 && i < _tabs.Tabs.Count - 1) _tabs.Move(i, i + 1);
                 break;
             }
             case PaneAction.MoveTabLeft:
             {
-                var i = tabs.IndexOf(tabs.ActiveTab);
-                if (i > 0) tabs.Move(i, i - 1);
+                var i = _tabs.IndexOf(_tabs.ActiveTab);
+                if (i > 0) _tabs.Move(i, i - 1);
                 break;
             }
             case PaneAction.ToggleVerticalTabsPinned:
-                // Route to the ITabHost via an event so the router
-                // stays free of direct ITabHost dependencies.
-                // MainWindow listens and calls TogglePinnedFromKeyboard
-                // on the VerticalTabHost if that's the active layout;
-                // horizontal layout ignores it.
-                ToggleVerticalTabsPinnedFromKeyboard?.Invoke(null, tabs);
+                ToggleVerticalTabsPinnedRequested?.Invoke(this, EventArgs.Empty);
                 break;
             case PaneAction.ToggleTabLayout:
-                // Runtime switch between horizontal and vertical tabs.
-                // MainWindow listens and calls ToggleTabLayout which
-                // animates the transition and persists the choice.
-                ToggleTabLayoutFromKeyboard?.Invoke(null, tabs);
+                ToggleTabLayoutRequested?.Invoke(this, EventArgs.Empty);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(action), action, null);
@@ -81,47 +108,24 @@ internal static class PaneActionRouter
     }
 
     /// <summary>
-    /// Raised when the Ctrl+Shift+Space chord fires. MainWindow
-    /// listens and calls <c>VerticalTabHost.TogglePinnedFromKeyboard</c>
-    /// if the current <see cref="ITabHost"/> is a VerticalTabHost.
-    /// </summary>
-    public static event EventHandler<TabManager>? ToggleVerticalTabsPinnedFromKeyboard;
-
-    /// <summary>
-    /// Raised when the Ctrl+Shift+Alt+V chord fires. MainWindow
-    /// listens and calls its own ToggleTabLayout which flips the
-    /// active tab host between horizontal and vertical with an
-    /// animated transition.
-    /// </summary>
-    public static event EventHandler<TabManager>? ToggleTabLayoutFromKeyboard;
-
-    /// <summary>
     /// Public dispatch entry used by non-keyboard triggers (context
     /// menu, title-bar button). Reuses the same event path so
     /// MainWindow has a single handler for every toggle source.
     /// </summary>
-    public static void RequestToggleTabLayout(TabManager tabs)
-        => ToggleTabLayoutFromKeyboard?.Invoke(null, tabs);
+    public void RequestToggleTabLayout()
+        => ToggleTabLayoutRequested?.Invoke(this, EventArgs.Empty);
 
-    private static void HandleProgressiveClose(TabManager tabs)
+    private void HandleProgressiveClose()
     {
         // If the active tab has more than one pane, close one and stop.
         // Otherwise the entire tab is being closed; emit the request
         // event so MainWindow can show the confirmation dialog
         // (TabManager has no XamlRoot).
-        if (tabs.ActiveTab.PaneHost.PaneCount > 1)
+        if (_tabs.ActiveTab.PaneHost.PaneCount > 1)
         {
-            tabs.ActiveTab.PaneHost.CloseActive();
+            _tabs.ActiveTab.PaneHost.CloseActive();
             return;
         }
-        TabCloseRequestedFromKeyboard?.Invoke(null, tabs);
+        TabCloseRequestedFromKeyboard?.Invoke(this, EventArgs.Empty);
     }
-
-    /// <summary>
-    /// Raised when the keyboard close chord targets a full-tab close.
-    /// MainWindow listens and shows the confirmation dialog (if needed)
-    /// before calling <see cref="TabManager.CloseTab"/>. The event lives
-    /// here so the router stays free of WinUI dialog dependencies.
-    /// </summary>
-    public static event EventHandler<TabManager>? TabCloseRequestedFromKeyboard;
 }

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -9,22 +9,18 @@ namespace Ghostty.Input;
 /// Dispatches a <see cref="PaneAction"/> against a target
 /// <see cref="TabManager"/>. Pane actions are routed to the active
 /// tab's <see cref="IPaneHost"/>; tab actions are routed to the
-/// manager directly. Single switch lives here so adding a new
+/// manager directly. Single switch lives here so that adding a new
 /// action is one place to edit.
 ///
-/// Escape hooks (full-tab close confirmation and vertical-tabs
-/// pinned toggle) are passed in as delegates per invocation rather
-/// than raised through static events. Static events would root
-/// every MainWindow closure forever — a real leak once multi-window
-/// lands. Per-call delegates keep the router stateless.
+/// CloseActiveProgressive is special: when a pane-only close suffices
+/// it goes directly to <see cref="IPaneHost.CloseActive"/>; when a
+/// full-tab close is needed, the router raises
+/// <see cref="TabCloseRequestedFromKeyboard"/> so MainWindow can show
+/// the multi-pane confirmation dialog from a context with an XamlRoot.
 /// </summary>
 internal static class PaneActionRouter
 {
-    public static void Invoke(
-        PaneAction action,
-        TabManager tabs,
-        Action<TabManager>? onTabCloseRequested = null,
-        Action<TabManager>? onToggleVerticalTabsPinned = null)
+    public static void Invoke(PaneAction action, TabManager tabs)
     {
         var pane = tabs.ActiveTab.PaneHost;
         var concrete = (PaneHost)pane;
@@ -41,7 +37,7 @@ internal static class PaneActionRouter
 
             // Tabs
             case PaneAction.NewTab: tabs.NewTab(); break;
-            case PaneAction.CloseActiveProgressive: HandleProgressiveClose(tabs, onTabCloseRequested); break;
+            case PaneAction.CloseActiveProgressive: HandleProgressiveClose(tabs); break;
             case PaneAction.NextTab: tabs.Next(); break;
             case PaneAction.PrevTab: tabs.Prev(); break;
             case PaneAction.JumpTab1: tabs.JumpTo(0); break;
@@ -66,23 +62,66 @@ internal static class PaneActionRouter
                 break;
             }
             case PaneAction.ToggleVerticalTabsPinned:
-                onToggleVerticalTabsPinned?.Invoke(tabs);
+                // Route to the ITabHost via an event so the router
+                // stays free of direct ITabHost dependencies.
+                // MainWindow listens and calls TogglePinnedFromKeyboard
+                // on the VerticalTabHost if that's the active layout;
+                // horizontal layout ignores it.
+                ToggleVerticalTabsPinnedFromKeyboard?.Invoke(null, tabs);
+                break;
+            case PaneAction.ToggleTabLayout:
+                // Runtime switch between horizontal and vertical tabs.
+                // MainWindow listens and calls ToggleTabLayout which
+                // animates the transition and persists the choice.
+                ToggleTabLayoutFromKeyboard?.Invoke(null, tabs);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(action), action, null);
         }
     }
 
-    private static void HandleProgressiveClose(TabManager tabs, Action<TabManager>? onTabCloseRequested)
+    /// <summary>
+    /// Raised when the Ctrl+Shift+Space chord fires. MainWindow
+    /// listens and calls <c>VerticalTabHost.TogglePinnedFromKeyboard</c>
+    /// if the current <see cref="ITabHost"/> is a VerticalTabHost.
+    /// </summary>
+    public static event EventHandler<TabManager>? ToggleVerticalTabsPinnedFromKeyboard;
+
+    /// <summary>
+    /// Raised when the Ctrl+Shift+Alt+V chord fires. MainWindow
+    /// listens and calls its own ToggleTabLayout which flips the
+    /// active tab host between horizontal and vertical with an
+    /// animated transition.
+    /// </summary>
+    public static event EventHandler<TabManager>? ToggleTabLayoutFromKeyboard;
+
+    /// <summary>
+    /// Public dispatch entry used by non-keyboard triggers (context
+    /// menu, title-bar button). Reuses the same event path so
+    /// MainWindow has a single handler for every toggle source.
+    /// </summary>
+    public static void RequestToggleTabLayout(TabManager tabs)
+        => ToggleTabLayoutFromKeyboard?.Invoke(null, tabs);
+
+    private static void HandleProgressiveClose(TabManager tabs)
     {
         // If the active tab has more than one pane, close one and stop.
-        // Otherwise the entire tab is being closed; let the caller show
-        // the confirmation dialog (TabManager has no XamlRoot).
+        // Otherwise the entire tab is being closed; emit the request
+        // event so MainWindow can show the confirmation dialog
+        // (TabManager has no XamlRoot).
         if (tabs.ActiveTab.PaneHost.PaneCount > 1)
         {
             tabs.ActiveTab.PaneHost.CloseActive();
             return;
         }
-        onTabCloseRequested?.Invoke(tabs);
+        TabCloseRequestedFromKeyboard?.Invoke(null, tabs);
     }
+
+    /// <summary>
+    /// Raised when the keyboard close chord targets a full-tab close.
+    /// MainWindow listens and shows the confirmation dialog (if needed)
+    /// before calling <see cref="TabManager.CloseTab"/>. The event lives
+    /// here so the router stays free of WinUI dialog dependencies.
+    /// </summary>
+    public static event EventHandler<TabManager>? TabCloseRequestedFromKeyboard;
 }

--- a/windows/Ghostty/Interop/ComCreate.cs
+++ b/windows/Ghostty/Interop/ComCreate.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Ghostty.Interop;
+
+/// <summary>
+/// Trim/AOT-safe replacement for the legacy
+/// <c>CoCreateInstance(out object)</c> P/Invoke. Returns the raw
+/// IUnknown* via <c>out IntPtr</c> and lets a
+/// <see cref="StrategyBasedComWrappers"/> instance wrap it into a
+/// strongly-typed managed interface.
+///
+/// Why this exists: <c>[GeneratedComInterface]</c> types are the
+/// modern way to declare COM contracts on .NET 8+ and the only
+/// path that survives <c>PublishAot</c> (CsWinRT #1927). The legacy
+/// <c>[MarshalAs(UnmanagedType.Interface)] out object</c> signature
+/// requires runtime marshalling and silently breaks under the
+/// trimmer. Migrating CoCreateInstance to <c>out IntPtr</c> + a
+/// shared <see cref="ComWrappers"/> instance lets every call site
+/// use the generated COM path without each one re-implementing
+/// QueryInterface.
+/// </summary>
+internal static partial class ComCreate
+{
+    /// <summary>
+    /// Shared ComWrappers instance. Strategy-based wrappers handle
+    /// QueryInterface dispatch across every <c>[GeneratedComInterface]</c>
+    /// the runtime knows about, so a single instance is enough for
+    /// the whole process.
+    /// </summary>
+    private static readonly StrategyBasedComWrappers s_wrappers = new();
+
+    public const uint CLSCTX_INPROC_SERVER = 0x1;
+
+    [LibraryImport("ole32.dll")]
+    private static partial int CoCreateInstance(
+        in Guid rclsid,
+        IntPtr pUnkOuter,
+        uint dwClsContext,
+        in Guid riid,
+        out IntPtr ppv);
+
+    /// <summary>
+    /// Activate <paramref name="clsid"/> and query for
+    /// <paramref name="iid"/>, then wrap the resulting IUnknown* in
+    /// a strongly-typed managed object. Caller is expected to cast
+    /// the returned object to the matching <c>[GeneratedComInterface]</c>
+    /// type. Throws on HRESULT failure.
+    /// </summary>
+    public static object Create(Guid clsid, Guid iid)
+    {
+        var hr = CoCreateInstance(in clsid, IntPtr.Zero, CLSCTX_INPROC_SERVER, in iid, out var ppv);
+        Marshal.ThrowExceptionForHR(hr);
+        try
+        {
+            return s_wrappers.GetOrCreateObjectForComInstance(ppv, CreateObjectFlags.None);
+        }
+        finally
+        {
+            // GetOrCreateObjectForComInstance AddRefs the unknown for
+            // its own lifetime tracking, so we release the reference
+            // CoCreateInstance gave us.
+            Marshal.Release(ppv);
+        }
+    }
+
+    /// <summary>
+    /// Wrap an existing IUnknown* in a managed object. Used when
+    /// QueryInterface'ing across <c>[GeneratedComInterface]</c>
+    /// types — e.g. an <c>IShellLinkW</c> instance also exposing
+    /// <c>IPropertyStore</c>.
+    /// </summary>
+    public static object Wrap(IntPtr unknown)
+        => s_wrappers.GetOrCreateObjectForComInstance(unknown, CreateObjectFlags.None);
+
+    /// <summary>
+    /// Reverse of <see cref="Wrap"/>: hand back the IUnknown* for a
+    /// managed RCW that was created via the shared
+    /// <see cref="StrategyBasedComWrappers"/>. Replacement for the
+    /// runtime-only <see cref="Marshal.GetIUnknownForObject"/>,
+    /// which warns SYSLIB1099 against <c>[GeneratedComInterface]</c>
+    /// targets. Caller owns the returned reference and must
+    /// <see cref="Marshal.Release"/> it.
+    /// </summary>
+    public static IntPtr GetIUnknown(object com)
+        => s_wrappers.GetOrCreateComInterfaceForObject(com, CreateComInterfaceFlags.None);
+}

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -251,13 +251,11 @@ internal enum GhosttyProgressState
 //   { int32 state; int8 progress; /* -1 if none, else 0..100 */ }
 // Marshalled manually in GhosttyHost since the action union layout
 // places this at a known offset inside the larger action struct.
-// Pinned offsets rather than LayoutKind.Sequential so any future
-// upstream reorder fails at build time rather than silently misreading.
-[StructLayout(LayoutKind.Explicit, Size = 8)]
+[StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyActionProgressReport
 {
-    [FieldOffset(0)] public int State;
-    [FieldOffset(4)] public sbyte Progress;
+    public int State;
+    public sbyte Progress;
 }
 
 // ghostty_action_set_title_s { const char* title; }

--- a/windows/Ghostty/Interop/ShellInterop.cs
+++ b/windows/Ghostty/Interop/ShellInterop.cs
@@ -1,37 +1,34 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Ghostty.Interop;
 
 /// <summary>
-/// ComImport declarations and P/Invoke for the Windows Shell APIs
-/// this project needs. Kept in one file so the ABI surface is easy
-/// to audit.
+/// <c>[GeneratedComInterface]</c> declarations for the Windows
+/// Shell APIs the jump-list code consumes, plus the
+/// <c>SetCurrentProcessExplicitAppUserModelID</c> P/Invoke and
+/// PROPVARIANT helpers needed to set <c>System.Title</c> on a
+/// shell link.
 ///
-/// Interfaces: ICustomDestinationList (jump list), IObjectCollection
-/// (category content), IObjectArray (read-only views), IShellLinkW
-/// (entries), IPropertyStore (link titles), plus the PROPERTYKEY /
-/// PROPVARIANT helpers needed to set System.Title on a shell link.
+/// Migrated from <c>[ComImport]</c> in the
+/// dotnet-windows-reviewer-skill review of PR 170: the legacy
+/// attribute relies on runtime marshalling and silently breaks
+/// under <c>PublishAot</c> (CsWinRT #1927). The
+/// <c>StringMarshalling = Utf16</c> setting matches the original
+/// <c>UnmanagedType.LPWStr</c> behavior so the wire format is
+/// unchanged.
 ///
-/// P/Invoke: SetCurrentProcessExplicitAppUserModelID from shell32.
+/// Activation goes through <see cref="ComCreate.Create"/>, which
+/// uses a shared <c>StrategyBasedComWrappers</c> to translate the
+/// raw IUnknown* into a strongly-typed managed wrapper.
 /// </summary>
-internal static class ShellInterop
+internal static partial class ShellInterop
 {
     // P/Invoke ---------------------------------------------------
 
-    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
-    public static extern void SetCurrentProcessExplicitAppUserModelID(
-        [MarshalAs(UnmanagedType.LPWStr)] string AppID);
-
-    [DllImport("ole32.dll", PreserveSig = false)]
-    public static extern void CoCreateInstance(
-        [In] ref Guid rclsid,
-        IntPtr pUnkOuter,
-        uint dwClsContext,
-        [In] ref Guid riid,
-        [MarshalAs(UnmanagedType.Interface)] out object ppv);
-
-    public const uint CLSCTX_INPROC_SERVER = 0x1;
+    [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16)]
+    public static partial int SetCurrentProcessExplicitAppUserModelID(string AppID);
 
     // CLSIDs -----------------------------------------------------
 
@@ -49,86 +46,110 @@ internal static class ShellInterop
 
     // ICustomDestinationList ------------------------------------
 
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("6332debf-87b5-4670-90c0-5e57b408a49e")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface ICustomDestinationList
+    public partial interface ICustomDestinationList
     {
         void SetAppID([MarshalAs(UnmanagedType.LPWStr)] string pszAppID);
-        void BeginList(out uint pcMaxSlots, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
-        void AppendCategory([MarshalAs(UnmanagedType.LPWStr)] string pszCategory, [MarshalAs(UnmanagedType.Interface)] IObjectArray poa);
+        void BeginList(out uint pcMaxSlots, in Guid riid, out IntPtr ppv);
+        void AppendCategory([MarshalAs(UnmanagedType.LPWStr)] string pszCategory, IObjectArray poa);
         void AppendKnownCategory(int category);
-        void AddUserTasks([MarshalAs(UnmanagedType.Interface)] IObjectArray poa);
+        void AddUserTasks(IObjectArray poa);
         void CommitList();
-        void GetRemovedDestinations([In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+        void GetRemovedDestinations(in Guid riid, out IntPtr ppv);
         void DeleteList([MarshalAs(UnmanagedType.LPWStr)] string pszAppID);
         void AbortList();
     }
 
+    // IObjectArray -----------------------------------------------
+
+    [GeneratedComInterface]
+    [Guid("92ca9dcd-5622-4bba-a805-5e9f541bd8c9")]
+    public partial interface IObjectArray
+    {
+        void GetCount(out uint pcObjects);
+        void GetAt(uint uiIndex, in Guid riid, out IntPtr ppv);
+    }
+
     // IObjectCollection (extends IObjectArray) -------------------
 
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("5632b1a4-e38a-400a-928a-d4cd63230295")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IObjectCollection
+    public partial interface IObjectCollection
     {
         // IObjectArray methods (this interface inherits from it)
         void GetCount(out uint pcObjects);
-        void GetAt(uint uiIndex, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
+        void GetAt(uint uiIndex, in Guid riid, out IntPtr ppv);
         // IObjectCollection additions
-        void AddObject([MarshalAs(UnmanagedType.IUnknown)] object punk);
-        void AddFromArray([MarshalAs(UnmanagedType.Interface)] IObjectArray poaSource);
+        void AddObject(IntPtr punk);
+        void AddFromArray(IObjectArray poaSource);
         void RemoveObjectAt(uint uiIndex);
         void Clear();
     }
 
-    [ComImport]
-    [Guid("92ca9dcd-5622-4bba-a805-5e9f541bd8c9")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IObjectArray
-    {
-        void GetCount(out uint pcObjects);
-        void GetAt(uint uiIndex, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppv);
-    }
+    // IShellLinkW ------------------------------------------------
 
-    // IShellLinkW -------------------------------------------------
-
-    [ComImport]
+    /// <summary>
+    /// IShellLinkW vtable. Only the Set* methods we actually need
+    /// are declared with full signatures; the Get* methods take
+    /// <c>StringBuilder</c> output buffers, which source-generated
+    /// COM does not support (SYSLIB1052). They are placeholders so
+    /// the vtable index of every Set* method matches the COM ABI —
+    /// each unused entry is declared as <c>void Reserved_NN()</c>
+    /// and never called from managed code.
+    /// </summary>
+    [GeneratedComInterface]
     [Guid("000214f9-0000-0000-c000-000000000046")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IShellLinkW
+    public partial interface IShellLinkW
     {
-        void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszFile, int cch, IntPtr pfd, uint fFlags);
+        // 0: GetPath — unused, output StringBuilder is unsupported
+        void GetPath_Reserved();
+        // 1: GetIDList
         void GetIDList(out IntPtr ppidl);
+        // 2: SetIDList
         void SetIDList(IntPtr pidl);
-        void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszName, int cch);
+        // 3: GetDescription — unused
+        void GetDescription_Reserved();
+        // 4
         void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
-        void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszDir, int cch);
+        // 5: GetWorkingDirectory — unused
+        void GetWorkingDirectory_Reserved();
+        // 6
         void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
-        void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszArgs, int cch);
+        // 7: GetArguments — unused
+        void GetArguments_Reserved();
+        // 8
         void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+        // 9
         void GetHotkey(out ushort pwHotkey);
+        // 10
         void SetHotkey(ushort wHotkey);
+        // 11
         void GetShowCmd(out int piShowCmd);
+        // 12
         void SetShowCmd(int iShowCmd);
-        void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder pszIconPath, int cch, out int piIcon);
+        // 13: GetIconLocation — unused
+        void GetIconLocation_Reserved();
+        // 14
         void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+        // 15
         void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
+        // 16
         void Resolve(IntPtr hwnd, uint fFlags);
+        // 17
         void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
     }
 
     // IPropertyStore ---------------------------------------------
 
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IPropertyStore
+    public partial interface IPropertyStore
     {
         void GetCount(out uint cProps);
         void GetAt(uint iProp, out PROPERTYKEY pkey);
-        void GetValue([In] ref PROPERTYKEY key, out PROPVARIANT pv);
-        void SetValue([In] ref PROPERTYKEY key, [In] ref PROPVARIANT pv);
+        void GetValue(in PROPERTYKEY key, out PROPVARIANT pv);
+        void SetValue(in PROPERTYKEY key, in PROPVARIANT pv);
         void Commit();
     }
 
@@ -158,8 +179,8 @@ internal static class ShellInterop
 
     public const ushort VT_LPWSTR = 31;
 
-    [DllImport("ole32.dll")]
-    public static extern int PropVariantClear(ref PROPVARIANT pvar);
+    [LibraryImport("ole32.dll")]
+    public static partial int PropVariantClear(ref PROPVARIANT pvar);
 
     /// <summary>
     /// Helper: populate a shell link's System.Title so the jump list
@@ -168,20 +189,34 @@ internal static class ShellInterop
     /// </summary>
     public static void SetShellLinkTitle(IShellLinkW link, string title)
     {
-        var store = (IPropertyStore)link;
-        var pv = new PROPVARIANT
-        {
-            vt = VT_LPWSTR,
-            pointerValue = Marshal.StringToCoTaskMemUni(title),
-        };
+        // The IShellLinkW COM object also implements IPropertyStore;
+        // cross-interface QI happens through the shared ComWrappers
+        // strategy. Reach the underlying IUnknown via the strategy
+        // wrappers (Marshal.GetIUnknownForObject is runtime-only and
+        // SYSLIB1099 against [GeneratedComInterface] types) and wrap
+        // it once for the IPropertyStore facet.
+        var unknown = ComCreate.GetIUnknown(link);
         try
         {
-            store.SetValue(ref PKEY_Title, ref pv);
-            store.Commit();
+            var store = (IPropertyStore)ComCreate.Wrap(unknown);
+            var pv = new PROPVARIANT
+            {
+                vt = VT_LPWSTR,
+                pointerValue = Marshal.StringToCoTaskMemUni(title),
+            };
+            try
+            {
+                store.SetValue(in PKEY_Title, in pv);
+                store.Commit();
+            }
+            finally
+            {
+                PropVariantClear(ref pv);
+            }
         }
         finally
         {
-            PropVariantClear(ref pv);
+            Marshal.Release(unknown);
         }
     }
 }

--- a/windows/Ghostty/Interop/ShellInterop.cs
+++ b/windows/Ghostty/Interop/ShellInterop.cs
@@ -14,26 +14,14 @@ namespace Ghostty.Interop;
 /// PROPVARIANT helpers needed to set System.Title on a shell link.
 ///
 /// P/Invoke: SetCurrentProcessExplicitAppUserModelID from shell32.
-///
-/// TODO(aot): these declarations use classic [ComImport] + [DllImport]
-/// which pull in runtime marshalling and are incompatible with
-/// [assembly: DisableRuntimeMarshalling] and NativeAOT. When the rest
-/// of the Windows shell flips to AOT, migrate this file to
-/// [GeneratedComInterface]/[LibraryImport] — or, preferably, replace
-/// it entirely with CsWin32-generated bindings (ICustomDestinationList,
-/// IShellLinkW, IPropertyStore, PROPVARIANT, CoCreateInstance and
-/// SetCurrentProcessExplicitAppUserModelID are all in Win32 metadata).
 /// </summary>
-internal static partial class ShellInterop
+internal static class ShellInterop
 {
     // P/Invoke ---------------------------------------------------
 
-    // SetCurrentProcessExplicitAppUserModelID is a plain void(LPCWSTR)
-    // export with no runtime-marshalling surface worth speaking of, so
-    // it's already AOT-friendly via LibraryImport.
-    [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16)]
-    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
-    public static partial void SetCurrentProcessExplicitAppUserModelID(string AppID);
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    public static extern void SetCurrentProcessExplicitAppUserModelID(
+        [MarshalAs(UnmanagedType.LPWStr)] string AppID);
 
     [DllImport("ole32.dll", PreserveSig = false)]
     public static extern void CoCreateInstance(
@@ -47,17 +35,17 @@ internal static partial class ShellInterop
 
     // CLSIDs -----------------------------------------------------
 
-    public static readonly Guid CLSID_DestinationList = new("77f10cf0-3db5-4966-b520-b7c54fd35ed6");
-    public static readonly Guid CLSID_EnumerableObjectCollection = new("2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
-    public static readonly Guid CLSID_ShellLink = new("00021401-0000-0000-c000-000000000046");
+    public static Guid CLSID_DestinationList = new("77f10cf0-3db5-4966-b520-b7c54fd35ed6");
+    public static Guid CLSID_EnumerableObjectCollection = new("2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
+    public static Guid CLSID_ShellLink = new("00021401-0000-0000-c000-000000000046");
 
     // Interface IIDs ---------------------------------------------
 
-    public static readonly Guid IID_ICustomDestinationList = new("6332debf-87b5-4670-90c0-5e57b408a49e");
-    public static readonly Guid IID_IObjectCollection = new("5632b1a4-e38a-400a-928a-d4cd63230295");
-    public static readonly Guid IID_IObjectArray = new("92ca9dcd-5622-4bba-a805-5e9f541bd8c9");
-    public static readonly Guid IID_IShellLinkW = new("000214f9-0000-0000-c000-000000000046");
-    public static readonly Guid IID_IPropertyStore = new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
+    public static Guid IID_ICustomDestinationList = new("6332debf-87b5-4670-90c0-5e57b408a49e");
+    public static Guid IID_IObjectCollection = new("5632b1a4-e38a-400a-928a-d4cd63230295");
+    public static Guid IID_IObjectArray = new("92ca9dcd-5622-4bba-a805-5e9f541bd8c9");
+    public static Guid IID_IShellLinkW = new("000214f9-0000-0000-c000-000000000046");
+    public static Guid IID_IPropertyStore = new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
 
     // ICustomDestinationList ------------------------------------
 
@@ -156,20 +144,12 @@ internal static partial class ShellInterop
     }
 
     /// <summary>System.Title: PKEY used to set the display name on a shell link for jump list entries.</summary>
-    public static readonly PROPERTYKEY PKEY_Title = new(new Guid("f29f85e0-4ff9-1068-ab91-08002b27b3d9"), 2);
+    public static PROPERTYKEY PKEY_Title = new(new Guid("f29f85e0-4ff9-1068-ab91-08002b27b3d9"), 2);
 
     // PROPVARIANT for VT_LPWSTR strings. Only the vt + union pointer
     // fields are used; the rest is padding. Caller is responsible for
     // allocating/freeing the string (CoTaskMemAlloc / PropVariantClear).
-    //
-    // Size is pinned explicitly: the native PROPVARIANT is 16 bytes on
-    // x86 and 24 bytes on x64 (8-byte header + 16-byte union — the
-    // largest union member being BLOB { ULONG cbSize; BYTE* pBlobData; }
-    // or CA* caXxx, both of which pad to 16 on x64). Without Size, the
-    // marshaller sizes the struct at max(offset+size)=16 and
-    // IPropertyStore::SetValue — which does a full-sized PropVariantCopy
-    // internally — would read 8 bytes past our managed storage on x64.
-    [StructLayout(LayoutKind.Explicit, Size = 24)]
+    [StructLayout(LayoutKind.Explicit)]
     public struct PROPVARIANT
     {
         [FieldOffset(0)] public ushort vt;

--- a/windows/Ghostty/Interop/ShellInterop.cs
+++ b/windows/Ghostty/Interop/ShellInterop.cs
@@ -35,17 +35,17 @@ internal static class ShellInterop
 
     // CLSIDs -----------------------------------------------------
 
-    public static Guid CLSID_DestinationList = new("77f10cf0-3db5-4966-b520-b7c54fd35ed6");
-    public static Guid CLSID_EnumerableObjectCollection = new("2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
-    public static Guid CLSID_ShellLink = new("00021401-0000-0000-c000-000000000046");
+    public static readonly Guid CLSID_DestinationList = new("77f10cf0-3db5-4966-b520-b7c54fd35ed6");
+    public static readonly Guid CLSID_EnumerableObjectCollection = new("2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
+    public static readonly Guid CLSID_ShellLink = new("00021401-0000-0000-c000-000000000046");
 
     // Interface IIDs ---------------------------------------------
 
-    public static Guid IID_ICustomDestinationList = new("6332debf-87b5-4670-90c0-5e57b408a49e");
-    public static Guid IID_IObjectCollection = new("5632b1a4-e38a-400a-928a-d4cd63230295");
-    public static Guid IID_IObjectArray = new("92ca9dcd-5622-4bba-a805-5e9f541bd8c9");
-    public static Guid IID_IShellLinkW = new("000214f9-0000-0000-c000-000000000046");
-    public static Guid IID_IPropertyStore = new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
+    public static readonly Guid IID_ICustomDestinationList = new("6332debf-87b5-4670-90c0-5e57b408a49e");
+    public static readonly Guid IID_IObjectCollection = new("5632b1a4-e38a-400a-928a-d4cd63230295");
+    public static readonly Guid IID_IObjectArray = new("92ca9dcd-5622-4bba-a805-5e9f541bd8c9");
+    public static readonly Guid IID_IShellLinkW = new("000214f9-0000-0000-c000-000000000046");
+    public static readonly Guid IID_IPropertyStore = new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
 
     // ICustomDestinationList ------------------------------------
 

--- a/windows/Ghostty/Interop/TaskbarInterop.cs
+++ b/windows/Ghostty/Interop/TaskbarInterop.cs
@@ -10,8 +10,8 @@ namespace Ghostty.Interop;
 /// </summary>
 internal static class TaskbarInterop
 {
-    public static readonly Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
-    public static readonly Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
+    public static Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
+    public static Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
 
     [ComImport]
     [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
@@ -31,8 +31,7 @@ internal static class TaskbarInterop
         void SetProgressState(IntPtr hwnd, TBPFLAG tbpFlags);
     }
 
-    // Not [Flags] — ITaskbarList3::SetProgressState takes exactly one
-    // of these values per call, not a combination.
+    [Flags]
     public enum TBPFLAG
     {
         NOPROGRESS    = 0,

--- a/windows/Ghostty/Interop/TaskbarInterop.cs
+++ b/windows/Ghostty/Interop/TaskbarInterop.cs
@@ -1,22 +1,27 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Ghostty.Interop;
 
 /// <summary>
-/// ComImport + CLSIDs / IIDs for <c>ITaskbarList3</c>. Sibling of
-/// <see cref="ShellInterop"/>. Kept narrow to the methods the
-/// progress facade actually invokes.
+/// <c>[GeneratedComInterface]</c> declaration for
+/// <c>ITaskbarList3</c>. Sibling of <see cref="ShellInterop"/>;
+/// kept narrow to the methods the progress facade actually
+/// invokes (HrInit, SetProgressValue, SetProgressState).
+///
+/// Migrated from <c>[ComImport]</c> in the
+/// dotnet-windows-reviewer-skill review of PR 170 — see
+/// <see cref="ShellInterop"/> for the rationale.
 /// </summary>
-internal static class TaskbarInterop
+internal static partial class TaskbarInterop
 {
     public static readonly Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
     public static readonly Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
 
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface ITaskbarList3
+    public partial interface ITaskbarList3
     {
         // ITaskbarList
         void HrInit();
@@ -26,7 +31,7 @@ internal static class TaskbarInterop
         void SetActiveAlt(IntPtr hwnd);
         // ITaskbarList2
         void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
-        // ITaskbarList3 — only SetProgressValue/SetProgressState used
+        // ITaskbarList3 — only SetProgressValue / SetProgressState used
         void SetProgressValue(IntPtr hwnd, ulong ullCompleted, ulong ullTotal);
         void SetProgressState(IntPtr hwnd, TBPFLAG tbpFlags);
     }

--- a/windows/Ghostty/Interop/TaskbarInterop.cs
+++ b/windows/Ghostty/Interop/TaskbarInterop.cs
@@ -10,8 +10,8 @@ namespace Ghostty.Interop;
 /// </summary>
 internal static class TaskbarInterop
 {
-    public static Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
-    public static Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
+    public static readonly Guid CLSID_TaskbarList = new("56fdf344-fd6d-11d0-958a-006097c9a090");
+    public static readonly Guid IID_ITaskbarList3 = new("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf");
 
     [ComImport]
     [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]

--- a/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
+++ b/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Ghostty.Core.JumpList;
 using Ghostty.Interop;
 
@@ -27,15 +28,9 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
 
     public CustomDestinationListFacade()
     {
-        var clsid = ShellInterop.CLSID_DestinationList;
-        var iid = ShellInterop.IID_ICustomDestinationList;
-        ShellInterop.CoCreateInstance(
-            ref clsid,
-            IntPtr.Zero,
-            ShellInterop.CLSCTX_INPROC_SERVER,
-            ref iid,
-            out var obj);
-        _list = (ShellInterop.ICustomDestinationList)obj;
+        _list = (ShellInterop.ICustomDestinationList)ComCreate.Create(
+            ShellInterop.CLSID_DestinationList,
+            ShellInterop.IID_ICustomDestinationList);
     }
 
     public void SetAppId(string appId) => _list.SetAppID(appId);
@@ -43,7 +38,7 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
     public uint BeginList()
     {
         var iid = ShellInterop.IID_IObjectArray;
-        _list.BeginList(out var maxSlots, ref iid, out _);
+        _list.BeginList(out var maxSlots, in iid, out _);
         return maxSlots;
     }
 
@@ -56,9 +51,12 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
         foreach (var e in entries)
         {
             var link = CreateShellLink(e.exePath, e.args, e.title);
-            collection.AddObject(link);
+            AddObjectToCollection(collection, link);
         }
-        var array = (ShellInterop.IObjectArray)collection;
+        // The IObjectCollection IUnknown is also queryable as
+        // IObjectArray; cross-interface QI happens through the
+        // shared ComWrappers strategy.
+        var array = QueryAsObjectArray(collection);
         _list.AppendCategory(categoryName, array);
     }
 
@@ -70,9 +68,9 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
             foreach (var t in _pendingTasks)
             {
                 var link = CreateShellLink(t.exe, t.args, t.title);
-                collection.AddObject(link);
+                AddObjectToCollection(collection, link);
             }
-            _list.AddUserTasks((ShellInterop.IObjectArray)collection);
+            _list.AddUserTasks(QueryAsObjectArray(collection));
             _pendingTasks.Clear();
         }
         _list.CommitList();
@@ -80,15 +78,9 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
 
     private static ShellInterop.IShellLinkW CreateShellLink(string exePath, string arguments, string title)
     {
-        var clsid = ShellInterop.CLSID_ShellLink;
-        var iid = ShellInterop.IID_IShellLinkW;
-        ShellInterop.CoCreateInstance(
-            ref clsid,
-            IntPtr.Zero,
-            ShellInterop.CLSCTX_INPROC_SERVER,
-            ref iid,
-            out var obj);
-        var link = (ShellInterop.IShellLinkW)obj;
+        var link = (ShellInterop.IShellLinkW)ComCreate.Create(
+            ShellInterop.CLSID_ShellLink,
+            ShellInterop.IID_IShellLinkW);
         link.SetPath(exePath);
         link.SetArguments(arguments);
         link.SetDescription(title);
@@ -100,15 +92,46 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
     }
 
     private static ShellInterop.IObjectCollection CreateCollection()
+        => (ShellInterop.IObjectCollection)ComCreate.Create(
+            ShellInterop.CLSID_EnumerableObjectCollection,
+            ShellInterop.IID_IObjectCollection);
+
+    /// <summary>
+    /// AddObject takes a raw IUnknown* under [GeneratedComInterface]
+    /// (the runtime-marshalled <c>UnmanagedType.IUnknown</c> path is
+    /// trim-unsafe). Bridge by calling Marshal.GetIUnknownForObject
+    /// for the duration of the call and releasing the reference
+    /// once the collection has AddRef'd it.
+    /// </summary>
+    private static void AddObjectToCollection(ShellInterop.IObjectCollection collection, object com)
     {
-        var clsid = ShellInterop.CLSID_EnumerableObjectCollection;
-        var iid = ShellInterop.IID_IObjectCollection;
-        ShellInterop.CoCreateInstance(
-            ref clsid,
-            IntPtr.Zero,
-            ShellInterop.CLSCTX_INPROC_SERVER,
-            ref iid,
-            out var obj);
-        return (ShellInterop.IObjectCollection)obj;
+        var unknown = ComCreate.GetIUnknown(com);
+        try
+        {
+            collection.AddObject(unknown);
+        }
+        finally
+        {
+            Marshal.Release(unknown);
+        }
+    }
+
+    /// <summary>
+    /// QueryInterface the IObjectCollection's underlying IUnknown
+    /// for IObjectArray and return the typed wrapper. The shared
+    /// ComWrappers strategy hands out a wrapper that implements both
+    /// interfaces against the same RCW identity.
+    /// </summary>
+    private static ShellInterop.IObjectArray QueryAsObjectArray(ShellInterop.IObjectCollection collection)
+    {
+        var unknown = ComCreate.GetIUnknown(collection);
+        try
+        {
+            return (ShellInterop.IObjectArray)ComCreate.Wrap(unknown);
+        }
+        finally
+        {
+            Marshal.Release(unknown);
+        }
     }
 }

--- a/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
+++ b/windows/Ghostty/JumpList/CustomDestinationListFacade.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using Ghostty.Core.JumpList;
 using Ghostty.Interop;
 
@@ -12,12 +11,11 @@ namespace Ghostty.JumpList;
 /// COM object via <see cref="ShellInterop.CoCreateInstance"/> on
 /// construction and forwards every facade call to it.
 ///
-/// The instance is single-use: one BeginList/Commit cycle per facade.
-/// Dispose after Commit to release the underlying STA RCW deterministically
-/// instead of waiting for the finalizer queue. Callers in App.xaml.cs
-/// wrap the facade in a <c>using</c> block.
+/// One instance per process is typical; <see cref="JumpListBuilder"/>
+/// calls <see cref="BeginList"/> and <see cref="Commit"/> in pairs
+/// to replace the list wholesale.
 /// </summary>
-internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade, IDisposable
+internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
 {
     private readonly ShellInterop.ICustomDestinationList _list;
     // AddUserTasks on ICustomDestinationList is a one-shot call per
@@ -60,43 +58,24 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
             var link = CreateShellLink(e.exePath, e.args, e.title);
             collection.AddObject(link);
         }
-        // QI cast: IObjectCollection inherits IObjectArray at the COM
-        // level but not in the C# type system (classic ComImport doesn't
-        // chain vtables), so this cast goes through the RCW's
-        // QueryInterface rather than a type-system coercion.
         var array = (ShellInterop.IObjectArray)collection;
         _list.AppendCategory(categoryName, array);
     }
 
     public void Commit()
     {
-        try
+        if (_pendingTasks.Count > 0)
         {
-            if (_pendingTasks.Count > 0)
+            var collection = CreateCollection();
+            foreach (var t in _pendingTasks)
             {
-                var collection = CreateCollection();
-                foreach (var t in _pendingTasks)
-                {
-                    var link = CreateShellLink(t.exe, t.args, t.title);
-                    collection.AddObject(link);
-                }
-                _list.AddUserTasks((ShellInterop.IObjectArray)collection);
+                var link = CreateShellLink(t.exe, t.args, t.title);
+                collection.AddObject(link);
             }
-            _list.CommitList();
-        }
-        finally
-        {
-            // Always drop pending state, even on failure, so a retried
-            // Commit() on the same facade doesn't replay stale tasks.
+            _list.AddUserTasks((ShellInterop.IObjectArray)collection);
             _pendingTasks.Clear();
         }
-    }
-
-    public void Dispose()
-    {
-        // Deterministically release the STA RCW so the underlying
-        // ICustomDestinationList doesn't sit on the finalizer queue.
-        Marshal.FinalReleaseComObject(_list);
+        _list.CommitList();
     }
 
     private static ShellInterop.IShellLinkW CreateShellLink(string exePath, string arguments, string title)
@@ -112,9 +91,10 @@ internal sealed class CustomDestinationListFacade : ICustomDestinationListFacade
         var link = (ShellInterop.IShellLinkW)obj;
         link.SetPath(exePath);
         link.SetArguments(arguments);
-        // Title shown in the jump list comes from System.Title on the
-        // IPropertyStore side of this object — IShellLinkW.SetDescription
-        // is ignored by the Shell jump list UI on Win10+. Skip it.
+        link.SetDescription(title);
+        // Title shown in the jump list comes from System.Title, not
+        // the description. Set it via the IPropertyStore side of the
+        // same object.
         ShellInterop.SetShellLinkTitle(link, title);
         return link;
     }

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -6,13 +6,106 @@
     Title="Ghostty">
 
     <!--
-        RootGrid background matches a typical terminal background (Windows
-        Terminal's default #0C0C0C). Without this, the Window's default
-        white content background bleeds through during a resize: WinUI 3
-        grows the SwapChainPanel before DX12 finishes ResizeBuffers and
-        re-renders, leaving a visible white frame around the still-old
-        swap chain contents. A dark fill makes that gap effectively
-        invisible against any dark color scheme.
+        Declarative layout for the dual tab-host shell.
+
+        Row 0 hosts either the horizontal TabHost's tab strip (spans
+        both columns) OR the vertical-mode title bar (also spans both
+        columns), depending on the active layout.
+
+        Row 1 hosts the shared PaneHostContainer in column 1 — that
+        container is the single owner of every PaneHost in the visual
+        tree and is never re-parented, so the DCOMP SwapChainPanel
+        handoff stays intact across tab switches and layout switches.
+
+        Column 0 is the vertical strip lane: 0 px wide in horizontal
+        mode, 40 px (collapsed) / 220 px (pinned) wide in vertical
+        mode. Width is animated from code-behind because WinUI 3 has
+        no native GridLengthAnimation and converting to Star units
+        would force the horizontal strip into a separate row.
+
+        Layout-mode visibility is toggled by SnapLayoutState in code-
+        behind via Visibility on the two hosts and the title bar. A
+        VisualStateManager state group would be the textbook
+        declarative choice but VSM.GoToState targets a Control, and
+        Window.Content here is a Grid — wrapping in a UserControl for
+        VSM alone would add a layer the rest of the shell does not
+        need. The key anti-pattern (mutating RowDefinition /
+        ColumnDefinition sizes in code-behind) is already addressed
+        by declaring the row/column structure here instead of in
+        BuildLayout().
+
+        The cross-fade Storyboard in code-behind targets
+        RenderTransform on each host so it stays compositor-driven.
+
+        The #0C0C0C fill mirrors Windows Terminal's default background
+        and hides the brief uncovered area during interactive resize
+        before DX12 finishes its ResizeBuffers pass.
     -->
-    <Grid x:Name="RootGrid" Background="#0C0C0C" />
+    <Grid x:Name="RootGrid" Background="#0C0C0C">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="StripColumn" Width="0"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!--
+            Vertical-mode title bar. Spans both columns so the drag
+            region and title text fill the window width; the caption
+            inset on the right reserves room for the OS min/max/close
+            buttons. Width of that inset is kept in sync with
+            AppWindow.TitleBar.RightInset from code-behind.
+        -->
+        <Grid x:Name="VerticalTitleBar"
+              Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+              Height="32"
+              Background="Transparent"
+              Visibility="Collapsed">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition x:Name="VerticalCaptionInset" Width="146"/>
+            </Grid.ColumnDefinitions>
+
+            <Grid x:Name="VerticalTitleDragRegion"
+                  Grid.Column="0"
+                  Background="Transparent">
+
+                <Button x:Name="VerticalSwitchButton"
+                        Width="32" Height="32"
+                        Padding="0"
+                        Margin="44,0,0,0"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Click="OnVerticalSwitchButtonClick">
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                              Glyph="&#xE8A9;"
+                              FontSize="{StaticResource BodyTextBlockFontSize}"/>
+                </Button>
+
+                <TextBlock x:Name="VerticalTitleText"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Center"
+                           FontSize="{StaticResource CaptionTextBlockFontSize}"
+                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                           TextTrimming="CharacterEllipsis"
+                           IsHitTestVisible="False"/>
+            </Grid>
+        </Grid>
+
+        <!--
+            Shared PaneHostContainer: every PaneHost lives here as a
+            sibling and only the active tab's PaneHost is Visible.
+            Row 1, Column 1 — never moves.
+        -->
+        <Grid x:Name="PaneHostContainer"
+              Grid.Row="1"
+              Grid.Column="1"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch"/>
+
+    </Grid>
 </Window>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1,26 +1,43 @@
 using System;
 using System.Runtime.InteropServices;
-using Ghostty.Controls;
-using Ghostty.Core.Panes;
 using Ghostty.Core.Tabs;
-using Ghostty.Core.Taskbar;
 using Ghostty.Dialogs;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Panes;
 using Ghostty.Settings;
+using Ghostty.Shell;
 using Ghostty.Tabs;
-using Ghostty.Taskbar;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Animation;
 using WinRT.Interop;
 
 namespace Ghostty;
 
+/// <summary>
+/// Composition root for the WinUI 3 shell. MainWindow holds the
+/// XAML structural elements (declared in MainWindow.xaml), wires
+/// the libghostty host, the tab manager, the two tab hosts, the
+/// pane action router, and three coordinators that own the rest
+/// of the cross-cutting plumbing:
+///
+///   - <see cref="LayoutCoordinator"/> handles the runtime switch
+///     between horizontal and vertical layouts (cross-fade
+///     Storyboard + strip-column tween + concurrent-tween guard).
+///   - <see cref="TitleBarCoordinator"/> owns the title bar
+///     drag-region selection, the caption-inset DPI sync, the
+///     active-leaf TitleChanged hook, and the vertical-mode title
+///     TextBlock binding.
+///   - <see cref="TaskbarHost"/> wires the Ghostty.Core taskbar
+///     progress coordinator into ITaskbarList3.
+///
+/// MainWindow itself only owns construction order, the dialog
+/// tracker, the keyboard accelerator install, and the Win32 class
+/// brush hack for resize flicker.
+/// </summary>
 public sealed partial class MainWindow : Window
 {
     private readonly GhosttyHost _host;
@@ -28,30 +45,15 @@ public sealed partial class MainWindow : Window
     private readonly TabManager _tabManager;
     private readonly PaneActionRouter _router;
     private readonly DialogTracker _dialogs = new();
-    private TaskbarList3Facade? _taskbarFacade;
-    private TaskbarProgressCoordinator? _taskbarCoordinator;
-    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _taskbarTickTimer;
+    private readonly UiSettings _uiSettings;
 
-    // Both tab hosts are instantiated at startup so the user can
-    // runtime-switch without ever tearing down any PaneHost or its
-    // SwapChainPanel. _tabHost tracks the currently-active one for
-    // accelerator/title-bar routing; the inactive one sits in the
-    // visual tree with Opacity=0 and IsHitTestVisible=false.
     private readonly TabHost _horizontalTabHost;
     private readonly VerticalTabHost _verticalTabHost;
     private ITabHost _tabHost;
 
-    private readonly UiSettings _uiSettings;
-    private TabModel? _verticalTitleBoundTab;
-    private bool _switchingLayout;
-    private LeafPane? _activeLeaf;
-
-    // Concurrent-tween guard. Both ApplyLayoutMode (on runtime
-    // layout switch) and the chevron toggle via
-    // VerticalTabHost.StripWidthChangeRequested can start a width
-    // tween targeting StripColumn. Keep a handle to the most recent
-    // timer so a second tween cancels the first instead of racing.
-    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _activeColumnTween;
+    private readonly LayoutCoordinator _layout;
+    private readonly TitleBarCoordinator _titleBar;
+    private readonly TaskbarHost _taskbar;
 
     // Dedup guard for KeyboardAccelerator double-dispatch. WinUI 3
     // fires accelerator Invoked twice for a single key event when the
@@ -85,9 +87,6 @@ public sealed partial class MainWindow : Window
     [DllImport("gdi32.dll")]
     private static extern IntPtr CreateSolidBrush(uint crColor);
 
-    private const double VerticalStripCollapsedWidth = 40;
-    private const int SwitchDurationMs = 220;
-
     public MainWindow()
     {
         InitializeComponent();
@@ -110,11 +109,9 @@ public sealed partial class MainWindow : Window
 
         // Extend content into the title bar: remove the system-drawn
         // title bar chrome and let TabHost's TabView strip render
-        // where the title bar used to be. The caption buttons
-        // (min / max / close) are still drawn by the system on the
-        // right; TabView's TabStripFooter reserves room for them.
-        // Must be set before the TabHost is parented so the content
-        // area is sized without the default title bar row.
+        // where the title bar used to be. Must be set before the
+        // TabHost is parented so the content area is sized without
+        // the default title bar row.
         ExtendsContentIntoTitleBar = true;
 
         _factory = new PaneHostFactory(_host);
@@ -124,16 +121,6 @@ public sealed partial class MainWindow : Window
 
         _horizontalTabHost = new TabHost(_tabManager, _router, _dialogs);
         _verticalTabHost = new VerticalTabHost(_tabManager, _router, _dialogs, _host);
-
-        // Chevron (and keyboard pinned toggle) forwards a new strip
-        // width. MainWindow tweens both the RootGrid outer strip
-        // column and the VerticalTabHost's own internal column in
-        // lockstep so the sidebar actually grows past 40 px.
-        _verticalTabHost.StripWidthChangeRequested += (_, width) =>
-        {
-            TweenColumnWidth(StripColumn, StripColumn.Width.Value, width, SwitchDurationMs,
-                onTick: v => _verticalTabHost.SetInternalStripWidth(v));
-        };
 
         // Place both tab hosts in their RootGrid slots. The
         // horizontal host spans both columns in row 0 so its TabView
@@ -150,17 +137,14 @@ public sealed partial class MainWindow : Window
         RootGrid.Children.Add(_verticalTabHost);
 
         // Parent every existing and future PaneHost into the shared
-        // container (declared in MainWindow.xaml as PaneHostContainer).
-        // This is the single owner for PaneHost lifetime in the visual
-        // tree — both tab hosts read from it without ever reparenting.
+        // container declared in MainWindow.xaml. This is the single
+        // owner for PaneHost lifetime in the visual tree — both tab
+        // hosts read from it without ever reparenting.
         foreach (var t in _tabManager.Tabs) AddPaneHost(t);
         SwapActivePane();
         _tabManager.TabAdded += (_, t) => { AddPaneHost(t); SwapActivePane(); };
         _tabManager.TabRemoved += (_, t) => RemovePaneHost(t);
         _tabManager.ActiveTabChanged += (_, _) => SwapActivePane();
-
-        RebindVerticalTitle();
-        _tabManager.ActiveTabChanged += (_, _) => RebindVerticalTitle();
 
         // Tooltip chord label is sourced from KeyBindings.Default so
         // the button description cannot drift from the accelerator.
@@ -172,69 +156,47 @@ public sealed partial class MainWindow : Window
                 : $"Switch to horizontal tabs ({chord})");
 
         _tabHost = _uiSettings.VerticalTabs ? _verticalTabHost : _horizontalTabHost;
-        SnapLayoutState(_uiSettings.VerticalTabs);
 
-        SetTitleBarForCurrentMode();
-        SyncCaptionInset();
+        _layout = new LayoutCoordinator(
+            DispatcherQueue,
+            StripColumn,
+            (FrameworkElement)_horizontalTabHost.HostElement,
+            _verticalTabHost,
+            VerticalTitleBar);
+        _layout.Snap(_uiSettings.VerticalTabs);
+
+        _titleBar = new TitleBarCoordinator(
+            this,
+            _tabManager,
+            _horizontalTabHost,
+            _verticalTabHost,
+            VerticalTitleDragRegion,
+            VerticalTitleText,
+            VerticalCaptionInset,
+            isVerticalMode: () => _tabHost is VerticalTabHost);
+        _titleBar.ApplyForCurrentMode();
+        _titleBar.SyncCaptionInset();
+
+        _taskbar = new TaskbarHost(this, _tabManager);
+
+        AppWindow.Changed += (_, _) =>
+        {
+            _taskbar.OnAppWindowChanged(AppWindow);
+            _titleBar.SyncCaptionInset();
+        };
 
         InstallPaneAccelerators();
 
-        _tabManager.ActiveTabChanged += (_, _) => HookActiveTabTitle();
-        _tabManager.WindowTitleChanged += (_, _) => Title = _tabManager.ActiveTab.EffectiveTitle;
-        HookActiveTabTitle();
-
         _tabManager.LastTabClosed += (_, _) => Close();
-
-        // Taskbar progress: wire a TaskbarProgressCoordinator through
-        // a real ITaskbarList3 facade, driven by a 2s DispatcherQueueTimer.
-        // Wrapped in try/catch because a COM failure here must not
-        // block window construction — the taskbar indicator is a
-        // nice-to-have.
-        try
-        {
-            var taskbarHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            _taskbarFacade = new TaskbarList3Facade(taskbarHwnd);
-            _taskbarCoordinator = new TaskbarProgressCoordinator(
-                _tabManager,
-                _taskbarFacade,
-                () => System.DateTime.UtcNow);
-            _taskbarTickTimer = DispatcherQueue.CreateTimer();
-            _taskbarTickTimer.Interval = System.TimeSpan.FromSeconds(2);
-            _taskbarTickTimer.IsRepeating = true;
-            _taskbarTickTimer.Tick += (_, _) => _taskbarCoordinator!.Tick();
-            _taskbarTickTimer.Start();
-
-            // Pause cycling when minimized so the taskbar does not
-            // churn while the window is hidden. AppWindow.Changed
-            // fires on presenter state transitions.
-            this.AppWindow.Changed += (_, _) =>
-            {
-                if (this.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter op)
-                {
-                    if (op.State == Microsoft.UI.Windowing.OverlappedPresenterState.Minimized)
-                        _taskbarCoordinator?.Pause();
-                    else
-                        _taskbarCoordinator?.Resume();
-                }
-                SyncCaptionInset();
-            };
-        }
-        catch (System.Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Taskbar progress wiring failed: {ex.Message}");
-        }
 
         Closed += OnClosedAsync;
     }
 
     private async void OnClosedAsync(object sender, WindowEventArgs args)
     {
-        // Let any in-flight ContentDialog complete before we tear
-        // down the libghostty host. Files #17363 reproducer:
-        // disposing MainWindow while a dialog is still animating its
-        // data-binding teardown throws a COMException out of the
-        // XAML runtime. The tracker awaits the tasks that the tab
-        // hosts push in via RequestCloseTabAsync / RenameTabDialog.
+        // Let any in-flight ContentDialog complete before tearing
+        // down the libghostty host. files-community/Files #17363
+        // documents the COMException that fires otherwise.
         try
         {
             if (_dialogs.PendingCount > 0)
@@ -244,6 +206,8 @@ public sealed partial class MainWindow : Window
         {
             System.Diagnostics.Debug.WriteLine($"DialogTracker drain failed: {ex.Message}");
         }
+
+        _taskbar.Dispose();
 
         // Surface lifetime is decoupled from Loaded/Unloaded
         // (see TerminalControl.DisposeSurface), so we have to
@@ -256,57 +220,7 @@ public sealed partial class MainWindow : Window
     private void OnVerticalSwitchButtonClick(object sender, RoutedEventArgs e)
         => _router.RequestToggleTabLayout();
 
-    private void RebindVerticalTitle()
-    {
-        if (_verticalTitleBoundTab is not null)
-            _verticalTitleBoundTab.PropertyChanged -= OnVerticalTitlePropertyChanged;
-        _verticalTitleBoundTab = _tabManager.ActiveTab;
-        if (_verticalTitleBoundTab is not null)
-            _verticalTitleBoundTab.PropertyChanged += OnVerticalTitlePropertyChanged;
-        UpdateVerticalTitleText();
-    }
-
-    private void OnVerticalTitlePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
-            e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
-            e.PropertyName == nameof(TabModel.UserOverrideTitle))
-        {
-            UpdateVerticalTitleText();
-        }
-    }
-
-    private void UpdateVerticalTitleText()
-    {
-        VerticalTitleText.Text = _verticalTitleBoundTab?.EffectiveTitle ?? "Ghostty";
-    }
-
-    /// <summary>
-    /// Keep the right-hand caption inset in sync with the real
-    /// OS-reserved width for min/max/close buttons. AppWindow's
-    /// TitleBar.RightInset is DPI- and theme-aware; the previous
-    /// hard-coded 146 DIP was a best-guess for 1x DPI.
-    /// </summary>
-    private void SyncCaptionInset()
-    {
-        try
-        {
-            var inset = AppWindow.TitleBar.RightInset;
-            // RightInset is in physical pixels; scale by the current
-            // rasterization scale so we land on the right DIP.
-            var scale = (Content as FrameworkElement)?.XamlRoot?.RasterizationScale ?? 1.0;
-            var dip = scale > 0 ? inset / scale : inset;
-            if (dip > 0)
-                VerticalCaptionInset.Width = new GridLength(dip);
-        }
-        catch
-        {
-            // RightInset can throw early during construction; leave
-            // the XAML default (146) in place.
-        }
-    }
-
-    private void AddPaneHost(Core.Tabs.TabModel tab)
+    private void AddPaneHost(TabModel tab)
     {
         var paneHost = (PaneHost)tab.PaneHost;
         paneHost.HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -315,7 +229,7 @@ public sealed partial class MainWindow : Window
         PaneHostContainer.Children.Add(paneHost);
     }
 
-    private void RemovePaneHost(Core.Tabs.TabModel tab)
+    private void RemovePaneHost(TabModel tab)
     {
         var paneHost = (PaneHost)tab.PaneHost;
         PaneHostContainer.Children.Remove(paneHost);
@@ -340,233 +254,13 @@ public sealed partial class MainWindow : Window
     /// </summary>
     internal void ToggleTabLayout()
     {
-        if (_switchingLayout) return;
+        if (_layout.IsSwitching) return;
         var toVertical = !_uiSettings.VerticalTabs;
         _uiSettings.VerticalTabs = toVertical;
         _uiSettings.Save();
         _tabHost = toVertical ? _verticalTabHost : _horizontalTabHost;
-        AnimateLayoutSwitch(toVertical);
-        SetTitleBarForCurrentMode();
-    }
-
-    private void SetTitleBarForCurrentMode()
-    {
-        // In horizontal mode the drag region is the TabStripFooter
-        // inside TabHost. In vertical mode it is the MainWindow-owned
-        // title bar grid (row 0 full width).
-        if (_tabHost is VerticalTabHost)
-            SetTitleBar(VerticalTitleDragRegion);
-        else
-            SetTitleBar(_horizontalTabHost.DragRegion as FrameworkElement);
-    }
-
-    /// <summary>
-    /// Snap both hosts and the vertical title bar to the end state
-    /// for <paramref name="verticalTabs"/>. Used at construction
-    /// (animate=false) and from the Storyboard Completed handler to
-    /// guarantee a consistent end state regardless of mid-flight
-    /// cancellation.
-    /// </summary>
-    private void SnapLayoutState(bool verticalTabs)
-    {
-        var verticalHost = (FrameworkElement)_verticalTabHost;
-        var horizontalHost = (FrameworkElement)_horizontalTabHost.HostElement;
-
-        StripColumn.Width = new GridLength(verticalTabs ? VerticalStripCollapsedWidth : 0);
-        _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth);
-
-        verticalHost.Opacity = verticalTabs ? 1 : 0;
-        verticalHost.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
-        verticalHost.IsHitTestVisible = verticalTabs;
-
-        horizontalHost.Opacity = verticalTabs ? 0 : 1;
-        horizontalHost.Visibility = verticalTabs ? Visibility.Collapsed : Visibility.Visible;
-        horizontalHost.IsHitTestVisible = !verticalTabs;
-
-        VerticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
-        VerticalTitleBar.Opacity = verticalTabs ? 1 : 0;
-
-        // Reset any dangling translate offsets so future switches
-        // start from origin. Safe to overwrite: SnapLayoutState is
-        // only called when no transform animation is in flight.
-        GetOrCreateTranslate(verticalHost).X = 0;
-        GetOrCreateTranslate(verticalHost).Y = 0;
-        GetOrCreateTranslate(horizontalHost).X = 0;
-        GetOrCreateTranslate(horizontalHost).Y = 0;
-    }
-
-    /// <summary>
-    /// Cross-fade + slide animation between horizontal and vertical
-    /// layouts. Drives the chrome transforms via a Storyboard
-    /// (compositor-backed) and the strip column width via
-    /// <see cref="TweenColumnWidth"/> because GridLength cannot be
-    /// animated by the Storyboard system.
-    /// </summary>
-    private void AnimateLayoutSwitch(bool verticalTabs)
-    {
-        var verticalHost = (FrameworkElement)_verticalTabHost;
-        var horizontalHost = (FrameworkElement)_horizontalTabHost.HostElement;
-        var targetColWidth = verticalTabs ? VerticalStripCollapsedWidth : 0;
-
-        _switchingLayout = true;
-        VerticalTitleBar.Visibility = Visibility.Visible;
-        verticalHost.Visibility = Visibility.Visible;
-        horizontalHost.Visibility = Visibility.Visible;
-
-        // Incoming chrome is prepped at Opacity 0 with a translate
-        // offset, then animates to Opacity 1 / offset 0.
-        var incoming = verticalTabs ? verticalHost : horizontalHost;
-        var outgoing = verticalTabs ? horizontalHost : verticalHost;
-        var incomingOffset = verticalTabs
-            ? new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0)
-            : new Windows.Foundation.Point(0, -32);
-        var outgoingOffset = verticalTabs
-            ? new Windows.Foundation.Point(0, -32)
-            : new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0);
-
-        incoming.IsHitTestVisible = true;
-        var incomingTx = GetOrCreateTranslate(incoming);
-        incomingTx.X = incomingOffset.X;
-        incomingTx.Y = incomingOffset.Y;
-        incoming.Opacity = 0;
-
-        var sb = new Storyboard();
-        sb.Children.Add(MakeDoubleAnim(incoming, "Opacity", 0, 1));
-        sb.Children.Add(MakeDoubleAnim(outgoing, "Opacity", outgoing.Opacity, 0));
-        sb.Children.Add(MakeDoubleAnim(VerticalTitleBar, "Opacity",
-            verticalTabs ? 0 : 1, verticalTabs ? 1 : 0));
-
-        sb.Children.Add(MakeTransformAnim(incoming, "X", incomingTx.X, 0));
-        sb.Children.Add(MakeTransformAnim(incoming, "Y", incomingTx.Y, 0));
-        var outgoingTx = GetOrCreateTranslate(outgoing);
-        sb.Children.Add(MakeTransformAnim(outgoing, "X", outgoingTx.X, outgoingOffset.X));
-        sb.Children.Add(MakeTransformAnim(outgoing, "Y", outgoingTx.Y, outgoingOffset.Y));
-
-        sb.Completed += (_, _) =>
-        {
-            SnapLayoutState(verticalTabs);
-            _switchingLayout = false;
-        };
-        sb.Begin();
-
-        // Column width tween runs in parallel (see AnimateLayoutSwitch
-        // docstring for why it's code-driven, not Storyboard-driven).
-        TweenColumnWidth(StripColumn, StripColumn.Width.Value, targetColWidth, SwitchDurationMs,
-            onTick: _ => _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth));
-    }
-
-    private static TranslateTransform GetOrCreateTranslate(FrameworkElement fe)
-    {
-        if (fe.RenderTransform is TranslateTransform t) return t;
-        var nt = new TranslateTransform();
-        fe.RenderTransform = nt;
-        return nt;
-    }
-
-    private static DoubleAnimation MakeDoubleAnim(DependencyObject target, string path, double from, double to)
-    {
-        var anim = new DoubleAnimation
-        {
-            From = from,
-            To = to,
-            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
-            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
-        };
-        Storyboard.SetTarget(anim, target);
-        Storyboard.SetTargetProperty(anim, path);
-        return anim;
-    }
-
-    private static DoubleAnimation MakeTransformAnim(FrameworkElement target, string axis, double from, double to)
-    {
-        var anim = new DoubleAnimation
-        {
-            From = from,
-            To = to,
-            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
-            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
-        };
-        Storyboard.SetTarget(anim, target.RenderTransform);
-        Storyboard.SetTargetProperty(anim, axis);
-        return anim;
-    }
-
-    /// <summary>
-    /// Tween a <see cref="ColumnDefinition.Width"/> from its current
-    /// value to <paramref name="to"/> over <paramref name="durationMs"/>.
-    /// Only one tween is active per column at a time: if a previous
-    /// tween is still running when this is called it is stopped and
-    /// replaced. GridLength cannot be animated by Storyboard so this
-    /// is unavoidable.
-    /// </summary>
-    private void TweenColumnWidth(ColumnDefinition col, double from, double to, int durationMs, Action<double>? onTick = null)
-    {
-        // Cancel any previous in-flight tween so chevron + layout
-        // switch can't race on the same column.
-        _activeColumnTween?.Stop();
-
-        var startTime = DateTime.UtcNow;
-        var duration = TimeSpan.FromMilliseconds(durationMs);
-        var timer = DispatcherQueue.CreateTimer();
-        timer.Interval = TimeSpan.FromMilliseconds(16);
-        timer.IsRepeating = true;
-        timer.Tick += (t, _) =>
-        {
-            var elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-            var progress = Math.Min(1.0, elapsed / duration.TotalMilliseconds);
-            var eased = 1 - (1 - progress) * (1 - progress);
-            var value = from + (to - from) * eased;
-            col.Width = new GridLength(value);
-            onTick?.Invoke(value);
-            if (progress >= 1.0)
-            {
-                t.Stop();
-                if (ReferenceEquals(_activeColumnTween, t))
-                    _activeColumnTween = null;
-            }
-        };
-        _activeColumnTween = timer;
-        timer.Start();
-    }
-
-    /// <summary>
-    /// Subscribe the active tab's active leaf to live title-change
-    /// updates and write the title into <see cref="TabModel.ShellReportedTitle"/>.
-    /// Re-runs every time the active tab changes or the active leaf
-    /// within the active tab changes. The leaf-title hook lives here
-    /// (not in <see cref="TabManager"/>) because it touches WinUI
-    /// types that Ghostty.Core cannot reach.
-    /// </summary>
-    private void HookActiveTabTitle()
-    {
-        if (_activeLeaf is { } previous)
-            previous.Terminal().TitleChanged -= OnLiveTitleChanged;
-
-        var tab = _tabManager.ActiveTab;
-        var leaf = tab.PaneHost.ActiveLeaf;
-        _activeLeaf = leaf;
-        leaf.Terminal().TitleChanged += OnLiveTitleChanged;
-        tab.ShellReportedTitle = leaf.Terminal().CurrentTitle;
-        Title = tab.EffectiveTitle;
-
-        tab.PaneHost.LeafFocused -= OnActiveTabLeafFocused;
-        tab.PaneHost.LeafFocused += OnActiveTabLeafFocused;
-    }
-
-    private void OnActiveTabLeafFocused(object? sender, LeafPane leaf)
-    {
-        if (_activeLeaf is { } previous)
-            previous.Terminal().TitleChanged -= OnLiveTitleChanged;
-        _activeLeaf = leaf;
-        leaf.Terminal().TitleChanged += OnLiveTitleChanged;
-        _tabManager.ActiveTab.ShellReportedTitle = leaf.Terminal().CurrentTitle;
-    }
-
-    private void OnLiveTitleChanged(object? sender, string title)
-    {
-        // TabManager raises WindowTitleChanged in response, which
-        // sets Title via the constructor's subscription.
-        _tabManager.ActiveTab.ShellReportedTitle = title;
+        _layout.Animate(toVertical);
+        _titleBar.ApplyForCurrentMode();
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -8,8 +8,10 @@ using Ghostty.Taskbar;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Panes;
+using Ghostty.Settings;
 using Ghostty.Tabs;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
@@ -28,7 +30,25 @@ public sealed partial class MainWindow : Window
     private TaskbarList3Facade? _taskbarFacade;
     private TaskbarProgressCoordinator? _taskbarCoordinator;
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _taskbarTickTimer;
-    private readonly ITabHost _tabHost;
+    // Both tab hosts are instantiated at startup so the user can
+    // runtime-switch without ever tearing down any PaneHost or its
+    // SwapChainPanel. _tabHost tracks the currently-active one for
+    // accelerator/title-bar routing; the inactive one sits in the
+    // visual tree with Opacity=0 and IsHitTestVisible=false.
+    private readonly TabHost _horizontalTabHost;
+    private readonly VerticalTabHost _verticalTabHost;
+    private ITabHost _tabHost;
+    private readonly Grid _paneHostContainer;
+    // Title bar strip shown when vertical tabs are active. Hosts the
+    // switch-layout button on the left, the active-tab title centered,
+    // and a 146 DIP right inset for the OS caption buttons. Lives in
+    // RootGrid row 0 at col span 2 so it spans the full window.
+    private Grid _verticalTitleBar = null!;
+    private TextBlock _verticalTitleText = null!;
+    private Grid _verticalTitleDragRegion = null!;
+    private TabModel? _verticalTitleBoundTab;
+    private readonly UiSettings _uiSettings;
+    private bool _switchingLayout;
     private LeafPane? _activeLeaf;
 
     // Dedup guard for KeyboardAccelerator double-dispatch. WinUI 3
@@ -94,14 +114,56 @@ public sealed partial class MainWindow : Window
 
         _factory = new PaneHostFactory(_host);
         _tabManager = new TabManager(() => _factory.Create());
-        _tabHost = CreateTabHost(_tabManager);
-        RootGrid.Children.Add(_tabHost.HostElement);
+        _uiSettings = UiSettings.Load();
 
-        // Declare the drag region AFTER _tabHost is in the visual
-        // tree so DragRegion (the TabStripFooter Grid) is live.
-        // Clicking anywhere in that Grid drags the window; the tabs
-        // themselves are hit-test targets and remain interactive.
-        SetTitleBar(_tabHost.DragRegion as FrameworkElement);
+        // Build the dual-chrome layout: both tab hosts coexist in
+        // the same RootGrid, only one is visible at a time. The
+        // shared PaneHostContainer lives in the same grid slot
+        // forever so no SwapChainPanel is ever reparented.
+        BuildLayout(out _paneHostContainer);
+
+        _horizontalTabHost = new TabHost(_tabManager);
+        _verticalTabHost = new VerticalTabHost(_tabManager, _host);
+
+        // Chevron (and keyboard pinned toggle) forwards a new strip
+        // width. MainWindow tweens both the RootGrid outer strip
+        // column and the VerticalTabHost's own internal column in
+        // lockstep so the sidebar actually grows past 40 px.
+        _verticalTabHost.StripWidthChangeRequested += (_, width) =>
+        {
+            var col = RootGrid.ColumnDefinitions[0];
+            TweenColumnWidth(col, col.Width.Value, width, SwitchDurationMs,
+                onTick: v => _verticalTabHost.SetInternalStripWidth(v));
+        };
+
+        RebindVerticalTitle();
+        _tabManager.ActiveTabChanged += (_, _) => RebindVerticalTitle();
+
+        // Place both tab hosts in their RootGrid slots.
+        Grid.SetRow((FrameworkElement)_horizontalTabHost.HostElement, 0);
+        Grid.SetColumn((FrameworkElement)_horizontalTabHost.HostElement, 0);
+        Grid.SetColumnSpan((FrameworkElement)_horizontalTabHost.HostElement, 2);
+        RootGrid.Children.Add(_horizontalTabHost.HostElement);
+
+        Grid.SetRow(_verticalTabHost, 0);
+        Grid.SetColumn(_verticalTabHost, 0);
+        Grid.SetRowSpan(_verticalTabHost, 2);
+        RootGrid.Children.Add(_verticalTabHost);
+
+        // Parent every existing and future PaneHost into the shared
+        // container. This is the single owner for PaneHost lifetime
+        // in the visual tree — both tab hosts read from it without
+        // ever reparenting.
+        foreach (var t in _tabManager.Tabs) AddPaneHost(t);
+        SwapActivePane();
+        _tabManager.TabAdded += (_, t) => { AddPaneHost(t); SwapActivePane(); };
+        _tabManager.TabRemoved += (_, t) => RemovePaneHost(t);
+        _tabManager.ActiveTabChanged += (_, _) => SwapActivePane();
+
+        _tabHost = _uiSettings.VerticalTabs ? _verticalTabHost : _horizontalTabHost;
+        ApplyLayoutMode(_uiSettings.VerticalTabs, animate: false);
+
+        SetTitleBarForCurrentMode();
 
         InstallPaneAccelerators();
 
@@ -113,75 +175,44 @@ public sealed partial class MainWindow : Window
 
         // Taskbar progress: wire a TaskbarProgressCoordinator through
         // a real ITaskbarList3 facade, driven by a 2s DispatcherQueueTimer.
-        //
-        // Narrow try/catch on COMException only: if CoCreateInstance /
-        // HrInit genuinely fails (explorer down, session 0, etc.) the
-        // indicator is a nice-to-have and we keep the window alive.
-        // Any other exception (NRE, OOM, arg errors) is a real bug and
-        // we let it propagate so it is visible in debug and telemetry.
+        // Wrapped in try/catch because a COM failure here must not
+        // block window construction — the taskbar indicator is a
+        // nice-to-have.
         try
         {
-            // Reuse the HWND resolved for the class-brush fix above.
-            var facade = new TaskbarList3Facade(hwnd);
-            var coord = new TaskbarProgressCoordinator(
+            var taskbarHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            _taskbarFacade = new TaskbarList3Facade(taskbarHwnd);
+            _taskbarCoordinator = new TaskbarProgressCoordinator(
                 _tabManager,
-                facade,
-                () => DateTime.UtcNow);
-            var timer = DispatcherQueue.CreateTimer();
-            timer.Interval = TimeSpan.FromSeconds(2);
-            timer.IsRepeating = true;
-            // Capture the coordinator locally rather than dereferencing
-            // the field via `!`, so a partially-torn-down state cannot
-            // NRE here.
-            timer.Tick += (_, _) => coord.Tick();
-            timer.Start();
-
-            _taskbarFacade = facade;
-            _taskbarCoordinator = coord;
-            _taskbarTickTimer = timer;
+                _taskbarFacade,
+                () => System.DateTime.UtcNow);
+            _taskbarTickTimer = DispatcherQueue.CreateTimer();
+            _taskbarTickTimer.Interval = System.TimeSpan.FromSeconds(2);
+            _taskbarTickTimer.IsRepeating = true;
+            _taskbarTickTimer.Tick += (_, _) => _taskbarCoordinator!.Tick();
+            _taskbarTickTimer.Start();
 
             // Pause cycling when minimized so the taskbar does not
             // churn while the window is hidden. AppWindow.Changed
-            // fires on presenter state transitions. Store the handler
-            // so Closed can detach it.
-            _appWindowChanged = (_, _) =>
+            // fires on presenter state transitions.
+            this.AppWindow.Changed += (_, _) =>
             {
                 if (this.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter op)
                 {
                     if (op.State == Microsoft.UI.Windowing.OverlappedPresenterState.Minimized)
-                        coord.Pause();
+                        _taskbarCoordinator?.Pause();
                     else
-                        coord.Resume();
+                        _taskbarCoordinator?.Resume();
                 }
             };
-            this.AppWindow.Changed += _appWindowChanged;
         }
-        catch (COMException ex)
+        catch (System.Exception ex)
         {
-            // Log loudly in debug; in release the taskbar indicator is
-            // simply absent for this window's lifetime.
-            System.Diagnostics.Debug.WriteLine(
-                $"Taskbar progress wiring failed: 0x{ex.HResult:X8} {ex.Message}");
-            System.Diagnostics.Debug.Fail("Taskbar progress wiring failed", ex.ToString());
+            System.Diagnostics.Debug.WriteLine($"Taskbar progress wiring failed: {ex.Message}");
         }
 
         Closed += (_, _) =>
         {
-            // Tear down the taskbar chain before disposing the host.
-            // Order: stop timer, detach window state handler, dispose
-            // coordinator (unhooks TabManager), dispose facade (releases
-            // the ITaskbarList3 RCW).
-            _taskbarTickTimer?.Stop();
-            if (_appWindowChanged is not null)
-            {
-                this.AppWindow.Changed -= _appWindowChanged;
-                _appWindowChanged = null;
-            }
-            _taskbarCoordinator?.Dispose();
-            _taskbarCoordinator = null;
-            _taskbarFacade?.Dispose();
-            _taskbarFacade = null;
-
             // Surface lifetime is decoupled from Loaded/Unloaded
             // (see TerminalControl.DisposeSurface), so we have to
             // free every leaf in every tab explicitly before tearing
@@ -192,18 +223,327 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Pick which <see cref="ITabHost"/> implementation to use based
-    /// on the stubbed <c>vertical-tabs</c> config flag. Horizontal
-    /// (<see cref="TabHost"/>) is the default; vertical
-    /// (<see cref="VerticalTabHost"/>) opts in.
+    /// Rewrite RootGrid into a 2x2 layout that both tab hosts share:
+    ///
+    ///   +------------------+----------------+
+    ///   | v-strip col 0    | title / h-strip|  row 0 (Auto)
+    ///   |  (0 px in        |    row 0 col 1 |
+    ///   |   horizontal)    +----------------+
+    ///   |                  | PaneHost *     |  row 1 (*)
+    ///   +------------------+----------------+
+    ///
+    /// PaneHostContainer is a direct child of RootGrid at row 1,
+    /// col 1 and never moves. This is the safe slot for every
+    /// PaneHost's SwapChainPanel.
     /// </summary>
-    private ITabHost CreateTabHost(TabManager manager)
+    private void BuildLayout(out Grid paneHostContainer)
     {
-        // TODO(config): vertical-tabs (bool, default false)
-        const bool verticalTabs = false;
-        return verticalTabs
-            ? (ITabHost)new VerticalTabHost(manager, _host)
-            : new TabHost(manager);
+        RootGrid.RowDefinitions.Clear();
+        RootGrid.ColumnDefinitions.Clear();
+        RootGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        RootGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        RootGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(0) });
+        RootGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        // Vertical-mode title bar (row 0, full width). Hosts the
+        // switch-layout button, the active-tab title, and the caption
+        // button inset. Visibility toggles with the active layout.
+        BuildVerticalTitleBar();
+        Grid.SetRow(_verticalTitleBar, 0);
+        Grid.SetColumn(_verticalTitleBar, 0);
+        Grid.SetColumnSpan(_verticalTitleBar, 2);
+        RootGrid.Children.Add(_verticalTitleBar);
+
+        paneHostContainer = new Grid
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        Grid.SetRow(paneHostContainer, 1);
+        Grid.SetColumn(paneHostContainer, 1);
+        RootGrid.Children.Add(paneHostContainer);
+    }
+
+    private void BuildVerticalTitleBar()
+    {
+        _verticalTitleBar = new Grid
+        {
+            Height = 32,
+            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            Visibility = Visibility.Collapsed,
+        };
+        _verticalTitleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        _verticalTitleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(146) });
+
+        _verticalTitleDragRegion = new Grid
+        {
+            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
+        };
+        Grid.SetColumn(_verticalTitleDragRegion, 0);
+
+        var switchButton = new Button
+        {
+            Width = 32,
+            Height = 32,
+            Padding = new Thickness(0),
+            // Sit just to the right of the sidebar column (40 px
+            // wide) so the button does not overlap the chevron that
+            // lives at the top of VerticalTabStrip.
+            Margin = new Thickness(44, 0, 0, 0),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            BorderThickness = new Thickness(0),
+            Content = new FontIcon
+            {
+                FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)
+                    Application.Current.Resources["SymbolThemeFontFamily"],
+                Glyph = "\uE8A9",
+                FontSize = 14,
+            },
+        };
+        ToolTipService.SetToolTip(switchButton, "Switch to horizontal tabs (Ctrl+Shift+Alt+V)");
+        switchButton.Click += (_, _) => PaneActionRouter.RequestToggleTabLayout(_tabManager);
+
+        _verticalTitleText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            FontSize = 12,
+            Foreground = (Microsoft.UI.Xaml.Media.Brush)
+                Application.Current.Resources["TextFillColorPrimaryBrush"],
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            IsHitTestVisible = false,
+        };
+
+        _verticalTitleDragRegion.Children.Add(switchButton);
+        _verticalTitleDragRegion.Children.Add(_verticalTitleText);
+        _verticalTitleBar.Children.Add(_verticalTitleDragRegion);
+    }
+
+    private void RebindVerticalTitle()
+    {
+        if (_verticalTitleBoundTab is not null)
+            _verticalTitleBoundTab.PropertyChanged -= OnVerticalTitlePropertyChanged;
+        _verticalTitleBoundTab = _tabManager.ActiveTab;
+        if (_verticalTitleBoundTab is not null)
+            _verticalTitleBoundTab.PropertyChanged += OnVerticalTitlePropertyChanged;
+        UpdateVerticalTitleText();
+    }
+
+    private void OnVerticalTitlePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
+            e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
+            e.PropertyName == nameof(TabModel.UserOverrideTitle))
+        {
+            UpdateVerticalTitleText();
+        }
+    }
+
+    private void UpdateVerticalTitleText()
+    {
+        _verticalTitleText.Text = _verticalTitleBoundTab?.EffectiveTitle ?? "Ghostty";
+    }
+
+    private void AddPaneHost(Core.Tabs.TabModel tab)
+    {
+        var paneHost = (PaneHost)tab.PaneHost;
+        paneHost.HorizontalAlignment = HorizontalAlignment.Stretch;
+        paneHost.VerticalAlignment = VerticalAlignment.Stretch;
+        paneHost.Visibility = Visibility.Collapsed;
+        _paneHostContainer.Children.Add(paneHost);
+    }
+
+    private void RemovePaneHost(Core.Tabs.TabModel tab)
+    {
+        var paneHost = (PaneHost)tab.PaneHost;
+        _paneHostContainer.Children.Remove(paneHost);
+    }
+
+    private void SwapActivePane()
+    {
+        var active = (PaneHost)_tabManager.ActiveTab.PaneHost;
+        foreach (UIElement child in _paneHostContainer.Children)
+        {
+            child.Visibility = ReferenceEquals(child, active)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        }
+    }
+
+    /// <summary>
+    /// Toggle between horizontal and vertical tab layouts at runtime.
+    /// Triggered by Ctrl+Shift+Alt+V, the title-bar icon button, and
+    /// the strip context menu. Persists the choice via
+    /// <see cref="UiSettings"/> so it survives the next launch.
+    /// </summary>
+    internal void ToggleTabLayout()
+    {
+        if (_switchingLayout) return;
+        var toVertical = !_uiSettings.VerticalTabs;
+        _uiSettings.VerticalTabs = toVertical;
+        _uiSettings.Save();
+        _tabHost = toVertical ? _verticalTabHost : _horizontalTabHost;
+        ApplyLayoutMode(toVertical, animate: true);
+        SetTitleBarForCurrentMode();
+    }
+
+    private void SetTitleBarForCurrentMode()
+    {
+        // In horizontal mode the drag region is the TabStripFooter
+        // inside TabHost. In vertical mode it is the MainWindow-owned
+        // title bar grid (row 0 full width).
+        if (_tabHost is VerticalTabHost)
+            SetTitleBar(_verticalTitleDragRegion);
+        else
+            SetTitleBar(_horizontalTabHost.DragRegion as FrameworkElement);
+    }
+
+    /// <summary>
+    /// Apply the given layout mode to the RootGrid column widths and
+    /// both tab hosts' visibility. On first call (animate=false) the
+    /// end state is snapped immediately; on toggle (animate=true) the
+    /// outgoing chrome slides away while the incoming chrome slides
+    /// in, and the vertical strip column width tweens in parallel.
+    /// </summary>
+    private const double VerticalStripCollapsedWidth = 40;
+    private const int SwitchDurationMs = 220;
+
+    private void ApplyLayoutMode(bool verticalTabs, bool animate)
+    {
+        var verticalHost = (FrameworkElement)_verticalTabHost;
+        var horizontalHost = (FrameworkElement)_horizontalTabHost.HostElement;
+
+        var stripCol = RootGrid.ColumnDefinitions[0];
+        var targetColWidth = verticalTabs ? VerticalStripCollapsedWidth : 0;
+
+        if (!animate)
+        {
+            stripCol.Width = new GridLength(targetColWidth);
+            _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth);
+            verticalHost.Opacity = verticalTabs ? 1 : 0;
+            verticalHost.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+            verticalHost.IsHitTestVisible = verticalTabs;
+            horizontalHost.Opacity = verticalTabs ? 0 : 1;
+            horizontalHost.Visibility = verticalTabs ? Visibility.Collapsed : Visibility.Visible;
+            horizontalHost.IsHitTestVisible = !verticalTabs;
+            _verticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+            _verticalTitleBar.Opacity = verticalTabs ? 1 : 0;
+            return;
+        }
+
+        _switchingLayout = true;
+        _verticalTitleBar.Visibility = Visibility.Visible;
+        verticalHost.Visibility = Visibility.Visible;
+        horizontalHost.Visibility = Visibility.Visible;
+
+        // Incoming chrome is prepped at Opacity 0 with a translate
+        // offset, then animates to Opacity 1 / offset 0.
+        var incoming = verticalTabs ? verticalHost : horizontalHost;
+        var outgoing = verticalTabs ? horizontalHost : verticalHost;
+        var incomingOffset = verticalTabs ? new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0) : new Windows.Foundation.Point(0, -32);
+        var outgoingOffset = verticalTabs ? new Windows.Foundation.Point(0, -32) : new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0);
+
+        incoming.IsHitTestVisible = true;
+        var incomingTx = GetOrCreateTranslate(incoming);
+        incomingTx.X = incomingOffset.X;
+        incomingTx.Y = incomingOffset.Y;
+        incoming.Opacity = 0;
+        incoming.Visibility = Visibility.Visible;
+
+        var sb = new Storyboard();
+
+        // Cross-fade.
+        sb.Children.Add(MakeDoubleAnim(incoming, "Opacity", 0, 1));
+        sb.Children.Add(MakeDoubleAnim(outgoing, "Opacity", outgoing.Opacity, 0));
+        // The vertical title bar fades with the vertical chrome.
+        sb.Children.Add(MakeDoubleAnim(_verticalTitleBar, "Opacity",
+            verticalTabs ? 0 : 1, verticalTabs ? 1 : 0));
+
+        // Slide.
+        sb.Children.Add(MakeTransformAnim(incoming, "X", incomingTx.X, 0));
+        sb.Children.Add(MakeTransformAnim(incoming, "Y", incomingTx.Y, 0));
+        var outgoingTx = GetOrCreateTranslate(outgoing);
+        sb.Children.Add(MakeTransformAnim(outgoing, "X", outgoingTx.X, outgoingOffset.X));
+        sb.Children.Add(MakeTransformAnim(outgoing, "Y", outgoingTx.Y, outgoingOffset.Y));
+
+        sb.Completed += (_, _) =>
+        {
+            outgoing.IsHitTestVisible = false;
+            outgoing.Opacity = 0;
+            outgoing.Visibility = Visibility.Collapsed;
+            // Reset outgoing back to origin so a subsequent switch
+            // animates from a known position instead of stacking.
+            outgoingTx.X = 0;
+            outgoingTx.Y = 0;
+            _verticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+            _switchingLayout = false;
+        };
+        sb.Begin();
+
+        // Column width tween runs in parallel via DispatcherQueueTimer
+        // because animating GridLength via Storyboard is clunky. Drive
+        // the VerticalTabHost's own internal column in lockstep so its
+        // visual sidebar fills the outer column.
+        TweenColumnWidth(stripCol, stripCol.Width.Value, targetColWidth, SwitchDurationMs,
+            onTick: _ => _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth));
+    }
+
+    private static TranslateTransform GetOrCreateTranslate(FrameworkElement fe)
+    {
+        if (fe.RenderTransform is TranslateTransform t) return t;
+        var nt = new TranslateTransform();
+        fe.RenderTransform = nt;
+        return nt;
+    }
+
+    private static DoubleAnimation MakeDoubleAnim(DependencyObject target, string path, double from, double to)
+    {
+        var anim = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
+            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(anim, target);
+        Storyboard.SetTargetProperty(anim, path);
+        return anim;
+    }
+
+    private static DoubleAnimation MakeTransformAnim(FrameworkElement target, string axis, double from, double to)
+    {
+        var anim = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
+            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(anim, target.RenderTransform);
+        Storyboard.SetTargetProperty(anim, axis);
+        return anim;
+    }
+
+    private void TweenColumnWidth(ColumnDefinition col, double from, double to, int durationMs, Action<double>? onTick = null)
+    {
+        var startTime = DateTime.UtcNow;
+        var duration = TimeSpan.FromMilliseconds(durationMs);
+        var timer = DispatcherQueue.CreateTimer();
+        timer.Interval = TimeSpan.FromMilliseconds(16);
+        timer.IsRepeating = true;
+        timer.Tick += (t, _) =>
+        {
+            var elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+            var progress = Math.Min(1.0, elapsed / duration.TotalMilliseconds);
+            var eased = 1 - (1 - progress) * (1 - progress);
+            var value = from + (to - from) * eased;
+            col.Width = new GridLength(value);
+            onTick?.Invoke(value);
+            if (progress >= 1.0) t.Stop();
+        };
+        timer.Start();
     }
 
     /// <summary>
@@ -297,52 +637,40 @@ public sealed partial class MainWindow : Window
                 // See https://github.com/deblasis/ghostty/issues/165.
                 if (_acceleratorFiredThisKeyDown == captured.Action) return;
                 _acceleratorFiredThisKeyDown = captured.Action;
-                PaneActionRouter.Invoke(
-                    captured.Action,
-                    _tabManager,
-                    onTabCloseRequested: OnTabCloseRequestedFromKeyboard,
-                    onToggleVerticalTabsPinned: OnToggleVerticalTabsPinnedFromKeyboard);
+                PaneActionRouter.Invoke(captured.Action, _tabManager);
             };
             _tabHost.HostElement.KeyboardAccelerators.Add(accel);
         }
 
         _tabHost.HostElement.KeyUp += (_, _) => _acceleratorFiredThisKeyDown = null;
         _tabHost.HostElement.KeyboardAcceleratorPlacementMode = KeyboardAcceleratorPlacementMode.Hidden;
-    }
 
-    // Route a keyboard-driven full-tab close through the shared
-    // RequestCloseTabAsync path so the confirmation dialog is the
-    // same code path as the per-tab X button and the context-menu
-    // Close item.
-    //
-    // async void is unavoidable here: this is invoked from a
-    // synchronous Action<TabManager> boundary inside the router. An
-    // unhandled exception from an async void method tears down the
-    // whole process, so we log and surface — but we do NOT swallow
-    // silently: Debug.Fail in debug builds makes bugs noisy, and the
-    // release path still logs to the debug stream for post-mortem.
-    private async void OnTabCloseRequestedFromKeyboard(TabManager mgr)
-    {
-        try
+        // Listen for keyboard-driven full-tab close. Route through
+        // TabHost.RequestCloseTabAsync so the confirmation dialog
+        // is the same code path as the per-tab X button and the
+        // context-menu Close item — single source of truth for
+        // close confirmation lives in TabHost, which has XamlRoot.
+        PaneActionRouter.TabCloseRequestedFromKeyboard += async (_, mgr) =>
         {
             if (!ReferenceEquals(mgr, _tabManager)) return;
             await _tabHost.RequestCloseTabAsync(_tabManager.ActiveTab);
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine(
-                $"[MainWindow] OnTabCloseRequestedFromKeyboard failed: {ex}");
-            System.Diagnostics.Debug.Fail("Tab close from keyboard threw", ex.ToString());
-        }
-    }
+        };
 
-    // Vertical-tabs pinned toggle via Ctrl+Shift+Space. No-op
-    // when the layout is horizontal (TabHost) — the chord is
-    // registered globally but only VerticalTabHost responds.
-    private void OnToggleVerticalTabsPinnedFromKeyboard(TabManager mgr)
-    {
-        if (!ReferenceEquals(mgr, _tabManager)) return;
-        if (_tabHost is VerticalTabHost vth)
-            vth.TogglePinnedFromKeyboard();
+        // Vertical-tabs pinned toggle via Ctrl+Shift+Space. No-op
+        // when the layout is horizontal (TabHost) — the chord is
+        // registered globally but only VerticalTabHost responds.
+        PaneActionRouter.ToggleVerticalTabsPinnedFromKeyboard += (_, mgr) =>
+        {
+            if (!ReferenceEquals(mgr, _tabManager)) return;
+            if (_tabHost is VerticalTabHost vth)
+                vth.TogglePinnedFromKeyboard();
+        };
+
+        // Runtime tab-layout switch via Ctrl+Shift+Alt+V.
+        PaneActionRouter.ToggleTabLayoutFromKeyboard += (_, mgr) =>
+        {
+            if (!ReferenceEquals(mgr, _tabManager)) return;
+            ToggleTabLayout();
+        };
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -4,20 +4,19 @@ using Ghostty.Controls;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Tabs;
 using Ghostty.Core.Taskbar;
-using Ghostty.Taskbar;
+using Ghostty.Dialogs;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Panes;
 using Ghostty.Settings;
 using Ghostty.Tabs;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media.Animation;
+using Ghostty.Taskbar;
 using Microsoft.UI.Composition.SystemBackdrops;
-using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Windows.System;
+using Microsoft.UI.Xaml.Media.Animation;
 using WinRT.Interop;
 
 namespace Ghostty;
@@ -27,9 +26,12 @@ public sealed partial class MainWindow : Window
     private readonly GhosttyHost _host;
     private readonly PaneHostFactory _factory;
     private readonly TabManager _tabManager;
+    private readonly PaneActionRouter _router;
+    private readonly DialogTracker _dialogs = new();
     private TaskbarList3Facade? _taskbarFacade;
     private TaskbarProgressCoordinator? _taskbarCoordinator;
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _taskbarTickTimer;
+
     // Both tab hosts are instantiated at startup so the user can
     // runtime-switch without ever tearing down any PaneHost or its
     // SwapChainPanel. _tabHost tracks the currently-active one for
@@ -38,18 +40,18 @@ public sealed partial class MainWindow : Window
     private readonly TabHost _horizontalTabHost;
     private readonly VerticalTabHost _verticalTabHost;
     private ITabHost _tabHost;
-    private readonly Grid _paneHostContainer;
-    // Title bar strip shown when vertical tabs are active. Hosts the
-    // switch-layout button on the left, the active-tab title centered,
-    // and a 146 DIP right inset for the OS caption buttons. Lives in
-    // RootGrid row 0 at col span 2 so it spans the full window.
-    private Grid _verticalTitleBar = null!;
-    private TextBlock _verticalTitleText = null!;
-    private Grid _verticalTitleDragRegion = null!;
-    private TabModel? _verticalTitleBoundTab;
+
     private readonly UiSettings _uiSettings;
+    private TabModel? _verticalTitleBoundTab;
     private bool _switchingLayout;
     private LeafPane? _activeLeaf;
+
+    // Concurrent-tween guard. Both ApplyLayoutMode (on runtime
+    // layout switch) and the chevron toggle via
+    // VerticalTabHost.StripWidthChangeRequested can start a width
+    // tween targeting StripColumn. Keep a handle to the most recent
+    // timer so a second tween cancels the first instead of racing.
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _activeColumnTween;
 
     // Dedup guard for KeyboardAccelerator double-dispatch. WinUI 3
     // fires accelerator Invoked twice for a single key event when the
@@ -83,6 +85,9 @@ public sealed partial class MainWindow : Window
     [DllImport("gdi32.dll")]
     private static extern IntPtr CreateSolidBrush(uint crColor);
 
+    private const double VerticalStripCollapsedWidth = 40;
+    private const int SwitchDurationMs = 220;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -114,16 +119,11 @@ public sealed partial class MainWindow : Window
 
         _factory = new PaneHostFactory(_host);
         _tabManager = new TabManager(() => _factory.Create());
+        _router = new PaneActionRouter(_tabManager);
         _uiSettings = UiSettings.Load();
 
-        // Build the dual-chrome layout: both tab hosts coexist in
-        // the same RootGrid, only one is visible at a time. The
-        // shared PaneHostContainer lives in the same grid slot
-        // forever so no SwapChainPanel is ever reparented.
-        BuildLayout(out _paneHostContainer);
-
-        _horizontalTabHost = new TabHost(_tabManager);
-        _verticalTabHost = new VerticalTabHost(_tabManager, _host);
+        _horizontalTabHost = new TabHost(_tabManager, _router, _dialogs);
+        _verticalTabHost = new VerticalTabHost(_tabManager, _router, _dialogs, _host);
 
         // Chevron (and keyboard pinned toggle) forwards a new strip
         // width. MainWindow tweens both the RootGrid outer strip
@@ -131,15 +131,14 @@ public sealed partial class MainWindow : Window
         // lockstep so the sidebar actually grows past 40 px.
         _verticalTabHost.StripWidthChangeRequested += (_, width) =>
         {
-            var col = RootGrid.ColumnDefinitions[0];
-            TweenColumnWidth(col, col.Width.Value, width, SwitchDurationMs,
+            TweenColumnWidth(StripColumn, StripColumn.Width.Value, width, SwitchDurationMs,
                 onTick: v => _verticalTabHost.SetInternalStripWidth(v));
         };
 
-        RebindVerticalTitle();
-        _tabManager.ActiveTabChanged += (_, _) => RebindVerticalTitle();
-
-        // Place both tab hosts in their RootGrid slots.
+        // Place both tab hosts in their RootGrid slots. The
+        // horizontal host spans both columns in row 0 so its TabView
+        // strip can grow under the title bar area; the vertical host
+        // anchors at col 0 and spans both rows.
         Grid.SetRow((FrameworkElement)_horizontalTabHost.HostElement, 0);
         Grid.SetColumn((FrameworkElement)_horizontalTabHost.HostElement, 0);
         Grid.SetColumnSpan((FrameworkElement)_horizontalTabHost.HostElement, 2);
@@ -151,19 +150,32 @@ public sealed partial class MainWindow : Window
         RootGrid.Children.Add(_verticalTabHost);
 
         // Parent every existing and future PaneHost into the shared
-        // container. This is the single owner for PaneHost lifetime
-        // in the visual tree — both tab hosts read from it without
-        // ever reparenting.
+        // container (declared in MainWindow.xaml as PaneHostContainer).
+        // This is the single owner for PaneHost lifetime in the visual
+        // tree — both tab hosts read from it without ever reparenting.
         foreach (var t in _tabManager.Tabs) AddPaneHost(t);
         SwapActivePane();
         _tabManager.TabAdded += (_, t) => { AddPaneHost(t); SwapActivePane(); };
         _tabManager.TabRemoved += (_, t) => RemovePaneHost(t);
         _tabManager.ActiveTabChanged += (_, _) => SwapActivePane();
 
+        RebindVerticalTitle();
+        _tabManager.ActiveTabChanged += (_, _) => RebindVerticalTitle();
+
+        // Tooltip chord label is sourced from KeyBindings.Default so
+        // the button description cannot drift from the accelerator.
+        var chord = KeyBindings.Default.Label(PaneAction.ToggleTabLayout);
+        ToolTipService.SetToolTip(
+            VerticalSwitchButton,
+            chord is null
+                ? "Switch to horizontal tabs"
+                : $"Switch to horizontal tabs ({chord})");
+
         _tabHost = _uiSettings.VerticalTabs ? _verticalTabHost : _horizontalTabHost;
-        ApplyLayoutMode(_uiSettings.VerticalTabs, animate: false);
+        SnapLayoutState(_uiSettings.VerticalTabs);
 
         SetTitleBarForCurrentMode();
+        SyncCaptionInset();
 
         InstallPaneAccelerators();
 
@@ -204,6 +216,7 @@ public sealed partial class MainWindow : Window
                     else
                         _taskbarCoordinator?.Resume();
                 }
+                SyncCaptionInset();
             };
         }
         catch (System.Exception ex)
@@ -211,115 +224,37 @@ public sealed partial class MainWindow : Window
             System.Diagnostics.Debug.WriteLine($"Taskbar progress wiring failed: {ex.Message}");
         }
 
-        Closed += (_, _) =>
-        {
-            // Surface lifetime is decoupled from Loaded/Unloaded
-            // (see TerminalControl.DisposeSurface), so we have to
-            // free every leaf in every tab explicitly before tearing
-            // down the libghostty host.
-            foreach (var t in _tabManager.Tabs) t.PaneHost.DisposeAllLeaves();
-            _host.Dispose();
-        };
+        Closed += OnClosedAsync;
     }
 
-    /// <summary>
-    /// Rewrite RootGrid into a 2x2 layout that both tab hosts share:
-    ///
-    ///   +------------------+----------------+
-    ///   | v-strip col 0    | title / h-strip|  row 0 (Auto)
-    ///   |  (0 px in        |    row 0 col 1 |
-    ///   |   horizontal)    +----------------+
-    ///   |                  | PaneHost *     |  row 1 (*)
-    ///   +------------------+----------------+
-    ///
-    /// PaneHostContainer is a direct child of RootGrid at row 1,
-    /// col 1 and never moves. This is the safe slot for every
-    /// PaneHost's SwapChainPanel.
-    /// </summary>
-    private void BuildLayout(out Grid paneHostContainer)
+    private async void OnClosedAsync(object sender, WindowEventArgs args)
     {
-        RootGrid.RowDefinitions.Clear();
-        RootGrid.ColumnDefinitions.Clear();
-        RootGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-        RootGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
-        RootGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(0) });
-        RootGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-
-        // Vertical-mode title bar (row 0, full width). Hosts the
-        // switch-layout button, the active-tab title, and the caption
-        // button inset. Visibility toggles with the active layout.
-        BuildVerticalTitleBar();
-        Grid.SetRow(_verticalTitleBar, 0);
-        Grid.SetColumn(_verticalTitleBar, 0);
-        Grid.SetColumnSpan(_verticalTitleBar, 2);
-        RootGrid.Children.Add(_verticalTitleBar);
-
-        paneHostContainer = new Grid
+        // Let any in-flight ContentDialog complete before we tear
+        // down the libghostty host. Files #17363 reproducer:
+        // disposing MainWindow while a dialog is still animating its
+        // data-binding teardown throws a COMException out of the
+        // XAML runtime. The tracker awaits the tasks that the tab
+        // hosts push in via RequestCloseTabAsync / RenameTabDialog.
+        try
         {
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-        };
-        Grid.SetRow(paneHostContainer, 1);
-        Grid.SetColumn(paneHostContainer, 1);
-        RootGrid.Children.Add(paneHostContainer);
+            if (_dialogs.PendingCount > 0)
+                await _dialogs.WhenAllClosedAsync();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"DialogTracker drain failed: {ex.Message}");
+        }
+
+        // Surface lifetime is decoupled from Loaded/Unloaded
+        // (see TerminalControl.DisposeSurface), so we have to
+        // free every leaf in every tab explicitly before tearing
+        // down the libghostty host.
+        foreach (var t in _tabManager.Tabs) t.PaneHost.DisposeAllLeaves();
+        _host.Dispose();
     }
 
-    private void BuildVerticalTitleBar()
-    {
-        _verticalTitleBar = new Grid
-        {
-            Height = 32,
-            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
-            Visibility = Visibility.Collapsed,
-        };
-        _verticalTitleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        _verticalTitleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(146) });
-
-        _verticalTitleDragRegion = new Grid
-        {
-            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
-        };
-        Grid.SetColumn(_verticalTitleDragRegion, 0);
-
-        var switchButton = new Button
-        {
-            Width = 32,
-            Height = 32,
-            Padding = new Thickness(0),
-            // Sit just to the right of the sidebar column (40 px
-            // wide) so the button does not overlap the chevron that
-            // lives at the top of VerticalTabStrip.
-            Margin = new Thickness(44, 0, 0, 0),
-            HorizontalAlignment = HorizontalAlignment.Left,
-            VerticalAlignment = VerticalAlignment.Center,
-            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
-            BorderThickness = new Thickness(0),
-            Content = new FontIcon
-            {
-                FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)
-                    Application.Current.Resources["SymbolThemeFontFamily"],
-                Glyph = "\uE8A9",
-                FontSize = 14,
-            },
-        };
-        ToolTipService.SetToolTip(switchButton, "Switch to horizontal tabs (Ctrl+Shift+Alt+V)");
-        switchButton.Click += (_, _) => PaneActionRouter.RequestToggleTabLayout(_tabManager);
-
-        _verticalTitleText = new TextBlock
-        {
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Center,
-            FontSize = 12,
-            Foreground = (Microsoft.UI.Xaml.Media.Brush)
-                Application.Current.Resources["TextFillColorPrimaryBrush"],
-            TextTrimming = TextTrimming.CharacterEllipsis,
-            IsHitTestVisible = false,
-        };
-
-        _verticalTitleDragRegion.Children.Add(switchButton);
-        _verticalTitleDragRegion.Children.Add(_verticalTitleText);
-        _verticalTitleBar.Children.Add(_verticalTitleDragRegion);
-    }
+    private void OnVerticalSwitchButtonClick(object sender, RoutedEventArgs e)
+        => _router.RequestToggleTabLayout();
 
     private void RebindVerticalTitle()
     {
@@ -343,7 +278,32 @@ public sealed partial class MainWindow : Window
 
     private void UpdateVerticalTitleText()
     {
-        _verticalTitleText.Text = _verticalTitleBoundTab?.EffectiveTitle ?? "Ghostty";
+        VerticalTitleText.Text = _verticalTitleBoundTab?.EffectiveTitle ?? "Ghostty";
+    }
+
+    /// <summary>
+    /// Keep the right-hand caption inset in sync with the real
+    /// OS-reserved width for min/max/close buttons. AppWindow's
+    /// TitleBar.RightInset is DPI- and theme-aware; the previous
+    /// hard-coded 146 DIP was a best-guess for 1x DPI.
+    /// </summary>
+    private void SyncCaptionInset()
+    {
+        try
+        {
+            var inset = AppWindow.TitleBar.RightInset;
+            // RightInset is in physical pixels; scale by the current
+            // rasterization scale so we land on the right DIP.
+            var scale = (Content as FrameworkElement)?.XamlRoot?.RasterizationScale ?? 1.0;
+            var dip = scale > 0 ? inset / scale : inset;
+            if (dip > 0)
+                VerticalCaptionInset.Width = new GridLength(dip);
+        }
+        catch
+        {
+            // RightInset can throw early during construction; leave
+            // the XAML default (146) in place.
+        }
     }
 
     private void AddPaneHost(Core.Tabs.TabModel tab)
@@ -352,19 +312,19 @@ public sealed partial class MainWindow : Window
         paneHost.HorizontalAlignment = HorizontalAlignment.Stretch;
         paneHost.VerticalAlignment = VerticalAlignment.Stretch;
         paneHost.Visibility = Visibility.Collapsed;
-        _paneHostContainer.Children.Add(paneHost);
+        PaneHostContainer.Children.Add(paneHost);
     }
 
     private void RemovePaneHost(Core.Tabs.TabModel tab)
     {
         var paneHost = (PaneHost)tab.PaneHost;
-        _paneHostContainer.Children.Remove(paneHost);
+        PaneHostContainer.Children.Remove(paneHost);
     }
 
     private void SwapActivePane()
     {
         var active = (PaneHost)_tabManager.ActiveTab.PaneHost;
-        foreach (UIElement child in _paneHostContainer.Children)
+        foreach (UIElement child in PaneHostContainer.Children)
         {
             child.Visibility = ReferenceEquals(child, active)
                 ? Visibility.Visible
@@ -385,7 +345,7 @@ public sealed partial class MainWindow : Window
         _uiSettings.VerticalTabs = toVertical;
         _uiSettings.Save();
         _tabHost = toVertical ? _verticalTabHost : _horizontalTabHost;
-        ApplyLayoutMode(toVertical, animate: true);
+        AnimateLayoutSwitch(toVertical);
         SetTitleBarForCurrentMode();
     }
 
@@ -395,46 +355,61 @@ public sealed partial class MainWindow : Window
         // inside TabHost. In vertical mode it is the MainWindow-owned
         // title bar grid (row 0 full width).
         if (_tabHost is VerticalTabHost)
-            SetTitleBar(_verticalTitleDragRegion);
+            SetTitleBar(VerticalTitleDragRegion);
         else
             SetTitleBar(_horizontalTabHost.DragRegion as FrameworkElement);
     }
 
     /// <summary>
-    /// Apply the given layout mode to the RootGrid column widths and
-    /// both tab hosts' visibility. On first call (animate=false) the
-    /// end state is snapped immediately; on toggle (animate=true) the
-    /// outgoing chrome slides away while the incoming chrome slides
-    /// in, and the vertical strip column width tweens in parallel.
+    /// Snap both hosts and the vertical title bar to the end state
+    /// for <paramref name="verticalTabs"/>. Used at construction
+    /// (animate=false) and from the Storyboard Completed handler to
+    /// guarantee a consistent end state regardless of mid-flight
+    /// cancellation.
     /// </summary>
-    private const double VerticalStripCollapsedWidth = 40;
-    private const int SwitchDurationMs = 220;
-
-    private void ApplyLayoutMode(bool verticalTabs, bool animate)
+    private void SnapLayoutState(bool verticalTabs)
     {
         var verticalHost = (FrameworkElement)_verticalTabHost;
         var horizontalHost = (FrameworkElement)_horizontalTabHost.HostElement;
 
-        var stripCol = RootGrid.ColumnDefinitions[0];
+        StripColumn.Width = new GridLength(verticalTabs ? VerticalStripCollapsedWidth : 0);
+        _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth);
+
+        verticalHost.Opacity = verticalTabs ? 1 : 0;
+        verticalHost.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+        verticalHost.IsHitTestVisible = verticalTabs;
+
+        horizontalHost.Opacity = verticalTabs ? 0 : 1;
+        horizontalHost.Visibility = verticalTabs ? Visibility.Collapsed : Visibility.Visible;
+        horizontalHost.IsHitTestVisible = !verticalTabs;
+
+        VerticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+        VerticalTitleBar.Opacity = verticalTabs ? 1 : 0;
+
+        // Reset any dangling translate offsets so future switches
+        // start from origin. Safe to overwrite: SnapLayoutState is
+        // only called when no transform animation is in flight.
+        GetOrCreateTranslate(verticalHost).X = 0;
+        GetOrCreateTranslate(verticalHost).Y = 0;
+        GetOrCreateTranslate(horizontalHost).X = 0;
+        GetOrCreateTranslate(horizontalHost).Y = 0;
+    }
+
+    /// <summary>
+    /// Cross-fade + slide animation between horizontal and vertical
+    /// layouts. Drives the chrome transforms via a Storyboard
+    /// (compositor-backed) and the strip column width via
+    /// <see cref="TweenColumnWidth"/> because GridLength cannot be
+    /// animated by the Storyboard system.
+    /// </summary>
+    private void AnimateLayoutSwitch(bool verticalTabs)
+    {
+        var verticalHost = (FrameworkElement)_verticalTabHost;
+        var horizontalHost = (FrameworkElement)_horizontalTabHost.HostElement;
         var targetColWidth = verticalTabs ? VerticalStripCollapsedWidth : 0;
 
-        if (!animate)
-        {
-            stripCol.Width = new GridLength(targetColWidth);
-            _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth);
-            verticalHost.Opacity = verticalTabs ? 1 : 0;
-            verticalHost.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
-            verticalHost.IsHitTestVisible = verticalTabs;
-            horizontalHost.Opacity = verticalTabs ? 0 : 1;
-            horizontalHost.Visibility = verticalTabs ? Visibility.Collapsed : Visibility.Visible;
-            horizontalHost.IsHitTestVisible = !verticalTabs;
-            _verticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
-            _verticalTitleBar.Opacity = verticalTabs ? 1 : 0;
-            return;
-        }
-
         _switchingLayout = true;
-        _verticalTitleBar.Visibility = Visibility.Visible;
+        VerticalTitleBar.Visibility = Visibility.Visible;
         verticalHost.Visibility = Visibility.Visible;
         horizontalHost.Visibility = Visibility.Visible;
 
@@ -442,26 +417,25 @@ public sealed partial class MainWindow : Window
         // offset, then animates to Opacity 1 / offset 0.
         var incoming = verticalTabs ? verticalHost : horizontalHost;
         var outgoing = verticalTabs ? horizontalHost : verticalHost;
-        var incomingOffset = verticalTabs ? new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0) : new Windows.Foundation.Point(0, -32);
-        var outgoingOffset = verticalTabs ? new Windows.Foundation.Point(0, -32) : new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0);
+        var incomingOffset = verticalTabs
+            ? new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0)
+            : new Windows.Foundation.Point(0, -32);
+        var outgoingOffset = verticalTabs
+            ? new Windows.Foundation.Point(0, -32)
+            : new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0);
 
         incoming.IsHitTestVisible = true;
         var incomingTx = GetOrCreateTranslate(incoming);
         incomingTx.X = incomingOffset.X;
         incomingTx.Y = incomingOffset.Y;
         incoming.Opacity = 0;
-        incoming.Visibility = Visibility.Visible;
 
         var sb = new Storyboard();
-
-        // Cross-fade.
         sb.Children.Add(MakeDoubleAnim(incoming, "Opacity", 0, 1));
         sb.Children.Add(MakeDoubleAnim(outgoing, "Opacity", outgoing.Opacity, 0));
-        // The vertical title bar fades with the vertical chrome.
-        sb.Children.Add(MakeDoubleAnim(_verticalTitleBar, "Opacity",
+        sb.Children.Add(MakeDoubleAnim(VerticalTitleBar, "Opacity",
             verticalTabs ? 0 : 1, verticalTabs ? 1 : 0));
 
-        // Slide.
         sb.Children.Add(MakeTransformAnim(incoming, "X", incomingTx.X, 0));
         sb.Children.Add(MakeTransformAnim(incoming, "Y", incomingTx.Y, 0));
         var outgoingTx = GetOrCreateTranslate(outgoing);
@@ -470,23 +444,14 @@ public sealed partial class MainWindow : Window
 
         sb.Completed += (_, _) =>
         {
-            outgoing.IsHitTestVisible = false;
-            outgoing.Opacity = 0;
-            outgoing.Visibility = Visibility.Collapsed;
-            // Reset outgoing back to origin so a subsequent switch
-            // animates from a known position instead of stacking.
-            outgoingTx.X = 0;
-            outgoingTx.Y = 0;
-            _verticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+            SnapLayoutState(verticalTabs);
             _switchingLayout = false;
         };
         sb.Begin();
 
-        // Column width tween runs in parallel via DispatcherQueueTimer
-        // because animating GridLength via Storyboard is clunky. Drive
-        // the VerticalTabHost's own internal column in lockstep so its
-        // visual sidebar fills the outer column.
-        TweenColumnWidth(stripCol, stripCol.Width.Value, targetColWidth, SwitchDurationMs,
+        // Column width tween runs in parallel (see AnimateLayoutSwitch
+        // docstring for why it's code-driven, not Storyboard-driven).
+        TweenColumnWidth(StripColumn, StripColumn.Width.Value, targetColWidth, SwitchDurationMs,
             onTick: _ => _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth));
     }
 
@@ -526,8 +491,20 @@ public sealed partial class MainWindow : Window
         return anim;
     }
 
+    /// <summary>
+    /// Tween a <see cref="ColumnDefinition.Width"/> from its current
+    /// value to <paramref name="to"/> over <paramref name="durationMs"/>.
+    /// Only one tween is active per column at a time: if a previous
+    /// tween is still running when this is called it is stopped and
+    /// replaced. GridLength cannot be animated by Storyboard so this
+    /// is unavoidable.
+    /// </summary>
     private void TweenColumnWidth(ColumnDefinition col, double from, double to, int durationMs, Action<double>? onTick = null)
     {
+        // Cancel any previous in-flight tween so chevron + layout
+        // switch can't race on the same column.
+        _activeColumnTween?.Stop();
+
         var startTime = DateTime.UtcNow;
         var duration = TimeSpan.FromMilliseconds(durationMs);
         var timer = DispatcherQueue.CreateTimer();
@@ -541,8 +518,14 @@ public sealed partial class MainWindow : Window
             var value = from + (to - from) * eased;
             col.Width = new GridLength(value);
             onTick?.Invoke(value);
-            if (progress >= 1.0) t.Stop();
+            if (progress >= 1.0)
+            {
+                t.Stop();
+                if (ReferenceEquals(_activeColumnTween, t))
+                    _activeColumnTween = null;
+            }
         };
+        _activeColumnTween = timer;
         timer.Start();
     }
 
@@ -604,9 +587,9 @@ public sealed partial class MainWindow : Window
     /// chords (it asks the same KeyBindings registry) to let the
     /// accelerator fire.
     ///
-    /// Bindings live in <see cref="KeyBindings.Default"/>; a future PR
-    /// will replace that with a config-driven loader and nothing here
-    /// has to change.
+    /// Router events are instance-scoped (no static subscriptions),
+    /// so MainWindow can be closed and garbage-collected cleanly once
+    /// the last tab closes.
     /// </summary>
     private void InstallPaneAccelerators()
     {
@@ -637,7 +620,7 @@ public sealed partial class MainWindow : Window
                 // See https://github.com/deblasis/ghostty/issues/165.
                 if (_acceleratorFiredThisKeyDown == captured.Action) return;
                 _acceleratorFiredThisKeyDown = captured.Action;
-                PaneActionRouter.Invoke(captured.Action, _tabManager);
+                _router.Invoke(captured.Action);
             };
             _tabHost.HostElement.KeyboardAccelerators.Add(accel);
         }
@@ -650,27 +633,22 @@ public sealed partial class MainWindow : Window
         // is the same code path as the per-tab X button and the
         // context-menu Close item — single source of truth for
         // close confirmation lives in TabHost, which has XamlRoot.
-        PaneActionRouter.TabCloseRequestedFromKeyboard += async (_, mgr) =>
+        _router.TabCloseRequestedFromKeyboard += async (_, _) =>
         {
-            if (!ReferenceEquals(mgr, _tabManager)) return;
             await _tabHost.RequestCloseTabAsync(_tabManager.ActiveTab);
         };
 
         // Vertical-tabs pinned toggle via Ctrl+Shift+Space. No-op
         // when the layout is horizontal (TabHost) — the chord is
         // registered globally but only VerticalTabHost responds.
-        PaneActionRouter.ToggleVerticalTabsPinnedFromKeyboard += (_, mgr) =>
+        _router.ToggleVerticalTabsPinnedRequested += (_, _) =>
         {
-            if (!ReferenceEquals(mgr, _tabManager)) return;
             if (_tabHost is VerticalTabHost vth)
                 vth.TogglePinnedFromKeyboard();
         };
 
-        // Runtime tab-layout switch via Ctrl+Shift+Alt+V.
-        PaneActionRouter.ToggleTabLayoutFromKeyboard += (_, mgr) =>
-        {
-            if (!ReferenceEquals(mgr, _tabManager)) return;
-            ToggleTabLayout();
-        };
+        // Runtime tab-layout switch via Ctrl+Shift+Alt+V (and the
+        // title-bar icon + context menu, which share the event path).
+        _router.ToggleTabLayoutRequested += (_, _) => ToggleTabLayout();
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -158,7 +158,6 @@ public sealed partial class MainWindow : Window
         _tabHost = _uiSettings.VerticalTabs ? _verticalTabHost : _horizontalTabHost;
 
         _layout = new LayoutCoordinator(
-            DispatcherQueue,
             StripColumn,
             (FrameworkElement)_horizontalTabHost.HostElement,
             _verticalTabHost,

--- a/windows/Ghostty/Settings/UiSettings.cs
+++ b/windows/Ghostty/Settings/UiSettings.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Ghostty.Settings;
 
@@ -10,6 +12,12 @@ namespace Ghostty.Settings;
 /// yet. One JSON file at
 /// <c>%APPDATA%\Ghostty\ui-settings.json</c>, loaded once at
 /// startup and written on every change.
+///
+/// Serialization goes through <see cref="UiSettingsContext"/> (a
+/// source-generated <see cref="JsonSerializerContext"/>) so this
+/// stays trim/AOT-safe if/when <c>PublishAot</c> is turned on.
+/// Reflection-based STJ would root type metadata and silently
+/// drop properties under the trimmer (PowerToys #42644).
 ///
 /// TODO(config): fold this into the real config layer when it lands
 /// on Windows. Until then this is the only piece of per-user UI
@@ -38,12 +46,15 @@ internal sealed class UiSettings
             var path = FilePath;
             if (!File.Exists(path)) return new UiSettings();
             var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
+            return JsonSerializer.Deserialize(json, UiSettingsContext.Default.UiSettings)
+                ?? new UiSettings();
         }
-        catch
+        catch (Exception ex)
         {
             // A malformed or inaccessible settings file must never
-            // block startup. Fall back to defaults silently.
+            // block startup. Fall back to defaults and trace the
+            // reason for post-mortem.
+            Debug.WriteLine($"UiSettings load failed, using defaults: {ex.Message}");
             return new UiSettings();
         }
     }
@@ -52,12 +63,19 @@ internal sealed class UiSettings
     {
         try
         {
-            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(this, UiSettingsContext.Default.UiSettings);
             File.WriteAllText(FilePath, json);
         }
-        catch
+        catch (Exception ex)
         {
             // Same policy as Load: never throw from a settings write.
+            Debug.WriteLine($"UiSettings save failed: {ex.Message}");
         }
     }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(UiSettings))]
+internal partial class UiSettingsContext : JsonSerializerContext
+{
 }

--- a/windows/Ghostty/Settings/UiSettings.cs
+++ b/windows/Ghostty/Settings/UiSettings.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Ghostty.Settings;
+
+/// <summary>
+/// Tiny persistent store for UI-layer preferences that need to
+/// survive restarts but do not belong in libghostty's config layer
+/// yet. One JSON file at
+/// <c>%APPDATA%\Ghostty\ui-settings.json</c>, loaded once at
+/// startup and written on every change.
+///
+/// TODO(config): fold this into the real config layer when it lands
+/// on Windows. Until then this is the only piece of per-user UI
+/// state (vertical-vs-horizontal tabs) that has to persist.
+/// </summary>
+internal sealed class UiSettings
+{
+    public bool VerticalTabs { get; set; }
+
+    private static string FilePath
+    {
+        get
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Ghostty");
+            Directory.CreateDirectory(dir);
+            return Path.Combine(dir, "ui-settings.json");
+        }
+    }
+
+    public static UiSettings Load()
+    {
+        try
+        {
+            var path = FilePath;
+            if (!File.Exists(path)) return new UiSettings();
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<UiSettings>(json) ?? new UiSettings();
+        }
+        catch
+        {
+            // A malformed or inaccessible settings file must never
+            // block startup. Fall back to defaults silently.
+            return new UiSettings();
+        }
+    }
+
+    public void Save()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(FilePath, json);
+        }
+        catch
+        {
+            // Same policy as Load: never throw from a settings write.
+        }
+    }
+}

--- a/windows/Ghostty/Shell/GridLengthAnimator.cs
+++ b/windows/Ghostty/Shell/GridLengthAnimator.cs
@@ -1,0 +1,67 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Shell;
+
+/// <summary>
+/// Bridges a <see cref="ColumnDefinition.Width"/> (a
+/// <see cref="GridLength"/>, which the WinUI 3 animation system
+/// cannot animate directly) to a <see cref="DoubleAnimation"/>.
+///
+/// Mechanism: a small <see cref="DependencyObject"/> with a single
+/// <c>double</c> dependency property. A <see cref="Storyboard"/>
+/// targets that property; the <c>PropertyChangedCallback</c>
+/// converts each tick value to a <see cref="GridLength"/> and
+/// writes it to the target column. An optional
+/// <see cref="OnTick"/> hook fires the same value out to a
+/// caller-supplied callback so collaborators (e.g.
+/// VerticalTabHost's internal strip column) can stay in lockstep.
+///
+/// Why this exists: WinUI 3 has no <c>GridLengthAnimation</c>.
+/// Either the app uses Star/Auto and lets layout drive the
+/// transition (a layout topology change we are not making in
+/// this PR), or it owns the conversion. The previous
+/// implementation drove the conversion off a 16 ms
+/// <see cref="Microsoft.UI.Dispatching.DispatcherQueueTimer"/>
+/// using <c>DateTime.UtcNow</c> for elapsed time. The Storyboard
+/// path runs on the framework animation timer, gets easing for
+/// free, and integrates with the cross-fade Storyboard so the
+/// two share a single Completed event.
+/// </summary>
+internal sealed class GridLengthAnimator : DependencyObject
+{
+    public static readonly DependencyProperty ValueProperty =
+        DependencyProperty.Register(
+            nameof(Value),
+            typeof(double),
+            typeof(GridLengthAnimator),
+            new PropertyMetadata(0.0, OnValueChanged));
+
+    public double Value
+    {
+        get => (double)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public ColumnDefinition Target { get; }
+    public Action<double>? OnTick { get; set; }
+
+    public GridLengthAnimator(ColumnDefinition target, double initial)
+    {
+        Target = target;
+        Value = initial;
+        // Snap the column to the initial value so the storyboard's
+        // first frame does not jump from whatever the layout had
+        // before.
+        target.Width = new GridLength(initial);
+    }
+
+    private static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var animator = (GridLengthAnimator)d;
+        var v = (double)e.NewValue;
+        animator.Target.Width = new GridLength(v);
+        animator.OnTick?.Invoke(v);
+    }
+}

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -1,6 +1,5 @@
 using System;
 using Ghostty.Tabs;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -28,7 +27,6 @@ internal sealed class LayoutCoordinator
     public const double VerticalStripCollapsedWidth = 40;
     public const int SwitchDurationMs = 220;
 
-    private readonly DispatcherQueue _dispatcher;
     private readonly ColumnDefinition _stripColumn;
     private readonly FrameworkElement _horizontalHost;
     private readonly VerticalTabHost _verticalTabHost;
@@ -36,16 +34,14 @@ internal sealed class LayoutCoordinator
     private readonly Grid _verticalTitleBar;
 
     private bool _switching;
-    private DispatcherQueueTimer? _activeColumnTween;
+    private Storyboard? _activeColumnSb;
 
     public LayoutCoordinator(
-        DispatcherQueue dispatcher,
         ColumnDefinition stripColumn,
         FrameworkElement horizontalHost,
         VerticalTabHost verticalTabHost,
         Grid verticalTitleBar)
     {
-        _dispatcher = dispatcher;
         _stripColumn = stripColumn;
         _horizontalHost = horizontalHost;
         _verticalTabHost = verticalTabHost;
@@ -98,9 +94,16 @@ internal sealed class LayoutCoordinator
 
     /// <summary>
     /// Cross-fade + slide animation between horizontal and vertical
-    /// layouts. Runs the chrome transforms via a Storyboard
-    /// (compositor-backed) and the strip column width via
-    /// <see cref="TweenStripColumn"/>.
+    /// layouts. Runs the chrome transforms (Opacity, RenderTransform)
+    /// AND the strip column width inside a single
+    /// <see cref="Storyboard"/> so all the animations share one
+    /// timeline and one Completed handler.
+    ///
+    /// The column width is animated through
+    /// <see cref="GridLengthAnimator"/>, a small DependencyObject
+    /// proxy that converts <c>double</c> ticks into
+    /// <see cref="GridLength"/> writes — WinUI 3 has no native
+    /// GridLengthAnimation.
     /// </summary>
     public void Animate(bool verticalTabs)
     {
@@ -128,6 +131,11 @@ internal sealed class LayoutCoordinator
         incomingTx.Y = incomingOffset.Y;
         incoming.Opacity = 0;
 
+        // Cancel any column tween from a previous chevron click so
+        // the storyboard owns the column width for its full duration.
+        _activeColumnSb?.Stop();
+        _activeColumnSb = null;
+
         var sb = new Storyboard();
         sb.Children.Add(MakeDoubleAnim(incoming, "Opacity", 0, 1));
         sb.Children.Add(MakeDoubleAnim(outgoing, "Opacity", outgoing.Opacity, 0));
@@ -140,49 +148,46 @@ internal sealed class LayoutCoordinator
         sb.Children.Add(MakeTransformAnim(outgoing, "X", outgoingTx.X, outgoingOffset.X));
         sb.Children.Add(MakeTransformAnim(outgoing, "Y", outgoingTx.Y, outgoingOffset.Y));
 
+        // Strip column width: bridge GridLength via the proxy.
+        // Snap the inner strip column once at the start — during a
+        // layout switch the chevron pinned-state never changes, so
+        // there is no per-frame onTick callback to drive.
+        _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth);
+        var widthProxy = new GridLengthAnimator(_stripColumn, _stripColumn.Width.Value);
+        sb.Children.Add(MakeDoubleAnim(widthProxy, "Value", _stripColumn.Width.Value, targetColWidth));
+
         sb.Completed += (_, _) =>
         {
             Snap(verticalTabs);
             _switching = false;
         };
         sb.Begin();
-
-        TweenStripColumn(_stripColumn.Width.Value, targetColWidth,
-            onTick: _ => _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth));
     }
 
     /// <summary>
     /// Tween <see cref="ColumnDefinition.Width"/> from its current
-    /// value to <paramref name="to"/>. Cancels any in-flight tween
-    /// so the chevron toggle and the layout switch cannot race on
-    /// the same column.
+    /// value to <paramref name="to"/>. Used by the chevron expand
+    /// path inside <see cref="VerticalTabHost"/>; the runtime layout
+    /// switch above bundles its column tween into the cross-fade
+    /// Storyboard instead.
+    ///
+    /// Cancels any in-flight column tween so the chevron toggle and
+    /// the layout switch cannot race on the same column.
     /// </summary>
     public void TweenStripColumn(double from, double to, Action<double>? onTick = null)
     {
-        _activeColumnTween?.Stop();
+        _activeColumnSb?.Stop();
 
-        var startTime = DateTime.UtcNow;
-        var duration = TimeSpan.FromMilliseconds(SwitchDurationMs);
-        var timer = _dispatcher.CreateTimer();
-        timer.Interval = TimeSpan.FromMilliseconds(16);
-        timer.IsRepeating = true;
-        timer.Tick += (t, _) =>
+        var proxy = new GridLengthAnimator(_stripColumn, from) { OnTick = onTick };
+        var sb = new Storyboard();
+        sb.Children.Add(MakeDoubleAnim(proxy, "Value", from, to));
+        sb.Completed += (s, _) =>
         {
-            var elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-            var progress = Math.Min(1.0, elapsed / duration.TotalMilliseconds);
-            var eased = 1 - (1 - progress) * (1 - progress);
-            var value = from + (to - from) * eased;
-            _stripColumn.Width = new GridLength(value);
-            onTick?.Invoke(value);
-            if (progress >= 1.0)
-            {
-                t.Stop();
-                if (ReferenceEquals(_activeColumnTween, t))
-                    _activeColumnTween = null;
-            }
+            if (ReferenceEquals(_activeColumnSb, s))
+                _activeColumnSb = null;
         };
-        _activeColumnTween = timer;
-        timer.Start();
+        _activeColumnSb = sb;
+        sb.Begin();
     }
 
     private static TranslateTransform GetOrCreateTranslate(FrameworkElement fe)

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -1,0 +1,223 @@
+using System;
+using Ghostty.Tabs;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Animation;
+
+namespace Ghostty.Shell;
+
+/// <summary>
+/// Owns every piece of state that drives the runtime switch
+/// between the horizontal and vertical tab layouts: the cross-fade
+/// Storyboard, the strip-column width tween, the snap-to-end-state
+/// helper, and the concurrent-tween guard.
+///
+/// Lifted out of MainWindow so the window itself stays a thin
+/// composition root. The two tab hosts and the vertical title bar
+/// are owned by MainWindow's XAML and passed in via the ctor; this
+/// type only animates and toggles them.
+///
+/// Why the column width tween is code-driven: WinUI 3 has no native
+/// GridLengthAnimation. Star/Auto refactoring is a separate piece
+/// of work tracked in the deferred review items list.
+/// </summary>
+internal sealed class LayoutCoordinator
+{
+    public const double VerticalStripCollapsedWidth = 40;
+    public const int SwitchDurationMs = 220;
+
+    private readonly DispatcherQueue _dispatcher;
+    private readonly ColumnDefinition _stripColumn;
+    private readonly FrameworkElement _horizontalHost;
+    private readonly VerticalTabHost _verticalTabHost;
+    private readonly FrameworkElement _verticalHost;
+    private readonly Grid _verticalTitleBar;
+
+    private bool _switching;
+    private DispatcherQueueTimer? _activeColumnTween;
+
+    public LayoutCoordinator(
+        DispatcherQueue dispatcher,
+        ColumnDefinition stripColumn,
+        FrameworkElement horizontalHost,
+        VerticalTabHost verticalTabHost,
+        Grid verticalTitleBar)
+    {
+        _dispatcher = dispatcher;
+        _stripColumn = stripColumn;
+        _horizontalHost = horizontalHost;
+        _verticalTabHost = verticalTabHost;
+        _verticalHost = verticalTabHost;
+        _verticalTitleBar = verticalTitleBar;
+
+        // The chevron toggle inside VerticalTabHost asks the outer
+        // shell to widen the strip column. Forward through the same
+        // tween path so chevron + layout switch can never race.
+        _verticalTabHost.StripWidthChangeRequested += (_, width) =>
+        {
+            TweenStripColumn(_stripColumn.Width.Value, width,
+                onTick: v => _verticalTabHost.SetInternalStripWidth(v));
+        };
+    }
+
+    public bool IsSwitching => _switching;
+
+    /// <summary>
+    /// Snap both hosts and the vertical title bar to the end state
+    /// for <paramref name="verticalTabs"/>. Used at construction
+    /// (no animation needed) and from the Storyboard Completed
+    /// handler to guarantee a consistent end state regardless of
+    /// mid-flight cancellation.
+    /// </summary>
+    public void Snap(bool verticalTabs)
+    {
+        _stripColumn.Width = new GridLength(verticalTabs ? VerticalStripCollapsedWidth : 0);
+        _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth);
+
+        _verticalHost.Opacity = verticalTabs ? 1 : 0;
+        _verticalHost.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+        _verticalHost.IsHitTestVisible = verticalTabs;
+
+        _horizontalHost.Opacity = verticalTabs ? 0 : 1;
+        _horizontalHost.Visibility = verticalTabs ? Visibility.Collapsed : Visibility.Visible;
+        _horizontalHost.IsHitTestVisible = !verticalTabs;
+
+        _verticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+        _verticalTitleBar.Opacity = verticalTabs ? 1 : 0;
+
+        // Reset any dangling translate offsets so future switches
+        // start from origin. Safe to overwrite: Snap is only called
+        // when no transform animation is in flight.
+        GetOrCreateTranslate(_verticalHost).X = 0;
+        GetOrCreateTranslate(_verticalHost).Y = 0;
+        GetOrCreateTranslate(_horizontalHost).X = 0;
+        GetOrCreateTranslate(_horizontalHost).Y = 0;
+    }
+
+    /// <summary>
+    /// Cross-fade + slide animation between horizontal and vertical
+    /// layouts. Runs the chrome transforms via a Storyboard
+    /// (compositor-backed) and the strip column width via
+    /// <see cref="TweenStripColumn"/>.
+    /// </summary>
+    public void Animate(bool verticalTabs)
+    {
+        if (_switching) return;
+        _switching = true;
+
+        var targetColWidth = verticalTabs ? VerticalStripCollapsedWidth : 0;
+
+        _verticalTitleBar.Visibility = Visibility.Visible;
+        _verticalHost.Visibility = Visibility.Visible;
+        _horizontalHost.Visibility = Visibility.Visible;
+
+        var incoming = verticalTabs ? _verticalHost : _horizontalHost;
+        var outgoing = verticalTabs ? _horizontalHost : _verticalHost;
+        var incomingOffset = verticalTabs
+            ? new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0)
+            : new Windows.Foundation.Point(0, -32);
+        var outgoingOffset = verticalTabs
+            ? new Windows.Foundation.Point(0, -32)
+            : new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0);
+
+        incoming.IsHitTestVisible = true;
+        var incomingTx = GetOrCreateTranslate(incoming);
+        incomingTx.X = incomingOffset.X;
+        incomingTx.Y = incomingOffset.Y;
+        incoming.Opacity = 0;
+
+        var sb = new Storyboard();
+        sb.Children.Add(MakeDoubleAnim(incoming, "Opacity", 0, 1));
+        sb.Children.Add(MakeDoubleAnim(outgoing, "Opacity", outgoing.Opacity, 0));
+        sb.Children.Add(MakeDoubleAnim(_verticalTitleBar, "Opacity",
+            verticalTabs ? 0 : 1, verticalTabs ? 1 : 0));
+
+        sb.Children.Add(MakeTransformAnim(incoming, "X", incomingTx.X, 0));
+        sb.Children.Add(MakeTransformAnim(incoming, "Y", incomingTx.Y, 0));
+        var outgoingTx = GetOrCreateTranslate(outgoing);
+        sb.Children.Add(MakeTransformAnim(outgoing, "X", outgoingTx.X, outgoingOffset.X));
+        sb.Children.Add(MakeTransformAnim(outgoing, "Y", outgoingTx.Y, outgoingOffset.Y));
+
+        sb.Completed += (_, _) =>
+        {
+            Snap(verticalTabs);
+            _switching = false;
+        };
+        sb.Begin();
+
+        TweenStripColumn(_stripColumn.Width.Value, targetColWidth,
+            onTick: _ => _verticalTabHost.SetInternalStripWidth(VerticalStripCollapsedWidth));
+    }
+
+    /// <summary>
+    /// Tween <see cref="ColumnDefinition.Width"/> from its current
+    /// value to <paramref name="to"/>. Cancels any in-flight tween
+    /// so the chevron toggle and the layout switch cannot race on
+    /// the same column.
+    /// </summary>
+    public void TweenStripColumn(double from, double to, Action<double>? onTick = null)
+    {
+        _activeColumnTween?.Stop();
+
+        var startTime = DateTime.UtcNow;
+        var duration = TimeSpan.FromMilliseconds(SwitchDurationMs);
+        var timer = _dispatcher.CreateTimer();
+        timer.Interval = TimeSpan.FromMilliseconds(16);
+        timer.IsRepeating = true;
+        timer.Tick += (t, _) =>
+        {
+            var elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+            var progress = Math.Min(1.0, elapsed / duration.TotalMilliseconds);
+            var eased = 1 - (1 - progress) * (1 - progress);
+            var value = from + (to - from) * eased;
+            _stripColumn.Width = new GridLength(value);
+            onTick?.Invoke(value);
+            if (progress >= 1.0)
+            {
+                t.Stop();
+                if (ReferenceEquals(_activeColumnTween, t))
+                    _activeColumnTween = null;
+            }
+        };
+        _activeColumnTween = timer;
+        timer.Start();
+    }
+
+    private static TranslateTransform GetOrCreateTranslate(FrameworkElement fe)
+    {
+        if (fe.RenderTransform is TranslateTransform t) return t;
+        var nt = new TranslateTransform();
+        fe.RenderTransform = nt;
+        return nt;
+    }
+
+    private static DoubleAnimation MakeDoubleAnim(DependencyObject target, string path, double from, double to)
+    {
+        var anim = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
+            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(anim, target);
+        Storyboard.SetTargetProperty(anim, path);
+        return anim;
+    }
+
+    private static DoubleAnimation MakeTransformAnim(FrameworkElement target, string axis, double from, double to)
+    {
+        var anim = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
+            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(anim, target.RenderTransform);
+        Storyboard.SetTargetProperty(anim, axis);
+        return anim;
+    }
+}

--- a/windows/Ghostty/Shell/TaskbarHost.cs
+++ b/windows/Ghostty/Shell/TaskbarHost.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Diagnostics;
+using Ghostty.Core.Tabs;
+using Ghostty.Core.Taskbar;
+using Ghostty.Taskbar;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+
+namespace Ghostty.Shell;
+
+/// <summary>
+/// Wires the per-tab progress reporting (Ghostty.Core.Taskbar.
+/// TaskbarProgressCoordinator) into the OS taskbar via
+/// ITaskbarList3, and pauses the cycling timer when the window is
+/// minimized.
+///
+/// Construction is wrapped in a try/catch because a COM failure
+/// here must not block window construction — the taskbar indicator
+/// is a nice-to-have. <see cref="IsAvailable"/> reports whether the
+/// wiring is live; if not, every call is a no-op.
+/// </summary>
+internal sealed class TaskbarHost : IDisposable
+{
+    private readonly TaskbarList3Facade? _facade;
+    private readonly TaskbarProgressCoordinator? _coordinator;
+    private readonly DispatcherQueueTimer? _tickTimer;
+
+    public bool IsAvailable => _coordinator is not null;
+
+    public TaskbarHost(Window window, TabManager tabs)
+    {
+        try
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+            _facade = new TaskbarList3Facade(hwnd);
+            _coordinator = new TaskbarProgressCoordinator(
+                tabs,
+                _facade,
+                () => DateTime.UtcNow);
+
+            _tickTimer = window.DispatcherQueue.CreateTimer();
+            _tickTimer.Interval = TimeSpan.FromSeconds(2);
+            _tickTimer.IsRepeating = true;
+            _tickTimer.Tick += (_, _) => _coordinator.Tick();
+            _tickTimer.Start();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Taskbar progress wiring failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Hand-off from MainWindow's <c>AppWindow.Changed</c> handler.
+    /// Pause the cycling timer when minimized so the taskbar does
+    /// not churn while the window is hidden, and resume otherwise.
+    /// </summary>
+    public void OnAppWindowChanged(AppWindow appWindow)
+    {
+        if (_coordinator is null) return;
+        if (appWindow.Presenter is OverlappedPresenter op)
+        {
+            if (op.State == OverlappedPresenterState.Minimized)
+                _coordinator.Pause();
+            else
+                _coordinator.Resume();
+        }
+    }
+
+    public void Dispose()
+    {
+        _tickTimer?.Stop();
+    }
+}

--- a/windows/Ghostty/Shell/TitleBarCoordinator.cs
+++ b/windows/Ghostty/Shell/TitleBarCoordinator.cs
@@ -1,0 +1,175 @@
+using System;
+using System.ComponentModel;
+using Ghostty.Controls;
+using Ghostty.Core.Panes;
+using Ghostty.Core.Tabs;
+using Ghostty.Panes;
+using Ghostty.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Shell;
+
+/// <summary>
+/// Owns every cross-cutting title-bar concern that used to live
+/// inside MainWindow:
+///
+///   1. Choosing which element <c>SetTitleBar</c> binds to
+///      depending on whether the active layout is horizontal
+///      (TabHost's footer) or vertical (the MainWindow-owned drag
+///      region next to the sidebar).
+///   2. Re-syncing the right-hand caption inset against
+///      <c>AppWindow.TitleBar.RightInset</c> so the OS min/max/
+///      close buttons get DPI- and theme-aware spacing instead of
+///      the hard-coded 146 DIP from the original PR.
+///   3. Mirroring the active leaf's TitleChanged stream into
+///      <c>TabModel.ShellReportedTitle</c> and the
+///      <c>Window.Title</c>.
+///   4. Keeping the vertical-mode title TextBlock in sync with the
+///      active tab's <c>EffectiveTitle</c>.
+///
+/// MainWindow stays the composition root and forwards
+/// <c>AppWindow.Changed</c> + the active tab/leaf change events.
+/// </summary>
+internal sealed class TitleBarCoordinator
+{
+    private readonly Window _window;
+    private readonly TabManager _tabs;
+    private readonly TabHost _horizontalTabHost;
+    private readonly VerticalTabHost _verticalTabHost;
+    private readonly FrameworkElement _verticalDragRegion;
+    private readonly TextBlock _verticalTitleText;
+    private readonly ColumnDefinition _captionInset;
+    private readonly Func<bool> _isVerticalMode;
+
+    private TabModel? _boundTab;
+    private LeafPane? _activeLeaf;
+
+    public TitleBarCoordinator(
+        Window window,
+        TabManager tabs,
+        TabHost horizontalTabHost,
+        VerticalTabHost verticalTabHost,
+        FrameworkElement verticalDragRegion,
+        TextBlock verticalTitleText,
+        ColumnDefinition captionInset,
+        Func<bool> isVerticalMode)
+    {
+        _window = window;
+        _tabs = tabs;
+        _horizontalTabHost = horizontalTabHost;
+        _verticalTabHost = verticalTabHost;
+        _verticalDragRegion = verticalDragRegion;
+        _verticalTitleText = verticalTitleText;
+        _captionInset = captionInset;
+        _isVerticalMode = isVerticalMode;
+
+        // Tab/title plumbing.
+        _tabs.ActiveTabChanged += (_, _) => RebindVerticalTitle();
+        _tabs.ActiveTabChanged += (_, _) => HookActiveTabTitle();
+        _tabs.WindowTitleChanged += (_, _) => _window.Title = _tabs.ActiveTab.EffectiveTitle;
+
+        RebindVerticalTitle();
+        HookActiveTabTitle();
+    }
+
+    /// <summary>
+    /// Update <c>SetTitleBar</c> for the layout the user just
+    /// switched to. Horizontal mode hands off to TabHost's footer;
+    /// vertical mode hands off to the MainWindow-owned drag region.
+    /// </summary>
+    public void ApplyForCurrentMode()
+    {
+        if (_isVerticalMode())
+            _window.SetTitleBar(_verticalDragRegion);
+        else
+            _window.SetTitleBar(_horizontalTabHost.DragRegion as FrameworkElement);
+    }
+
+    /// <summary>
+    /// Re-read <c>AppWindow.TitleBar.RightInset</c> and apply it to
+    /// the vertical title bar's caption-inset column. Called from
+    /// MainWindow's <c>AppWindow.Changed</c> handler so the inset
+    /// follows DPI / theme transitions instead of being frozen at
+    /// the XAML default.
+    /// </summary>
+    public void SyncCaptionInset()
+    {
+        try
+        {
+            var inset = _window.AppWindow.TitleBar.RightInset;
+            var scale = (_window.Content as FrameworkElement)?.XamlRoot?.RasterizationScale ?? 1.0;
+            var dip = scale > 0 ? inset / scale : inset;
+            if (dip > 0)
+                _captionInset.Width = new GridLength(dip);
+        }
+        catch
+        {
+            // RightInset can throw early during construction; leave
+            // the XAML default in place.
+        }
+    }
+
+    private void RebindVerticalTitle()
+    {
+        if (_boundTab is not null)
+            _boundTab.PropertyChanged -= OnBoundTabPropertyChanged;
+        _boundTab = _tabs.ActiveTab;
+        if (_boundTab is not null)
+            _boundTab.PropertyChanged += OnBoundTabPropertyChanged;
+        UpdateVerticalTitleText();
+    }
+
+    private void OnBoundTabPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
+            e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
+            e.PropertyName == nameof(TabModel.UserOverrideTitle))
+        {
+            UpdateVerticalTitleText();
+        }
+    }
+
+    private void UpdateVerticalTitleText()
+        => _verticalTitleText.Text = _boundTab?.EffectiveTitle ?? "Ghostty";
+
+    /// <summary>
+    /// Subscribe the active tab's active leaf to live title-change
+    /// updates and write the title into
+    /// <see cref="TabModel.ShellReportedTitle"/>. Re-runs every time
+    /// the active tab changes or the active leaf within the active
+    /// tab changes. Lives here (not inside TabManager) because it
+    /// touches WinUI types that Ghostty.Core cannot reach.
+    /// </summary>
+    private void HookActiveTabTitle()
+    {
+        if (_activeLeaf is { } previous)
+            previous.Terminal().TitleChanged -= OnLiveTitleChanged;
+
+        var tab = _tabs.ActiveTab;
+        var leaf = tab.PaneHost.ActiveLeaf;
+        _activeLeaf = leaf;
+        leaf.Terminal().TitleChanged += OnLiveTitleChanged;
+        tab.ShellReportedTitle = leaf.Terminal().CurrentTitle;
+        _window.Title = tab.EffectiveTitle;
+
+        tab.PaneHost.LeafFocused -= OnActiveTabLeafFocused;
+        tab.PaneHost.LeafFocused += OnActiveTabLeafFocused;
+    }
+
+    private void OnActiveTabLeafFocused(object? sender, LeafPane leaf)
+    {
+        if (_activeLeaf is { } previous)
+            previous.Terminal().TitleChanged -= OnLiveTitleChanged;
+        _activeLeaf = leaf;
+        leaf.Terminal().TitleChanged += OnLiveTitleChanged;
+        _tabs.ActiveTab.ShellReportedTitle = leaf.Terminal().CurrentTitle;
+    }
+
+    private void OnLiveTitleChanged(object? sender, string title)
+    {
+        // TabManager raises WindowTitleChanged in response, which
+        // sets Window.Title via the constructor's subscription.
+        _tabs.ActiveTab.ShellReportedTitle = title;
+    }
+}

--- a/windows/Ghostty/Tabs/ColumnDragHandle.cs
+++ b/windows/Ghostty/Tabs/ColumnDragHandle.cs
@@ -33,19 +33,7 @@ internal sealed class ColumnDragHandle : Grid
         // it. A 1px transparent strip is technically grabbable but
         // invisible, which was the original complaint.
         Width = 4;
-        // Look up the theme brush via TryGetValue and tolerate a missing
-        // or mistyped resource (some theme variants ship the key as a
-        // Color, not a SolidColorBrush). The fallback keeps the handle
-        // visible rather than throwing at ctor time.
-        if (Application.Current.Resources.TryGetValue("ControlStrokeColorDefaultBrush", out var res) &&
-            res is Brush brush)
-        {
-            Background = brush;
-        }
-        else
-        {
-            Background = new SolidColorBrush(Microsoft.UI.Colors.Gray);
-        }
+        Background = (SolidColorBrush)Application.Current.Resources["ControlStrokeColorDefaultBrush"];
         HorizontalAlignment = HorizontalAlignment.Right;
         VerticalAlignment = VerticalAlignment.Stretch;
         IsHitTestVisible = true;

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
+using Ghostty.Dialogs;
 using Ghostty.Input;
 using Ghostty.Settings;
 using Microsoft.UI.Xaml.Controls;
@@ -20,7 +21,12 @@ namespace Ghostty.Tabs;
 /// </summary>
 internal static class TabContextMenuBuilder
 {
-    public static MenuFlyout Build(TabManager manager, TabModel tab, Func<TabModel, Task> requestClose)
+    public static MenuFlyout Build(
+        TabManager manager,
+        TabModel tab,
+        Func<TabModel, Task> requestClose,
+        PaneActionRouter router,
+        DialogTracker dialogs)
     {
         var flyout = new MenuFlyout();
 
@@ -53,8 +59,7 @@ internal static class TabContextMenuBuilder
         {
             Text = settings.VerticalTabs ? "Switch to horizontal tabs" : "Switch to vertical tabs",
         };
-        switchLayout.Click += (_, _) =>
-            PaneActionRouter.RequestToggleTabLayout(manager);
+        switchLayout.Click += (_, _) => router.RequestToggleTabLayout();
         flyout.Items.Add(switchLayout);
 
         flyout.Items.Add(new MenuFlyoutSeparator());
@@ -65,9 +70,12 @@ internal static class TabContextMenuBuilder
             var target = flyout.Target;
             if (target?.XamlRoot is null) return;
             var dlg = new RenameTabDialog(tab.UserOverrideTitle) { XamlRoot = target.XamlRoot };
-            var res = await dlg.ShowAsync();
-            if (res == ContentDialogResult.Primary)
-                tab.UserOverrideTitle = string.IsNullOrWhiteSpace(dlg.Result) ? null : dlg.Result;
+            using (dialogs.Track(dlg))
+            {
+                var res = await dlg.ShowAsync();
+                if (res == ContentDialogResult.Primary)
+                    tab.UserOverrideTitle = string.IsNullOrWhiteSpace(dlg.Result) ? null : dlg.Result;
+            }
         };
         flyout.Items.Add(rename);
 

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
+using Ghostty.Input;
+using Ghostty.Settings;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Ghostty.Tabs;
@@ -38,6 +40,22 @@ internal static class TabContextMenuBuilder
         var closeRight = new MenuFlyoutItem { Text = "Close Tabs to the Right" };
         closeRight.Click += (_, _) => CloseToRight(manager, tab);
         flyout.Items.Add(closeRight);
+
+        flyout.Items.Add(new MenuFlyoutSeparator());
+
+        // Runtime tab layout switch. The label flips based on the
+        // currently persisted setting so users see where they will
+        // end up. Dispatches via PaneActionRouter so MainWindow's
+        // single ToggleTabLayout entry point is the only place that
+        // actually flips state.
+        var settings = UiSettings.Load();
+        var switchLayout = new MenuFlyoutItem
+        {
+            Text = settings.VerticalTabs ? "Switch to horizontal tabs" : "Switch to vertical tabs",
+        };
+        switchLayout.Click += (_, _) =>
+            PaneActionRouter.RequestToggleTabLayout(manager);
+        flyout.Items.Add(switchLayout);
 
         flyout.Items.Add(new MenuFlyoutSeparator());
 

--- a/windows/Ghostty/Tabs/TabHost.xaml
+++ b/windows/Ghostty/Tabs/TabHost.xaml
@@ -35,15 +35,14 @@
         the swap chain attachment survives indefinitely. This matches
         the pattern VerticalTabStrip will use in plan 2.
     -->
-    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
+    <!-- PaneHostContainer used to live here as Row 1 but the runtime
+         layout switch (#171) moved it up to MainWindow.RootGrid so
+         both tab hosts can share a single container without ever
+         reparenting the SwapChainPanels. This UserControl now renders
+         only the tab strip chrome. -->
+    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Top">
         <controls:TabView
             x:Name="TabViewControl"
-            Grid.Row="0"
             HorizontalAlignment="Stretch"
             CanReorderTabs="True"
             CanDragTabs="True"
@@ -53,6 +52,24 @@
             TabCloseRequested="OnTabCloseRequested"
             SelectionChanged="OnSelectionChanged"
             TabDragCompleted="OnTabDragCompleted">
+            <!-- Small button on the left side of the strip that
+                 switches to the vertical layout. Lives in the
+                 TabStripHeader slot (before the tabs) so it does not
+                 compete with the system caption buttons in the
+                 footer. -->
+            <controls:TabView.TabStripHeader>
+                <Button x:Name="SwitchToVerticalButton"
+                        Width="32" Height="32"
+                        Padding="0"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        ToolTipService.ToolTip="Switch to vertical tabs (Ctrl+Shift+Alt+V)"
+                        Click="OnSwitchLayoutClick">
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                              Glyph="&#xE89F;"
+                              FontSize="14"/>
+                </Button>
+            </controls:TabView.TabStripHeader>
             <!--
                 TabStripFooter is a right-side spacer that reserves
                 room for the OS caption buttons (min / max / close)
@@ -73,10 +90,5 @@
                       Background="Transparent"/>
             </controls:TabView.TabStripFooter>
         </controls:TabView>
-
-        <Grid x:Name="PaneHostContainer"
-              Grid.Row="1"
-              HorizontalAlignment="Stretch"
-              VerticalAlignment="Stretch"/>
     </Grid>
 </UserControl>

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -1,34 +1,37 @@
-using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
+using Ghostty.Input;
 using Ghostty.Panes;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
-using Windows.UI;
 
 namespace Ghostty.Tabs;
 
 /// <summary>
 /// WinUI host that visualises a <see cref="TabManager"/> as a
 /// <see cref="TabView"/>. Owns the bidirectional mapping between
-/// <see cref="TabModel"/>s and <see cref="TabViewItem"/>s.
+/// <see cref="TabModel"/>s and <see cref="TabViewItem"/>s. The
+/// per-tab progress indicator is rendered here as a 2px ProgressBar
+/// in the tab header template.
+///
+/// Vertical tabs are out of scope for this PR — they come in plan 2
+/// as a sibling user control sharing this same TabManager.
 /// </summary>
 internal sealed partial class TabHost : UserControl, ITabHost
 {
     private readonly TabManager _manager;
     private readonly Dictionary<TabModel, TabViewItem> _itemByModel = new();
-    private readonly Dictionary<TabViewItem, TabModel> _modelByItem = new();
-    // Keep a strong reference to each per-tab PropertyChanged handler so
-    // RemoveItem can detach it. A raw lambda closure could not be unhooked,
-    // which leaked the TabViewItem for the lifetime of the TabModel.
-    private readonly Dictionary<TabModel, PropertyChangedEventHandler> _headerHandlers = new();
     private bool _suppressSelectionEvent;
 
     public FrameworkElement HostElement => this;
 
+    /// <summary>
+    /// The Grid that sits in the TabView's TabStripFooter and
+    /// reserves room for the OS caption buttons. <see cref="MainWindow"/>
+    /// passes this to <c>Window.SetTitleBar</c> so clicks on the
+    /// empty strip area drag the window.
+    /// </summary>
     public UIElement DragRegion => CustomDragRegion;
 
     public TabHost(TabManager manager)
@@ -47,12 +50,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
     private void AddItem(TabModel tab)
     {
-        var paneHost = (PaneHost)tab.PaneHost;
-        paneHost.HorizontalAlignment = HorizontalAlignment.Stretch;
-        paneHost.VerticalAlignment = VerticalAlignment.Stretch;
-        paneHost.Visibility = Visibility.Collapsed;
-        PaneHostContainer.Children.Add(paneHost);
-
+        // PaneHost parenting and visibility are owned by MainWindow
+        // via a shared container (see #171), so both tab hosts can
+        // coexist without double-parenting the same PaneHost.
+        //
+        // The TabView item is a header-only placeholder. Content is
+        // null on purpose; the actual terminal lives in
+        // _paneHostContainer above.
+        //
         // Header is a StackPanel with a TextBlock for the title and a
         // 2px ProgressBar stacked below. Both update from TabModel's
         // INPC notifications — TabModel raises EffectiveTitle on title
@@ -78,11 +83,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
             ContextFlyout = TabContextMenuBuilder.Build(_manager, tab, RequestCloseTabAsync),
             DataContext = tab,
         };
-
-        // Named handler retained in a dictionary so RemoveItem can
-        // unhook it. A lambda captured inline would be unreachable
-        // and leak the TabViewItem.
-        PropertyChangedEventHandler handler = (_, e) =>
+        tab.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
                 e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
@@ -99,40 +100,18 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 headerBar.IsIndeterminate = p.State == TabProgressState.Kind.Indeterminate;
                 if (p.State != TabProgressState.Kind.Indeterminate)
                     headerBar.Value = p.Percent;
-                // Mirror the taskbar indicator's coloring so the inline
-                // bar and the taskbar agree on Paused/Error.
-                headerBar.Foreground = p.State switch
-                {
-                    TabProgressState.Kind.Error  => new SolidColorBrush(Colors.Red),
-                    TabProgressState.Kind.Paused => new SolidColorBrush(Colors.Goldenrod),
-                    _ => (Brush)Application.Current.Resources["SystemAccentColorBrush"],
-                };
             }
         };
-        tab.PropertyChanged += handler;
-        _headerHandlers[tab] = handler;
-
         _itemByModel[tab] = item;
-        _modelByItem[item] = tab;
         TabViewControl.TabItems.Add(item);
     }
 
     private void RemoveItem(TabModel tab)
     {
         if (!_itemByModel.TryGetValue(tab, out var item)) return;
-
-        if (_headerHandlers.TryGetValue(tab, out var handler))
-        {
-            tab.PropertyChanged -= handler;
-            _headerHandlers.Remove(tab);
-        }
-
         TabViewControl.TabItems.Remove(item);
         _itemByModel.Remove(tab);
-        _modelByItem.Remove(item);
-
-        var paneHost = (PaneHost)tab.PaneHost;
-        PaneHostContainer.Children.Remove(paneHost);
+        // PaneHost detach from the shared container is MainWindow's job.
     }
 
     private void MoveItem(TabModel tab, int to)
@@ -140,45 +119,43 @@ internal sealed partial class TabHost : UserControl, ITabHost
         if (!_itemByModel.TryGetValue(tab, out var item)) return;
         TabViewControl.TabItems.Remove(item);
         TabViewControl.TabItems.Insert(to, item);
+        // _paneHostContainer order does not matter — Visibility picks
+        // the active one. No reorder needed there.
     }
 
     private void SelectActive()
     {
+        // Active-tab PaneHost visibility is owned by MainWindow's
+        // shared container (see #171). This method only syncs the
+        // TabView strip selection.
         if (!_itemByModel.TryGetValue(_manager.ActiveTab, out var item)) return;
-
-        var activePaneHost = (PaneHost)_manager.ActiveTab.PaneHost;
-        foreach (UIElement child in PaneHostContainer.Children)
-        {
-            child.Visibility = ReferenceEquals(child, activePaneHost)
-                ? Visibility.Visible
-                : Visibility.Collapsed;
-        }
-
         if (ReferenceEquals(TabViewControl.SelectedItem, item)) return;
         _suppressSelectionEvent = true;
         TabViewControl.SelectedItem = item;
         _suppressSelectionEvent = false;
     }
 
+    private void RefreshHeader(TabViewItem item, TabModel tab)
+    {
+        // EffectiveTitle is a computed property; INPC events fire for
+        // ShellReportedTitle / UserOverrideTitle. Re-set Header to
+        // force the simple binding to re-read.
+        item.Header = tab.EffectiveTitle;
+    }
+
     private void OnAddTabButtonClick(TabView sender, object args) => _manager.NewTab();
+
+    private void OnSwitchLayoutClick(object sender, RoutedEventArgs e)
+        => PaneActionRouter.RequestToggleTabLayout(_manager);
 
     private async void OnTabCloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)
     {
-        // async void is forced by the WinUI event signature. An unhandled
-        // exception from an async void method terminates the process, so
-        // we catch at the boundary — but log loudly rather than swallow.
-        try
+        if (args.Item is TabViewItem item)
         {
-            if (args.Item is TabViewItem item &&
-                _modelByItem.TryGetValue(item, out var model))
+            foreach (var (model, vi) in _itemByModel)
             {
-                await RequestCloseTabAsync(model);
+                if (vi == item) { await RequestCloseTabAsync(model); return; }
             }
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[TabHost] OnTabCloseRequested failed: {ex}");
-            System.Diagnostics.Debug.Fail("Tab close failed", ex.ToString());
         }
     }
 
@@ -187,30 +164,60 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// X button, middle-click, context-menu Close, and the keyboard
     /// chord (via <see cref="MainWindow"/>'s accelerator handler).
     /// Shows the multi-pane confirmation dialog when needed and only
-    /// then calls <see cref="TabManager.CloseTab"/>.
+    /// then calls <see cref="TabManager.CloseTab"/>. Centralising
+    /// here keeps every close path consistent.
     /// </summary>
-    public Task RequestCloseTabAsync(TabModel tab) =>
-        TabCloseConfirmation.RequestAsync(_manager, tab, XamlRoot);
+    public async Task RequestCloseTabAsync(TabModel tab)
+    {
+        // TODO(config): confirm-close-multi-pane (bool, default true)
+        const bool confirmCloseMultiPane = true;
+
+        var paneCount = tab.PaneHost.PaneCount;
+        if (confirmCloseMultiPane && paneCount > 1)
+        {
+            var dlg = new ContentDialog
+            {
+                Title = "Close tab?",
+                Content = $"This tab has {paneCount} panes. Close all of them?",
+                PrimaryButtonText = "Close all",
+                SecondaryButtonText = "Cancel",
+                DefaultButton = ContentDialogButton.Secondary,
+                XamlRoot = XamlRoot,
+            };
+            var res = await dlg.ShowAsync();
+            if (res != ContentDialogResult.Primary) return;
+        }
+        _manager.CloseTab(tab);
+    }
 
     private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppressSelectionEvent) return;
-        if (TabViewControl.SelectedItem is TabViewItem item &&
-            _modelByItem.TryGetValue(item, out var model))
+        if (TabViewControl.SelectedItem is TabViewItem item)
         {
-            _manager.Activate(model);
+            foreach (var (model, vi) in _itemByModel)
+            {
+                if (vi == item) { _manager.Activate(model); return; }
+            }
         }
     }
 
     private void OnTabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)
     {
-        if (args.Item is TabViewItem item &&
-            _modelByItem.TryGetValue(item, out var model))
+        if (args.Item is TabViewItem item)
         {
             var newIndex = TabViewControl.TabItems.IndexOf(item);
-            var oldIndex = _manager.IndexOf(model);
-            if (oldIndex != newIndex && oldIndex >= 0)
-                _manager.Move(oldIndex, newIndex);
+            foreach (var (model, vi) in _itemByModel)
+            {
+                if (vi == item)
+                {
+                    var oldIndex = _manager.IndexOf(model);
+                    if (oldIndex != newIndex && oldIndex >= 0)
+                        _manager.Move(oldIndex, newIndex);
+                    return;
+                }
+            }
         }
     }
+
 }

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
+using Ghostty.Dialogs;
 using Ghostty.Input;
 using Ghostty.Panes;
 using Microsoft.UI.Xaml;
@@ -21,6 +22,8 @@ namespace Ghostty.Tabs;
 internal sealed partial class TabHost : UserControl, ITabHost
 {
     private readonly TabManager _manager;
+    private readonly PaneActionRouter _router;
+    private readonly DialogTracker _dialogs;
     private readonly Dictionary<TabModel, TabViewItem> _itemByModel = new();
     private bool _suppressSelectionEvent;
 
@@ -34,10 +37,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// </summary>
     public UIElement DragRegion => CustomDragRegion;
 
-    public TabHost(TabManager manager)
+    public TabHost(TabManager manager, PaneActionRouter router, DialogTracker dialogs)
     {
         InitializeComponent();
         _manager = manager;
+        _router = router;
+        _dialogs = dialogs;
 
         foreach (var t in _manager.Tabs) AddItem(t);
         SelectActive();
@@ -80,7 +85,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         {
             Header = headerPanel,
             Content = null,
-            ContextFlyout = TabContextMenuBuilder.Build(_manager, tab, RequestCloseTabAsync),
+            ContextFlyout = TabContextMenuBuilder.Build(_manager, tab, RequestCloseTabAsync, _router, _dialogs),
             DataContext = tab,
         };
         tab.PropertyChanged += (_, e) =>
@@ -146,7 +151,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private void OnAddTabButtonClick(TabView sender, object args) => _manager.NewTab();
 
     private void OnSwitchLayoutClick(object sender, RoutedEventArgs e)
-        => PaneActionRouter.RequestToggleTabLayout(_manager);
+        => _router.RequestToggleTabLayout();
 
     private async void OnTabCloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)
     {
@@ -184,8 +189,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 DefaultButton = ContentDialogButton.Secondary,
                 XamlRoot = XamlRoot,
             };
-            var res = await dlg.ShowAsync();
-            if (res != ContentDialogResult.Primary) return;
+            using (_dialogs.Track(dlg))
+            {
+                var res = await dlg.ShowAsync();
+                if (res != ContentDialogResult.Primary) return;
+            }
         }
         _manager.CloseTab(tab);
     }

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml
@@ -6,55 +6,19 @@
     RequestedTheme="Dark"
     HorizontalAlignment="Stretch"
     VerticalAlignment="Stretch">
+    <!-- Sidebar-only after #171. The title bar (with the active-tab
+         title text and the switch-layout button) moved up to
+         MainWindow so it can span the full window width even when
+         this UserControl is constrained to the strip column. -->
     <Grid Background="Transparent">
-        <Grid.RowDefinitions>
-            <!-- 40px title-bar grab row for window drag + caption buttons inset -->
-            <RowDefinition Height="Auto"/>
-            <!-- strip + content -->
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="StripColumn" Width="40"/>
+        </Grid.ColumnDefinitions>
 
-        <!-- Drag region for SetTitleBar: a 32px strip at the top of
-             the window, left-aligned, with a right-side spacer for
-             the caption buttons. -->
-        <Grid x:Name="TitleBarRow" Grid.Row="0" Height="32">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="146"/>
-            </Grid.ColumnDefinitions>
-            <Grid x:Name="CustomDragRegion" Grid.Column="0" Background="Transparent">
-                <TextBlock x:Name="TitleText"
-                           VerticalAlignment="Center"
-                           HorizontalAlignment="Center"
-                           FontSize="12"
-                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                           TextTrimming="CharacterEllipsis"
-                           IsHitTestVisible="False"/>
-            </Grid>
-        </Grid>
+        <ContentPresenter x:Name="StripHost" Grid.Column="0"/>
 
-        <!-- Row 1: strip in column 0, active PaneHost container in column 1. -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition x:Name="StripColumn" Width="40"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-
-            <ContentPresenter x:Name="StripHost" Grid.Column="0"/>
-
-            <!-- Grid host for the drag handle, right-aligned inside
-                 the strip column. Was originally a Canvas — Canvas
-                 ignores HorizontalAlignment on children, so the
-                 handle rendered at (0,0) with zero position and was
-                 invisible in practice. -->
-            <Grid x:Name="HandleHost"
-                  Grid.Column="0"
-                  HorizontalAlignment="Right"/>
-
-            <Grid x:Name="PaneHostContainer"
-                  Grid.Column="1"
-                  HorizontalAlignment="Stretch"
-                  VerticalAlignment="Stretch"/>
-        </Grid>
+        <Grid x:Name="HandleHost"
+              Grid.Column="0"
+              HorizontalAlignment="Right"/>
     </Grid>
 </UserControl>

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -1,9 +1,9 @@
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
 using Ghostty.Hosting;
+using Ghostty.Input;
 using Ghostty.Panes;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -19,6 +19,9 @@ namespace Ghostty.Tabs;
 /// as siblings in <c>PaneHostContainer</c> with Visibility toggled
 /// for the active one — same SwapChainPanel-safety pattern as
 /// <see cref="TabHost"/>.
+///
+/// Collapsed-only in this commit. Animation, expanded layout,
+/// drag handle, and hover-expand come in later commits.
 /// </summary>
 internal sealed partial class VerticalTabHost : UserControl, ITabHost
 {
@@ -32,12 +35,8 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     // TODO(config): vertical-tabs-pinned (bool, default false)
     private bool _pinnedExpanded = false;
 
-    // TODO(config): vertical-tabs-hover-expand (bool, default false).
-    // static readonly (not const) so the compiler does not fold the
-    // gated branches away; this avoids the CS0162 dead-code suppressions
-    // the const version needed and keeps both branches reachable for
-    // a single-line runtime flip during manual testing.
-    private static readonly bool HoverExpandEnabled = false;
+    // TODO(config): vertical-tabs-hover-expand (bool, default false)
+    private const bool HoverExpandEnabled = false;
     private const int HoverEnterDelayMs = 200;
     private const int HoverLeaveDelayMs = 400;
     private const int TypingSuppressionMs = 1500;
@@ -46,16 +45,18 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     private DispatcherQueueTimer? _hoverEnterTimer;
     private DispatcherQueueTimer? _hoverLeaveTimer;
 
-    // Width-tween state. Keeping these as fields (rather than per-call
-    // locals) lets a new TogglePinned cancel the in-flight timer so two
-    // animations cannot fight over StripColumn.Width.
-    private DispatcherQueueTimer? _widthTweenTimer;
-    private Stopwatch? _widthTweenClock;
-    private double _widthTweenStart;
-    private double _widthTweenTarget;
-
     public FrameworkElement HostElement => this;
-    public UIElement DragRegion => CustomDragRegion;
+
+    // Drag region lives in MainWindow now (see #171). MainWindow
+    // passes its own title-bar grid to SetTitleBar in vertical mode.
+    public UIElement DragRegion => this;
+
+    /// <summary>
+    /// Raised when the chevron or Ctrl+Shift+Space flips the pinned
+    /// state. MainWindow owns the outer strip column width (via
+    /// RootGrid.ColumnDefinitions[0]) and animates it in response.
+    /// </summary>
+    public event EventHandler<double>? StripWidthChangeRequested;
 
     public VerticalTabHost(TabManager manager, GhosttyHost? host = null)
     {
@@ -68,33 +69,41 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
         StripHost.Content = _strip;
 
         // Drag handle for live resize in pinned-expanded mode.
-        // Hidden by default; TogglePinned shows it on pin, hides on collapse.
+        // Hidden by default; TogglePinned shows it when entering
+        // the pinned state and hides it on collapse.
         _dragHandle = new ColumnDragHandle(
-            onWidthChanged: w => StripColumn.Width = new GridLength(w),
+            onWidthChanged: w =>
+            {
+                StripColumn.Width = new GridLength(w);
+                StripWidthChangeRequested?.Invoke(this, w);
+            },
             readCurrentWidth: () => StripColumn.Width.Value)
         {
             Visibility = Visibility.Collapsed,
+            Height = double.NaN, // stretch via Canvas parent sizing
         };
         HandleHost.Children.Add(_dragHandle);
-        // The handle's own VerticalAlignment=Stretch fills the host by
-        // default; we update Height on SizeChanged so it tracks the
-        // container exactly even across theme/DPI changes.
+        // Bind the handle's height to the HandleHost size so it
+        // spans the whole strip vertically.
         HandleHost.SizeChanged += (_, e) => _dragHandle.Height = e.NewSize.Height;
 
-        // Hover-expand pointer hooks. Subscribed unconditionally once
-        // at construction and gated at call time by HoverExpandEnabled
-        // — that avoids the re-subscription leak that per-event hooking
-        // would cause, and keeps both branches reachable.
-        StripHost.PointerEntered += OnStripPointerEntered;
-        StripHost.PointerExited += OnStripPointerExited;
+        // Hover-expand pointer hooks. The state machine is gated
+        // behind HoverExpandEnabled so flipping the constant is
+        // the only thing needed to test it. The constant makes one
+        // branch of the if statically unreachable; suppress CS0162
+        // here specifically because the whole point of this gate
+        // is to be toggled for manual testing.
+#pragma warning disable CS0162
+        if (HoverExpandEnabled)
+        {
+            StripHost.PointerEntered += OnStripPointerEntered;
+            StripHost.PointerExited += OnStripPointerExited;
+        }
+#pragma warning restore CS0162
 
-        foreach (var t in _manager.Tabs) AddPane(t);
-        SwapActivePane();
-        RebindActiveTitle();
-
-        _manager.TabAdded += (_, t) => { AddPane(t); SwapActivePane(); };
-        _manager.TabRemoved += (_, t) => RemovePane(t);
-        _manager.ActiveTabChanged += (_, _) => { SwapActivePane(); RebindActiveTitle(); };
+        // PaneHost parenting and visibility are owned by MainWindow
+        // via a shared container (see #171). Same for the title-bar
+        // TextBlock that used to live in this UserControl.
 
         _strip.NewTabRequested += (_, _) => _manager.NewTab();
         _strip.ChevronToggled += (_, _) => TogglePinned();
@@ -102,149 +111,82 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
 
     /// <summary>
     /// Toggle the pinned-expanded state. Called by the chevron
-    /// button and by the Ctrl+Shift+Space keyboard chord.
+    /// button click and (in a later commit) by the
+    /// Ctrl+Shift+Space keyboard chord.
     /// </summary>
     internal void TogglePinnedFromKeyboard() => TogglePinned();
+
+    private void OnSwitchLayoutClick(object sender, RoutedEventArgs e)
+        => PaneActionRouter.RequestToggleTabLayout(_manager);
 
     private void TogglePinned()
     {
         _pinnedExpanded = !_pinnedExpanded;
         _strip.IsExpanded = _pinnedExpanded;
-        AnimateColumnWidth(_pinnedExpanded ? ExpandedWidth : 40);
+        var target = _pinnedExpanded ? ExpandedWidth : 40;
+        // MainWindow listens on this event and tweens both its
+        // RootGrid outer strip column AND our internal column in
+        // lockstep so the sidebar actually grows on-screen.
+        StripWidthChangeRequested?.Invoke(this, target);
         _dragHandle.Visibility = _pinnedExpanded ? Visibility.Visible : Visibility.Collapsed;
     }
 
-    private void AnimateColumnWidth(double target)
+    /// <summary>
+    /// Called by MainWindow's tween loop to update our own internal
+    /// column so the strip visual fills the outer column that
+    /// MainWindow is simultaneously tweening.
+    /// </summary>
+    internal void SetInternalStripWidth(double width)
     {
-        // WinUI 3's Storyboard + GridLengthProxy combination does not
-        // resolve against a field-held DependencyObject, so we drive
-        // the tween manually on the dispatcher queue.
-        //
-        // Stopwatch instead of DateTime.UtcNow: DateTime has ~15 ms
-        // resolution on Windows and jumps on NTP sync / DST changes,
-        // both of which can stall or rewind the tween. Stopwatch uses
-        // QueryPerformanceCounter and is monotonic.
-        //
-        // Cancel any in-flight tween before starting a new one —
-        // otherwise a rapid chord-toggle would leave two timers
-        // fighting over StripColumn.Width.
-        _widthTweenTimer?.Stop();
-
-        _widthTweenStart = StripColumn.Width.Value;
-        _widthTweenTarget = target;
-        _widthTweenClock = Stopwatch.StartNew();
-
-        var duration = TimeSpan.FromMilliseconds(150);
-        _widthTweenTimer ??= DispatcherQueue.CreateTimer();
-        _widthTweenTimer.Interval = TimeSpan.FromMilliseconds(16);
-        _widthTweenTimer.IsRepeating = true;
-        // Subscribe once; a field-held timer means the handler must
-        // not re-add itself per Start(). Guarded via _widthTweenClock
-        // so a canceled tween stops cleanly.
-        _widthTweenTimer.Tick -= OnWidthTweenTick;
-        _widthTweenTimer.Tick += OnWidthTweenTick;
-        _widthTweenTimer.Start();
-
-        void OnWidthTweenTick(DispatcherQueueTimer sender, object args)
-        {
-            var clock = _widthTweenClock;
-            if (clock is null) { sender.Stop(); return; }
-
-            var progress = Math.Min(1.0, clock.Elapsed.TotalMilliseconds / duration.TotalMilliseconds);
-            // Ease-out quadratic: 1 - (1 - p)^2
-            var eased = 1 - (1 - progress) * (1 - progress);
-            var current = _widthTweenStart + (_widthTweenTarget - _widthTweenStart) * eased;
-            StripColumn.Width = new GridLength(current);
-
-            if (progress >= 1.0)
-            {
-                sender.Stop();
-                _widthTweenClock = null;
-                // Reflow the terminal once at the final size rather
-                // than on every tick. libghostty's resize is driven by
-                // LayoutUpdated, so forcing a layout pass here makes
-                // that fire exactly once with settled dimensions.
-                PaneHostContainer.InvalidateMeasure();
-                PaneHostContainer.UpdateLayout();
-            }
-        }
+        StripColumn.Width = new GridLength(width);
     }
 
-    private void AddPane(TabModel tab)
-    {
-        var paneHost = (PaneHost)tab.PaneHost;
-        paneHost.HorizontalAlignment = HorizontalAlignment.Stretch;
-        paneHost.VerticalAlignment = VerticalAlignment.Stretch;
-        paneHost.Visibility = Visibility.Collapsed;
-        PaneHostContainer.Children.Add(paneHost);
-    }
+    // AnimateColumnWidth (old in-host tween) was removed in #171.
+    // MainWindow now owns the animation so it can drive the RootGrid
+    // strip column in lockstep with our internal column.
 
-    private void RemovePane(TabModel tab)
-    {
-        var paneHost = (PaneHost)tab.PaneHost;
-        PaneHostContainer.Children.Remove(paneHost);
-    }
-
-    private void SwapActivePane()
-    {
-        var active = (PaneHost)_manager.ActiveTab.PaneHost;
-        foreach (UIElement child in PaneHostContainer.Children)
-        {
-            child.Visibility = ReferenceEquals(child, active)
-                ? Visibility.Visible
-                : Visibility.Collapsed;
-        }
-    }
+    // PaneHost parenting/visibility moved to MainWindow in #171. See
+    // there for the shared container the two tab hosts both sit on top of.
 
     // Hover-expand state machine -----------------------------------------
 
     private void OnStripPointerEntered(object sender, PointerRoutedEventArgs e)
     {
-        if (!HoverExpandEnabled) return;
         if (_state != VerticalTabStripState.Collapsed) return;
         if (_pinnedExpanded) return;
         if (IsUserCurrentlyTyping()) return;
 
-        // Timer allocated lazily, Tick hooked ONCE for the life of the
-        // host. Starting / stopping is idempotent; re-subscribing per
-        // PointerEntered (as the earlier revision did) would duplicate
-        // the handler every hover.
-        if (_hoverEnterTimer is null)
-        {
-            _hoverEnterTimer = DispatcherQueue.CreateTimer();
-            _hoverEnterTimer.IsRepeating = false;
-            _hoverEnterTimer.Tick += OnHoverEnterTick;
-        }
+        _hoverEnterTimer ??= DispatcherQueue.CreateTimer();
         _hoverEnterTimer.Interval = TimeSpan.FromMilliseconds(HoverEnterDelayMs);
+        _hoverEnterTimer.IsRepeating = false;
+        _hoverEnterTimer.Tick += OnHoverEnterTick;
         _hoverEnterTimer.Start();
     }
 
     private void OnHoverEnterTick(DispatcherQueueTimer sender, object args)
     {
         sender.Stop();
+        sender.Tick -= OnHoverEnterTick;
         if (_state != VerticalTabStripState.Collapsed) return;
         BeginHoverExpand();
     }
 
     private void OnStripPointerExited(object sender, PointerRoutedEventArgs e)
     {
-        if (!HoverExpandEnabled) return;
         _hoverEnterTimer?.Stop();
         if (_state != VerticalTabStripState.HoverExpanded) return;
 
-        if (_hoverLeaveTimer is null)
-        {
-            _hoverLeaveTimer = DispatcherQueue.CreateTimer();
-            _hoverLeaveTimer.IsRepeating = false;
-            _hoverLeaveTimer.Tick += OnHoverLeaveTick;
-        }
+        _hoverLeaveTimer ??= DispatcherQueue.CreateTimer();
         _hoverLeaveTimer.Interval = TimeSpan.FromMilliseconds(HoverLeaveDelayMs);
+        _hoverLeaveTimer.IsRepeating = false;
+        _hoverLeaveTimer.Tick += OnHoverLeaveTick;
         _hoverLeaveTimer.Start();
     }
 
     private void OnHoverLeaveTick(DispatcherQueueTimer sender, object args)
     {
         sender.Stop();
+        sender.Tick -= OnHoverLeaveTick;
         if (_state != VerticalTabStripState.HoverExpanded) return;
         BeginHoverCollapse();
     }
@@ -252,20 +194,17 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     private bool IsUserCurrentlyTyping()
     {
         if (_host is null) return false;
-        // TickCount64 is a monotonic millisecond counter — immune to
-        // NTP / DST jumps and cheaper than DateTime arithmetic.
-        var elapsed = Environment.TickCount64 - _host.LastKeystrokeTick;
+        var elapsed = (DateTime.UtcNow - _host.LastKeystrokeTimestamp).TotalMilliseconds;
         return elapsed < TypingSuppressionMs;
     }
 
     private void BeginHoverExpand()
     {
-        // Render the strip as an overlay: raise its Z-order (attached
-        // Canvas.ZIndex works on any UIElement, including Grid children)
-        // and give it an explicit Width so it floats over the terminal
-        // column without resizing the ColumnDefinition. The terminal
-        // content therefore does not reflow — that's the key difference
-        // from pinned-expanded.
+        // Render the strip as an overlay: raise its Z-order and
+        // give it an explicit Width so it floats over the terminal
+        // column. The ColumnDefinition is NOT resized, so the
+        // terminal content does not reflow — that's the key
+        // difference from pinned-expanded.
         _state = VerticalTabStripState.HoverExpanding;
         _strip.IsExpanded = true;
         Canvas.SetZIndex(StripHost, 100);
@@ -282,34 +221,29 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
         _state = VerticalTabStripState.Collapsed;
     }
 
-    // Active-tab title binding for the custom title bar.
-    private TabModel? _titleBoundTab;
-    private void RebindActiveTitle()
-    {
-        if (_titleBoundTab is not null)
-            _titleBoundTab.PropertyChanged -= OnActiveTitlePropertyChanged;
-        _titleBoundTab = _manager.ActiveTab;
-        if (_titleBoundTab is not null)
-            _titleBoundTab.PropertyChanged += OnActiveTitlePropertyChanged;
-        UpdateTitleText();
-    }
-
-    private void OnActiveTitlePropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
-            e.PropertyName == nameof(TabModel.ShellReportedTitle) ||
-            e.PropertyName == nameof(TabModel.UserOverrideTitle))
-        {
-            UpdateTitleText();
-        }
-    }
-
-    private void UpdateTitleText()
-    {
-        TitleText.Text = _titleBoundTab?.EffectiveTitle ?? "Ghostty";
-    }
+    // Active-tab title tracking moved to MainWindow in #171.
 
     /// <inheritdoc/>
-    public Task RequestCloseTabAsync(TabModel tab) =>
-        TabCloseConfirmation.RequestAsync(_manager, tab, XamlRoot);
+    public async Task RequestCloseTabAsync(TabModel tab)
+    {
+        // TODO(config): confirm-close-multi-pane (bool, default true)
+        const bool confirmCloseMultiPane = true;
+
+        var paneCount = tab.PaneHost.PaneCount;
+        if (confirmCloseMultiPane && paneCount > 1)
+        {
+            var dlg = new ContentDialog
+            {
+                Title = "Close tab?",
+                Content = $"This tab has {paneCount} panes. Close all of them?",
+                PrimaryButtonText = "Close all",
+                SecondaryButtonText = "Cancel",
+                DefaultButton = ContentDialogButton.Secondary,
+                XamlRoot = XamlRoot,
+            };
+            var res = await dlg.ShowAsync();
+            if (res != ContentDialogResult.Primary) return;
+        }
+        _manager.CloseTab(tab);
+    }
 }

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
+using Ghostty.Dialogs;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Panes;
@@ -26,6 +27,8 @@ namespace Ghostty.Tabs;
 internal sealed partial class VerticalTabHost : UserControl, ITabHost
 {
     private readonly TabManager _manager;
+    private readonly PaneActionRouter _router;
+    private readonly DialogTracker _dialogs;
     private readonly GhosttyHost? _host;
     private readonly VerticalTabStrip _strip;
     private readonly ColumnDragHandle _dragHandle;
@@ -58,10 +61,12 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     /// </summary>
     public event EventHandler<double>? StripWidthChangeRequested;
 
-    public VerticalTabHost(TabManager manager, GhosttyHost? host = null)
+    public VerticalTabHost(TabManager manager, PaneActionRouter router, DialogTracker dialogs, GhosttyHost? host = null)
     {
         InitializeComponent();
         _manager = manager;
+        _router = router;
+        _dialogs = dialogs;
         _host = host;
 
         _strip = new VerticalTabStrip(manager);
@@ -117,7 +122,7 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     internal void TogglePinnedFromKeyboard() => TogglePinned();
 
     private void OnSwitchLayoutClick(object sender, RoutedEventArgs e)
-        => PaneActionRouter.RequestToggleTabLayout(_manager);
+        => _router.RequestToggleTabLayout();
 
     private void TogglePinned()
     {
@@ -156,17 +161,26 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
         if (_pinnedExpanded) return;
         if (IsUserCurrentlyTyping()) return;
 
-        _hoverEnterTimer ??= DispatcherQueue.CreateTimer();
+        EnsureHoverEnterTimer();
+        _hoverEnterTimer!.Start();
+    }
+
+    private void EnsureHoverEnterTimer()
+    {
+        if (_hoverEnterTimer is not null) return;
+        _hoverEnterTimer = DispatcherQueue.CreateTimer();
         _hoverEnterTimer.Interval = TimeSpan.FromMilliseconds(HoverEnterDelayMs);
         _hoverEnterTimer.IsRepeating = false;
+        // Subscribe once: Start/Stop controls firing, not subscription
+        // state. Re-subscribing on every PointerEntered would stack
+        // handlers because the previous subscription is only removed
+        // in OnHoverEnterTick, which never runs on a Stopped timer.
         _hoverEnterTimer.Tick += OnHoverEnterTick;
-        _hoverEnterTimer.Start();
     }
 
     private void OnHoverEnterTick(DispatcherQueueTimer sender, object args)
     {
         sender.Stop();
-        sender.Tick -= OnHoverEnterTick;
         if (_state != VerticalTabStripState.Collapsed) return;
         BeginHoverExpand();
     }
@@ -176,17 +190,23 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
         _hoverEnterTimer?.Stop();
         if (_state != VerticalTabStripState.HoverExpanded) return;
 
-        _hoverLeaveTimer ??= DispatcherQueue.CreateTimer();
+        EnsureHoverLeaveTimer();
+        _hoverLeaveTimer!.Start();
+    }
+
+    private void EnsureHoverLeaveTimer()
+    {
+        if (_hoverLeaveTimer is not null) return;
+        _hoverLeaveTimer = DispatcherQueue.CreateTimer();
         _hoverLeaveTimer.Interval = TimeSpan.FromMilliseconds(HoverLeaveDelayMs);
         _hoverLeaveTimer.IsRepeating = false;
+        // Subscribe once; see EnsureHoverEnterTimer for the rationale.
         _hoverLeaveTimer.Tick += OnHoverLeaveTick;
-        _hoverLeaveTimer.Start();
     }
 
     private void OnHoverLeaveTick(DispatcherQueueTimer sender, object args)
     {
         sender.Stop();
-        sender.Tick -= OnHoverLeaveTick;
         if (_state != VerticalTabStripState.HoverExpanded) return;
         BeginHoverCollapse();
     }
@@ -241,8 +261,11 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
                 DefaultButton = ContentDialogButton.Secondary,
                 XamlRoot = XamlRoot,
             };
-            var res = await dlg.ShowAsync();
-            if (res != ContentDialogResult.Primary) return;
+            using (_dialogs.Track(dlg))
+            {
+                var res = await dlg.ShowAsync();
+                if (res != ContentDialogResult.Primary) return;
+            }
         }
         _manager.CloseTab(tab);
     }

--- a/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
@@ -21,15 +21,9 @@ internal sealed class TaskbarList3Facade : ITaskbarProgressSink
     public TaskbarList3Facade(IntPtr hwnd)
     {
         _hwnd = hwnd;
-        var clsid = TaskbarInterop.CLSID_TaskbarList;
-        var iid = TaskbarInterop.IID_ITaskbarList3;
-        ShellInterop.CoCreateInstance(
-            ref clsid,
-            IntPtr.Zero,
-            ShellInterop.CLSCTX_INPROC_SERVER,
-            ref iid,
-            out var obj);
-        _taskbar = (TaskbarInterop.ITaskbarList3)obj;
+        _taskbar = (TaskbarInterop.ITaskbarList3)ComCreate.Create(
+            TaskbarInterop.CLSID_TaskbarList,
+            TaskbarInterop.IID_ITaskbarList3);
         _taskbar.HrInit();
     }
 

--- a/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarList3Facade.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Ghostty.Core.Tabs;
 using Ghostty.Core.Taskbar;
 using Ghostty.Interop;
@@ -13,16 +11,12 @@ namespace Ghostty.Taskbar;
 /// HrInit once, and forwards sink writes to SetProgressValue and
 /// SetProgressState against the window's HWND.
 ///
-/// One facade per window. MainWindow constructs it with its HWND
-/// and disposes it on Closed so the RCW is released deterministically
-/// rather than waiting on GC.
+/// One facade per window. MainWindow constructs it with its HWND.
 /// </summary>
-internal sealed class TaskbarList3Facade : ITaskbarProgressSink, IDisposable
+internal sealed class TaskbarList3Facade : ITaskbarProgressSink
 {
-    private const ulong ProgressTotal = 100UL;
-
     private readonly IntPtr _hwnd;
-    private TaskbarInterop.ITaskbarList3? _taskbar;
+    private readonly TaskbarInterop.ITaskbarList3 _taskbar;
 
     public TaskbarList3Facade(IntPtr hwnd)
     {
@@ -41,73 +35,27 @@ internal sealed class TaskbarList3Facade : ITaskbarProgressSink, IDisposable
 
     public void Write(TabProgressState state)
     {
-        var taskbar = _taskbar;
-        if (taskbar is null) return;
-
-        // COM RPC can fail at any time (explorer restart, desktop switch,
-        // taskbar in a transient state). The taskbar indicator is a
-        // nice-to-have, so swallow + log rather than take the window
-        // down through the PropertyChanged chain that reaches us.
-        try
+        switch (state.State)
         {
-            switch (state.State)
-            {
-                case TabProgressState.Kind.None:
-                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NOPROGRESS);
-                    return;
-                case TabProgressState.Kind.Indeterminate:
-                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.INDETERMINATE);
-                    return;
-                case TabProgressState.Kind.Normal:
-                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NORMAL);
-                    taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), ProgressTotal);
-                    return;
-                case TabProgressState.Kind.Paused:
-                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.PAUSED);
-                    taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), ProgressTotal);
-                    return;
-                case TabProgressState.Kind.Error:
-                    taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.ERROR);
-                    taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), ProgressTotal);
-                    return;
-                default:
-                    Debug.Fail($"Unknown TabProgressState.Kind: {state.State}");
-                    return;
-            }
+            case TabProgressState.Kind.None:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NOPROGRESS);
+                return;
+            case TabProgressState.Kind.Indeterminate:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.INDETERMINATE);
+                return;
+            case TabProgressState.Kind.Normal:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NORMAL);
+                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
+                return;
+            case TabProgressState.Kind.Paused:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.PAUSED);
+                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
+                return;
+            case TabProgressState.Kind.Error:
+                _taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.ERROR);
+                _taskbar.SetProgressValue(_hwnd, (ulong)Clamp(state.Percent), 100UL);
+                return;
         }
-        catch (COMException ex)
-        {
-            // Explorer restarts, DWM transitions and remote-session
-            // teardown can all kill the live ITaskbarList3 instance.
-            // We don't want to take the window down because the
-            // taskbar indicator stopped responding — but we DO want
-            // debug builds to fail loudly so real bugs are not hidden.
-            // Release builds log to the debug stream and the sink
-            // becomes a no-op for the rest of the window's lifetime.
-            _taskbar = null;
-            Debug.WriteLine($"[TaskbarList3Facade] SetProgress* failed: 0x{ex.HResult:X8} {ex.Message}");
-            Debug.Fail("ITaskbarList3 call failed", ex.ToString());
-        }
-    }
-
-    public void Dispose()
-    {
-        var taskbar = _taskbar;
-        _taskbar = null;
-        if (taskbar is null) return;
-        try
-        {
-            // Best-effort clear so the indicator does not linger after
-            // the window closes.
-            taskbar.SetProgressState(_hwnd, TaskbarInterop.TBPFLAG.NOPROGRESS);
-        }
-        catch (COMException ex)
-        {
-            // Tearing down; the RCW is still released below. Log so
-            // a recurring teardown failure is visible in debug builds.
-            Debug.WriteLine($"[TaskbarList3Facade] teardown clear failed: 0x{ex.HResult:X8} {ex.Message}");
-        }
-        Marshal.FinalReleaseComObject(taskbar);
     }
 
     private static int Clamp(int v) => v < 0 ? 0 : v > 100 ? 100 : v;


### PR DESCRIPTION
> IMPORTANT: part 4 of 4 in a stacked PR chain.
> Stack order:
> 1. #167 windows-tabs-vertical -> windows
> 2. #168 windows-tabs-jumplist -> windows-tabs-vertical
> 3. #169 windows-tabs-taskbar-progress -> windows-tabs-jumplist
> 4. windows-tabs-runtime-switch (this PR) -> windows-tabs-taskbar-progress
>
> GitHub will auto-retarget this PR as parent PRs merge.

## Summary
Runtime switch between horizontal and vertical tabs, triggered by Ctrl+Shift+Alt+V, a small icon button in each chrome, or a new item in every tab's right-click menu. The active tab stays selected, every pane split is preserved, and the last-used layout is restored on next launch.

Both TabHost and VerticalTabHost became strip-only. The shared PaneHostContainer that used to live inside each of them moved up to MainWindow.RootGrid so both hosts coexist in the visual tree without ever reparenting a PaneHost — which is the only way to keep every tab's SwapChainPanel DCOMP handoff intact across the switch. The vertical-mode title bar (with the active tab title and the switch-layout button) also moved to MainWindow so it can span the full window width while VerticalTabHost stays constrained to the 40 px sidebar column.

The animation cross-fades the two chromes while the outer strip column tweens between 0 and 40 px. VerticalTabHost forwards chevron expand and collapse through the same tween path so the outer RootGrid column and the internal VerticalTabHost column stay in lockstep. A tiny UiSettings file at %APPDATA%\Ghostty\ui-settings.json persists the choice — marked TODO(config) until the real config layer lands.

## Test plan
- [ ] Ctrl+Shift+Alt+V switches layout with a smooth cross-fade + slide
- [ ] Title-bar button in horizontal mode (TabStripHeader) triggers the same switch
- [ ] Title-bar button in vertical mode (just past the sidebar edge) triggers the same switch
- [ ] Tab right-click shows "Switch to horizontal/vertical tabs" that cycles layouts
- [ ] Active tab stays selected and every pane split inside it stays intact across the switch
- [ ] Chevron still expands the sidebar 40 -> 220 in vertical mode
- [ ] Close and relaunch: last layout is restored