### PR TITLE
feat(windows): configuration management with live reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 *.log
 .DS_Store
 .vscode/
+.vs/
+
+# .NET build output
+**/bin/
+**/obj/
 .direnv/
 .envrc.local
 .flatpak-builder/

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@
 .vscode/
 .vs/
 
-# .NET build output
-**/bin/
-**/obj/
+# .NET build output (scoped to windows/ to avoid masking Zig build paths)
+windows/**/bin/
+windows/**/obj/
 .direnv/
 .envrc.local
 .flatpak-builder/

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3664,6 +3664,8 @@ else
 /// changes on disk. Uses a platform-specific file watcher (e.g.
 /// FileSystemWatcher on Windows). When false, config is only
 /// reloaded via explicit keybind or menu action.
+///
+/// Available since: 1.1.1
 @"auto-reload-config": bool = false,
 
 /// Enable the built-in Settings UI on Windows. On other platforms,
@@ -3671,6 +3673,8 @@ else
 /// opens the config file in the default editor (matching macOS
 /// behavior). When true, opens the built-in settings window with
 /// structured editing.
+///
+/// Available since: 1.1.1
 @"windows-settings-ui": bool = false,
 
 /// If `true` (default), applications running in the terminal can show desktop

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3660,6 +3660,19 @@ else
 /// Available since: 1.1.0
 @"gtk-custom-css": RepeatablePath = .{},
 
