### PR TITLE
feat(windows): background-opacity config plumbing, DX12 blend fix, dark theme (#194)

### DIFF
--- a/justfile
+++ b/justfile
@@ -107,10 +107,21 @@ build-win:
 # bash shebang to `exec` the .exe, which forced git-bash on Windows for no
 # reason - launching a Windows .exe works fine from pwsh.
 
-# Build the DLL and the shell, then launch it.
+# Build the DLL and the shell, copy ghostty.dll into the output, then launch.
+# The explicit copy works around MSBuild incremental-build caching: when the
+# output dir already exists from a prior build that lacked the DLL, MSBuild's
+# PreserveNewest check does not re-evaluate and the DLL never arrives.
 [windows]
 run-win: build-dll build-win
+    New-Item -ItemType Directory -Force -Path windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/native | Out-Null; Copy-Item -Force zig-out/lib/ghostty.dll windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/native/ghostty.dll
     ./windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/Ghostty.exe
+
+# NativeAOT: build the static lib, publish as a single-file exe, then launch.
+# Uses dotnet publish which links ghostty-static.lib directly into the exe.
+[windows]
+run-win-aot: build-dll
+    dotnet publish windows/Ghostty/Ghostty.csproj -r win-x64 -c Release /p:Platform=x64
+    ./windows/Ghostty/bin/x64/Release/net9.0-windows10.0.19041.0/win-x64/publish/Ghostty.exe
 
 # === Upstream Sync ===
 

--- a/justfile
+++ b/justfile
@@ -116,8 +116,10 @@ run-win: build-dll build-win
     New-Item -ItemType Directory -Force -Path windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/native | Out-Null; Copy-Item -Force zig-out/lib/ghostty.dll windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/native/ghostty.dll
     ./windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/Ghostty.exe
 
-# NativeAOT: build the static lib, publish as a single-file exe, then launch.
-# Uses dotnet publish which links ghostty-static.lib directly into the exe.
+# NativeAOT: publish as a single-file exe and launch. Depends on build-dll
+# because `dotnet publish` needs ghostty.dll present for P/Invoke resolution
+# at build time, even though the final NativeAOT binary statically links
+# ghostty-static.lib and does not ship the DLL. No DLL copy step needed.
 [windows]
 run-win-aot: build-dll
     dotnet publish windows/Ghostty/Ghostty.csproj -r win-x64 -c Release /p:Platform=x64

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -241,6 +241,7 @@ pub const Shaders = struct {
             .root_signature = root_sig,
             .vs_bytecode = shader_bytecode.bg_color_vs,
             .ps_bytecode = shader_bytecode.bg_color_ps,
+            .blend = .premultiplied_alpha,
         });
         pipelines.cell_bg = try Pipeline.init(.{
             .device = dev,

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -22,6 +22,11 @@ public interface IConfigService : IDisposable
     bool SettingsUiEnabled { get; }
 
     /// <summary>
+    /// Background opacity from config (0.0 fully transparent, 1.0 opaque).
+    /// </summary>
+    double BackgroundOpacity { get; }
+
+    /// <summary>
     /// Re-read config from disk and apply it. Returns true on
     /// success, false if the reload failed (old config stays active).
     /// </summary>

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -27,6 +27,19 @@ public interface IConfigService : IDisposable
     double BackgroundOpacity { get; }
 
     /// <summary>
+    /// Window theme from config: "light", "dark", "system", or "auto".
+    /// Controls both the XAML ElementTheme and the DWM title bar chrome.
+    /// </summary>
+    string WindowTheme { get; }
+
+    /// <summary>
+    /// Background color from config as packed 0x00RRGGBB (no alpha).
+    /// Used by the "auto" window-theme mode to derive light/dark from
+    /// the terminal background luminance.
+    /// </summary>
+    uint BackgroundColor { get; }
+
+    /// <summary>
     /// Re-read config from disk and apply it. Returns true on
     /// success, false if the reload failed (old config stays active).
     /// </summary>

--- a/windows/Ghostty.Core/Config/IThemeProvider.cs
+++ b/windows/Ghostty.Core/Config/IThemeProvider.cs
@@ -13,7 +13,6 @@ public interface IThemeProvider
     uint ForegroundColor { get; }
     uint CursorColor { get; }
     uint SelectionColor { get; }
-    double BackgroundOpacity { get; }
     string? FontFamily { get; }
     double FontSize { get; }
     string? ThemeName { get; }

--- a/windows/Ghostty.Core/Config/WindowTransparencyState.cs
+++ b/windows/Ghostty.Core/Config/WindowTransparencyState.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Pure-logic type that computes what window layers should do based on
+/// the background-opacity config value. No Win32 or WinUI dependencies
+/// so it can be unit-tested directly.
+/// </summary>
+public readonly struct WindowTransparencyState : IEquatable<WindowTransparencyState>
+{
+    /// <summary>
+    /// The clamped opacity value (0.0 to 1.0).
+    /// </summary>
+    public double Opacity { get; }
+
+    /// <summary>
+    /// Whether the window should use transparent compositing.
+    /// True when opacity is strictly less than 1.0.
+    /// </summary>
+    public bool IsTransparent { get; }
+
+    /// <summary>
+    /// Whether a system backdrop (e.g. Mica) should be applied.
+    /// False when transparent -- the backdrop would paint opaque
+    /// behind the swap chain and defeat the transparency.
+    /// </summary>
+    public bool UseSystemBackdrop { get; }
+
+    /// <summary>
+    /// Whether DWM glass margins should extend into the client area.
+    /// True when transparent -- tells DWM to composite the swap
+    /// chain's premultiplied alpha against the desktop.
+    /// </summary>
+    public bool ExtendDwmGlass { get; }
+
+    /// <summary>
+    /// Whether the Win32 class brush should be hollow (transparent).
+    /// True when transparent so DWM sees through to the swap chain.
+    /// False when opaque -- a dark brush hides resize flicker.
+    /// </summary>
+    public bool UseHollowClassBrush { get; }
+
+    private WindowTransparencyState(double opacity)
+    {
+        Opacity = Math.Clamp(opacity, 0.0, 1.0);
+        IsTransparent = Opacity < 1.0;
+        UseSystemBackdrop = !IsTransparent;
+        ExtendDwmGlass = IsTransparent;
+        UseHollowClassBrush = IsTransparent;
+    }
+
+    /// <summary>
+    /// Create a transparency state from a raw opacity value.
+    /// Values outside [0, 1] are clamped.
+    /// </summary>
+    public static WindowTransparencyState FromOpacity(double opacity) => new(opacity);
+
+    public bool Equals(WindowTransparencyState other) => Opacity.Equals(other.Opacity);
+    public override bool Equals(object? obj) => obj is WindowTransparencyState other && Equals(other);
+    public override int GetHashCode() => Opacity.GetHashCode();
+    public static bool operator ==(WindowTransparencyState left, WindowTransparencyState right) => left.Equals(right);
+    public static bool operator !=(WindowTransparencyState left, WindowTransparencyState right) => !left.Equals(right);
+}

--- a/windows/Ghostty.Core/Config/WindowTransparencyState.cs
+++ b/windows/Ghostty.Core/Config/WindowTransparencyState.cs
@@ -6,6 +6,11 @@ namespace Ghostty.Core.Config;
 /// Pure-logic type that computes what window layers should do based on
 /// the background-opacity config value. No Win32 or WinUI dependencies
 /// so it can be unit-tested directly.
+///
+/// Not yet consumed by MainWindow -- this is scaffolding for issue #196
+/// (actual window transparency via HWND + DirectComposition). The type
+/// and its tests land here so the follow-up PR can wire it in without
+/// a large diff.
 /// </summary>
 public readonly struct WindowTransparencyState : IEquatable<WindowTransparencyState>
 {
@@ -43,6 +48,9 @@ public readonly struct WindowTransparencyState : IEquatable<WindowTransparencySt
 
     private WindowTransparencyState(double opacity)
     {
+        // Defensive clamp: IConfigService.BackgroundOpacity already
+        // guarantees [0,1], but this type must be safe standalone since
+        // it is the public API for computing transparency decisions.
         Opacity = Math.Clamp(opacity, 0.0, 1.0);
         IsTransparent = Opacity < 1.0;
         UseSystemBackdrop = !IsTransparent;

--- a/windows/Ghostty.Tests/Config/WindowTransparencyStateTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowTransparencyStateTests.cs
@@ -1,0 +1,136 @@
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public class WindowTransparencyStateTests
+{
+    [Fact]
+    public void FullyOpaque_DisablesTransparency()
+    {
+        var state = WindowTransparencyState.FromOpacity(1.0);
+
+        Assert.False(state.IsTransparent);
+        Assert.True(state.UseSystemBackdrop);
+        Assert.False(state.ExtendDwmGlass);
+        Assert.False(state.UseHollowClassBrush);
+        Assert.Equal(1.0, state.Opacity);
+    }
+
+    [Fact]
+    public void HalfOpacity_EnablesTransparency()
+    {
+        var state = WindowTransparencyState.FromOpacity(0.5);
+
+        Assert.True(state.IsTransparent);
+        Assert.False(state.UseSystemBackdrop);
+        Assert.True(state.ExtendDwmGlass);
+        Assert.True(state.UseHollowClassBrush);
+        Assert.Equal(0.5, state.Opacity);
+    }
+
+    [Fact]
+    public void FullyTransparent_EnablesTransparency()
+    {
+        var state = WindowTransparencyState.FromOpacity(0.0);
+
+        Assert.True(state.IsTransparent);
+        Assert.False(state.UseSystemBackdrop);
+        Assert.True(state.ExtendDwmGlass);
+        Assert.True(state.UseHollowClassBrush);
+        Assert.Equal(0.0, state.Opacity);
+    }
+
+    [Theory]
+    [InlineData(0.01)]
+    [InlineData(0.5)]
+    [InlineData(0.99)]
+    public void AnyOpacityBelowOne_IsTransparent(double opacity)
+    {
+        var state = WindowTransparencyState.FromOpacity(opacity);
+        Assert.True(state.IsTransparent);
+    }
+
+    [Theory]
+    [InlineData(-1.0, 0.0)]
+    [InlineData(-0.5, 0.0)]
+    [InlineData(1.5, 1.0)]
+    [InlineData(100.0, 1.0)]
+    public void OutOfRange_ClampedTo01(double input, double expected)
+    {
+        var state = WindowTransparencyState.FromOpacity(input);
+        Assert.Equal(expected, state.Opacity);
+    }
+
+    [Fact]
+    public void NegativeValue_ClampsToZero_IsTransparent()
+    {
+        var state = WindowTransparencyState.FromOpacity(-0.5);
+
+        Assert.True(state.IsTransparent);
+        Assert.Equal(0.0, state.Opacity);
+    }
+
+    [Fact]
+    public void AboveOne_ClampsToOne_IsOpaque()
+    {
+        var state = WindowTransparencyState.FromOpacity(1.5);
+
+        Assert.False(state.IsTransparent);
+        Assert.Equal(1.0, state.Opacity);
+    }
+
+    [Fact]
+    public void SameOpacity_AreEqual()
+    {
+        var a = WindowTransparencyState.FromOpacity(0.7);
+        var b = WindowTransparencyState.FromOpacity(0.7);
+
+        Assert.Equal(a, b);
+        Assert.True(a == b);
+    }
+
+    [Fact]
+    public void DifferentOpacity_AreNotEqual()
+    {
+        var a = WindowTransparencyState.FromOpacity(0.5);
+        var b = WindowTransparencyState.FromOpacity(0.7);
+
+        Assert.NotEqual(a, b);
+        Assert.True(a != b);
+    }
+
+    [Fact]
+    public void SystemBackdrop_InverseOfTransparency()
+    {
+        // When transparent, no system backdrop (it would be opaque behind the swap chain).
+        // When opaque, system backdrop is fine.
+        var transparent = WindowTransparencyState.FromOpacity(0.5);
+        var opaque = WindowTransparencyState.FromOpacity(1.0);
+
+        Assert.Equal(transparent.IsTransparent, !transparent.UseSystemBackdrop);
+        Assert.Equal(opaque.IsTransparent, !opaque.UseSystemBackdrop);
+    }
+
+    [Fact]
+    public void DwmGlass_MatchesTransparency()
+    {
+        var transparent = WindowTransparencyState.FromOpacity(0.5);
+        var opaque = WindowTransparencyState.FromOpacity(1.0);
+
+        Assert.Equal(transparent.IsTransparent, transparent.ExtendDwmGlass);
+        Assert.Equal(opaque.IsTransparent, opaque.ExtendDwmGlass);
+    }
+
+    [Fact]
+    public void NaN_TreatedAsOpaque()
+    {
+        // Math.Clamp with NaN returns NaN; NaN < 1.0 is false,
+        // so NaN defaults to opaque behavior (safe fallback).
+        var state = WindowTransparencyState.FromOpacity(double.NaN);
+
+        Assert.False(state.IsTransparent);
+        Assert.True(state.UseSystemBackdrop);
+        Assert.False(state.ExtendDwmGlass);
+    }
+}

--- a/windows/Ghostty/App.xaml
+++ b/windows/Ghostty/App.xaml
@@ -6,6 +6,10 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:tabs="using:Ghostty.Tabs"
     RequestedTheme="Dark">
+    <!-- RequestedTheme="Dark" is a fallback default. WindowThemeManager
+         overrides this at runtime per the window-theme config value
+         (see issue #195). Removing it entirely would flash white on
+         startup before the manager applies the resolved theme. -->
     <!--
       Application.Resources here SHADOWS the framework's automatic
       load of the WinUI 3 controls theme resources unless we

--- a/windows/Ghostty/App.xaml
+++ b/windows/Ghostty/App.xaml
@@ -4,7 +4,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:tabs="using:Ghostty.Tabs">
+    xmlns:tabs="using:Ghostty.Tabs"
+    RequestedTheme="Dark">
     <!--
       Application.Resources here SHADOWS the framework's automatic
       load of the WinUI 3 controls theme resources unless we

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -8,14 +8,17 @@ internal sealed class BuiltInCommandSource : ICommandSource
 {
     private readonly Func<PaneAction, Action<CommandItem>> _paneActionFactory;
     private readonly Func<string, Action<CommandItem>> _bindingActionFactory;
+    private readonly Action<int>? _opacityAction;
     private List<CommandItem>? _cache;
 
     public BuiltInCommandSource(
         Func<PaneAction, Action<CommandItem>> paneActionFactory,
-        Func<string, Action<CommandItem>> bindingActionFactory)
+        Func<string, Action<CommandItem>> bindingActionFactory,
+        Action<int>? opacityAction = null)
     {
         _paneActionFactory = paneActionFactory;
         _bindingActionFactory = bindingActionFactory;
+        _opacityAction = opacityAction;
     }
 
     public IReadOnlyList<CommandItem> GetCommands()
@@ -64,6 +67,41 @@ internal sealed class BuiltInCommandSource : ICommandSource
         // AddBindingCommand(commands, "toggle_fullscreen", "Toggle Fullscreen", "Enter or exit fullscreen mode", CommandCategory.Terminal, "\uE740");
         // AddBindingCommand(commands, "equalize_splits", "Equalize Splits", "Make all split panes equal size", CommandCategory.Pane);
         // AddBindingCommand(commands, "toggle_split_zoom", "Toggle Split Zoom", "Zoom the current split to fill the tab", CommandCategory.Pane);
+
+        // Opacity adjustment (Ctrl+Shift+Scroll, or from palette)
+        if (_opacityAction is not null)
+        {
+            var adjust = _opacityAction;
+            commands.Add(new CommandItem
+            {
+                Id = "shell:increase_opacity",
+                Title = "Increase Opacity",
+                Description = "Increase background opacity by 5%",
+                Subtitle = "Ctrl+Shift+Scroll Up",
+                Category = CommandCategory.Terminal,
+                LeadingIcon = "\uE706",
+                Execute = _ => adjust(1),
+            });
+            commands.Add(new CommandItem
+            {
+                Id = "shell:decrease_opacity",
+                Title = "Decrease Opacity",
+                Description = "Decrease background opacity by 5%",
+                Subtitle = "Ctrl+Shift+Scroll Down",
+                Category = CommandCategory.Terminal,
+                LeadingIcon = "\uE708",
+                Execute = _ => adjust(-1),
+            });
+            commands.Add(new CommandItem
+            {
+                Id = "shell:reset_opacity",
+                Title = "Reset Opacity",
+                Description = "Reset background opacity to 100%",
+                Category = CommandCategory.Terminal,
+                LeadingIcon = "\uE7A5",
+                Execute = _ => adjust(0),
+            });
+        }
 
         return commands;
     }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -523,6 +523,19 @@ public sealed partial class TerminalControl : UserControl
         var rawDelta = pt.Properties.MouseWheelDelta;
         var isHorizontal = pt.Properties.IsHorizontalMouseWheel;
 
+        // Ctrl+Shift+Wheel adjusts background opacity (matches Windows
+        // Terminal). Intercept before the normal scroll path so the
+        // terminal viewport does not move.
+        var mods = CurrentMods();
+        if (!isHorizontal
+            && (mods & GhosttyMods.Ctrl) != 0
+            && (mods & GhosttyMods.Shift) != 0)
+        {
+            Host?.RequestOpacityAdjust(rawDelta > 0 ? 1 : -1);
+            e.Handled = true;
+            return;
+        }
+
         // Detect precision input (touchpad) vs discrete mouse wheel.
         // PointerDeviceType.Touchpad is only reported when the user has a
         // precision-touchpad driver; legacy touchpads masquerade as Mouse

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -45,6 +45,24 @@ internal sealed class GhosttyHost : IDisposable
     public event EventHandler? OpenConfigRequested;
     public event EventHandler? ReloadConfigRequested;
 
+    /// <summary>
+    /// Raised when a terminal surface requests an opacity adjustment
+    /// (Ctrl+Shift+scroll wheel). The int argument is the direction:
+    /// +1 = increase, -1 = decrease.
+    /// </summary>
+    public event EventHandler<int>? OpacityAdjustRequested;
+
+    /// <summary>
+    /// Called by <see cref="TerminalControl"/> when Ctrl+Shift+Wheel
+    /// is detected. Dispatches to the UI thread and raises
+    /// <see cref="OpacityAdjustRequested"/>.
+    /// </summary>
+    internal void RequestOpacityAdjust(int direction)
+    {
+        _dispatcher.TryEnqueue(() =>
+            OpacityAdjustRequested?.Invoke(this, direction));
+    }
+
     private ClipboardBridge? _clipboardBridge;
 
     // Delegates must be retained as fields; P/Invoke hands out native

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -66,7 +66,6 @@
         <Grid x:Name="VerticalTitleBar"
               Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
               Height="32"
-              RequestedTheme="Dark"
               Visibility="Collapsed">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="TitleBarStripMirror" Width="0"/>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -48,6 +48,8 @@ namespace Ghostty;
 public sealed partial class MainWindow : Window
 {
     private readonly GhosttyHost _host;
+    private readonly ConfigService _configService;
+    private readonly ConfigFileEditor _configEditor;
     private readonly PaneHostFactory _factory;
     private readonly TabManager _tabManager;
     private readonly PaneActionRouter _router;
@@ -63,6 +65,7 @@ public sealed partial class MainWindow : Window
     private readonly LayoutCoordinator _layout;
     private readonly TitleBarCoordinator _titleBar;
     private readonly TaskbarHost _taskbar;
+    private readonly WindowThemeManager _themeManager;
 
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
@@ -107,19 +110,12 @@ public sealed partial class MainWindow : Window
     [LibraryImport("gdi32.dll")]
     private static partial IntPtr CreateSolidBrush(uint crColor);
 
-    [LibraryImport("dwmapi.dll")]
-    private static partial int DwmSetWindowAttribute(IntPtr hwnd, int dwAttribute, in int pvAttribute, int cbAttribute);
-
-    // Forces the title bar caption buttons (min/max/close) to dark or
-    // light rendering. XAML's RequestedTheme and AppWindow.TitleBar
-    // button color properties are both ignored when
-    // ExtendsContentIntoTitleBar is true -- only this DWM attribute
-    // controls the OS-rendered non-client area.
-    private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
-
     internal MainWindow(ConfigService configService)
     {
         InitializeComponent();
+
+        _configService = configService;
+        _configEditor = new ConfigFileEditor(configService.ConfigFilePath);
 
         _host = new GhosttyHost(DispatcherQueue, configService.ConfigHandle);
         configService.SetApp(_host.App);
@@ -170,14 +166,15 @@ public sealed partial class MainWindow : Window
         // the default title bar row.
         ExtendsContentIntoTitleBar = true;
 
-        // Force the non-client area (caption buttons) to dark mode.
-        // XAML RequestedTheme and AppWindow.TitleBar button colors are
-        // both ignored when ExtendsContentIntoTitleBar is true -- only
-        // this DWM attribute controls the OS-rendered chrome. Will be
-        // replaced by proper window-theme support (issue 195).
-        int useDarkMode = 1;
-        DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-            in useDarkMode, sizeof(int));
+        // Apply window-theme from config. The manager resolves the
+        // config value ("light"/"dark"/"system"/"auto") to a concrete
+        // dark/light choice and sets both ElementTheme on the XAML root
+        // and the DWM immersive dark mode attribute for the title bar
+        // caption buttons (which XAML cannot control when
+        // ExtendsContentIntoTitleBar is true).
+        _themeManager = new WindowThemeManager(configService, DispatcherQueue);
+        ApplyTheme();
+        _themeManager.ThemeChanged += _ => ApplyTheme();
 
         _factory = new PaneHostFactory(_host);
         _tabManager = new TabManager(() => _factory.Create());
@@ -358,6 +355,9 @@ public sealed partial class MainWindow : Window
 
         _host.ReloadConfigRequested += (_, _) => configService.Reload();
 
+        // Ctrl+Shift+Scroll wheel opacity adjustment from any terminal surface.
+        _host.OpacityAdjustRequested += (_, direction) => AdjustOpacity(direction);
+
         _tabManager.LastTabClosed += (_, _) => Close();
 
         Closed += OnClosedAsync;
@@ -379,6 +379,7 @@ public sealed partial class MainWindow : Window
         }
 
         _taskbar.Dispose();
+        _themeManager.Dispose();
 
         // Surface lifetime is decoupled from Loaded/Unloaded
         // (see TerminalControl.DisposeSurface), so we have to
@@ -535,6 +536,18 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Apply the resolved window theme to the XAML visual tree and the
+    /// DWM non-client area. Called once at startup and again whenever
+    /// the <see cref="WindowThemeManager"/> detects a change.
+    /// </summary>
+    private void ApplyTheme()
+    {
+        if (Content is FrameworkElement root)
+            root.RequestedTheme = _themeManager.ElementTheme;
+        _themeManager.ApplyToWindow(this);
+    }
+
+    /// <summary>
     /// Toggle between fullscreen and default window presenter. Uses
     /// <see cref="Microsoft.UI.Windowing.AppWindowPresenterKind"/> so
     /// the window chrome (title bar, borders) is hidden in fullscreen
@@ -547,6 +560,31 @@ public sealed partial class MainWindow : Window
             kind == Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen
                 ? Microsoft.UI.Windowing.AppWindowPresenterKind.Default
                 : Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen);
+    }
+
+    /// <summary>
+    /// Adjust background opacity by a step. Direction: +1 = increase,
+    /// -1 = decrease, 0 = reset to 1.0. Writes the new value to the
+    /// config file and triggers a reload so all surfaces pick it up.
+    /// Step size matches the Settings UI slider (0.05).
+    /// </summary>
+    private void AdjustOpacity(int direction)
+    {
+        const double step = 0.05;
+        var current = _configService.BackgroundOpacity;
+        var next = direction switch
+        {
+            0 => 1.0,
+            _ => Math.Clamp(current + direction * step, 0.0, 1.0),
+        };
+
+        // Skip the write+reload round-trip when nothing changed.
+        if (Math.Abs(next - current) < 0.001) return;
+
+        _configService.SuppressWatcher(true);
+        _configEditor.SetValue("background-opacity", next.ToString("F2"));
+        _configService.SuppressWatcher(false);
+        _configService.Reload();
     }
 
     private void ToggleCommandPalette()
@@ -605,7 +643,8 @@ public sealed partial class MainWindow : Window
         // Popup teardown and PaneHost Rebuild (e.g. close-pane).
         var builtIn = new BuiltInCommandSource(
             paneActionFactory: action => _ => DispatcherQueue.TryEnqueue(() => _router.Invoke(action)),
-            bindingActionFactory: actionKey => _ => DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)));
+            bindingActionFactory: actionKey => _ => DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)),
+            opacityAction: direction => DispatcherQueue.TryEnqueue(() => AdjustOpacity(direction)));
 
         var jump = new JumpCommandSource(
             _tabManager,

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -107,6 +107,16 @@ public sealed partial class MainWindow : Window
     [LibraryImport("gdi32.dll")]
     private static partial IntPtr CreateSolidBrush(uint crColor);
 
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmSetWindowAttribute(IntPtr hwnd, int dwAttribute, in int pvAttribute, int cbAttribute);
+
+    // Forces the title bar caption buttons (min/max/close) to dark or
+    // light rendering. XAML's RequestedTheme and AppWindow.TitleBar
+    // button color properties are both ignored when
+    // ExtendsContentIntoTitleBar is true -- only this DWM attribute
+    // controls the OS-rendered non-client area.
+    private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+
     internal MainWindow(ConfigService configService)
     {
         InitializeComponent();
@@ -159,6 +169,15 @@ public sealed partial class MainWindow : Window
         // TabHost is parented so the content area is sized without
         // the default title bar row.
         ExtendsContentIntoTitleBar = true;
+
+        // Force the non-client area (caption buttons) to dark mode.
+        // XAML RequestedTheme and AppWindow.TitleBar button colors are
+        // both ignored when ExtendsContentIntoTitleBar is true -- only
+        // this DWM attribute controls the OS-rendered chrome. Will be
+        // replaced by proper window-theme support (issue 195).
+        int useDarkMode = 1;
+        DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+            in useDarkMode, sizeof(int));
 
         _factory = new PaneHostFactory(_host);
         _tabManager = new TabManager(() => _factory.Create());

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -29,6 +29,7 @@ internal sealed class ConfigService : IConfigService
     public string ConfigFilePath { get; }
     public bool AutoReloadEnabled { get; private set; }
     public bool SettingsUiEnabled { get; private set; }
+    public double BackgroundOpacity { get; private set; } = 1.0;
     public int DiagnosticsCount { get; private set; }
 
     /// <summary>
@@ -136,6 +137,7 @@ internal sealed class ConfigService : IConfigService
     {
         AutoReloadEnabled = GetBool("auto-reload-config");
         SettingsUiEnabled = GetBool("windows-settings-ui");
+        BackgroundOpacity = Math.Clamp(GetDouble("background-opacity", 1.0), 0.0, 1.0);
     }
 
     private unsafe bool GetBool(string key)
@@ -150,6 +152,21 @@ internal sealed class ConfigService : IConfigService
                 (IntPtr)keyPtr,
                 (UIntPtr)keyBytes.Length);
             return found && result != 0;
