### PR TITLE
fix: ghost visual after pane close, add equalize/zoom/fullscreen

### DIFF
--- a/windows/Ghostty.Core/Panes/PaneTree.cs
+++ b/windows/Ghostty.Core/Panes/PaneTree.cs
@@ -151,4 +151,19 @@ internal static class PaneTree
         else gpSplit.Child2 = sibling;
         return root;
     }
+
+    /// <summary>
+    /// Reset every <see cref="SplitPane.Ratio"/> in the tree to 0.5,
+    /// giving all leaves equal space. Mirrors upstream's
+    /// <c>equalize_splits</c> keybind (both Zig and Swift). No-op on
+    /// a single leaf.
+    /// </summary>
+    public static void Equalize(PaneNode root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        if (root is not SplitPane split) return;
+        split.Ratio = 0.5;
+        Equalize(split.Child1);
+        Equalize(split.Child2);
+    }
 }

--- a/windows/Ghostty.Tests/PaneTreeTests.cs
+++ b/windows/Ghostty.Tests/PaneTreeTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Ghostty.Core.Panes;
 using Xunit;
 
@@ -53,6 +54,17 @@ public sealed class PaneTreeTests
         Assert.NotNull(parentOfC);
         Assert.Same(inner, parentOfC!.Value.Parent);
         Assert.False(parentOfC.Value.TargetIsChild1);
+    }
+
+    [Fact]
+    public void FindParent_NodeNotInTree_ReturnsNull()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, a, b);
+        var outsider = new LeafPane();
+
+        Assert.Null(PaneTree.FindParent(root, outsider));
     }
 
     // FirstLeaf --------------------------------------------------------
@@ -149,6 +161,18 @@ public sealed class PaneTreeTests
     }
 
     [Fact]
+    public void Close_ParentIsRoot_ClosingChild2_SiblingBecomesRoot()
+    {
+        var sibling = new LeafPane();
+        var target = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Horizontal, sibling, target);
+
+        var newRoot = PaneTree.Close(root, target);
+
+        Assert.Same(sibling, newRoot);
+    }
+
+    [Fact]
     public void Close_NestedTarget_CollapsesParentInPlace()
     {
         // root = V(a, H(target, c))
@@ -187,6 +211,77 @@ public sealed class PaneTreeTests
         Assert.Same(e, ((SplitPane)root.Child2).Child2);
     }
 
+    [Fact]
+    public void Close_ThreeLevelsDeep_CollapsesCorrectly()
+    {
+        // root = V(a, H(V(target, b), c))
+        // closing target should leave root = V(a, H(b, c)).
+        var a = new LeafPane();
+        var target = new LeafPane();
+        var b = new LeafPane();
+        var c = new LeafPane();
+        var deepSplit = new SplitPane(PaneOrientation.Vertical, target, b);
+        var mid = new SplitPane(PaneOrientation.Horizontal, deepSplit, c);
+        var root = new SplitPane(PaneOrientation.Vertical, a, mid);
+
+        var newRoot = PaneTree.Close(root, target);
+
+        Assert.Same(root, newRoot);
+        Assert.Same(a, root.Child1);
+        var midAfter = Assert.IsType<SplitPane>(root.Child2);
+        Assert.Same(b, midAfter.Child1);
+        Assert.Same(c, midAfter.Child2);
+    }
+
+    [Fact]
+    public void Close_TargetNotInTree_ReturnsOriginalRoot()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, a, b);
+        var outsider = new LeafPane();
+
+        var newRoot = PaneTree.Close(root, outsider);
+
+        Assert.Same(root, newRoot);
+    }
+
+    [Fact]
+    public void Close_LeavesAfterClose_ReflectsCollapsedTree()
+    {
+        // root = V(a, H(target, c)) -> after close -> V(a, c)
+        var a = new LeafPane();
+        var target = new LeafPane();
+        var c = new LeafPane();
+        var inner = new SplitPane(PaneOrientation.Horizontal, target, c);
+        var root = new SplitPane(PaneOrientation.Vertical, a, inner);
+
+        var newRoot = PaneTree.Close(root, target)!;
+
+        Assert.Equal(new[] { a, c }, PaneTree.Leaves(newRoot).ToArray());
+    }
+
+    [Fact]
+    public void Close_ThenSplit_RoundTrip()
+    {
+        // Start with V(a, b), close a -> b is root.
+        // Split b -> V(b, c) is new root.
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, a, b);
+
+        var afterClose = PaneTree.Close(root, a)!;
+        Assert.Same(b, afterClose);
+
+        var c = new LeafPane();
+        var afterSplit = PaneTree.Split(afterClose, b, c, PaneOrientation.Horizontal);
+
+        var split = Assert.IsType<SplitPane>(afterSplit);
+        Assert.Same(b, split.Child1);
+        Assert.Same(c, split.Child2);
+        Assert.Equal(new[] { b, c }, PaneTree.Leaves(afterSplit).ToArray());
+    }
+
     // Leaves -----------------------------------------------------------
 
     [Fact]