+/// Automatically reload the configuration when the config file
+/// changes on disk. Uses a platform-specific file watcher (e.g.
+/// FileSystemWatcher on Windows). When false, config is only
+/// reloaded via explicit keybind or menu action.
+@"auto-reload-config": bool = false,
+
+/// Enable the built-in Settings UI on Windows. On other platforms,
+/// this option has no effect. When false, the "open config" action
+/// opens the config file in the default editor (matching macOS
+/// behavior). When true, opens the built-in settings window with
+/// structured editing.
+@"windows-settings-ui": bool = false,
+
 /// If `true` (default), applications running in the terminal can show desktop
 /// notifications using certain escape sequences such as OSC 9 or OSC 777.
 @"desktop-notifications": bool = true,

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -23,7 +23,7 @@ pub const Options = struct {
 pub fn config(alloc: Allocator, opts: Options) ![]u8 {
     return try dir(alloc, opts, .{
         .env = "XDG_CONFIG_HOME",
-        .windows_env = "LOCALAPPDATA",
+        .windows_env = "APPDATA",
         .default_subdir = ".config",
     });
 }
@@ -69,7 +69,8 @@ fn dir(
 
     // First check the env var. On Windows we have to allocate so this tracks
     // both whether we have the env var and whether we own it.
-    // on Windows we treat `LOCALAPPDATA` as a fallback for `XDG_CONFIG_HOME`
+    // on Windows we treat `APPDATA` (config) or `LOCALAPPDATA` (cache/state)
+    // as a fallback for the corresponding XDG variable
     const env_ = try env_os.getenvNotEmpty(alloc, internal_opts.env) orelse switch (builtin.os.tag) {
         else => null,
         .windows => try env_os.getenvNotEmpty(alloc, internal_opts.windows_env),

--- a/windows/Ghostty.Core/Config/ConfigFileParser.cs
+++ b/windows/Ghostty.Core/Config/ConfigFileParser.cs
@@ -1,0 +1,73 @@
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Pure-logic operations on ghostty config file lines.
+/// Works on string arrays (the caller handles file I/O).
+/// Ghostty uses last-wins semantics for duplicate keys.
+/// </summary>
+public static class ConfigFileParser
+{
+    /// <summary>
+    /// Find the index of the last uncommented line matching the key.
+    /// Returns -1 if not found.
+    /// </summary>
+    public static int FindLastUncommented(string[] lines, string key)
+    {
+        for (int i = lines.Length - 1; i >= 0; i--)
+        {
+            var parsed = ConfigLine.Parse(lines[i]);
+            if (!parsed.IsComment && parsed.Key == key)
+                return i;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Set a value for a key. Replaces the last uncommented occurrence
+    /// or appends at the end if the key doesn't exist.
+    /// </summary>
+    public static string[] SetValue(string[] lines, string key, string value)
+    {
+        var index = FindLastUncommented(lines, key);
+        var result = new string[index >= 0 ? lines.Length : lines.Length + 1];
+        Array.Copy(lines, result, lines.Length);
+
+        if (index >= 0)
+        {
+            result[index] = $"{key} = {value}";
+        }
+        else
+        {
+            result[lines.Length] = $"{key} = {value}";
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Comment out all uncommented occurrences of a key.
+    /// </summary>
+    public static string[] RemoveValue(string[] lines, string key)
+    {
+        var result = new string[lines.Length];
+        Array.Copy(lines, result, lines.Length);
+
+        for (int i = 0; i < result.Length; i++)
+        {
+            var parsed = ConfigLine.Parse(result[i]);
+            if (!parsed.IsComment && parsed.Key == key)
+                result[i] = "# " + result[i];
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Append a keybind line. Keybindings accumulate (don't override).
+    /// </summary>
+    public static string[] SetKeybind(string[] lines, string bindingValue)
+    {
+        var result = new string[lines.Length + 1];
+        Array.Copy(lines, result, lines.Length);
+        result[lines.Length] = $"keybind = {bindingValue}";
+        return result;
+    }
+}

--- a/windows/Ghostty.Core/Config/ConfigLine.cs
+++ b/windows/Ghostty.Core/Config/ConfigLine.cs
@@ -1,0 +1,30 @@
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Parsed representation of a single line from a ghostty config file.
+/// The format is: key = value (one per line, # for comments).
+/// </summary>
+public readonly record struct ConfigLine(
+    string? Key,
+    string? Value,
+    bool IsComment,
+    bool IsEmpty)
+{
+    public static ConfigLine Parse(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return new ConfigLine(null, null, false, true);
+
+        var trimmed = raw.TrimStart();
+        if (trimmed.StartsWith('#'))
+            return new ConfigLine(null, null, true, false);
+
+        var eqIndex = trimmed.IndexOf('=');
+        if (eqIndex < 0)
+            return new ConfigLine(null, null, false, false);
+
+        var key = trimmed[..eqIndex].TrimEnd();
+        var value = trimmed[(eqIndex + 1)..].TrimStart();
+        return new ConfigLine(key, value, false, false);
+    }
+}

--- a/windows/Ghostty.Core/Config/IConfigFileEditor.cs
+++ b/windows/Ghostty.Core/Config/IConfigFileEditor.cs
@@ -1,0 +1,29 @@
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Reads and writes the ghostty config file on disk.
+/// Supports surgical "sniper edit" (modify one key, preserve
+/// everything else) and raw full-file read/write.
+/// </summary>
+public interface IConfigFileEditor
+{
+    /// <summary>Path to the config file being edited.</summary>
+    string FilePath { get; }
+
+    /// <summary>Read the entire config file as a string.</summary>
+    string ReadAll();
+
+    /// <summary>
+    /// Set a config value. If the key already exists (uncommented),
+    /// replaces the last occurrence. Otherwise appends at the end.
+    /// </summary>
+    void SetValue(string key, string value);
+
+    /// <summary>
+    /// Comment out all uncommented occurrences of a key (prefix with "# ").
+    /// </summary>
+    void RemoveValue(string key);
+
+    /// <summary>Write raw text content to the config file atomically.</summary>
+    void WriteRaw(string content);
+}

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Owns the libghostty config lifecycle: load, reload, and
+/// change notification. Consumers subscribe to ConfigChanged
+/// and re-read values they care about.
+/// </summary>
+public interface IConfigService : IDisposable
+{
+    /// <summary>Fired on the UI thread after a successful config reload.</summary>
+    event Action<IConfigService>? ConfigChanged;
+
+    /// <summary>Path to the active config file.</summary>
+    string ConfigFilePath { get; }
+
+    /// <summary>Whether auto-reload-config is enabled.</summary>
+    bool AutoReloadEnabled { get; }
+
+    /// <summary>Whether windows-settings-ui is enabled.</summary>
+    bool SettingsUiEnabled { get; }
+
+    /// <summary>
+    /// Re-read config from disk and apply it. Returns true on
+    /// success, false if the reload failed (old config stays active).
+    /// </summary>
+    bool Reload();
+
+    /// <summary>
+    /// Temporarily suppress or resume file-system watcher events.
+    /// Call with true before writing to the config file, false after,
+    /// to avoid a redundant reload from your own save.
+    /// </summary>
+    void SuppressWatcher(bool suppress);
+
+    /// <summary>Number of diagnostics from the last load/reload.</summary>
+    int DiagnosticsCount { get; }
+
+    /// <summary>Get diagnostic message at the given index.</summary>
+    string GetDiagnostic(int index);
+}

--- a/windows/Ghostty.Core/Config/IKeyBindingsProvider.cs
+++ b/windows/Ghostty.Core/Config/IKeyBindingsProvider.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Binding entry for display in UI. Action is the ghostty action
+/// name (e.g. "new_tab"), KeyCombo is the human-readable chord
+/// (e.g. "Ctrl+Shift+T"), Source indicates default vs user override.
+/// </summary>
+public readonly record struct BindingEntry(
+    string Action,
+    string KeyCombo,
+    string Source);
+
+public interface IKeyBindingsProvider
+{
+    /// <summary>All current bindings for UI display.</summary>
+    IReadOnlyList<BindingEntry> All { get; }
+
+    /// <summary>Get the key combo for a given action, or null.</summary>
+    string? GetBinding(string action);
+
+    /// <summary>Search bindings by action name or key combo substring.</summary>
+    IReadOnlyList<BindingEntry> Search(string query);
+}

--- a/windows/Ghostty.Core/Config/IThemeProvider.cs
+++ b/windows/Ghostty.Core/Config/IThemeProvider.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Provides resolved theme values from config. Colors are
+/// represented as uint (ARGB) to avoid WinUI dependencies
+/// in Ghostty.Core.
+/// </summary>
+public interface IThemeProvider
+{
+    uint BackgroundColor { get; }
+    uint ForegroundColor { get; }
+    uint CursorColor { get; }
+    uint SelectionColor { get; }
+    double BackgroundOpacity { get; }
+    string? FontFamily { get; }
+    double FontSize { get; }
+    string? ThemeName { get; }
+
+    /// <summary>Available theme names (bundled + user).</summary>
+    IReadOnlyList<string> AvailableThemes { get; }
+}

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -22,6 +22,8 @@ internal enum GhosttyActionTag
     ToggleCommandPalette = 11,
     Scrollbar = 26,
     SetTitle = 32,
+    OpenConfig = 40,
+    ReloadConfig = 47,
     CloseWindow = 49,
     RingBell = 50,
     ProgressReport = 56,

--- a/windows/Ghostty.Tests/Config/ConfigFileParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigFileParserTests.cs
@@ -1,0 +1,70 @@
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public class ConfigFileParserTests
+{
+    [Fact]
+    public void SetValue_ExistingKey_ReplacesLastOccurrence()
+    {
+        var lines = new[] { "font-size = 12", "# a comment", "font-size = 14" };
+        var result = ConfigFileParser.SetValue(lines, "font-size", "16");
+        Assert.Equal("font-size = 12", result[0]);
+        Assert.Equal("# a comment", result[1]);
+        Assert.Equal("font-size = 16", result[2]);
+    }
+
+    [Fact]
+    public void SetValue_NewKey_AppendsAtEnd()
+    {
+        var lines = new[] { "font-size = 14" };
+        var result = ConfigFileParser.SetValue(lines, "background", "#000000");
+        Assert.Equal(2, result.Length);
+        Assert.Equal("font-size = 14", result[0]);
+        Assert.Equal("background = #000000", result[1]);
+    }
+
+    [Fact]
+    public void RemoveValue_CommentsOutAllOccurrences()
+    {
+        var lines = new[] { "font-size = 12", "background = #000000", "font-size = 14" };
+        var result = ConfigFileParser.RemoveValue(lines, "font-size");
+        Assert.Equal("# font-size = 12", result[0]);
+        Assert.Equal("background = #000000", result[1]);
+        Assert.Equal("# font-size = 14", result[2]);
+    }
+
+    [Fact]
+    public void SetValue_SkipsCommentedOccurrences()
+    {
+        var lines = new[] { "# font-size = 12", "font-size = 14" };
+        var result = ConfigFileParser.SetValue(lines, "font-size", "16");
+        Assert.Equal("# font-size = 12", result[0]);
+        Assert.Equal("font-size = 16", result[1]);
+    }
+
+    [Fact]
+    public void SetKeybind_AppendsNewLine()
+    {
+        var lines = new[] { "keybind = ctrl+shift+t=new_tab" };
+        var result = ConfigFileParser.SetKeybind(lines, "ctrl+shift+d=new_split:right");
+        Assert.Equal(2, result.Length);
+        Assert.Equal("keybind = ctrl+shift+t=new_tab", result[0]);
+        Assert.Equal("keybind = ctrl+shift+d=new_split:right", result[1]);
+    }
+
+    [Fact]
+    public void FindLastUncommented_ReturnsCorrectIndex()
+    {
+        var lines = new[] { "font-size = 12", "# font-size = 10", "font-size = 14", "background = #000000" };
+        Assert.Equal(2, ConfigFileParser.FindLastUncommented(lines, "font-size"));
+    }
+
+    [Fact]
+    public void FindLastUncommented_ReturnsNegativeOneWhenNotFound()
+    {
+        var lines = new[] { "# font-size = 12", "background = #000000" };
+        Assert.Equal(-1, ConfigFileParser.FindLastUncommented(lines, "font-size"));
+    }
+}

--- a/windows/Ghostty.Tests/Config/ConfigLineTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigLineTests.cs
@@ -1,0 +1,58 @@
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public class ConfigLineTests
+{
+    [Fact]
+    public void ParseKeyValue()
+    {
+        var line = ConfigLine.Parse("font-size = 14");
+        Assert.Equal("font-size", line.Key);
+        Assert.Equal("14", line.Value);
+        Assert.False(line.IsComment);
+        Assert.False(line.IsEmpty);
+    }
+
+    [Fact]
+    public void ParseComment()
+    {
+        var line = ConfigLine.Parse("# font-size = 14");
+        Assert.True(line.IsComment);
+        Assert.Null(line.Key);
+    }
+
+    [Fact]
+    public void ParseEmpty()
+    {
+        var line = ConfigLine.Parse("");
+        Assert.True(line.IsEmpty);
+        Assert.Null(line.Key);
+    }
+
+    [Fact]
+    public void ParseNoSpaces()
+    {
+        var line = ConfigLine.Parse("font-size=14");
+        Assert.Equal("font-size", line.Key);
+        Assert.Equal("14", line.Value);
+    }
+
+    [Fact]
+    public void ParseValueWithEquals()
+    {
+        var line = ConfigLine.Parse("keybind = ctrl+shift+t=new_tab");
+        Assert.Equal("keybind", line.Key);
+        Assert.Equal("ctrl+shift+t=new_tab", line.Value);
+    }
+
+    [Fact]
+    public void ParseValueWithTrailingHash()
+    {
+        // Ghostty does NOT support inline comments, so # is part of the value
+        var line = ConfigLine.Parse("background = #1e1e2e");
+        Assert.Equal("background", line.Key);
+        Assert.Equal("#1e1e2e", line.Value);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Ghostty.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 
 namespace Ghostty;
@@ -127,7 +129,9 @@ public partial class App : Application
             // Jump list is nice-to-have; failure here does not block startup.
         }
 
-        _window = new MainWindow();
+        var configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
+
+        _window = new MainWindow(configService);
         _window.Activate();
     }
 }

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -42,6 +42,8 @@ internal sealed class GhosttyHost : IDisposable
     internal void NoteKeystroke() => LastKeystrokeTimestamp = DateTime.UtcNow;
 
     public event EventHandler? CommandPaletteToggleRequested;
+    public event EventHandler? OpenConfigRequested;
+    public event EventHandler? ReloadConfigRequested;
 
     private ClipboardBridge? _clipboardBridge;
 
@@ -62,15 +64,10 @@ internal sealed class GhosttyHost : IDisposable
 
     public GhosttyApp App => _app;
 
-    public GhosttyHost(DispatcherQueue dispatcher)
+    public GhosttyHost(DispatcherQueue dispatcher, GhosttyConfig config)
     {
         _dispatcher = dispatcher;
-
-        NativeMethods.Init(UIntPtr.Zero, IntPtr.Zero);
-
-        _config = NativeMethods.ConfigNew();
-        NativeMethods.ConfigLoadDefaultFiles(_config);
-        NativeMethods.ConfigFinalize(_config);
+        _config = config;
 
         _wakeupCb = OnWakeup;
         _actionCb = OnAction;
@@ -129,7 +126,7 @@ internal sealed class GhosttyHost : IDisposable
         // teardown miss the lookup and become harmless no-ops.
         _surfaces.Clear();
         if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
-        if (_config.Handle != IntPtr.Zero) NativeMethods.ConfigFree(_config);
+        // Config lifetime is owned by ConfigService; do not free here.
         _app = default;
         _config = default;
         _wakeupCb = null;
@@ -181,14 +178,35 @@ internal sealed class GhosttyHost : IDisposable
         // handle silently misses every dictionary lookup.
         if (actionPtr == IntPtr.Zero || targetPtr == IntPtr.Zero) return false;
 
+        // ghostty_action_s layout: { int32 tag; <union> action; }
+        // Union starts at offset 8 (8-byte aligned on x64).
+        var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
         var targetTag = Marshal.ReadInt32(targetPtr);
+        // App-level actions (target = GHOSTTY_TARGET_APP) don't carry
+        // a surface handle. Handle them before the surface lookup.
+        if (targetTag == GhosttyTargetApp)
+        {
+            switch (tag)
+            {
+                case GhosttyActionTag.OpenConfig:
+                    _dispatcher.TryEnqueue(() =>
+                        OpenConfigRequested?.Invoke(this, EventArgs.Empty));
+                    return true;
+
+                case GhosttyActionTag.ReloadConfig:
+                    _dispatcher.TryEnqueue(() =>
+                        ReloadConfigRequested?.Invoke(this, EventArgs.Empty));
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
         if (targetTag != GhosttyTargetSurface) return false;
         var surfaceHandle = Marshal.ReadIntPtr(targetPtr, 8);
         if (!_surfaces.TryGetValue(surfaceHandle, out var control)) return false;
 
-        // ghostty_action_s layout: { int32 tag; <union> action; }
-        // Union starts at offset 8 (8-byte aligned on x64).
-        var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
         switch (tag)
         {
             case GhosttyActionTag.ToggleCommandPalette:

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -250,10 +250,10 @@ internal struct GhosttyString
 {
     public IntPtr Ptr;      // const char*
     public UIntPtr Len;
-    // Zig bool is 1 byte. Under LibraryImport source generation with
-    // DisableRuntimeMarshalling, C# bool marshals as 1 byte by default
-    // so no [MarshalAs] annotation is needed.
-    public bool Sentinel;
+    // Zig c.String has a trailing bool (1 byte) for sentinel, but we
+    // only use Ptr and Len. The struct has trailing padding to pointer
+    // alignment so the bool sits in padding space on x64.
+    private byte _sentinel;
 }
 
 [StructLayout(LayoutKind.Sequential)]

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -240,6 +240,31 @@ internal struct GhosttyActionSetTitle
 }
 
 [StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyDiagnostic
+{
+    public IntPtr Message;  // const char*
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyString
+{
+    public IntPtr Ptr;      // const char*
+    public UIntPtr Len;
+    // Zig bool is 1 byte. Under LibraryImport source generation with
+    // DisableRuntimeMarshalling, C# bool marshals as 1 byte by default
+    // so no [MarshalAs] annotation is needed.
+    public bool Sentinel;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyInputTrigger
+{
+    public int Tag;         // 0=physical, 1=unicode, 2=catch_all
+    public uint Key;        // union: translated, physical, or unicode
+    public uint Mods;       // modifier flags
+}
+
+[StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyRuntimeConfig
 {
     public IntPtr Userdata;
@@ -286,6 +311,31 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void ConfigFinalize(GhosttyConfig config);
 
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_clone")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial GhosttyConfig ConfigClone(GhosttyConfig config);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_get")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static partial bool ConfigGet(GhosttyConfig config, IntPtr output, IntPtr key, UIntPtr keyLen);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_trigger")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial GhosttyInputTrigger ConfigTrigger(GhosttyConfig config, IntPtr action, UIntPtr actionLen);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_diagnostics_count")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial uint ConfigDiagnosticsCount(GhosttyConfig config);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_get_diagnostic")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial GhosttyDiagnostic ConfigGetDiagnostic(GhosttyConfig config, uint index);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_open_path")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial GhosttyString ConfigOpenPath();
+
     // ---- app -----------------------------------------------------------
 
     [LibraryImport(Dll, EntryPoint = "ghostty_app_new")]
@@ -307,6 +357,10 @@ internal static partial class NativeMethods
     [LibraryImport(Dll, EntryPoint = "ghostty_app_set_color_scheme")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void AppSetColorScheme(GhosttyApp app, GhosttyColorScheme scheme);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_app_update_config")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void AppUpdateConfig(GhosttyApp app, GhosttyConfig config);
 
     // ---- surface lifecycle ---------------------------------------------
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -7,9 +7,10 @@ using Ghostty.Controls;
 using Ghostty.Core.Tabs;
 using Ghostty.Dialogs;
 using Ghostty.Hosting;
-using Ghostty.Input;
 using Ghostty.Interop;
+using Ghostty.Input;
 using Ghostty.Core.Panes;
+using Ghostty.Services;
 using Ghostty.Panes;
 using Ghostty.Settings;
 using Ghostty.Shell;
@@ -52,6 +53,8 @@ public sealed partial class MainWindow : Window
     private readonly PaneActionRouter _router;
     private readonly DialogTracker _dialogs = new();
     private readonly UiSettings _uiSettings;
+    // Kept as a field so the ColorValuesChanged subscription is not GC'd.
+    private readonly Windows.UI.ViewManagement.UISettings _systemUiSettings;
 
     private readonly TabHost _horizontalTabHost;
     private readonly VerticalTabHost _verticalTabHost;
@@ -104,11 +107,37 @@ public sealed partial class MainWindow : Window
     [LibraryImport("gdi32.dll")]
     private static partial IntPtr CreateSolidBrush(uint crColor);
 
-    public MainWindow()
+    internal MainWindow(ConfigService configService)
     {
         InitializeComponent();
 
-        _host = new GhosttyHost(DispatcherQueue);
+        _host = new GhosttyHost(DispatcherQueue, configService.ConfigHandle);
+        configService.SetApp(_host.App);
+
+        // Detect initial system theme and notify libghostty so conditional
+        // config blocks (e.g. palette dark/light) take effect immediately.
+        // UISettings.Foreground is white in dark mode and black in light mode,
+        // so R > 128 reliably distinguishes the two without needing the UWP
+        // ApplicationTheme enum (which isn't available outside a UWP package).
+        _systemUiSettings = new Windows.UI.ViewManagement.UISettings();
+        var initialFg = _systemUiSettings.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
+        var initialDark = initialFg.R > 128;
+        Ghostty.Interop.NativeMethods.AppSetColorScheme(
+            _host.App,
+            initialDark ? Ghostty.Interop.GhosttyColorScheme.Dark : Ghostty.Interop.GhosttyColorScheme.Light);
+
+        // Subscribe to runtime theme changes. ColorValuesChanged fires on a
+        // background thread, so dispatch back to the UI thread before calling
+        // into libghostty (which expects UI-thread callers for App-level ops).
+        _systemUiSettings.ColorValuesChanged += (s, _) =>
+        {
+            var fg = s.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
+            var dark = fg.R > 128;
+            DispatcherQueue.TryEnqueue(() =>
+                Ghostty.Interop.NativeMethods.AppSetColorScheme(
+                    _host.App,
+                    dark ? Ghostty.Interop.GhosttyColorScheme.Dark : Ghostty.Interop.GhosttyColorScheme.Light));
+        };
 
         // Match the RootGrid background (#0C0C0C). Win32 COLORREF is 0x00BBGGRR.
         var hwnd = WindowNative.GetWindowHandle(this);
@@ -267,6 +296,48 @@ public sealed partial class MainWindow : Window
 
         _host.CommandPaletteToggleRequested += (_, _) =>
             DispatcherQueue.TryEnqueue(ToggleCommandPalette);
+
+        _host.OpenConfigRequested += (_, _) =>
+        {
+            if (configService.SettingsUiEnabled)
+            {
+                var editor = new ConfigFileEditor(configService.ConfigFilePath);
+                var keybindings = new KeyBindingsProvider(configService);
+                var themeProvider = new ThemeProvider(configService);
+                var settingsWin = new Ghostty.Settings.SettingsWindow(
+                    configService, editor, keybindings, themeProvider);
+                settingsWin.Activate();
+                return;
+            }
+
+            var path = configService.ConfigFilePath;
+            if (string.IsNullOrEmpty(path)) return;
+            try
+            {
+                // The config file has no extension so UseShellExecute
+                // may fail to find an associated program. Try shell
+                // execute first (respects user file associations), then
+                // fall back to notepad which can always open text files.
+                try
+                {
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = path,
+                        UseShellExecute = true,
+                    });
+                }
+                catch
+                {
+                    System.Diagnostics.Process.Start("notepad.exe", path);
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Console.Error.WriteLine($"[MainWindow] Failed to open config file: {ex.Message}");
+            }
+        };
+
+        _host.ReloadConfigRequested += (_, _) => configService.Reload();
 
         _tabManager.LastTabClosed += (_, _) => Close();
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -333,7 +333,7 @@ public sealed partial class MainWindow : Window
             }
             catch (System.Exception ex)
             {
-                Console.Error.WriteLine($"[MainWindow] Failed to open config file: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"[MainWindow] Failed to open config file: {ex.Message}");
             }
         };
 

--- a/windows/Ghostty/Services/ConfigFileEditor.cs
+++ b/windows/Ghostty/Services/ConfigFileEditor.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using Ghostty.Core.Config;
+
+namespace Ghostty.Services;
+
+/// <summary>
+/// File I/O wrapper around <see cref="ConfigFileParser"/>.
+/// Reads/writes the config file on disk with atomic writes
+/// (write-to-temp, then rename) to prevent partial reads.
+/// </summary>
+internal sealed class ConfigFileEditor : IConfigFileEditor
+{
+    public string FilePath { get; }
+
+    public ConfigFileEditor(string filePath)
+    {
+        FilePath = filePath;
+    }
+
+    public string ReadAll()
+    {
+        return File.Exists(FilePath) ? File.ReadAllText(FilePath) : string.Empty;
+    }
+
+    public void SetValue(string key, string value)
+    {
+        var lines = ReadLines();
+        var updated = ConfigFileParser.SetValue(lines, key, value);
+        WriteAtomic(updated);
+    }
+
+    public void RemoveValue(string key)
+    {
+        var lines = ReadLines();
+        var updated = ConfigFileParser.RemoveValue(lines, key);
+        WriteAtomic(updated);
+    }
+
+    public void WriteRaw(string content)
+    {
+        WriteAtomic(content);
+    }
+
+    private string[] ReadLines()
+    {
+        return File.Exists(FilePath) ? File.ReadAllLines(FilePath) : Array.Empty<string>();
+    }
+
+    private void WriteAtomic(string[] lines)
+    {
+        // Use \n (not Environment.NewLine) so the config file stays
+        // Unix-style, matching what ghostty's own writer produces and
+        // avoiding issues if the file is shared with WSL or synced
+        // to a non-Windows machine.
+        WriteAtomic(string.Join("\n", lines) + "\n");
+    }
+
+    private void WriteAtomic(string content)
+    {
+        var dir = Path.GetDirectoryName(FilePath);
+        if (dir != null) Directory.CreateDirectory(dir);
+
+        var tmp = FilePath + ".tmp";
+        File.WriteAllText(tmp, content);
+        File.Move(tmp, FilePath, overwrite: true);
+    }
+}

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Ghostty.Core.Config;
+using Ghostty.Interop;
+using Microsoft.UI.Dispatching;
+
+namespace Ghostty.Services;
+
+/// <summary>
+/// Owns the libghostty config lifecycle: init, load from disk,
+/// reload, and file-system watching (behind <c>auto-reload-config</c>).
+/// Fires <see cref="ConfigChanged"/> on the UI thread after every
+/// successful reload so consumers can re-read values they depend on.
+/// </summary>
+internal sealed class ConfigService : IConfigService
+{
+    private GhosttyConfig _config;
+    private GhosttyApp _app;
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounceTimer;
+    private readonly DispatcherQueue _dispatcher;
+    private volatile bool _suppressWatcher;
+
+    public event Action<IConfigService>? ConfigChanged;
+    public string ConfigFilePath { get; }
+    public bool AutoReloadEnabled { get; private set; }
+    public bool SettingsUiEnabled { get; private set; }
+    public int DiagnosticsCount { get; private set; }
+
+    /// <summary>
+    /// The current config handle. Passed to <see cref="GhosttyHost"/>
+    /// so it can create the app with the loaded config.
+    /// </summary>
+    public GhosttyConfig ConfigHandle => _config;
+
+    public ConfigService(DispatcherQueue dispatcher)
+    {
+        _dispatcher = dispatcher;
+
+        NativeMethods.Init(UIntPtr.Zero, IntPtr.Zero);
+
+        _config = NativeMethods.ConfigNew();
+        NativeMethods.ConfigLoadDefaultFiles(_config);
+        NativeMethods.ConfigFinalize(_config);
+
+        var pathStr = NativeMethods.ConfigOpenPath();
+        var rawPath = pathStr.Ptr != IntPtr.Zero
+            ? Marshal.PtrToStringUTF8(pathStr.Ptr, (int)pathStr.Len) ?? string.Empty
+            : string.Empty;
+        // Normalize mixed separators from Zig (forward slash) + Windows
+        // (backslash) so the path looks clean in UI and logs.
+        ConfigFilePath = Path.GetFullPath(rawPath);
+
+        CacheDiagnostics();
+        ReadFlags();
+    }
+
+    /// <summary>
+    /// Must be called after <c>ghostty_app_new()</c> so reloads can
+    /// push the new config into the running app via
+    /// <c>ghostty_app_update_config</c>.
+    /// </summary>
+    public void SetApp(GhosttyApp app)
+    {
+        _app = app;
+        if (AutoReloadEnabled) StartWatcher();
+    }
+
+    public bool Reload()
+    {
+        GhosttyConfig newConfig;
+        try
+        {
+            newConfig = NativeMethods.ConfigNew();
+            NativeMethods.ConfigLoadDefaultFiles(newConfig);
+            NativeMethods.ConfigFinalize(newConfig);
+        }
+        catch
+        {
+            return false;
+        }
+
+        var oldConfig = _config;
+
+        if (_app.Handle != IntPtr.Zero)
+        {
+            NativeMethods.AppUpdateConfig(_app, newConfig);
+        }
+
+        _config = newConfig;
+        CacheDiagnostics();
+        ReadFlags();
+
+        if (oldConfig.Handle != IntPtr.Zero)
+            NativeMethods.ConfigFree(oldConfig);
+
+        _dispatcher.TryEnqueue(() => ConfigChanged?.Invoke(this));
+        return true;
+    }
+
+    public string GetDiagnostic(int index)
+    {
+        if (index < 0 || index >= DiagnosticsCount) return string.Empty;
+        var diag = NativeMethods.ConfigGetDiagnostic(_config, (uint)index);
+        return diag.Message != IntPtr.Zero
+            ? Marshal.PtrToStringUTF8(diag.Message) ?? string.Empty
+            : string.Empty;
+    }
+
+    /// <summary>
+    /// Temporarily suppress or resume file-system watcher events.
+    /// Used by <see cref="ConfigFileEditor"/> during writes so our
+    /// own save does not trigger a redundant reload.
+    /// </summary>
+    public void SuppressWatcher(bool suppress) => _suppressWatcher = suppress;
+
+    private void CacheDiagnostics()
+    {
+        DiagnosticsCount = (int)NativeMethods.ConfigDiagnosticsCount(_config);
+    }
+
+    private void ReadFlags()
+    {
+        AutoReloadEnabled = GetBool("auto-reload-config");
+        SettingsUiEnabled = GetBool("windows-settings-ui");
+    }
+
+    private unsafe bool GetBool(string key)
+    {
+        byte result = 0;
+        var keyBytes = System.Text.Encoding.UTF8.GetBytes(key);
+        fixed (byte* keyPtr = keyBytes)
+        {
+            var found = NativeMethods.ConfigGet(
+                _config,
+                (IntPtr)(&result),
+                (IntPtr)keyPtr,
+                (UIntPtr)keyBytes.Length);
+            return found && result != 0;
+        }
+    }
+
+    private void StartWatcher()
+    {
+        if (_watcher != null) return;
+        var dir = Path.GetDirectoryName(ConfigFilePath);
+        var file = Path.GetFileName(ConfigFilePath);
+        if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(file)) return;
+        if (!Directory.Exists(dir)) return;
+
+        _watcher = new FileSystemWatcher(dir, file)
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime,
+            EnableRaisingEvents = true,
+        };
+        _watcher.Changed += OnFileChanged;
+        _watcher.Created += OnFileChanged;
+        _watcher.Renamed += (s, e) => OnFileChanged(s, e);
+    }
+
+    private void StopWatcher()
+    {
+        if (_watcher == null) return;
+        _watcher.EnableRaisingEvents = false;
+        _watcher.Dispose();
+        _watcher = null;
+    }
+
+    private void OnFileChanged(object? sender, FileSystemEventArgs e)
+    {
+        if (_suppressWatcher) return;
+        _debounceTimer?.Dispose();
+        _debounceTimer = new Timer(_ =>
+        {
+            _dispatcher.TryEnqueue(() => Reload());
+        }, null, 300, Timeout.Infinite);
+    }
+
+    public void Dispose()
+    {
+        StopWatcher();
+        _debounceTimer?.Dispose();
+        if (_config.Handle != IntPtr.Zero)
+            NativeMethods.ConfigFree(_config);
+    }
+}

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -20,6 +21,7 @@ internal sealed class ConfigService : IConfigService
     private GhosttyApp _app;
     private FileSystemWatcher? _watcher;
     private Timer? _debounceTimer;
+    private readonly Lock _timerLock = new();
     private readonly DispatcherQueue _dispatcher;
     private volatile bool _suppressWatcher;
 
@@ -70,6 +72,10 @@ internal sealed class ConfigService : IConfigService
 
     public bool Reload()
     {
+        // Don't reload before the app is created -- the initial config
+        // is the one passed to ghostty_app_new and must stay alive.
+        if (_app.Handle == IntPtr.Zero) return false;
+
         GhosttyConfig newConfig;
         try
         {
@@ -77,17 +83,20 @@ internal sealed class ConfigService : IConfigService
             NativeMethods.ConfigLoadDefaultFiles(newConfig);
             NativeMethods.ConfigFinalize(newConfig);
         }
-        catch
+        catch (Exception ex)
         {
+            Debug.WriteLine($"[ConfigService] Reload failed to create new config: {ex.Message}");
             return false;
         }
 
         var oldConfig = _config;
 
-        if (_app.Handle != IntPtr.Zero)
-        {
-            NativeMethods.AppUpdateConfig(_app, newConfig);
-        }
+        // Suppress the watcher for the duration of the update so our
+        // own config swap doesn't trigger a redundant file-change reload.
+        var wasSuppressed = _suppressWatcher;
+        _suppressWatcher = true;
+
+        NativeMethods.AppUpdateConfig(_app, newConfig);
 
         _config = newConfig;
         CacheDiagnostics();
@@ -95,6 +104,8 @@ internal sealed class ConfigService : IConfigService
 
         if (oldConfig.Handle != IntPtr.Zero)
             NativeMethods.ConfigFree(oldConfig);
+
+        _suppressWatcher = wasSuppressed;
 
         _dispatcher.TryEnqueue(() => ConfigChanged?.Invoke(this));
         return true;
@@ -171,17 +182,23 @@ internal sealed class ConfigService : IConfigService
     private void OnFileChanged(object? sender, FileSystemEventArgs e)
     {
         if (_suppressWatcher) return;
-        _debounceTimer?.Dispose();
-        _debounceTimer = new Timer(_ =>
+        lock (_timerLock)
         {
-            _dispatcher.TryEnqueue(() => Reload());
-        }, null, 300, Timeout.Infinite);
+            _debounceTimer?.Dispose();
+            _debounceTimer = new Timer(_ =>
+            {
+                _dispatcher.TryEnqueue(() => Reload());
+            }, null, 300, Timeout.Infinite);
+        }
     }
 
     public void Dispose()
     {
         StopWatcher();
-        _debounceTimer?.Dispose();
+        lock (_timerLock)
+        {
+            _debounceTimer?.Dispose();
+        }
         if (_config.Handle != IntPtr.Zero)
             NativeMethods.ConfigFree(_config);
     }

--- a/windows/Ghostty/Services/KeyBindingsProvider.cs
+++ b/windows/Ghostty/Services/KeyBindingsProvider.cs
@@ -5,7 +5,7 @@ using Ghostty.Core.Config;
 
 namespace Ghostty.Services;
 
-internal sealed class KeyBindingsProvider : IKeyBindingsProvider
+internal sealed class KeyBindingsProvider : IKeyBindingsProvider, IDisposable
 {
     private readonly IConfigService _configService;
     private List<BindingEntry> _bindings = new();
@@ -35,6 +35,11 @@ internal sealed class KeyBindingsProvider : IKeyBindingsProvider
             .Where(b => b.Action.Contains(query, StringComparison.OrdinalIgnoreCase)
                      || b.KeyCombo.Contains(query, StringComparison.OrdinalIgnoreCase))
             .ToList();
+    }
+
+    public void Dispose()
+    {
+        _configService.ConfigChanged -= OnConfigChanged;
     }
 
     private void OnConfigChanged(IConfigService _) => Refresh();

--- a/windows/Ghostty/Services/KeyBindingsProvider.cs
+++ b/windows/Ghostty/Services/KeyBindingsProvider.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Config;
+
+namespace Ghostty.Services;
+
+internal sealed class KeyBindingsProvider : IKeyBindingsProvider
+{
+    private readonly IConfigService _configService;
+    private List<BindingEntry> _bindings = new();
+
+    public IReadOnlyList<BindingEntry> All => _bindings;
+
+    public KeyBindingsProvider(IConfigService configService)
+    {
+        _configService = configService;
+        _configService.ConfigChanged += OnConfigChanged;
+        Refresh();
+    }
+
+    public string? GetBinding(string action)
+    {
+        foreach (var b in _bindings)
+        {
+            if (b.Action == action) return b.KeyCombo;
+        }
+        return null;
+    }
+
+    public IReadOnlyList<BindingEntry> Search(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return _bindings;
+        return _bindings
+            .Where(b => b.Action.Contains(query, StringComparison.OrdinalIgnoreCase)
+                     || b.KeyCombo.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private void OnConfigChanged(IConfigService _) => Refresh();
+
+    private void Refresh()
+    {
+        // Read bindings from the hardcoded defaults for now.
+        // When ghostty_config_trigger P/Invoke is fully wired,
+        // this will query libghostty for each known action.
+        var entries = new List<BindingEntry>();
+        foreach (var b in Input.KeyBindings.Default.All)
+        {
+            var label = Input.KeyBindings.Default.Label(b.Action);
+            if (label != null)
+            {
+                entries.Add(new BindingEntry(
+                    b.Action.ToString(),
+                    label,
+                    "default"));
+            }
+        }
+        _bindings = entries;
+    }
+}

--- a/windows/Ghostty/Services/ThemeProvider.cs
+++ b/windows/Ghostty/Services/ThemeProvider.cs
@@ -6,7 +6,7 @@ using Ghostty.Core.Config;
 
 namespace Ghostty.Services;
 
-internal sealed class ThemeProvider : IThemeProvider
+internal sealed class ThemeProvider : IThemeProvider, IDisposable
 {
     private readonly IConfigService _configService;
 
@@ -25,6 +25,11 @@ internal sealed class ThemeProvider : IThemeProvider
         _configService = configService;
         _configService.ConfigChanged += OnConfigChanged;
         Refresh();
+    }
+
+    public void Dispose()
+    {
+        _configService.ConfigChanged -= OnConfigChanged;
     }
 
     private void OnConfigChanged(IConfigService _) => Refresh();

--- a/windows/Ghostty/Services/ThemeProvider.cs
+++ b/windows/Ghostty/Services/ThemeProvider.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Ghostty.Core.Config;
+
+namespace Ghostty.Services;
+
+internal sealed class ThemeProvider : IThemeProvider
+{
+    private readonly IConfigService _configService;
+
+    public uint BackgroundColor { get; private set; } = 0xFF1E1E2E;
+    public uint ForegroundColor { get; private set; } = 0xFFCDD6F4;
+    public uint CursorColor { get; private set; } = 0xFFF5E0DC;
+    public uint SelectionColor { get; private set; } = 0xFF585B70;
+    public double BackgroundOpacity { get; private set; } = 1.0;
+    public string? FontFamily { get; private set; }
+    public double FontSize { get; private set; } = 13.0;
+    public string? ThemeName { get; private set; }
+    public IReadOnlyList<string> AvailableThemes { get; private set; } = Array.Empty<string>();
+
+    public ThemeProvider(IConfigService configService)
+    {
+        _configService = configService;
+        _configService.ConfigChanged += OnConfigChanged;
+        Refresh();
+    }
+
+    private void OnConfigChanged(IConfigService _) => Refresh();
+
+    private void Refresh()
+    {
+        // Enumerate theme files from the user themes directory.
+        // Ghostty looks for themes in <config_dir>/themes/<name>.
+        var configDir = Path.GetDirectoryName(_configService.ConfigFilePath);
+        if (string.IsNullOrEmpty(configDir))
+        {
+            AvailableThemes = Array.Empty<string>();
+            return;
+        }
+
+        var themesDir = Path.Combine(configDir, "themes");
+        if (!Directory.Exists(themesDir))
+        {
+            AvailableThemes = Array.Empty<string>();
+            return;
+        }
+
+        // Each file in the themes directory is a theme. The filename
+        // (without extension) is the theme name.
+        AvailableThemes = Directory.EnumerateFiles(themesDir)
+            .Select(Path.GetFileName)
+            .Where(n => n is not null)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList()!;
+    }
+}

--- a/windows/Ghostty/Settings/Pages/AdvancedPage.xaml
+++ b/windows/Ghostty/Settings/Pages/AdvancedPage.xaml
@@ -1,0 +1,16 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.AdvancedPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer Padding="24">
+        <StackPanel Spacing="8" MaxWidth="600">
+            <TextBlock Text="Advanced" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+
+            <TextBlock
+                Text="Advanced settings property grid will be built once config key enumeration is available from libghostty."
+                TextWrapping="Wrap"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/windows/Ghostty/Settings/Pages/AdvancedPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AdvancedPage.xaml.cs
@@ -1,0 +1,17 @@
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class AdvancedPage : Page
+{
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
+
+    public AdvancedPage(IConfigService configService, IConfigFileEditor editor)
+    {
+        _configService = configService;
+        _editor = editor;
+        InitializeComponent();
+    }
+}

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -1,0 +1,35 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.AppearancePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer Padding="24">
+        <StackPanel Spacing="8" MaxWidth="600">
+            <TextBlock Text="Appearance" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+
+            <AutoSuggestBox
+                x:Name="FontFamilySearch"
+                Header="Font family"
+                PlaceholderText="Search fonts..."
+                QueryIcon="Find" />
+
+            <NumberBox
+                x:Name="FontSizeBox"
+                Header="Font size"
+                Value="13"
+                Minimum="6"
+                Maximum="72"
+                SpinButtonPlacementMode="Compact"
+                ValueChanged="FontSize_ValueChanged" />
+
+            <!-- Background opacity: not yet supported by the DX12
+                 renderer (see issue 194). Hidden until implemented. -->
+
+            <TextBox
+                x:Name="ShaderPathBox"
+                Header="Custom shader path"
+                PlaceholderText="Path to .glsl shader file"
+                LostFocus="ShaderPath_LostFocus" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Ghostty.Core.Config;
@@ -155,6 +156,7 @@ internal sealed partial class AppearancePage : Page
         if (sender is TextBox tb) OnValueChanged("custom-shader", tb.Text);
     }
 
-    [DllImport("dwrite.dll", ExactSpelling = true)]
-    private static unsafe extern int DWriteCreateFactory(int factoryType, Guid* iid, IntPtr* factory);
+    [LibraryImport("dwrite.dll", EntryPoint = "DWriteCreateFactory")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvStdcall) })]
+    private static unsafe partial int DWriteCreateFactory(int factoryType, Guid* iid, IntPtr* factory);
 }

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class AppearancePage : Page
+{
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
+    private readonly SearchableList _fontList;
+    private bool _loading = true;
+
+    public AppearancePage(IConfigService configService, IConfigFileEditor editor)
+    {
+        _configService = configService;
+        _editor = editor;
+        InitializeComponent();
+        _fontList = new SearchableList(FontFamilySearch, chosen => OnValueChanged("font-family", chosen));
+        _loading = false;
+        LoadFontsAsync();
+    }
+
+    private void LoadFontsAsync()
+    {
+        FontFamilySearch.PlaceholderText = "Loading fonts...";
+        var dispatcher = DispatcherQueue;
+        Task.Run(() =>
+        {
+            var fonts = EnumerateSystemFonts();
+            dispatcher.TryEnqueue(() =>
+            {
+                _fontList.SetItems(fonts);
+                FontFamilySearch.PlaceholderText = $"Search {fonts.Count} fonts...";
+            });
+        });
+    }
+
+    private static unsafe List<string> EnumerateSystemFonts()
+    {
+        var families = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var iid = new Guid("b859ee5a-d838-4b5b-a2e8-1adc7d93db48");
+        IntPtr factory;
+        if (DWriteCreateFactory(0, &iid, &factory) != 0 || factory == IntPtr.Zero)
+            return new List<string>();
+
+        try
+        {
+            // IDWriteFactory: IUnknown(3) + GetSystemFontCollection(3)
+            // checkForUpdates=1 to include per-user installed fonts.
+            var vtable = (IntPtr*)*(IntPtr*)factory;
+            IntPtr collection;
+            var getCollection = (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int, int>)vtable[3];
+            if (getCollection(factory, &collection, 1) != 0 || collection == IntPtr.Zero)
+                return new List<string>();
+
+            try
+            {
+                var cvt = (IntPtr*)*(IntPtr*)collection;
+                // IDWriteFontCollection: GetFontFamilyCount(3), GetFontFamily(4)
+                // (verified against src/font/directwrite.zig:585)
+                var getCount = (delegate* unmanaged[Stdcall]<IntPtr, uint>)cvt[3];
+                var getFamily = (delegate* unmanaged[Stdcall]<IntPtr, uint, IntPtr*, int>)cvt[4];
+                var count = getCount(collection);
+
+                for (uint i = 0; i < count; i++)
+                {
+                    IntPtr familyPtr;
+                    if (getFamily(collection, i, &familyPtr) != 0 || familyPtr == IntPtr.Zero)
+                        continue;
+                    try
+                    {
+                        var name = GetFamilyName(familyPtr);
+                        if (name != null) families.Add(name);
+                    }
+                    finally
+                    {
+                        Marshal.Release(familyPtr);
+                    }
+                }
+            }
+            finally
+            {
+                Marshal.Release(collection);
+            }
+        }
+        finally
+        {
+            Marshal.Release(factory);
+        }
+
+        // Ghostty embeds JetBrains Mono in the binary so it's always
+        // available even if not installed on the system.
+        families.Add("JetBrains Mono");
+
+        return families.OrderBy(f => f, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private static unsafe string? GetFamilyName(IntPtr familyPtr)
+    {
+        var fvt = (IntPtr*)*(IntPtr*)familyPtr;
+        // IDWriteFontFamily: IUnknown(3) + IDWriteFontList(3) + GetFamilyNames(6)
+        // (verified against src/font/directwrite.zig:549)
+        IntPtr namesPtr;
+        var getNames = (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)fvt[6];
+        if (getNames(familyPtr, &namesPtr) != 0 || namesPtr == IntPtr.Zero)
+            return null;
+
+        try
+        {
+            var nvt = (IntPtr*)*(IntPtr*)namesPtr;
+            // IDWriteLocalizedStrings: GetCount(3), GetStringLength(7), GetString(8)
+            // (verified against src/font/directwrite.zig:120)
+            var getCount = (delegate* unmanaged[Stdcall]<IntPtr, uint>)nvt[3];
+            if (getCount(namesPtr) == 0) return null;
+
+            uint len;
+            var getLen = (delegate* unmanaged[Stdcall]<IntPtr, uint, uint*, int>)nvt[7];
+            if (getLen(namesPtr, 0, &len) != 0) return null;
+
+            var buf = stackalloc char[(int)len + 1];
+            var getString = (delegate* unmanaged[Stdcall]<IntPtr, uint, char*, uint, int>)nvt[8];
+            if (getString(namesPtr, 0, buf, len + 1) != 0) return null;
+
+            return new string(buf, 0, (int)len);
+        }
+        finally
+        {
+            Marshal.Release(namesPtr);
+        }
+    }
+
+    private void OnValueChanged(string key, string value)
+    {
+        if (_loading) return;
+        _configService.SuppressWatcher(true);
+        _editor.SetValue(key, value);
+        _configService.SuppressWatcher(false);
+        _configService.Reload();
+    }
+
+    private void FontSize_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        OnValueChanged("font-size", sender.Value.ToString());
+    }
+
+    private void ShaderPath_LostFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb) OnValueChanged("custom-shader", tb.Text);
+    }
+
+    [DllImport("dwrite.dll", ExactSpelling = true)]
+    private static unsafe extern int DWriteCreateFactory(int factoryType, Guid* iid, IntPtr* factory);
+}

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml
@@ -1,0 +1,22 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.ColorsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer Padding="24">
+        <StackPanel Spacing="8" MaxWidth="600">
+            <TextBlock Text="Colors" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+
+            <AutoSuggestBox
+                x:Name="ThemeSearch"
+                Header="Theme"
+                PlaceholderText="Search themes..."
+                QueryIcon="Find" />
+
+            <TextBox Header="Foreground" PlaceholderText="#cdd6f4" LostFocus="Foreground_LostFocus" />
+            <TextBox Header="Background" PlaceholderText="#1e1e2e" LostFocus="Background_LostFocus" />
+            <TextBox Header="Cursor color" PlaceholderText="#f5e0dc" LostFocus="CursorColor_LostFocus" />
+            <TextBox Header="Selection color" PlaceholderText="#585b70" LostFocus="SelectionColor_LostFocus" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -1,0 +1,52 @@
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class ColorsPage : Page
+{
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
+    private readonly SearchableList _themeList;
+    private bool _loading = true;
+
+    public ColorsPage(IConfigService configService, IConfigFileEditor editor, IThemeProvider theme)
+    {
+        _configService = configService;
+        _editor = editor;
+        InitializeComponent();
+        _themeList = new SearchableList(ThemeSearch, chosen => OnValueChanged("theme", chosen));
+        _themeList.SetItems(theme.AvailableThemes);
+        _loading = false;
+    }
+
+    private void OnValueChanged(string key, string value)
+    {
+        if (_loading) return;
+        _configService.SuppressWatcher(true);
+        _editor.SetValue(key, value);
+        _configService.SuppressWatcher(false);
+        _configService.Reload();
+    }
+
+    private void Foreground_LostFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb) OnValueChanged("foreground", tb.Text);
+    }
+
+    private void Background_LostFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb) OnValueChanged("background", tb.Text);
+    }
+
+    private void CursorColor_LostFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb) OnValueChanged("cursor-color", tb.Text);
+    }
+
+    private void SelectionColor_LostFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb) OnValueChanged("selection-foreground", tb.Text);
+    }
+}

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -47,6 +47,6 @@ internal sealed partial class ColorsPage : Page
 
     private void SelectionColor_LostFocus(object sender, RoutedEventArgs e)
     {
-        if (sender is TextBox tb) OnValueChanged("selection-foreground", tb.Text);
+        if (sender is TextBox tb) OnValueChanged("selection-background", tb.Text);
     }
 }

