### PR TITLE
Command palette (Ctrl+Shift+P)

### DIFF
--- a/windows/Ghostty.Core/Commands/ActionAutoCompleter.cs
+++ b/windows/Ghostty.Core/Commands/ActionAutoCompleter.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Commands;
+
+internal sealed class ActionAutoCompleter
+{
+    private readonly Dictionary<string, ActionSchema> _actions;
+    private readonly List<string> _sortedNames;
+
+    public ActionAutoCompleter(Dictionary<string, ActionSchema> actions)
+    {
+        _actions = actions;
+        _sortedNames = actions.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    public AutocompleteResult Complete(string input)
+    {
+        var colonIndex = input.IndexOf(':');
+
+        if (colonIndex < 0)
+        {
+            var matches = _sortedNames
+                .Where(n => n.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+                .Select(n => new AutocompleteSuggestion(n, _actions[n].Description))
+                .ToList();
+
+            var ghost = matches.Count > 0 ? matches[0].Name[input.Length..] : null;
+            return new AutocompleteResult(matches, ghost);
+        }
+
+        var actionPart = input[..colonIndex];
+        var paramPart = input[(colonIndex + 1)..];
+
+        if (!_actions.TryGetValue(actionPart, out var schema))
+            return AutocompleteResult.Empty;
+
+        if (schema.Parameters is null || schema.Parameters.Length == 0)
+            return AutocompleteResult.Empty;
+
+        var paramMatches = schema.Parameters
+            .Where(p => p.StartsWith(paramPart, StringComparison.OrdinalIgnoreCase))
+            .Select(p => new AutocompleteSuggestion(p, $"{schema.Name}:{p}"))
+            .ToList();
+
+        var paramGhost = paramMatches.Count > 0 ? paramMatches[0].Name[paramPart.Length..] : null;
+        return new AutocompleteResult(paramMatches, paramGhost);
+    }
+
+    public bool IsValid(string input)
+    {
+        var colonIndex = input.IndexOf(':');
+
+        if (colonIndex < 0)
+            return _actions.TryGetValue(input, out var schema) && !schema.RequiresParameter;
+
+        var actionPart = input[..colonIndex];
+        var paramPart = input[(colonIndex + 1)..];
+
+        if (!_actions.TryGetValue(actionPart, out var s))
+            return false;
+
+        if (s.Parameters is null || s.Parameters.Length == 0)
+            return false;
+
+        return Array.Exists(s.Parameters, p => p.Equals(paramPart, StringComparison.OrdinalIgnoreCase));
+    }
+}
+
+internal sealed record ActionSchema
+{
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+    public string[]? Parameters { get; init; }
+    public required bool RequiresParameter { get; init; }
+}
+
+internal sealed record AutocompleteSuggestion(string Name, string Description);
+
+internal sealed record AutocompleteResult(
+    IReadOnlyList<AutocompleteSuggestion> Suggestions,
+    string? GhostText)
+{
+    public static AutocompleteResult Empty { get; } = new([], null);
+}

--- a/windows/Ghostty.Core/Commands/FrecencyStore.cs
+++ b/windows/Ghostty.Core/Commands/FrecencyStore.cs
@@ -60,17 +60,10 @@ internal sealed class FrecencyStore
         }
     }
 
-    private static string FilePath
-    {
-        get
-        {
-            var dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "Ghostty");
-            Directory.CreateDirectory(dir);
-            return Path.Combine(dir, "command-frecency.json");
-        }
-    }
+    private static string FilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Ghostty",
+        "command-frecency.json");
 
     public static FrecencyStore Load()
     {
@@ -92,7 +85,9 @@ internal sealed class FrecencyStore
     {
         try
         {
-            File.WriteAllText(FilePath, ToJson());
+            var path = FilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, ToJson());
         }
         catch (Exception ex)
         {

--- a/windows/Ghostty.Core/Commands/FrecencyStore.cs
+++ b/windows/Ghostty.Core/Commands/FrecencyStore.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Ghostty.Commands;
+
+internal sealed class FrecencyStore
+{
+    public Dictionary<string, FrecencyEntry> Entries { get; set; } = [];
+
+    public void RecordUse(string commandId)
+    {
+        if (Entries.TryGetValue(commandId, out var entry))
+        {
+            entry.UseCount++;
+            entry.LastUsed = DateTime.UtcNow;
+        }
+        else
+        {
+            Entries[commandId] = new FrecencyEntry
+            {
+                UseCount = 1,
+                LastUsed = DateTime.UtcNow,
+            };
+        }
+    }
+
+    public double Score(string commandId)
+    {
+        if (!Entries.TryGetValue(commandId, out var entry))
+            return 0.0;
+
+        var daysSince = (DateTime.UtcNow - entry.LastUsed).TotalDays;
+        var recencyWeight = Math.Pow(0.9, daysSince);
+        return entry.UseCount * recencyWeight;
+    }
+
+    public string ToJson()
+    {
+        return JsonSerializer.Serialize(this, FrecencyStoreContext.Default.FrecencyStore);
+    }
+
+    public static FrecencyStore FromJson(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+            return new FrecencyStore();
+
+        try
+        {
+            return JsonSerializer.Deserialize(json, FrecencyStoreContext.Default.FrecencyStore)
+                ?? new FrecencyStore();
+        }
+        catch (JsonException ex)
+        {
+            Debug.WriteLine($"FrecencyStore parse failed: {ex.Message}");
+            return new FrecencyStore();
+        }
+    }
+
+    private static string FilePath
+    {
+        get
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Ghostty");
+            Directory.CreateDirectory(dir);
+            return Path.Combine(dir, "command-frecency.json");
+        }
+    }
+
+    public static FrecencyStore Load()
+    {
+        try
+        {
+            var path = FilePath;
+            if (!File.Exists(path)) return new FrecencyStore();
+            var json = File.ReadAllText(path);
+            return FromJson(json);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"FrecencyStore load failed: {ex.Message}");
+            return new FrecencyStore();
+        }
+    }
+
+    public void Save()
+    {
+        try
+        {
+            File.WriteAllText(FilePath, ToJson());
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"FrecencyStore save failed: {ex.Message}");
+        }
+    }
+}
+
+internal sealed class FrecencyEntry
+{
+    public int UseCount { get; set; }
+    public DateTime LastUsed { get; set; }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(FrecencyStore))]
+internal partial class FrecencyStoreContext : JsonSerializerContext
+{
+}

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -19,6 +19,7 @@ namespace Ghostty.Core.Interop;
 // to "return false" in GhosttyHost.OnAction.
 internal enum GhosttyActionTag
 {
+    ToggleCommandPalette = 11,
     Scrollbar = 26,
     SetTitle = 32,
     CloseWindow = 49,

--- a/windows/Ghostty.Tests/Commands/ActionAutoCompleterTests.cs
+++ b/windows/Ghostty.Tests/Commands/ActionAutoCompleterTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using Ghostty.Commands;
+using Xunit;
+
+namespace Ghostty.Tests.Commands;
+
+public class ActionAutoCompleterTests
+{
+    private static ActionAutoCompleter CreateCompleter()
+    {
+        return new ActionAutoCompleter(new Dictionary<string, ActionSchema>
+        {
+            ["new_split"] = new()
+            {
+                Name = "new_split",
+                Description = "Create a new split pane",
+                Parameters = ["right", "down", "left", "up"],
+                RequiresParameter = true,
+            },
+            ["new_tab"] = new()
+            {
+                Name = "new_tab",
+                Description = "Open a new tab",
+                Parameters = null,
+                RequiresParameter = false,
+            },
+            ["new_window"] = new()
+            {
+                Name = "new_window",
+                Description = "Open a new window",
+                Parameters = null,
+                RequiresParameter = false,
+            },
+            ["goto_tab"] = new()
+            {
+                Name = "goto_tab",
+                Description = "Jump to a specific tab",
+                Parameters = ["1", "2", "3", "previous", "next", "last"],
+                RequiresParameter = true,
+            },
+            ["reset"] = new()
+            {
+                Name = "reset",
+                Description = "Reset the terminal",
+                Parameters = null,
+                RequiresParameter = false,
+            },
+        });
+    }
+
+    [Fact]
+    public void Complete_EmptyInput_ReturnsAllActions()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("");
+        Assert.Equal(5, result.Suggestions.Count);
+    }
+
+    [Fact]
+    public void Complete_Prefix_FiltersActions()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("new");
+        Assert.Equal(3, result.Suggestions.Count);
+        Assert.All(result.Suggestions, s => Assert.StartsWith("new", s.Name));
+    }
+
+    [Fact]
+    public void Complete_ExactMatch_NoParameter_ShowsAction()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("reset");
+        Assert.Single(result.Suggestions);
+        Assert.Equal("reset", result.Suggestions[0].Name);
+    }
+
+    [Fact]
+    public void Complete_ColonPrefix_ShowsParameters()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("new_split:");
+        Assert.Equal(4, result.Suggestions.Count);
+        Assert.Contains(result.Suggestions, s => s.Name == "right");
+    }
+
+    [Fact]
+    public void Complete_ColonWithPartialParam_FiltersParameters()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("new_split:r");
+        Assert.Single(result.Suggestions);
+        Assert.Equal("right", result.Suggestions[0].Name);
+    }
+
+    [Fact]
+    public void Complete_UnknownAction_ReturnsEmpty()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("nonexistent");
+        Assert.Empty(result.Suggestions);
+    }
+
+    [Fact]
+    public void Complete_GhostText_ShowsTopSuggestion()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("new");
+        Assert.NotNull(result.GhostText);
+    }
+
+    [Fact]
+    public void Complete_ColonOnNoParamAction_ReturnsEmpty()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("reset:");
+        Assert.Empty(result.Suggestions);
+    }
+
+    [Fact]
+    public void IsValid_CompleteAction_ReturnsTrue()
+    {
+        var c = CreateCompleter();
+        Assert.True(c.IsValid("reset"));
+        Assert.True(c.IsValid("new_split:right"));
+    }
+
+    [Fact]
+    public void IsValid_IncompleteRequired_ReturnsFalse()
+    {
+        var c = CreateCompleter();
+        Assert.False(c.IsValid("new_split"));
+        Assert.False(c.IsValid("new_split:bogus"));
+    }
+
+    [Fact]
+    public void IsValid_Unknown_ReturnsFalse()
+    {
+        var c = CreateCompleter();
+        Assert.False(c.IsValid("does_not_exist"));
+    }
+}

--- a/windows/Ghostty.Tests/Commands/FrecencyStoreTests.cs
+++ b/windows/Ghostty.Tests/Commands/FrecencyStoreTests.cs
@@ -1,0 +1,83 @@
+using System;
+using Ghostty.Commands;
+using Xunit;
+
+namespace Ghostty.Tests.Commands;
+
+public class FrecencyStoreTests
+{
+    [Fact]
+    public void RecordUse_NewEntry_CreatesWithCountOne()
+    {
+        var store = new FrecencyStore();
+        store.RecordUse("reset");
+        Assert.Equal(1, store.Entries["reset"].UseCount);
+    }
+
+    [Fact]
+    public void RecordUse_ExistingEntry_IncrementsCount()
+    {
+        var store = new FrecencyStore();
+        store.RecordUse("reset");
+        store.RecordUse("reset");
+        Assert.Equal(2, store.Entries["reset"].UseCount);
+    }
+
+    [Fact]
+    public void Score_NeverUsed_ReturnsZero()
+    {
+        var store = new FrecencyStore();
+        Assert.Equal(0.0, store.Score("unknown"));
+    }
+
+    [Fact]
+    public void Score_UsedToday_ReturnsUseCount()
+    {
+        var store = new FrecencyStore();
+        store.RecordUse("reset");
+        store.RecordUse("reset");
+        store.RecordUse("reset");
+        Assert.Equal(3.0, store.Score("reset"), 5);
+    }
+
+    [Fact]
+    public void Score_UsedDaysAgo_Decays()
+    {
+        var store = new FrecencyStore();
+        store.Entries["old"] = new FrecencyEntry
+        {
+            UseCount = 10,
+            LastUsed = DateTime.UtcNow.AddDays(-7),
+        };
+        var score = store.Score("old");
+        Assert.True(score > 4.0 && score < 5.0, $"Expected ~4.78, got {score}");
+    }
+
+    [Fact]
+    public void Serialize_RoundTrips()
+    {
+        var store = new FrecencyStore();
+        store.RecordUse("reset");
+        store.RecordUse("new_tab");
+
+        var json = store.ToJson();
+        var restored = FrecencyStore.FromJson(json);
+
+        Assert.Equal(1, restored.Entries["reset"].UseCount);
+        Assert.Equal(1, restored.Entries["new_tab"].UseCount);
+    }
+
+    [Fact]
+    public void FromJson_InvalidJson_ReturnsEmpty()
+    {
+        var store = FrecencyStore.FromJson("not json");
+        Assert.Empty(store.Entries);
+    }
+
+    [Fact]
+    public void FromJson_Null_ReturnsEmpty()
+    {
+        var store = FrecencyStore.FromJson(null);
+        Assert.Empty(store.Entries);
+    }
+}

