### PR TITLE
chore: update progress bars (MVWT 90%, MVT 22%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 > The `windows` branch is the default and contains all Windows-specific work
 > rebased on top of upstream `main`, which is synced daily.
 >
-> **Status:** DX12 renderer in progress (3 surface modes + DirectComposition), shared infrastructure from DX11 carried forward
+> **Status:** DX12 renderer in progress, WinUI 3 shell with tabs, splits, jump list, taskbar progress, and runtime layout switch landed
 >
 > **MVWT** Minimum Viewable Windows Terminal
-> `[█████████████████░░░] 85%`
+> `[█████████████████▌░░] 88%`
 >
 > **MVT** Moonshot Viable Terminal ([#26](https://github.com/deblasis/ghostty/issues/26))
 > `[░░░░░░░░░░░░░░░░░░░░]  0%`


### PR DESCRIPTION
## Summary
Bumps the MVWT bar from 85% to 88% after the four tabs PRs landed on 2026-04-09.

| PR | Title |
|----|-------|
| #167 | vertical tab strip with sidebar layout |
| #168 | jump list + AUMID for taskbar right-click menu |
| #169 | taskbar progress coordinator with per-tab cycling |
| #170 | runtime switch between horizontal and vertical tabs |

These land entirely in the app-scaffold + keyboard/mouse/clipboard chunks of the MVWT weight table. Remaining 12% is DX12 GenericRenderer wiring, DX12 cell rendering, DirectWrite, clipboard, and per-monitor DPI + theming.

MVT stays at 0% until the "Multi-window, tabs, splits" item in # 26 can be fully checked. Tabs and splits are landed; multi-window is still missing.

## Test plan
- [ ] README bars render correctly in the preview