--- a/windows/Ghostty/Settings/Pages/DiagnosticsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/DiagnosticsPage.xaml
@@ -1,0 +1,29 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.DiagnosticsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid Padding="24" RowDefinitions="Auto,*,Auto">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+            <TextBlock Text="Diagnostics" Style="{StaticResource TitleTextBlockStyle}" />
+            <InfoBadge x:Name="CountBadge" />
+        </StackPanel>
+
+        <ListView x:Name="DiagList" Grid.Row="1" Margin="0,16,0,0"
+                  SelectionMode="None">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <!-- Text set from ContainerContentChanging (AOT-safe,
+                         avoids reflection-based {Binding}). -->
+                    <TextBlock FontFamily="Cascadia Code, Consolas, monospace"
+                               TextWrapping="Wrap" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
+            <Button Content="Reload and Refresh" Click="ReloadButton_Click" />
+            <TextBlock x:Name="StatusText" VerticalAlignment="Center" Margin="16,0,0,0" />
+        </StackPanel>
+    </Grid>
+</Page>

--- a/windows/Ghostty/Settings/Pages/DiagnosticsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/DiagnosticsPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Ghostty.Core.Config;
 using Microsoft.UI.Xaml;
@@ -43,12 +44,16 @@ internal sealed partial class DiagnosticsPage : Page
 
     private void Refresh()
     {
-        _diagnostics.Clear();
         var count = _configService.DiagnosticsCount;
+        var items = new List<string>(count);
         for (int i = 0; i < count; i++)
-        {
-            _diagnostics.Add(_configService.GetDiagnostic(i));
-        }
+            items.Add(_configService.GetDiagnostic(i));
+
+        // Batch update: clear and repopulate in one pass to minimize
+        // per-item UI change notifications.
+        _diagnostics.Clear();
+        foreach (var item in items)
+            _diagnostics.Add(item);
 
         CountBadge.Value = count;
         StatusText.Text = count == 0

--- a/windows/Ghostty/Settings/Pages/DiagnosticsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/DiagnosticsPage.xaml.cs
@@ -1,0 +1,63 @@
+using System.Collections.ObjectModel;
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class DiagnosticsPage : Page
+{
+    private readonly IConfigService _configService;
+    private readonly ObservableCollection<string> _diagnostics = new();
+
+    public DiagnosticsPage(IConfigService configService)
+    {
+        _configService = configService;
+        InitializeComponent();
+        DiagList.ItemsSource = _diagnostics;
+        // AOT-safe: populate TextBlock from code-behind instead of
+        // {Binding} which relies on reflection that NativeAOT trims.
+        DiagList.ContainerContentChanging += OnContainerContentChanging;
+        _configService.ConfigChanged += OnConfigChanged;
+        Unloaded += OnUnloaded;
+        Refresh();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _configService.ConfigChanged -= OnConfigChanged;
+    }
+
+    private static void OnContainerContentChanging(
+        ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.InRecycleQueue) return;
+        if (args.ItemContainer.ContentTemplateRoot is TextBlock tb
+            && args.Item is string text)
+        {
+            tb.Text = text;
+        }
+    }
+
+    private void OnConfigChanged(IConfigService _) => Refresh();
+
+    private void Refresh()
+    {
+        _diagnostics.Clear();
+        var count = _configService.DiagnosticsCount;
+        for (int i = 0; i < count; i++)
+        {
+            _diagnostics.Add(_configService.GetDiagnostic(i));
+        }
+
+        CountBadge.Value = count;
+        StatusText.Text = count == 0
+            ? "No issues found"
+            : $"{count} diagnostic(s)";
+    }
+
+    private void ReloadButton_Click(object sender, RoutedEventArgs e)
+    {
+        _configService.Reload();
+    }
+}