--- a/windows/Ghostty/App.xaml
+++ b/windows/Ghostty/App.xaml
@@ -4,8 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:tabs="using:Ghostty.Tabs"
-    xmlns:converters="using:Ghostty.Converters">
+    xmlns:tabs="using:Ghostty.Tabs">
     <!--
       Application.Resources here SHADOWS the framework's automatic
       load of the WinUI 3 controls theme resources unless we
@@ -19,7 +18,6 @@
                 <controls:XamlControlsResources/>
             </ResourceDictionary.MergedDictionaries>
             <tabs:ProgressVisibilityConverter x:Key="ProgressVisibilityConverter"/>
-            <converters:NullToCollapsedConverter x:Key="NullToCollapsed"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/windows/Ghostty/App.xaml
+++ b/windows/Ghostty/App.xaml
@@ -4,7 +4,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:tabs="using:Ghostty.Tabs">
+    xmlns:tabs="using:Ghostty.Tabs"
+    xmlns:converters="using:Ghostty.Converters">
     <!--
       Application.Resources here SHADOWS the framework's automatic
       load of the WinUI 3 controls theme resources unless we
@@ -18,6 +19,7 @@
                 <controls:XamlControlsResources/>
             </ResourceDictionary.MergedDictionaries>
             <tabs:ProgressVisibilityConverter x:Key="ProgressVisibilityConverter"/>
+            <converters:NullToCollapsedConverter x:Key="NullToCollapsed"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Input;
+
+namespace Ghostty.Commands;
+
+internal sealed class BuiltInCommandSource : ICommandSource
+{
+    private readonly Func<PaneAction, Action<CommandItem>> _paneActionFactory;
+    private readonly Func<string, Action<CommandItem>> _bindingActionFactory;
+    private List<CommandItem>? _cache;
+
+    public BuiltInCommandSource(
+        Func<PaneAction, Action<CommandItem>> paneActionFactory,
+        Func<string, Action<CommandItem>> bindingActionFactory)
+    {
+        _paneActionFactory = paneActionFactory;
+        _bindingActionFactory = bindingActionFactory;
+    }
+
+    public IReadOnlyList<CommandItem> GetCommands()
+    {
+        _cache ??= BuildCommands();
+        return _cache;
+    }
+
+    public void Refresh() => _cache = null;
+
+    private List<CommandItem> BuildCommands()
+    {
+        var commands = new List<CommandItem>();
+
+        // PaneAction-backed commands
+        AddPaneCommand(commands, PaneAction.SplitVertical, "Split Vertically", "Split the current pane vertically", CommandCategory.Pane, "\uF57E");
+        AddPaneCommand(commands, PaneAction.SplitHorizontal, "Split Horizontally", "Split the current pane horizontally", CommandCategory.Pane, "\uF57E");
+        AddPaneCommand(commands, PaneAction.NewTab, "New Tab", "Open a new terminal tab", CommandCategory.Tab, "\uE710");
+        AddPaneCommand(commands, PaneAction.CloseActiveProgressive, "Close", "Close active pane, tab, or window", CommandCategory.Tab, "\uE711");
+        AddPaneCommand(commands, PaneAction.NextTab, "Next Tab", "Switch to the next tab", CommandCategory.Tab, "\uE76C");
+        AddPaneCommand(commands, PaneAction.PrevTab, "Previous Tab", "Switch to the previous tab", CommandCategory.Tab, "\uE76B");
+        AddPaneCommand(commands, PaneAction.FocusLeft, "Focus Pane Left", "Move focus to the left pane", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.FocusRight, "Focus Pane Right", "Move focus to the right pane", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.FocusUp, "Focus Pane Up", "Move focus to the pane above", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.FocusDown, "Focus Pane Down", "Move focus to the pane below", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.MoveTabRight, "Move Tab Right", "Move the active tab one position right", CommandCategory.Tab);
+        AddPaneCommand(commands, PaneAction.MoveTabLeft, "Move Tab Left", "Move the active tab one position left", CommandCategory.Tab);
+        AddPaneCommand(commands, PaneAction.ToggleVerticalTabsPinned, "Toggle Vertical Tabs Pinned", "Pin or unpin the vertical tab sidebar", CommandCategory.Tab);
+        AddPaneCommand(commands, PaneAction.ToggleTabLayout, "Toggle Tab Layout", "Switch between horizontal and vertical tab layout", CommandCategory.Tab, "\uE8AB");
+
+        // Binding-action-backed commands
+        AddBindingCommand(commands, "reset", "Reset Terminal", "Reset the terminal to a clean state", CommandCategory.Terminal, "\uE777");
+        AddBindingCommand(commands, "copy_to_clipboard", "Copy to Clipboard", "Copy the current selection to clipboard", CommandCategory.Terminal, "\uE8C8");
+        AddBindingCommand(commands, "paste_from_clipboard", "Paste from Clipboard", "Paste clipboard contents into terminal", CommandCategory.Terminal, "\uE77F");
+        AddBindingCommand(commands, "select_all", "Select All", "Select all terminal content", CommandCategory.Terminal);
+        AddBindingCommand(commands, "increase_font_size:1", "Increase Font Size", "Make terminal text larger", CommandCategory.Terminal, "\uE8E8");
+        AddBindingCommand(commands, "decrease_font_size:1", "Decrease Font Size", "Make terminal text smaller", CommandCategory.Terminal, "\uE71F");
+        AddBindingCommand(commands, "reset_font_size", "Reset Font Size", "Reset font size to default", CommandCategory.Terminal);
+        AddBindingCommand(commands, "clear_screen", "Clear Screen", "Clear the terminal screen and scrollback", CommandCategory.Terminal, "\uE894");
+        AddBindingCommand(commands, "scroll_to_top", "Scroll to Top", "Jump to the top of scrollback", CommandCategory.Terminal);
+        AddBindingCommand(commands, "scroll_to_bottom", "Scroll to Bottom", "Jump to the bottom of scrollback", CommandCategory.Terminal);
+        AddBindingCommand(commands, "open_config", "Open Config", "Open the Ghostty configuration file", CommandCategory.Config, "\uE713");
+        AddBindingCommand(commands, "reload_config", "Reload Config", "Reload configuration from disk", CommandCategory.Config, "\uE72C");
+        AddBindingCommand(commands, "toggle_fullscreen", "Toggle Fullscreen", "Enter or exit fullscreen mode", CommandCategory.Terminal, "\uE740");
+        AddBindingCommand(commands, "equalize_splits", "Equalize Splits", "Make all split panes equal size", CommandCategory.Pane);
+        AddBindingCommand(commands, "toggle_split_zoom", "Toggle Split Zoom", "Zoom the current split to fill the tab", CommandCategory.Pane);
+
+        return commands;
+    }
+
+    private void AddPaneCommand(List<CommandItem> list, PaneAction action, string title,
+        string description, CommandCategory category, string? icon = null)
+    {
+        var shortcut = FindShortcut(action);
+        list.Add(new CommandItem
+        {
+            Id = $"pane:{action}",
+            Title = title,
+            Description = description,
+            ActionKey = action.ToString().ToLowerInvariant(),
+            Category = category,
+            LeadingIcon = icon,
+            Shortcut = shortcut,
+            Execute = _paneActionFactory(action),
+        });
+    }
+
+    private void AddBindingCommand(List<CommandItem> list, string actionKey, string title,
+        string description, CommandCategory category, string? icon = null)
+    {
+        list.Add(new CommandItem
+        {
+            Id = $"binding:{actionKey}",
+            Title = title,
+            Description = description,
+            ActionKey = actionKey,
+            Category = category,
+            LeadingIcon = icon,
+            Execute = _bindingActionFactory(actionKey),
+        });
+    }
+
+    private static KeyBinding? FindShortcut(PaneAction action)
+    {
+        foreach (var b in KeyBindings.Default.All)
+        {
+            if (b.Action == action) return b;
+        }
+        return null;
+    }
+}

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -34,7 +34,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.SplitVertical, "Split Vertically", "Split the current pane vertically", CommandCategory.Pane, "\uF57E");
         AddPaneCommand(commands, PaneAction.SplitHorizontal, "Split Horizontally", "Split the current pane horizontally", CommandCategory.Pane, "\uF57E");
         AddPaneCommand(commands, PaneAction.NewTab, "New Tab", "Open a new terminal tab", CommandCategory.Tab, "\uE710");
-        AddPaneCommand(commands, PaneAction.CloseActiveProgressive, "Close", "Close active pane, tab, or window", CommandCategory.Tab, "\uE711");
+        AddPaneCommand(commands, PaneAction.CloseActiveProgressive, "Close Pane / Tab", "Close active pane; if last pane, close tab; if last tab, close window", CommandCategory.Tab, "\uE711");
         AddPaneCommand(commands, PaneAction.NextTab, "Next Tab", "Switch to the next tab", CommandCategory.Tab, "\uE76C");
         AddPaneCommand(commands, PaneAction.PrevTab, "Previous Tab", "Switch to the previous tab", CommandCategory.Tab, "\uE76B");
         AddPaneCommand(commands, PaneAction.FocusLeft, "Focus Pane Left", "Move focus to the left pane", CommandCategory.Pane);

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -59,9 +59,11 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddBindingCommand(commands, "scroll_to_bottom", "Scroll to Bottom", "Jump to the bottom of scrollback", CommandCategory.Terminal);
         AddBindingCommand(commands, "open_config", "Open Config", "Open the Ghostty configuration file", CommandCategory.Config, "\uE713");
         AddBindingCommand(commands, "reload_config", "Reload Config", "Reload configuration from disk", CommandCategory.Config, "\uE72C");
-        AddBindingCommand(commands, "toggle_fullscreen", "Toggle Fullscreen", "Enter or exit fullscreen mode", CommandCategory.Terminal, "\uE740");
-        AddBindingCommand(commands, "equalize_splits", "Equalize Splits", "Make all split panes equal size", CommandCategory.Pane);
-        AddBindingCommand(commands, "toggle_split_zoom", "Toggle Split Zoom", "Zoom the current split to fill the tab", CommandCategory.Pane);
+        // The following binding actions require apprt-level support that
+        // the Windows port doesn't implement yet. Uncomment as they land:
+        // AddBindingCommand(commands, "toggle_fullscreen", "Toggle Fullscreen", "Enter or exit fullscreen mode", CommandCategory.Terminal, "\uE740");
+        // AddBindingCommand(commands, "equalize_splits", "Equalize Splits", "Make all split panes equal size", CommandCategory.Pane);
+        // AddBindingCommand(commands, "toggle_split_zoom", "Toggle Split Zoom", "Zoom the current split to fill the tab", CommandCategory.Pane);
 
         return commands;
     }

