### PR TITLE
refactor(windows): move ghostty_action layout types to Ghostty.Core + pin via tests

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -6,18 +6,18 @@ namespace Ghostty.Core.Interop;
 // Windows apprt. They live in Ghostty.Core (pure net9.0, no WinAppSDK)
 // so unit tests can assert ordinal values and struct sizes without
 // dragging PRI/MRT into the test project. Ghostty/Interop/NativeMethods.cs
-// re-exports these via `using Ghostty.Core.Interop;`.
+// imports these via `using Ghostty.Core.Interop;` so existing call sites
+// in GhosttyHost compile unchanged.
 //
-// Synced against include/ghostty.h. To verify after a rebase:
-//   grep -n GHOSTTY_ACTION_ include/ghostty.h | grep -nE 'SCROLLBAR|SET_TITLE|CLOSE_WINDOW|RING_BELL|PROGRESS_REPORT'
-// and confirm the ordinal positions still match the values below.
-// GhosttyActionsLayoutTests in Ghostty.Tests pins these at build time.
+// GhosttyActionsLayoutTests in Ghostty.Tests pins the ordinals and
+// struct layouts at build time; that test file also carries the grep
+// command for re-verifying against include/ghostty.h after a rebase.
 
 // Subset of ghostty_action_tag_e that the Windows apprt dispatches on.
 // Indices are pinned explicitly so an upstream reorder cannot silently
 // misroute a tag to the wrong handler — any unlisted tag falls through
 // to "return false" in GhosttyHost.OnAction.
