### PR TITLE
feat(windows): native ScrollBar overlay with auto-fade

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -22,6 +22,7 @@
     x:Class="Ghostty.Controls.TerminalControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     IsTabStop="True"
     TabNavigation="Cycle"
     HorizontalAlignment="Stretch"
@@ -36,15 +37,51 @@
     KeyUp="OnKeyUp"
     CharacterReceived="OnCharacterReceived">
 
-    <SwapChainPanel
-        x:Name="Panel"
-        IsTabStop="False"
+    <!--
+        Overlay layout: the SwapChainPanel fills the cell; the ScrollBar
+        sits on top of it on the right edge. We deliberately avoid wrapping
+        the panel in a ScrollViewer because libghostty owns its own
+        viewport state and a XAML ScrollViewer would fight with it (and
+        eat wheel events before OnPointerWheelChanged fires).
+
+        The ScrollBar here is the bare Microsoft.UI.Xaml.Controls.Primitives
+        control, NOT a ScrollViewer: we drive Minimum/Maximum/ViewportSize/
+        Value from the GHOSTTY_ACTION_SCROLLBAR callback, and forward the
+        user's drag back into libghostty via the scroll_to_row binding
+        action. WinUI's default ScrollBar template already honors the
+        system IndicatorMode (Mouse vs Touch) and animates opacity on
+        hover/pointer-leave, so we get the native Windows 11 auto-fade
+        for free without a custom Storyboard.
+    -->
+    <Grid
         HorizontalAlignment="Stretch"
-        VerticalAlignment="Stretch"
-        SizeChanged="OnSizeChanged"
-        CompositionScaleChanged="OnCompositionScaleChanged"
-        PointerPressed="OnPointerPressed"
-        PointerMoved="OnPointerMoved"
-        PointerReleased="OnPointerReleased"
-        PointerWheelChanged="OnPointerWheelChanged" />
+        VerticalAlignment="Stretch">
+        <SwapChainPanel
+            x:Name="Panel"
+            IsTabStop="False"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            SizeChanged="OnSizeChanged"
+            CompositionScaleChanged="OnCompositionScaleChanged"
+            PointerPressed="OnPointerPressed"
+            PointerMoved="OnPointerMoved"
+            PointerReleased="OnPointerReleased"
+            PointerWheelChanged="OnPointerWheelChanged" />
+
+        <primitives:ScrollBar
+            x:Name="VerticalScrollBar"
+            Orientation="Vertical"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Stretch"
+            Minimum="0"
+            Maximum="0"
+            ViewportSize="1"
+            Value="0"
+            SmallChange="1"
+            LargeChange="1"
+            IndicatorMode="MouseIndicator"
+            Visibility="Collapsed"
+            Scroll="OnScrollBarScroll"
+            PointerWheelChanged="OnScrollBarPointerWheelChanged" />
+    </Grid>
 </UserControl>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -56,6 +56,24 @@ public sealed partial class TerminalControl : UserControl
     // requiring CharacterReceived to re-derive the original VirtualKey.
     private bool _suppressNextCharacter;
 
+    // Set while RaiseScrollbarChanged is writing into VerticalScrollBar.
+    // Prevents the resulting Scroll event from round-tripping back into
+    // libghostty as a "scroll_to_row" binding action (feedback loop).
+    private bool _suppressScrollEvent;
+
+    // Latest scrollbar state pushed from libghostty's thread. Read on
+    // the UI thread by FlushPendingScrollbar. Guarded by _scrollbarLock
+    // so the three row counts are read coherently.
+    private readonly object _scrollbarLock = new();
+    private ulong _pendingScrollbarTotal;
+    private ulong _pendingScrollbarOffset;
+    private ulong _pendingScrollbarLen;
+    private bool _pendingScrollbarDirty;
+
+    // Cached dispatcher delegate — avoids allocating a
+    // DispatcherQueueHandler on every scrollbar update.
+    private Microsoft.UI.Dispatching.DispatcherQueueHandler? _flushScrollbarHandler;
+
     // Pinned managed handle to `this`, passed to libghostty as the
     // per-surface userdata. Per-surface callbacks (close_surface_cb,
     // read/write clipboard) receive this pointer back so GhosttyHost can