--- a/windows/Ghostty/Commands/CommandItem.cs
+++ b/windows/Ghostty/Commands/CommandItem.cs
@@ -1,0 +1,33 @@
+using System;
+using Windows.UI;
+
+namespace Ghostty.Commands;
+
+internal enum CommandCategory
+{
+    Recent,
+    Tab,
+    Pane,
+    Navigation,
+    Terminal,
+    Search,
+    Config,
+    Custom,
+}
+
+internal record CommandItem
+{
+    public required string Id { get; init; }
+    public required string Title { get; init; }
+    public required string Description { get; init; }
+    public string? Subtitle { get; init; }
+    public string? ActionKey { get; init; }
+    public Input.KeyBinding? Shortcut { get; init; }
+    public CommandCategory Category { get; init; }
+    public Color? LeadingColor { get; init; }
+    public string? LeadingIcon { get; init; }
+    public bool Emphasis { get; init; }
+    public string? Badge { get; init; }
+    public string? PreviewText { get; init; }
+    public required Action<CommandItem> Execute { get; init; }
+}

--- a/windows/Ghostty/Commands/CommandItem.cs
+++ b/windows/Ghostty/Commands/CommandItem.cs
@@ -5,12 +5,10 @@ namespace Ghostty.Commands;
 
 internal enum CommandCategory
 {
-    Recent,
     Tab,
     Pane,
     Navigation,
     Terminal,
-    Search,
     Config,
     Custom,
 }

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -144,13 +144,16 @@ internal partial class CommandPaletteViewModel : ObservableObject
                 (c.ActionKey?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false));
         }
 
-        var sorted = filtered
-            .OrderByDescending(c => _frecency.Score(c.Id))
-            .ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase);
-
         FilteredCommands = _groupByCategory
-            ? sorted.OrderBy(c => c.Category).ThenByDescending(c => _frecency.Score(c.Id)).ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase).ToList()
-            : sorted.ToList();
+            ? filtered
+                .OrderBy(c => c.Category)
+                .ThenByDescending(c => _frecency.Score(c.Id))
+                .ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+            : filtered
+                .OrderByDescending(c => _frecency.Score(c.Id))
+                .ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
         GhostText = null;
         StatusText = FilteredCommands.Count == 1

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Ghostty.Commands;
+
+internal enum PaletteMode
+{
+    Search,
+    CommandLine,
+}
+
+// Suppress MVVMTK0045: this ViewModel is internal and accessed from code-behind,
+// never directly x:Bind'd from XAML, so the WinRT-marshalling AOT concern does not apply.
+#pragma warning disable MVVMTK0045
+internal partial class CommandPaletteViewModel : ObservableObject
+{
+    private readonly IReadOnlyList<ICommandSource> _sources;
+    private readonly FrecencyStore _frecency;
+    private readonly ActionAutoCompleter? _autoCompleter;
+    private readonly bool _groupByCategory;
+    private List<CommandItem> _allCommands = [];
+
+    [ObservableProperty]
+    private bool _isOpen;
+
+    [ObservableProperty]
+    private string _searchText = "";
+
+    [ObservableProperty]
+    private PaletteMode _mode = PaletteMode.Search;
+
+    [ObservableProperty]
+    private bool _isPinned;
+
+    [ObservableProperty]
+    private CommandItem? _selectedCommand;
+
+    [ObservableProperty]
+    private List<CommandItem> _filteredCommands = [];
+
+    [ObservableProperty]
+    private string? _ghostText;
+
+    [ObservableProperty]
+    private string _statusText = "";
+
+    [ObservableProperty]
+    private string _modeLabel = "Search";
+
+    public CommandPaletteViewModel(
+        IReadOnlyList<ICommandSource> sources,
+        FrecencyStore frecency,
+        ActionAutoCompleter? autoCompleter,
+        bool groupByCategory = false)
+    {
+        _sources = sources;
+        _frecency = frecency;
+        _autoCompleter = autoCompleter;
+        _groupByCategory = groupByCategory;
+    }
+
+    public void Open()
+    {
+        foreach (var source in _sources)
+            source.Refresh();
+
+        _allCommands = _sources.SelectMany(s => s.GetCommands()).ToList();
+
+        IsOpen = true;
+        SearchText = "";
+        IsPinned = false;
+        Mode = PaletteMode.Search;
+        ApplyFilter();
+    }
+
+    public void Close()
+    {
+        IsOpen = false;
+        SearchText = "";
+        IsPinned = false;
+        Mode = PaletteMode.Search;
+        FilteredCommands = [];
+        GhostText = null;
+    }
+
+    public void Toggle()
+    {
+        if (IsOpen) Close();
+        else Open();
+    }
+
+    [RelayCommand]
+    public void ExecuteSelectedCommand()
+    {
+        if (SelectedCommand is null) return;
+
+        _frecency.RecordUse(SelectedCommand.Id);
+        SelectedCommand.Execute(SelectedCommand);
+
+        if (IsPinned)
+        {
+            SearchText = "";
+            ApplyFilter();
+        }
+        else
+        {
+            Close();
+        }
+    }
+
+    partial void OnSearchTextChanged(string value)
+    {
+        if (value.StartsWith('>'))
+        {
+            Mode = PaletteMode.CommandLine;
+            ModeLabel = "Command";
+            ApplyCommandLineFilter(value[1..].TrimStart());
+        }
+        else
+        {
+            Mode = PaletteMode.Search;
+            ModeLabel = "Search";
+            ApplyFilter();
+        }
+    }
+
+    private void ApplyFilter()
+    {
+        var query = SearchText;
+        IEnumerable<CommandItem> filtered;
+
+        if (string.IsNullOrEmpty(query))
+        {
+            filtered = _allCommands;
+        }
+        else
+        {
+            filtered = _allCommands.Where(c =>
+                c.Title.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                (c.Subtitle?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (c.ActionKey?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false));
+        }
+
+        var sorted = filtered
+            .OrderByDescending(c => _frecency.Score(c.Id))
+            .ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase);
+
+        FilteredCommands = _groupByCategory
+            ? sorted.OrderBy(c => c.Category).ThenByDescending(c => _frecency.Score(c.Id)).ThenBy(c => c.Title, StringComparer.OrdinalIgnoreCase).ToList()
+            : sorted.ToList();
+
+        GhostText = null;
+        StatusText = FilteredCommands.Count == 1
+            ? "1 command"
+            : $"{FilteredCommands.Count} commands";
+
+        if (FilteredCommands.Count > 0)
+            SelectedCommand = FilteredCommands[0];
+    }
+
+    private void ApplyCommandLineFilter(string input)
+    {
+        if (_autoCompleter is null)
+        {
+            FilteredCommands = [];
+            GhostText = null;
+            StatusText = "No autocomplete available";
+            return;
+        }
+
+        var result = _autoCompleter.Complete(input);
+
+        FilteredCommands = result.Suggestions
+            .Select(s => new CommandItem
+            {
+                Id = $"cmdline:{s.Name}",
+                Title = s.Name,
+                Description = s.Description,
+                ActionKey = s.Name,
+                Category = CommandCategory.Custom,
+                Execute = _ => { },
+            })
+            .ToList();
+
+        GhostText = result.GhostText;
+        StatusText = FilteredCommands.Count == 1
+            ? "1 action"
+            : $"{FilteredCommands.Count} actions";
+
+        if (FilteredCommands.Count > 0)
+            SelectedCommand = FilteredCommands[0];
+    }
+
+    public void AcceptAutocomplete()
+    {
+        if (Mode != PaletteMode.CommandLine || GhostText is null) return;
+        SearchText += GhostText;
+    }
+
+    public void MoveSelectionUp()
+    {
+        if (FilteredCommands.Count == 0) return;
+        var idx = SelectedCommand is not null ? FilteredCommands.IndexOf(SelectedCommand) : 0;
+        idx = Math.Max(0, idx - 1);
+        SelectedCommand = FilteredCommands[idx];
+    }
+
+    public void MoveSelectionDown()
+    {
+        if (FilteredCommands.Count == 0) return;
+        var idx = SelectedCommand is not null ? FilteredCommands.IndexOf(SelectedCommand) : -1;
+        idx = Math.Min(FilteredCommands.Count - 1, idx + 1);
+        SelectedCommand = FilteredCommands[idx];
+    }
+}
+#pragma warning restore MVVMTK0045

--- a/windows/Ghostty/Commands/ConfigCommandSource.cs
+++ b/windows/Ghostty/Commands/ConfigCommandSource.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Commands;
+
+internal sealed class ConfigCommandSource : ICommandSource
+{
+    private readonly Func<string, Action<CommandItem>> _bindingActionFactory;
+
+    public ConfigCommandSource(Func<string, Action<CommandItem>> bindingActionFactory)
+    {
+        _bindingActionFactory = bindingActionFactory;
+    }
+
+    public IReadOnlyList<CommandItem> GetCommands() => [];
+
+    public void Refresh()
+    {
+        // Will call ghostty_config_command_list when interop lands
+    }
+}