-public enum GhosttyActionTag
+internal enum GhosttyActionTag
 {
     Scrollbar = 26,
     SetTitle = 32,
@@ -32,7 +32,7 @@ public enum GhosttyActionTag
 // is the top visible row, `len` is the visible row count. The bar is
 // "at rest" / unnecessary when total <= len.
 [StructLayout(LayoutKind.Sequential)]
-public struct GhosttyActionScrollbar
+internal struct GhosttyActionScrollbar
 {
     public ulong Total;
     public ulong Offset;
@@ -40,7 +40,7 @@ public struct GhosttyActionScrollbar
 }
 
 // ghostty_action_progress_report_state_e.
-public enum GhosttyProgressState
+internal enum GhosttyProgressState
 {
     Remove = 0,
     Set = 1,
@@ -52,7 +52,7 @@ public enum GhosttyProgressState
 // ghostty_action_progress_report_s:
 //   { int32 state; int8 progress; /* -1 if none, else 0..100 */ }
 [StructLayout(LayoutKind.Sequential)]
-public struct GhosttyActionProgressReport
+internal struct GhosttyActionProgressReport
 {
     public int State;
     public sbyte Progress;

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -1,0 +1,59 @@
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Core.Interop;
+
+// Layout types mirroring the ghostty_action_* subset dispatched by the
+// Windows apprt. They live in Ghostty.Core (pure net9.0, no WinAppSDK)
+// so unit tests can assert ordinal values and struct sizes without
+// dragging PRI/MRT into the test project. Ghostty/Interop/NativeMethods.cs
+// re-exports these via `using Ghostty.Core.Interop;`.
+//
+// Synced against include/ghostty.h. To verify after a rebase:
+//   grep -n GHOSTTY_ACTION_ include/ghostty.h | grep -nE 'SCROLLBAR|SET_TITLE|CLOSE_WINDOW|RING_BELL|PROGRESS_REPORT'
+// and confirm the ordinal positions still match the values below.
+// GhosttyActionsLayoutTests in Ghostty.Tests pins these at build time.
+
+// Subset of ghostty_action_tag_e that the Windows apprt dispatches on.
+// Indices are pinned explicitly so an upstream reorder cannot silently
+// misroute a tag to the wrong handler — any unlisted tag falls through
+// to "return false" in GhosttyHost.OnAction.
+public enum GhosttyActionTag
+{
+    Scrollbar = 26,
+    SetTitle = 32,
+    CloseWindow = 49,
+    RingBell = 50,
+    ProgressReport = 56,
+}
+
+// ghostty_action_scrollbar_s:
+//   { uint64 total; uint64 offset; uint64 len; }
+// All values are row counts. `total` is scrollback+viewport, `offset`
+// is the top visible row, `len` is the visible row count. The bar is
+// "at rest" / unnecessary when total <= len.
+[StructLayout(LayoutKind.Sequential)]
+public struct GhosttyActionScrollbar
+{
+    public ulong Total;
+    public ulong Offset;
+    public ulong Len;
+}
+
+// ghostty_action_progress_report_state_e.
+public enum GhosttyProgressState
+{
+    Remove = 0,
+    Set = 1,
+    Error = 2,
+    Indeterminate = 3,
+    Pause = 4,
+}
+
+// ghostty_action_progress_report_s:
+//   { int32 state; int8 progress; /* -1 if none, else 0..100 */ }
+[StructLayout(LayoutKind.Sequential)]
+public struct GhosttyActionProgressReport
+{
+    public int State;
+    public sbyte Progress;
+}

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -1,0 +1,68 @@
+using System.Runtime.InteropServices;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+// Pins the ordinal values and struct layouts of the ghostty_action_*
+// subset the Windows apprt dispatches on. If any of these drift away
+// from include/ghostty.h, CI fails here instead of users seeing a
+// silently-misrouted action at runtime.
+//
+// When libghostty rebases and these break, re-verify against
+// include/ghostty.h:
+//   grep -n GHOSTTY_ACTION_ include/ghostty.h | \
+//     grep -nE 'SCROLLBAR|SET_TITLE|CLOSE_WINDOW|RING_BELL|PROGRESS_REPORT'
+// then update the constants in Ghostty.Core/Interop/GhosttyActions.cs.
+public class GhosttyActionsLayoutTests
+{
+    [Theory]
+    [InlineData(GhosttyActionTag.Scrollbar, 26)]
+    [InlineData(GhosttyActionTag.SetTitle, 32)]
+    [InlineData(GhosttyActionTag.CloseWindow, 49)]
+    [InlineData(GhosttyActionTag.RingBell, 50)]
+    [InlineData(GhosttyActionTag.ProgressReport, 56)]
+    public void ActionTag_Ordinal_Matches_Upstream(GhosttyActionTag tag, int expected)
+    {
+        Assert.Equal(expected, (int)tag);
+    }
+
+    [Theory]
+    [InlineData(GhosttyProgressState.Remove, 0)]
+    [InlineData(GhosttyProgressState.Set, 1)]
+    [InlineData(GhosttyProgressState.Error, 2)]
+    [InlineData(GhosttyProgressState.Indeterminate, 3)]
+    [InlineData(GhosttyProgressState.Pause, 4)]
+    public void ProgressState_Ordinal_Matches_Upstream(GhosttyProgressState state, int expected)
+    {
+        Assert.Equal(expected, (int)state);
+    }
+
+    [Fact]
+    public void ScrollbarStruct_Size_Is_24_Bytes()
+    {
+        // { uint64 total; uint64 offset; uint64 len; } -> 3 * 8 = 24
+        Assert.Equal(24, Marshal.SizeOf<GhosttyActionScrollbar>());
+    }
+
+    [Fact]
+    public void ScrollbarStruct_Field_Offsets_Match_C_Layout()
+    {
+        // GhosttyHost reads this struct at (actionPtr + 8) via
+        // Unsafe.ReadUnaligned, so the three fields MUST sit at
+        // +0/+8/+16 within the struct itself.
+        Assert.Equal(0,  (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Total)));
+        Assert.Equal(8,  (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Offset)));
+        Assert.Equal(16, (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Len)));
+    }
+
+    [Fact]
+    public void ProgressReportStruct_Field_Offsets_Match_C_Layout()
+    {
+        // ghostty_action_progress_report_s is read at +8/+12 inside
+        // the action union. The struct itself sits at +0/+4 with the
+        // sbyte right after the int32 (no packing tricks on x64).
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionProgressReport>(nameof(GhosttyActionProgressReport.State)));
+        Assert.Equal(4, (int)Marshal.OffsetOf<GhosttyActionProgressReport>(nameof(GhosttyActionProgressReport.Progress)));
+    }
+}

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -16,26 +16,29 @@ namespace Ghostty.Tests.Interop;
 // then update the constants in Ghostty.Core/Interop/GhosttyActions.cs.
 public class GhosttyActionsLayoutTests
 {
+    // Parameters are typed as `int` (not the enum) so the public test
+    // method doesn't leak the now-internal enum type across its public
+    // signature — xUnit requires test classes to be public.
     [Theory]
-    [InlineData(GhosttyActionTag.Scrollbar, 26)]
-    [InlineData(GhosttyActionTag.SetTitle, 32)]
-    [InlineData(GhosttyActionTag.CloseWindow, 49)]
-    [InlineData(GhosttyActionTag.RingBell, 50)]
-    [InlineData(GhosttyActionTag.ProgressReport, 56)]
-    public void ActionTag_Ordinal_Matches_Upstream(GhosttyActionTag tag, int expected)
+    [InlineData((int)GhosttyActionTag.Scrollbar, 26)]
+    [InlineData((int)GhosttyActionTag.SetTitle, 32)]
+    [InlineData((int)GhosttyActionTag.CloseWindow, 49)]
+    [InlineData((int)GhosttyActionTag.RingBell, 50)]
+    [InlineData((int)GhosttyActionTag.ProgressReport, 56)]
+    public void ActionTag_Ordinal_Matches_Upstream(int tag, int expected)
     {
-        Assert.Equal(expected, (int)tag);
+        Assert.Equal(expected, tag);
     }
 
     [Theory]
-    [InlineData(GhosttyProgressState.Remove, 0)]
-    [InlineData(GhosttyProgressState.Set, 1)]
-    [InlineData(GhosttyProgressState.Error, 2)]
-    [InlineData(GhosttyProgressState.Indeterminate, 3)]
-    [InlineData(GhosttyProgressState.Pause, 4)]
-    public void ProgressState_Ordinal_Matches_Upstream(GhosttyProgressState state, int expected)
+    [InlineData((int)GhosttyProgressState.Remove, 0)]
+    [InlineData((int)GhosttyProgressState.Set, 1)]
+    [InlineData((int)GhosttyProgressState.Error, 2)]
+    [InlineData((int)GhosttyProgressState.Indeterminate, 3)]
+    [InlineData((int)GhosttyProgressState.Pause, 4)]
+    public void ProgressState_Ordinal_Matches_Upstream(int state, int expected)
     {
-        Assert.Equal(expected, (int)state);
+        Assert.Equal(expected, state);
     }
 
     [Fact]
@@ -54,6 +57,15 @@ public class GhosttyActionsLayoutTests
         Assert.Equal(0,  (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Total)));
         Assert.Equal(8,  (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Offset)));
         Assert.Equal(16, (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Len)));