--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml
@@ -1,0 +1,28 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.GeneralPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer Padding="24">
+        <StackPanel Spacing="8" MaxWidth="600">
+            <TextBlock Text="General" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+
+            <ToggleSwitch
+                x:Name="AutoReloadToggle"
+                Header="Auto-reload config"
+                OffContent="Manual reload only"
+                OnContent="Watch file for changes"
+                Toggled="AutoReloadToggle_Toggled" />
+
+            <ToggleSwitch
+                x:Name="VerticalTabsToggle"
+                Header="Vertical tabs"
+                OffContent="Horizontal tab bar"
+                OnContent="Vertical tab sidebar"
+                Toggled="VerticalTabsToggle_Toggled" />
+
+            <Button Content="Reload Configuration" Click="ReloadButton_Click" Margin="0,16,0,0" />
+            <Button Content="Open Config File" Click="OpenFileButton_Click" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
@@ -1,0 +1,68 @@
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class GeneralPage : Page
+{
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
+    private bool _loading = true;
+
+    public GeneralPage(IConfigService configService, IConfigFileEditor editor)
+    {
+        _configService = configService;
+        _editor = editor;
+        InitializeComponent();
+        LoadValues();
+        _loading = false;
+    }
+
+    private void LoadValues()
+    {
+        AutoReloadToggle.IsOn = _configService.AutoReloadEnabled;
+        VerticalTabsToggle.IsOn = Ghostty.Settings.UiSettings.Load().VerticalTabs;
+    }
+
+    private void AutoReloadToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+        _configService.SuppressWatcher(true);
+        _editor.SetValue("auto-reload-config", AutoReloadToggle.IsOn ? "true" : "false");
+        _configService.SuppressWatcher(false);
+        _configService.Reload();
+    }
+
+    private void VerticalTabsToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+        var settings = Ghostty.Settings.UiSettings.Load();
+        settings.VerticalTabs = VerticalTabsToggle.IsOn;
+        settings.Save();
+    }
+
+    private void ReloadButton_Click(object sender, RoutedEventArgs e)
+    {
+        _configService.Reload();
+    }
+
+    private void OpenFileButton_Click(object sender, RoutedEventArgs e)
+    {
+        var path = _configService.ConfigFilePath;
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = path,
+                UseShellExecute = true,
+            });
+        }
+        catch (System.Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to open config file: {ex.Message}");
+        }
+    }
+}

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
@@ -1,0 +1,35 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.KeybindingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid Padding="24" RowDefinitions="Auto,Auto,*">
+        <TextBlock Text="Keybindings" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+
+        <AutoSuggestBox
+            x:Name="SearchBox"
+            Grid.Row="1"
+            PlaceholderText="Search by action or key combo..."
+            QueryIcon="Find"
+            TextChanged="SearchBox_TextChanged"
+            Margin="0,0,0,16" />
+
+        <ListView x:Name="BindingsList" Grid.Row="2" SelectionMode="None">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <!-- Properties set from ContainerContentChanging
+                         (AOT-safe, avoids reflection-based {Binding}). -->
+                    <Grid ColumnDefinitions="*,200,80" Padding="4">
+                        <TextBlock x:Name="ActionText" VerticalAlignment="Center" />
+                        <TextBlock x:Name="KeyComboText" Grid.Column="1"
+                                   FontFamily="Cascadia Code, Consolas, monospace"
+                                   VerticalAlignment="Center" />
+                        <TextBlock x:Name="SourceText" Grid.Column="2"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   VerticalAlignment="Center" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </Grid>
+</Page>

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -1,0 +1,41 @@
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class KeybindingsPage : Page
+{
+    private readonly IKeyBindingsProvider _keybindings;
+
+    public KeybindingsPage(IKeyBindingsProvider keybindings)
+    {
+        _keybindings = keybindings;
+        InitializeComponent();
+        BindingsList.ItemsSource = _keybindings.All;
+        // AOT-safe: populate TextBlocks from code-behind instead of
+        // {Binding} which relies on reflection that NativeAOT trims.
+        BindingsList.ContainerContentChanging += OnContainerContentChanging;
+    }
+
+    private static void OnContainerContentChanging(
+        ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.InRecycleQueue) return;
+        if (args.ItemContainer.ContentTemplateRoot is not Grid grid) return;
+        if (args.Item is not BindingEntry entry) return;
+
+        if (grid.FindName("ActionText") is TextBlock action)
+            action.Text = entry.Action;
+        if (grid.FindName("KeyComboText") is TextBlock combo)
+            combo.Text = entry.KeyCombo;
+        if (grid.FindName("SourceText") is TextBlock source)
+            source.Text = entry.Source;
+    }
+
+    private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+        BindingsList.ItemsSource = _keybindings.Search(sender.Text);
+    }
+}