--- a/windows/Ghostty/Commands/ConfigCommandSource.cs
+++ b/windows/Ghostty/Commands/ConfigCommandSource.cs
@@ -1,17 +1,9 @@
-using System;
 using System.Collections.Generic;
 
 namespace Ghostty.Commands;
 
 internal sealed class ConfigCommandSource : ICommandSource
 {
-    private readonly Func<string, Action<CommandItem>> _bindingActionFactory;
-
-    public ConfigCommandSource(Func<string, Action<CommandItem>> bindingActionFactory)
-    {
-        _bindingActionFactory = bindingActionFactory;
-    }
-
     public IReadOnlyList<CommandItem> GetCommands() => [];
 
     public void Refresh()

--- a/windows/Ghostty/Commands/ICommandSource.cs
+++ b/windows/Ghostty/Commands/ICommandSource.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Commands;
+
+internal interface ICommandSource
+{
+    IReadOnlyList<CommandItem> GetCommands();
+    void Refresh();
+}

--- a/windows/Ghostty/Commands/JumpCommandSource.cs
+++ b/windows/Ghostty/Commands/JumpCommandSource.cs
@@ -27,6 +27,7 @@ internal sealed class JumpCommandSource : ICommandSource
     private List<CommandItem> BuildCommands()
     {
         var commands = new List<CommandItem>();
+        if (_tabs.Tabs.Count == 0) return commands;
 
         for (int tabIdx = 0; tabIdx < _tabs.Tabs.Count; tabIdx++)
         {

--- a/windows/Ghostty/Commands/JumpCommandSource.cs
+++ b/windows/Ghostty/Commands/JumpCommandSource.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Commands;
+
+internal sealed class JumpCommandSource : ICommandSource
+{
+    private readonly TabManager _tabs;
+    private readonly Action<int, int?> _jumpAction;
+    private List<CommandItem>? _cache;
+
+    public JumpCommandSource(TabManager tabs, Action<int, int?> jumpAction)
+    {
+        _tabs = tabs;
+        _jumpAction = jumpAction;
+    }
+
+    public IReadOnlyList<CommandItem> GetCommands()
+    {
+        _cache ??= BuildCommands();
+        return _cache;
+    }
+
+    public void Refresh() => _cache = null;
+
+    private List<CommandItem> BuildCommands()
+    {
+        var commands = new List<CommandItem>();
+
+        for (int tabIdx = 0; tabIdx < _tabs.Tabs.Count; tabIdx++)
+        {
+            var tab = _tabs.Tabs[tabIdx];
+            var paneCount = tab.PaneHost.PaneCount;
+
+            if (paneCount <= 1)
+            {
+                var capturedTab = tabIdx;
+                commands.Add(new CommandItem
+                {
+                    Id = $"jump:tab{tabIdx}",
+                    Title = $"Focus: {tab.EffectiveTitle}",
+                    Description = $"Switch to tab {tabIdx + 1}",
+                    Category = CommandCategory.Navigation,
+                    LeadingIcon = "\uE737",
+                    Execute = _ => _jumpAction(capturedTab, null),
+                });
+            }
+            else
+            {
+                for (int paneIdx = 0; paneIdx < paneCount; paneIdx++)
+                {
+                    var capturedTab = tabIdx;
+                    var capturedPane = paneIdx;
+                    commands.Add(new CommandItem
+                    {
+                        Id = $"jump:tab{tabIdx}:pane{paneIdx}",
+                        Title = $"Focus: {tab.EffectiveTitle} \u2014 pane {paneIdx + 1}",
+                        Description = $"Switch to tab {tabIdx + 1}, pane {paneIdx + 1}",
+                        Category = CommandCategory.Navigation,
+                        LeadingIcon = "\uE737",
+                        Execute = _ => _jumpAction(capturedTab, capturedPane),
+                    });
+                }
+            }
+        }
+
+        return commands;
+    }
+}

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    CommandPaletteControl: A floating command palette with search, filtered
+    results, and keyboard navigation.
+
+    Layout philosophy: all data binding is done from code-behind via the
+    Bind(CommandPaletteViewModel) method. We deliberately avoid x:Bind here
+    because CommandPaletteViewModel is internal and lives in a different
+    namespace; x:Bind's AOT-generated code would require the type to be
+    public. Code-behind subscribes to PropertyChanged and pushes values
+    into the named UI elements directly.
+
+    The ListView's ItemsSource is also set from code-behind when
+    FilteredCommands changes. The DataTemplate accesses item properties
+    via Tag-forwarding: each container's Tag is set to the CommandItem by
+    code-behind after the items are loaded, so the template can reference
+    named elements that code-behind populates in ContainerContentChanging.
+    For simplicity we use a plain DataTemplate with TextBlock elements that
+    code-behind populates by hooking ContainerContentChanging.
+-->
+<UserControl
+    x:Class="Ghostty.Controls.CommandPalette.CommandPaletteControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Ghostty.Converters"
+    Width="560"
+    HorizontalAlignment="Center"
+    VerticalAlignment="Top">
+
+    <UserControl.Resources>
+        <converters:NullToCollapsedConverter x:Key="NullToCollapsed"/>
+
+        <!--
+            Item template for a single CommandItem row.
+            Elements are populated from code-behind via
+            ContainerContentChanging, not via Binding/x:Bind,
+            because CommandItem is an internal record type.
+
+            Layout: [color-dot] [icon] [title + description] [shortcut]
+        -->
+        <DataTemplate x:Key="CommandItemTemplate">
+            <Grid Height="44" Padding="8,0">
+                <Grid.ColumnDefinitions>
+                    <!-- Leading color dot -->
+                    <ColumnDefinition Width="12"/>
+                    <!-- Leading icon -->
+                    <ColumnDefinition Width="24"/>
+                    <!-- Title + description stack -->
+                    <ColumnDefinition Width="*"/>
+                    <!-- Shortcut -->
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Leading color dot: 8x8 Ellipse, filled from code-behind -->
+                <Ellipse x:Name="LeadingColorDot"
+                         Grid.Column="0"
+                         Width="8" Height="8"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         Visibility="Collapsed"/>
+
+                <!-- Leading icon glyph: 16px FontIcon from LeadingIcon -->
+                <FontIcon x:Name="LeadingIcon"
+                          Grid.Column="1"
+                          FontFamily="{StaticResource SymbolThemeFontFamily}"
+                          FontSize="16"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          Visibility="Collapsed"/>
+
+                <!-- Title + optional description -->
+                <StackPanel Grid.Column="2"
+                            VerticalAlignment="Center"
+                            Spacing="1">
+                    <TextBlock x:Name="ItemTitle"
+                               FontSize="{StaticResource BodyTextBlockFontSize}"
+                               Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                               TextTrimming="CharacterEllipsis"/>
+                    <TextBlock x:Name="ItemDescription"
+                               FontSize="{StaticResource CaptionTextBlockFontSize}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               TextTrimming="CharacterEllipsis"
+                               Visibility="Collapsed"/>
+                </StackPanel>
+
+                <!-- Shortcut hint: simple TextBlock styled as a key cap -->
+                <Border x:Name="ShortcutBorder"
+                        Grid.Column="3"
+                        Padding="6,2"
+                        CornerRadius="4"
+                        Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        VerticalAlignment="Center"
+                        Margin="8,0,0,0"
+                        Visibility="Collapsed">
+                    <TextBlock x:Name="ShortcutText"
+                               FontSize="{StaticResource CaptionTextBlockFontSize}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               FontFamily="Cascadia Code, Consolas, Courier New"/>
+                </Border>
+            </Grid>
+        </DataTemplate>
+
+        <!-- ListViewItem container style: subtle hover/selected states -->
+        <Style x:Key="CommandItemContainerStyle" TargetType="ListViewItem">
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="UseSystemFocusVisuals" Value="True"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListViewItem">
+                        <Grid x:Name="ItemRoot">
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal"/>
+                                    <VisualState x:Name="PointerOver">
+                                        <VisualState.Setters>
+                                            <Setter Target="ItemBg.Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Pressed">
+                                        <VisualState.Setters>
+                                            <Setter Target="ItemBg.Background" Value="{ThemeResource SubtleFillColorTertiaryBrush}"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Selected">
+                                        <VisualState.Setters>
+                                            <Setter Target="ItemBg.Background" Value="{ThemeResource SubtleFillColorTertiaryBrush}"/>
+                                            <Setter Target="SelectionBar.Visibility" Value="Visible"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="PointerOverSelected">
+                                        <VisualState.Setters>
+                                            <Setter Target="ItemBg.Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}"/>
+                                            <Setter Target="SelectionBar.Visibility" Value="Visible"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="PressedSelected">
+                                        <VisualState.Setters>
+                                            <Setter Target="ItemBg.Background" Value="{ThemeResource SubtleFillColorTertiaryBrush}"/>
+                                            <Setter Target="SelectionBar.Visibility" Value="Visible"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+
+                            <Border x:Name="ItemBg"
+                                    Background="Transparent"
+                                    CornerRadius="4"/>
+
+                            <!-- Left accent bar for selected state -->
+                            <Rectangle x:Name="SelectionBar"
+                                       Width="3"
+                                       HorizontalAlignment="Left"
+                                       Fill="{ThemeResource AccentFillColorDefaultBrush}"
+                                       RadiusX="1.5" RadiusY="1.5"
+                                       Visibility="Collapsed"/>
+
+                            <ContentPresenter
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                ContentTransitions="{TemplateBinding ContentTransitions}"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"/>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <!--
+        Outer Border: floating card appearance.
+        ThemeShadow gives depth; AcrylicInAppFillColorDefaultBrush
+        provides the frosted-glass background.
+        CornerRadius=8 matches WinUI 3 flyout conventions.
+    -->
+    <Border x:Name="OuterBorder"
+            CornerRadius="8"
+            BorderThickness="1"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            Background="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
+            Padding="0">
+        <Border.Shadow>
+            <ThemeShadow/>
+        </Border.Shadow>
+
+        <Grid>
+            <Grid.RowDefinitions>
+                <!-- Row 0: Header (mode label + pin button) -->
+                <RowDefinition Height="Auto"/>
+                <!-- Row 1: Search TextBox -->
+                <RowDefinition Height="Auto"/>
+                <!-- Row 2: Separator -->
+                <RowDefinition Height="Auto"/>
+                <!-- Row 3: Results ListView -->
+                <RowDefinition Height="Auto"/>
+                <!-- Row 4: Separator -->
+                <RowDefinition Height="Auto"/>
+                <!-- Row 5: Footer -->
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- ── Row 0: Header ── -->
+            <Grid Grid.Row="0" Padding="12,8,8,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Mode label: "Search" or "Command" -->
+                <TextBlock x:Name="ModeLabel"
+                           Grid.Column="0"
+                           Text="Search"
+                           FontSize="{StaticResource CaptionTextBlockFontSize}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           VerticalAlignment="Center"/>
+
+                <!-- Pin toggle button -->
+                <ToggleButton x:Name="PinButton"
+                              Grid.Column="1"
+                              Width="28" Height="28"
+                              Padding="0"
+                              Background="Transparent"
+                              BorderThickness="0"
+                              ToolTipService.ToolTip="Keep open after executing a command (Pin)"
+                              Checked="OnPinChecked"
+                              Unchecked="OnPinUnchecked">
+                    <!-- Segoe Fluent Icons: U+E718 = Pin -->
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                              Glyph="&#xE718;"
+                              FontSize="14"/>
+                </ToggleButton>
+            </Grid>
+
+            <!-- ── Row 1: Search box ── -->
+            <TextBox x:Name="SearchBox"
+                     Grid.Row="1"
+                     Margin="8,0"
+                     Padding="8,10"
+                     PlaceholderText="Search commands or type &gt; for actions..."
+                     Background="Transparent"
+                     BorderThickness="0"
+                     FontSize="{StaticResource BodyTextBlockFontSize}"
+                     TextChanged="OnSearchTextChanged"
+                     KeyDown="OnSearchKeyDown"
+                     HorizontalAlignment="Stretch"/>
+
+            <!-- ── Row 2: Separator ── -->
+            <Border Grid.Row="2"
+                    Height="1"
+                    Background="{ThemeResource DividerStrokeColorDefaultBrush}"
+                    Margin="0"/>
+
+            <!-- ── Row 3: Results list ── -->
+            <ListView x:Name="ResultsList"
+                      Grid.Row="3"
+                      MaxHeight="320"
+                      SelectionMode="Single"
+                      IsItemClickEnabled="True"
+                      Padding="4,4,4,4"
+                      ItemTemplate="{StaticResource CommandItemTemplate}"
+                      ItemContainerStyle="{StaticResource CommandItemContainerStyle}"
+                      ItemClick="OnItemClick"
+                      SelectionChanged="OnResultsSelectionChanged"
+                      ContainerContentChanging="OnContainerContentChanging"
+                      ScrollViewer.HorizontalScrollMode="Disabled"
+                      ScrollViewer.HorizontalScrollBarVisibility="Hidden"/>
+
+            <!-- ── Row 4: Separator (only shown when footer has content) ── -->
+            <Border x:Name="FooterSeparator"
+                    Grid.Row="4"
+                    Height="1"
+                    Background="{ThemeResource DividerStrokeColorDefaultBrush}"
+                    Margin="0"/>
+
+            <!-- ── Row 5: Footer ── -->
+            <Grid Grid.Row="5" Padding="12,6,12,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Status text: "N commands" / "N actions" -->
+                <TextBlock x:Name="StatusLabel"
+                           Grid.Column="0"
+                           FontSize="{StaticResource CaptionTextBlockFontSize}"
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           VerticalAlignment="Center"/>
+
+                <!-- Shortcut hints: Escape / Enter / Tab -->
+                <TextBlock x:Name="ShortcutHints"
+                           Grid.Column="1"
+                           FontSize="{StaticResource CaptionTextBlockFontSize}"
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           VerticalAlignment="Center"
+                           Text="↑↓ navigate   ↵ run   Esc close"/>
+            </Grid>
+
+            <!--
+                Hidden live region for screen-reader announcements.
+                Sits outside the visual layout at z-order 0 with
+                Width/Height=0 so it consumes no space.
+                AutomationProperties.LiveSetting=Polite ensures
+                changes are announced after the user finishes their
+                current interaction, not immediately (which would be
+                Assertive).
+            -->
+            <TextBlock x:Name="LiveAnnouncer"
+                       Grid.Row="0" Grid.RowSpan="6"
+                       Width="0" Height="0"
+                       Opacity="0"
+                       IsHitTestVisible="False"
+                       AutomationProperties.LiveSetting="Polite"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -64,6 +64,16 @@ internal sealed partial class CommandPaletteControl : UserControl
         SyncAll();
     }
 
+    /// <summary>
+    /// Moves keyboard focus into the search TextBox.
+    /// Called by MainWindow after opening the Popup, because WinUI Popups
+    /// don't automatically move focus into their content.
+    /// </summary>
+    public void FocusSearchBox()
+    {
+        SearchBox.Focus(FocusState.Programmatic);
+    }
+
     // ── ViewModel → UI ────────────────────────────────────────────────────────
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -1,0 +1,354 @@
+using System;
+using System.ComponentModel;
+using Ghostty.Commands;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using Windows.System;
+using Windows.UI;
+
+namespace Ghostty.Controls.CommandPalette;
+
+/// <summary>
+/// Floating command-palette control.
+///
+/// The control is intentionally dumb: it owns only the visual tree and
+/// user-interaction handling. All state lives in <see cref="CommandPaletteViewModel"/>.
+/// The two are connected by <see cref="Bind"/>, which subscribes to
+/// PropertyChanged and pushes ViewModel state into the named XAML elements.
+///
+/// We deliberately avoid x:Bind / DataContext assignment because
+/// <see cref="CommandPaletteViewModel"/> is an <c>internal</c> type and
+/// AOT-safe x:Bind requires public types. Code-behind binding lets the type
+/// stay internal.
+/// </summary>
+internal sealed partial class CommandPaletteControl : UserControl
+{
+    private CommandPaletteViewModel? _vm;
+
+    // Suppress "Event never fired" — fired by WinUI runtime via ContainerContentChanging.
+    public CommandPaletteControl()
+    {
+        InitializeComponent();
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Connects the control to a <see cref="CommandPaletteViewModel"/>.
+    /// May be called multiple times; each call replaces the previous subscription.
+    /// </summary>
+    public void Bind(CommandPaletteViewModel viewModel)
+    {
+        if (_vm is not null)
+            _vm.PropertyChanged -= OnViewModelPropertyChanged;
+
+        _vm = viewModel;
+        _vm.PropertyChanged += OnViewModelPropertyChanged;
+
+        // Sync initial state
+        SyncAll();
+    }
+
+    // ── ViewModel → UI ────────────────────────────────────────────────────────
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // All UI updates must happen on the UI thread.
+        if (DispatcherQueue is null) return;
+
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_vm is null) return;
+
+            switch (e.PropertyName)
+            {
+                case nameof(CommandPaletteViewModel.ModeLabel):
+                    ModeLabel.Text = _vm.ModeLabel;
+                    UpdateFooterHints();
+                    break;
+
+                case nameof(CommandPaletteViewModel.IsPinned):
+                    PinButton.IsChecked = _vm.IsPinned;
+                    break;
+
+                case nameof(CommandPaletteViewModel.SearchText):
+                    // Only sync when ViewModel drives the change (not when
+                    // the TextBox itself fired TextChanged — avoids cursor jump).
+                    if (SearchBox.Text != _vm.SearchText)
+                        SearchBox.Text = _vm.SearchText;
+                    break;
+
+                case nameof(CommandPaletteViewModel.FilteredCommands):
+                    SyncFilteredCommands();
+                    break;
+
+                case nameof(CommandPaletteViewModel.SelectedCommand):
+                    SyncSelectedItem();
+                    break;
+
+                case nameof(CommandPaletteViewModel.StatusText):
+                    StatusLabel.Text = _vm.StatusText;
+                    LiveAnnouncer.Text = _vm.StatusText;
+                    break;
+            }
+        });
+    }
+
+    private void SyncAll()
+    {
+        if (_vm is null) return;
+
+        ModeLabel.Text = _vm.ModeLabel;
+        PinButton.IsChecked = _vm.IsPinned;
+        SearchBox.Text = _vm.SearchText;
+        StatusLabel.Text = _vm.StatusText;
+        SyncFilteredCommands();
+        UpdateFooterHints();
+    }
+
+    private void SyncFilteredCommands()
+    {
+        if (_vm is null) return;
+
+        // Replace ItemsSource with a new list snapshot so WinUI re-creates
+        // the containers and ContainerContentChanging fires for all items.
+        ResultsList.ItemsSource = _vm.FilteredCommands.ToArray();
+
+        SyncSelectedItem();
+    }
+
+    private void SyncSelectedItem()
+    {
+        if (_vm is null) return;
+
+        // Map ViewModel.SelectedCommand back to the ListView's SelectedItem.
+        // The ListView's ItemsSource is a CommandItem[], so we match by index.
+        if (_vm.SelectedCommand is null)
+        {
+            ResultsList.SelectedItem = null;
+            return;
+        }
+
+        var idx = _vm.FilteredCommands.IndexOf(_vm.SelectedCommand);
+        if (idx >= 0 && ResultsList.Items.Count > idx)
+        {
+            ResultsList.SelectedIndex = idx;
+            ResultsList.ScrollIntoView(ResultsList.Items[idx]);
+        }
+    }
+
+    private void UpdateFooterHints()
+    {
+        if (_vm is null) return;
+
+        ShortcutHints.Text = _vm.Mode == PaletteMode.CommandLine
+            ? "Tab autocomplete   ↑↓ navigate   ↵ run   Esc close"
+            : "↑↓ navigate   ↵ run   Esc close";
+    }
+
+    // ── ContainerContentChanging: populate DataTemplate elements ─────────────
+
+    /// <summary>
+    /// Populates the named elements inside each <see cref="CommandItemTemplate"/>
+    /// with data from the corresponding <see cref="CommandItem"/>.
+    ///
+    /// This replaces XAML data-binding: because <see cref="CommandItem"/> is
+    /// <c>internal</c>, x:Bind would require public types, and regular
+    /// {Binding} on a record is fragile with AOT. Code-behind element lookup
+    /// is straightforward and AOT-safe.
+    /// </summary>
+    private void OnContainerContentChanging(
+        ListViewBase sender,
+        ContainerContentChangingEventArgs args)
+    {
+        if (args.Item is not CommandItem item) return;
+
+        // Phase 0 fires synchronously during measure; grab the template root.
+        if (args.ItemContainer.ContentTemplateRoot is not Grid root) return;
+
+        // Color dot
+        if (root.FindName("LeadingColorDot") is Ellipse dot)
+        {
+            if (item.LeadingColor is { } color)
+            {
+                dot.Fill = new SolidColorBrush(
+                    Color.FromArgb(color.A, color.R, color.G, color.B));
+                dot.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                dot.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        // Leading icon glyph
+        if (root.FindName("LeadingIcon") is FontIcon icon)
+        {
+            if (!string.IsNullOrEmpty(item.LeadingIcon))
+            {
+                icon.Glyph = item.LeadingIcon;
+                icon.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                icon.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        // Title
+        if (root.FindName("ItemTitle") is TextBlock title)
+            title.Text = item.Title;
+
+        // Description
+        if (root.FindName("ItemDescription") is TextBlock desc)
+        {
+            if (!string.IsNullOrEmpty(item.Description))
+            {
+                desc.Text = item.Description;
+                desc.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                desc.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        // Shortcut
+        if (root.FindName("ShortcutBorder") is Border shortcutBorder &&
+            root.FindName("ShortcutText") is TextBlock shortcutText)
+        {
+            if (item.Shortcut is { } kb)
+            {
+                shortcutText.Text = FormatKeyBinding(kb);
+                shortcutBorder.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                shortcutBorder.Visibility = Visibility.Collapsed;
+            }
+        }
+    }
+
+    // ── UI → ViewModel ────────────────────────────────────────────────────────
+
+    private void OnSearchTextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_vm is null) return;
+
+        // Push the raw text into the ViewModel; OnSearchTextChanged partial
+        // method there will update Mode, FilteredCommands, etc.
+        _vm.SearchText = SearchBox.Text;
+    }
+
+    private void OnSearchKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (_vm is null) return;
+
+        var ctrl = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
+        var isCtrl = ctrl.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+
+        switch (e.Key)
+        {
+            case VirtualKey.Escape:
+                _vm.Close();
+                e.Handled = true;
+                break;
+
+            case VirtualKey.Enter:
+                _vm.ExecuteSelectedCommand();
+                e.Handled = true;
+                break;
+
+            case VirtualKey.Tab:
+                if (_vm.Mode == PaletteMode.CommandLine)
+                {
+                    _vm.AcceptAutocomplete();
+                    // Sync the TextBox immediately so the cursor lands at end.
+                    SearchBox.Text = _vm.SearchText;
+                    SearchBox.SelectionStart = SearchBox.Text.Length;
+                    e.Handled = true;
+                }
+                break;
+
+            case VirtualKey.Up:
+                _vm.MoveSelectionUp();
+                e.Handled = true;
+                break;
+
+            case VirtualKey.Down:
+                _vm.MoveSelectionDown();
+                e.Handled = true;
+                break;
+
+            case VirtualKey.P when isCtrl:
+                _vm.MoveSelectionUp();
+                e.Handled = true;
+                break;
+
+            case VirtualKey.N when isCtrl:
+                _vm.MoveSelectionDown();
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void OnItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (_vm is null) return;
+        if (e.ClickedItem is CommandItem item)
+        {
+            _vm.SelectedCommand = item;
+            _vm.ExecuteSelectedCommand();
+        }
+    }
+
+    private void OnResultsSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        // When the user clicks a different item without executing, keep the
+        // ViewModel's SelectedCommand in sync so keyboard Enter works on the
+        // visually-selected item.
+        if (_vm is null) return;
+        if (ResultsList.SelectedItem is CommandItem item)
+            _vm.SelectedCommand = item;
+    }
+
+    private void OnPinChecked(object sender, RoutedEventArgs e)
+    {
+        if (_vm is not null) _vm.IsPinned = true;
+    }
+
+    private void OnPinUnchecked(object sender, RoutedEventArgs e)
+    {
+        if (_vm is not null) _vm.IsPinned = false;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Formats a <see cref="Input.KeyBinding"/> into a compact display string
+    /// suitable for the shortcut key-cap, e.g. "Ctrl+Shift+P".
+    /// </summary>
+    private static string FormatKeyBinding(Input.KeyBinding kb)
+    {
+        var parts = new System.Collections.Generic.List<string>();
+
+        if (kb.Modifiers.HasFlag(VirtualKeyModifiers.Control)) parts.Add("Ctrl");
+        if (kb.Modifiers.HasFlag(VirtualKeyModifiers.Menu))    parts.Add("Alt");
+        if (kb.Modifiers.HasFlag(VirtualKeyModifiers.Shift))   parts.Add("Shift");
+        if (kb.Modifiers.HasFlag(VirtualKeyModifiers.Windows)) parts.Add("Win");
+
+        // Convert VirtualKey to a display name.
+        var key = kb.Key.ToString();
+
+        // Trim "Number" prefix from digit keys (VirtualKey.Number0 → "0")
+        if (key.StartsWith("Number", StringComparison.Ordinal))
+            key = key["Number".Length..];
+
+        parts.Add(key);
+        return string.Join("+", parts);
+    }
+}

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -49,7 +49,18 @@ internal sealed partial class CommandPaletteControl : UserControl
         _vm = viewModel;
         _vm.PropertyChanged += OnViewModelPropertyChanged;
 
-        // Sync initial state
+        // Defer initial sync until the control is loaded into the visual tree.
+        // Setting ItemsSource on a ListView that hasn't been measured yet throws
+        // ArgumentException from WinUI's ItemsControl.
+        if (IsLoaded)
+            SyncAll();
+        else
+            Loaded += OnFirstLoaded;
+    }
+
+    private void OnFirstLoaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnFirstLoaded;
         SyncAll();
     }
 

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -216,10 +216,13 @@ internal sealed partial class CommandPaletteControl : UserControl
         if (args.Item is not CommandItem item) return;
 
         // Phase 0 fires synchronously during measure; grab the template root.
-        if (args.ItemContainer.ContentTemplateRoot is not Grid root) return;
+        // Children are indexed by column order in the DataTemplate:
+        //   [0] Ellipse  [1] FontIcon  [2] StackPanel  [3] Border>TextBlock
+        if (args.ItemContainer.ContentTemplateRoot is not Grid root || root.Children.Count < 4)
+            return;
 
-        // Color dot
-        if (root.FindName("LeadingColorDot") is Ellipse dot)
+        // Color dot (column 0)
+        if (root.Children[0] is Ellipse dot)
         {
             if (item.LeadingColor is { } color)
             {
@@ -233,8 +236,8 @@ internal sealed partial class CommandPaletteControl : UserControl
             }
         }
 
-        // Leading icon glyph
-        if (root.FindName("LeadingIcon") is FontIcon icon)
+        // Leading icon glyph (column 1)
+        if (root.Children[1] is FontIcon icon)
         {
             if (!string.IsNullOrEmpty(item.LeadingIcon))
             {
@@ -247,31 +250,33 @@ internal sealed partial class CommandPaletteControl : UserControl
             }
         }
 
-        // Title
-        if (root.FindName("ItemTitle") is TextBlock title)
-            title.Text = item.Title;
-
-        // Description
-        if (root.FindName("ItemDescription") is TextBlock desc)
+        // Title + Description (column 2 = StackPanel with 2 TextBlocks)
+        if (root.Children[2] is StackPanel stack && stack.Children.Count >= 2)
         {
-            if (!string.IsNullOrEmpty(item.Description))
+            if (stack.Children[0] is TextBlock title)
+                title.Text = item.Title;
+
+            if (stack.Children[1] is TextBlock desc)
             {
-                desc.Text = item.Description;
-                desc.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                desc.Visibility = Visibility.Collapsed;
+                if (!string.IsNullOrEmpty(item.Description))
+                {
+                    desc.Text = item.Description;
+                    desc.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    desc.Visibility = Visibility.Collapsed;
+                }
             }
         }
 
-        // Shortcut
-        if (root.FindName("ShortcutBorder") is Border shortcutBorder &&
-            root.FindName("ShortcutText") is TextBlock shortcutText)
+        // Shortcut (column 3 = Border containing TextBlock)
+        if (root.Children[3] is Border shortcutBorder)
         {
             if (item.Shortcut is { } kb)
             {
-                shortcutText.Text = FormatKeyBinding(kb);
+                if (shortcutBorder.Child is TextBlock shortcutText)
+                    shortcutText.Text = FormatKeyBinding(kb);
                 shortcutBorder.Visibility = Visibility.Visible;
             }
             else

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -125,9 +125,13 @@ internal sealed partial class CommandPaletteControl : UserControl
     {
         if (_vm is null) return;
 
-        // Replace ItemsSource with a new list snapshot so WinUI re-creates
-        // the containers and ContainerContentChanging fires for all items.
-        ResultsList.ItemsSource = _vm.FilteredCommands.ToArray();
+        // WinUI's ItemsSource setter throws ArgumentException for internal
+        // types because the XAML runtime can't access them via reflection.
+        // Use Items.Clear() + Add() instead — the ContainerContentChanging
+        // handler populates the template elements from the CommandItem.
+        ResultsList.Items.Clear();
+        foreach (var cmd in _vm.FilteredCommands)
+            ResultsList.Items.Add(cmd);
 
         SyncSelectedItem();
     }

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -74,6 +74,29 @@ internal sealed partial class CommandPaletteControl : UserControl
         SearchBox.Focus(FocusState.Programmatic);
     }
 
+    /// <summary>
+    /// Applies the configured background material to the outer Border.
+    ///
+    /// Supported values:
+    ///   "acrylic" (default) — in-app acrylic via <c>AcrylicInAppFillColorDefaultBrush</c>.
+    ///     This is the frosted-glass translucent look that uses the WinUI acrylic brush.
+    ///     In high contrast mode, WinUI's ThemeResource automatically substitutes a
+    ///     solid system color so no special handling is needed.
+    ///   "mica"    — Mica is a window-level SystemBackdrop, not a per-element brush.
+    ///     For individual control surfaces we approximate it with the solid base fill
+    ///     (<c>SolidBackgroundFillColorBaseBrush</c>).
+    ///   "opaque"  — fully opaque solid fill using <c>SolidBackgroundFillColorBaseBrush</c>.
+    /// </summary>
+    public void ApplySettings(string backgroundSetting)
+    {
+        OuterBorder.Background = backgroundSetting switch
+        {
+            "mica" => (Brush)Application.Current.Resources["SolidBackgroundFillColorBaseBrush"],
+            "opaque" => (Brush)Application.Current.Resources["SolidBackgroundFillColorBaseBrush"],
+            _ => (Brush)Application.Current.Resources["AcrylicInAppFillColorDefaultBrush"],
+        };
+    }
+
     // ── ViewModel → UI ────────────────────────────────────────────────────────
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -22,6 +22,13 @@ namespace Ghostty.Controls;
 /// </summary>
 public sealed partial class TerminalControl : UserControl
 {
+    /// <summary>
+    /// Set by MainWindow when the command palette opens/closes. When true,
+    /// OnKeyDown returns immediately so keystrokes go to the palette's
+    /// TextBox instead of libghostty.
+    /// </summary>
+    internal static bool CommandPaletteIsOpen { get; set; }
+
     // Handles ------------------------------------------------------------
 
     private GhosttySurface _surface;
@@ -567,6 +574,8 @@ public sealed partial class TerminalControl : UserControl
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
+        if (CommandPaletteIsOpen) return;
+
         // Stamp the shared host so VerticalTabHost's hover-expand
         // suppression knows the user is mid-typing and holds back
         // the sidebar pop-open. Unconditional: we want every key

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -25,9 +25,10 @@ public sealed partial class TerminalControl : UserControl
     /// <summary>
     /// Set by MainWindow when the command palette opens/closes. When true,
     /// OnKeyDown returns immediately so keystrokes go to the palette's
-    /// TextBox instead of libghostty.
+    /// TextBox instead of libghostty. Instance-scoped so multi-window
+    /// does not suppress input in unrelated windows.
     /// </summary>
-    internal static bool CommandPaletteIsOpen { get; set; }
+    internal bool CommandPaletteIsOpen { get; set; }
 
     // Handles ------------------------------------------------------------
 

--- a/windows/Ghostty/Converters/NullToCollapsedConverter.cs
+++ b/windows/Ghostty/Converters/NullToCollapsedConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace Ghostty.Converters;
+
+/// <summary>
+/// Returns <see cref="Visibility.Collapsed"/> when the value is
+/// <c>null</c> or an empty string, and <see cref="Visibility.Visible"/>
+/// otherwise.
+/// </summary>
+internal sealed partial class NullToCollapsedConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object parameter, string language) =>
+        value is null or "" ? Visibility.Collapsed : Visibility.Visible;
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -41,6 +41,8 @@ internal sealed class GhosttyHost : IDisposable
 
     internal void NoteKeystroke() => LastKeystrokeTimestamp = DateTime.UtcNow;
 
+    public event EventHandler? CommandPaletteToggleRequested;
+
     private ClipboardBridge? _clipboardBridge;
 
     // Delegates must be retained as fields; P/Invoke hands out native
@@ -189,6 +191,11 @@ internal sealed class GhosttyHost : IDisposable
         var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
         switch (tag)
         {
+            case GhosttyActionTag.ToggleCommandPalette:
+                _dispatcher.TryEnqueue(() =>
+                    CommandPaletteToggleRequested?.Invoke(this, EventArgs.Empty));
+                return true;
+
             case GhosttyActionTag.SetTitle:
             {
                 var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -124,6 +124,8 @@ internal sealed class KeyBindings
         // Runtime switch between horizontal and vertical tab layouts
         // (Ctrl+Shift+, -- same chord as Edge's vertical tabs toggle).
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, (VirtualKey)188, PaneAction.ToggleTabLayout),
+        // Command palette
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.P, PaneAction.ToggleCommandPalette),
     });
 
     /// <summary>