@@ -209,5 +304,60 @@ public sealed class PaneTreeTests
             new SplitPane(PaneOrientation.Horizontal, c, d));
 
         Assert.Equal(new[] { a, b, c, d }, PaneTree.Leaves(root));
+    }
+
+    [Fact]
+    public void Leaves_Count_MatchesManualCount()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var c = new LeafPane();
+        var root = new SplitPane(
+            PaneOrientation.Vertical, a,
+            new SplitPane(PaneOrientation.Horizontal, b, c));
+
+        Assert.Equal(3, PaneTree.Leaves(root).Count());
+    }
+
+    // Equalize ---------------------------------------------------------
+
+    [Fact]
+    public void Equalize_SingleLeaf_NoOp()
+    {
+        var leaf = new LeafPane();
+        PaneTree.Equalize(leaf); // should not throw
+    }
+
+    [Fact]
+    public void Equalize_ResetsRatiosToHalf()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var c = new LeafPane();
+        var inner = new SplitPane(PaneOrientation.Horizontal, b, c, ratio: 0.3);
+        var root = new SplitPane(PaneOrientation.Vertical, a, inner) { Ratio = 0.7 };
+
+        PaneTree.Equalize(root);
+
+        Assert.Equal(0.5, root.Ratio);
+        Assert.Equal(0.5, inner.Ratio);
+    }
+
+    [Fact]
+    public void Equalize_DeepTree_ResetsAllLevels()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var c = new LeafPane();
+        var d = new LeafPane();
+        var deep = new SplitPane(PaneOrientation.Vertical, c, d, ratio: 0.2);
+        var mid = new SplitPane(PaneOrientation.Horizontal, b, deep) { Ratio = 0.8 };
+        var root = new SplitPane(PaneOrientation.Vertical, a, mid) { Ratio = 0.6 };
+
+        PaneTree.Equalize(root);
+
+        Assert.Equal(0.5, root.Ratio);
+        Assert.Equal(0.5, mid.Ratio);
+        Assert.Equal(0.5, deep.Ratio);
     }
 }

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -99,6 +99,9 @@ internal sealed class KeyBindings
         new KeyBinding(VirtualKeyModifiers.Menu, VirtualKey.Right, PaneAction.FocusRight),
         new KeyBinding(VirtualKeyModifiers.Menu, VirtualKey.Up, PaneAction.FocusUp),
         new KeyBinding(VirtualKeyModifiers.Menu, VirtualKey.Down, PaneAction.FocusDown),
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Enter, PaneAction.ToggleSplitZoom),
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, (VirtualKey)187, PaneAction.EqualizeSplits), // '='
+        new KeyBinding(VirtualKeyModifiers.None, VirtualKey.F11, PaneAction.ToggleFullscreen),
 
         // Tabs (this PR). Ctrl+Shift+W is now CloseActiveProgressive
         // (pane -> tab -> window with confirmation), no longer plain ClosePane.

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -90,6 +90,9 @@ internal sealed class KeyBindings
     /// muscle memory: Ctrl+Shift+D / E for splits, Ctrl+Shift+W to
     /// close, Alt+Arrows for directional focus.
     /// </summary>