@@ -99,6 +117,116 @@ public sealed partial class TerminalControl : UserControl
     {
         CurrentProgress = state;
         ProgressChanged?.Invoke(this, state);
+    }
+
+    // Called on the libghostty thread. Stashes the latest state and
+    // enqueues a single UI-thread flush. Coalescing: if libghostty
+    // emits multiple updates before the UI thread catches up, the
+    // cached delegate runs once and reads the most recent values.
+    internal void QueueScrollbarChanged(ulong total, ulong offset, ulong len)
+    {
+        bool needEnqueue;
+        lock (_scrollbarLock)
+        {
+            _pendingScrollbarTotal = total;
+            _pendingScrollbarOffset = offset;
+            _pendingScrollbarLen = len;
+            needEnqueue = !_pendingScrollbarDirty;
+            _pendingScrollbarDirty = true;
+        }
+        if (needEnqueue)
+        {
+            _flushScrollbarHandler ??= FlushPendingScrollbar;
+            DispatcherQueue.TryEnqueue(_flushScrollbarHandler);
+        }
+    }
+
+    // UI thread. Reads the latest coalesced state and writes it into
+    // the overlay ScrollBar. Guards against the feedback loop where
+    // assigning ScrollBar.Value re-fires Scroll and round-trips back
+    // into libghostty.
+    private void FlushPendingScrollbar()
+    {
+        ulong total, offset, len;
+        lock (_scrollbarLock)
+        {
+            total = _pendingScrollbarTotal;
+            offset = _pendingScrollbarOffset;
+            len = _pendingScrollbarLen;
+            _pendingScrollbarDirty = false;
+        }
+
+        // total <= len means there is nothing off-screen to scroll to;
+        // hide the bar entirely to match native "no overflow, no chrome"
+        // behavior (Explorer, Edge).
+        if (total <= len)
+        {
+            VerticalScrollBar.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        // ScrollBar uses double. uint64 row counts beyond 2^53 would lose
+        // precision but that would require a multi-petabyte scrollback.
+        var maximum = (double)(total - len);
+        var viewport = (double)len;
+        var value = Math.Min((double)offset, maximum);
+
+        _suppressScrollEvent = true;
+        try
+        {
+            VerticalScrollBar.Maximum = maximum;
+            VerticalScrollBar.ViewportSize = viewport;
+            // LargeChange = page, SmallChange = single row — matches the
+            // arrow-click / page-click behavior of native Windows apps.
+            VerticalScrollBar.LargeChange = viewport;
+            VerticalScrollBar.SmallChange = 1;
+            VerticalScrollBar.Value = value;
+            VerticalScrollBar.Visibility = Visibility.Visible;
+        }
+        finally
+        {
+            _suppressScrollEvent = false;
+        }
+    }
+
+    private void OnScrollBarScroll(
+        object sender,
+        Microsoft.UI.Xaml.Controls.Primitives.ScrollEventArgs e)
+    {
+        if (_suppressScrollEvent) return;
+        if (_surface.Handle == IntPtr.Zero) return;
+
+        // ScrollBar already clamps NewValue to [Minimum, Maximum].
+        var row = (ulong)Math.Round(e.NewValue);
+
+        // Zero-alloc path: drag events fire at pointer-move rates, so
+        // we format "scroll_to_row:N" straight into a stack buffer and
+        // hand libghostty a raw pointer. This is the GTK apprt's
+        // vadjustment-value-changed path (src/apprt/gtk/class/
+        // surface.zig::vadjValueChanged); libghostty de-duplicates
+        // identical rows internally so per-pixel drag noise is cheap.
+        unsafe
+        {
+            // 14 bytes prefix + max 20 digits for ulong = 34. Round up.
+            Span<byte> buf = stackalloc byte[48];
+            "scroll_to_row:"u8.CopyTo(buf);
+            if (!System.Buffers.Text.Utf8Formatter.TryFormat(row, buf[14..], out int digits))
+                return;
+            int total = 14 + digits;
+            fixed (byte* p = buf)
+            {
+                NativeMethods.SurfaceBindingAction(_surface, p, (UIntPtr)total);
+            }
+        }
+    }
+
+    // Forward wheel events that land on the ScrollBar overlay region
+    // back to the existing Panel handler, so spinning the wheel near
+    // the right edge still scrolls the terminal via libghostty's own
+    // viewport path rather than being eaten by the bar.
+    private void OnScrollBarPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        OnPointerWheelChanged(Panel, e);
     }
 
     /// <summary>Most recent OSC 9;4 state reported for this leaf.</summary>

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -219,6 +219,30 @@ internal sealed class GhosttyHost : IDisposable
                 return true;
             }
 