--- a/windows/Ghostty/Input/PaneAction.cs
+++ b/windows/Ghostty/Input/PaneAction.cs
@@ -32,4 +32,5 @@ internal enum PaneAction
     MoveTabLeft,
     ToggleVerticalTabsPinned,
     ToggleTabLayout,
+    ToggleCommandPalette,
 }

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -49,6 +49,12 @@ internal sealed class PaneActionRouter
     public event EventHandler? ToggleTabLayoutRequested;
 
     /// <summary>
+    /// Raised when the Ctrl+Shift+P chord fires. MainWindow listens
+    /// and shows or hides the command palette overlay.
+    /// </summary>
+    public event EventHandler? CommandPaletteToggleRequested;
+
+    /// <summary>
     /// Raised when the keyboard close chord targets a full-tab close.
     /// MainWindow listens and shows the confirmation dialog (if needed)
     /// before calling <see cref="TabManager.CloseTab"/>.
@@ -101,6 +107,9 @@ internal sealed class PaneActionRouter
                 break;
             case PaneAction.ToggleTabLayout:
                 ToggleTabLayoutRequested?.Invoke(this, EventArgs.Empty);
+                break;
+            case PaneAction.ToggleCommandPalette:
+                CommandPaletteToggleRequested?.Invoke(this, EventArgs.Empty);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(action), action, null);

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -63,6 +63,21 @@ internal sealed class PaneActionRouter
 
     public void Invoke(PaneAction action)
     {
+        // Event-only actions that don't need pane/tab state — handle
+        // before accessing ActiveTab.PaneHost to avoid null/cast issues.
+        switch (action)
+        {
+            case PaneAction.ToggleVerticalTabsPinned:
+                ToggleVerticalTabsPinnedRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ToggleTabLayout:
+                ToggleTabLayoutRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ToggleCommandPalette:
+                CommandPaletteToggleRequested?.Invoke(this, EventArgs.Empty);
+                return;
+        }
+
         var pane = _tabs.ActiveTab.PaneHost;
         var concrete = (PaneHost)pane;
         switch (action)
@@ -102,15 +117,6 @@ internal sealed class PaneActionRouter
                 if (i > 0) _tabs.Move(i, i - 1);
                 break;
             }
