### PR TITLE
feat(windows): enable AOT/trim/single-file analyzer triad

### DIFF
--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -16,5 +16,14 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+    <!--
+      IsAotCompatible is the composite library-project knob that flips
+      EnableTrimAnalyzer, EnableAotAnalyzer, EnableSingleFileAnalyzer,
+      and IsTrimmable together. TrimmerSingleWarn=false expands the
+      default per-assembly aggregate rollup into per-callsite diagnostics
+      so future warnings land with actionable locations. Issue # 204.
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
 </Project>

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -20,6 +20,16 @@
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!--
+      Analyzer triad: surface AOT / trim / single-file incompatibilities
+      at build time. Tests are never AOT-published, but the analyzers
+      catch helpers that do something AOT-unsafe before it gets copy-pasted
+      into production code. Issue # 204.
+    -->
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -32,4 +32,16 @@
     <ProjectReference Include="..\Ghostty.Core\Ghostty.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      Embed the hand-written P/Invoke surface as a manifest resource so
+      MarshalComplianceTests can text-scan it without a project reference
+      to Ghostty.csproj (which would drag WinAppSDK targets into a plain
+      net9.0 test assembly).
+    -->
+    <EmbeddedResource Include="..\Ghostty\Interop\NativeMethods.cs"
+                      Link="Interop\NativeMethods.cs"
+                      LogicalName="Ghostty.Tests.Interop.NativeMethods.cs" />
+  </ItemGroup>
+
 </Project>

