### PR TITLE
feat(windows): clipboard via libghostty callbacks

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2408,10 +2408,11 @@ keybind: Keybinds = .{},
 /// Middle-click paste will always use the selection clipboard. Middle-click
 /// paste is always enabled even if this is `false`.
 ///
-/// The default value is true on Linux and macOS.
+/// The default value is true on Linux, macOS, and Windows.
 @"copy-on-select": CopyOnSelect = switch (builtin.os.tag) {
     .linux => .true,
     .macos => .true,
+    .windows => .true,
     else => .false,
 },
 

--- a/windows/Ghostty.Core/Clipboard/ClipboardConfirmRequest.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardConfirmRequest.cs
@@ -1,0 +1,12 @@
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// Mirrors ghostty_clipboard_request_e. The reason libghostty is asking
+/// the user to confirm a clipboard operation.
+/// </summary>
+public enum ClipboardConfirmRequest
+{
+    Paste = 0,
+    Osc52Read = 1,
+    Osc52Write = 2,
+}

--- a/windows/Ghostty.Core/Clipboard/ClipboardContentMarshaller.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardContentMarshaller.cs
@@ -42,7 +42,7 @@ public static class ClipboardContentMarshaller
 
         for (nuint i = 0; i < count; i++)
         {
-            var entryAddr = IntPtr.Add(content, (int)(i * (nuint)StructSize));
+            var entryAddr = IntPtr.Add(content, checked((int)(i * (nuint)StructSize)));
             var mimePtr = Marshal.ReadIntPtr(entryAddr, 0);
             var dataPtr = Marshal.ReadIntPtr(entryAddr, IntPtr.Size);
 

--- a/windows/Ghostty.Core/Clipboard/ClipboardContentMarshaller.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardContentMarshaller.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// Walks a libghostty (ghostty_clipboard_content_s*, count) array and
+/// produces managed ClipboardPayload values. Extracted from the WinUI
+/// bridge so the marshalling logic is unit-testable in pure net9.0,
+/// without WinUI dependencies.
+///
+/// Memory ownership: the native pointers are owned by libghostty for
+/// the duration of the write_clipboard_cb callback. This method MUST
+/// be called synchronously from inside that callback (or from a copy
+/// taken before the callback returns) so the resulting strings are
+/// managed copies and are safe to use after the callback returns.
+///
+/// The native struct layout is:
+///   typedef struct {
+///     const char *mime;
+///     const char *data;
+///   } ghostty_clipboard_content_s;
+/// which marshals to two pointers back-to-back, sized 2*sizeof(void*).
+/// </summary>
+public static class ClipboardContentMarshaller
+{
+    // sizeof(ghostty_clipboard_content_s) on the current platform.
+    private static readonly int StructSize = 2 * IntPtr.Size;
+
+    /// <summary>
+    /// Read <paramref name="count"/> entries starting at <paramref name="content"/>.
+    /// Returns an empty list when content is null or count is zero.
+    /// Skips entries whose mime or data pointer is null (defensive).
+    /// </summary>
+    public static IReadOnlyList<ClipboardPayload> Read(IntPtr content, nuint count)
+    {
+        if (content == IntPtr.Zero || count == 0)
+            return Array.Empty<ClipboardPayload>();
+
+        var result = new List<ClipboardPayload>((int)count);
+
+        for (nuint i = 0; i < count; i++)
+        {
+            var entryAddr = IntPtr.Add(content, (int)(i * (nuint)StructSize));
+            var mimePtr = Marshal.ReadIntPtr(entryAddr, 0);
+            var dataPtr = Marshal.ReadIntPtr(entryAddr, IntPtr.Size);
+
+            if (mimePtr == IntPtr.Zero || dataPtr == IntPtr.Zero)
+                continue;
+
+            var mime = Marshal.PtrToStringUTF8(mimePtr) ?? string.Empty;
+            var data = Marshal.PtrToStringUTF8(dataPtr) ?? string.Empty;
+
+            result.Add(new ClipboardPayload(mime, data));
+        }
+
+        return result;
+    }
+}

--- a/windows/Ghostty.Core/Clipboard/ClipboardKind.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardKind.cs
@@ -1,0 +1,12 @@
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// Mirrors ghostty_clipboard_e. Selection is a no-op on Windows because
+/// Win32 has no PRIMARY-style selection clipboard; we keep the enum value
+/// so the bridge can route requests defensively.
+/// </summary>
+public enum ClipboardKind
+{
+    Standard = 0,
+    Selection = 1,
+}

--- a/windows/Ghostty.Core/Clipboard/ClipboardMime.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardMime.cs
@@ -1,0 +1,11 @@
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// MIME type strings used by libghostty when passing clipboard payloads
+/// across the C ABI. Matches the values produced by src/Surface.zig.
+/// </summary>
+public static class ClipboardMime
+{
+    public const string TextPlain = "text/plain";
+    public const string TextHtml = "text/html";
+}

--- a/windows/Ghostty.Core/Clipboard/ClipboardPayload.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardPayload.cs
@@ -1,0 +1,6 @@
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// One MIME-tagged clipboard entry. Mirrors ghostty_clipboard_content_s.
+/// </summary>
+public readonly record struct ClipboardPayload(string Mime, string Data);

--- a/windows/Ghostty.Core/Clipboard/ClipboardService.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardService.cs
@@ -84,4 +84,13 @@ public sealed class ClipboardService
 
         await _backend.WriteAsync(supported);
     }
+
+    public ValueTask<bool> HandleConfirmAsync(string text, ClipboardConfirmRequest request)
+    {
+        // Pass-through to the platform confirmer. Kept as a service
+        // method (rather than calling the confirmer directly from the
+        // bridge) so the routing rules for what gets confirmed and how
+        // live in one testable place if they grow more complex later.
+        return _confirmer.ConfirmAsync(text, request);
+    }
 }

--- a/windows/Ghostty.Core/Clipboard/ClipboardService.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardService.cs
@@ -41,11 +41,12 @@ public sealed class ClipboardService
         {
             return await _backend.ReadTextAsync();
         }
-        catch
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
-            // Clipboard read can throw when another process holds the
-            // clipboard open. Surfacing null lets the keybind fall
-            // through to the terminal, matching macOS.
+            // Interface boundary: any IClipboardBackend can throw. Translate
+            // to null so the paste keybind falls through to the terminal,
+            // matching macOS. Fatal runtime conditions are still allowed to
+            // propagate so we do not mask real crashes.
             return null;
         }
     }
@@ -53,7 +54,8 @@ public sealed class ClipboardService
     public async ValueTask HandleWriteAsync(
         ClipboardKind kind,
         IReadOnlyList<ClipboardPayload> payloads,
-        bool confirm)
+        bool confirm,
+        IntPtr originSurface = default)
     {
         if (kind == ClipboardKind.Selection)
             return;
@@ -79,15 +81,15 @@ public sealed class ClipboardService
             // Need a text/plain entry to show as the dialog preview.
             // No preview means we drop the write rather than render an
             // empty or HTML-only dialog.
-            var textPlain = supported.FirstOrDefault(p => p.Mime == ClipboardMime.TextPlain);
-            if (textPlain == default)
+            if (supported.FirstOrDefault(p => p.Mime == ClipboardMime.TextPlain) is not { Mime: not null } textPlain)
                 return;
 
             // libghostty's setClipboard with confirm=true is OSC 52 write
             // (the only path that asks for confirmation on writes).
             var accepted = await _confirmer.ConfirmAsync(
                 textPlain.Data,
-                ClipboardConfirmRequest.Osc52Write);
+                ClipboardConfirmRequest.Osc52Write,
+                originSurface);
             if (!accepted)
                 return;
         }
@@ -95,12 +97,12 @@ public sealed class ClipboardService
         await _backend.WriteAsync(supported);
     }
 
-    public ValueTask<bool> HandleConfirmAsync(string text, ClipboardConfirmRequest request)
+    public ValueTask<bool> HandleConfirmAsync(string text, ClipboardConfirmRequest request, IntPtr originSurface = default)
     {
         // Pass-through to the platform confirmer. Kept as a service
         // method (rather than calling the confirmer directly from the
         // bridge) so the routing rules for what gets confirmed and how
         // live in one testable place if they grow more complex later.
-        return _confirmer.ConfirmAsync(text, request);
+        return _confirmer.ConfirmAsync(text, request, originSurface);
     }
 }

--- a/windows/Ghostty.Core/Clipboard/ClipboardService.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// Pure-logic clipboard service. Mediates between libghostty's three
+/// clipboard callbacks and the platform backend/confirmer. Knows nothing
+/// about WinUI 3 and is fully unit-tested in Ghostty.Tests.
+///
+/// Key rules baked in:
+///   * Selection clipboard is a no-op on Windows (no PRIMARY-style buffer).
+///   * Backend exceptions on read are swallowed and surface as null so
+///     paste keybinds fall through to the terminal.
+///   * Writes never call the backend with an empty payload list, and
+///     never call the backend if no payload has a known MIME (don't
+///     clear the clipboard with an empty package).
+/// </summary>
+public sealed class ClipboardService
+{
+    private readonly IClipboardBackend _backend;
+    private readonly IClipboardConfirmer _confirmer;
+
+    public ClipboardService(IClipboardBackend backend, IClipboardConfirmer confirmer)
+    {
+        _backend = backend;
+        _confirmer = confirmer;
+    }
+
+    public async ValueTask<string?> HandleReadAsync(ClipboardKind kind)
+    {
+        if (kind == ClipboardKind.Selection)
+            return null;
+
+        try
+        {
+            return await _backend.ReadTextAsync();
+        }
+        catch
+        {
+            // Clipboard read can throw when another process holds the
+            // clipboard open. Surfacing null lets the keybind fall
+            // through to the terminal, matching macOS.
+            return null;
+        }
+    }
+}