--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml
@@ -1,0 +1,24 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.RawEditorPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid Padding="24" RowDefinitions="Auto,*,Auto">
+        <TextBlock Text="Raw Config Editor" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+
+        <TextBox
+            x:Name="Editor"
+            Grid.Row="1"
+            AcceptsReturn="True"
+            TextWrapping="NoWrap"
+            FontFamily="Cascadia Code, Consolas, monospace"
+            FontSize="13"
+            IsSpellCheckEnabled="False" />
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
+            <Button Content="Save and Reload" Style="{StaticResource AccentButtonStyle}" Click="SaveButton_Click" />
+            <Button Content="Revert" Click="RevertButton_Click" />
+            <TextBlock x:Name="StatusText" VerticalAlignment="Center" Margin="16,0,0,0" />
+        </StackPanel>
+    </Grid>
+</Page>

--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
@@ -1,0 +1,42 @@
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class RawEditorPage : Page
+{
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
+
+    public RawEditorPage(IConfigService configService, IConfigFileEditor editor)
+    {
+        _configService = configService;
+        _editor = editor;
+        InitializeComponent();
+        LoadContent();
+    }
+
+    private void LoadContent()
+    {
+        Editor.Text = _editor.ReadAll();
+        StatusText.Text = $"Loaded from {_configService.ConfigFilePath}";
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        _configService.SuppressWatcher(true);
+        _editor.WriteRaw(Editor.Text);
+        _configService.SuppressWatcher(false);
+
+        var success = _configService.Reload();
+        StatusText.Text = success
+            ? $"Saved and reloaded ({_configService.DiagnosticsCount} diagnostics)"
+            : "Reload failed -- check diagnostics";
+    }
+
+    private void RevertButton_Click(object sender, RoutedEventArgs e)
+    {
+        LoadContent();
+    }
+}

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml
@@ -1,0 +1,36 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.TerminalPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer Padding="24">
+        <StackPanel Spacing="8" MaxWidth="600">
+            <TextBlock Text="Terminal" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+
+            <NumberBox
+                x:Name="ScrollbackBox"
+                Header="Scrollback limit"
+                Value="10000"
+                Minimum="0"
+                Maximum="1000000"
+                SpinButtonPlacementMode="Compact"
+                ValueChanged="Scrollback_ValueChanged" />
+
+            <ComboBox
+                x:Name="CursorStyleBox"
+                Header="Cursor style"
+                PlaceholderText="Select..."
+                SelectionChanged="CursorStyle_SelectionChanged" />
+
+            <ToggleSwitch
+                x:Name="CursorBlinkToggle"
+                Header="Cursor blink"
+                Toggled="CursorBlink_Toggled" />
+
+            <ToggleSwitch
+                x:Name="MouseHideToggle"
+                Header="Hide mouse while typing"
+                Toggled="MouseHide_Toggled" />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
@@ -1,0 +1,50 @@
+using Ghostty.Core.Config;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class TerminalPage : Page
+{
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
+    private bool _loading = true;
+
+    public TerminalPage(IConfigService configService, IConfigFileEditor editor)
+    {
+        _configService = configService;
+        _editor = editor;
+        InitializeComponent();
+        CursorStyleBox.ItemsSource = new[] { "block", "bar", "underline" };
+        _loading = false;
+    }
+
+    private void OnValueChanged(string key, string value)
+    {
+        if (_loading) return;
+        _configService.SuppressWatcher(true);
+        _editor.SetValue(key, value);
+        _configService.SuppressWatcher(false);
+        _configService.Reload();
+    }
+
+    private void Scrollback_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        OnValueChanged("scrollback-limit", ((int)sender.Value).ToString());
+    }
+
+    private void CursorStyle_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (CursorStyleBox.SelectedItem is string style) OnValueChanged("cursor-style", style);
+    }
+
+    private void CursorBlink_Toggled(object sender, RoutedEventArgs e)
+    {
+        OnValueChanged("cursor-style-blink", CursorBlinkToggle.IsOn ? "true" : "false");
+    }
+
+    private void MouseHide_Toggled(object sender, RoutedEventArgs e)
+    {
+        OnValueChanged("mouse-hide-while-typing", MouseHideToggle.IsOn ? "true" : "false");
+    }
+}