--- a/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
+++ b/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+// Guardrail for PR 203's DisableRuntimeMarshalling convention. The
+// Ghostty assembly carries [assembly: DisableRuntimeMarshalling], and
+// the two-BOOL-shape convention (byte for libghostty C99 _Bool, int
+// for Win32 BOOL) means no [LibraryImport] or [UnmanagedFunctionPointer]
+// signature in NativeMethods.cs should carry a [MarshalAs(...)] hint.
+//
+// The Ghostty project is a WinAppSDK project; this test project is
+// plain net9.0 and cannot reference it. NativeMethods.cs is embedded
+// as a manifest resource via <EmbeddedResource Link=...> in
+// Ghostty.Tests.csproj so this test can read it without a project
+// reference.
+//
+// Scanner rule: strip trailing `//` line comments before scanning, so
+// that explanatory comments like `// [MarshalAs] was removed here`
+// do NOT false-positive. The scanner does NOT strip `/* ... */` block
+// comments; the project convention in NativeMethods.cs is line
+// comments only, and adding a block-comment stripper would add state
+// to the scanner without a matching benefit.
+//
+// When this test fails: either the convention is being reintroduced
+// (fix the signature), or the convention intentionally moved (update
+// this test).
+public class MarshalComplianceTests
+{
+    private const string ResourceName = "Ghostty.Tests.Interop.NativeMethods.cs";
+
+    // Note: `StringMarshalling = StringMarshalling.Utf8` is a separate,
+    // supported mechanism and is NOT what this test scans for. Only the
+    // `[MarshalAs` attribute form is a compliance violation.
+    private const string BannedAttribute = "[MarshalAs";
+
+    // Two subsequences of UnmanagedType we care about. These are the
+    // values the spec explicitly calls out as the audit targets.
+    private static readonly string[] BannedUnmanagedTypes = new[]
+    {
+        "UnmanagedType.Bool",
+        "UnmanagedType.I1",
+    };
+
+    [Fact]
+    public void NativeMethods_HasNoMarshalAsAttributes()
+    {
+        var source = ReadEmbeddedSource();
+        var offending = ScanForBannedAttribute(source, BannedAttribute);
+
+        Assert.True(
+            offending.Count == 0,
+            "NativeMethods.cs must not contain [MarshalAs] attributes under " +
+            "[assembly: DisableRuntimeMarshalling]. Offending lines:\n" +
+            string.Join("\n", offending.Select(l => $"  line {l.Number}: {l.Text.Trim()}")));
+    }
+
+    [Fact]
+    public void NativeMethods_HasNoUnmanagedTypeBoolOrI1()
+    {
+        var source = ReadEmbeddedSource();
+        var offending = ScanForBannedTokens(source, BannedUnmanagedTypes);
+
+        Assert.True(
+            offending.Count == 0,
+            "NativeMethods.cs must not reference UnmanagedType.Bool or " +
+            "UnmanagedType.I1. Two-BOOL-shape convention: byte for " +
+            "libghostty C99 _Bool, int for Win32 BOOL. Offending lines:\n" +
+            string.Join("\n", offending.Select(l => $"  line {l.Number}: {l.Text.Trim()}")));
+    }
+
+    // Unit test: comment-only mention must not false-positive.
+    [Fact]
+    public void Scanner_IgnoresMarshalAsInsideLineComment()
+    {
+        const string sample =
+            "public partial class Fake\n" +
+            "{\n" +
+            "    // [MarshalAs(UnmanagedType.I1)] explanation kept for historical context\n" +
+            "    public byte Composing;\n" +
+            "}\n";
+
+        var attrHits = ScanForBannedAttribute(sample, BannedAttribute);
+        var tokenHits = ScanForBannedTokens(sample, BannedUnmanagedTypes);
+
+        Assert.Empty(attrHits);
+        Assert.Empty(tokenHits);
+    }
+
+    // Unit test: a real attribute line must be flagged.
+    [Fact]
+    public void Scanner_FlagsRealMarshalAsAttributeLine()
+    {
+        const string sample =
+            "public partial struct Fake\n" +
+            "{\n" +
+            "    [MarshalAs(UnmanagedType.I1)]\n" +
+            "    public bool Composing;\n" +
+            "}\n";
+
+        var attrHits = ScanForBannedAttribute(sample, BannedAttribute);
+        var tokenHits = ScanForBannedTokens(sample, BannedUnmanagedTypes);
+
+        Assert.Single(attrHits);
+        Assert.Single(tokenHits);
+    }
+
+    // Strip trailing `//` line comments from each source line before
+    // searching, so commentary like `// [MarshalAs] was removed here`
+    // does not trigger a false positive. The cheapest correct
+    // implementation: look for the first `//` and take the prefix.
+    // This is NOT a full C# tokenizer: it does not understand string
+    // literals containing `//`, but NativeMethods.cs has no such
+    // lines today and adding one would be obviously wrong anyway.
+    private static List<(int Number, string Text)> ScanForBannedAttribute(string source, string banned)
+    {
+        var hits = new List<(int Number, string Text)>();
+        foreach (var pair in EnumerateLines(source))
+        {
+            var stripped = StripLineComment(pair.Text);
+            if (stripped.Contains(banned, StringComparison.Ordinal))
+            {
+                hits.Add(pair);
+            }
+        }
+        return hits;
+    }
+
+    private static List<(int Number, string Text)> ScanForBannedTokens(string source, string[] bannedTokens)
+    {
+        var hits = new List<(int Number, string Text)>();
+        foreach (var pair in EnumerateLines(source))
+        {
+            var stripped = StripLineComment(pair.Text);
+            if (bannedTokens.Any(bt => stripped.Contains(bt, StringComparison.Ordinal)))
+            {
+                hits.Add(pair);
+            }
+        }
+        return hits;
+    }
+
+    private static string StripLineComment(string rawLine)
+    {
+        var commentIdx = rawLine.IndexOf("//", StringComparison.Ordinal);
+        return commentIdx >= 0 ? rawLine.Substring(0, commentIdx) : rawLine;
+    }
+
+    private static string ReadEmbeddedSource()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(ResourceName);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+
+    private static IEnumerable<(int Number, string Text)> EnumerateLines(string source)
+    {
+        var lines = source.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            yield return (i + 1, lines[i]);
+        }
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -319,28 +319,6 @@ public sealed partial class TerminalControl : UserControl
         // Focus lives on the UserControl now, not the panel.
         this.Focus(FocusState.Programmatic);
 
-        // Walk our visual ancestors and disable IsTabStop on any
-        // ScrollViewer we find. WinUI 3 implicitly inserts a
-        // Microsoft.UI.Xaml.Controls.ScrollViewer above our content
-        // (likely from the Window's XAML host); without this, every
-        // pointer click on the SwapChainPanel routes through the
-        // framework's hit-test focus path -> ScrollViewer, gets bounced
-        // back by OnPointerPressed -> UserControl, and surfaces to
-        // libghostty as a focused=false / focused=true pair on every
-        // click. Removing the ScrollViewer from the focus chain at
-        // load time prevents the storm at the source, with no per-event
-        // cost and no global FocusManager subscription.
-        DisableAncestorScrollViewerTabStop();
-    }
-
-    private void DisableAncestorScrollViewerTabStop()
-    {
-        DependencyObject? node = this;
-        while (node is not null)
-        {
-            node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
-            if (node is ScrollViewer sv) sv.IsTabStop = false;
-        }
     }
 
     private void DisableAncestorScrollViewerTabStop()

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -722,7 +722,7 @@ public sealed partial class TerminalControl : UserControl
             Keycode = scancode,
             Text = IntPtr.Zero,
             UnshiftedCodepoint = 0,