--- a/windows/Ghostty.Core/Clipboard/ClipboardService.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardService.cs
@@ -57,9 +57,6 @@ public sealed class ClipboardService
         if (payloads.Count == 0)
             return;
 
-        // Defence in depth: filter to MIMEs the backend knows about.
-        // Backend will skip unknowns too, but filtering here lets us
-        // detect "all unknown" and avoid clearing the clipboard.
         var supported = payloads
             .Where(p => WindowsClipboardFormatMap.FromMime(p.Mime) is not null)
             .ToList();
@@ -67,7 +64,24 @@ public sealed class ClipboardService
         if (supported.Count == 0)
             return;
 
-        // confirm == true is handled in Task 8.
+        if (confirm)
+        {
+            // Need a text/plain entry to show as the dialog preview.
+            // No preview means we drop the write rather than render an
+            // empty or HTML-only dialog.
+            var textPlain = supported.FirstOrDefault(p => p.Mime == ClipboardMime.TextPlain);
+            if (textPlain == default)
+                return;
+
+            // libghostty's setClipboard with confirm=true is OSC 52 write
+            // (the only path that asks for confirmation on writes).
+            var accepted = await _confirmer.ConfirmAsync(
+                textPlain.Data,
+                ClipboardConfirmRequest.Osc52Write);
+            if (!accepted)
+                return;
+        }
+
         await _backend.WriteAsync(supported);
     }
 }

--- a/windows/Ghostty.Core/Clipboard/ClipboardService.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardService.cs
@@ -46,4 +46,28 @@ public sealed class ClipboardService
             return null;
         }
     }
+
+    public async ValueTask HandleWriteAsync(
+        ClipboardKind kind,
+        IReadOnlyList<ClipboardPayload> payloads,
+        bool confirm)
+    {
+        if (kind == ClipboardKind.Selection)
+            return;
+        if (payloads.Count == 0)
+            return;
+
+        // Defence in depth: filter to MIMEs the backend knows about.
+        // Backend will skip unknowns too, but filtering here lets us
+        // detect "all unknown" and avoid clearing the clipboard.
+        var supported = payloads
+            .Where(p => WindowsClipboardFormatMap.FromMime(p.Mime) is not null)
+            .ToList();
+
+        if (supported.Count == 0)
+            return;
+
+        // confirm == true is handled in Task 8.
+        await _backend.WriteAsync(supported);
+    }
 }

--- a/windows/Ghostty.Core/Clipboard/ClipboardService.cs
+++ b/windows/Ghostty.Core/Clipboard/ClipboardService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -25,6 +26,8 @@ public sealed class ClipboardService
 
     public ClipboardService(IClipboardBackend backend, IClipboardConfirmer confirmer)
     {
+        ArgumentNullException.ThrowIfNull(backend);
+        ArgumentNullException.ThrowIfNull(confirmer);
         _backend = backend;
         _confirmer = confirmer;
     }
@@ -63,6 +66,13 @@ public sealed class ClipboardService
 
         if (supported.Count == 0)
             return;
+
+        // Mirrors the macOS apprt assertion. libghostty's contract is at
+        // most one text/plain entry per write; the confirmation preview
+        // and the WinUI DataPackage both assume this.
+        Debug.Assert(
+            supported.Count(p => p.Mime == ClipboardMime.TextPlain) <= 1,
+            "clipboard payloads should have at most one text/plain entry");
 
         if (confirm)
         {

--- a/windows/Ghostty.Core/Clipboard/IClipboardBackend.cs
+++ b/windows/Ghostty.Core/Clipboard/IClipboardBackend.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// Abstracts the Windows clipboard so the service layer is unit-testable
+/// without WinUI. The production implementation lives in the WinUI
+/// project as WinUiClipboardBackend.
+/// </summary>
+public interface IClipboardBackend
+{
+    /// <summary>
+    /// Returns the current clipboard text, or null when there is no
+    /// text-format content. Returning null lets the caller propagate
+    /// "false" to libghostty's read_clipboard_cb so paste keybinds
+    /// fall through to the terminal. Matches the macOS contract from
+    /// NSPasteboard.getOpinionatedStringContents.
+    /// </summary>
+    ValueTask<string?> ReadTextAsync();
+
+    /// <summary>
+    /// Atomically writes one or more MIME-tagged payloads as a single
+    /// Clipboard.SetContent call. Backend skips MIMEs it does not
+    /// recognise. The caller has already filtered out unsupported MIMEs
+    /// in the service layer; this is defence in depth.
+    /// </summary>
+    ValueTask WriteAsync(IReadOnlyList<ClipboardPayload> payloads);
+}

--- a/windows/Ghostty.Core/Clipboard/IClipboardConfirmer.cs
+++ b/windows/Ghostty.Core/Clipboard/IClipboardConfirmer.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// Renders the clipboard confirmation dialog libghostty asks for via
+/// confirm_read_clipboard_cb (paste, OSC 52 read, OSC 52 write). The
+/// production implementation is DialogClipboardConfirmer in the WinUI
+/// project.
+/// </summary>
+public interface IClipboardConfirmer
+{
+    /// <summary>
+    /// Show a dialog with the supplied preview as the body and return
+    /// true if the user accepts. Implementations must default to Cancel
+    /// (return false) for safety and must be safe to call concurrently.
+    /// </summary>
+    ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request);
+}

--- a/windows/Ghostty.Core/Clipboard/IClipboardConfirmer.cs
+++ b/windows/Ghostty.Core/Clipboard/IClipboardConfirmer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Ghostty.Core.Clipboard;
@@ -15,5 +16,13 @@ public interface IClipboardConfirmer
     /// true if the user accepts. Implementations must default to Cancel
     /// (return false) for safety and must be safe to call concurrently.
     /// </summary>
-    ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request);
+    /// <param name="originSurface">
+    /// Opaque handle identifying the surface (and therefore the window)
+    /// that triggered the request. WinUI uses this to resolve the correct
+    /// XamlRoot so the dialog appears on the originating window instead
+    /// of whichever window happens to be first in the surfaces registry.
+    /// Pass <see cref="IntPtr.Zero"/> when no origin is available; the
+    /// implementation may then fall back to any active root.
+    /// </param>
+    ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request, IntPtr originSurface);
 }