-            case PaneAction.ToggleVerticalTabsPinned:
-                ToggleVerticalTabsPinnedRequested?.Invoke(this, EventArgs.Empty);
-                break;
-            case PaneAction.ToggleTabLayout:
-                ToggleTabLayoutRequested?.Invoke(this, EventArgs.Empty);
-                break;
-            case PaneAction.ToggleCommandPalette:
-                CommandPaletteToggleRequested?.Invoke(this, EventArgs.Empty);
-                break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(action), action, null);
         }

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -3,6 +3,7 @@
     x:Class="Ghostty.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:cmdpalette="using:Ghostty.Controls.CommandPalette"
     Title="Ghostty">
 
     <!--
@@ -111,6 +112,15 @@
               Grid.Column="1"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"/>
+
+        <!-- Command palette popup overlay -->
+        <Popup x:Name="CommandPalettePopup"
+               IsLightDismissEnabled="True"
+               ShouldConstrainToRootBounds="True"
+               Grid.Row="0" Grid.RowSpan="2"
+               Grid.Column="0" Grid.ColumnSpan="2">
+            <cmdpalette:CommandPaletteControl x:Name="CommandPaletteUI"/>
+        </Popup>
 
     </Grid>
 </Window>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -61,6 +61,7 @@ public sealed partial class MainWindow : Window
     private readonly TaskbarHost _taskbar;
 
     private CommandPaletteViewModel? _commandPaletteVm;