--- a/windows/Ghostty/Settings/SearchableList.cs
+++ b/windows/Ghostty/Settings/SearchableList.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings;
+
+/// <summary>
+/// Wires an <see cref="AutoSuggestBox"/> to a filterable string list
+/// with dropdown-on-focus and case-insensitive search. Keeps the
+/// pattern DRY across font and theme pickers.
+/// </summary>
+internal sealed class SearchableList
+{
+    private readonly AutoSuggestBox _box;
+    private readonly Action<string>? _onChosen;
+    private IReadOnlyList<string> _items = Array.Empty<string>();
+
+    public SearchableList(AutoSuggestBox box, Action<string>? onChosen = null)
+    {
+        _box = box;
+        _onChosen = onChosen;
+        _box.TextChanged += OnTextChanged;
+        _box.SuggestionChosen += OnSuggestionChosen;
+        _box.GotFocus += OnGotFocus;
+    }
+
+    public void SetItems(IReadOnlyList<string> items)
+    {
+        _items = items;
+    }
+
+    private void OnTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+        var query = sender.Text;
+        sender.ItemsSource = string.IsNullOrWhiteSpace(query)
+            ? _items
+            : _items.Where(i => i.Contains(query, StringComparison.OrdinalIgnoreCase)).ToList();
+        sender.IsSuggestionListOpen = true;
+    }
+
+    private void OnGotFocus(object sender, RoutedEventArgs e)
+    {
+        if (_items.Count == 0) return;
+        _box.ItemsSource = _items;
+        _box.IsSuggestionListOpen = true;
+    }
+
+    private void OnSuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+    {
+        if (args.SelectedItem is string chosen)
+        {
+            sender.Text = chosen;
+            _onChosen?.Invoke(chosen);
+        }
+    }
+}

