### PR TITLE
feat(windows): DX12 shared texture surface mode

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1142,21 +1142,24 @@ GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t)
 // cross-device synchronization issues. Returns NULL on non-DX12 builds or if
 // the renderer device is not yet initialized.
 GHOSTTY_API void* ghostty_surface_get_d3d12_device(ghostty_surface_t);
+
 // Snapshot of the shared-texture state for a surface. All fields are
 // filled in atomically by a single ghostty_surface_shared_texture()
 // call so consumers never observe a torn read.
+//
+// Ownership: ghostty retains both NT HANDLEs in this struct for the
+// surface lifetime -- do NOT CloseHandle either of them. The
+// ID3D12Resource and ID3D12Fence returned by OpenSharedHandle on the
+// consumer's device ARE owned by the consumer; Release() them when
+// done, and re-open the resource whenever `version` changes.
 typedef struct {
   // NT HANDLE from CreateSharedHandle on the underlying ID3D12Resource.
   // Consumers open via ID3D12Device::OpenSharedHandle on their own
-  // device (cross-device) or on ghostty's device (same-device). Ghostty
-  // retains ownership of the handle -- do NOT CloseHandle. Re-open a
-  // new ID3D12Resource whenever `version` changes and release the old
-  // one.
+  // device (cross-device) or on ghostty's device (same-device).
   void* resource_handle;
 
   // NT HANDLE from CreateSharedHandle on ghostty's ID3D12Fence. Stable
-  // for the surface lifetime (does not change on resize). Ghostty
-  // retains ownership -- do NOT CloseHandle.
+  // for the surface lifetime (does not change on resize).
   void* fence_handle;
 
   // Fence value ghostty will signal after completing the most recently
@@ -1183,6 +1186,7 @@ typedef struct {
 GHOSTTY_API bool ghostty_surface_shared_texture(
     ghostty_surface_t,
     ghostty_surface_shared_texture_s* out);
+
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -456,14 +456,24 @@ typedef struct {
 } ghostty_platform_ios_s;
 
 typedef struct {
+  // Exactly one of the surface mode fields below should be set:
+  //   - hwnd != NULL             -> HWND surface (DirectComposition)
+  //   - swap_chain_panel != NULL -> SwapChainPanel surface (WinUI 3)
+  //   - shared_texture.enabled   -> offscreen shared texture
   void* hwnd;
   void* swap_chain_panel;
-  // OUT: receives the DXGI shared handle for the render texture.
-  // Open with OpenSharedResource1 on the device returned by
-  // ghostty_surface_get_d3d12_device to avoid cross-device sync issues.
-  void* shared_texture_out;
-  uint32_t texture_width;
-  uint32_t texture_height;
+
+  // Shared-texture surface configuration. When `enabled` is true and
+  // both `hwnd` and `swap_chain_panel` are NULL, the renderer creates
+  // an offscreen ID3D12Resource at the given initial pixel dimensions.
+  // This sub-struct carries only the INITIAL configuration. Retrieve
+  // the current shared handle, fence, and dimensions via
+  // ghostty_surface_shared_texture().
+  struct {
+    bool enabled;
+    uint32_t width;
+    uint32_t height;
+  } shared_texture;
 } ghostty_platform_windows_s;
 
 typedef union {
@@ -1132,15 +1142,47 @@ GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t)
 // cross-device synchronization issues. Returns NULL on non-DX12 builds or if
 // the renderer device is not yet initialized.
 GHOSTTY_API void* ghostty_surface_get_d3d12_device(ghostty_surface_t);
-// Returns the ID3D12Resource* ghostty renders to in shared texture mode.
-// Same-process consumers can record a copy from this directly on ghostty's
-// command queue. The resource pointer changes on resize -- re-read after
-// ghostty_surface_set_size. Returns NULL if not in shared texture mode.
-//
-// NOTE: shared texture mode is not yet wired up on the DX12 renderer.
-// This accessor currently always returns NULL and is reserved for the
-// upcoming shared-texture implementation.
-GHOSTTY_API void* ghostty_surface_get_d3d12_shared_texture(ghostty_surface_t);
+// Snapshot of the shared-texture state for a surface. All fields are
+// filled in atomically by a single ghostty_surface_shared_texture()
+// call so consumers never observe a torn read.
+typedef struct {
+  // NT HANDLE from CreateSharedHandle on the underlying ID3D12Resource.
+  // Consumers open via ID3D12Device::OpenSharedHandle on their own
+  // device (cross-device) or on ghostty's device (same-device). Ghostty
+  // retains ownership of the handle -- do NOT CloseHandle. Re-open a
+  // new ID3D12Resource whenever `version` changes and release the old
+  // one.
+  void* resource_handle;
+
+  // NT HANDLE from CreateSharedHandle on ghostty's ID3D12Fence. Stable
+  // for the surface lifetime (does not change on resize). Ghostty
+  // retains ownership -- do NOT CloseHandle.
+  void* fence_handle;
+
+  // Fence value ghostty will signal after completing the most recently
+  // submitted frame. Consumers Wait for this value on their own
+  // command queue before sampling the resource.
+  uint64_t fence_value;
+
+  // Pixel dimensions of the shared resource. These match the size the
+  // renderer most recently (re)created the resource at, and stay in
+  // sync with `version` -- they change in the same atomic snapshot.
+  uint32_t width;
+  uint32_t height;
+
+  // Monotonically increasing counter, incremented whenever the shared
+  // resource is recreated (initial creation, resize, device-removed
+  // recovery). Re-open the shared handle whenever this changes.
+  uint64_t version;
+} ghostty_surface_shared_texture_s;
+
+// Fill `out` with the current shared-texture state for this surface.
+// Returns true on success, false if the surface is not in shared
+// texture mode (in which case `out` is left untouched). The read is
+// atomic -- all fields correspond to the same renderer state snapshot.
+GHOSTTY_API bool ghostty_surface_shared_texture(
+    ghostty_surface_t,
+    ghostty_surface_shared_texture_s* out);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                                      ghostty_color_scheme_e);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1853,7 +1853,7 @@ pub const CAPI = struct {
     ) bool {
         if (comptime builtin.os.tag != .windows) return false;
         const api_ptr = &surface.core_surface.renderer.api;
-        if (comptime !@hasField(@TypeOf(api_ptr.*), "dev")) return false;
+        if (comptime @TypeOf(api_ptr.*) != renderer.DirectX12) return false;
         if (api_ptr.dev == null) return false;
         const dev = &api_ptr.dev.?;
 
@@ -1865,7 +1865,7 @@ pub const CAPI = struct {
         out.* = .{
             .resource_handle = @ptrCast(st.resource_handle),
             .fence_handle = @ptrCast(st.fence_handle),
-            .fence_value = dev.fence_value,
+            .fence_value = dev.fence_value.load(.acquire),
             .width = st.width,
             .height = st.height,
             .version = st.version,

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1834,22 +1834,43 @@ pub const CAPI = struct {
         return @ptrCast(dev.device);
     }
 
-    /// Return the ID3D12Resource* ghostty renders to in shared texture
-    /// mode. Same-process consumers can record a copy from this resource
-    /// on ghostty's command queue. The resource pointer changes on
-    /// resize -- re-read after ghostty_surface_set_size.
-    ///
-    /// NOTE: shared texture mode is not yet implemented on the DX12
-    /// renderer. This accessor currently always returns null; the ABI
-    /// slot is reserved for the upcoming implementation (tracked in
-    /// deblasis/ghostty#176).
-    export fn ghostty_surface_get_d3d12_shared_texture(surface: *Surface) ?*anyopaque {
-        // TODO(deblasis/ghostty#176): wire to the DX12 shared-texture
-        // surface mode in the follow-up PR. Kept as a reserved ABI slot
-        // so .NET consumers can bind the P/Invoke ahead of the
-        // implementation landing.
-        _ = surface;
-        return null;
+    /// Mirrors ghostty_surface_shared_texture_s in include/ghostty.h.
+    const SharedTextureSnapshotC = extern struct {
+        resource_handle: ?*anyopaque,
+        fence_handle: ?*anyopaque,
+        fence_value: u64,
+        width: u32,
+        height: u32,
+        version: u64,
+    };
+
+    /// Fill `out` with an atomic snapshot of the shared-texture state
+    /// for this surface. Returns false if the surface is not in
+    /// shared-texture mode (in which case `out` is untouched).
+    export fn ghostty_surface_shared_texture(
+        surface: *Surface,
+        out: *SharedTextureSnapshotC,
+    ) bool {
+        if (comptime builtin.os.tag != .windows) return false;
+        const api_ptr = &surface.core_surface.renderer.api;
+        if (comptime !@hasField(@TypeOf(api_ptr.*), "dev")) return false;
+        if (api_ptr.dev == null) return false;
+        const dev = &api_ptr.dev.?;
+
+        dev.shared_texture_mutex.lock();
+        defer dev.shared_texture_mutex.unlock();
+
+        const st = dev.shared_texture orelse return false;
+
+        out.* = .{
+            .resource_handle = @ptrCast(st.resource_handle),
+            .fence_handle = @ptrCast(st.fence_handle),
+            .fence_value = dev.fence_value,
+            .width = st.width,
+            .height = st.height,
+            .version = st.version,
+        };
+        return true;
     }
 
     /// Update the size of a surface. This will trigger resize notifications

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -362,12 +362,17 @@ pub const Platform = union(PlatformTag) {
         hwnd: ?std.os.windows.HANDLE,
         /// ISwapChainPanelNative pointer for composition swap chain, or null.
         swap_chain_panel: ?*anyopaque = null,
-        /// OUT pointer for shared texture DXGI handle, or null.
-        shared_texture_out: ?*anyopaque = null,
-        /// Width of the shared texture in pixels. Required when shared_texture_out is set.
-        texture_width: u32 = 0,
-        /// Height of the shared texture in pixels. Required when shared_texture_out is set.
-        texture_height: u32 = 0,
+        /// Shared-texture surface configuration. Only honoured when
+        /// both `hwnd` and `swap_chain_panel` are null and
+        /// `shared_texture.enabled` is true. Mirrors the nested
+        /// `shared_texture` struct in ghostty_platform_windows_s.
+        shared_texture: SharedTexture = .{},
+
+        pub const SharedTexture = struct {
+            enabled: bool = false,
+            width: u32 = 0,
+            height: u32 = 0,
+        };
     } else void;
 
     // The C ABI compatible version of this union. The tag is expected
@@ -384,9 +389,15 @@ pub const Platform = union(PlatformTag) {
         windows: extern struct {
             hwnd: ?*anyopaque,
             swap_chain_panel: ?*anyopaque,
-            shared_texture_out: ?*anyopaque,
-            texture_width: u32,
-            texture_height: u32,
+            // Mirrors the anonymous `shared_texture` sub-struct in
+            // ghostty_platform_windows_s. The C side declares this as
+            // an anonymous nested struct; we flatten it into an inline
+            // extern struct here to preserve the same layout.
+            shared_texture: extern struct {
+                enabled: bool,
+                width: u32,
+                height: u32,
+            },
         },
     };
 
@@ -411,9 +422,11 @@ pub const Platform = union(PlatformTag) {
             .windows => if (Windows != void) .{ .windows = .{
                 .hwnd = c_platform.windows.hwnd,
                 .swap_chain_panel = c_platform.windows.swap_chain_panel,
-                .shared_texture_out = c_platform.windows.shared_texture_out,
-                .texture_width = c_platform.windows.texture_width,
-                .texture_height = c_platform.windows.texture_height,
+                .shared_texture = .{
+                    .enabled = c_platform.windows.shared_texture.enabled,
+                    .width = c_platform.windows.shared_texture.width,
+                    .height = c_platform.windows.shared_texture.height,
+                },
             } } else error.UnsupportedPlatform,
         };
     }

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -683,20 +683,44 @@ pub inline fn beginFrame(
     const dev_ptr = &(api.dev orelse return error.NoDevice);
 
     // If the apprt asked for a new surface size since the last frame,
-    // resize the swap chain now -- on the renderer thread, before any
-    // command list work. setTargetSize only records the desired size;
-    // it cannot touch GPU state because it runs on the apprt thread.
-    // Shared-texture mode has a fixed-size resource; ResizeBuffers does
-    // not apply.
-    if (api.swap_chain3 != null) {
-        const want = unpackSize(api.desired_size.load(.monotonic));
-        if (want.width != 0 and want.height != 0 and
-            (want.width != api.applied_width or want.height != api.applied_height))
-        {
+    // resize now -- on the renderer thread, before any command list work.
+    // setTargetSize only records the desired size; it cannot touch GPU
+    // state because it runs on the apprt thread.
+    //
+    // Swap-chain mode calls ResizeBuffers and re-acquires back buffers.
+    // Shared-texture mode calls recreateSharedTexture and refreshes the
+    // single RTV at heap slot 0 so subsequent beginFrame calls use the
+    // new resource dimensions. The two paths are mutually exclusive.
+    const want = unpackSize(api.desired_size.load(.monotonic));
+    if (want.width != 0 and want.height != 0 and
+        (want.width != api.applied_width or want.height != api.applied_height))
+    {
+        if (api.swap_chain3 != null) {
             api.resizeSwapChain(want.width, want.height) catch |err| {
                 log.err("DX12 swap chain resize failed: {}", .{err});
                 return error.ResizeFailed;
             };
+        } else if (dev_ptr.shared_texture != null) {
+            // Shared-texture mode has no swap chain to resize; recreate the
+            // shared resource, refresh the single RTV, and bump the version
+            // counter so consumers re-open their handle.
+            dev_ptr.recreateSharedTexture(want.width, want.height) catch |err| {
+                log.err("recreateSharedTexture failed: {}", .{err});
+                api.device_lost = true;
+                return error.ResizeFailed;
+            };
+            // Refresh the single RTV to point at the new resource.
+            // Slot 0 is the fixed shared-texture slot allocated in init();
+            // overwriting the descriptor is safe because waitForGpu inside
+            // recreateSharedTexture already drained all in-flight GPU work.
+            if (api.rtv_heap) |*heap| {
+                const st = &dev_ptr.shared_texture.?;
+                const rtv_handle = heap.cpuHandle(0);
+                dev_ptr.device.CreateRenderTargetView(st.resource, null, rtv_handle);
+                api.shared_rtv = rtv_handle;
+            }
+            api.applied_width = want.width;
+            api.applied_height = want.height;
         }
     }
 

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -680,16 +680,15 @@ pub inline fn beginFrame(
     _ = self;
     const api: *DirectX12 = &renderer.api;
     if (api.device_lost) return error.DeviceLost;
-    // SharedTexture surfaces have no swap chain; they need a separate
-    // submission path that is not yet implemented.
-    const sc3 = api.swap_chain3 orelse return error.NoSwapChain;
     const dev_ptr = &(api.dev orelse return error.NoDevice);
 
     // If the apprt asked for a new surface size since the last frame,
     // resize the swap chain now -- on the renderer thread, before any
     // command list work. setTargetSize only records the desired size;
     // it cannot touch GPU state because it runs on the apprt thread.
-    {
+    // Shared-texture mode has a fixed-size resource; ResizeBuffers does
+    // not apply.
+    if (api.swap_chain3 != null) {
         const want = unpackSize(api.desired_size.load(.monotonic));
         if (want.width != 0 and want.height != 0 and
             (want.width != api.applied_width or want.height != api.applied_height))
@@ -701,8 +700,38 @@ pub inline fn beginFrame(
         }
     }
 
-    // Which back buffer does the swap chain want us to render to?
-    const frame_idx = sc3.GetCurrentBackBufferIndex();
+    // Determine which frame slot and render target to use.
+    // Swap-chain mode rotates through back_buffers[]; shared-texture mode
+    // has a single render target and always uses slot 0.
+    const frame_idx: u32 = blk: {
+        if (api.swap_chain3) |sc3| {
+            const index = sc3.GetCurrentBackBufferIndex();
+            api.pending_frame_index = index;
+            break :blk index;
+        }
+        // Shared-texture mode: no back-buffer rotation, index is always 0.
+        // pending_frame_index was already 0 at init; keep it.
+        break :blk 0;
+    };
+
+    const rtv_handle: d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = blk: {
+        if (api.swap_chain3 != null) {
+            break :blk api.rtv_handles[frame_idx];
+        }
+        // Shared-texture mode uses the single RTV created in init().
+        break :blk api.shared_rtv orelse return error.NoRenderTarget;
+    };
+
+    const render_target: ?*d3d12.ID3D12Resource = blk: {
+        if (api.swap_chain3 != null) {
+            break :blk api.back_buffers[frame_idx];
+        }
+        // Shared-texture mode: render into the shared ID3D12Resource.
+        // The resource lives permanently in D3D12_RESOURCE_STATE_COMMON
+        // (ALLOW_SIMULTANEOUS_ACCESS), so no PRESENT->RENDER_TARGET
+        // barrier is needed -- COMMON implicitly promotes for RT writes.
+        break :blk dev_ptr.shared_texture.?.resource;
+    };
 
     // Extract the frame for this slot and wait for its previous GPU work.
     var frame = api.gpu_frames[frame_idx] orelse return error.FrameNotReady;
@@ -713,9 +742,9 @@ pub inline fn beginFrame(
         _ = d3d12.WaitForSingleObject(dev_ptr.fence_event, d3d12.INFINITE);
     }
 
-    // Point the target at this back buffer.
-    target.resource = api.back_buffers[frame_idx];
-    target.rtv_handle = api.rtv_handles[frame_idx];
+    // Point the target at the chosen render target resource and RTV.
+    target.resource = render_target;
+    target.rtv_handle = rtv_handle;
 
     // Reset and open the command list for recording.
     try frame.reset();

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -899,3 +899,11 @@ test "device_lost flag is independent of device presence" {
     api.device_lost = true;
     try std.testing.expect(api.device_lost);
 }
+
+// Pull the directx12 integration test file into the test graph.
+// gpu_test.zig is otherwise orphaned -- it has no consumer outside
+// tests -- so without this @import it would never be compiled or
+// executed by `zig build test`.
+test {
+    _ = @import("directx12/gpu_test.zig");
+}

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -112,6 +112,12 @@ back_buffers: [device.Device.frame_count]?*d3d12.ID3D12Resource = .{ null, null,
 rtv_handles: [device.Device.frame_count]d3d12.D3D12_CPU_DESCRIPTOR_HANDLE =
     .{ .{ .ptr = 0 }, .{ .ptr = 0 }, .{ .ptr = 0 } },
 
+/// RTV for the shared-texture resource. Null for HWND and
+/// SwapChainPanel modes (which use the rtv_handles array above).
+/// Shared-texture mode has exactly one render target -- the shared
+/// ID3D12Resource -- so it gets a single RTV in heap slot 0.
+shared_rtv: ?d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = null,
+
 /// Command list from the current beginFrame, executed in drawFrameEnd.
 /// Also temporarily set to the init command list during init() so that
 /// initAtlasTexture can record resource barriers for placeholder textures.
@@ -289,6 +295,15 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
             dev_ptr.device.CreateRenderTargetView(resource, null, rtv_handle);
             result.rtv_handles[i] = rtv_handle;
         }
+    } else if (dev_ptr.shared_texture != null) {
+        // Shared-texture mode: one RTV pointing at the shared resource.
+        // Use RTV heap slot 0 -- we only ever need one slot because
+        // the shared resource is the sole render target and is never
+        // rotated with a back-buffer cycle.
+        const st = &dev_ptr.shared_texture.?;
+        const rtv_handle = result.rtv_heap.?.cpuHandle(0);
+        dev_ptr.device.CreateRenderTargetView(st.resource, null, rtv_handle);
+        result.shared_rtv = rtv_handle;
     }
     errdefer {
         for (&result.back_buffers) |*bb| {

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -365,9 +365,14 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
         result.pending_command_list = init_cl;
     }
 
-    result.desired_size.store(packSize(size.width, size.height), .monotonic);
-    result.applied_width = size.width;
-    result.applied_height = size.height;
+    // For shared-texture mode, use the texture dimensions as the initial
+    // applied size so beginFrame doesn't trigger a redundant recreate on
+    // the first frame. For swap-chain modes, use the screen size.
+    const init_width = if (w.shared_texture.enabled) w.shared_texture.width else size.width;
+    const init_height = if (w.shared_texture.enabled) w.shared_texture.height else size.height;
+    result.desired_size.store(packSize(init_width, init_height), .monotonic);
+    result.applied_width = init_width;
+    result.applied_height = init_height;
 
     return result;
 }
@@ -508,13 +513,23 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     // Present may have already advanced the current back buffer.
     // Safe without sync because rendering is single-threaded per surface.
     const frame_idx = self.pending_frame_index;
-    dev_ptr.fence_value += 1;
+    const new_fence_value = dev_ptr.fence_value.fetchAdd(1, .release) + 1;
     if (self.gpu_frames[frame_idx]) |*f| {
-        f.fence_value = dev_ptr.fence_value;
+        f.fence_value = new_fence_value;
     }
-    const hr = dev_ptr.command_queue.Signal(dev_ptr.fence, dev_ptr.fence_value);
-    if (com.FAILED(hr)) {
-        log.err("fence Signal failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+    const signal_hr = dev_ptr.command_queue.Signal(dev_ptr.fence, new_fence_value);
+    if (com.FAILED(signal_hr)) {
+        log.err("fence Signal failed: 0x{x}", .{@as(u32, @bitCast(signal_hr))});
+    }
+
+    // Shared-texture mode has no Present call to detect device-removed.
+    // Check after Signal so a TDR during this frame sets device_lost
+    // instead of letting the next beginFrame deadlock on the fence.
+    if (self.swap_chain3 == null) {
+        const reason = dev_ptr.device.GetDeviceRemovedReason();
+        if (com.FAILED(reason)) {
+            self.handleDeviceRemoved();
+        }
     }
 }
 
@@ -719,6 +734,12 @@ pub inline fn beginFrame(
                 dev_ptr.device.CreateRenderTargetView(st.resource, null, rtv_handle);
                 api.shared_rtv = rtv_handle;
             }
+            // Reset stale frame fence values -- waitForGpu in
+            // recreateSharedTexture already drained all in-flight work,
+            // mirroring the reset in resizeSwapChain.
+            for (&api.gpu_frames) |*gf| {
+                if (gf.*) |*f| f.fence_value = 0;
+            }
             api.applied_width = want.width;
             api.applied_height = want.height;
         }
@@ -727,32 +748,23 @@ pub inline fn beginFrame(
     // Determine which frame slot and render target to use.
     // Swap-chain mode rotates through back_buffers[]; shared-texture mode
     // has a single render target and always uses slot 0.
-    const frame_idx: u32 = blk: {
-        if (api.swap_chain3) |sc3| {
-            break :blk sc3.GetCurrentBackBufferIndex();
-        }
-        // Shared-texture mode: no back-buffer rotation, index is always 0.
-        break :blk 0;
-    };
+    const frame_idx: u32 = if (api.swap_chain3) |sc3|
+        sc3.GetCurrentBackBufferIndex()
+    else
+        0;
 
-    const rtv_handle: d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = blk: {
-        if (api.swap_chain3) |_| {
-            break :blk api.rtv_handles[frame_idx];
-        }
-        // Shared-texture mode uses the single RTV created in init().
-        break :blk api.shared_rtv orelse return error.NoRenderTarget;
-    };
+    const rtv_handle: d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = if (api.swap_chain3 != null)
+        api.rtv_handles[frame_idx]
+    else
+        api.shared_rtv orelse return error.NoRenderTarget;
 
-    const render_target: ?*d3d12.ID3D12Resource = blk: {
-        if (api.swap_chain3) |_| {
-            break :blk api.back_buffers[frame_idx];
-        }
-        // Shared-texture mode: render into the shared ID3D12Resource.
-        // The resource lives permanently in D3D12_RESOURCE_STATE_COMMON
-        // (ALLOW_SIMULTANEOUS_ACCESS), so no PRESENT->RENDER_TARGET
-        // barrier is needed -- COMMON implicitly promotes for RT writes.
-        break :blk dev_ptr.shared_texture.?.resource;
-    };
+    // Shared-texture mode: the resource lives in D3D12_RESOURCE_STATE_COMMON
+    // (ALLOW_SIMULTANEOUS_ACCESS), so no PRESENT->RENDER_TARGET barrier is
+    // needed -- COMMON implicitly promotes for RT writes.
+    const render_target: ?*d3d12.ID3D12Resource = if (api.swap_chain3 != null)
+        api.back_buffers[frame_idx]
+    else
+        dev_ptr.shared_texture.?.resource;
 
     // Extract the frame for this slot and wait for its previous GPU work.
     var frame = api.gpu_frames[frame_idx] orelse return error.FrameNotReady;

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -705,17 +705,14 @@ pub inline fn beginFrame(
     // has a single render target and always uses slot 0.
     const frame_idx: u32 = blk: {
         if (api.swap_chain3) |sc3| {
-            const index = sc3.GetCurrentBackBufferIndex();
-            api.pending_frame_index = index;
-            break :blk index;
+            break :blk sc3.GetCurrentBackBufferIndex();
         }
         // Shared-texture mode: no back-buffer rotation, index is always 0.
-        // pending_frame_index was already 0 at init; keep it.
         break :blk 0;
     };
 
     const rtv_handle: d3d12.D3D12_CPU_DESCRIPTOR_HANDLE = blk: {
-        if (api.swap_chain3 != null) {
+        if (api.swap_chain3) |_| {
             break :blk api.rtv_handles[frame_idx];
         }
         // Shared-texture mode uses the single RTV created in init().
@@ -723,7 +720,7 @@ pub inline fn beginFrame(
     };
 
     const render_target: ?*d3d12.ID3D12Resource = blk: {
-        if (api.swap_chain3 != null) {
+        if (api.swap_chain3) |_| {
             break :blk api.back_buffers[frame_idx];
         }
         // Shared-texture mode: render into the shared ID3D12Resource.

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -184,12 +184,10 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
     else if (w.swap_chain_panel) |panel|
         // panel is an opaque COM-compatible pointer from apprt; alignment is guaranteed.
         .{ .swap_chain_panel = @ptrCast(@alignCast(panel)) }
-    else if (w.shared_texture_out) |out_ptr|
-        // out_ptr is an opaque pointer from apprt; alignment is guaranteed.
+    else if (w.shared_texture.enabled)
         .{ .shared_texture = .{
-            .handle_out = @ptrCast(@alignCast(out_ptr)),
-            .width = w.texture_width,
-            .height = w.texture_height,
+            .width = w.shared_texture.width,
+            .height = w.shared_texture.height,
         } }
     else
         return error.NoWindowsSurface;

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -18,6 +18,10 @@ const LPCWSTR = [*:0]const u16;
 pub const D3D_FEATURE_LEVEL_12_0: u32 = 0xc000;
 pub const D3D_FEATURE_LEVEL_12_1: u32 = 0xc100;
 
+/// Windows access right used by CreateSharedHandle. Equivalent to the
+/// Win32 GENERIC_ALL access mask from winnt.h.
+pub const GENERIC_ALL: u32 = 0x10000000;
+
 // --- Enums ---
 
 pub const D3D12_COMMAND_LIST_TYPE = enum(u32) {
@@ -95,6 +99,18 @@ pub const D3D12_RESOURCE_FLAGS = enum(u32) {
     DENY_SHADER_RESOURCE = 0x8,
     ALLOW_CROSS_ADAPTER = 0x10,
     ALLOW_SIMULTANEOUS_ACCESS = 0x20,
+    _,
+};
+
+pub const D3D12_HEAP_FLAGS = enum(u32) {
+    NONE = 0,
+    SHARED = 0x1,
+    DENY_BUFFERS = 0x4,
+    ALLOW_DISPLAY = 0x8,
+    SHARED_CROSS_ADAPTER = 0x20,
+    DENY_RT_DS_TEXTURES = 0x40,
+    DENY_NON_RT_DS_TEXTURES = 0x80,
+    ALLOW_ALL_BUFFERS_AND_TEXTURES = 0,
     _,
 };
 
@@ -1410,7 +1426,14 @@ pub const ID3D12Device = extern struct {
         // slot 30
         CreateReservedResource: Reserved,
         // slot 31
-        CreateSharedHandle: Reserved,
+        CreateSharedHandle: *const fn (
+            *ID3D12Device,
+            pObject: *IUnknown,
+            pAttributes: ?*const anyopaque, // SECURITY_ATTRIBUTES*
+            Access: u32,
+            Name: ?[*:0]const u16,
+            pHandle: *HANDLE,
+        ) callconv(.winapi) HRESULT,
         // slot 32
         OpenSharedHandle: Reserved,
         // slot 33
@@ -1479,6 +1502,22 @@ pub const ID3D12Device = extern struct {
 
     pub inline fn CreateCommittedResource(self: *ID3D12Device, heap_props: *const D3D12_HEAP_PROPERTIES, heap_flags: u32, desc: *const D3D12_RESOURCE_DESC, initial_state: D3D12_RESOURCE_STATES, optimized_clear: ?*const anyopaque, riid: *const GUID, pp: *?*anyopaque) HRESULT {
         return self.vtable.CreateCommittedResource(self, heap_props, heap_flags, desc, initial_state, optimized_clear, riid, pp);
+    }
+
+    pub inline fn CreateSharedHandle(
+        self: *ID3D12Device,
+        object: *IUnknown,
+        access: u32,
+        handle_out: *HANDLE,
+    ) HRESULT {
+        return self.vtable.CreateSharedHandle(
+            self,
+            object,
+            null, // default security attributes
+            access,
+            null, // unnamed
+            handle_out,
+        );
     }
 
     pub inline fn CreateFence(self: *ID3D12Device, initial_value: u64, flags: D3D12_FENCE_FLAGS, riid: *const GUID, pp: *?*anyopaque) HRESULT {

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -18,8 +18,10 @@ const LPCWSTR = [*:0]const u16;
 pub const D3D_FEATURE_LEVEL_12_0: u32 = 0xc000;
 pub const D3D_FEATURE_LEVEL_12_1: u32 = 0xc100;
 
-/// Windows access right used by CreateSharedHandle. Equivalent to the
-/// Win32 GENERIC_ALL access mask from winnt.h.
+// --- Win32 access rights ---
+
+/// Equivalent to the Win32 GENERIC_ALL access mask from winnt.h. Used
+/// as the `Access` parameter to CreateSharedHandle.
 pub const GENERIC_ALL: u32 = 0x10000000;
 
 // --- Enums ---
@@ -110,7 +112,6 @@ pub const D3D12_HEAP_FLAGS = enum(u32) {
     SHARED_CROSS_ADAPTER = 0x20,
     DENY_RT_DS_TEXTURES = 0x40,
     DENY_NON_RT_DS_TEXTURES = 0x80,
-    ALLOW_ALL_BUFFERS_AND_TEXTURES = 0,
     _,
 };
 
@@ -1426,14 +1427,7 @@ pub const ID3D12Device = extern struct {
         // slot 30
         CreateReservedResource: Reserved,
         // slot 31
-        CreateSharedHandle: *const fn (
-            *ID3D12Device,
-            pObject: *IUnknown,
-            pAttributes: ?*const anyopaque, // SECURITY_ATTRIBUTES*
-            Access: u32,
-            Name: ?[*:0]const u16,
-            pHandle: *HANDLE,
-        ) callconv(.winapi) HRESULT,
+        CreateSharedHandle: *const fn (*ID3D12Device, *IUnknown, ?*const anyopaque, u32, ?[*:0]const u16, *HANDLE) callconv(.winapi) HRESULT,
         // slot 32
         OpenSharedHandle: Reserved,
         // slot 33

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -33,7 +33,7 @@ pub const frame_count: u32 = 3;
 device: *d3d12.ID3D12Device,
 command_queue: *d3d12.ID3D12CommandQueue,
 fence: *d3d12.ID3D12Fence,
-fence_value: u64,
+fence_value: std.atomic.Value(u64),
 fence_event: std.os.windows.HANDLE,
 
 swap_chain: ?*dxgi.IDXGISwapChain1,
@@ -43,19 +43,17 @@ dcomp_device: ?*dcomp.IDCompositionDevice,
 dcomp_target: ?*dcomp.IDCompositionTarget,
 dcomp_visual: ?*dcomp.IDCompositionVisual,
 
-/// Shared-texture mode state. Null for HWND / SwapChainPanel modes.
-/// Populated by Device.init when the surface variant is shared_texture
-/// and mutated by recreateSharedTexture on resize. Readers must hold
+/// Null for HWND / SwapChainPanel modes. Readers must hold
 /// shared_texture_mutex.
 shared_texture: ?SharedTextureState = null,
 
-/// Guards shared_texture and the fence_value counter for atomic reads
-/// by ghostty_surface_shared_texture() on the apprt thread.
+/// Guards shared_texture for atomic snapshot reads by
+/// ghostty_surface_shared_texture() on the apprt thread.
 shared_texture_mutex: std.Thread.Mutex = .{},
 
 /// Shared-texture mode state. Populated by Device.init when the
 /// surface variant is .shared_texture, torn down in Device.deinit,
-/// and recreated on resize. Readers must hold `shared_texture_mutex`.
+/// and recreated on resize.
 pub const SharedTextureState = struct {
     /// The ID3D12Resource ghostty renders into. Owned by Device.
     resource: *d3d12.ID3D12Resource,
@@ -70,6 +68,111 @@ pub const SharedTextureState = struct {
     height: u32,
     /// Monotonically increasing; bumped by recreateSharedTexture.
     version: u64,
+
+    /// Create a shared committed ID3D12Resource and NT handles for both
+    /// the resource and the given fence. Returns a populated
+    /// SharedTextureState ready to be stored on Device.
+    ///
+    /// Format is B8G8R8A8_UNORM to match the renderer's swap-chain path
+    /// (no shader or pipeline permutations required). Flags are
+    /// ALLOW_RENDER_TARGET (ghostty writes to it) plus
+    /// ALLOW_SIMULTANEOUS_ACCESS (consumers can read while ghostty writes
+    /// without explicit state transitions). Initial state is COMMON, the
+    /// only state ALLOW_SIMULTANEOUS_ACCESS resources are ever allowed to
+    /// be in on either device -- the fence is our sole synchronization
+    /// primitive.
+    ///
+    /// Width/height are clamped to a minimum of 1 because
+    /// CreateCommittedResource rejects zero dimensions.
+    pub fn init(
+        device: *d3d12.ID3D12Device,
+        fence: *d3d12.ID3D12Fence,
+        width: u32,
+        height: u32,
+    ) !SharedTextureState {
+        const w: u32 = @max(width, 1);
+        const h: u32 = @max(height, 1);
+
+        const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
+            .Type = .DEFAULT,
+            .CPUPageProperty = 0,
+            .MemoryPoolPreference = 0,
+            .CreationNodeMask = 0,
+            .VisibleNodeMask = 0,
+        };
+
+        const desc = d3d12.D3D12_RESOURCE_DESC{
+            .Dimension = .TEXTURE2D,
+            .Alignment = 0,
+            .Width = @as(u64, w),
+            .Height = h,
+            .DepthOrArraySize = 1,
+            .MipLevels = 1,
+            .Format = .B8G8R8A8_UNORM,
+            .SampleDesc = .{ .Count = 1, .Quality = 0 },
+            .Layout = .UNKNOWN,
+            .Flags = @enumFromInt(
+                @intFromEnum(d3d12.D3D12_RESOURCE_FLAGS.ALLOW_RENDER_TARGET) |
+                    @intFromEnum(d3d12.D3D12_RESOURCE_FLAGS.ALLOW_SIMULTANEOUS_ACCESS),
+            ),
+        };
+
+        var resource: ?*d3d12.ID3D12Resource = null;
+        {
+            const hr = device.CreateCommittedResource(
+                &heap_props,
+                @intFromEnum(d3d12.D3D12_HEAP_FLAGS.SHARED),
+                &desc,
+                .COMMON,
+                null,
+                &d3d12.ID3D12Resource.IID,
+                @ptrCast(&resource),
+            );
+            if (FAILED(hr)) {
+                log.err("CreateCommittedResource (shared) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.SharedResourceCreationFailed;
+            }
+        }
+        const res = resource orelse return error.SharedResourceCreationFailed;
+        errdefer _ = res.Release();
+
+        var resource_handle: std.os.windows.HANDLE = undefined;
+        {
+            const hr = device.CreateSharedHandle(
+                @ptrCast(res),
+                d3d12.GENERIC_ALL,
+                &resource_handle,
+            );
+            if (FAILED(hr)) {
+                log.err("CreateSharedHandle (resource) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.SharedHandleCreationFailed;
+            }
+        }
+        errdefer _ = d3d12.CloseHandle(resource_handle);
+
+        var fence_handle: std.os.windows.HANDLE = undefined;
+        {
+            const hr = device.CreateSharedHandle(
+                @ptrCast(fence),
+                d3d12.GENERIC_ALL,
+                &fence_handle,
+            );
+            if (FAILED(hr)) {
+                log.err("CreateSharedHandle (fence) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+                return error.SharedHandleCreationFailed;
+            }
+        }
+        errdefer _ = d3d12.CloseHandle(fence_handle);
+
+        return .{
+            .resource = res,
+            .resource_handle = resource_handle,
+            .fence_handle = fence_handle,
+            .width = w,
+            .height = h,
+            .version = 1,
+        };
+    }
 };
 
 pub const InitOptions = struct {
@@ -151,8 +254,8 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
     // debug layer from warning about attempting to share an unshared
     // fence, and CreateFence itself does not care either way.
     const fence_flags: d3d12.D3D12_FENCE_FLAGS = switch (surface) {
+        .hwnd, .swap_chain_panel => .NONE,
         .shared_texture => .SHARED,
-        else => .NONE,
     };
 
     // -- Fence --
@@ -240,7 +343,7 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
             // SharedTexture: no swap chain. Create the shared committed
             // resource + NT handles for the resource and the fence so the
             // consumer device can OpenSharedHandle on both.
-            result_shared_texture = try createSharedTextureState(
+            result_shared_texture = try SharedTextureState.init(
                 dev,
                 fence.?,
                 cfg.width,
@@ -264,7 +367,7 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
         .device = dev,
         .command_queue = command_queue.?,
         .fence = fence.?,
-        .fence_value = 0,
+        .fence_value = std.atomic.Value(u64).init(0),
         .fence_event = fence_event,
         .swap_chain = swap_chain,
         .dcomp_device = dcomp_device_ptr,
@@ -301,8 +404,7 @@ pub fn deinit(self: *Device) void {
 
 /// Signal the fence from the command queue and block until the GPU catches up.
 pub fn waitForGpu(self: *Device) !void {
-    self.fence_value += 1;
-    const signal_value = self.fence_value;
+    const signal_value = self.fence_value.fetchAdd(1, .release) + 1;
 
     var hr = self.command_queue.Signal(self.fence, signal_value);
     if (FAILED(hr)) return error.FenceSignalFailed;
@@ -324,7 +426,7 @@ pub fn waitForGpu(self: *Device) !void {
 /// The fence handle is preserved across resize -- the fence itself
 /// is stable for the surface lifetime, and re-issuing a shared
 /// handle for it would force every consumer to re-open the fence
-/// every time the window resized. createSharedTextureState
+/// every time the window resized. SharedTextureState.init
 /// unavoidably produces a fresh fence handle as part of its output;
 /// we close it immediately.
 ///
@@ -341,10 +443,10 @@ pub fn recreateSharedTexture(self: *Device, width: u32, height: u32) !void {
         return err;
     };
 
-    // Build a fresh state off-lock. createSharedTextureState does
+    // Build a fresh state off-lock. SharedTextureState.init does
     // its own errdefer cleanup on failure, so nothing leaks if this
     // returns an error.
-    const new_state = try createSharedTextureState(
+    const new_state = try SharedTextureState.init(
         self.device,
         self.fence,
         width,
@@ -502,116 +604,6 @@ fn createDCompVisual(
     }
 
     return visual.?;
-}
-
-/// Create a shared committed ID3D12Resource and NT handles for both
-/// the resource and the given fence. Returns a populated
-/// SharedTextureState ready to be stored on Device.
-///
-/// Format is B8G8R8A8_UNORM to match the renderer's swap-chain path
-/// (no shader or pipeline permutations required). Flags are
-/// ALLOW_RENDER_TARGET (ghostty writes to it) plus
-/// ALLOW_SIMULTANEOUS_ACCESS (consumers can read while ghostty writes
-/// without explicit state transitions). Initial state is COMMON, the
-/// only state ALLOW_SIMULTANEOUS_ACCESS resources are ever allowed to
-/// be in on either device -- the fence is our sole synchronization
-/// primitive.
-///
-/// Width/height are clamped to a minimum of 1 because
-/// CreateCommittedResource rejects zero dimensions.
-fn createSharedTextureState(
-    device: *d3d12.ID3D12Device,
-    fence: *d3d12.ID3D12Fence,
-    width: u32,
-    height: u32,
-) !SharedTextureState {
-    const w: u32 = @max(width, 1);
-    const h: u32 = @max(height, 1);
-
-    const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
-        .Type = .DEFAULT,
-        .CPUPageProperty = 0,
-        .MemoryPoolPreference = 0,
-        .CreationNodeMask = 0,
-        .VisibleNodeMask = 0,
-    };
-
-    const desc = d3d12.D3D12_RESOURCE_DESC{
-        .Dimension = .TEXTURE2D,
-        .Alignment = 0,
-        .Width = @as(u64, w),
-        .Height = h,
-        .DepthOrArraySize = 1,
-        .MipLevels = 1,
-        .Format = .B8G8R8A8_UNORM,
-        .SampleDesc = .{ .Count = 1, .Quality = 0 },
-        .Layout = .UNKNOWN,
-        .Flags = @enumFromInt(
-            @intFromEnum(d3d12.D3D12_RESOURCE_FLAGS.ALLOW_RENDER_TARGET) |
-                @intFromEnum(d3d12.D3D12_RESOURCE_FLAGS.ALLOW_SIMULTANEOUS_ACCESS),
-        ),
-    };
-
-    var resource: ?*d3d12.ID3D12Resource = null;
-    {
-        const hr = device.CreateCommittedResource(
-            &heap_props,
-            @intFromEnum(d3d12.D3D12_HEAP_FLAGS.SHARED),
-            &desc,
-            .COMMON,
-            null,
-            &d3d12.ID3D12Resource.IID,
-            @ptrCast(&resource),
-        );
-        if (FAILED(hr)) {
-            log.err("CreateCommittedResource (shared) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
-            return error.SharedResourceCreationFailed;
-        }
-    }
-    const res = resource orelse return error.SharedResourceCreationFailed;
-    errdefer _ = res.Release();
-
-    var resource_handle: std.os.windows.HANDLE = undefined;
-    {
-        const hr = device.CreateSharedHandle(
-            @ptrCast(res),
-            d3d12.GENERIC_ALL,
-            &resource_handle,
-        );
-        if (FAILED(hr)) {
-            log.err("CreateSharedHandle (resource) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
-            return error.SharedHandleCreationFailed;
-        }
-    }
-    errdefer _ = d3d12.CloseHandle(resource_handle);
-
-    var fence_handle: std.os.windows.HANDLE = undefined;
-    {
-        const hr = device.CreateSharedHandle(
-            @ptrCast(fence),
-            d3d12.GENERIC_ALL,
-            &fence_handle,
-        );
-        if (FAILED(hr)) {
-            log.err("CreateSharedHandle (fence) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
-            // resource_handle and res are cleaned up by their
-            // respective errdefers above. fence_handle is never set
-            // because CreateSharedHandle failed.
-            return error.SharedHandleCreationFailed;
-        }
-    }
-    // NOTE: no errdefer on fence_handle. Nothing between this point
-    // and the return can fail, so the errdefer would be dead code.
-    // If future edits add a fallible step here, add an errdefer too.
-
-    return .{
-        .resource = res,
-        .resource_handle = resource_handle,
-        .fence_handle = fence_handle,
-        .width = w,
-        .height = h,
-        .version = 1,
-    };
 }
 
 // --- Tests ---

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -145,12 +145,22 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
     }
     errdefer _ = command_queue.?.Release();
 
+    // Fence must be created with SHARED flag when we will later call
+    // CreateSharedHandle on it (shared-texture mode). The flag is
+    // noise for the HWND/SwapChainPanel paths but would prevent the
+    // debug layer from warning about attempting to share an unshared
+    // fence, and CreateFence itself does not care either way.
+    const fence_flags: d3d12.D3D12_FENCE_FLAGS = switch (surface) {
+        .shared_texture => .SHARED,
+        else => .NONE,
+    };
+
     // -- Fence --
     var fence: ?*d3d12.ID3D12Fence = null;
     {
         const hr = dev.CreateFence(
             0,
-            .NONE,
+            fence_flags,
             &d3d12.ID3D12Fence.IID,
             @ptrCast(&fence),
         );

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -43,6 +43,35 @@ dcomp_device: ?*dcomp.IDCompositionDevice,
 dcomp_target: ?*dcomp.IDCompositionTarget,
 dcomp_visual: ?*dcomp.IDCompositionVisual,
 
+/// Shared-texture mode state. Null for HWND / SwapChainPanel modes.
+/// Populated by Device.init when the surface variant is shared_texture
+/// and mutated by recreateSharedTexture on resize. Readers must hold
+/// shared_texture_mutex.
+shared_texture: ?SharedTextureState = null,
+
+/// Guards shared_texture and the fence_value counter for atomic reads
+/// by ghostty_surface_shared_texture() on the apprt thread.
+shared_texture_mutex: std.Thread.Mutex = .{},
+
+/// Shared-texture mode state. Populated by Device.init when the
+/// surface variant is .shared_texture, torn down in Device.deinit,
+/// and recreated on resize. Readers must hold `shared_texture_mutex`.
+pub const SharedTextureState = struct {
+    /// The ID3D12Resource ghostty renders into. Owned by Device.
+    resource: *d3d12.ID3D12Resource,
+    /// NT HANDLE from CreateSharedHandle on `resource`. Owned by
+    /// Device. Closed and reborn on resize.
+    resource_handle: std.os.windows.HANDLE,
+    /// NT HANDLE from CreateSharedHandle on the Device's fence. Owned
+    /// by Device. Stable for the surface lifetime.
+    fence_handle: std.os.windows.HANDLE,
+    /// Pixel dimensions of `resource`.
+    width: u32,
+    height: u32,
+    /// Monotonically increasing; bumped by recreateSharedTexture.
+    version: u64,
+};
+
 pub const InitOptions = struct {
     /// Initial back buffer width. Ignored for SharedTexture (uses its own size).
     width: u32 = 800,

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -248,6 +248,17 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
             );
         },
     }
+    // If anything between here and the final `return` ever gains a
+    // fallible step, this errdefer tears down the shared texture state
+    // instead of leaking the resource and both NT handles. Today it is
+    // defensive -- nothing after this point can fail -- but the cost
+    // is nil and the alternative is a latent leak waiting for the next
+    // edit.
+    errdefer if (result_shared_texture) |st| {
+        _ = d3d12.CloseHandle(st.fence_handle);
+        _ = d3d12.CloseHandle(st.resource_handle);
+        _ = st.resource.Release();
+    };
 
     return .{
         .device = dev,
@@ -449,7 +460,7 @@ fn createSharedTextureState(
     const desc = d3d12.D3D12_RESOURCE_DESC{
         .Dimension = .TEXTURE2D,
         .Alignment = 0,
-        .Width = w,
+        .Width = @as(u64, w),
         .Height = h,
         .DepthOrArraySize = 1,
         .MipLevels = 1,
@@ -504,10 +515,15 @@ fn createSharedTextureState(
         );
         if (FAILED(hr)) {
             log.err("CreateSharedHandle (fence) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            // resource_handle and res are cleaned up by their
+            // respective errdefers above. fence_handle is never set
+            // because CreateSharedHandle failed.
             return error.SharedHandleCreationFailed;
         }
     }
-    errdefer _ = d3d12.CloseHandle(fence_handle);
+    // NOTE: no errdefer on fence_handle. Nothing between this point
+    // and the return can fail, so the errdefer would be dead code.
+    // If future edits add a fallible step here, add an errdefer too.
 
     return .{
         .resource = res,

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -182,6 +182,7 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
     var dcomp_device_ptr: ?*dcomp.IDCompositionDevice = null;
     var dcomp_target_ptr: ?*dcomp.IDCompositionTarget = null;
     var dcomp_visual_ptr: ?*dcomp.IDCompositionVisual = null;
+    var result_shared_texture: ?SharedTextureState = null;
 
     switch (surface) {
         .hwnd => |hwnd| {
@@ -235,9 +236,16 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
                 return error.SwapChainPanelBindFailed;
             }
         },
-        .shared_texture => {
-            // SharedTexture: no swap chain, rendering goes to a shared texture.
-            // The shared texture resource will be created by the caller.
+        .shared_texture => |cfg| {
+            // SharedTexture: no swap chain. Create the shared committed
+            // resource + NT handles for the resource and the fence so the
+            // consumer device can OpenSharedHandle on both.
+            result_shared_texture = try createSharedTextureState(
+                dev,
+                fence.?,
+                cfg.width,
+                cfg.height,
+            );
         },
     }
 
@@ -251,6 +259,7 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
         .dcomp_device = dcomp_device_ptr,
         .dcomp_target = dcomp_target_ptr,
         .dcomp_visual = dcomp_visual_ptr,
+        .shared_texture = result_shared_texture,
     };
 }
 
@@ -403,6 +412,111 @@ fn createDCompVisual(
     }
 
     return visual.?;
+}
+
+/// Create a shared committed ID3D12Resource and NT handles for both
+/// the resource and the given fence. Returns a populated
+/// SharedTextureState ready to be stored on Device.
+///
+/// Format is B8G8R8A8_UNORM to match the renderer's swap-chain path
+/// (no shader or pipeline permutations required). Flags are
+/// ALLOW_RENDER_TARGET (ghostty writes to it) plus
+/// ALLOW_SIMULTANEOUS_ACCESS (consumers can read while ghostty writes
+/// without explicit state transitions). Initial state is COMMON, the
+/// only state ALLOW_SIMULTANEOUS_ACCESS resources are ever allowed to
+/// be in on either device -- the fence is our sole synchronization
+/// primitive.
+///
+/// Width/height are clamped to a minimum of 1 because
+/// CreateCommittedResource rejects zero dimensions.
+fn createSharedTextureState(
+    device: *d3d12.ID3D12Device,
+    fence: *d3d12.ID3D12Fence,
+    width: u32,
+    height: u32,
+) !SharedTextureState {
+    const w: u32 = @max(width, 1);
+    const h: u32 = @max(height, 1);
+
+    const heap_props = d3d12.D3D12_HEAP_PROPERTIES{
+        .Type = .DEFAULT,
+        .CPUPageProperty = 0,
+        .MemoryPoolPreference = 0,
+        .CreationNodeMask = 0,
+        .VisibleNodeMask = 0,
+    };
+
+    const desc = d3d12.D3D12_RESOURCE_DESC{
+        .Dimension = .TEXTURE2D,
+        .Alignment = 0,
+        .Width = w,
+        .Height = h,
+        .DepthOrArraySize = 1,
+        .MipLevels = 1,
+        .Format = .B8G8R8A8_UNORM,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .Layout = .UNKNOWN,
+        .Flags = @enumFromInt(
+            @intFromEnum(d3d12.D3D12_RESOURCE_FLAGS.ALLOW_RENDER_TARGET) |
+                @intFromEnum(d3d12.D3D12_RESOURCE_FLAGS.ALLOW_SIMULTANEOUS_ACCESS),
+        ),
+    };
+
+    var resource: ?*d3d12.ID3D12Resource = null;
+    {
+        const hr = device.CreateCommittedResource(
+            &heap_props,
+            @intFromEnum(d3d12.D3D12_HEAP_FLAGS.SHARED),
+            &desc,
+            .COMMON,
+            null,
+            &d3d12.ID3D12Resource.IID,
+            @ptrCast(&resource),
+        );
+        if (FAILED(hr)) {
+            log.err("CreateCommittedResource (shared) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return error.SharedResourceCreationFailed;
+        }
+    }
+    const res = resource orelse return error.SharedResourceCreationFailed;
+    errdefer _ = res.Release();
+
+    var resource_handle: std.os.windows.HANDLE = undefined;
+    {
+        const hr = device.CreateSharedHandle(
+            @ptrCast(res),
+            d3d12.GENERIC_ALL,
+            &resource_handle,
+        );
+        if (FAILED(hr)) {
+            log.err("CreateSharedHandle (resource) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return error.SharedHandleCreationFailed;
+        }
+    }
+    errdefer _ = d3d12.CloseHandle(resource_handle);
+
+    var fence_handle: std.os.windows.HANDLE = undefined;
+    {
+        const hr = device.CreateSharedHandle(
+            @ptrCast(fence),
+            d3d12.GENERIC_ALL,
+            &fence_handle,
+        );
+        if (FAILED(hr)) {
+            log.err("CreateSharedHandle (fence) failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return error.SharedHandleCreationFailed;
+        }
+    }
+    errdefer _ = d3d12.CloseHandle(fence_handle);
+
+    return .{
+        .resource = res,
+        .resource_handle = resource_handle,
+        .fence_handle = fence_handle,
+        .width = w,
+        .height = h,
+        .version = 1,
+    };
 }
 
 // --- Tests ---

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -314,6 +314,77 @@ pub fn waitForGpu(self: *Device) !void {
     }
 }
 
+/// Recreate the shared texture resource and its NT handle at a new
+/// size. Called by the renderer thread on resize. Blocks on
+/// waitForGpu to let any in-flight frame referencing the old
+/// resource drain, then swaps the state under shared_texture_mutex
+/// so ghostty_surface_shared_texture() readers observe either the
+/// old or new snapshot, never a mix.
+///
+/// The fence handle is preserved across resize -- the fence itself
+/// is stable for the surface lifetime, and re-issuing a shared
+/// handle for it would force every consumer to re-open the fence
+/// every time the window resized. createSharedTextureState
+/// unavoidably produces a fresh fence handle as part of its output;
+/// we close it immediately.
+///
+/// Returns error.NotSharedTextureMode if the surface is not in
+/// shared-texture mode (programmer error -- the renderer should not
+/// call this for HWND or SwapChainPanel surfaces).
+pub fn recreateSharedTexture(self: *Device, width: u32, height: u32) !void {
+    // Drain GPU work referencing the old resource before releasing
+    // anything it might still touch.
+    try self.waitForGpu();
+
+    // Build a fresh state off-lock. createSharedTextureState does
+    // its own errdefer cleanup on failure, so nothing leaks if this
+    // returns an error.
+    var new_state = try createSharedTextureState(
+        self.device,
+        self.fence,
+        width,
+        height,
+    );
+
+    // The fence handle from createSharedTextureState is a brand new
+    // NT handle for the same underlying fence -- we already have a
+    // handle for that fence from the initial Device.init, and we
+    // promised consumers that fence_handle is stable. Discard the
+    // new one.
+    _ = d3d12.CloseHandle(new_state.fence_handle);
+    new_state.fence_handle = undefined;
+
+    self.shared_texture_mutex.lock();
+    defer self.shared_texture_mutex.unlock();
+
+    const old = self.shared_texture orelse {
+        // Caller violated the contract: this method only makes
+        // sense in shared-texture mode. Clean up the new state we
+        // just built before reporting the error.
+        _ = d3d12.CloseHandle(new_state.resource_handle);
+        _ = new_state.resource.Release();
+        return error.NotSharedTextureMode;
+    };
+
+    const next_version = old.version + 1;
+
+    // Swap. Close the old resource handle and release the old
+    // resource only AFTER the new state is fully staged, so any
+    // failure path above leaves the old state intact.
+    _ = d3d12.CloseHandle(old.resource_handle);
+    _ = old.resource.Release();
+
+    self.shared_texture = .{
+        .resource = new_state.resource,
+        .resource_handle = new_state.resource_handle,
+        // Preserved from the old state -- fence handle is stable.
+        .fence_handle = old.fence_handle,
+        .width = new_state.width,
+        .height = new_state.height,
+        .version = next_version,
+    };
+}
+
 // ---- Private helpers ----
 
 fn enableDebugLayer() void {

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -287,6 +287,13 @@ pub fn deinit(self: *Device) void {
     if (self.dcomp_device) |d| _ = d.Release();
     if (self.swap_chain) |sc| _ = sc.Release();
 
+    if (self.shared_texture) |st| {
+        _ = d3d12.CloseHandle(st.fence_handle);
+        _ = d3d12.CloseHandle(st.resource_handle);
+        _ = st.resource.Release();
+        self.shared_texture = null;
+    }
+
     _ = self.device.Release();
 
     self.* = undefined;

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -333,26 +333,27 @@ pub fn waitForGpu(self: *Device) !void {
 /// call this for HWND or SwapChainPanel surfaces).
 pub fn recreateSharedTexture(self: *Device, width: u32, height: u32) !void {
     // Drain GPU work referencing the old resource before releasing
-    // anything it might still touch.
-    try self.waitForGpu();
+    // anything it might still touch. Log on failure so a TDR mid-
+    // resize leaves a trail in the renderer log; the caller still
+    // has to set device_lost, but at least the diagnostic is here.
+    self.waitForGpu() catch |err| {
+        log.err("waitForGpu failed during recreateSharedTexture: {}", .{err});
+        return err;
+    };
 
     // Build a fresh state off-lock. createSharedTextureState does
     // its own errdefer cleanup on failure, so nothing leaks if this
     // returns an error.
-    var new_state = try createSharedTextureState(
+    const new_state = try createSharedTextureState(
         self.device,
         self.fence,
         width,
         height,
     );
 
-    // The fence handle from createSharedTextureState is a brand new
-    // NT handle for the same underlying fence -- we already have a
-    // handle for that fence from the initial Device.init, and we
-    // promised consumers that fence_handle is stable. Discard the
-    // new one.
+    // Fence handle is stable across resize; discard the new one
+    // (see doc comment above).
     _ = d3d12.CloseHandle(new_state.fence_handle);
-    new_state.fence_handle = undefined;
 
     self.shared_texture_mutex.lock();
     defer self.shared_texture_mutex.unlock();

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -672,7 +672,7 @@ test "Device: shared texture 0x0 dimensions does not crash" {
     if (comptime builtin.os.tag != .windows) return;
 
     // SharedTexture mode has no swap chain, so 0x0 should not hit DXGI.
-    // createSharedTextureState clamps both dimensions to 1.
+    // SharedTextureState.init clamps both dimensions to 1.
     var device = Device.init(.{ .shared_texture = .{
         .width = 0,
         .height = 0,
@@ -680,7 +680,7 @@ test "Device: shared texture 0x0 dimensions does not crash" {
     defer device.deinit();
 
     try std.testing.expect(device.swap_chain == null);
-    try std.testing.expect(device.fence_value == 0);
+    try std.testing.expectEqual(@as(u64, 0), device.fence_value.load(.monotonic));
 
     const st = device.shared_texture orelse return error.SharedTextureNotPopulated;
     try std.testing.expectEqual(@as(u32, 1), st.width);

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -687,6 +687,47 @@ test "Device: shared texture 0x0 dimensions does not crash" {
     try std.testing.expectEqual(@as(u32, 1), st.height);
 }
 
+test "Device: recreateSharedTexture bumps version and changes handle" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    var device = Device.init(.{ .shared_texture = .{
+        .width = 320,
+        .height = 240,
+    } }, .{}) catch return;
+    defer device.deinit();
+
+    const st_before = device.shared_texture.?;
+    const version_before = st_before.version;
+    const handle_before = st_before.resource_handle;
+    const fence_handle_before = st_before.fence_handle;
+
+    device.recreateSharedTexture(800, 600) catch return;
+
+    const st_after = device.shared_texture.?;
+    try std.testing.expect(st_after.version > version_before);
+    try std.testing.expect(st_after.resource_handle != handle_before);
+    // Fence handle is stable across resize.
+    try std.testing.expectEqual(fence_handle_before, st_after.fence_handle);
+    try std.testing.expectEqual(@as(u32, 800), st_after.width);
+    try std.testing.expectEqual(@as(u32, 600), st_after.height);
+}
+
+test "Device: shared texture deinit does not leak" {
+    if (comptime builtin.os.tag != .windows) return;
+
+    // Create + destroy several times; if handles leak, the OS will
+    // eventually refuse new allocations. This is a weak guarantee but
+    // catches gross mistakes.
+    var i: usize = 0;
+    while (i < 16) : (i += 1) {
+        var device = Device.init(.{ .shared_texture = .{
+            .width = 64,
+            .height = 64,
+        } }, .{}) catch return;
+        device.deinit();
+    }
+}
+
 test "Device: HWND surface with 0x0 dimensions clamps to 1x1" {
     if (comptime builtin.os.tag != .windows) return;
 

--- a/src/renderer/directx12/gpu_test.zig
+++ b/src/renderer/directx12/gpu_test.zig
@@ -84,7 +84,7 @@ fn createTestDevice() !TestDevice {
     var hr = d3d12.D3D12CreateDevice(
         null,
         d3d12.D3D_FEATURE_LEVEL_12_0,
-        &d3d12.IID_ID3D12Device,
+        &d3d12.ID3D12Device.IID,
         @ptrCast(&device),
     );
     if (com.FAILED(hr) or device == null) return error.DeviceCreationFailed;
@@ -100,7 +100,7 @@ fn createTestDevice() !TestDevice {
     };
     hr = device.?.CreateCommandQueue(
         &queue_desc,
-        &d3d12.IID_ID3D12CommandQueue,
+        &d3d12.ID3D12CommandQueue.IID,
         @ptrCast(&command_queue),
     );
     if (com.FAILED(hr) or command_queue == null) return error.CommandQueueCreationFailed;
@@ -110,7 +110,7 @@ fn createTestDevice() !TestDevice {
     var command_allocator: ?*d3d12.ID3D12CommandAllocator = null;
     hr = device.?.CreateCommandAllocator(
         .DIRECT,
-        &d3d12.IID_ID3D12CommandAllocator,
+        &d3d12.ID3D12CommandAllocator.IID,
         @ptrCast(&command_allocator),
     );
     if (com.FAILED(hr) or command_allocator == null) return error.CommandAllocatorCreationFailed;
@@ -123,7 +123,7 @@ fn createTestDevice() !TestDevice {
         .DIRECT,
         command_allocator.?,
         null,
-        &d3d12.IID_ID3D12GraphicsCommandList,
+        &d3d12.ID3D12GraphicsCommandList.IID,
         @ptrCast(&command_list),
     );
     if (com.FAILED(hr) or command_list == null) return error.CommandListCreationFailed;
@@ -134,7 +134,7 @@ fn createTestDevice() !TestDevice {
     hr = device.?.CreateFence(
         0,
         .NONE,
-        &d3d12.IID_ID3D12Fence,
+        &d3d12.ID3D12Fence.IID,
         @ptrCast(&fence),
     );
     if (com.FAILED(hr) or fence == null) return error.FenceCreationFailed;
@@ -452,7 +452,7 @@ test "Texture: replaceRegion updates sub-region" {
 
     // State should be back to PIXEL_SHADER_RESOURCE after replaceRegion.
     try std.testing.expectEqual(
-        d3d12.D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+        d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RESOURCE,
         tex.state,
     );
 }
@@ -550,8 +550,11 @@ test "Frame: create, reset, deinit" {
     // Frame starts with command list closed. Reset opens it.
     try frame.reset();
 
-    // Close it again to verify the reset worked.
-    const hr = frame.command_list.Close();
+    // Close it again to verify the reset worked. command_list is
+    // optional on Frame because Frame.init may not have populated
+    // it yet; after frame.reset() it is guaranteed non-null.
+    const cl = frame.command_list orelse return error.CommandListMissing;
+    const hr = cl.Close();
     try std.testing.expect(!com.FAILED(hr));
 }
 
@@ -640,11 +643,7 @@ test "Device: HWND surface uses DirectComposition with PREMULTIPLIED alpha" {
 test "Device: shared texture mode has no swap chain or dcomp" {
     if (comptime builtin.os.tag != .windows) return;
 
-    const HANDLE = std.os.windows.HANDLE;
-    var shared_handle: ?HANDLE = null;
-
     var device = Device.init(.{ .shared_texture = .{
-        .handle_out = &shared_handle,
         .width = 640,
         .height = 480,
     } }, .{}) catch return;
@@ -655,6 +654,16 @@ test "Device: shared texture mode has no swap chain or dcomp" {
     try std.testing.expect(device.dcomp_device == null);
     try std.testing.expect(device.dcomp_target == null);
     try std.testing.expect(device.dcomp_visual == null);
+
+    // Shared texture state is populated with a non-null resource,
+    // both NT handles, and version starts at 1.
+    const st = device.shared_texture orelse return error.SharedTextureNotPopulated;
+    try std.testing.expect(@intFromPtr(st.resource) != 0);
+    try std.testing.expect(@intFromPtr(st.resource_handle) != 0);
+    try std.testing.expect(@intFromPtr(st.fence_handle) != 0);
+    try std.testing.expectEqual(@as(u64, 1), st.version);
+    try std.testing.expectEqual(@as(u32, 640), st.width);
+    try std.testing.expectEqual(@as(u32, 480), st.height);
 }
 
 // ---- Device.init edge case tests ----
@@ -662,12 +671,9 @@ test "Device: shared texture mode has no swap chain or dcomp" {
 test "Device: shared texture 0x0 dimensions does not crash" {
     if (comptime builtin.os.tag != .windows) return;
 
-    const HANDLE = std.os.windows.HANDLE;
-    var shared_handle: ?HANDLE = null;
-
     // SharedTexture mode has no swap chain, so 0x0 should not hit DXGI.
+    // createSharedTextureState clamps both dimensions to 1.
     var device = Device.init(.{ .shared_texture = .{
-        .handle_out = &shared_handle,
         .width = 0,
         .height = 0,
     } }, .{}) catch return;
@@ -675,6 +681,10 @@ test "Device: shared texture 0x0 dimensions does not crash" {
 
     try std.testing.expect(device.swap_chain == null);
     try std.testing.expect(device.fence_value == 0);
+
+    const st = device.shared_texture orelse return error.SharedTextureNotPopulated;
+    try std.testing.expectEqual(@as(u32, 1), st.width);
+    try std.testing.expectEqual(@as(u32, 1), st.height);
 }
 
 test "Device: HWND surface with 0x0 dimensions clamps to 1x1" {

--- a/src/renderer/directx12/surface.zig
+++ b/src/renderer/directx12/surface.zig
@@ -4,7 +4,6 @@
 //! - HWND: for standalone windows and test harnesses
 //! - SwapChainPanel: for WinUI 3 / XAML composition hosts
 //! - SharedTexture: for game engines and offscreen rendering
-const std = @import("std");
 const dxgi = @import("dxgi.zig");
 
 pub const HWND = dxgi.HWND;
@@ -16,10 +15,8 @@ pub const Surface = union(enum) {
 };
 
 pub const SharedTextureConfig = struct {
-    /// Output parameter: the shared handle will be written here after
-    /// device creation. The caller owns the storage and must keep it
-    /// alive until init returns.
-    handle_out: *?std.os.windows.HANDLE,
+    /// Initial pixel width of the shared render target.
     width: u32,
+    /// Initial pixel height of the shared render target.
     height: u32,
 };

--- a/windows/Ghostty.Core/Interop/GhosttySharedTexture.cs
+++ b/windows/Ghostty.Core/Interop/GhosttySharedTexture.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Core.Interop;
+
+// Mirrors the nested `struct { bool enabled; uint32_t width; uint32_t height; }`
+// inside ghostty_platform_windows_s. Used when constructing the platform
+// config for shared-texture surface mode.
+[StructLayout(LayoutKind.Sequential)]
+public struct GhosttySharedTextureConfig
+{
+    [MarshalAs(UnmanagedType.I1)]
+    public bool Enabled;
+    public uint Width;
+    public uint Height;
+}
+
+// Mirrors ghostty_surface_shared_texture_s -- the atomic snapshot returned
+// by ghostty_surface_shared_texture(). Field order is ABI-critical.
+[StructLayout(LayoutKind.Sequential)]
+public struct GhosttySharedTextureSnapshot
+{
+    public IntPtr ResourceHandle;  // NT HANDLE -- do NOT CloseHandle; ghostty retains ownership
+    public IntPtr FenceHandle;     // NT HANDLE -- do NOT CloseHandle; stable for surface lifetime
+    public ulong FenceValue;
+    public uint Width;
+    public uint Height;
+    public ulong Version;
+}

--- a/windows/Ghostty.Core/Interop/GhosttySharedTexture.cs
+++ b/windows/Ghostty.Core/Interop/GhosttySharedTexture.cs
@@ -6,22 +6,31 @@ namespace Ghostty.Core.Interop;
 // Mirrors the nested `struct { bool enabled; uint32_t width; uint32_t height; }`
 // inside ghostty_platform_windows_s. Used when constructing the platform
 // config for shared-texture surface mode.
+//
+// Uses byte instead of bool for Enabled to keep the struct blittable and
+// forward-compatible with DisableRuntimeMarshalling / NativeAOT.
 [StructLayout(LayoutKind.Sequential)]
-public struct GhosttySharedTextureConfig
+internal struct GhosttySharedTextureConfig
 {
-    [MarshalAs(UnmanagedType.I1)]
-    public bool Enabled;
+    public byte Enabled;
     public uint Width;
     public uint Height;
+
+    public bool IsEnabled => Enabled != 0;
 }
 
 // Mirrors ghostty_surface_shared_texture_s -- the atomic snapshot returned
 // by ghostty_surface_shared_texture(). Field order is ABI-critical.
+//
+// ResourceHandle and FenceHandle are NT HANDLEs owned by the native side.
+// Do NOT call CloseHandle on either of them. The consumer should open its
+// own resources via ID3D12Device::OpenSharedHandle and Release() those
+// when done; re-open whenever Version changes (resize / device recovery).
 [StructLayout(LayoutKind.Sequential)]
-public struct GhosttySharedTextureSnapshot
+internal struct GhosttySharedTextureSnapshot
 {
-    public IntPtr ResourceHandle;  // NT HANDLE -- do NOT CloseHandle; ghostty retains ownership
-    public IntPtr FenceHandle;     // NT HANDLE -- do NOT CloseHandle; stable for surface lifetime
+    public IntPtr ResourceHandle;
+    public IntPtr FenceHandle;
     public ulong FenceValue;
     public uint Width;
     public uint Height;

--- a/windows/Ghostty.Tests/Interop/GhosttySharedTextureLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttySharedTextureLayoutTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.InteropServices;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+// Pins the struct layouts of the DX12 shared-texture interop types
+// against the C ABI defined in include/ghostty.h.  If the C header
+// changes (field reorder, new field, type change), these tests fail
+// before a runtime ABI mismatch can cause data corruption.
+public class GhosttySharedTextureLayoutTests
+{
+    // -- GhosttySharedTextureConfig -----------------------------------
+    // Mirrors the anonymous nested struct inside ghostty_platform_windows_s:
+    //   struct { bool enabled; uint32_t width; uint32_t height; }
+    // Total: 1 (bool) + 3 (padding) + 4 + 4 = 12 bytes on x64.
+
+    [Fact]
+    public void SharedTextureConfig_Size_Is_12_Bytes()
+    {
+        Assert.Equal(12, Marshal.SizeOf<GhosttySharedTextureConfig>());
+    }
+
+    [Fact]
+    public void SharedTextureConfig_Field_Offsets_Match_C_Layout()
+    {
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttySharedTextureConfig>(
+            nameof(GhosttySharedTextureConfig.Enabled)));
+        Assert.Equal(4, (int)Marshal.OffsetOf<GhosttySharedTextureConfig>(
+            nameof(GhosttySharedTextureConfig.Width)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<GhosttySharedTextureConfig>(
+            nameof(GhosttySharedTextureConfig.Height)));
+    }
+
+    // -- GhosttySharedTextureSnapshot ---------------------------------
+    // Mirrors ghostty_surface_shared_texture_s:
+    //   void* resource_handle;    offset  0
+    //   void* fence_handle;       offset  8
+    //   uint64_t fence_value;     offset 16
+    //   uint32_t width;           offset 24
+    //   uint32_t height;          offset 28
+    //   uint64_t version;         offset 32
+    //   total = 40 bytes on x64.
+
+    [Fact]
+    public void SharedTextureSnapshot_Size_Is_40_Bytes()
+    {
+        Assert.Equal(40, Marshal.SizeOf<GhosttySharedTextureSnapshot>());
+    }
+
+    [Fact]
+    public void SharedTextureSnapshot_Field_Offsets_Match_C_Layout()
+    {
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(
+            nameof(GhosttySharedTextureSnapshot.ResourceHandle)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(
+            nameof(GhosttySharedTextureSnapshot.FenceHandle)));
+        Assert.Equal(16, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(
+            nameof(GhosttySharedTextureSnapshot.FenceValue)));
+        Assert.Equal(24, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(
+            nameof(GhosttySharedTextureSnapshot.Width)));
+        Assert.Equal(28, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(
+            nameof(GhosttySharedTextureSnapshot.Height)));
+        Assert.Equal(32, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(
+            nameof(GhosttySharedTextureSnapshot.Version)));
+    }
+}

--- a/windows/Ghostty.Tests/Interop/GhosttySharedTextureLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttySharedTextureLayoutTests.cs
@@ -9,12 +9,15 @@ namespace Ghostty.Tests.Interop;
 // against the C ABI defined in include/ghostty.h.  If the C header
 // changes (field reorder, new field, type change), these tests fail
 // before a runtime ABI mismatch can cause data corruption.
+//
+// The Snapshot assertions assume x64 pointer size (IntPtr = 8 bytes).
+// On non-x64 runtimes those tests are skipped via early return.
 public class GhosttySharedTextureLayoutTests
 {
     // -- GhosttySharedTextureConfig -----------------------------------
     // Mirrors the anonymous nested struct inside ghostty_platform_windows_s:
     //   struct { bool enabled; uint32_t width; uint32_t height; }
-    // Total: 1 (bool) + 3 (padding) + 4 + 4 = 12 bytes on x64.
+    // Total: 1 (byte) + 3 (padding) + 4 + 4 = 12 bytes.
 
     [Fact]
     public void SharedTextureConfig_Size_Is_12_Bytes()
@@ -46,12 +49,14 @@ public class GhosttySharedTextureLayoutTests
     [Fact]
     public void SharedTextureSnapshot_Size_Is_40_Bytes()
     {
+        if (IntPtr.Size != 8) return; // x64 only
         Assert.Equal(40, Marshal.SizeOf<GhosttySharedTextureSnapshot>());
     }
 
     [Fact]
     public void SharedTextureSnapshot_Field_Offsets_Match_C_Layout()
     {
+        if (IntPtr.Size != 8) return; // x64 only
         Assert.Equal(0, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(
             nameof(GhosttySharedTextureSnapshot.ResourceHandle)));
         Assert.Equal(8, (int)Marshal.OffsetOf<GhosttySharedTextureSnapshot>(

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -291,11 +291,7 @@ public sealed partial class TerminalControl : UserControl
         var panelPtr = SwapChainPanelInterop.QueryInterface(Panel);
         surfaceConfig.Platform.Windows = new GhosttyPlatformWindows
         {
-            Hwnd = IntPtr.Zero,
             SwapChainPanel = panelPtr,
-            SharedTextureOut = IntPtr.Zero,
-            TextureWidth = 0,
-            TextureHeight = 0,
         };
         surfaceConfig.ScaleFactor = Panel.CompositionScaleX > 0 ? Panel.CompositionScaleX : 1.0;
         surfaceConfig.Context = GhosttySurfaceContext.Window;

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -111,13 +111,31 @@ internal struct GhosttyInputKey
 }
 
 [StructLayout(LayoutKind.Sequential)]
+internal struct GhosttySharedTextureConfig
+{
+    [MarshalAs(UnmanagedType.I1)]
+    public bool Enabled;
+    public uint Width;
+    public uint Height;
+}
+
+[StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyPlatformWindows
 {
-    public IntPtr Hwnd;               // null for composition mode
-    public IntPtr SwapChainPanel;     // ISwapChainPanelNative*
-    public IntPtr SharedTextureOut;   // OUT: HANDLE
-    public uint TextureWidth;
-    public uint TextureHeight;
+    public IntPtr Hwnd;                        // null for composition mode
+    public IntPtr SwapChainPanel;              // ISwapChainPanelNative*
+    public GhosttySharedTextureConfig SharedTexture;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttySharedTextureSnapshot
+{
+    public IntPtr ResourceHandle;  // NT HANDLE -- do NOT CloseHandle; ghostty retains ownership
+    public IntPtr FenceHandle;     // NT HANDLE -- do NOT CloseHandle; stable for surface lifetime
+    public ulong FenceValue;
+    public uint Width;
+    public uint Height;
+    public ulong Version;
 }
 
 // ghostty_platform_u — explicit layout so all three variants share memory.
@@ -335,6 +353,12 @@ internal static partial class NativeMethods
 
     [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_size")]
     internal static extern GhosttySurfaceSize SurfaceSize(GhosttySurface surface);
+
+    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_shared_texture")]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool SurfaceSharedTexture(
+        GhosttySurface surface,
+        out GhosttySharedTextureSnapshot snapshot);
 
     // ---- surface input -------------------------------------------------
 

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -110,14 +110,9 @@ internal struct GhosttyInputKey
     public bool Composing;
 }
 
-[StructLayout(LayoutKind.Sequential)]
-internal struct GhosttySharedTextureConfig
-{
-    [MarshalAs(UnmanagedType.I1)]
-    public bool Enabled;
-    public uint Width;
-    public uint Height;
-}
+// GhosttySharedTextureConfig and GhosttySharedTextureSnapshot live in
+// Ghostty.Core/Interop/GhosttySharedTexture.cs so the test project can
+// pin their layouts without depending on the WinUI 3 app project.
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyPlatformWindows
@@ -125,17 +120,6 @@ internal struct GhosttyPlatformWindows
     public IntPtr Hwnd;                        // null for composition mode
     public IntPtr SwapChainPanel;              // ISwapChainPanelNative*
     public GhosttySharedTextureConfig SharedTexture;
-}
-
-[StructLayout(LayoutKind.Sequential)]
-internal struct GhosttySharedTextureSnapshot
-{
-    public IntPtr ResourceHandle;  // NT HANDLE -- do NOT CloseHandle; ghostty retains ownership
-    public IntPtr FenceHandle;     // NT HANDLE -- do NOT CloseHandle; stable for surface lifetime
-    public ulong FenceValue;
-    public uint Width;
-    public uint Height;
-    public ulong Version;
 }
 
 // ghostty_platform_u — explicit layout so all three variants share memory.


### PR DESCRIPTION
Implements the DX12 shared-texture surface mode from the spec in docs/superpowers/specs/2026-04-09-dx12-shared-texture-design.md.

Closes deblasis/ghostty#176.

## Changes

**C ABI (ghostty.h):**
- Reshaped `ghostty_platform_windows_s`: shared-texture config is now a nested sub-struct (`enabled`, `width`, `height`), replacing the flat `shared_texture_out` / `texture_width` / `texture_height`.
- New `ghostty_surface_shared_texture_s` struct + `ghostty_surface_shared_texture()` accessor returning an atomic snapshot: resource NT handle, fence NT handle, fence value, dimensions, and a version counter that bumps on resize.
- Dropped the null-stub `ghostty_surface_get_d3d12_shared_texture` from PR #177.

**DX12 renderer (Zig):**
- `d3d12.zig`: wired `CreateSharedHandle` vtable slot, added `D3D12_HEAP_FLAGS` enum and `GENERIC_ALL` constant.
- `device.zig`: new `SharedTextureState` type on `Device`; `Device.init` creates a shared committed `ID3D12Resource` (B8G8R8A8_UNORM, `HEAP_FLAG_SHARED` + `ALLOW_SIMULTANEOUS_ACCESS`) plus two NT handles (resource + shared fence); `Device.deinit` tears them down; `recreateSharedTexture` drains GPU, swaps the resource under `shared_texture_mutex`, bumps version, preserves the fence handle.
- `DirectX12.zig`: `beginFrame`/`drawFrameEnd` branch on shared-texture vs swap-chain mode (single RTV, no Present, no back-buffer rotation); resize path calls `recreateSharedTexture` and refreshes the RTV.
- `embedded.zig`: Zig mirrors of the C struct reshaped; new `ghostty_surface_shared_texture` export reads a mutex-guarded snapshot.
- `surface.zig`: simplified `SharedTextureConfig` (dropped one-shot `handle_out`).

**C# shell:**
- `NativeMethods.cs`: `GhosttyPlatformWindows` reshaped; `SurfaceSharedTexture` P/Invoke added.
- `TerminalControl.xaml.cs`: construction site updated.
- `Ghostty.Core/Interop/GhosttySharedTexture.cs`: shared-texture structs extracted so the test project can pin them.
- `Ghostty.Tests`: 4 layout-pinning tests for the new ABI structs.

**DX12 integration tests (gpu_test.zig):**
- Wired the previously-orphaned gpu_test.zig into the test runner (3 pre-existing drift bugs fixed).
- Shared-texture init asserts resource, handles, version, dimensions.
- Resize test: version bumps, resource handle changes, fence handle stable.
- Deinit loop (16 iterations): catches gross handle/resource leaks.

## Test plan

- [x] `just build-dll` green
- [x] `just build-win` green, 0 warnings
- [x] `zig build test` green (including 27+ DX12 integration tests)
- [x] `dotnet test` -- 89 passed, 0 failed
- [ ] `just run-win` SwapChainPanel mode still works (manual)
- [ ] Unity example in libghostty-dotnet examples repo (follow-up)