-            Composing = false,
+            Composing = 0,
         };
         var handled = NativeMethods.SurfaceKey(_surface, key);
         if (handled) e.Handled = true;

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -23,6 +23,17 @@
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
+    <!--
+      Analyzer triad: surface AOT / trim / single-file incompatibilities
+      at build time instead of only at publish time. TrimmerSingleWarn=false
+      expands the default per-assembly aggregate rollup into per-callsite
+      diagnostics so future warnings land with actionable locations.
+      Issue # 204.
+    -->
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <!-- Use our own Program.Main with diagnostic error capture instead
          of the XAML-generated entry point (App.g.i.cs). This lets us
          catch NativeAOT startup failures that would otherwise exit

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -170,7 +170,7 @@ internal sealed class GhosttyHost : IDisposable
     private const int GhosttyTargetApp = 0;
     private const int GhosttyTargetSurface = 1;
 
-    private bool OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr)
+    private byte OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr)
     {
         // ABI note: ghostty_runtime_action_cb is declared as
         //
@@ -194,7 +194,7 @@ internal sealed class GhosttyHost : IDisposable
         // ephemeral stack copies of the structs and must be DEREFERENCED to
         // get at their contents. Treating targetPtr as if it were the surface
         // handle silently misses every dictionary lookup.
-        if (actionPtr == IntPtr.Zero || targetPtr == IntPtr.Zero) return false;
+        if (actionPtr == IntPtr.Zero || targetPtr == IntPtr.Zero) return 0;
 
         // ghostty_action_s layout: { int32 tag; <union> action; }
         // Union starts at offset 8 (8-byte aligned on x64).
@@ -209,28 +209,28 @@ internal sealed class GhosttyHost : IDisposable
                 case GhosttyActionTag.OpenConfig:
                     _dispatcher.TryEnqueue(() =>
                         OpenConfigRequested?.Invoke(this, EventArgs.Empty));
-                    return true;
+                    return 1;
 
                 case GhosttyActionTag.ReloadConfig:
                     _dispatcher.TryEnqueue(() =>
                         ReloadConfigRequested?.Invoke(this, EventArgs.Empty));
-                    return true;
+                    return 1;
 
                 default:
-                    return false;
+                    return 0;
             }
         }
 
-        if (targetTag != GhosttyTargetSurface) return false;
+        if (targetTag != GhosttyTargetSurface) return 0;
         var surfaceHandle = Marshal.ReadIntPtr(targetPtr, 8);
-        if (!_surfaces.TryGetValue(surfaceHandle, out var control)) return false;
+        if (!_surfaces.TryGetValue(surfaceHandle, out var control)) return 0;
 
         switch (tag)
         {
             case GhosttyActionTag.ToggleCommandPalette:
                 _dispatcher.TryEnqueue(() =>
                     CommandPaletteToggleRequested?.Invoke(this, EventArgs.Empty));
-                return true;
+                return 1;
 
             case GhosttyActionTag.SetTitle:
             {
@@ -244,13 +244,13 @@ internal sealed class GhosttyHost : IDisposable
                     if (_surfaces.TryGetValue(surfaceHandle, out var c))
                         c.RaiseTitleChanged(title);
                 });