--- a/windows/Ghostty/Settings/SettingsWindow.xaml
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="Ghostty.Settings.SettingsWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Ghostty Settings">
+
+    <NavigationView
+        x:Name="NavView"
+        IsBackButtonVisible="Collapsed"
+        IsSettingsVisible="False"
+        PaneDisplayMode="Left"
+        SelectionChanged="NavView_SelectionChanged">
+
+        <NavigationView.MenuItems>
+            <NavigationViewItem Content="General" Tag="general">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Setting" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+            <NavigationViewItem Content="Appearance" Tag="appearance">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Font" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+            <NavigationViewItem Content="Colors" Tag="colors">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Highlight" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+            <NavigationViewItem Content="Terminal" Tag="terminal">
+                <NavigationViewItem.Icon>
+                    <FontIcon Glyph="&#xE756;" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+            <NavigationViewItem Content="Keybindings" Tag="keybindings">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Keyboard" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+            <NavigationViewItem Content="Advanced" Tag="advanced">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Repair" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+
+            <NavigationViewItemSeparator />
+
+            <NavigationViewItem Content="Raw Editor" Tag="raw">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Edit" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+            <NavigationViewItem Content="Diagnostics" Tag="diagnostics">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Important" />
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+        </NavigationView.MenuItems>
+
+        <Frame x:Name="ContentFrame" />
+    </NavigationView>
+</Window>

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -1,0 +1,63 @@
+using Ghostty.Core.Config;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using WinRT.Interop;
+
+namespace Ghostty.Settings;
+
+internal sealed partial class SettingsWindow : Window
+{
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
+    private readonly IKeyBindingsProvider _keybindings;
+    private readonly IThemeProvider _theme;
+
+    public SettingsWindow(
+        IConfigService configService,
+        IConfigFileEditor editor,
+        IKeyBindingsProvider keybindings,
+        IThemeProvider theme)
+    {
+        _configService = configService;
+        _editor = editor;
+        _keybindings = keybindings;
+        _theme = theme;
+        InitializeComponent();
+
+        // Mica backdrop so the window isn't a black flash while XAML
+        // measures its first layout pass.
+        SystemBackdrop = new MicaBackdrop();
+
+        // WinUI 3 Window doesn't expose Width/Height in XAML.
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
+        var appWindow = AppWindow.GetFromWindowId(windowId);
+        appWindow.Resize(new Windows.Graphics.SizeInt32(900, 650));
+
+        NavView.SelectedItem = NavView.MenuItems[0];
+    }
+
+    private void NavView_SelectionChanged(
+        NavigationView sender,
+        NavigationViewSelectionChangedEventArgs args)
+    {
+        if (args.SelectedItem is not NavigationViewItem item) return;
+        var tag = item.Tag?.ToString();
+
+        ContentFrame.Content = tag switch
+        {
+            "general" => new Pages.GeneralPage(_configService, _editor),
+            "appearance" => new Pages.AppearancePage(_configService, _editor),
+            "colors" => new Pages.ColorsPage(_configService, _editor, _theme),
+            "terminal" => new Pages.TerminalPage(_configService, _editor),
+            "keybindings" => new Pages.KeybindingsPage(_keybindings),
+            "advanced" => new Pages.AdvancedPage(_configService, _editor),
+            "raw" => new Pages.RawEditorPage(_configService, _editor),
+            "diagnostics" => new Pages.DiagnosticsPage(_configService),
+            _ => null,
+        };
+    }
+}

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Ghostty.Core.Config;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
@@ -14,6 +16,7 @@ internal sealed partial class SettingsWindow : Window
     private readonly IConfigFileEditor _editor;
     private readonly IKeyBindingsProvider _keybindings;
     private readonly IThemeProvider _theme;