+    // OEM virtual-key codes that lack a named VirtualKey member.
+    private const VirtualKey VkEquals = (VirtualKey)187;
+
     public static KeyBindings Default { get; } = new(new[]
     {
         // Panes (#163)
@@ -100,7 +103,7 @@ internal sealed class KeyBindings
         new KeyBinding(VirtualKeyModifiers.Menu, VirtualKey.Up, PaneAction.FocusUp),
         new KeyBinding(VirtualKeyModifiers.Menu, VirtualKey.Down, PaneAction.FocusDown),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Enter, PaneAction.ToggleSplitZoom),
-        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, (VirtualKey)187, PaneAction.EqualizeSplits), // '='
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VkEquals, PaneAction.EqualizeSplits),
         new KeyBinding(VirtualKeyModifiers.None, VirtualKey.F11, PaneAction.ToggleFullscreen),
 
         // Tabs (this PR). Ctrl+Shift+W is now CloseActiveProgressive

--- a/windows/Ghostty/Input/PaneAction.cs
+++ b/windows/Ghostty/Input/PaneAction.cs
@@ -19,6 +19,9 @@ internal enum PaneAction
     FocusRight,
     FocusUp,
     FocusDown,
+    EqualizeSplits,
+    ToggleSplitZoom,
+    ToggleFullscreen,
 
     // Tab operations (this PR)
     NewTab,

--- a/windows/Ghostty/Input/PaneAction.cs
+++ b/windows/Ghostty/Input/PaneAction.cs
@@ -12,28 +12,28 @@ namespace Ghostty.Input;
 internal enum PaneAction
 {
     // Pane operations (#163)
-    SplitVertical,
-    SplitHorizontal,
-    ClosePane, // legacy: pane-only close, no chord points to it after tabs landed
-    FocusLeft,
-    FocusRight,
-    FocusUp,
-    FocusDown,
-    EqualizeSplits,
-    ToggleSplitZoom,
-    ToggleFullscreen,
+    SplitVertical = 0,
+    SplitHorizontal = 1,
+    ClosePane = 2, // legacy: pane-only close, no chord points to it after tabs landed
+    FocusLeft = 3,
+    FocusRight = 4,
+    FocusUp = 5,
+    FocusDown = 6,
+    EqualizeSplits = 7,
+    ToggleSplitZoom = 8,
+    ToggleFullscreen = 9,
 
     // Tab operations (this PR)
-    NewTab,
-    CloseActiveProgressive, // pane -> tab -> window with confirmation
-    NextTab,
-    PrevTab,
-    JumpTab1, JumpTab2, JumpTab3, JumpTab4,
-    JumpTab5, JumpTab6, JumpTab7, JumpTab8,
-    JumpTabLast,
-    MoveTabRight,
-    MoveTabLeft,
-    ToggleVerticalTabsPinned,
-    ToggleTabLayout,
-    ToggleCommandPalette,
+    NewTab = 10,
+    CloseActiveProgressive = 11, // pane -> tab -> window with confirmation
+    NextTab = 12,
+    PrevTab = 13,
+    JumpTab1 = 14, JumpTab2 = 15, JumpTab3 = 16, JumpTab4 = 17,
+    JumpTab5 = 18, JumpTab6 = 19, JumpTab7 = 20, JumpTab8 = 21,
+    JumpTabLast = 22,
+    MoveTabRight = 23,
+    MoveTabLeft = 24,
+    ToggleVerticalTabsPinned = 25,
+    ToggleTabLayout = 26,
+    ToggleCommandPalette = 27,
 }

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -99,9 +99,6 @@ internal sealed class PaneActionRouter
             case PaneAction.FocusDown:       concrete.FocusDirection(FocusDirection.Down); break;
             case PaneAction.EqualizeSplits:  concrete.EqualizeSplits(); break;
             case PaneAction.ToggleSplitZoom: concrete.ToggleSplitZoom(); break;
-            case PaneAction.ToggleFullscreen:
-                ToggleFullscreenRequested?.Invoke(this, EventArgs.Empty);
-                break;
 
             // Tabs
             case PaneAction.NewTab: _tabs.NewTab(); break;

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -61,6 +61,13 @@ internal sealed class PaneActionRouter
     /// </summary>
     public event EventHandler? TabCloseRequestedFromKeyboard;
 