+            case GhosttyActionTag.Scrollbar:
+            {
+                // ghostty_action_scrollbar_s sits at union offset 8.
+                // Layout is authoritative in GhosttyActionScrollbar;
+                // read it as a single blit instead of three offset
+                // reads so the struct declaration is the single source
+                // of truth.
+                GhosttyActionScrollbar s;
+                unsafe
+                {
+                    s = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyActionScrollbar>(
+                        (void*)(actionPtr + 8));
+                }
+
+                // TerminalControl coalesces updates on its own side
+                // and hops to the UI thread with a cached delegate,
+                // so we don't need the dispatcher here — just resolve
+                // the surface and hand off. If the surface has already
+                // been disposed we silently drop the update.
+                if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                    c.QueueScrollbarChanged(s.Total, s.Offset, s.Len);
+                return true;
+            }
+
             case GhosttyActionTag.ProgressReport:
             {
                 // ghostty_action_progress_report_s sits at union offset 8

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -225,14 +225,29 @@ internal struct GhosttyTarget
 // callback and the core uses its default behavior.
 //
 // Synced against include/ghostty.h @ 2598bef60. To verify after a rebase:
-//   grep -n GHOSTTY_ACTION_ include/ghostty.h | grep -nE 'SET_TITLE|CLOSE_WINDOW|RING_BELL'
+//   grep -n GHOSTTY_ACTION_ include/ghostty.h | grep -nE 'SCROLLBAR|SET_TITLE|CLOSE_WINDOW|RING_BELL|PROGRESS_REPORT'
 // and confirm the ordinal positions still match the values below.
 internal enum GhosttyActionTag
 {
+    Scrollbar = 26,
     SetTitle = 32,
     CloseWindow = 49,
     RingBell = 50,
     ProgressReport = 56,
+}
+
+// ghostty_action_scrollbar_s:
+//   { uint64 total; uint64 offset; uint64 len; }
+// All values are row counts. `total` is the number of rows in the
+// scrollback+viewport, `offset` is the top row currently visible, and
+// `len` is the number of visible rows. The scrollbar is "at rest" /
+// unnecessary when `total <= len`.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionScrollbar
+{
+    public ulong Total;
+    public ulong Offset;
+    public ulong Len;
 }
 
 // ghostty_action_progress_report_state_e ordinal values, matching
@@ -390,6 +405,23 @@ internal static partial class NativeMethods
 
     [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_mouse_scroll")]
     internal static extern void SurfaceMouseScroll(GhosttySurface surface, double x, double y, int scrollMods);
+
+    // ghostty_surface_binding_action takes a non-NUL-terminated UTF-8
+    // string plus length and runs it through input.Binding.Action.parse.
+    // Used to forward ScrollBar drag events back into libghostty as a
+    // "scroll_to_row:N" binding action — the same path GTK uses from
+    // its vadjustment value-changed signal (see src/apprt/gtk/class/
+    // surface.zig::vadjValueChanged).
+    // Raw-pointer overload for zero-alloc hot paths (scrollbar drag):
+    // caller owns the UTF-8 buffer (typically stackalloc'd) and passes
+    // its length in bytes. No NUL terminator required on the native
+    // side — libghostty takes (ptr, len).
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_binding_action")]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern unsafe bool SurfaceBindingAction(
+        GhosttySurface surface,
+        byte* action,
+        UIntPtr actionLen);
 
     // ---- surface misc --------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds a vertical ScrollBar to the Windows terminal surface, driven by libghostty's `GHOSTTY_ACTION_SCROLLBAR` and forwarded back to the core via the `scroll_to_row` binding action — mirroring the GTK apprt's `vadjustment` value-changed pattern.
- The bar is overlaid on top of the `SwapChainPanel` inside a Grid (not a `ScrollViewer`) so libghostty keeps ownership of viewport state and `PointerWheelChanged` still reaches `TerminalControl`.
- Uses the bare `Microsoft.UI.Xaml.Controls.Primitives.ScrollBar` with `IndicatorMode="MouseIndicator"`, so Windows 11's native auto-fade and hover-expand animation come for free — no custom `Storyboard`.
- Hides the bar entirely when `total <= len` (no scrollback to reach).
- Guards against the feedback loop where `ScrollBar.Value` assignment re-fires `Scroll` and round-trips back into libghostty.

## Interop
- `GhosttyActionTag.Scrollbar = 26` added to the dispatch enum (verified against `include/ghostty.h`).
- New `GhosttyActionScrollbar` struct read via explicit offsets from the action union — same pattern as `ProgressReport`.
- `NativeMethods.SurfaceBindingAction` wraps `ghostty_surface_binding_action(surface, "scroll_to_row:N", len)`.

## Not in this PR
- **Momentum parity with macOS.** WinUI 3 pointer events do not expose AppKit's `momentumPhase`, so inertial-scroll parity needs a separate design pass.

## Test plan
- [ ] `dotnet build windows/Ghostty/Ghostty.csproj` passes (verified locally)
- [ ] Fresh shell with empty scrollback — scrollbar hidden (`total == len`)
- [ ] Fill scrollback with `yes | head -n 5000` — scrollbar appears, shrinks to reflect viewport size
- [ ] Scrollbar auto-fades after mouse leaves, expands on hover (IndicatorMode default)
- [ ] Drag the thumb — terminal viewport tracks; no feedback loop / stutter
- [ ] Wheel scrolling still works and the bar's thumb updates to match
- [ ] Horizontal scroll wheel still works (untouched path)

