### PR TITLE
feat(windows): bump Microsoft.WindowsAppSDK to 1.8.6

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -58,7 +58,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250602001" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Bumps `Microsoft.WindowsAppSDK` from `1.6.250602001` to `1.8.260317003` (1.8.6, released 2026-03-18).
- Option A from the # 205 reshape: dep bump only. No `TitleBar` migration, no `AppIconBadge` consolidation, no custom titlebar deletion. The tabs-fused-into-the-title-bar look is preserved.
- Single-line diff in `windows/Ghostty/Ghostty.csproj`. No source code changes.

## What we inherit

- 1.8.0 `ExtendsContentIntoTitleBar` hover-flicker fix.
- Mica and acrylic tint refinements from 1.7 and 1.8.
- Input routing improvements.
- CsWinRT projection updates.

## Size impact

NativeAOT publish is essentially flat: 33.5 MB -> 33.2 MB. The # 206 follow-ups plan budgeted 40-50 MB as a pessimistic ceiling; actual impact was smaller thanks to tighter 1.8 trim behaviour on transitive WebView2 projection.

## Warning diff

Zero new CsWinRT1028. Zero new IL2104/IL3053. Two pre-existing WebView2 transitive IL warnings from the 1.6 baseline no longer surface on 1.8.6, a net improvement for the # 204 analyzer triad follow-up.

## Non-goals

No TitleBar migration. No AppIconBadge collapse. No TitleBarCoordinator deletion. Minimum Windows version stays at 10.0.17763.0.

## Test plan

- [x] Clean dotnet build Debug and Release
- [x] dotnet publish -c Release -r win-x64 (NativeAOT) succeeds
- [x] Warning diff vs pre-bump baseline: only net improvement
- [x] dotnet test windows/Ghostty.Tests (156 passed before and after)
- [ ] Manual smoke on Windows 11: drag regions, maximize/restore, hover-flicker fix, AppIconBadge in both layouts, Alt+Tab thumbnail, taskbar progress, edge resize

> **IMPORTANT**: stacked PR. Part 1 of 7 in the PR 206 follow-ups chain. Parent: \`windows\`. Stack: # 205 -> # 203 -> # 204 -> # 200 -> # 202 -> # 199 -> # 201.

Refs: # 205