+    /// <summary>
+    /// Raised when <see cref="PaneAction.ToggleFullscreen"/> fires.
+    /// MainWindow listens and toggles
+    /// <c>AppWindow.SetPresenter(FullScreen/Default)</c>.
+    /// </summary>
+    public event EventHandler? ToggleFullscreenRequested;
+
     public void Invoke(PaneAction action)
     {
         // Event-only actions that don't need pane/tab state — handle
@@ -90,6 +97,11 @@ internal sealed class PaneActionRouter
             case PaneAction.FocusRight:      concrete.FocusDirection(FocusDirection.Right); break;
             case PaneAction.FocusUp:         concrete.FocusDirection(FocusDirection.Up); break;
             case PaneAction.FocusDown:       concrete.FocusDirection(FocusDirection.Down); break;
+            case PaneAction.EqualizeSplits:  concrete.EqualizeSplits(); break;
+            case PaneAction.ToggleSplitZoom: concrete.ToggleSplitZoom(); break;
+            case PaneAction.ToggleFullscreen:
+                ToggleFullscreenRequested?.Invoke(this, EventArgs.Empty);
+                break;
 
             // Tabs
             case PaneAction.NewTab: _tabs.NewTab(); break;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -439,8 +439,26 @@ public sealed partial class MainWindow : Window
         _router.ToggleTabLayoutRequested += (_, _) => ToggleTabLayout();
 
         _router.CommandPaletteToggleRequested += (_, _) => ToggleCommandPalette();
+
+        // Fullscreen toggle via F11.
+        _router.ToggleFullscreenRequested += (_, _) => ToggleFullscreen();
     }
 
+
+    /// <summary>
+    /// Toggle between fullscreen and default window presenter. Uses
+    /// <see cref="Microsoft.UI.Windowing.AppWindowPresenterKind"/> so
+    /// the window chrome (title bar, borders) is hidden in fullscreen
+    /// and restored on exit.
+    /// </summary>
+    private void ToggleFullscreen()
+    {
+        var kind = AppWindow.Presenter.Kind;
+        AppWindow.SetPresenter(
+            kind == Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen
+                ? Microsoft.UI.Windowing.AppWindowPresenterKind.Default
+                : Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen);
+    }
     private void ToggleCommandPalette()
     {
         if (_commandPaletteVm is not { } vm) return;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -444,7 +444,6 @@ public sealed partial class MainWindow : Window
         _router.ToggleFullscreenRequested += (_, _) => ToggleFullscreen();
     }
 
-
     /// <summary>
     /// Toggle between fullscreen and default window presenter. Uses
     /// <see cref="Microsoft.UI.Windowing.AppWindowPresenterKind"/> so
@@ -459,6 +458,7 @@ public sealed partial class MainWindow : Window
                 ? Microsoft.UI.Windowing.AppWindowPresenterKind.Default
                 : Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen);
     }