+    }
+
+    [Fact]
+    public void ProgressReportStruct_Size_Is_8_Bytes()
+    {
+        // { int32 state; sbyte progress; } + 3 bytes of trailing
+        // alignment padding on x64 -> 8. Pinning total size catches
+        // a future field reorder that only shuffles trailing padding.
+        Assert.Equal(8, Marshal.SizeOf<GhosttyActionProgressReport>());
     }
 
     [Fact]

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using Ghostty.Clipboard;
 using Ghostty.Controls;
 using Ghostty.Core.Clipboard;
+using Ghostty.Core.Interop;
 using Ghostty.Interop;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Ghostty.Core.Interop;
 
 namespace Ghostty.Interop;
 
@@ -218,60 +219,15 @@ internal struct GhosttyTarget
     [FieldOffset(8)] public IntPtr Surface;
 }
 
-// Subset of ghostty_action_tag_e from include/ghostty.h that we actually
-// dispatch on. Indices are pinned explicitly to the upstream values so a
-// reorder upstream cannot silently misroute one tag to another handler -
-// any tag we don't list falls through to "return false" in the action
-// callback and the core uses its default behavior.
+// GhosttyActionTag, GhosttyActionScrollbar, GhosttyProgressState, and
+// GhosttyActionProgressReport now live in Ghostty.Core.Interop so
+// Ghostty.Tests (pure net9.0, no WinAppSDK) can pin their ordinals and
+// struct sizes. They are re-exported here via the `using
+// Ghostty.Core.Interop;` at the top of this file.
 //
