### PR TITLE
fix(windows): detect TDR in Signal failure path to prevent deadlock

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -520,6 +520,16 @@ pub fn drawFrameEnd(self: *DirectX12) void {
     const signal_hr = dev_ptr.command_queue.Signal(dev_ptr.fence, new_fence_value);
     if (com.FAILED(signal_hr)) {
         log.err("fence Signal failed: 0x{x}", .{@as(u32, @bitCast(signal_hr))});
+        // A TDR between Present and Signal leaves the fence unsignaled.
+        // Without this check the next beginFrame would deadlock waiting
+        // on a fence that will never advance.
+        if (signal_hr == com.DXGI_ERROR_DEVICE_REMOVED or
+            signal_hr == com.DXGI_ERROR_DEVICE_HUNG or
+            signal_hr == com.DXGI_ERROR_DEVICE_RESET)
+        {
+            self.handleDeviceRemoved();
+            return;
+        }
     }
 
     // Shared-texture mode has no Present call to detect device-removed.

--- a/src/renderer/directx12/com_test.zig
+++ b/src/renderer/directx12/com_test.zig
@@ -79,6 +79,39 @@ test "DXGI device-loss error codes are all failures" {
     try std.testing.expect(com.FAILED(com.DXGI_ERROR_DEVICE_RESET));
 }
 
+// Verify the device-loss check pattern used in drawFrameEnd's Signal
+// failure path (and the other three call sites) catches all three codes.
+// This pins the invariant: FAILED(hr) must be true AND the specific
+// equality check must match for each device-loss HRESULT.
+
+test "device-loss check pattern matches all three codes" {
+    const device_loss_codes = [_]com.HRESULT{
+        com.DXGI_ERROR_DEVICE_REMOVED,
+        com.DXGI_ERROR_DEVICE_HUNG,
+        com.DXGI_ERROR_DEVICE_RESET,
+    };
+    for (device_loss_codes) |hr| {
+        // Outer gate: FAILED() must be true so we enter the error branch.
+        try std.testing.expect(com.FAILED(hr));
+        // Inner gate: at least one equality arm must match.
+        const matched = (hr == com.DXGI_ERROR_DEVICE_REMOVED or
+            hr == com.DXGI_ERROR_DEVICE_HUNG or
+            hr == com.DXGI_ERROR_DEVICE_RESET);
+        try std.testing.expect(matched);
+    }
+}
+
+test "non-device-loss failures do not match device-loss pattern" {
+    // E_FAIL is a generic COM error -- it should pass FAILED() but not
+    // match the device-loss equality check.
+    const e_fail: com.HRESULT = @bitCast(@as(u32, 0x80004005));
+    try std.testing.expect(com.FAILED(e_fail));
+    const matched = (e_fail == com.DXGI_ERROR_DEVICE_REMOVED or
+        e_fail == com.DXGI_ERROR_DEVICE_HUNG or
+        e_fail == com.DXGI_ERROR_DEVICE_RESET);
+    try std.testing.expect(!matched);
+}
+
 test "Buffer type instantiation compiles" {
     const buffer_mod = @import("buffer.zig");
     _ = buffer_mod.Buffer(f32);


### PR DESCRIPTION
## Summary

- Closes the TDR gap in `drawFrameEnd`'s fence Signal failure path: a device-removed error between Present and Signal left the fence unsignaled, causing the next `beginFrame` to deadlock
- Adds device-removed/hung/reset check to the Signal failure handler, matching the pattern at the other three call sites (Present, ResizeBuffers, presentLastTarget)
- The shared-texture fallback at the end of `drawFrameEnd` remains as defense-in-depth

## Test plan

- [x] New tests in `com_test.zig` verify the device-loss check pattern matches all three DXGI error codes
- [x] Negative test confirms non-device-loss failures (E_FAIL) do not match the pattern
- [x] Existing DXGI error constant and `FAILED()` tests still pass