+
     private void ToggleCommandPalette()
     {
         if (_commandPaletteVm is not { } vm) return;

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -75,6 +75,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
 
     private PaneNode _root;
     private LeafPane _activeLeaf;
+    // When non-null, the active leaf is "zoomed" — it fills the entire
+    // host and the rest of the tree is hidden. Mirrors upstream's
+    // toggle_split_zoom keybind. Unzoom restores the tree via Rebuild.
+    private LeafPane? _zoomedLeaf;
     // Set once the last leaf has been closed and the window is tearing
     // down. DisposeAllLeaves honors it so it does not walk a tree that
     // has already been disposed leaf-by-leaf in CloseLeaf.
@@ -222,6 +226,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public void Split(PaneOrientation orientation)
     {
+        // Unzoom before splitting so the new sub-Grid is inserted into
+        // the full tree, not into the zoomed single-leaf visual.
+        if (_zoomedLeaf is not null)
+        {
+            _zoomedLeaf = null;
+            Rebuild();
+        }
+
         var oldActive = _activeLeaf;
         var wasRoot = ReferenceEquals(_root, oldActive);
         var newTerminal = CreateTerminal();
@@ -330,6 +342,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // do it explicitly here.
         leaf.Terminal().DisposeSurface();
 
+        // Detach the closed terminal from its visual parent Grid so the
+        // old split Grid does not hold a reference that keeps the WinUI
+        // compositor rendering a ghost DXGI swap chain surface. Without
+        // this, the disposed TerminalControl stays in the old Grid's
+        // Children and can remain visually rendered even after the Grid
+        // itself is removed from the host. (#185)
+        DetachFromParent(leaf.Terminal());
+
         var newRoot = PaneTree.Close(_root, leaf);
         if (newRoot is null)
         {
@@ -342,6 +362,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         }
 
         _root = newRoot;
+        // Clear zoom if the zoomed leaf was closed or if only one leaf
+        // remains (zoom is meaningless on a single pane).
+        if (_zoomedLeaf is not null
+            && (ReferenceEquals(_zoomedLeaf, leaf) || _root is LeafPane))
+        {
+            _zoomedLeaf = null;
+        }
+
         // Focus the first leaf of the (former) sibling subtree. We
         // pick the parent's sibling first so the focus stays close to
         // where the closed pane was.
@@ -353,12 +381,64 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     }
 
     /// <summary>
+    /// Reset every split ratio to 0.5, giving all panes equal space.
+    /// Mirrors upstream's <c>equalize_splits</c> keybind.
+    /// </summary>
+    public void EqualizeSplits()
+    {
+        PaneTree.Equalize(_root);
+        if (_zoomedLeaf is not null) return; // ratios updated, visual rebuild deferred to unzoom
+        Rebuild();
+        UpdateHighlightPosition();
+    }
+
+    /// <summary>
+    /// Toggle zoom on the active leaf. When zoomed, the active leaf
+    /// fills the entire host and the rest of the tree is hidden. When
+    /// unzoomed, the tree visual is restored. No-op on a single leaf.
+    /// Mirrors upstream's <c>toggle_split_zoom</c> keybind.
+    /// </summary>
+    public void ToggleSplitZoom()
+    {
+        if (PaneCount <= 1) return;
+
+        if (_zoomedLeaf is not null)
+        {
+            // Unzoom: restore the full tree visual.
+            _zoomedLeaf = null;
+            Rebuild();
+            UpdateHighlightPosition();
+            DispatcherQueue.TryEnqueue(() => _activeLeaf.Terminal().Focus(FocusState.Programmatic));
+        }
+        else
+        {
+            // Zoom: replace the tree visual with just the active leaf.
+            _zoomedLeaf = _activeLeaf;
+            if (Content is not Grid hostGrid) return;
+            ClearVisualTree(_treeRoot);
+            hostGrid.Children.Remove(_treeRoot);
+            DetachFromParent(_activeLeaf.Terminal());
+            _treeRoot = _activeLeaf.Terminal();
+            hostGrid.Children.Insert(0, _treeRoot);
+            _highlightOverlay.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    /// <summary>
+    /// Whether the active leaf is currently zoomed to fill the host.
+    /// </summary>
+    public bool IsZoomed => _zoomedLeaf is not null;
+
+    /// <summary>
     /// Move focus to the leaf nearest the active leaf in the requested
     /// direction. Geometric (uses rendered rects), not tree-order.
     /// No-op if no leaf lies in that direction.
     /// </summary>
     public void FocusDirection(FocusDirection direction)
     {
+        // No-op while zoomed -- only one leaf is visible.
+        if (_zoomedLeaf is not null) return;
+
         var allLeaves = PaneTree.Leaves(_root).ToList();
         if (allLeaves.Count <= 1) return;
 
@@ -549,9 +629,18 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // Split (and for Close); incremental splits mutate the
         // visual tree directly without a full rebuild.
         if (Content is not Grid hostGrid) return;
+
+        // Clear old tree children recursively before removal so the
+        // compositor drops all references to stale swap chain panels.
+        // Without this, removed Grids that still contain child elements
+        // can leave ghost visuals on screen. (#185)
+        ClearVisualTree(_treeRoot);
+
         hostGrid.Children.Remove(_treeRoot);
         _treeRoot = BuildVisual(_root);
         hostGrid.Children.Insert(0, _treeRoot);
+        // Restore the highlight overlay after unzoom (zoom hides it).
+        _highlightOverlay.Visibility = Visibility.Visible;
     }
 
     private FrameworkElement BuildVisual(PaneNode node)
@@ -641,6 +730,21 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
                 grid.RowDefinitions[1].Height = new GridLength(1 - split.Ratio, GridUnitType.Star);
             }
         }
+    }
+
+    /// <summary>
+    /// Recursively clear all children from a visual subtree. This breaks
+    /// compositor references to stale DXGI swap chain panels so removed
+    /// Grids do not leave ghost visuals on screen. Surviving
+    /// TerminalControls are re-parented by <see cref="BuildVisual"/>
+    /// immediately after this runs.
+    /// </summary>
+    private static void ClearVisualTree(FrameworkElement element)
+    {
+        if (element is not Panel panel) return;
+        foreach (var child in panel.Children.OfType<FrameworkElement>().ToList())
+            ClearVisualTree(child);
+        panel.Children.Clear();
     }
 
     private static void DetachFromParent(FrameworkElement child)

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -387,7 +387,9 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     public void EqualizeSplits()
     {
         PaneTree.Equalize(_root);
-        if (_zoomedLeaf is not null) return; // ratios updated, visual rebuild deferred to unzoom
+        // When zoomed, only update ratios — ToggleSplitZoom.Rebuild()
+        // will apply them when the user unzooms.
+        if (_zoomedLeaf is not null) return;
         Rebuild();
         UpdateHighlightPosition();
     }