+        }
+    }
+
+    private unsafe double GetDouble(string key, double defaultValue)
+    {
+        double result = 0;
+        var keyBytes = System.Text.Encoding.UTF8.GetBytes(key);
+        fixed (byte* keyPtr = keyBytes)
+        {
+            var found = NativeMethods.ConfigGet(
+                _config,
+                (IntPtr)(&result),
+                (IntPtr)keyPtr,
+                (UIntPtr)keyBytes.Length);
+            return found ? result : defaultValue;
         }
     }
 

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -30,6 +30,8 @@ internal sealed class ConfigService : IConfigService
     public bool AutoReloadEnabled { get; private set; }
     public bool SettingsUiEnabled { get; private set; }
     public double BackgroundOpacity { get; private set; } = 1.0;
+    public string WindowTheme { get; private set; } = "auto";
+    public uint BackgroundColor { get; private set; } = 0x001E1E2E;
     public int DiagnosticsCount { get; private set; }
 
     /// <summary>
@@ -137,7 +139,12 @@ internal sealed class ConfigService : IConfigService
     {
         AutoReloadEnabled = GetBool("auto-reload-config");
         SettingsUiEnabled = GetBool("windows-settings-ui");
+        // Clamp here so all consumers get a safe [0,1] value without
+        // needing their own validation. WindowTransparencyState also
+        // clamps defensively as a standalone value type.
         BackgroundOpacity = Math.Clamp(GetDouble("background-opacity", 1.0), 0.0, 1.0);
+        WindowTheme = GetString("window-theme", "auto");
+        BackgroundColor = GetColor("background", 0x001E1E2E);
     }
 
     private unsafe bool GetBool(string key)
