### PR TITLE
feat(windows): detect precision touchpad scroll and set ScrollMods bit

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -395,27 +395,20 @@ public sealed partial class TerminalControl : UserControl
         // PointerDeviceType.Touchpad is only reported when the user has a
         // precision-touchpad driver; legacy touchpads masquerade as Mouse
         // and correctly fall through to the discrete branch below.
-        var precision = pt.PointerDeviceType == Microsoft.UI.Input.PointerDeviceType.Touchpad;
-
-        double delta;
-        int scrollMods;
-        if (precision)
+        //
+        // Precision path: Surface.zig treats the offset as pixels and
+        // applies mouse_scroll_multiplier.precision. Windows touchpads
+        // report small sub-WHEEL_DELTA values (~8..40 per frame) which
+        // map reasonably to pixel counts, so we pass the raw delta
+        // through without the /120 normalization used for wheels.
+        //
+        // Discrete wheel path: 120 units = one notch (WHEEL_DELTA).
+        // Surface.zig multiplies this by cell_size * discrete multiplier.
+        var (delta, scrollMods) = pt.PointerDeviceType switch
         {
-            // Precision path: Surface.zig treats the offset as pixels and
-            // applies mouse_scroll_multiplier.precision. Windows touchpads
-            // report small sub-WHEEL_DELTA values (~8..40 per frame) which
-            // map reasonably to pixel counts, so we pass the raw delta
-            // through without the /120 normalization used for wheels.
-            delta = rawDelta;
-            scrollMods = ScrollModsPrecision;
-        }
-        else
-        {
-            // Discrete wheel path: 120 units = one notch (WHEEL_DELTA).
-            // Surface.zig multiplies this by cell_size * discrete multiplier.
-            delta = rawDelta / 120.0;
-            scrollMods = 0;
-        }
+            PointerDeviceType.Touchpad => ((double)rawDelta, ScrollModsPrecision),
+            _ => (rawDelta / 120.0, 0),
+        };
 
         NativeMethods.SurfaceMouseScroll(
             _surface,

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -376,17 +376,52 @@ public sealed partial class TerminalControl : UserControl
         NativeMethods.SurfaceMousePos(_surface, pt.X, pt.Y, CurrentMods());
     }
 
+    // libghostty's ScrollMods is a u8 packed struct (src/input/mouse.zig):
+    //   bit 0       : precision (bool) — high-precision/pixel scroll
+    //   bits 1..3   : momentum (u3 enum) — inertial phase (macOS-only today)
+    //   bits 4..7   : padding
+    // WinUI 3 does not surface AppKit-style momentum phases, so we only
+    // set the precision bit. Momentum stays .none (0).
+    private const int ScrollModsPrecision = 0b0000_0001;
+
     private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
         if (_surface.Handle == IntPtr.Zero) return;
         var pt = e.GetCurrentPoint(Panel);
-        var delta = pt.Properties.MouseWheelDelta / 120.0;  // 120 = one notch
+        var rawDelta = pt.Properties.MouseWheelDelta;
         var isHorizontal = pt.Properties.IsHorizontalMouseWheel;
+
+        // Detect precision input (touchpad) vs discrete mouse wheel.
+        // PointerDeviceType.Touchpad is only reported when the user has a
+        // precision-touchpad driver; legacy touchpads masquerade as Mouse
+        // and correctly fall through to the discrete branch below.
+        var precision = pt.PointerDeviceType == Microsoft.UI.Input.PointerDeviceType.Touchpad;
+
+        double delta;
+        int scrollMods;
+        if (precision)
+        {
+            // Precision path: Surface.zig treats the offset as pixels and
+            // applies mouse_scroll_multiplier.precision. Windows touchpads
+            // report small sub-WHEEL_DELTA values (~8..40 per frame) which
+            // map reasonably to pixel counts, so we pass the raw delta
+            // through without the /120 normalization used for wheels.
+            delta = rawDelta;
+            scrollMods = ScrollModsPrecision;
+        }
+        else
+        {
+            // Discrete wheel path: 120 units = one notch (WHEEL_DELTA).
+            // Surface.zig multiplies this by cell_size * discrete multiplier.
+            delta = rawDelta / 120.0;
+            scrollMods = 0;
+        }
+
         NativeMethods.SurfaceMouseScroll(
             _surface,
             isHorizontal ? delta : 0.0,
             isHorizontal ? 0.0 : delta,
-            0);  // scroll mods packed bitfield - wire when we need them
+            scrollMods);
     }
 
     private void SendMouseButton(PointerRoutedEventArgs e, GhosttyMouseState state)


### PR DESCRIPTION
## Summary
- Windows apprt hardcoded `ScrollMods` to `0`, so libghostty applied the discrete-wheel multiplier even for precision touchpads — producing coarse, choppy scrolling.
- Detect `PointerDeviceType.Touchpad` in `OnPointerWheelChanged` and set the `precision` bit of `ScrollMods` (bit 0, per `src/input/mouse.zig`).
- On the precision path, pass raw `MouseWheelDelta` through (no `/120`) because `Surface.zig` interprets the offset as pixels and applies `mouse_scroll_multiplier.precision`. Discrete wheels keep the `/120` normalization.
- Momentum phases stay `.none`: WinUI 3 does not surface AppKit-style `momentumPhase`, so macOS parity there needs a separate design pass.

Addresses the scroll-handling gap identified when comparing `macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift:1044` against `windows/Ghostty/Controls/TerminalControl.xaml.cs:370`.

## Test plan
- [x] Scroll with a precision touchpad — smooth, pixel-grained scrolling
- [x] Scroll with a discrete USB mouse wheel — one notch still scrolls discrete rows
- [x] Horizontal scroll (Shift+wheel or two-finger horizontal) works in both modes
- [x] `dotnet build windows/Ghostty/Ghostty.csproj` passes
