### PR TITLE
build: add libghostty pkg-config modules (shared + static)

### DIFF
--- a/src/build/GhosttyLib.zig
+++ b/src/build/GhosttyLib.zig
@@ -10,11 +10,13 @@ const LipoStep = @import("LipoStep.zig");
 /// The step that generates the file.
 step: *std.Build.Step,
 
-/// The final library file (DLL or static .lib/.a).
+/// The final library file
 output: std.Build.LazyPath,
 /// The import library for DLL builds on Windows (.lib), null otherwise.
 implib: ?std.Build.LazyPath = null,
 dsym: ?std.Build.LazyPath,
+pkg_config: ?std.Build.LazyPath,
+pkg_config_static: ?std.Build.LazyPath,
 
 pub fn initStatic(
     b: *std.Build,
@@ -56,6 +58,8 @@ pub fn initStatic(
         .step = &lib.step,
         .output = lib.getEmittedBin(),
         .dsym = null,
+        .pkg_config = null,
+        .pkg_config_static = null,
     };
 
     // Create a static lib that contains all our dependencies.
@@ -72,6 +76,8 @@ pub fn initStatic(
 
         // Static libraries cannot have dSYMs because they aren't linked.
         .dsym = null,
+        .pkg_config = null,
+        .pkg_config_static = null,
     };
 }
 
@@ -156,6 +162,14 @@ pub fn initShared(
         break :dsymutil output;
     };
 
+    // pkg-config
+    //
+    // pkg-config's --static only expands Libs.private / Requires.private;
+    // it doesn't change -lghostty into an archive-only reference when
+    // both shared and static libraries are installed. Install a dedicated
+    // static module so consumers can request the archive explicitly.
+    const pcs = pkgConfigFiles(b, deps);
+
     return .{
         .step = &lib.step,
         .output = lib.getEmittedBin(),
@@ -164,6 +178,8 @@ pub fn initShared(
         else
             null,
         .dsym = dsymutil,
+        .pkg_config = pcs.shared,
+        .pkg_config_static = pcs.static,
     };
 }
 
@@ -194,13 +210,31 @@ pub fn initMacOSUniversal(
         // You can't run dsymutil on a universal binary, you have to
         // do it on the individual binaries.
         .dsym = null,
+        .pkg_config = null,
+        .pkg_config_static = null,
     };
 }
 
 pub fn install(self: *const GhosttyLib, name: []const u8) void {
     const b = self.step.owner;
+    const step = b.getInstallStep();
     const lib_install = b.addInstallLibFile(self.output, name);
-    b.getInstallStep().dependOn(&lib_install.step);
+    step.dependOn(&lib_install.step);
+
+    if (self.pkg_config) |pc| {
+        step.dependOn(&b.addInstallFileWithDir(
+            pc,
+            .prefix,
+            "share/pkgconfig/libghostty.pc",
+        ).step);
+    }
+    if (self.pkg_config_static) |pc| {
+        step.dependOn(&b.addInstallFileWithDir(
+            pc,
+            .prefix,
+            "share/pkgconfig/libghostty-static.pc",
+        ).step);
+    }
 }
 
 pub fn installHeader(self: *const GhosttyLib) void {
@@ -210,4 +244,55 @@ pub fn installHeader(self: *const GhosttyLib) void {
         "ghostty.h",
     );
     b.getInstallStep().dependOn(&header_install.step);
+}
+
+const PkgConfigFiles = struct {
+    shared: std.Build.LazyPath,
+    static: std.Build.LazyPath,
+};
+
+fn pkgConfigFiles(
+    b: *std.Build,
+    deps: *const SharedDeps,
+) PkgConfigFiles {
+    const os_tag = deps.config.target.result.os.tag;
+    const wf = b.addWriteFiles();
+
+    return .{
+        .shared = wf.add("libghostty.pc", b.fmt(
+            \\prefix={s}
+            \\includedir=${{prefix}}/include
+            \\libdir=${{prefix}}/lib
+            \\
+            \\Name: libghostty
+            \\URL: https://github.com/ghostty-org/ghostty
+            \\Description: Ghostty terminal emulator library
+            \\Version: {f}
+            \\Cflags: -I${{includedir}}
+            \\Libs: -L${{libdir}} -lghostty
+            \\Libs.private:
+            \\Requires.private:
+        , .{ b.install_prefix, deps.config.version })),
+        .static = wf.add("libghostty-static.pc", b.fmt(
+            \\prefix={s}
+            \\includedir=${{prefix}}/include
+            \\libdir=${{prefix}}/lib
+            \\
+            \\Name: libghostty-static
+            \\URL: https://github.com/ghostty-org/ghostty
+            \\Description: Ghostty terminal emulator library (static)
+            \\Version: {f}
+            \\Cflags: -I${{includedir}}
+            \\Libs: ${{libdir}}/{s}
+            \\Libs.private:
+            \\Requires.private:
+        , .{ b.install_prefix, deps.config.version, staticLibraryName(os_tag) })),
+    };
+}
+
+fn staticLibraryName(os_tag: std.Target.Os.Tag) []const u8 {
+    return if (os_tag == .windows)
+        "ghostty-static.lib"
+    else
+        "libghostty.a";
 }


### PR DESCRIPTION
## Summary

- Mirror the libghostty-vt-static pkg-config pattern from upstream #12210 for the full libghostty library
- Adds `libghostty.pc` (shared, `-lghostty`) and `libghostty-static.pc` (static, direct archive reference) so consumers can discover either variant via pkg-config
- The static module points at the platform-correct archive name (`ghostty-static.lib` on Windows, `libghostty.a` elsewhere)
- pkg-config files are generated during shared builds and installed via `GhosttyLib.install()`

Intended for upstream contribution -- validates the static pkg-config direction from #12210 with a real Windows consumer.

## Test plan

- [x] `zig build` succeeds on Windows (default target)
- [x] `libghostty.pc` and `libghostty-static.pc` appear in `zig-out/share/pkgconfig/`
- [x] Static .pc points at `ghostty-static.lib` (Windows) / `libghostty.a` (Unix)
- [x] Shared .pc uses standard `-L -l` flags
- [x] Existing libghostty-vt pkg-config files are unaffected