@@ -168,6 +175,53 @@ internal sealed class ConfigService : IConfigService
                 (UIntPtr)keyBytes.Length);
             return found ? result : defaultValue;
         }
+    }
+
+    /// <summary>
+    /// Read a string-typed config value (enums are returned as
+    /// NUL-terminated UTF-8 strings by <c>ghostty_config_get</c>).
+    /// </summary>
+    private unsafe string GetString(string key, string defaultValue)
+    {
+        IntPtr result = IntPtr.Zero;
+        var keyBytes = System.Text.Encoding.UTF8.GetBytes(key);
+        fixed (byte* keyPtr = keyBytes)
+        {
+            var found = NativeMethods.ConfigGet(
+                _config,
+                (IntPtr)(&result),
+                (IntPtr)keyPtr,
+                (UIntPtr)keyBytes.Length);
+            if (!found || result == IntPtr.Zero) return defaultValue;
+            return Marshal.PtrToStringUTF8(result) ?? defaultValue;
+        }
+    }
+
+    /// <summary>
+    /// Read a color config value. libghostty returns colors as
+    /// <c>ghostty_config_color_s { r: u8, g: u8, b: u8 }</c>.
+    /// We pack it into 0x00RRGGBB for easy consumption.
+    /// </summary>
+    private unsafe uint GetColor(string key, uint defaultValue)
+    {
+        // ghostty_config_color_s is 3 bytes: r, g, b (no padding).
+        byte r = 0, g = 0, b = 0;
+        // Stack a 3-byte buffer for the color struct.
+        byte* colorBuf = stackalloc byte[3];
+        var keyBytes = System.Text.Encoding.UTF8.GetBytes(key);
+        fixed (byte* keyPtr = keyBytes)
+        {
+            var found = NativeMethods.ConfigGet(
+                _config,
+                (IntPtr)colorBuf,
+                (IntPtr)keyPtr,
+                (UIntPtr)keyBytes.Length);
+            if (!found) return defaultValue;
+            r = colorBuf[0];
+            g = colorBuf[1];
+            b = colorBuf[2];
+        }
+        return ((uint)r << 16) | ((uint)g << 8) | b;
     }
 
     private void StartWatcher()