+    private FrecencyStore? _frecencyStore;
     private Controls.TerminalControl? _previousFocusSurface;
 
     // Dedup guard for KeyboardAccelerator double-dispatch. WinUI 3
@@ -206,6 +207,21 @@ public sealed partial class MainWindow : Window
 
         _commandPaletteVm = CreateCommandPaletteViewModel();
         CommandPaletteUI.Bind(_commandPaletteVm);
+
+        // When the ViewModel closes itself (e.g. after executing a command),
+        // sync the Popup and focus state.
+        _commandPaletteVm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(CommandPaletteViewModel.IsOpen) && !_commandPaletteVm.IsOpen)
+            {
+                CommandPalettePopup.IsOpen = false;
+                Controls.TerminalControl.CommandPaletteIsOpen = false;
+                _frecencyStore.Save();
+                _previousFocusSurface?.Focus(FocusState.Programmatic);
+            }
+        };
+
+        // When the Popup is light-dismissed (click outside), sync the ViewModel.
         CommandPalettePopup.Closed += (_, _) =>
         {
             _commandPaletteVm.Close();
@@ -420,7 +436,8 @@ public sealed partial class MainWindow : Window
 
     private CommandPaletteViewModel CreateCommandPaletteViewModel()
     {
-        var frecency = FrecencyStore.Load();
+        _frecencyStore = FrecencyStore.Load();
+        var frecency = _frecencyStore;
 
         var builtIn = new BuiltInCommandSource(
             paneActionFactory: action => _ => _router.Invoke(action),

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -458,16 +458,19 @@ public sealed partial class MainWindow : Window
         _frecencyStore = FrecencyStore.Load();
         var frecency = _frecencyStore;
 
+        // Defer command execution to the next dispatcher tick so the
+        // palette closes first, avoiding visual tree contention between
+        // Popup teardown and PaneHost Rebuild (e.g. close-pane).
         var builtIn = new BuiltInCommandSource(
-            paneActionFactory: action => _ => _router.Invoke(action),
-            bindingActionFactory: actionKey => _ => ExecuteBindingAction(actionKey));
+            paneActionFactory: action => _ => DispatcherQueue.TryEnqueue(() => _router.Invoke(action)),
+            bindingActionFactory: actionKey => _ => DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)));
 
         var jump = new JumpCommandSource(
             _tabManager,
-            jumpAction: (tabIdx, _) => _tabManager.JumpTo(tabIdx));
+            jumpAction: (tabIdx, _) => DispatcherQueue.TryEnqueue(() => _tabManager.JumpTo(tabIdx)));
 
         var config = new ConfigCommandSource(
-            bindingActionFactory: actionKey => _ => ExecuteBindingAction(actionKey));
+            bindingActionFactory: actionKey => _ => DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)));
 
         var sources = new List<ICommandSource> { builtIn, jump, config };
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -208,6 +208,7 @@ public sealed partial class MainWindow : Window
 
         _commandPaletteVm = CreateCommandPaletteViewModel();
         CommandPaletteUI.Bind(_commandPaletteVm);
+        CommandPaletteUI.ApplySettings(_uiSettings.CommandPaletteBackground);
 
         // When the ViewModel closes itself (e.g. after executing a command),
         // sync the Popup and focus state. Guard: only act once per close.

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
+using Ghostty.Commands;
+using Ghostty.Controls;
 using Ghostty.Core.Tabs;
 using Ghostty.Dialogs;
 using Ghostty.Hosting;
 using Ghostty.Input;
+using Ghostty.Interop;
 using Ghostty.Panes;
 using Ghostty.Settings;
 using Ghostty.Shell;
@@ -54,6 +59,9 @@ public sealed partial class MainWindow : Window
     private readonly LayoutCoordinator _layout;
     private readonly TitleBarCoordinator _titleBar;
     private readonly TaskbarHost _taskbar;
+
+    private CommandPaletteViewModel? _commandPaletteVm;
+    private Controls.TerminalControl? _previousFocusSurface;
 
     // Dedup guard for KeyboardAccelerator double-dispatch. WinUI 3
     // fires accelerator Invoked twice for a single key event when the
@@ -195,6 +203,18 @@ public sealed partial class MainWindow : Window
         };
 
         InstallPaneAccelerators();
+
+        _commandPaletteVm = CreateCommandPaletteViewModel();
+        CommandPaletteUI.Bind(_commandPaletteVm);
+        CommandPalettePopup.Closed += (_, _) =>
+        {
+            _commandPaletteVm.Close();
+            Controls.TerminalControl.CommandPaletteIsOpen = false;
+            _previousFocusSurface?.Focus(FocusState.Programmatic);
+        };
+
+        _host.CommandPaletteToggleRequested += (_, _) =>
+            DispatcherQueue.TryEnqueue(ToggleCommandPalette);
 
         _tabManager.LastTabClosed += (_, _) => Close();
 
@@ -365,5 +385,98 @@ public sealed partial class MainWindow : Window
         // Runtime tab-layout switch via Ctrl+Shift+Alt+V (and the
         // title-bar icon + context menu, which share the event path).
         _router.ToggleTabLayoutRequested += (_, _) => ToggleTabLayout();