@@ -421,6 +423,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             _treeRoot = _activeLeaf.Terminal();
             hostGrid.Children.Insert(0, _treeRoot);
             _highlightOverlay.Visibility = Visibility.Collapsed;
+            DispatcherQueue.TryEnqueue(() => _activeLeaf.Terminal().Focus(FocusState.Programmatic));
         }
     }
 
@@ -742,8 +745,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     private static void ClearVisualTree(FrameworkElement element)
     {
         if (element is not Panel panel) return;
-        foreach (var child in panel.Children.OfType<FrameworkElement>().ToList())
-            ClearVisualTree(child);
+        for (var i = panel.Children.Count - 1; i >= 0; i--)
+        {
+            if (panel.Children[i] is FrameworkElement child)
+                ClearVisualTree(child);
+        }
         panel.Children.Clear();
     }
 


### PR DESCRIPTION
## Summary

- Fix #185: closing a pane left a ghost visual on screen. The closed terminal's DXGI swap chain panel was never detached from its parent Grid, so the WinUI compositor kept rendering it. Now CloseLeaf detaches the terminal before Rebuild, and Rebuild clears old tree children recursively.
- Fix #187: wire EqualizeSplits (Ctrl+Shift+=), ToggleSplitZoom (Ctrl+Shift+Enter), and ToggleFullscreen (F11) as PaneActions end-to-end. Zoom-aware: Split unzooms first, Close clears zoom if the zoomed leaf dies or only one pane remains, FocusDirection no-ops while zoomed.
- Partial #166: add PaneTree.Equalize (recursive ratio reset to 0.5) and 10 new unit tests bringing PaneTree coverage from 14 to 24 tests.

## Changes

| File | What |
|------|------|
| PaneHost.cs | DetachFromParent in CloseLeaf, ClearVisualTree in Rebuild, zoom state + EqualizeSplits/ToggleSplitZoom, zoom guards in Split/Close/FocusDirection |
| PaneTree.cs | Equalize method |
| PaneAction.cs | EqualizeSplits, ToggleSplitZoom, ToggleFullscreen enum values |
| PaneActionRouter.cs | Route new actions + ToggleFullscreenRequested event |
| KeyBindings.cs | Ctrl+Shift+Enter, Ctrl+Shift+=, F11 |
| MainWindow.xaml.cs | ToggleFullscreen via AppWindow.SetPresenter |
| PaneTreeTests.cs | 10 new tests (close edge cases, equalize, round-trips) |

## Test plan

- [x] All 107 existing tests pass (dotnet test)
- [ ] Manual: split vertically, close one pane -- no ghost visual remains
- [ ] Manual: split 3+ panes, Ctrl+Shift+= -- all panes equalize
- [ ] Manual: split, Ctrl+Shift+Enter -- active pane fills host; again to unzoom
- [ ] Manual: F11 toggles fullscreen on/off
- [ ] Manual: zoom then close zoomed pane -- unzooms and shows sibling
- [ ] Manual: zoom then split -- unzooms first, then splits normally