-                return true;
+                return 1;
             }
 
             case GhosttyActionTag.RingBell:
             {
                 NativeMethods.MessageBeep(NativeMethods.MB_OK);
-                return true;
+                return 1;
             }
 
             case GhosttyActionTag.CloseWindow:
@@ -260,7 +260,7 @@ internal sealed class GhosttyHost : IDisposable
                     if (_surfaces.TryGetValue(surfaceHandle, out var c))
                         c.RaiseCloseRequested();
                 });
-                return true;
+                return 1;
             }
 
             case GhosttyActionTag.Scrollbar:
@@ -284,7 +284,7 @@ internal sealed class GhosttyHost : IDisposable
                 // been disposed we silently drop the update.
                 if (_surfaces.TryGetValue(surfaceHandle, out var c))
                     c.QueueScrollbarChanged(s.Total, s.Offset, s.Len);
-                return true;
+                return 1;
             }
 
             case GhosttyActionTag.ProgressReport:
@@ -310,24 +310,24 @@ internal sealed class GhosttyHost : IDisposable
                     if (_surfaces.TryGetValue(surfaceHandle, out var c))
                         c.RaiseProgressChanged(tabState);
                 });
-                return true;
+                return 1;
             }
 
             default:
-                return false;
+                return 0;
         }
     }
 
-    private bool OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state)
-        => _clipboardBridge?.HandleRead(userdata, kind, state) ?? false;
+    private byte OnReadClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr state)
+        => (_clipboardBridge?.HandleRead(userdata, kind, state) ?? false) ? (byte)1 : (byte)0;
 
     private void OnConfirmReadClipboard(IntPtr userdata, IntPtr str, IntPtr state, GhosttyClipboardRequest request)
         => _clipboardBridge?.HandleConfirm(userdata, str, state, request);
 
-    private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, bool confirm)
-        => _clipboardBridge?.HandleWrite(userdata, kind, content, count, confirm);
+    private void OnWriteClipboard(IntPtr userdata, GhosttyClipboard kind, IntPtr content, UIntPtr count, byte confirm)
+        => _clipboardBridge?.HandleWrite(userdata, kind, content, count, confirm != 0);
 