-// Synced against include/ghostty.h @ 2598bef60. To verify after a rebase:
-//   grep -n GHOSTTY_ACTION_ include/ghostty.h | grep -nE 'SCROLLBAR|SET_TITLE|CLOSE_WINDOW|RING_BELL|PROGRESS_REPORT'
-// and confirm the ordinal positions still match the values below.
-internal enum GhosttyActionTag
-{
-    Scrollbar = 26,
-    SetTitle = 32,
-    CloseWindow = 49,
-    RingBell = 50,
-    ProgressReport = 56,
-}
-
-// ghostty_action_scrollbar_s:
-//   { uint64 total; uint64 offset; uint64 len; }
-// All values are row counts. `total` is the number of rows in the
-// scrollback+viewport, `offset` is the top row currently visible, and
-// `len` is the number of visible rows. The scrollbar is "at rest" /
-// unnecessary when `total <= len`.
-[StructLayout(LayoutKind.Sequential)]
-internal struct GhosttyActionScrollbar
-{
-    public ulong Total;
-    public ulong Offset;
-    public ulong Len;
-}
-
-// ghostty_action_progress_report_state_e ordinal values, matching
-// the enum in include/ghostty.h around line 850. Do not reorder —
-// these are read by value out of the action payload.
-internal enum GhosttyProgressState
-{
-    Remove = 0,
-    Set = 1,
-    Error = 2,
-    Indeterminate = 3,
-    Pause = 4,
-}
-
-// ghostty_action_progress_report_s:
-//   { int32 state; int8 progress; /* -1 if none, else 0..100 */ }
-// Marshalled manually in GhosttyHost since the action union layout
-// places this at a known offset inside the larger action struct.
-[StructLayout(LayoutKind.Sequential)]
-internal struct GhosttyActionProgressReport
-{
-    public int State;
-    public sbyte Progress;
-}
+// Synced against include/ghostty.h. See GhosttyActions.cs for the
+// verification grep and GhosttyActionsLayoutTests for the build-time
+// assertions.
 
 // ghostty_action_set_title_s { const char* title; }
 // We only read .title; the struct is declared so the offset is explicit.

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -222,12 +222,12 @@ internal struct GhosttyTarget
 // GhosttyActionTag, GhosttyActionScrollbar, GhosttyProgressState, and
 // GhosttyActionProgressReport now live in Ghostty.Core.Interop so
 // Ghostty.Tests (pure net9.0, no WinAppSDK) can pin their ordinals and
-// struct sizes. They are re-exported here via the `using
-// Ghostty.Core.Interop;` at the top of this file.
+// struct sizes. Call sites in GhosttyHost see them unchanged via the
+// `using Ghostty.Core.Interop;` at the top of this file.
 //
-// Synced against include/ghostty.h. See GhosttyActions.cs for the
-// verification grep and GhosttyActionsLayoutTests for the build-time
-// assertions.
+// See GhosttyActionsLayoutTests in Ghostty.Tests for the build-time
+// assertions and the grep command for re-verifying against
+// include/ghostty.h after a libghostty rebase.
 
 // ghostty_action_set_title_s { const char* title; }
 // We only read .title; the struct is declared so the offset is explicit.


### PR DESCRIPTION
## Summary
- Move `GhosttyActionTag`, `GhosttyActionScrollbar`, `GhosttyProgressState`, and `GhosttyActionProgressReport` from `Ghostty/Interop/NativeMethods.cs` into a new `Ghostty.Core/Interop/GhosttyActions.cs`.
- `Ghostty.Core` is plain net9.0 with no WinAppSDK, so `Ghostty.Tests` can now reference these types directly without pulling PRI/MRT into the test project.
- `NativeMethods.cs` re-exports them via `using Ghostty.Core.Interop;`, so every existing call site in `GhosttyHost.cs` compiles unchanged. Visibility widens from `internal` to `public` because they now cross an assembly boundary.

## Why
Follow-up to the review on #174: the ordinal values and struct layouts of the `ghostty_action_*` types are the single most brittle piece of the Windows apprt's interop surface. Today they're only verified by a comment pointing at a grep command; if libghostty reorders `ghostty_action_tag_e`, an action silently routes to the wrong handler at runtime.

With the types in `Ghostty.Core`, `GhosttyActionsLayoutTests` pins:
- ordinal values for each dispatched `GhosttyActionTag` (`Scrollbar=26`, `SetTitle=32`, `CloseWindow=49`, `RingBell=50`, `ProgressReport=56`)
- ordinal values for each `GhosttyProgressState`
- `GhosttyActionScrollbar` size (24) and field offsets (+0/+8/+16) — matches what `GhosttyHost.OnAction` reads at `actionPtr + 8`
- `GhosttyActionProgressReport` field offsets (+0/+4)

CI now fails on the test project instead of users seeing a misrouted dispatch.

## Stacking
Stacked on #174 (`windows-native-scrollbar`) because the new `GhosttyActions.cs` file includes the `Scrollbar = 26` entry that PR introduces. Once #174 merges, rebase onto `windows` and retarget the base branch.

## Test plan
- [x] `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj --filter GhosttyActionsLayoutTests` — 13 passed
- [x] `dotnet build windows/Ghostty/Ghostty.csproj` — clean
- [ ] Manual smoke after merge: title changes, bell, window close, progress report, scrollbar drag still route correctly (all exercise the moved enum via the unchanged `GhosttyHost.OnAction` switch).