--- a/windows/Ghostty/Services/ThemeProvider.cs
+++ b/windows/Ghostty/Services/ThemeProvider.cs
@@ -36,6 +36,8 @@ internal sealed class ThemeProvider : IThemeProvider, IDisposable
 
     private void Refresh()
     {
+        BackgroundOpacity = _configService.BackgroundOpacity;
+
         // Enumerate theme files from the user themes directory.
         // Ghostty looks for themes in <config_dir>/themes/<name>.
         var configDir = Path.GetDirectoryName(_configService.ConfigFilePath);

--- a/windows/Ghostty/Services/ThemeProvider.cs
+++ b/windows/Ghostty/Services/ThemeProvider.cs
@@ -14,7 +14,6 @@ internal sealed class ThemeProvider : IThemeProvider, IDisposable
     public uint ForegroundColor { get; private set; } = 0xFFCDD6F4;
     public uint CursorColor { get; private set; } = 0xFFF5E0DC;
     public uint SelectionColor { get; private set; } = 0xFF585B70;
-    public double BackgroundOpacity { get; private set; } = 1.0;
     public string? FontFamily { get; private set; }
     public double FontSize { get; private set; } = 13.0;
     public string? ThemeName { get; private set; }
@@ -36,8 +35,6 @@ internal sealed class ThemeProvider : IThemeProvider, IDisposable
 
     private void Refresh()
     {
-        BackgroundOpacity = _configService.BackgroundOpacity;
-
         // Enumerate theme files from the user themes directory.
         // Ghostty looks for themes in <config_dir>/themes/<name>.
         var configDir = Path.GetDirectoryName(_configService.ConfigFilePath);

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Runtime.InteropServices;
+using Ghostty.Core.Config;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using WinRT.Interop;
+
+namespace Ghostty.Services;
+
+/// <summary>
+/// Maps the libghostty <c>window-theme</c> config value to WinUI 3
+/// ElementTheme and the DWM immersive dark mode attribute. Handles
+/// "light", "dark", "system" (follows OS), and "auto" (derives from
+/// background color luminance, matching the macOS port).
+///
+/// Subscribe to <see cref="ThemeChanged"/> for live-reload updates.
+/// </summary>
+internal sealed class WindowThemeManager : IDisposable
+{
+    private readonly IConfigService _configService;
+    private readonly DispatcherQueue _dispatcher;
+
+    // System theme tracking for "system" mode.
+    private readonly Windows.UI.ViewManagement.UISettings _uiSettings;
+
+    /// <summary>
+    /// Fired on the UI thread whenever the resolved theme changes.
+    /// The bool argument is true when dark mode is active.
+    /// </summary>
+    public event Action<bool>? ThemeChanged;
+
+    /// <summary>Current resolved dark-mode state.</summary>
+    public bool IsDarkMode { get; private set; }
+
+    /// <summary>
+    /// The ElementTheme to apply to the XAML root element.
+    /// </summary>
+    public ElementTheme ElementTheme => IsDarkMode ? ElementTheme.Dark : ElementTheme.Light;
+
+    public WindowThemeManager(IConfigService configService, DispatcherQueue dispatcher)
+    {
+        _configService = configService;
+        _dispatcher = dispatcher;
+        _uiSettings = new Windows.UI.ViewManagement.UISettings();
+
+        _configService.ConfigChanged += OnConfigChanged;
+        _uiSettings.ColorValuesChanged += OnSystemThemeChanged;
+
+        Resolve();
+    }
+
+    public void Dispose()
+    {
+        _configService.ConfigChanged -= OnConfigChanged;
+        _uiSettings.ColorValuesChanged -= OnSystemThemeChanged;
+    }
+
+    /// <summary>
+    /// Apply the current theme to a window's DWM non-client area.
+    /// Must be called from the UI thread.
+    /// </summary>
+    public void ApplyToWindow(Window window)
+    {
+        var hwnd = WindowNative.GetWindowHandle(window);
+        int useDarkMode = IsDarkMode ? 1 : 0;
+        DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+            in useDarkMode, sizeof(int));
+    }
+
+    private void OnConfigChanged(IConfigService _)
+    {
+        var previous = IsDarkMode;
+        Resolve();
+        if (IsDarkMode != previous)
+            ThemeChanged?.Invoke(IsDarkMode);
+    }
+
+    private void OnSystemThemeChanged(
+        Windows.UI.ViewManagement.UISettings sender, object args)
+    {
+        // ColorValuesChanged fires on a background thread.
+        _dispatcher.TryEnqueue(() =>
+        {
+            // System theme changes only affect "system" mode. "Auto"
+            // derives from the config background color, not the OS.
+            if (_configService.WindowTheme != "system") return;
+
+            var previous = IsDarkMode;
+            Resolve();
+            if (IsDarkMode != previous)
+                ThemeChanged?.Invoke(IsDarkMode);
+        });
+    }
+
+    private void Resolve()
+    {
+        IsDarkMode = _configService.WindowTheme switch
+        {
+            "light" => false,
+            "dark" => true,
+            "system" => IsSystemDark(),
+            "auto" => IsBackgroundDark(),
+            _ => true, // default to dark
+        };
+    }
+
+    /// <summary>
+    /// Check whether the OS is currently in dark mode by reading
+    /// the foreground color from UISettings. White foreground means
+    /// dark mode (light text on dark background).
+    /// </summary>
+    private bool IsSystemDark()
+    {
+        var fg = _uiSettings.GetColorValue(
+            Windows.UI.ViewManagement.UIColorType.Foreground);
+        return fg.R > 128;
+    }
+
+    /// <summary>
+    /// Derive theme from the terminal background color luminance,
+    /// matching the macOS port's "auto" behavior. A background with
+    /// relative luminance below 0.5 is considered dark.
+    /// </summary>
+    private bool IsBackgroundDark()
+    {
+        // BackgroundColor is packed 0x00RRGGBB.
+        var color = _configService.BackgroundColor;
+        var r = (color >> 16) & 0xFF;
+        var g = (color >> 8) & 0xFF;
+        var b = color & 0xFF;
+
+        // Same luminance test the macOS port uses via NSColor.isLightColor:
+        // relative luminance (BT.709 coefficients). A color is "light" if
+        // luminance >= 0.5, matching the NSColor extension upstream.
+        var luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0;
+        return luminance < 0.5;
+    }
+
+    // DWM interop
+    private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmSetWindowAttribute(
+        IntPtr hwnd, int dwAttribute, in int pvAttribute, int cbAttribute);
+}

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -22,8 +22,16 @@
                 SpinButtonPlacementMode="Compact"
                 ValueChanged="FontSize_ValueChanged" />
 
-            <!-- Background opacity: not yet supported by the DX12
-                 renderer (see issue 194). Hidden until implemented. -->
+            <Slider
+                x:Name="OpacitySlider"
+                Header="Background opacity"
+                Minimum="0"
+                Maximum="1"
+                StepFrequency="0.05"
+                TickFrequency="0.1"
+                TickPlacement="BottomRight"
+                Value="1"
+                ValueChanged="Opacity_ValueChanged" />
 
             <TextBox
                 x:Name="ShaderPathBox"

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -7,6 +7,16 @@
         <StackPanel Spacing="8" MaxWidth="600">
             <TextBlock Text="Appearance" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
 
+            <ComboBox
+                x:Name="WindowThemeCombo"
+                Header="Window theme"
+                SelectionChanged="WindowTheme_SelectionChanged">
+                <ComboBoxItem Content="Auto" Tag="auto" />
+                <ComboBoxItem Content="System" Tag="system" />
+                <ComboBoxItem Content="Light" Tag="light" />
+                <ComboBoxItem Content="Dark" Tag="dark" />
+            </ComboBox>
+
             <AutoSuggestBox
                 x:Name="FontFamilySearch"
                 Header="Font family"

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -24,8 +24,23 @@ internal sealed partial class AppearancePage : Page
         InitializeComponent();
         _fontList = new SearchableList(FontFamilySearch, chosen => OnValueChanged("font-family", chosen));
         OpacitySlider.Value = configService.BackgroundOpacity;
+        SelectWindowTheme(configService.WindowTheme);
         _loading = false;
         LoadFontsAsync();
+    }
+
+    private void SelectWindowTheme(string theme)
+    {
+        foreach (ComboBoxItem item in WindowThemeCombo.Items)
+        {
+            if (string.Equals(item.Tag?.ToString(), theme, StringComparison.OrdinalIgnoreCase))
+            {
+                WindowThemeCombo.SelectedItem = item;
+                return;
+            }
+        }
+        // Default to "auto" if the value is unrecognized.
+        WindowThemeCombo.SelectedIndex = 0;
     }
 
     private void LoadFontsAsync()