+
+        _router.CommandPaletteToggleRequested += (_, _) => ToggleCommandPalette();
+    }
+
+    private void ToggleCommandPalette()
+    {
+        if (_commandPaletteVm!.IsOpen)
+        {
+            _commandPaletteVm.Close();
+            CommandPalettePopup.IsOpen = false;
+            Controls.TerminalControl.CommandPaletteIsOpen = false;
+            _previousFocusSurface?.Focus(FocusState.Programmatic);
+        }
+        else
+        {
+            _previousFocusSurface = FocusManager.GetFocusedElement(Content.XamlRoot) as Controls.TerminalControl;
+
+            var windowWidth = AppWindow.Size.Width;
+            var paletteWidth = Math.Min(600, windowWidth * 0.9);
+            CommandPalettePopup.HorizontalOffset = (windowWidth - paletteWidth) / 2;
+            CommandPalettePopup.VerticalOffset = 48;
+            CommandPaletteUI.Width = paletteWidth;
+
+            _commandPaletteVm.Open();
+            CommandPalettePopup.IsOpen = true;
+            Controls.TerminalControl.CommandPaletteIsOpen = true;
+        }
+    }
+
+    private CommandPaletteViewModel CreateCommandPaletteViewModel()
+    {
+        var frecency = FrecencyStore.Load();
+
+        var builtIn = new BuiltInCommandSource(
+            paneActionFactory: action => _ => _router.Invoke(action),
+            bindingActionFactory: actionKey => _ => ExecuteBindingAction(actionKey));
+
+        var jump = new JumpCommandSource(
+            _tabManager,
+            jumpAction: (tabIdx, _) => _tabManager.JumpTo(tabIdx));
+
+        var config = new ConfigCommandSource(
+            bindingActionFactory: actionKey => _ => ExecuteBindingAction(actionKey));
+
+        var sources = new List<ICommandSource> { builtIn, jump, config };
+
+        // Build the action autocompleter with a minimal set of action schemas.
+        var schemas = new Dictionary<string, ActionSchema>
+        {
+            ["reset"] = new() { Name = "reset", Description = "Reset the terminal", RequiresParameter = false },
+            ["copy_to_clipboard"] = new() { Name = "copy_to_clipboard", Description = "Copy selection to clipboard", RequiresParameter = false },
+            ["paste_from_clipboard"] = new() { Name = "paste_from_clipboard", Description = "Paste from clipboard", RequiresParameter = false },
+            ["select_all"] = new() { Name = "select_all", Description = "Select all terminal content", RequiresParameter = false },
+            ["increase_font_size"] = new() { Name = "increase_font_size", Description = "Increase font size", RequiresParameter = true, Parameters = ["1", "2"] },
+            ["decrease_font_size"] = new() { Name = "decrease_font_size", Description = "Decrease font size", RequiresParameter = true, Parameters = ["1", "2"] },
+            ["reset_font_size"] = new() { Name = "reset_font_size", Description = "Reset font size to default", RequiresParameter = false },
+            ["clear_screen"] = new() { Name = "clear_screen", Description = "Clear screen and scrollback", RequiresParameter = false },
+            ["scroll_to_top"] = new() { Name = "scroll_to_top", Description = "Scroll to top of scrollback", RequiresParameter = false },
+            ["scroll_to_bottom"] = new() { Name = "scroll_to_bottom", Description = "Scroll to bottom", RequiresParameter = false },
+            ["open_config"] = new() { Name = "open_config", Description = "Open configuration file", RequiresParameter = false },
+            ["reload_config"] = new() { Name = "reload_config", Description = "Reload configuration", RequiresParameter = false },
+            ["toggle_fullscreen"] = new() { Name = "toggle_fullscreen", Description = "Toggle fullscreen mode", RequiresParameter = false },
+            ["equalize_splits"] = new() { Name = "equalize_splits", Description = "Equalize split panes", RequiresParameter = false },
+            ["toggle_split_zoom"] = new() { Name = "toggle_split_zoom", Description = "Zoom current split", RequiresParameter = false },
+        };
+
+        var autoCompleter = new ActionAutoCompleter(schemas);
+
+        return new CommandPaletteViewModel(
+            sources,
+            frecency,
+            autoCompleter,
+            groupByCategory: _uiSettings.CommandPaletteGroupCommands);
+    }
+
+    private void ExecuteBindingAction(string actionKey)
+    {
+        var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
+        if (leaf is null) return;
+
+        var terminal = leaf.Terminal();
+        var surfaceHandle = terminal.SurfaceHandle;
+        if (surfaceHandle == IntPtr.Zero) return;
+
+        var surface = new GhosttySurface(surfaceHandle);
+        var actionBytes = Encoding.UTF8.GetBytes(actionKey);
+        unsafe
+        {
+            fixed (byte* p = actionBytes)
+            {
+                NativeMethods.SurfaceBindingAction(surface, p, (UIntPtr)actionBytes.Length);
+            }
+        }
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -63,6 +63,7 @@ public sealed partial class MainWindow : Window
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
     private Controls.TerminalControl? _previousFocusSurface;
+    private bool _paletteClosing;
 
     // Dedup guard for KeyboardAccelerator double-dispatch. WinUI 3
     // fires accelerator Invoked twice for a single key event when the
@@ -209,21 +210,34 @@ public sealed partial class MainWindow : Window
         CommandPaletteUI.Bind(_commandPaletteVm);
 
         // When the ViewModel closes itself (e.g. after executing a command),
-        // sync the Popup and focus state.
+        // sync the Popup and focus state. Guard: only act once per close.
         _commandPaletteVm.PropertyChanged += (_, e) =>
         {
-            if (e.PropertyName == nameof(CommandPaletteViewModel.IsOpen) && !_commandPaletteVm.IsOpen)
+            if (e.PropertyName != nameof(CommandPaletteViewModel.IsOpen)) return;
+            if (_commandPaletteVm.IsOpen) return;
+
+            // Prevent Popup.Closed from re-entering.
+            _paletteClosing = true;
+            try
             {
                 CommandPalettePopup.IsOpen = false;
                 Controls.TerminalControl.CommandPaletteIsOpen = false;
-                _frecencyStore.Save();
-                _previousFocusSurface?.Focus(FocusState.Programmatic);
+                _frecencyStore?.Save();
+
+                // Don't focus a surface that may have just been disposed
+                // by the command we executed (e.g. close pane).
+                // Let the tab/pane system handle focus naturally.
+            }
+            finally
+            {
+                _paletteClosing = false;
             }
         };
 
         // When the Popup is light-dismissed (click outside), sync the ViewModel.
         CommandPalettePopup.Closed += (_, _) =>
         {
+            if (_paletteClosing) return; // already handled by PropertyChanged
             _commandPaletteVm.Close();
             Controls.TerminalControl.CommandPaletteIsOpen = false;
             _previousFocusSurface?.Focus(FocusState.Programmatic);
@@ -409,10 +423,15 @@ public sealed partial class MainWindow : Window
     {
         if (_commandPaletteVm!.IsOpen)
         {
-            _commandPaletteVm.Close();
-            CommandPalettePopup.IsOpen = false;
-            Controls.TerminalControl.CommandPaletteIsOpen = false;
-            _previousFocusSurface?.Focus(FocusState.Programmatic);
+            _paletteClosing = true;
+            try
+            {
+                _commandPaletteVm.Close();
+                CommandPalettePopup.IsOpen = false;
+                Controls.TerminalControl.CommandPaletteIsOpen = false;
+                _previousFocusSurface?.Focus(FocusState.Programmatic);
+            }
+            finally { _paletteClosing = false; }
         }
         else
         {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -236,12 +236,21 @@ public sealed partial class MainWindow : Window
         };
 
         // When the Popup is light-dismissed (click outside), sync the ViewModel.
+        // For command-execution closes, _paletteClosing prevents re-entry, but
+        // Popup.Closed may fire asynchronously after the flag resets. Use
+        // _commandPaletteVm.IsOpen as the definitive check — if the ViewModel
+        // already closed, we only need to restore focus for light-dismiss.
         CommandPalettePopup.Closed += (_, _) =>
         {
-            if (_paletteClosing) return; // already handled by PropertyChanged
+            if (_paletteClosing) return;
+            var wasCommandExecution = !_commandPaletteVm.IsOpen;
             _commandPaletteVm.Close();
             Controls.TerminalControl.CommandPaletteIsOpen = false;
-            _previousFocusSurface?.Focus(FocusState.Programmatic);
+            // Only restore previous focus for light-dismiss (Escape, click outside).
+            // For command execution, let the command's own focus handling win
+            // (e.g., PaneHost focuses the new split pane).
+            if (!wasCommandExecution)
+                _previousFocusSurface?.Focus(FocusState.Programmatic);
         };
 
         _host.CommandPaletteToggleRequested += (_, _) =>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using Ghostty.Dialogs;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Interop;
+using Ghostty.Core.Panes;
 using Ghostty.Panes;
 using Ghostty.Settings;
 using Ghostty.Shell;
@@ -63,7 +64,13 @@ public sealed partial class MainWindow : Window
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
     private Controls.TerminalControl? _previousFocusSurface;
-    private bool _paletteClosing;
+
+    /// <summary>
+    /// Palette close state: prevents re-entrant close handling between
+    /// ViewModel.PropertyChanged and Popup.Closed callbacks.
+    /// </summary>
+    private enum PaletteCloseState { Idle, ClosingFromCommand, ClosingFromToggle }
+    private PaletteCloseState _paletteCloseState;
 
     // Dedup guard for KeyboardAccelerator double-dispatch. WinUI 3
     // fires accelerator Invoked twice for a single key event when the
@@ -211,18 +218,18 @@ public sealed partial class MainWindow : Window
         CommandPaletteUI.ApplySettings(_uiSettings.CommandPaletteBackground);
 
         // When the ViewModel closes itself (e.g. after executing a command),
-        // sync the Popup and focus state. Guard: only act once per close.
+        // sync the Popup and focus state.
         _commandPaletteVm.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName != nameof(CommandPaletteViewModel.IsOpen)) return;
             if (_commandPaletteVm.IsOpen) return;
+            if (_paletteCloseState != PaletteCloseState.Idle) return;
 
-            // Prevent Popup.Closed from re-entering.
-            _paletteClosing = true;
+            _paletteCloseState = PaletteCloseState.ClosingFromCommand;
             try
             {
                 CommandPalettePopup.IsOpen = false;
-                Controls.TerminalControl.CommandPaletteIsOpen = false;
+                SetCommandPaletteOpenOnAllTerminals(false);
                 _frecencyStore?.Save();
 
                 // Don't focus a surface that may have just been disposed
@@ -231,26 +238,31 @@ public sealed partial class MainWindow : Window
             }
             finally
             {
-                _paletteClosing = false;
+                _paletteCloseState = PaletteCloseState.Idle;
             }
         };
 
         // When the Popup is light-dismissed (click outside), sync the ViewModel.
-        // For command-execution closes, _paletteClosing prevents re-entry, but
-        // Popup.Closed may fire asynchronously after the flag resets. Use
-        // _commandPaletteVm.IsOpen as the definitive check — if the ViewModel
-        // already closed, we only need to restore focus for light-dismiss.
         CommandPalettePopup.Closed += (_, _) =>
         {
-            if (_paletteClosing) return;
-            var wasCommandExecution = !_commandPaletteVm.IsOpen;
-            _commandPaletteVm.Close();
-            Controls.TerminalControl.CommandPaletteIsOpen = false;
-            // Only restore previous focus for light-dismiss (Escape, click outside).
-            // For command execution, let the command's own focus handling win
-            // (e.g., PaneHost focuses the new split pane).
-            if (!wasCommandExecution)
-                _previousFocusSurface?.Focus(FocusState.Programmatic);
+            if (_paletteCloseState != PaletteCloseState.Idle) return;
+
+            _paletteCloseState = PaletteCloseState.ClosingFromCommand;
+            try
+            {
+                var wasOpen = _commandPaletteVm.IsOpen;
+                _commandPaletteVm.Close();
+                SetCommandPaletteOpenOnAllTerminals(false);
+                // Only restore previous focus for light-dismiss (Escape, click outside).
+                // For command execution, let the command's own focus handling win
+                // (e.g., PaneHost focuses the new split pane).
+                if (wasOpen)
+                    _previousFocusSurface?.Focus(FocusState.Programmatic);
+            }
+            finally
+            {
+                _paletteCloseState = PaletteCloseState.Idle;
+            }
         };
 
         _host.CommandPaletteToggleRequested += (_, _) =>
@@ -431,17 +443,19 @@ public sealed partial class MainWindow : Window
 
     private void ToggleCommandPalette()
     {
-        if (_commandPaletteVm!.IsOpen)
+        if (_commandPaletteVm is not { } vm) return;
+
+        if (vm.IsOpen)
         {
-            _paletteClosing = true;
+            _paletteCloseState = PaletteCloseState.ClosingFromToggle;
             try
             {
-                _commandPaletteVm.Close();
+                vm.Close();
                 CommandPalettePopup.IsOpen = false;
-                Controls.TerminalControl.CommandPaletteIsOpen = false;
+                SetCommandPaletteOpenOnAllTerminals(false);
                 _previousFocusSurface?.Focus(FocusState.Programmatic);
             }
-            finally { _paletteClosing = false; }
+            finally { _paletteCloseState = PaletteCloseState.Idle; }
         }
         else
         {
@@ -453,13 +467,23 @@ public sealed partial class MainWindow : Window
             CommandPalettePopup.VerticalOffset = 48;
             CommandPaletteUI.Width = paletteWidth;
 
-            _commandPaletteVm.Open();
+            vm.Open();
             CommandPalettePopup.IsOpen = true;
-            Controls.TerminalControl.CommandPaletteIsOpen = true;
+            SetCommandPaletteOpenOnAllTerminals(true);
 
             // WinUI Popups don't auto-focus their content. Dispatch the
             // focus call so it runs after the Popup finishes layout.
             DispatcherQueue.TryEnqueue(() => CommandPaletteUI.FocusSearchBox());
+        }
+    }
+
+    private void SetCommandPaletteOpenOnAllTerminals(bool isOpen)
+    {
+        foreach (var tab in _tabManager.Tabs)
+        {
+            var paneHost = (Panes.PaneHost)tab.PaneHost;
+            foreach (var leaf in PaneTree.Leaves(paneHost.RootNode))
+                leaf.Terminal().CommandPaletteIsOpen = isOpen;
         }
     }
 
@@ -479,8 +503,7 @@ public sealed partial class MainWindow : Window
             _tabManager,
             jumpAction: (tabIdx, _) => DispatcherQueue.TryEnqueue(() => _tabManager.JumpTo(tabIdx)));
 
-        var config = new ConfigCommandSource(
-            bindingActionFactory: actionKey => _ => DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)));
+        var config = new ConfigCommandSource();
 
         var sources = new List<ICommandSource> { builtIn, jump, config };
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -411,6 +411,10 @@ public sealed partial class MainWindow : Window
             _commandPaletteVm.Open();
             CommandPalettePopup.IsOpen = true;
             Controls.TerminalControl.CommandPaletteIsOpen = true;
+
+            // WinUI Popups don't auto-focus their content. Dispatch the
+            // focus call so it runs after the Popup finishes layout.
+            DispatcherQueue.TryEnqueue(() => CommandPaletteUI.FocusSearchBox());
         }
     }
 

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -128,6 +128,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public LeafPane ActiveLeaf => _activeLeaf;
 
+    internal PaneNode RootNode => _root;
+
     /// <summary>
     /// Number of leaves in the tree. Implemented via a tree walk; the
     /// trees are tiny (typically &lt;10 leaves) so this is cheap.

--- a/windows/Ghostty/Settings/UiSettings.cs
+++ b/windows/Ghostty/Settings/UiSettings.cs
@@ -26,6 +26,8 @@ namespace Ghostty.Settings;
 internal sealed class UiSettings
 {
     public bool VerticalTabs { get; set; }
+    public bool CommandPaletteGroupCommands { get; set; }
+    public string CommandPaletteBackground { get; set; } = "acrylic";
 
     private static string FilePath
     {


### PR DESCRIPTION
## Summary

- Native WinUI 3 command palette with fuzzy search, command-line mode (`>` prefix with autocomplete), frecency ranking, and configurable theming
- ~29 built-in commands (pane/tab/terminal ops) + jump commands (switch between surfaces) + config entries (stub for `command-palette-entry` interop)
- Popup overlay anchored top-center, Acrylic background, styled key caps for shortcuts, pin toggle
- Wired via existing KeyboardAccelerator/PaneActionRouter system + new `toggle_command_palette` apprt action (ordinal 11)
- 19 new unit tests (FrecencyStore + ActionAutoCompleter), 116 total tests passing

## New files (15)
- `Commands/`: CommandItem, ICommandSource, BuiltInCommandSource, JumpCommandSource, ConfigCommandSource, CommandPaletteViewModel
- `Ghostty.Core/Commands/`: FrecencyStore, ActionAutoCompleter
- `Controls/CommandPalette/`: CommandPaletteControl.xaml/.cs
- `Converters/`: NullToCollapsedConverter
- Tests: FrecencyStoreTests, ActionAutoCompleterTests

## Modified files (9)
- PaneAction, KeyBindings, PaneActionRouter — ToggleCommandPalette + Ctrl+Shift+P
- UiSettings — command-palette-group-commands, command-palette-background
- GhosttyActions — ordinal 11
- GhosttyHost — CommandPaletteToggleRequested event
- MainWindow.xaml/.cs — Popup + wiring
- TerminalControl — CommandPaletteIsOpen guard

## Known issues
- Close pane leaves ghost visual — pre-existing bug in `windows` branch, tracked in #185
- Config command source is a stub (returns empty) until `ghostty_config_command_list` interop is wired
- ViewModel tests skipped (WinUI project can't be referenced from headless test runner)

## Test plan
- [ ] Ctrl+Shift+P opens palette with all commands listed
- [ ] Typing filters the list, Escape closes
- [ ] Enter executes selected command, palette closes
- [ ] `>` prefix enters command-line mode with autocomplete
- [ ] Tab accepts autocomplete suggestion
- [ ] Pin toggle keeps palette open after execution
- [ ] Frecency persists across sessions (`%APPDATA%\Ghostty\command-frecency.json`)
- [ ] High contrast mode: text readable, key caps visible