+    private readonly Dictionary<string, Page> _pageCache = new();
 
     public SettingsWindow(
         IConfigService configService,
@@ -37,7 +40,17 @@ internal sealed partial class SettingsWindow : Window
         var appWindow = AppWindow.GetFromWindowId(windowId);
         appWindow.Resize(new Windows.Graphics.SizeInt32(900, 650));
 
+        Closed += OnClosed;
         NavView.SelectedItem = NavView.MenuItems[0];
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        // Unsubscribe providers from ConfigChanged to avoid leaking
+        // event subscriptions back to the long-lived ConfigService.
+        (_keybindings as IDisposable)?.Dispose();
+        (_theme as IDisposable)?.Dispose();
+        _pageCache.Clear();
     }
 
     private void NavView_SelectionChanged(
@@ -46,18 +59,25 @@ internal sealed partial class SettingsWindow : Window
     {
         if (args.SelectedItem is not NavigationViewItem item) return;
         var tag = item.Tag?.ToString();
+        if (tag == null) return;
 
-        ContentFrame.Content = tag switch
+        if (!_pageCache.TryGetValue(tag, out var page))
         {
-            "general" => new Pages.GeneralPage(_configService, _editor),
-            "appearance" => new Pages.AppearancePage(_configService, _editor),
-            "colors" => new Pages.ColorsPage(_configService, _editor, _theme),
-            "terminal" => new Pages.TerminalPage(_configService, _editor),
-            "keybindings" => new Pages.KeybindingsPage(_keybindings),
-            "advanced" => new Pages.AdvancedPage(_configService, _editor),
-            "raw" => new Pages.RawEditorPage(_configService, _editor),
-            "diagnostics" => new Pages.DiagnosticsPage(_configService),
-            _ => null,
-        };
+            page = tag switch
+            {
+                "general" => new Pages.GeneralPage(_configService, _editor),
+                "appearance" => new Pages.AppearancePage(_configService, _editor),
+                "colors" => new Pages.ColorsPage(_configService, _editor, _theme),
+                "terminal" => new Pages.TerminalPage(_configService, _editor),
+                "keybindings" => new Pages.KeybindingsPage(_keybindings),
+                "advanced" => new Pages.AdvancedPage(_configService, _editor),
+                "raw" => new Pages.RawEditorPage(_configService, _editor),
+                "diagnostics" => new Pages.DiagnosticsPage(_configService),
+                _ => null,
+            };
+            if (page != null) _pageCache[tag] = page;
+        }
+
+        ContentFrame.Content = page;
     }
 }


### PR DESCRIPTION
## Summary

- Config path fix: XDG_CONFIG_HOME maps to %APPDATA% (Roaming) on Windows, matching Alacritty/Go/Rust conventions. Cache and state stay on %LOCALAPPDATA%.
- ConfigService singleton owns libghostty config lifecycle with reload support and FileSystemWatcher (behind auto-reload-config option)
- ConfigFileEditor with surgical "sniper edit" that modifies only the touched line, preserving comments and formatting
- KeyBindingsProvider and ThemeProvider subscribe to config changes
- Full Settings UI (feature-gated behind windows-settings-ui option) with 8 pages: General, Appearance, Colors, Terminal, Keybindings, Advanced, Raw Editor, Diagnostics
- Font picker via DirectWrite COM interop (AOT-safe, async enumeration)
- Theme picker enumerating user themes from %APPDATA%\ghostty\themes
- Dark/light mode detection via UISettings.ColorValuesChanged, notifies libghostty for conditional config re-evaluation
- Handle open_config and reload_config apprt actions (app-level dispatch)
- Two new config options: auto-reload-config (bool, default false), windows-settings-ui (bool, default false)

**IMPORTANT**: This is part of the stacked branch series for Windows config management.
Stack order: windows -> **windows-config-management (this PR)**

## Known limitations

- Background opacity not yet supported by DX12 renderer (# 194)
- Config reload updates background colors live but existing terminal text keeps stale foreground colors until new text is typed (# 193)
- Config file created empty on first launch; no starter template yet (# 190)

## Test plan

- [x] Verify config loads from %APPDATA%\ghostty\config
- [x] Verify windows-settings-ui = true opens Settings window instead of editor
- [x] Verify theme search filters and applies selected theme
- [x] Verify font search enumerates system + bundled fonts via DirectWrite
- [x] Verify diagnostics page shows parse errors
- [x] Verify keybindings search filters by action/combo
- [x] Verify dark/light mode switch triggers theme update
- [x] Run Ghostty.Tests to verify ConfigFileParser unit tests pass