@@ -155,6 +170,12 @@ internal sealed partial class AppearancePage : Page
     private void Opacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
         OnValueChanged("background-opacity", e.NewValue.ToString("F2"));
+    }
+
+    private void WindowTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (sender is ComboBox combo && combo.SelectedItem is ComboBoxItem item)
+            OnValueChanged("window-theme", item.Tag?.ToString() ?? "auto");
     }
 
     private void ShaderPath_LostFocus(object sender, RoutedEventArgs e)

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -23,6 +23,7 @@ internal sealed partial class AppearancePage : Page
         _editor = editor;
         InitializeComponent();
         _fontList = new SearchableList(FontFamilySearch, chosen => OnValueChanged("font-family", chosen));
+        OpacitySlider.Value = configService.BackgroundOpacity;
         _loading = false;
         LoadFontsAsync();
     }
@@ -149,6 +150,11 @@ internal sealed partial class AppearancePage : Page
     private void FontSize_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
     {
         OnValueChanged("font-size", sender.Value.ToString());
+    }
+
+    private void Opacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+    {
+        OnValueChanged("background-opacity", e.NewValue.ToString("F2"));
     }
 
     private void ShaderPath_LostFocus(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Fix DX12 bg_color pipeline missing premultiplied alpha blend state
- Add background-opacity config reading from libghostty (GetDouble + IConfigService)
- Fix white-on-white title bar/tabs on light system theme (App.xaml dark + DWM attribute)
- Add opacity slider to Settings UI Appearance page
- Add WindowTransparencyState pure-logic type with 17 unit tests
- Fix justfile run-win DLL copy + add run-win-aot recipe

> **IMPORTANT:** This is part of a stack. Actual window transparency (desktop showing through) is blocked by SwapChainPanel compositing opaquely regardless of swap chain alpha mode. Tracked in #196.

## Related issues

- Closes #194 (this PR)
- #195 -- window-theme light/dark/system support
- #196 -- window transparency via HWND + DirectComposition
- #197 -- progressive acrylic with custom tint and noise textures

## Test plan

- [ ] Build with `just run-win-aot` -- verify dark title bar on light system theme
- [ ] Set `background-opacity = 0.5` in config -- verify slider reads the value in Settings
- [ ] Adjust slider -- verify config file updates and reload fires
- [ ] Verify 156 unit tests pass (`dotnet test`)
- [ ] Verify no regression on opaque mode (opacity = 1.0)