--- a/windows/Ghostty.Core/Clipboard/WindowsClipboardFormat.cs
+++ b/windows/Ghostty.Core/Clipboard/WindowsClipboardFormat.cs
@@ -15,7 +15,7 @@ public static class WindowsClipboardFormatMap
 {
     /// <summary>
     /// Map a libghostty MIME string to the Windows format we will write.
-    /// Returns null when the MIME is unknown, null, or empty — callers
+    /// Returns null when the MIME is unknown, null, or empty. Callers
     /// should treat that as "skip this entry".
     /// </summary>
     public static WindowsClipboardFormat? FromMime(string? mime) => mime switch

--- a/windows/Ghostty.Core/Clipboard/WindowsClipboardFormat.cs
+++ b/windows/Ghostty.Core/Clipboard/WindowsClipboardFormat.cs
@@ -1,0 +1,27 @@
+namespace Ghostty.Core.Clipboard;
+
+/// <summary>
+/// The Windows-side clipboard formats we know how to write. This is the
+/// analogue of macOS NSPasteboard.PasteboardType. Anything else libghostty
+/// hands us is silently skipped (forward-compatible with future MIMEs).
+/// </summary>
+public enum WindowsClipboardFormat
+{
+    Text,
+    Html,
+}
+
+public static class WindowsClipboardFormatMap
+{
+    /// <summary>
+    /// Map a libghostty MIME string to the Windows format we will write.
+    /// Returns null when the MIME is unknown, null, or empty — callers
+    /// should treat that as "skip this entry".
+    /// </summary>
+    public static WindowsClipboardFormat? FromMime(string? mime) => mime switch
+    {
+        ClipboardMime.TextPlain => WindowsClipboardFormat.Text,
+        ClipboardMime.TextHtml => WindowsClipboardFormat.Html,
+        _ => null,
+    };
+}

--- a/windows/Ghostty.Tests/Clipboard/ClipboardContentMarshallerTests.cs
+++ b/windows/Ghostty.Tests/Clipboard/ClipboardContentMarshallerTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Ghostty.Core.Clipboard;
+using Xunit;
+
+namespace Ghostty.Tests.Clipboard;
+
+/// <summary>
+/// Tests ClipboardContentMarshaller against real native struct layouts
+/// built with Marshal.AllocHGlobal. These tests exercise actual struct
+/// dereferencing through the same code path the WinUI bridge uses,
+/// catching ABI mistakes before they ship.
+/// </summary>
+public sealed class ClipboardContentMarshallerTests
+{
+    // ghostty_clipboard_content_s = { const char* mime; const char* data; }
+    // sizeof(struct) = 2 * pointer size
+    private static readonly int StructSize = 2 * IntPtr.Size;
+
+    /// <summary>
+    /// Build an unmanaged array of N ghostty_clipboard_content_s entries,
+    /// allocating each C string separately. Returns the array pointer
+    /// plus a list of every allocation so the caller can free them.
+    /// </summary>
+    private static (IntPtr Array, IntPtr[] AllAllocs) BuildArray(params (string Mime, string Data)[] entries)
+    {
+        var allocs = new System.Collections.Generic.List<IntPtr>();
+        var array = Marshal.AllocHGlobal(StructSize * entries.Length);
+        allocs.Add(array);
+
+        for (int i = 0; i < entries.Length; i++)
+        {
+            var mimePtr = Marshal.StringToCoTaskMemUTF8(entries[i].Mime);
+            var dataPtr = Marshal.StringToCoTaskMemUTF8(entries[i].Data);
+            allocs.Add(mimePtr);
+            allocs.Add(dataPtr);
+
+            var entryAddr = IntPtr.Add(array, i * StructSize);
+            Marshal.WriteIntPtr(entryAddr, 0, mimePtr);
+            Marshal.WriteIntPtr(entryAddr, IntPtr.Size, dataPtr);
+        }
+
+        return (array, allocs.ToArray());
+    }
+
+    private static void FreeAll(IntPtr[] allocs)
+    {
+        // First entry is the array itself (HGlobal); the rest are
+        // CoTaskMemUTF8 strings.
+        Marshal.FreeHGlobal(allocs[0]);
+        for (int i = 1; i < allocs.Length; i++)
+            Marshal.FreeCoTaskMem(allocs[i]);
+    }
+
+    [Fact]
+    public void Read_NullPointer_ReturnsEmpty()
+    {
+        var result = ClipboardContentMarshaller.Read(IntPtr.Zero, 5);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Read_ZeroCount_ReturnsEmpty()
+    {
+        var (array, allocs) = BuildArray(("text/plain", "hello"));
+        try
+        {
+            var result = ClipboardContentMarshaller.Read(array, 0);
+            Assert.Empty(result);
+        }
+        finally { FreeAll(allocs); }
+    }
+
+    [Fact]
+    public void Read_SingleTextPlain_ReturnsOne()
+    {
+        var (array, allocs) = BuildArray(("text/plain", "hello"));
+        try
+        {
+            var result = ClipboardContentMarshaller.Read(array, 1);
+            var entry = Assert.Single(result);
+            Assert.Equal("text/plain", entry.Mime);
+            Assert.Equal("hello", entry.Data);
+        }
+        finally { FreeAll(allocs); }
+    }
+
+    [Fact]
+    public void Read_TwoEntries_TextPlainAndTextHtml_ReturnsBothInOrder()
+    {
+        // The bug-fix test: the current stub treats `content` as a single
+        // pointer and ignores `count`. With the fix, both entries must
+        // come back in declaration order.
+        var (array, allocs) = BuildArray(
+            ("text/plain", "hello"),
+            ("text/html", "<b>hello</b>"));
+        try
+        {
+            var result = ClipboardContentMarshaller.Read(array, 2);
+            Assert.Equal(2, result.Count);
+            Assert.Equal("text/plain", result[0].Mime);
+            Assert.Equal("hello", result[0].Data);
+            Assert.Equal("text/html", result[1].Mime);
+            Assert.Equal("<b>hello</b>", result[1].Data);
+        }
+        finally { FreeAll(allocs); }
+    }
+
+    [Fact]
+    public void Read_LongUtf8_RoundTrips()
+    {
+        // Multi-byte chars in both fields. UTF-8 encoded length is what
+        // matters across the ABI; the marshaller must use UTF-8 decode.
+        var japanese = "こんにちは世界";
+        var emoji = "📋✨🚀";
+        var (array, allocs) = BuildArray((japanese, emoji));
+        try
+        {
+            var result = ClipboardContentMarshaller.Read(array, 1);
+            var entry = Assert.Single(result);
+            Assert.Equal(japanese, entry.Mime);
+            Assert.Equal(emoji, entry.Data);
+        }
+        finally { FreeAll(allocs); }
+    }
+
+    [Fact]
+    public void Read_EmptyDataString_ReturnsEmptyData()
+    {
+        var (array, allocs) = BuildArray(("text/plain", ""));
+        try
+        {
+            var result = ClipboardContentMarshaller.Read(array, 1);
+            var entry = Assert.Single(result);
+            Assert.Equal("text/plain", entry.Mime);
+            Assert.Equal("", entry.Data);
+        }
+        finally { FreeAll(allocs); }
+    }
+}

--- a/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
+++ b/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
@@ -170,4 +170,64 @@ public sealed class ClipboardServiceTests
 
         Assert.Equal(0, backend.WriteCallCount);
     }
+
+    // Write path with confirmation
+
+    [Fact]
+    public async Task HandleWriteAsync_ConfirmTrue_AsksConfirmer_PreviewIsTextPlain()
+    {
+        var (svc, _, confirmer) = Make();
+        confirmer.EnqueueResponse(true);
+        var payloads = new[]
+        {
+            new ClipboardPayload(ClipboardMime.TextPlain, "preview text"),
+            new ClipboardPayload(ClipboardMime.TextHtml, "<b>preview text</b>"),
+        };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: true);
+
+        var call = Assert.Single(confirmer.Calls);
+        Assert.Equal("preview text", call.Preview);
+        Assert.Equal(ClipboardConfirmRequest.Osc52Write, call.Request);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_ConfirmTrue_UserAccepts_WritesPayload()
+    {
+        var (svc, backend, confirmer) = Make();
+        confirmer.EnqueueResponse(true);
+        var payloads = new[] { new ClipboardPayload(ClipboardMime.TextPlain, "ok") };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: true);
+
+        Assert.Equal(1, backend.WriteCallCount);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_ConfirmTrue_UserDeclines_DoesNotWrite()
+    {
+        var (svc, backend, confirmer) = Make();
+        confirmer.EnqueueResponse(false);
+        var payloads = new[] { new ClipboardPayload(ClipboardMime.TextPlain, "nope") };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: true);
+
+        Assert.Equal(0, backend.WriteCallCount);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_ConfirmTrue_NoTextPlainEntry_DoesNotWrite()
+    {
+        // Without a text/plain payload there is nothing to show in the
+        // confirmation preview, so the safe default is to drop the
+        // write rather than show an empty dialog or HTML-only dialog.
+        var (svc, backend, confirmer) = Make();
+        confirmer.EnqueueResponse(true);
+        var payloads = new[] { new ClipboardPayload(ClipboardMime.TextHtml, "<b>html only</b>") };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: true);
+
+        Assert.Equal(0, backend.WriteCallCount);
+        Assert.Empty(confirmer.Calls);
+    }
 }

--- a/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
+++ b/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
@@ -66,4 +66,108 @@ public sealed class ClipboardServiceTests
 
         Assert.Null(result);
     }
+
+    // Write path (no confirmation)
+
+    [Fact]
+    public async Task HandleWriteAsync_TextPlainOnly_WritesPlainText()
+    {
+        var (svc, backend, _) = Make();
+        var payloads = new[] { new ClipboardPayload(ClipboardMime.TextPlain, "hello") };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: false);
+
+        Assert.NotNull(backend.LastWrite);
+        var written = Assert.Single(backend.LastWrite!);
+        Assert.Equal(ClipboardMime.TextPlain, written.Mime);
+        Assert.Equal("hello", written.Data);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_TextHtmlOnly_WritesHtml()
+    {
+        var (svc, backend, _) = Make();
+        var payloads = new[] { new ClipboardPayload(ClipboardMime.TextHtml, "<b>hi</b>") };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: false);
+
+        Assert.NotNull(backend.LastWrite);
+        var written = Assert.Single(backend.LastWrite!);
+        Assert.Equal(ClipboardMime.TextHtml, written.Mime);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_TextPlainAndHtml_WritesBothInOneCall()
+    {
+        // The mixed-format case: libghostty's `mixed` copy format sends
+        // both text/plain and text/html in a single write. We must
+        // forward both atomically (one backend call), so a Notepad
+        // paste gets text and a Word paste gets HTML.
+        var (svc, backend, _) = Make();
+        var payloads = new[]
+        {
+            new ClipboardPayload(ClipboardMime.TextPlain, "hello"),
+            new ClipboardPayload(ClipboardMime.TextHtml, "<b>hello</b>"),
+        };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: false);
+
+        Assert.Equal(1, backend.WriteCallCount);
+        Assert.NotNull(backend.LastWrite);
+        Assert.Equal(2, backend.LastWrite!.Count);
+        Assert.Contains(backend.LastWrite, p => p.Mime == ClipboardMime.TextPlain && p.Data == "hello");
+        Assert.Contains(backend.LastWrite, p => p.Mime == ClipboardMime.TextHtml && p.Data == "<b>hello</b>");
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_UnknownMime_SkippedSilently()
+    {
+        var (svc, backend, _) = Make();
+        var payloads = new[]
+        {
+            new ClipboardPayload(ClipboardMime.TextPlain, "kept"),
+            new ClipboardPayload("application/x-something", "dropped"),
+        };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: false);
+
+        Assert.NotNull(backend.LastWrite);
+        var written = Assert.Single(backend.LastWrite!);
+        Assert.Equal(ClipboardMime.TextPlain, written.Mime);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_AllUnknownMimes_DoesNotCallBackend()
+    {
+        // Crucially: do NOT clear the clipboard by sending an empty
+        // package. Stay quiet.
+        var (svc, backend, _) = Make();
+        var payloads = new[] { new ClipboardPayload("image/png", "binary blob") };
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, payloads, confirm: false);
+
+        Assert.Equal(0, backend.WriteCallCount);
+        Assert.Null(backend.LastWrite);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_EmptyPayloadList_DoesNotCallBackend()
+    {
+        var (svc, backend, _) = Make();
+
+        await svc.HandleWriteAsync(ClipboardKind.Standard, Array.Empty<ClipboardPayload>(), confirm: false);
+
+        Assert.Equal(0, backend.WriteCallCount);
+    }
+
+    [Fact]
+    public async Task HandleWriteAsync_Selection_DoesNotCallBackend()
+    {
+        var (svc, backend, _) = Make();
+        var payloads = new[] { new ClipboardPayload(ClipboardMime.TextPlain, "hello") };
+
+        await svc.HandleWriteAsync(ClipboardKind.Selection, payloads, confirm: false);
+
+        Assert.Equal(0, backend.WriteCallCount);
+    }
 }