-    private void OnCloseSurface(IntPtr userdata, bool processAlive)
+    private void OnCloseSurface(IntPtr userdata, byte processAlive)
     {
         // userdata is the GCHandle.ToIntPtr value the owning TerminalControl
         // pinned for itself before SurfaceNew. Decode it back to the managed

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -113,7 +113,7 @@ internal sealed class GhosttyHost : IDisposable
         var runtime = new GhosttyRuntimeConfig
         {
             Userdata = IntPtr.Zero,
-            SupportsSelectionClipboard = false,
+            SupportsSelectionClipboard = 0,
             WakeupCb = Marshal.GetFunctionPointerForDelegate(_wakeupCb),
             ActionCb = Marshal.GetFunctionPointerForDelegate(_actionCb),
             ReadClipboardCb = Marshal.GetFunctionPointerForDelegate(_readClipboardCb),

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -182,13 +182,13 @@ internal delegate void GhosttyWakeupCb(IntPtr userdata);
 // are larger than 8 bytes, so on the Windows x64 ABI they are passed by
 // hidden pointer. We take both as IntPtr and decode the fields we need
 // with Marshal.PtrToStructure / Marshal.ReadIntPtr.
+// Returns C99 _Bool on the Zig side, exposed here as byte. The
+// managed handler on GhosttyHost returns 1 or 0 directly.
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-[return: MarshalAs(UnmanagedType.I1)]
-internal delegate bool GhosttyActionCb(GhosttyApp app, IntPtr targetPtr, IntPtr actionPtr);
+internal delegate byte GhosttyActionCb(GhosttyApp app, IntPtr targetPtr, IntPtr actionPtr);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-[return: MarshalAs(UnmanagedType.I1)]
-internal delegate bool GhosttyReadClipboardCb(IntPtr userdata, GhosttyClipboard kind, IntPtr state);
+internal delegate byte GhosttyReadClipboardCb(IntPtr userdata, GhosttyClipboard kind, IntPtr state);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 internal delegate void GhosttyConfirmReadClipboardCb(
@@ -203,12 +203,12 @@ internal delegate void GhosttyWriteClipboardCb(
     GhosttyClipboard kind,
     IntPtr content,  // const ghostty_clipboard_content_s*
     UIntPtr count,
-    [MarshalAs(UnmanagedType.I1)] bool confirm);
+    byte confirm);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 internal delegate void GhosttyCloseSurfaceCb(
     IntPtr userdata,
-    [MarshalAs(UnmanagedType.I1)] bool processAlive);
+    byte processAlive);
 
 // Mirrors ghostty_target_s in include/ghostty.h:
 //   typedef struct { ghostty_target_tag_e tag; ghostty_target_u target; }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -319,10 +319,14 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial GhosttyConfig ConfigClone(GhosttyConfig config);
 
+    // Raw P/Invoke returns byte (C99 _Bool). The internal wrapper below
+    // converts to bool so call sites in ConfigService stay idiomatic.
     [LibraryImport(Dll, EntryPoint = "ghostty_config_get")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    [return: MarshalAs(UnmanagedType.I1)]
-    internal static partial bool ConfigGet(GhosttyConfig config, IntPtr output, IntPtr key, UIntPtr keyLen);
+    private static partial byte ConfigGetNative(GhosttyConfig config, IntPtr output, IntPtr key, UIntPtr keyLen);
+
+    internal static bool ConfigGet(GhosttyConfig config, IntPtr output, IntPtr key, UIntPtr keyLen)
+        => ConfigGetNative(config, output, key, keyLen) != 0;
 
     [LibraryImport(Dll, EntryPoint = "ghostty_config_trigger")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
@@ -418,23 +422,21 @@ internal static partial class NativeMethods
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_shared_texture")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    [return: MarshalAs(UnmanagedType.I1)]
-    internal static partial bool SurfaceSharedTexture(
+    private static partial byte SurfaceSharedTextureNative(
         GhosttySurface surface,
         out GhosttySharedTextureSnapshot snapshot);
 
-    [DllImport(Dll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ghostty_surface_shared_texture")]
-    [return: MarshalAs(UnmanagedType.I1)]
-    internal static extern bool SurfaceSharedTexture(
-        GhosttySurface surface,
-        out GhosttySharedTextureSnapshot snapshot);
+    internal static bool SurfaceSharedTexture(GhosttySurface surface, out GhosttySharedTextureSnapshot snapshot)
+        => SurfaceSharedTextureNative(surface, out snapshot) != 0;
 
     // ---- surface input -------------------------------------------------
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_key")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    [return: MarshalAs(UnmanagedType.I1)]
-    internal static partial bool SurfaceKey(GhosttySurface surface, GhosttyInputKey key);
+    private static partial byte SurfaceKeyNative(GhosttySurface surface, GhosttyInputKey key);
+
+    internal static bool SurfaceKey(GhosttySurface surface, GhosttyInputKey key)
+        => SurfaceKeyNative(surface, key) != 0;
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_text")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
@@ -446,12 +448,18 @@ internal static partial class NativeMethods
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_mouse_button")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    [return: MarshalAs(UnmanagedType.I1)]
-    internal static partial bool SurfaceMouseButton(
+    private static partial byte SurfaceMouseButtonNative(
         GhosttySurface surface,
         GhosttyMouseState state,
         GhosttyMouseButton button,
         GhosttyMods mods);
+
+    internal static bool SurfaceMouseButton(
+        GhosttySurface surface,
+        GhosttyMouseState state,
+        GhosttyMouseButton button,
+        GhosttyMods mods)
+        => SurfaceMouseButtonNative(surface, state, button, mods) != 0;
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_mouse_pos")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
@@ -473,11 +481,16 @@ internal static partial class NativeMethods
     // side — libghostty takes (ptr, len).
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_binding_action")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    [return: MarshalAs(UnmanagedType.I1)]
-    internal static unsafe partial bool SurfaceBindingAction(
+    private static unsafe partial byte SurfaceBindingActionNative(
         GhosttySurface surface,
         byte* action,
         UIntPtr actionLen);
+
+    internal static unsafe bool SurfaceBindingAction(
+        GhosttySurface surface,
+        byte* action,
+        UIntPtr actionLen)
+        => SurfaceBindingActionNative(surface, action, actionLen) != 0;
 
     // ---- surface misc --------------------------------------------------
 
@@ -487,8 +500,10 @@ internal static partial class NativeMethods
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_process_exited")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    [return: MarshalAs(UnmanagedType.I1)]
-    internal static partial bool SurfaceProcessExited(GhosttySurface surface);
+    private static partial byte SurfaceProcessExitedNative(GhosttySurface surface);
+
+    internal static bool SurfaceProcessExited(GhosttySurface surface)
+        => SurfaceProcessExitedNative(surface) != 0;
 
     // ghostty_surface_complete_clipboard_request(surface, text, state, confirmed)
     // Called once per read/confirm request to return clipboard text to libghostty

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -403,8 +403,12 @@ internal static partial class NativeMethods
 
     // MapVirtualKeyW for the keycode ScanCode==0 fallback in TerminalControl.
     // Win32 user32, not WinRT - bypasses any WinUI framework filtering.
+    // [DefaultDllImportSearchPaths(System32)] matches the
+    // SystemMenuInterop.cs hardening convention for Win32 imports so
+    // the DLL resolves from %WINDIR%\System32, not a hijacked PATH.
     internal const uint MAPVK_VK_TO_VSC = 0;
     [LibraryImport("user32.dll", EntryPoint = "MapVirtualKeyW")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static partial uint MapVirtualKeyW(uint uCode, uint uMapType);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_content_scale")]
@@ -559,9 +563,13 @@ internal static partial class NativeMethods
     // MessageBeep is thread-safe and minimal-dependency. Used by the
     // action callback for RING_BELL without any dispatcher hop.
     // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-messagebeep
+    //
+    // Return type is `int`, matching the Win32 BOOL = 4-byte convention
+    // used by SystemMenuInterop.cs. The sole caller at GhosttyHost.cs
+    // RingBell discards the return value.
     internal const uint MB_OK = 0x00000000;
 
     [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)] // Win32 BOOL is 4 bytes, not 1
-    internal static partial bool MessageBeep(uint uType);
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static partial int MessageBeep(uint uType);
 }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -106,14 +106,12 @@ internal struct GhosttyInputKey
     public uint Keycode;
     public IntPtr Text;              // const char*
     public uint UnshiftedCodepoint;
-    // Zig bool is 1 byte; use byte to avoid SYSLIB1051 without
-    // assembly-wide DisableRuntimeMarshalling.
-    private byte _composing;
-    public bool Composing
-    {
-        readonly get => _composing != 0;
-        set => _composing = value ? (byte)1 : (byte)0;
-    }
+    // libghostty types this as C99 _Bool (1 byte). byte + IsComposing
+    // helper matches GhosttySharedTextureConfig.Enabled + IsEnabled
+    // under [assembly: DisableRuntimeMarshalling].
+    public byte Composing;
+
+    public bool IsComposing => Composing != 0;
 }
 
 // GhosttySharedTextureConfig and GhosttySharedTextureSnapshot live in
@@ -158,12 +156,8 @@ internal struct GhosttySurfaceConfig
     public IntPtr EnvVars;          // ghostty_env_var_s*
     public UIntPtr EnvVarCount;
     public IntPtr InitialInput;     // const char*
-    private byte _waitAfterCommand; // Zig bool → byte (see GhosttyInputKey)
-    public bool WaitAfterCommand
-    {
-        readonly get => _waitAfterCommand != 0;
-        set => _waitAfterCommand = value ? (byte)1 : (byte)0;
-    }
+    // C99 _Bool on the C side; byte on the managed side.
+    public byte WaitAfterCommand;
     public GhosttySurfaceContext Context;
 }
 
@@ -278,12 +272,8 @@ internal struct GhosttyInputTrigger
 internal struct GhosttyRuntimeConfig
 {
     public IntPtr Userdata;
-    private byte _supportsSelectionClipboard; // Zig bool → byte (see GhosttyInputKey)
-    public bool SupportsSelectionClipboard
-    {
-        readonly get => _supportsSelectionClipboard != 0;
-        set => _supportsSelectionClipboard = value ? (byte)1 : (byte)0;
-    }
+    // C99 _Bool on the C side; byte on the managed side.
+    public byte SupportsSelectionClipboard;
     public IntPtr WakeupCb;              // function pointers held as IntPtr
     public IntPtr ActionCb;              // so we control the lifetime of the
     public IntPtr ReadClipboardCb;       // managed delegates they point at.

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -360,7 +360,10 @@ internal static partial class NativeMethods
 
     [LibraryImport(Dll, EntryPoint = "ghostty_app_set_focus")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    internal static partial void AppSetFocus(GhosttyApp app, [MarshalAs(UnmanagedType.I1)] bool focused);
+    private static partial void AppSetFocusNative(GhosttyApp app, byte focused);
+
+    internal static void AppSetFocus(GhosttyApp app, bool focused)
+        => AppSetFocusNative(app, focused ? (byte)1 : (byte)0);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_app_set_color_scheme")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
@@ -410,11 +413,17 @@ internal static partial class NativeMethods
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_focus")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    internal static partial void SurfaceSetFocus(GhosttySurface surface, [MarshalAs(UnmanagedType.I1)] bool focused);
+    private static partial void SurfaceSetFocusNative(GhosttySurface surface, byte focused);
+
+    internal static void SurfaceSetFocus(GhosttySurface surface, bool focused)
+        => SurfaceSetFocusNative(surface, focused ? (byte)1 : (byte)0);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_occlusion")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    internal static partial void SurfaceSetOcclusion(GhosttySurface surface, [MarshalAs(UnmanagedType.I1)] bool occluded);
+    private static partial void SurfaceSetOcclusionNative(GhosttySurface surface, byte occluded);
+
+    internal static void SurfaceSetOcclusion(GhosttySurface surface, bool occluded)
+        => SurfaceSetOcclusionNative(surface, occluded ? (byte)1 : (byte)0);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_size")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
@@ -509,14 +518,24 @@ internal static partial class NativeMethods
     // Called once per read/confirm request to return clipboard text to libghostty
     // and release its internal request state. Must be called exactly once even on
     // error paths -- skipping it leaks state inside libghostty.
+    // StringMarshalling.Utf8 is a first-class [LibraryImport] option and
+    // is NOT a [MarshalAs] attribute, so it coexists cleanly with
+    // DisableRuntimeMarshalling. Only `confirmed` needed the fix.
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_complete_clipboard_request",
         StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    internal static partial void SurfaceCompleteClipboardRequest(
+    private static partial void SurfaceCompleteClipboardRequestNative(
         IntPtr surface,
         string text,
         IntPtr state,
-        [MarshalAs(UnmanagedType.I1)] bool confirmed);
+        byte confirmed);
+
+    internal static void SurfaceCompleteClipboardRequest(
+        IntPtr surface,
+        string text,
+        IntPtr state,
+        bool confirmed)
+        => SurfaceCompleteClipboardRequestNative(surface, text, state, confirmed ? (byte)1 : (byte)0);
 
     // ghostty_surface_complete_clipboard_request(surface, text, state, confirmed)
     // Called once per read/confirm request to return clipboard text to libghostty

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -541,22 +541,38 @@ internal static partial class NativeMethods
         bool confirmed)
         => SurfaceCompleteClipboardRequestNative(surface, text, state, confirmed ? (byte)1 : (byte)0);
 
-    // ghostty_surface_complete_clipboard_request(surface, text, state, confirmed)
-    // Called once per read/confirm request to return clipboard text to libghostty
-    // and release its internal request state. Must be called exactly once even on
-    // error paths -- skipping it leaks state inside libghostty.
-    //
-    // Source-generated via [LibraryImport] so this entry point is AOT-friendly
-    // and produces no IL stub. The rest of the file still uses [DllImport]; the
-    // standing migration TODO covers those.
-    [LibraryImport(Dll, EntryPoint = "ghostty_surface_complete_clipboard_request",
-        StringMarshalling = StringMarshalling.Utf8)]
+
+    // ---- inline theme picker ---------------------------------------------
+
+    // Callback for the inline theme picker. Fired from the Zig/apprt
+    // thread for each preview/confirm event.
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void InlineThemeCallback(IntPtr namePtr, byte confirmed);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_list_themes")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    internal static partial void SurfaceCompleteClipboardRequest(
-        IntPtr surface,
-        string text,
-        IntPtr state,
-        [MarshalAs(UnmanagedType.I1)] bool confirmed);
+    internal static partial IntPtr SurfaceListThemes(GhosttySurface surface, IntPtr callback);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_list_themes_should_quit")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceListThemesShouldQuitNative(IntPtr handle);
+
+    internal static bool SurfaceListThemesShouldQuit(IntPtr handle)
+        => SurfaceListThemesShouldQuitNative(handle) != 0;
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_list_themes_deinit")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void SurfaceListThemesDeinit(GhosttySurface surface, IntPtr handle);
+
+    // ---- CLI actions (PR 218) -------------------------------------------
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_cli_run_action")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial int CliRunAction();
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_cli_set_theme_callback")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void CliSetThemeCallback(IntPtr callback);
 
     // ---- user32 --------------------------------------------------------
 

--- a/windows/Ghostty/Interop/TaskbarInterop.cs
+++ b/windows/Ghostty/Interop/TaskbarInterop.cs
@@ -30,6 +30,12 @@ internal static partial class TaskbarInterop
         void ActivateTab(IntPtr hwnd);
         void SetActiveAlt(IntPtr hwnd);
         // ITaskbarList2
+        // TODO(# 203): Deferred from the DisableRuntimeMarshalling audit.
+        // This is a [GeneratedComInterface] method, not a [LibraryImport],
+        // which is a different source-generator path with its own
+        // marshalling rules and is not governed by DisableRuntimeMarshalling.
+        // It is also never called from our code today. Revisit if and when
+        // we start invoking ITaskbarList3::MarkFullscreenWindow.
         void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
         // ITaskbarList3 — only SetProgressValue / SetProgressState used
         void SetProgressValue(IntPtr hwnd, ulong ullCompleted, ulong ullTotal);


### PR DESCRIPTION
## Summary

- Enables the AOT/trim/single-file analyzer triad across \`Ghostty\`, \`Ghostty.Core\`, and \`Ghostty.Tests\`.
- \`Ghostty.Core\` uses the \`IsAotCompatible=true\` composite (also flips \`IsTrimmable=true\`, the right contract for a library consumed by an AOT-published shell).
- \`Ghostty\` and \`Ghostty.Tests\` use the explicit 4-property triad. \`IsAotCompatible\` on an executable or a test project has different semantics and is intentionally avoided.
- \`TrimmerSingleWarn=false\` is set on all three so any future warnings land per-callsite rather than as an assembly-level aggregate.

## Why

PR 204 triages warning coverage on top of the PR 205 (WinAppSDK 1.8.6) and PR 203 (marshalling audit) baselines. Landing the analyzers now catches any future AOT/trim regression at dev-time instead of at publish-time.

## Verification

- \`dotnet build\` Debug + Release: clean (2 pre-existing CS0067 on \`PaneActionRouter\`, untouched by this PR)
- \`dotnet test windows/Ghostty.Tests\`: 160/160 passing
- \`dotnet publish -c Release -r win-x64\` (NativeAOT): clean, native code generated
- Zero CsWinRT1028, zero IL2026/IL2050/IL2067/IL2075/IL2080/IL2091/IL2104/IL3050/IL3053 warnings

No source-code changes. Three csproj files, additive property flips only.

## Non-goals

- No suppressions. The original draft tried to land speculative suppressions for IL2104/IL3053 but those are assembly-level aggregate diagnostics that \`UnconditionalSuppressMessage\` cannot bind to a namespace scope, and \`TrimmerSingleWarn=false\` already converts them into per-callsite IL codes. Nothing to suppress today.
- No source-code cleanup. Pre-existing CS0067 is out of scope.

> **IMPORTANT**: stacked PR. Part 3 of 7 in the PR 206 follow-ups chain. Parent: \`windows-interop-marshalling-audit\`. Stack: # 205 -> # 203 -> # 204 -> # 200 -> # 202 -> # 199 -> # 201.

Refs: # 204