--- a/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
+++ b/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ghostty.Core.Clipboard;
+using Ghostty.Tests.Clipboard.Fakes;
+using Xunit;
+
+namespace Ghostty.Tests.Clipboard;
+
+/// <summary>
+/// Pure-logic tests for ClipboardService. Uses real Ghostty.Core types
+/// with hand-written fake backend and confirmer; no mocking framework,
+/// no source-stubs.
+/// </summary>
+public sealed class ClipboardServiceTests
+{
+    private static (ClipboardService Service, FakeClipboardBackend Backend, FakeClipboardConfirmer Confirmer) Make()
+    {
+        var backend = new FakeClipboardBackend();
+        var confirmer = new FakeClipboardConfirmer();
+        return (new ClipboardService(backend, confirmer), backend, confirmer);
+    }
+
+    // Read path
+
+    [Fact]
+    public async Task HandleReadAsync_Standard_BackendHasText_ReturnsText()
+    {
+        var (svc, backend, _) = Make();
+        backend.StoredText = "hello";
+
+        var result = await svc.HandleReadAsync(ClipboardKind.Standard);
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task HandleReadAsync_Standard_BackendEmpty_ReturnsNull()
+    {
+        var (svc, backend, _) = Make();
+        backend.StoredText = null;
+
+        var result = await svc.HandleReadAsync(ClipboardKind.Standard);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task HandleReadAsync_Selection_AlwaysReturnsNull()
+    {
+        var (svc, backend, _) = Make();
+        backend.StoredText = "this should never be returned";
+
+        var result = await svc.HandleReadAsync(ClipboardKind.Selection);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task HandleReadAsync_BackendThrows_ReturnsNull()
+    {
+        var (svc, backend, _) = Make();
+        backend.OnRead = () => throw new InvalidOperationException("clipboard locked");
+
+        var result = await svc.HandleReadAsync(ClipboardKind.Standard);
+
+        Assert.Null(result);
+    }
+}

--- a/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
+++ b/windows/Ghostty.Tests/Clipboard/ClipboardServiceTests.cs
@@ -230,4 +230,56 @@ public sealed class ClipboardServiceTests
         Assert.Equal(0, backend.WriteCallCount);
         Assert.Empty(confirmer.Calls);
     }
+
+    // Confirm path (libghostty -> dialog -> response)
+
+    [Fact]
+    public async Task HandleConfirmAsync_Paste_AsksConfirmerWithPasteRequest()
+    {
+        var (svc, _, confirmer) = Make();
+        confirmer.EnqueueResponse(true);
+
+        await svc.HandleConfirmAsync("dangerous text", ClipboardConfirmRequest.Paste);
+
+        var call = Assert.Single(confirmer.Calls);
+        Assert.Equal("dangerous text", call.Preview);
+        Assert.Equal(ClipboardConfirmRequest.Paste, call.Request);
+    }
+
+    [Fact]
+    public async Task HandleConfirmAsync_Osc52Read_AsksConfirmerWithOsc52ReadRequest()
+    {
+        var (svc, _, confirmer) = Make();
+        confirmer.EnqueueResponse(false);
+
+        await svc.HandleConfirmAsync("clipboard contents", ClipboardConfirmRequest.Osc52Read);
+
+        var call = Assert.Single(confirmer.Calls);
+        Assert.Equal(ClipboardConfirmRequest.Osc52Read, call.Request);
+    }
+
+    [Fact]
+    public async Task HandleConfirmAsync_Osc52Write_AsksConfirmerWithOsc52WriteRequest()
+    {
+        var (svc, _, confirmer) = Make();
+        confirmer.EnqueueResponse(true);
+
+        await svc.HandleConfirmAsync("incoming text", ClipboardConfirmRequest.Osc52Write);
+
+        var call = Assert.Single(confirmer.Calls);
+        Assert.Equal(ClipboardConfirmRequest.Osc52Write, call.Request);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task HandleConfirmAsync_ReturnsConfirmerDecision(bool decision)
+    {
+        var (svc, _, confirmer) = Make();
+        confirmer.EnqueueResponse(decision);
+
+        var result = await svc.HandleConfirmAsync("text", ClipboardConfirmRequest.Paste);
+
+        Assert.Equal(decision, result);
+    }
 }

--- a/windows/Ghostty.Tests/Clipboard/Fakes/FakeClipboardBackend.cs
+++ b/windows/Ghostty.Tests/Clipboard/Fakes/FakeClipboardBackend.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ghostty.Core.Clipboard;
+
+namespace Ghostty.Tests.Clipboard.Fakes;
+
+/// <summary>
+/// Hand-written fake of IClipboardBackend. Records the last write,
+/// supplies a queued read response, and can simulate read failures
+/// (clipboard locked by another process).
+/// </summary>
+internal sealed class FakeClipboardBackend : IClipboardBackend
+{
+    public string? StoredText { get; set; }
+
+    public IReadOnlyList<ClipboardPayload>? LastWrite { get; private set; }
+    public int WriteCallCount { get; private set; }
+
+    public Func<string?>? OnRead { get; set; }
+
+    public ValueTask<string?> ReadTextAsync()
+    {
+        if (OnRead is not null)
+            return new ValueTask<string?>(OnRead());
+        return new ValueTask<string?>(StoredText);
+    }
+
+    public ValueTask WriteAsync(IReadOnlyList<ClipboardPayload> payloads)
+    {
+        LastWrite = payloads;
+        WriteCallCount++;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/windows/Ghostty.Tests/Clipboard/Fakes/FakeClipboardConfirmer.cs
+++ b/windows/Ghostty.Tests/Clipboard/Fakes/FakeClipboardConfirmer.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ghostty.Core.Clipboard;
+
+namespace Ghostty.Tests.Clipboard.Fakes;
+
+/// <summary>
+/// Hand-written fake of IClipboardConfirmer. Returns pre-programmed
+/// responses in FIFO order; records every call as (preview, request).
+/// Defaults to "false" (deny) when the response queue runs out, matching
+/// the production safety default.
+/// </summary>
+internal sealed class FakeClipboardConfirmer : IClipboardConfirmer
+{
+    private readonly Queue<bool> _responses = new();
+
+    public List<(string Preview, ClipboardConfirmRequest Request)> Calls { get; } = new();
+
+    public void EnqueueResponse(bool accept) => _responses.Enqueue(accept);
+
+    public ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request)
+    {
+        Calls.Add((preview, request));
+        var result = _responses.Count > 0 ? _responses.Dequeue() : false;
+        return new ValueTask<bool>(result);
+    }
+}

--- a/windows/Ghostty.Tests/Clipboard/Fakes/FakeClipboardConfirmer.cs
+++ b/windows/Ghostty.Tests/Clipboard/Fakes/FakeClipboardConfirmer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
@@ -6,7 +7,7 @@ namespace Ghostty.Tests.Clipboard.Fakes;
 
 /// <summary>
 /// Hand-written fake of IClipboardConfirmer. Returns pre-programmed
-/// responses in FIFO order; records every call as (preview, request).
+/// responses in FIFO order; records every call as (preview, request, origin).
 /// Defaults to "false" (deny) when the response queue runs out, matching
 /// the production safety default.
 /// </summary>
@@ -14,13 +15,13 @@ internal sealed class FakeClipboardConfirmer : IClipboardConfirmer
 {
     private readonly Queue<bool> _responses = new();
 
-    public List<(string Preview, ClipboardConfirmRequest Request)> Calls { get; } = new();
+    public List<(string Preview, ClipboardConfirmRequest Request, IntPtr OriginSurface)> Calls { get; } = new();
 
     public void EnqueueResponse(bool accept) => _responses.Enqueue(accept);
 
-    public ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request)
+    public ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request, IntPtr originSurface)
     {
-        Calls.Add((preview, request));
+        Calls.Add((preview, request, originSurface));
         var result = _responses.Count > 0 ? _responses.Dequeue() : false;
         return new ValueTask<bool>(result);
     }

--- a/windows/Ghostty.Tests/Clipboard/WindowsClipboardFormatMapTests.cs
+++ b/windows/Ghostty.Tests/Clipboard/WindowsClipboardFormatMapTests.cs
@@ -1,0 +1,48 @@
+using Ghostty.Core.Clipboard;
+using Xunit;
+
+namespace Ghostty.Tests.Clipboard;
+
+/// <summary>
+/// Mirrors macos/Tests/NSPasteboardTests.swift. Verifies the MIME types
+/// libghostty emits map to the Windows clipboard formats we support, and
+/// that everything else maps to null (silently skipped, not an error).
+/// </summary>
+public sealed class WindowsClipboardFormatMapTests
+{
+    [Fact]
+    public void FromMime_TextPlain_ReturnsText()
+    {
+        Assert.Equal(WindowsClipboardFormat.Text,
+            WindowsClipboardFormatMap.FromMime("text/plain"));
+    }
+
+    [Fact]
+    public void FromMime_TextHtml_ReturnsHtml()
+    {
+        Assert.Equal(WindowsClipboardFormat.Html,
+            WindowsClipboardFormatMap.FromMime("text/html"));
+    }
+
+    [Fact]
+    public void FromMime_ImagePng_ReturnsNull()
+    {
+        // Negative analogue of the macOS image/png test: macOS supports
+        // image/png natively via NSPasteboard.PasteboardType. We do not.
+        // Documented difference, not an oversight.
+        Assert.Null(WindowsClipboardFormatMap.FromMime("image/png"));
+    }
+
+    [Fact]
+    public void FromMime_UnknownMime_ReturnsNull()
+    {
+        Assert.Null(WindowsClipboardFormatMap.FromMime("application/x-something"));
+    }
+
+    [Fact]
+    public void FromMime_NullOrEmpty_ReturnsNull()
+    {
+        Assert.Null(WindowsClipboardFormatMap.FromMime(null));
+        Assert.Null(WindowsClipboardFormatMap.FromMime(""));
+    }
+}

--- a/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
+++ b/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
@@ -24,16 +24,16 @@ internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
     private static readonly TimeSpan ConcurrentDialogWaitTimeout = TimeSpan.FromSeconds(30);
 
     private readonly DispatcherQueue _dispatcher;
-    private readonly Func<XamlRoot?> _xamlRootProvider;
+    private readonly Func<IntPtr, XamlRoot?> _xamlRootProvider;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    public DialogClipboardConfirmer(DispatcherQueue dispatcher, Func<XamlRoot?> xamlRootProvider)
+    public DialogClipboardConfirmer(DispatcherQueue dispatcher, Func<IntPtr, XamlRoot?> xamlRootProvider)
     {
         _dispatcher = dispatcher;
         _xamlRootProvider = xamlRootProvider;
     }
 
-    public async ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request)
+    public async ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request, IntPtr originSurface)
     {
         // Serialize concurrent dialogs. Auto-deny if the previous
         // dialog hangs around for too long.
@@ -48,7 +48,7 @@ internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
             {
                 try
                 {
-                    var xamlRoot = _xamlRootProvider();
+                    var xamlRoot = _xamlRootProvider(originSurface);
                     if (xamlRoot is null)
                     {
                         tcs.TrySetResult(false);
@@ -75,7 +75,7 @@ internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
                                     Content = new TextBlock
                                     {
                                         Text = preview,
-                                        FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Cascadia Mono, Consolas, monospace"),
+                                        FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Cascadia Mono, Consolas, Courier New"),
                                         FontSize = 12,
                                         IsTextSelectionEnabled = true,
                                         TextWrapping = TextWrapping.Wrap,

--- a/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
+++ b/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Clipboard;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Clipboard;
+
+/// <summary>
+/// Renders the libghostty clipboard confirmation dialog as a WinUI 3
+/// ContentDialog. Resolves the active XamlRoot via a callback so the
+/// confirmer is independent of which TerminalControl is focused.
+///
+/// WinUI 3 only allows one ContentDialog per XamlRoot at a time, so
+/// concurrent confirmations are serialized via a SemaphoreSlim. If the
+/// wait exceeds 30 seconds, the request is auto-denied as the safe
+/// default for a security-relevant dialog.
+/// </summary>
+internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
+{
+    private static readonly TimeSpan ConcurrentDialogWaitTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly DispatcherQueue _dispatcher;
+    private readonly Func<XamlRoot?> _xamlRootProvider;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public DialogClipboardConfirmer(DispatcherQueue dispatcher, Func<XamlRoot?> xamlRootProvider)
+    {
+        _dispatcher = dispatcher;
+        _xamlRootProvider = xamlRootProvider;
+    }
+
+    public async ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request)
+    {
+        // Serialize concurrent dialogs. Auto-deny if the previous
+        // dialog hangs around for too long.
+        if (!await _gate.WaitAsync(ConcurrentDialogWaitTimeout))
+            return false;
+
+        try
+        {
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var enqueued = _dispatcher.TryEnqueue(async () =>
+            {
+                try
+                {
+                    var xamlRoot = _xamlRootProvider();
+                    if (xamlRoot is null)
+                    {
+                        tcs.TrySetResult(false);
+                        return;
+                    }
+
+                    var (title, body) = LabelsFor(request);
+                    var dialog = new ContentDialog
+                    {
+                        Title = title,
+                        Content = new StackPanel
+                        {
+                            Children =
+                            {
+                                new TextBlock
+                                {
+                                    Text = body,
+                                    TextWrapping = TextWrapping.Wrap,
+                                    Margin = new Thickness(0, 0, 0, 12),
+                                },
+                                new ScrollViewer
+                                {
+                                    MaxHeight = 200,
+                                    Content = new TextBlock
+                                    {
+                                        Text = preview,
+                                        FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Cascadia Mono, Consolas, monospace"),
+                                        FontSize = 12,
+                                        IsTextSelectionEnabled = true,
+                                        TextWrapping = TextWrapping.Wrap,
+                                    },
+                                },
+                            },
+                        },
+                        PrimaryButtonText = "Allow",
+                        CloseButtonText = "Cancel",
+                        DefaultButton = ContentDialogButton.Close, // Safety default: Cancel
+                        XamlRoot = xamlRoot,
+                    };
+
+                    var result = await dialog.ShowAsync();
+                    tcs.TrySetResult(result == ContentDialogResult.Primary);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[clipboard] confirm dialog failed: {ex.Message}");
+                    tcs.TrySetResult(false);
+                }
+            });
+
+            if (!enqueued)
+                return false;
+
+            return await tcs.Task;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private static (string Title, string Body) LabelsFor(ClipboardConfirmRequest request) => request switch
+    {
+        ClipboardConfirmRequest.Paste => (
+            "Paste from clipboard",
+            "An application is asking to paste the following text into the terminal."),
+        ClipboardConfirmRequest.Osc52Read => (
+            "Allow clipboard read",
+            "A terminal application is asking to read the contents of your clipboard."),
+        ClipboardConfirmRequest.Osc52Write => (
+            "Allow clipboard write",
+            "A terminal application is asking to write the following text to your clipboard."),
+        _ => ("Clipboard", "Confirm clipboard access."),
+    };
+}

--- a/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
+++ b/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
@@ -10,6 +10,11 @@ using WinClipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
 
 namespace Ghostty.Clipboard;
 
+// TODO(logging): replace Debug.WriteLine with ILogger<T> once the
+// Windows port has structured logging infrastructure. Debug.WriteLine
+// disappears in Release builds, so production failures here are
+// currently invisible.
+
 /// <summary>
 /// Production IClipboardBackend backed by Windows.ApplicationModel.
 /// DataTransfer.Clipboard. Must be called from the UI thread; the
@@ -72,17 +77,26 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
         {
             WinClipboard.SetContent(package);
         }
-        catch (COMException ex) when (ex.HResult == CO_E_NOTINITIALIZED)
+        catch (COMException ex)
         {
-            // Window not ready yet. Retry once on the next dispatcher tick.
-            _dispatcher.TryEnqueue(() =>
+            Debug.WriteLine($"[clipboard] write failed: 0x{ex.HResult:X8}");
+
+            // CO_E_NOTINITIALIZED is a known WinUI 3 startup race: the
+            // clipboard broker is not ready yet. Retry once on the next
+            // dispatcher tick. Other HResults (notably CLIPBRD_E_CANT_OPEN
+            // when another process holds the clipboard) are logged and
+            // dropped -- there is no useful retry strategy.
+            if (ex.HResult == CO_E_NOTINITIALIZED)
             {
-                try { WinClipboard.SetContent(package); }
-                catch (COMException retryEx)
+                _dispatcher.TryEnqueue(() =>
                 {
-                    Debug.WriteLine($"[clipboard] write retry failed: 0x{retryEx.HResult:X8}");
-                }
-            });
+                    try { WinClipboard.SetContent(package); }
+                    catch (COMException retryEx)
+                    {
+                        Debug.WriteLine($"[clipboard] write retry failed: 0x{retryEx.HResult:X8}");
+                    }
+                });
+            }
         }
 
         return ValueTask.CompletedTask;

--- a/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
+++ b/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
@@ -53,6 +53,41 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
 
     public ValueTask WriteAsync(IReadOnlyList<ClipboardPayload> payloads)
     {
+        try
+        {
+            WinClipboard.SetContent(BuildPackage(payloads));
+        }
+        catch (COMException ex)
+        {
+            Debug.WriteLine($"[clipboard] write failed: 0x{ex.HResult:X8}");
+
+            // CO_E_NOTINITIALIZED is a known WinUI 3 startup race: the
+            // clipboard broker is not ready yet. Retry once on the next
+            // dispatcher tick. Other HResults (notably CLIPBRD_E_CANT_OPEN
+            // when another process holds the clipboard) are logged and
+            // dropped -- there is no useful retry strategy.
+            //
+            // DataPackage is a single-use transfer object: once handed to
+            // SetContent the runtime takes ownership, so the retry must
+            // build a fresh package instead of reusing the one that threw.
+            if (ex.HResult == CO_E_NOTINITIALIZED)
+            {
+                _dispatcher.TryEnqueue(() =>
+                {
+                    try { WinClipboard.SetContent(BuildPackage(payloads)); }
+                    catch (COMException retryEx)
+                    {
+                        Debug.WriteLine($"[clipboard] write retry failed: 0x{retryEx.HResult:X8}");
+                    }
+                });
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private static DataPackage BuildPackage(IReadOnlyList<ClipboardPayload> payloads)
+    {
         var package = new DataPackage();
         foreach (var payload in payloads)
         {
@@ -72,33 +107,6 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
                     break;
             }
         }
-
-        try
-        {
-            WinClipboard.SetContent(package);
-        }
-        catch (COMException ex)
-        {
-            Debug.WriteLine($"[clipboard] write failed: 0x{ex.HResult:X8}");
-
-            // CO_E_NOTINITIALIZED is a known WinUI 3 startup race: the
-            // clipboard broker is not ready yet. Retry once on the next
-            // dispatcher tick. Other HResults (notably CLIPBRD_E_CANT_OPEN
-            // when another process holds the clipboard) are logged and
-            // dropped -- there is no useful retry strategy.
-            if (ex.HResult == CO_E_NOTINITIALIZED)
-            {
-                _dispatcher.TryEnqueue(() =>
-                {
-                    try { WinClipboard.SetContent(package); }
-                    catch (COMException retryEx)
-                    {
-                        Debug.WriteLine($"[clipboard] write retry failed: 0x{retryEx.HResult:X8}");
-                    }
-                });
-            }
-        }
-
-        return ValueTask.CompletedTask;
+        return package;
     }
 }

--- a/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
+++ b/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Ghostty.Core.Clipboard;
+using Microsoft.UI.Dispatching;
+using Windows.ApplicationModel.DataTransfer;
+using WinClipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
+
+namespace Ghostty.Clipboard;
+
+/// <summary>
+/// Production IClipboardBackend backed by Windows.ApplicationModel.
+/// DataTransfer.Clipboard. Must be called from the UI thread; the
+/// bridge dispatches all calls before invoking us.
+/// </summary>
+internal sealed class WinUiClipboardBackend : IClipboardBackend
+{
+    // CO_E_NOTINITIALIZED is the WinUI 3 startup race when SetContent is
+    // called before the window's clipboard broker is fully ready.
+    // See memory/reference_winui3_quirks.md.
+    private const int CO_E_NOTINITIALIZED = unchecked((int)0x800401F0);
+
+    private readonly DispatcherQueue _dispatcher;
+
+    public WinUiClipboardBackend(DispatcherQueue dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public async ValueTask<string?> ReadTextAsync()
+    {
+        try
+        {
+            var view = WinClipboard.GetContent();
+            if (!view.Contains(StandardDataFormats.Text))
+                return null;
+            return await view.GetTextAsync();
+        }
+        catch (COMException ex)
+        {
+            // Clipboard locked by another process. Treated as "no text".
+            Debug.WriteLine($"[clipboard] read failed: 0x{ex.HResult:X8}");
+            return null;
+        }
+    }
+
+    public ValueTask WriteAsync(IReadOnlyList<ClipboardPayload> payloads)
+    {
+        var package = new DataPackage();
+        foreach (var payload in payloads)
+        {
+            switch (WindowsClipboardFormatMap.FromMime(payload.Mime))
+            {
+                case WindowsClipboardFormat.Text:
+                    package.SetText(payload.Data);
+                    break;
+                case WindowsClipboardFormat.Html:
+                    // CreateHtmlFormat wraps the body in the CF_HTML
+                    // header that Word and Outlook understand.
+                    package.SetHtmlFormat(HtmlFormatHelper.CreateHtmlFormat(payload.Data));
+                    break;
+                default:
+                    // Unknown MIME: already filtered by the service, but
+                    // be defensive in case the contract drifts.
+                    break;
+            }
+        }
+
+        try
+        {
+            WinClipboard.SetContent(package);
+        }
+        catch (COMException ex) when (ex.HResult == CO_E_NOTINITIALIZED)
+        {
+            // Window not ready yet. Retry once on the next dispatcher tick.
+            _dispatcher.TryEnqueue(() =>
+            {
+                try { WinClipboard.SetContent(package); }
+                catch (COMException retryEx)
+                {
+                    Debug.WriteLine($"[clipboard] write retry failed: 0x{retryEx.HResult:X8}");
+                }
+            });
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -72,6 +72,15 @@ public sealed partial class TerminalControl : UserControl
     internal GhosttyHost? Host { get; set; }
 
     /// <summary>
+    /// The raw libghostty surface handle for this control. Used by
+    /// <see cref="Ghostty.Hosting.GhosttyHost"/> to resolve a per-surface
+    /// userdata pointer back to the handle for clipboard callback completion.
+    /// Returns <see cref="IntPtr.Zero"/> before the surface is created or
+    /// after it is disposed.
+    /// </summary>
+    internal IntPtr SurfaceHandle => _surface.Handle;
+
+    /// <summary>
     /// Last title pushed by libghostty for this surface, or null if no
     /// title has been set yet. Used by MainWindow to update the window
     /// chrome immediately on focus change without waiting for the next

--- a/windows/Ghostty/Hosting/ClipboardBridge.cs
+++ b/windows/Ghostty/Hosting/ClipboardBridge.cs
@@ -19,7 +19,20 @@ namespace Ghostty.Hosting;
 /// Surface liveness is checked via the supplied IsSurfaceAlive callback
 /// before completing requests, in case the TerminalControl was disposed
 /// between the dispatch and the continuation.
+///
+/// Lifetime story: the IsSurfaceAlive check before
+/// SurfaceCompleteClipboardRequest is intentional. When a surface is
+/// destroyed by libghostty, libghostty also frees any pending clipboard
+/// request state for that surface. If the surface dies mid-flight we
+/// skip the completion call rather than calling it on a freed handle
+/// (use-after-free). The same reasoning applies to the dispatcher
+/// shutdown path: if TryEnqueue succeeds but the queue drops the
+/// callback during shutdown, the surface itself is being destroyed
+/// shortly after, and libghostty cleans up the request state via the
+/// surface destroy path.
 /// </summary>
+// TODO(logging): replace Debug.WriteLine with ILogger<T> once the
+// Windows port has structured logging infrastructure.
 internal sealed class ClipboardBridge
 {
     private readonly DispatcherQueue _dispatcher;

--- a/windows/Ghostty/Hosting/ClipboardBridge.cs
+++ b/windows/Ghostty/Hosting/ClipboardBridge.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Ghostty.Core.Clipboard;
+using Ghostty.Interop;
+using Microsoft.UI.Dispatching;
+
+namespace Ghostty.Hosting;
+
+/// <summary>
+/// Marshals libghostty clipboard callbacks into ClipboardService calls
+/// and back. Owns the threading model: native callbacks return
+/// immediately, all clipboard / dialog work runs inside
+/// DispatcherQueue.TryEnqueue, and SurfaceCompleteClipboardRequest
+/// is invoked once per read/confirm regardless of success or failure
+/// (so libghostty never leaks request state).
+///
+/// Surface liveness is checked via the supplied IsSurfaceAlive callback
+/// before completing requests, in case the TerminalControl was disposed
+/// between the dispatch and the continuation.
+/// </summary>
+internal sealed class ClipboardBridge
+{
+    private readonly DispatcherQueue _dispatcher;
+    private readonly ClipboardService _service;
+    private readonly Func<IntPtr, IntPtr> _resolveSurface;   // userdata -> surface
+    private readonly Func<IntPtr, bool> _isSurfaceAlive;     // surface  -> alive?
+
+    public ClipboardBridge(
+        DispatcherQueue dispatcher,
+        ClipboardService service,
+        Func<IntPtr, IntPtr> resolveSurface,
+        Func<IntPtr, bool> isSurfaceAlive)
+    {
+        _dispatcher = dispatcher;
+        _service = service;
+        _resolveSurface = resolveSurface;
+        _isSurfaceAlive = isSurfaceAlive;
+    }
+
+    // read_clipboard_cb
+
+    public bool HandleRead(IntPtr userdata, GhosttyClipboard kind, IntPtr state)
+    {
+        var surface = _resolveSurface(userdata);
+        if (surface == IntPtr.Zero)
+            return false;
+
+        var managedKind = (ClipboardKind)kind;
+        if (managedKind == ClipboardKind.Selection)
+            return false;
+
+        var enqueued = _dispatcher.TryEnqueue(async () =>
+        {
+            string textToReturn = string.Empty;
+            try
+            {
+                var text = await _service.HandleReadAsync(managedKind);
+                textToReturn = text ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[clipboard] read handler failed: {ex.Message}");
+            }
+            finally
+            {
+                if (_isSurfaceAlive(surface))
+                {
+                    NativeMethods.SurfaceCompleteClipboardRequest(
+                        surface, textToReturn, state, false);
+                }
+            }
+        });
+
+        if (!enqueued)
+        {
+            // Dispatcher shutting down. Complete synchronously so
+            // libghostty does not leak the request state.
+            if (_isSurfaceAlive(surface))
+            {
+                NativeMethods.SurfaceCompleteClipboardRequest(
+                    surface, string.Empty, state, false);
+            }
+        }
+
+        return true;
+    }
+
+    // confirm_read_clipboard_cb
+
+    public void HandleConfirm(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest request)
+    {
+        var surface = _resolveSurface(userdata);
+        if (surface == IntPtr.Zero)
+            return;
+
+        // CRITICAL: copy the C string before the callback returns.
+        // libghostty owns the buffer for the duration of this call only.
+        var text = Marshal.PtrToStringUTF8(str) ?? string.Empty;
+        var managedRequest = (ClipboardConfirmRequest)request;
+
+        var enqueued = _dispatcher.TryEnqueue(async () =>
+        {
+            bool confirmed = false;
+            try
+            {
+                confirmed = await _service.HandleConfirmAsync(text, managedRequest);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[clipboard] confirm handler failed: {ex.Message}");
+            }
+            finally
+            {
+                if (_isSurfaceAlive(surface))
+                {
+                    NativeMethods.SurfaceCompleteClipboardRequest(
+                        surface, text, state, confirmed);
+                }
+            }
+        });
+
+        if (!enqueued && _isSurfaceAlive(surface))
+        {
+            NativeMethods.SurfaceCompleteClipboardRequest(
+                surface, text, state, false);
+        }
+    }
+
+    // write_clipboard_cb
+
+    public void HandleWrite(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm)
+    {
+        if (_resolveSurface(userdata) == IntPtr.Zero)
+            return;
+
+        var managedKind = (ClipboardKind)kind;
+        if (managedKind == ClipboardKind.Selection)
+            return;
+
+        // Walk the array WHILE STILL ON THE CALLER'S THREAD. The native
+        // memory may be freed once the callback returns.
+        var payloads = ClipboardContentMarshaller.Read(content, (nuint)(ulong)count);
+        if (payloads.Count == 0)
+            return;
+
+        _dispatcher.TryEnqueue(async () =>
+        {
+            try
+            {
+                await _service.HandleWriteAsync(managedKind, payloads, confirm);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[clipboard] write handler failed: {ex.Message}");
+            }
+        });
+    }
+}

--- a/windows/Ghostty/Hosting/ClipboardBridge.cs
+++ b/windows/Ghostty/Hosting/ClipboardBridge.cs
@@ -118,7 +118,7 @@ internal sealed class ClipboardBridge
             bool confirmed = false;
             try
             {
-                confirmed = await _service.HandleConfirmAsync(text, managedRequest);
+                confirmed = await _service.HandleConfirmAsync(text, managedRequest, surface);
             }
             catch (Exception ex)
             {
@@ -145,7 +145,8 @@ internal sealed class ClipboardBridge
 
     public void HandleWrite(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm)
     {
-        if (_resolveSurface(userdata) == IntPtr.Zero)
+        var surface = _resolveSurface(userdata);
+        if (surface == IntPtr.Zero)
             return;
 
         var managedKind = (ClipboardKind)kind;
@@ -154,7 +155,7 @@ internal sealed class ClipboardBridge
 
         // Walk the array WHILE STILL ON THE CALLER'S THREAD. The native
         // memory may be freed once the callback returns.
-        var payloads = ClipboardContentMarshaller.Read(content, (nuint)(ulong)count);
+        var payloads = ClipboardContentMarshaller.Read(content, (nuint)count);
         if (payloads.Count == 0)
             return;
 
@@ -162,7 +163,7 @@ internal sealed class ClipboardBridge
         {
             try
             {
-                await _service.HandleWriteAsync(managedKind, payloads, confirm);
+                await _service.HandleWriteAsync(managedKind, payloads, confirm, surface);
             }
             catch (Exception ex)
             {

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -309,7 +309,7 @@ internal sealed class GhosttyHost : IDisposable
             if (handle.IsAllocated && handle.Target is TerminalControl ctrl)
                 return ctrl.SurfaceHandle;
         }
-        catch { }
+        catch (InvalidOperationException) { }
         return IntPtr.Zero;
     }
 

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -84,7 +84,7 @@ internal sealed class GhosttyHost : IDisposable
         var clipboardBackend = new WinUiClipboardBackend(_dispatcher);
         var clipboardConfirmer = new DialogClipboardConfirmer(
             _dispatcher,
-            xamlRootProvider: ResolveActiveXamlRoot);
+            xamlRootProvider: ResolveXamlRootForSurface);
         var clipboardService = new ClipboardService(clipboardBackend, clipboardConfirmer);
         _clipboardBridge = new ClipboardBridge(
             _dispatcher,
@@ -322,18 +322,25 @@ internal sealed class GhosttyHost : IDisposable
         return surface != IntPtr.Zero && _surfaces.ContainsKey(surface);
     }
 
-    private XamlRoot? ResolveActiveXamlRoot()
+    private XamlRoot? ResolveXamlRootForSurface(IntPtr surface)
     {
-        // GhosttyHost has no direct reference to a Window. The least-coupling
-        // approach that does not require threading extra state through the
-        // construction chain: grab any live TerminalControl from the surfaces
-        // registry and return its XamlRoot. All controls in a single window
-        // share the same XamlRoot, so "any" is equivalent to "the right one".
+        // Look up the TerminalControl that owns this specific surface so
+        // the confirmation dialog lands on the originating window. In a
+        // multi-window host, falling back to any live XamlRoot would put
+        // an OSC 52 dialog from a background window on top of the
+        // foreground one.
         //
-        // If no surface is live yet (race during startup) or the dictionary
-        // was cleared during shutdown, XamlRoot will be null and
-        // DialogClipboardConfirmer auto-denies the request -- the safe
-        // fallback for a security-relevant dialog.
+        // If the surface is not (or no longer) registered, fall back to
+        // any live control so a request during a focus-change race still
+        // gets a dialog rather than silently auto-denying. If nothing is
+        // live, return null and let DialogClipboardConfirmer auto-deny --
+        // the safe fallback for a security-relevant dialog.
+        if (surface != IntPtr.Zero && _surfaces.TryGetValue(surface, out var owner))
+        {
+            var ownerRoot = owner.XamlRoot;
+            if (ownerRoot is not null) return ownerRoot;
+        }
+
         foreach (var ctrl in _surfaces.Values)
         {
             var root = ctrl.XamlRoot;

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -2,9 +2,12 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Ghostty.Clipboard;
 using Ghostty.Controls;
+using Ghostty.Core.Clipboard;
 using Ghostty.Interop;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 
 namespace Ghostty.Hosting;
 
@@ -36,6 +39,8 @@ internal sealed class GhosttyHost : IDisposable
     public DateTime LastKeystrokeTimestamp { get; private set; } = DateTime.MinValue;
 
     internal void NoteKeystroke() => LastKeystrokeTimestamp = DateTime.UtcNow;
+
+    private ClipboardBridge? _clipboardBridge;
 
     // Delegates must be retained as fields; P/Invoke hands out native
     // function pointers the GC cannot track.
@@ -70,6 +75,22 @@ internal sealed class GhosttyHost : IDisposable
         _confirmReadClipboardCb = OnConfirmReadClipboard;
         _writeClipboardCb = OnWriteClipboard;
         _closeSurfaceCb = OnCloseSurface;
+
+        // Build the clipboard bridge after all delegate fields are assigned.
+        // The bridge takes lambdas that close over `this`, so the delegates
+        // themselves are not captured -- the ordering relative to the runtime
+        // config struct does not matter for correctness, but keeping it here
+        // makes the construction visually adjacent to the callbacks it serves.
+        var clipboardBackend = new WinUiClipboardBackend(_dispatcher);
+        var clipboardConfirmer = new DialogClipboardConfirmer(
+            _dispatcher,
+            xamlRootProvider: ResolveActiveXamlRoot);
+        var clipboardService = new ClipboardService(clipboardBackend, clipboardConfirmer);
+        _clipboardBridge = new ClipboardBridge(
+            _dispatcher,
+            clipboardService,
+            resolveSurface: ResolveSurfaceFromUserdata,
+            isSurfaceAlive: IsSurfaceAlive);
 
         var runtime = new GhosttyRuntimeConfig
         {
@@ -114,6 +135,7 @@ internal sealed class GhosttyHost : IDisposable
         _confirmReadClipboardCb = null;
         _writeClipboardCb = null;
         _closeSurfaceCb = null;
+        _clipboardBridge = null;
     }
 
     private void OnWakeup(IntPtr userdata)
@@ -228,9 +250,14 @@ internal sealed class GhosttyHost : IDisposable
         }
     }
 
-    private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state) => false;
-    private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest request) { }
-    private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm) { }
+    private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state)
+        => _clipboardBridge?.HandleRead(userdata, kind, state) ?? false;
+
+    private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest request)
+        => _clipboardBridge?.HandleConfirm(userdata, str, state, request);
+
+    private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm)
+        => _clipboardBridge?.HandleWrite(userdata, kind, content, count, confirm);
 
     private void OnCloseSurface(IntPtr userdata, bool processAlive)
     {
@@ -269,5 +296,49 @@ internal sealed class GhosttyHost : IDisposable
         foreach (var c in _surfaces.Values)
             if (ReferenceEquals(c, control)) return true;
         return false;
+    }
+
+    // Clipboard bridge helpers -------------------------------------------
+
+    private IntPtr ResolveSurfaceFromUserdata(IntPtr userdata)
+    {
+        if (userdata == IntPtr.Zero) return IntPtr.Zero;
+        try
+        {
+            var handle = GCHandle.FromIntPtr(userdata);
+            if (handle.IsAllocated && handle.Target is TerminalControl ctrl)
+                return ctrl.SurfaceHandle;
+        }
+        catch { }
+        return IntPtr.Zero;
+    }
+
+    private bool IsSurfaceAlive(IntPtr surface)
+    {
+        // The _surfaces dictionary is the authoritative live-surface registry.
+        // Checking it here is cheap (ConcurrentDictionary ContainsKey), and
+        // guards against a TerminalControl whose DisposeSurface() ran between
+        // the bridge's dispatch and the async continuation completing.
+        return surface != IntPtr.Zero && _surfaces.ContainsKey(surface);
+    }
+
+    private XamlRoot? ResolveActiveXamlRoot()
+    {
+        // GhosttyHost has no direct reference to a Window. The least-coupling
+        // approach that does not require threading extra state through the
+        // construction chain: grab any live TerminalControl from the surfaces
+        // registry and return its XamlRoot. All controls in a single window
+        // share the same XamlRoot, so "any" is equivalent to "the right one".
+        //
+        // If no surface is live yet (race during startup) or the dictionary
+        // was cleared during shutdown, XamlRoot will be null and
+        // DialogClipboardConfirmer auto-denies the request -- the safe
+        // fallback for a security-relevant dialog.
+        foreach (var ctrl in _surfaces.Values)
+        {
+            var root = ctrl.XamlRoot;
+            if (root is not null) return root;
+        }
+        return null;
     }
 }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -404,6 +404,8 @@ internal static class NativeMethods
     // Called once per read/confirm request to return clipboard text to libghostty
     // and release its internal request state. Must be called exactly once even on
     // error paths -- skipping it leaks state inside libghostty.
+    // TODO(aot): migrate this and the rest of NativeMethods to
+    // [LibraryImport] partial class for NativeAOT compatibility.
     [DllImport(Dll, CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "ghostty_surface_complete_clipboard_request")]
     internal static extern void SurfaceCompleteClipboardRequest(

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -400,6 +400,18 @@ internal static class NativeMethods
     [return: MarshalAs(UnmanagedType.I1)]
     internal static extern bool SurfaceProcessExited(GhosttySurface surface);
 
+    // ghostty_surface_complete_clipboard_request(surface, text, state, confirmed)
+    // Called once per read/confirm request to return clipboard text to libghostty
+    // and release its internal request state. Must be called exactly once even on
+    // error paths -- skipping it leaks state inside libghostty.
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "ghostty_surface_complete_clipboard_request")]
+    internal static extern void SurfaceCompleteClipboardRequest(
+        IntPtr surface,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string text,
+        IntPtr state,
+        [MarshalAs(UnmanagedType.I1)] bool confirmed);
+
     // ---- user32 --------------------------------------------------------
 
     // MessageBeep is thread-safe and minimal-dependency. Used by the

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -280,7 +280,7 @@ internal struct GhosttyRuntimeConfig
     public IntPtr CloseSurfaceCb;
 }
 
-internal static class NativeMethods
+internal static partial class NativeMethods
 {
     // Name only, no extension or path. .NET's native loader handles the
     // platform-specific suffix and searches the app base directory first,
@@ -404,13 +404,16 @@ internal static class NativeMethods
     // Called once per read/confirm request to return clipboard text to libghostty
     // and release its internal request state. Must be called exactly once even on
     // error paths -- skipping it leaks state inside libghostty.
-    // TODO(aot): migrate this and the rest of NativeMethods to
-    // [LibraryImport] partial class for NativeAOT compatibility.
-    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl,
-        EntryPoint = "ghostty_surface_complete_clipboard_request")]
-    internal static extern void SurfaceCompleteClipboardRequest(
+    //
+    // Source-generated via [LibraryImport] so this entry point is AOT-friendly
+    // and produces no IL stub. The rest of the file still uses [DllImport]; the
+    // standing migration TODO covers those.
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_complete_clipboard_request",
+        StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void SurfaceCompleteClipboardRequest(
         IntPtr surface,
-        [MarshalAs(UnmanagedType.LPUTF8Str)] string text,
+        string text,
         IntPtr state,
         [MarshalAs(UnmanagedType.I1)] bool confirmed);
 


### PR DESCRIPTION
Wires libghostty's three clipboard callbacks (read, confirm, write) into the WinUI 3 shell, replacing the no-op stubs in GhosttyHost. After this, copy/paste works end to end:

- Ctrl+Shift+C copies the terminal selection. When libghostty's mixed copy format is used (text/plain + text/html), both formats land on the clipboard atomically so Notepad gets text and Word gets the styled HTML.
- Ctrl+Shift+V pastes the Windows clipboard into the terminal. Empty clipboard does not crash; the keybind currently completes with empty text rather than falling through (documented divergence from macOS).
- OSC 52 read and write work, gated by libghostty's confirmation flow rendered as a WinUI 3 ContentDialog. Default button is Cancel.

## Architecture

Mirrors `macos/Sources/Ghostty/Ghostty.App.swift`. Three layers:

- `Ghostty.Core/Clipboard/` (plain net9.0): pure logic. `ClipboardService` mediates between the callbacks and the platform; `ClipboardContentMarshaller` walks the native `(content*, count)` array and fixes a latent ABI bug where the previous stub treated `content` as a single pointer and ignored `count`. Fully unit-tested with hand-written fakes.
- `Ghostty/Clipboard/` (WinUI 3): `WinUiClipboardBackend` wraps `Windows.ApplicationModel.DataTransfer.Clipboard` (handles `CO_E_NOTINITIALIZED` startup race and logs other COMException HResults instead of swallowing them). `DialogClipboardConfirmer` renders the ContentDialog with a SemaphoreSlim gate so concurrent OSC 52 confirms serialize.
- `Ghostty/Hosting/ClipboardBridge.cs`: the interop edge. Walks the array and decodes UTF-8 strings synchronously from the libghostty IO thread, then dispatches to the UI thread, then calls `ghostty_surface_complete_clipboard_request` with the preserved opaque state.

`SupportsSelectionClipboard` stays false: Win32 has no PRIMARY-style buffer.

## What is not in this PR

libghostty owns paste safety. No client-side paste filtering, no bracketed-paste wrapping, no multiline warning logic on the C# side. Drag and drop, path translation for WSL/Cygwin/MSYS2, image and RTF clipboard formats, and Win+V history are out of scope and will be follow-ups if there's demand.

## Tests

31 new unit tests in `Ghostty.Tests/Clipboard/`:

- 5 MIME map tests (mirrors `macos/Tests/NSPasteboardTests.swift`)
- 20 ClipboardService tests covering read, write, confirm-write, and confirm paths
- 6 marshaller tests built on real native struct layouts via `Marshal.AllocHGlobal`, including the bug-fix test for two-entry arrays

71 of 71 tests pass on this branch. Reviewer pass via dotnet-windows-reviewer and ghostty-reviewer skills found no critical issues; the small fixes they did flag (broaden COMException handling, mirror macOS Debug.Assert for at-most-one text/plain, ArgumentNullException.ThrowIfNull, checked() narrowing cast, narrow exception catch) are folded into commit a65e49ec3.

## Manual smoke tests (not yet run)

- [x] Copy from terminal, paste into Notepad
- [x] Copy from terminal, paste into Word (HTML format preserved)
- [x] Paste from another app into terminal
- [x] OSC 52 write: `printf '\e]52;c;SGVsbG8K\a'`
- [x] OSC 52 read: `printf '\e]52;c;?\a'` shows confirm dialog, both Allow and Cancel work
- [x] Multi-line paste with `clipboard-paste-protection = true` shows confirm dialog
- [x] Empty clipboard + Ctrl+Shift+V is a no-op (no crash)
- [x] Tight OSC 52 read loop serializes through one dialog at a time
- [x] Two split panes: copy in one, paste in the other
- [x] Close window while a confirm dialog is open