### PR TITLE
feat(windows): add snap layout zone picker for tab detach

### DIFF
--- a/windows/Ghostty.Core/Tabs/SnapMonitorShape.cs
+++ b/windows/Ghostty.Core/Tabs/SnapMonitorShape.cs
@@ -1,0 +1,37 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Monitor-shape bucket used by SnapZoneCatalog to choose which
+/// zone set to offer. Mirrors the Windows 11 shell's own heuristic:
+/// the shell swaps to three-column layouts around the 21:9 aspect
+/// ratio boundary, and to vertical thirds on portrait monitors.
+/// </summary>
+internal enum SnapMonitorShape
+{
+    StandardLandscape,
+    UltraWideLandscape,
+    Portrait,
+}
+
+/// <summary>
+/// Pure-logic zone catalog. Given the physical width and height of a
+/// monitor work area, returns the zone set that matches what the
+/// Windows 11 shell would show for that monitor's maximize-button
+/// flyout. SnapZoneCatalog has no WinUI dependency so it is directly
+/// unit-testable from Ghostty.Tests.
+/// </summary>
+internal static partial class SnapZoneCatalog
+{
+    // The Windows 11 shell flips to three-column ultra-wide layouts
+    // around 21:9 (2.333). 16:9 (1.78) and 16:10 (1.6) stay in the
+    // standard bucket. 2.1 is the conventional cut-off.
+    public const double UltraWideAspect = 2.1;
+
+    public static SnapMonitorShape Classify(int width, int height)
+    {
+        if (width < height) return SnapMonitorShape.Portrait;
+        double ratio = width / (double)height;
+        if (ratio >= UltraWideAspect) return SnapMonitorShape.UltraWideLandscape;
+        return SnapMonitorShape.StandardLandscape;
+    }
+}

--- a/windows/Ghostty.Core/Tabs/SnapMonitorShape.cs
+++ b/windows/Ghostty.Core/Tabs/SnapMonitorShape.cs
@@ -34,4 +34,42 @@ internal static partial class SnapZoneCatalog
         if (ratio >= UltraWideAspect) return SnapMonitorShape.UltraWideLandscape;
         return SnapMonitorShape.StandardLandscape;
     }
+
+    // Cached arrays returned via IReadOnlyList so no allocation on
+    // every call (the picker opens on every right-click).
+    private static readonly SnapZone[] StandardLandscapeZones =
+    {
+        SnapZone.LeftHalf, SnapZone.RightHalf,
+        SnapZone.TopHalf, SnapZone.BottomHalf,
+        SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+        SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+        SnapZone.Maximize,
+    };
+
+    private static readonly SnapZone[] UltraWideZones =
+    {
+        SnapZone.LeftHalf, SnapZone.RightHalf,
+        SnapZone.LeftThird, SnapZone.MiddleThird, SnapZone.RightThird,
+        SnapZone.LeftTwoThirds, SnapZone.RightTwoThirds,
+        SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+        SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+        SnapZone.Maximize,
+    };
+
+    private static readonly SnapZone[] PortraitZones =
+    {
+        SnapZone.TopHalf, SnapZone.BottomHalf,
+        SnapZone.TopThird, SnapZone.MiddleThirdHorizontal, SnapZone.BottomThird,
+        SnapZone.Maximize,
+    };
+
+    public static System.Collections.Generic.IReadOnlyList<SnapZone> ZonesFor(int width, int height)
+    {
+        return Classify(width, height) switch
+        {
+            SnapMonitorShape.UltraWideLandscape => UltraWideZones,
+            SnapMonitorShape.Portrait => PortraitZones,
+            _ => StandardLandscapeZones,
+        };
+    }
 }

--- a/windows/Ghostty.Core/Tabs/SnapZone.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZone.cs
@@ -1,0 +1,42 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// The set of Snap Layouts zones Ghostty offers. This is the union of
+/// the zones shown for standard-landscape, ultra-wide, and portrait
+/// monitors; SnapZoneCatalog picks the subset actually rendered by
+/// the picker based on the current monitor's aspect ratio.
+///
+/// Values intentionally mirror the Windows 11 shell's maximize-button
+/// flyout layout. There is no public API to query the shell's own
+/// preset list, so this enum is the source of truth.
+/// </summary>
+internal enum SnapZone
+{
+    Maximize,
+
+    // Halves (landscape and portrait both use these).
+    LeftHalf,
+    RightHalf,
+    TopHalf,
+    BottomHalf,
+
+    // Quarters (standard landscape + ultra-wide).
+    TopLeftQuarter,
+    TopRightQuarter,
+    BottomLeftQuarter,
+    BottomRightQuarter,
+
+    // Ultra-wide vertical thirds.
+    LeftThird,
+    MiddleThird,
+    RightThird,
+    LeftTwoThirds,
+    RightTwoThirds,
+
+    // Portrait horizontal thirds. Named with the "Horizontal" suffix
+    // so the middle row does not collide with the ultra-wide
+    // MiddleThird (vertical column).
+    TopThird,
+    MiddleThirdHorizontal,
+    BottomThird,
+}

--- a/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
@@ -30,6 +30,11 @@ internal static class SnapZoneMath
             SnapZone.TopHalf    => new SnapZoneRect(x,         y,         w,     halfH),
             SnapZone.BottomHalf => new SnapZoneRect(x,         y + halfH, w,     restH),
 
+            SnapZone.TopLeftQuarter     => new SnapZoneRect(x,         y,         halfW, halfH),
+            SnapZone.TopRightQuarter    => new SnapZoneRect(x + halfW, y,         restW, halfH),
+            SnapZone.BottomLeftQuarter  => new SnapZoneRect(x,         y + halfH, halfW, restH),
+            SnapZone.BottomRightQuarter => new SnapZoneRect(x + halfW, y + halfH, restW, restH),
+
             _ => throw new ArgumentOutOfRangeException(nameof(zone), zone, "Unhandled zone"),
         };
     }

--- a/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
@@ -21,6 +21,10 @@ internal static class SnapZoneMath
         int restW = w - halfW; // remainder lives in the right/bottom
         int restH = h - halfH;
 
+        int thirdW = w / 3;
+        int twoThirdW = 2 * thirdW;
+        int restThirdW = w - twoThirdW; // remainder for right third
+
         return zone switch
         {
             SnapZone.Maximize => new SnapZoneRect(x, y, w, h),
@@ -34,6 +38,12 @@ internal static class SnapZoneMath
             SnapZone.TopRightQuarter    => new SnapZoneRect(x + halfW, y,         restW, halfH),
             SnapZone.BottomLeftQuarter  => new SnapZoneRect(x,         y + halfH, halfW, restH),
             SnapZone.BottomRightQuarter => new SnapZoneRect(x + halfW, y + halfH, restW, restH),
+
+            SnapZone.LeftThird      => new SnapZoneRect(x,              y, thirdW,     h),
+            SnapZone.MiddleThird    => new SnapZoneRect(x + thirdW,     y, thirdW,     h),
+            SnapZone.RightThird     => new SnapZoneRect(x + twoThirdW,  y, restThirdW, h),
+            SnapZone.LeftTwoThirds  => new SnapZoneRect(x,              y, twoThirdW,  h),
+            SnapZone.RightTwoThirds => new SnapZoneRect(x + thirdW,     y, w - thirdW, h),
 
             _ => throw new ArgumentOutOfRangeException(nameof(zone), zone, "Unhandled zone"),
         };

--- a/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
@@ -25,6 +25,10 @@ internal static class SnapZoneMath
         int twoThirdW = 2 * thirdW;
         int restThirdW = w - twoThirdW; // remainder for right third
 
+        int thirdH = h / 3;
+        int twoThirdH = 2 * thirdH;
+        int restThirdH = h - twoThirdH;
+
         return zone switch
         {
             SnapZone.Maximize => new SnapZoneRect(x, y, w, h),
@@ -44,6 +48,10 @@ internal static class SnapZoneMath
             SnapZone.RightThird     => new SnapZoneRect(x + twoThirdW,  y, restThirdW, h),
             SnapZone.LeftTwoThirds  => new SnapZoneRect(x,              y, twoThirdW,  h),
             SnapZone.RightTwoThirds => new SnapZoneRect(x + thirdW,     y, w - thirdW, h),
+
+            SnapZone.TopThird              => new SnapZoneRect(x, y,             w, thirdH),
+            SnapZone.MiddleThirdHorizontal => new SnapZoneRect(x, y + thirdH,    w, thirdH),
+            SnapZone.BottomThird           => new SnapZoneRect(x, y + twoThirdH, w, restThirdH),
 
             _ => throw new ArgumentOutOfRangeException(nameof(zone), zone, "Unhandled zone"),
         };

--- a/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Pure rect math for Snap Layouts zones. Integer arithmetic only:
+/// work-area coordinates come from DisplayArea.WorkArea as physical
+/// pixels and go straight to AppWindow.MoveAndResize, so converting
+/// to double and back risks rounding off-by-ones.
+///
+/// The odd-width split always rounds the left half DOWN and gives
+/// the remainder to the right half, keeping left + right equal to
+/// the input width with no seam crossing the mid-line.
+/// </summary>
+internal static class SnapZoneMath
+{
+    public static SnapZoneRect RectFor(SnapZone zone, int x, int y, int w, int h)
+    {
+        int halfW = w / 2;
+        int halfH = h / 2;
+        int restW = w - halfW; // remainder lives in the right/bottom
+        int restH = h - halfH;
+
+        return zone switch
+        {
+            SnapZone.Maximize => new SnapZoneRect(x, y, w, h),
+
+            SnapZone.LeftHalf   => new SnapZoneRect(x,         y,         halfW, h),
+            SnapZone.RightHalf  => new SnapZoneRect(x + halfW, y,         restW, h),
+            SnapZone.TopHalf    => new SnapZoneRect(x,         y,         w,     halfH),
+            SnapZone.BottomHalf => new SnapZoneRect(x,         y + halfH, w,     restH),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(zone), zone, "Unhandled zone"),
+        };
+    }
+}

--- a/windows/Ghostty.Core/Tabs/SnapZoneRect.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZoneRect.cs
@@ -1,0 +1,9 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Pure-int rectangle for SnapZoneMath. Deliberately does NOT
+/// reference Windows.Graphics.RectInt32 so Ghostty.Core stays free
+/// of the WindowsAppSDK dependency. The WinUI shell converts to
+/// RectInt32 at the call site via SnapZoneRectInterop.
+/// </summary>
+internal readonly record struct SnapZoneRect(int X, int Y, int Width, int Height);

--- a/windows/Ghostty.Tests/Tabs/SnapZoneCatalogTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneCatalogTests.cs
@@ -1,0 +1,35 @@
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class SnapZoneCatalogTests
+{
+    [Theory]
+    [InlineData(1920, 1080, (int)SnapMonitorShape.StandardLandscape)] // 16:9
+    [InlineData(2560, 1600, (int)SnapMonitorShape.StandardLandscape)] // 16:10
+    [InlineData(1920, 1200, (int)SnapMonitorShape.StandardLandscape)] // 16:10
+    [InlineData(3440, 1440, (int)SnapMonitorShape.UltraWideLandscape)] // 21:9 = 2.388
+    [InlineData(5120, 1440, (int)SnapMonitorShape.UltraWideLandscape)] // 32:9 = 3.555
+    [InlineData(1080, 1920, (int)SnapMonitorShape.Portrait)]
+    [InlineData(1200, 1920, (int)SnapMonitorShape.Portrait)]
+    [InlineData(1000, 1000, (int)SnapMonitorShape.StandardLandscape)] // square -> landscape
+    public void Classify_returns_expected_shape(int w, int h, int expected)
+    {
+        Assert.Equal((SnapMonitorShape)expected, SnapZoneCatalog.Classify(w, h));
+    }
+
+    [Fact]
+    public void Classify_threshold_2point1_exact_is_ultrawide()
+    {
+        // 2100 x 1000 = 2.1 exact -> ultra-wide (>= 2.1)
+        Assert.Equal(SnapMonitorShape.UltraWideLandscape, SnapZoneCatalog.Classify(2100, 1000));
+    }
+
+    [Fact]
+    public void Classify_just_below_threshold_is_standard()
+    {
+        // 2099 x 1000 = 2.099 -> standard
+        Assert.Equal(SnapMonitorShape.StandardLandscape, SnapZoneCatalog.Classify(2099, 1000));
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/SnapZoneCatalogTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneCatalogTests.cs
@@ -32,4 +32,45 @@ public class SnapZoneCatalogTests
         // 2099 x 1000 = 2.099 -> standard
         Assert.Equal(SnapMonitorShape.StandardLandscape, SnapZoneCatalog.Classify(2099, 1000));
     }
+
+    [Fact]
+    public void ZonesFor_standard_landscape_returns_halves_quarters_plus_maximize()
+    {
+        var zones = SnapZoneCatalog.ZonesFor(1920, 1080);
+        Assert.Equal(new[]
+        {
+            SnapZone.LeftHalf, SnapZone.RightHalf,
+            SnapZone.TopHalf, SnapZone.BottomHalf,
+            SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+            SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+            SnapZone.Maximize,
+        }, zones);
+    }
+
+    [Fact]
+    public void ZonesFor_ultrawide_returns_halves_thirds_quarters_plus_maximize()
+    {
+        var zones = SnapZoneCatalog.ZonesFor(3440, 1440);
+        Assert.Equal(new[]
+        {
+            SnapZone.LeftHalf, SnapZone.RightHalf,
+            SnapZone.LeftThird, SnapZone.MiddleThird, SnapZone.RightThird,
+            SnapZone.LeftTwoThirds, SnapZone.RightTwoThirds,
+            SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+            SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+            SnapZone.Maximize,
+        }, zones);
+    }
+
+    [Fact]
+    public void ZonesFor_portrait_returns_halves_horizontal_thirds_plus_maximize()
+    {
+        var zones = SnapZoneCatalog.ZonesFor(1080, 1920);
+        Assert.Equal(new[]
+        {
+            SnapZone.TopHalf, SnapZone.BottomHalf,
+            SnapZone.TopThird, SnapZone.MiddleThirdHorizontal, SnapZone.BottomThird,
+            SnapZone.Maximize,
+        }, zones);
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
@@ -53,4 +53,49 @@ public class SnapZoneMathTests
         Assert.Equal(new SnapZoneRect(960, 0, 961, 1080), right);
         Assert.Equal(1921, left.Width + right.Width);
     }
+
+    [Fact]
+    public void TopLeftQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.TopLeftQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 960, 540), r);
+    }
+
+    [Fact]
+    public void TopRightQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.TopRightQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(960, 0, 960, 540), r);
+    }
+
+    [Fact]
+    public void BottomLeftQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.BottomLeftQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 540, 960, 540), r);
+    }
+
+    [Fact]
+    public void BottomRightQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.BottomRightQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(960, 540, 960, 540), r);
+    }
+
+    [Fact]
+    public void Quarters_odd_dimensions_cover_input_without_seam()
+    {
+        var tl = SnapZoneMath.RectFor(SnapZone.TopLeftQuarter, 0, 0, 1921, 1081);
+        var tr = SnapZoneMath.RectFor(SnapZone.TopRightQuarter, 0, 0, 1921, 1081);
+        var bl = SnapZoneMath.RectFor(SnapZone.BottomLeftQuarter, 0, 0, 1921, 1081);
+        var br = SnapZoneMath.RectFor(SnapZone.BottomRightQuarter, 0, 0, 1921, 1081);
+
+        // Widths sum to 1921 on top row.
+        Assert.Equal(1921, tl.Width + tr.Width);
+        // Heights sum to 1081 on left column.
+        Assert.Equal(1081, tl.Height + bl.Height);
+        // BR starts exactly where TL ends.
+        Assert.Equal(tl.X + tl.Width, br.X);
+        Assert.Equal(tl.Y + tl.Height, br.Y);
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
@@ -98,4 +98,54 @@ public class SnapZoneMathTests
         Assert.Equal(tl.X + tl.Width, br.X);
         Assert.Equal(tl.Y + tl.Height, br.Y);
     }
+
+    [Fact]
+    public void LeftThird_of_3440_wide()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.LeftThird, 0, 0, 3440, 1440);
+        // 3440 / 3 = 1146 (int)
+        Assert.Equal(new SnapZoneRect(0, 0, 1146, 1440), r);
+    }
+
+    [Fact]
+    public void MiddleThird_of_3440_wide()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.MiddleThird, 0, 0, 3440, 1440);
+        Assert.Equal(new SnapZoneRect(1146, 0, 1146, 1440), r);
+    }
+
+    [Fact]
+    public void RightThird_of_3440_wide_absorbs_remainder()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.RightThird, 0, 0, 3440, 1440);
+        // Starts at 2*1146 = 2292, width = 3440 - 2292 = 1148.
+        Assert.Equal(new SnapZoneRect(2292, 0, 1148, 1440), r);
+    }
+
+    [Fact]
+    public void Thirds_cover_input_without_seam()
+    {
+        var l = SnapZoneMath.RectFor(SnapZone.LeftThird, 0, 0, 3440, 1440);
+        var m = SnapZoneMath.RectFor(SnapZone.MiddleThird, 0, 0, 3440, 1440);
+        var r = SnapZoneMath.RectFor(SnapZone.RightThird, 0, 0, 3440, 1440);
+        Assert.Equal(3440, l.Width + m.Width + r.Width);
+        Assert.Equal(l.X + l.Width, m.X);
+        Assert.Equal(m.X + m.Width, r.X);
+    }
+
+    [Fact]
+    public void LeftTwoThirds_matches_LeftThird_plus_MiddleThird()
+    {
+        var lt = SnapZoneMath.RectFor(SnapZone.LeftTwoThirds, 0, 0, 3440, 1440);
+        // 2 * (3440/3) = 2292
+        Assert.Equal(new SnapZoneRect(0, 0, 2292, 1440), lt);
+    }
+
+    [Fact]
+    public void RightTwoThirds_matches_MiddleThird_plus_RightThird()
+    {
+        var rt = SnapZoneMath.RectFor(SnapZone.RightTwoThirds, 0, 0, 3440, 1440);
+        // Starts at w/3 = 1146, width = 3440 - 1146 = 2294.
+        Assert.Equal(new SnapZoneRect(1146, 0, 2294, 1440), rt);
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
@@ -148,4 +148,38 @@ public class SnapZoneMathTests
         // Starts at w/3 = 1146, width = 3440 - 1146 = 2294.
         Assert.Equal(new SnapZoneRect(1146, 0, 2294, 1440), rt);
     }
+
+    [Fact]
+    public void TopThird_of_1080x1920_portrait()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.TopThird, 0, 0, 1080, 1920);
+        // 1920 / 3 = 640
+        Assert.Equal(new SnapZoneRect(0, 0, 1080, 640), r);
+    }
+
+    [Fact]
+    public void MiddleThirdHorizontal_of_1080x1920_portrait()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.MiddleThirdHorizontal, 0, 0, 1080, 1920);
+        Assert.Equal(new SnapZoneRect(0, 640, 1080, 640), r);
+    }
+
+    [Fact]
+    public void BottomThird_of_1080x1920_portrait_absorbs_remainder()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.BottomThird, 0, 0, 1080, 1920);
+        // 2*640 = 1280, remainder = 640
+        Assert.Equal(new SnapZoneRect(0, 1280, 1080, 640), r);
+    }
+
+    [Fact]
+    public void Horizontal_thirds_cover_input_without_seam()
+    {
+        var t = SnapZoneMath.RectFor(SnapZone.TopThird, 0, 0, 1080, 1921);
+        var m = SnapZoneMath.RectFor(SnapZone.MiddleThirdHorizontal, 0, 0, 1080, 1921);
+        var b = SnapZoneMath.RectFor(SnapZone.BottomThird, 0, 0, 1080, 1921);
+        Assert.Equal(1921, t.Height + m.Height + b.Height);
+        Assert.Equal(t.Y + t.Height, m.Y);
+        Assert.Equal(m.Y + m.Height, b.Y);
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
@@ -1,0 +1,56 @@
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class SnapZoneMathTests
+{
+    [Fact]
+    public void Maximize_returns_input_rect()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.Maximize, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 1920, 1080), r);
+    }
+
+    [Fact]
+    public void LeftHalf_splits_even_width_in_half()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.LeftHalf, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 960, 1080), r);
+    }
+
+    [Fact]
+    public void RightHalf_has_matching_offset_and_remainder_width()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.RightHalf, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(960, 0, 960, 1080), r);
+    }
+
+    [Fact]
+    public void TopHalf_and_BottomHalf_split_height()
+    {
+        var top = SnapZoneMath.RectFor(SnapZone.TopHalf, 0, 0, 1920, 1080);
+        var bot = SnapZoneMath.RectFor(SnapZone.BottomHalf, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 1920, 540), top);
+        Assert.Equal(new SnapZoneRect(0, 540, 1920, 540), bot);
+    }
+
+    [Fact]
+    public void RespectsNonZeroOrigin_including_negative_left()
+    {
+        // Secondary monitor left of primary, taskbar at top.
+        var r = SnapZoneMath.RectFor(SnapZone.LeftHalf, -1920, 100, 1920, 1040);
+        Assert.Equal(new SnapZoneRect(-1920, 100, 960, 1040), r);
+    }
+
+    [Fact]
+    public void OddWidth_rounds_LeftHalf_down_RightHalf_takes_remainder()
+    {
+        // Width 1921 -> left 960, right 961, right origin at 960. Sum 1921.
+        var left = SnapZoneMath.RectFor(SnapZone.LeftHalf, 0, 0, 1921, 1080);
+        var right = SnapZoneMath.RectFor(SnapZone.RightHalf, 0, 0, 1921, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 960, 1080), left);
+        Assert.Equal(new SnapZoneRect(960, 0, 961, 1080), right);
+        Assert.Equal(1921, left.Width + right.Width);
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -447,43 +447,15 @@ public sealed partial class MainWindow : Window
     /// </summary>
     internal void DetachTabToNewWindow(TabModel tab)
     {
-        if (_tabManager.Tabs.Count <= 1)
-            throw new InvalidOperationException(
-                "DetachTabToNewWindow: guarded menu fired on single-tab window.");
-
-        // Source-side: detach the model. The manager's TabRemoved
-        // subscribers already drain visual state (RemovePaneHost in
-        // this MainWindow, RemoveItem in each tab host).
-        var detached = _tabManager.DetachTab(tab);
-
-        var bootstrap = App.BootstrapHost
-            ?? throw new InvalidOperationException(
-                "DetachTabToNewWindow: no bootstrap host; App.OnLaunched did not run.");
-        var supervisor = App.LifetimeSupervisor
-            ?? throw new InvalidOperationException(
-                "DetachTabToNewWindow: no lifetime supervisor; App.OnLaunched did not run.");
-
-        // Rehost the pane tree's terminals to a fresh per-window host
-        // built inside the new window. RehostTo is what actually moves
-        // the surface entries out of this window's _surfaces into the
-        // new window's _surfaces AND rewrites App._hostBySurface.
-        var newWindow = MainWindow.CreateForAdoption(_configService, bootstrap, supervisor, detached);
-        var newHost = newWindow._host;
-        ((Panes.PaneHost)detached.PaneHost).RehostTo(newHost);
-
-        // Cursor-anchored placement. Size = this window's current size
-        // so there is no jarring resize.
-        var placement = ComputeCursorAnchoredPlacement(newWindow);
-        var rect = new Windows.Graphics.RectInt32(
-            placement.X, placement.Y, placement.Width, placement.Height);
-        newWindow.AppWindow.MoveAndResize(rect);
-
-        // Subscribe the new window to the process-wide last-window-exit
-        // handler. WindowsByRoot insertion happens inside the new
-        // window's own Content.Loaded handler.
-        newWindow.Closed += ((App)Application.Current).OnAnyWindowClosedInternal;
-
-        newWindow.Activate();
+        DetachTabToWindow(tab, newWindow =>
+        {
+            // Cursor-anchored placement. Size = this window's current size
+            // so there is no jarring resize.
+            var placement = ComputeCursorAnchoredPlacement(newWindow);
+            var rect = new Windows.Graphics.RectInt32(
+                placement.X, placement.Y, placement.Width, placement.Height);
+            newWindow.AppWindow.MoveAndResize(rect);
+        });
     }
 
     /// <summary>
@@ -493,31 +465,56 @@ public sealed partial class MainWindow : Window
     /// </summary>
     internal void DetachTabToZone(TabModel tab, Ghostty.Core.Tabs.SnapZone zone)
     {
+        DetachTabToWindow(tab, newWindow =>
+        {
+            // Snap to zone on the source window's monitor. MoveAndResize
+            // BEFORE Activate so the window never flashes at the default
+            // origin.
+            var display = Tabs.SnapPlacement.ResolveDisplayFor(AppWindow);
+            Tabs.SnapPlacement.ApplyZone(newWindow.AppWindow, display, zone);
+        });
+    }
+
+    /// <summary>
+    /// Shared detach-rehost-activate logic. Detaches <paramref name="tab"/>
+    /// from this window, creates a new <see cref="MainWindow"/>, rehosts
+    /// the pane tree, runs <paramref name="placementAction"/> for
+    /// positioning, then activates the new window.
+    /// </summary>
+    private void DetachTabToWindow(TabModel tab, Action<MainWindow> placementAction)
+    {
         if (_tabManager.Tabs.Count <= 1)
             throw new InvalidOperationException(
-                "DetachTabToZone: guarded menu fired on single-tab window.");
+                "DetachTabToWindow: guarded menu fired on single-tab window.");
 
+        // Source-side: detach the model. The manager's TabRemoved
+        // subscribers already drain visual state (RemovePaneHost in
+        // this MainWindow, RemoveItem in each tab host).
         var detached = _tabManager.DetachTab(tab);
 
         var bootstrap = App.BootstrapHost
             ?? throw new InvalidOperationException(
-                "DetachTabToZone: no bootstrap host; App.OnLaunched did not run.");
+                "DetachTabToWindow: no bootstrap host; App.OnLaunched did not run.");
         var supervisor = App.LifetimeSupervisor
             ?? throw new InvalidOperationException(
-                "DetachTabToZone: no lifetime supervisor; App.OnLaunched did not run.");
+                "DetachTabToWindow: no lifetime supervisor; App.OnLaunched did not run.");
 
+        // Rehost the pane tree's terminals to a fresh per-window host
+        // built inside the new window. RehostTo is what actually moves
+        // the surface entries out of this window's _surfaces into the
+        // new window's _surfaces AND rewrites App._hostBySurface.
         var newWindow = MainWindow.CreateForAdoption(_configService, bootstrap, supervisor, detached);
         var newHost = newWindow._host;
         ((Panes.PaneHost)detached.PaneHost).RehostTo(newHost);
 
-        // Snap to zone on the source window's monitor. MoveAndResize
-        // BEFORE Activate so the window never flashes at the default
-        // origin.
-        var display = Tabs.SnapPlacement.ResolveDisplayFor(AppWindow);
-        Tabs.SnapPlacement.ApplyZone(newWindow.AppWindow, display, zone);
+        placementAction(newWindow);
 
+        // Subscribe the new window to the process-wide last-window-exit
+        // handler. WindowsByRoot insertion happens inside the new
+        // window's own Content.Loaded handler.
         newWindow.Closed += ((App)Application.Current).OnAnyWindowClosedInternal;
-        newWindow.ActivateAfterPlacement();
+
+        newWindow.Activate();
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -487,6 +487,40 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Detach <paramref name="tab"/> into a new window and snap it to
+    /// the given <paramref name="zone"/> on the current monitor BEFORE
+    /// activation, so there is no visible placement flicker.
+    /// </summary>
+    internal void DetachTabToZone(TabModel tab, Ghostty.Core.Tabs.SnapZone zone)
+    {
+        if (_tabManager.Tabs.Count <= 1)
+            throw new InvalidOperationException(
+                "DetachTabToZone: guarded menu fired on single-tab window.");
+
+        var detached = _tabManager.DetachTab(tab);
+
+        var bootstrap = App.BootstrapHost
+            ?? throw new InvalidOperationException(
+                "DetachTabToZone: no bootstrap host; App.OnLaunched did not run.");
+        var supervisor = App.LifetimeSupervisor
+            ?? throw new InvalidOperationException(
+                "DetachTabToZone: no lifetime supervisor; App.OnLaunched did not run.");
+
+        var newWindow = MainWindow.CreateForAdoption(_configService, bootstrap, supervisor, detached);
+        var newHost = newWindow._host;
+        ((Panes.PaneHost)detached.PaneHost).RehostTo(newHost);
+
+        // Snap to zone on the source window's monitor. MoveAndResize
+        // BEFORE Activate so the window never flashes at the default
+        // origin.
+        var display = Tabs.SnapPlacement.ResolveDisplayFor(AppWindow);
+        Tabs.SnapPlacement.ApplyZone(newWindow.AppWindow, display, zone);
+
+        newWindow.Closed += ((App)Application.Current).OnAnyWindowClosedInternal;
+        newWindow.ActivateAfterPlacement();
+    }
+
+    /// <summary>
     /// Compute the cursor-anchored target rect for a newly built
     /// <see cref="MainWindow"/>. Queries <c>GetCursorPos</c> (via
     /// CsWin32), resolves the monitor the cursor is on via

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -429,6 +429,15 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Pre-activation hook for Snap Layouts placement. PR 199's
+    /// detach flow constructs a MainWindow but MUST NOT call
+    /// Activate until any snap target has been applied, otherwise
+    /// the window flashes at the wrong origin. Call this once
+    /// placement is done.
+    /// </summary>
+    internal void ActivateAfterPlacement() => Activate();
+
+    /// <summary>
     /// Move <paramref name="tab"/> out of this window into a brand
     /// new <see cref="MainWindow"/>. The new window is positioned
     /// near the current mouse cursor on the monitor the cursor is

--- a/windows/Ghostty/Tabs/SnapPlacement.cs
+++ b/windows/Ghostty/Tabs/SnapPlacement.cs
@@ -25,9 +25,9 @@ internal static class SnapPlacement
     {
         var work = display.WorkArea; // RectInt32
         var rect = SnapZoneMath.RectFor(zone, work.X, work.Y, work.Width, work.Height);
-        // Two-argument MoveAndResize: rect is interpreted as offsets
-        // inside the given DisplayArea, which avoids coordinate-space
-        // confusion when the source monitor has negative screen origin.
+        // Two-argument MoveAndResize takes absolute screen coordinates.
+        // SnapZoneMath.RectFor already produces absolute coords because
+        // we pass the work area's origin (work.X, work.Y) above.
         target.MoveAndResize(rect.ToRectInt32(), display);
     }
 }

--- a/windows/Ghostty/Tabs/SnapPlacement.cs
+++ b/windows/Ghostty/Tabs/SnapPlacement.cs
@@ -1,0 +1,33 @@
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Windowing;
+using Windows.Graphics;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Resolves the target display for a source window and applies a
+/// Snap Layouts zone to a target window via
+/// <see cref="AppWindow.MoveAndResize(RectInt32, DisplayArea)"/>.
+///
+/// Uses <see cref="DisplayArea.GetFromWindowId"/> with
+/// <see cref="DisplayAreaFallback.Nearest"/> so a monitor disconnect
+/// between menu open and menu click degrades gracefully to the
+/// nearest available display. Never calls
+/// <see cref="DisplayArea.FindAll"/> (known iteration bug in the
+/// microsoft-ui-xaml repo).
+/// </summary>
+internal static class SnapPlacement
+{
+    public static DisplayArea ResolveDisplayFor(AppWindow source) =>
+        DisplayArea.GetFromWindowId(source.Id, DisplayAreaFallback.Nearest);
+
+    public static void ApplyZone(AppWindow target, DisplayArea display, SnapZone zone)
+    {
+        var work = display.WorkArea; // RectInt32
+        var rect = SnapZoneMath.RectFor(zone, work.X, work.Y, work.Width, work.Height);
+        // Two-argument MoveAndResize: rect is interpreted as offsets
+        // inside the given DisplayArea, which avoids coordinate-space
+        // confusion when the source monitor has negative screen origin.
+        target.MoveAndResize(rect.ToRectInt32(), display);
+    }
+}

--- a/windows/Ghostty/Tabs/SnapZonePicker.xaml
+++ b/windows/Ghostty/Tabs/SnapZonePicker.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Tabs.SnapZonePicker"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <!--
+        The picker is a fixed-pixel miniature of the current monitor.
+        Width/Height are set from code-behind so the miniature matches
+        the monitor's aspect ratio exactly; the Canvas is the layout
+        surface for zone Buttons positioned by SetLeft/SetTop.
+    -->
+    <Border
+        x:Name="PickerBorder"
+        Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
+        BorderBrush="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
+        BorderThickness="1"
+        CornerRadius="8"
+        Padding="12">
+        <Canvas
+            x:Name="PickerCanvas"
+            Width="220"
+            Height="140" />
+    </Border>
+</UserControl>

--- a/windows/Ghostty/Tabs/SnapZonePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/SnapZonePicker.xaml.cs
@@ -1,0 +1,125 @@
+using System;
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Visual picker for Snap Layouts zones. Renders a miniature of the
+/// current monitor with a clickable Button per zone, styled to
+/// resemble the Windows 11 maximize-button hover flyout.
+///
+/// The picker does NOT query DisplayArea itself: the caller passes
+/// the work-area width and height so this control stays unit-testable
+/// in principle and lets the detach flow resolve the monitor on the
+/// source window side (so the new window lands on the same monitor).
+/// </summary>
+internal sealed partial class SnapZonePicker : UserControl
+{
+    /// <summary>Raised when the user clicks a zone. Caller must
+    /// close the owning Flyout and run the detach-with-placement
+    /// flow. Never raised more than once per picker instance.</summary>
+    public event EventHandler<SnapZone>? ZoneSelected;
+
+    // Miniature dimensions. The Canvas Width and Height are reset
+    // from Render() so the miniature's aspect ratio matches the real
+    // monitor's aspect. These defaults are only the initial XAML
+    // values so Blend/design-time rendering has something to draw.
+    private const double MaxMiniatureWidth = 220.0;
+    private const double MaxMiniatureHeight = 140.0;
+
+    public SnapZonePicker()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Populate the canvas with one Button per zone returned by
+    /// <see cref="SnapZoneCatalog"/>. Must be called before the
+    /// picker is added to the visual tree.
+    /// </summary>
+    public void Render(int workAreaWidth, int workAreaHeight)
+    {
+        // Guard against degenerate monitors (DisplayArea fallback).
+        if (workAreaWidth <= 0 || workAreaHeight <= 0)
+        {
+            workAreaWidth = 1920;
+            workAreaHeight = 1080;
+        }
+
+        // Fit the monitor into the miniature bounds while preserving
+        // aspect ratio. Landscape monitors use the full width; portrait
+        // monitors use the full height. Ultra-wide monitors pick the
+        // smaller scale factor so neither dimension exceeds the max.
+        double scaleW = MaxMiniatureWidth / workAreaWidth;
+        double scaleH = MaxMiniatureHeight / workAreaHeight;
+        double scale = Math.Min(scaleW, scaleH);
+
+        double miniW = workAreaWidth * scale;
+        double miniH = workAreaHeight * scale;
+
+        PickerCanvas.Width = miniW;
+        PickerCanvas.Height = miniH;
+        PickerCanvas.Children.Clear();
+
+        var zones = SnapZoneCatalog.ZonesFor(workAreaWidth, workAreaHeight);
+        foreach (var zone in zones)
+        {
+            // Use a synthetic 0-origin work area so the rect fractions
+            // map linearly to the miniature. The real window placement
+            // uses the true work-area origin later.
+            var rect = SnapZoneMath.RectFor(zone, 0, 0, workAreaWidth, workAreaHeight);
+            var btn = MakeZoneButton(zone, rect, scale);
+            PickerCanvas.Children.Add(btn);
+        }
+    }
+
+    private Button MakeZoneButton(SnapZone zone, SnapZoneRect rect, double scale)
+    {
+        var btn = new Button
+        {
+            Width = Math.Max(1.0, rect.Width * scale),
+            Height = Math.Max(1.0, rect.Height * scale),
+            Padding = new Thickness(0),
+            CornerRadius = new CornerRadius(2),
+            Margin = new Thickness(1),
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            BorderBrush = (Brush)Application.Current.Resources[
+                "SystemControlForegroundBaseMediumBrush"],
+            BorderThickness = new Thickness(1),
+        };
+        AutomationProperties.SetName(btn, ReadableName(zone));
+        ToolTipService.SetToolTip(btn, ReadableName(zone));
+
+        Canvas.SetLeft(btn, rect.X * scale);
+        Canvas.SetTop(btn, rect.Y * scale);
+
+        btn.Click += (_, _) => ZoneSelected?.Invoke(this, zone);
+        return btn;
+    }
+
+    private static string ReadableName(SnapZone zone) => zone switch
+    {
+        SnapZone.Maximize => "Maximize",
+        SnapZone.LeftHalf => "Left half",
+        SnapZone.RightHalf => "Right half",
+        SnapZone.TopHalf => "Top half",
+        SnapZone.BottomHalf => "Bottom half",
+        SnapZone.TopLeftQuarter => "Top-left quarter",
+        SnapZone.TopRightQuarter => "Top-right quarter",
+        SnapZone.BottomLeftQuarter => "Bottom-left quarter",
+        SnapZone.BottomRightQuarter => "Bottom-right quarter",
+        SnapZone.LeftThird => "Left third",
+        SnapZone.MiddleThird => "Middle third",
+        SnapZone.RightThird => "Right third",
+        SnapZone.LeftTwoThirds => "Left two-thirds",
+        SnapZone.RightTwoThirds => "Right two-thirds",
+        SnapZone.TopThird => "Top third",
+        SnapZone.MiddleThirdHorizontal => "Middle third",
+        SnapZone.BottomThird => "Bottom third",
+        _ => zone.ToString(),
+    };
+}

--- a/windows/Ghostty/Tabs/SnapZonePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/SnapZonePicker.xaml.cs
@@ -120,6 +120,6 @@ internal sealed partial class SnapZonePicker : UserControl
         SnapZone.TopThird => "Top third",
         SnapZone.MiddleThirdHorizontal => "Middle third",
         SnapZone.BottomThird => "Bottom third",
-        _ => zone.ToString(),
+        _ => throw new ArgumentOutOfRangeException(nameof(zone), zone, null),
     };
 }

--- a/windows/Ghostty/Tabs/SnapZoneRectInterop.cs
+++ b/windows/Ghostty/Tabs/SnapZoneRectInterop.cs
@@ -1,0 +1,18 @@
+using Ghostty.Core.Tabs;
+using Windows.Graphics;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Adapts the WinUI-free <see cref="SnapZoneRect"/> to
+/// <see cref="RectInt32"/>, the type required by
+/// <see cref="Microsoft.UI.Windowing.AppWindow.MoveAndResize"/>.
+///
+/// Lives in the WinUI project (not Ghostty.Core) so Ghostty.Core
+/// does not have to reference the WindowsAppSDK.
+/// </summary>
+internal static class SnapZoneRectInterop
+{
+    public static RectInt32 ToRectInt32(this SnapZoneRect r) =>
+        new(r.X, r.Y, r.Width, r.Height);
+}

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -32,7 +32,7 @@ internal static class TabContextMenuBuilder
         Action<TabModel> requestDetachToNewWindow,
         DialogTracker dialogs,
         Func<SnapZoneSource>? getSnapSource = null,
-        Func<TabModel, SnapZone, Task>? detachWithZoneAsync = null)
+        Action<TabModel, SnapZone>? detachWithZone = null)
     {
         var flyout = new MenuFlyout();
 
@@ -85,7 +85,7 @@ internal static class TabContextMenuBuilder
         // zones. Only shown when both snap callbacks are wired and
         // there is more than one tab (detaching the last tab is a no-op).
         MenuFlyoutItem? moveToZone = null;
-        if (getSnapSource is not null && detachWithZoneAsync is not null)
+        if (getSnapSource is not null && detachWithZone is not null)
         {
             moveToZone = new MenuFlyoutItem { Text = "Move Tab to Zone" };
             moveToZone.IsEnabled = manager.Tabs.Count > 1;
@@ -104,10 +104,10 @@ internal static class TabContextMenuBuilder
                     Placement = FlyoutPlacementMode.Bottom,
                 };
 
-                picker.ZoneSelected += async (_, zone) =>
+                picker.ZoneSelected += (_, zone) =>
                 {
                     pickerFlyout.Hide();
-                    await detachWithZoneAsync(tab, zone);
+                    detachWithZone(tab, zone);
                 };
 
                 pickerFlyout.ShowAt(target);

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -10,6 +10,15 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 namespace Ghostty.Tabs;
 
 /// <summary>
+/// Information the picker needs when "Move Tab to Zone" is clicked.
+/// Supplied by the TabHost caller so TabContextMenuBuilder does not
+/// have to reach into WinUI windowing APIs itself.
+/// </summary>
+internal readonly record struct SnapZoneSource(
+    int WorkAreaWidth,
+    int WorkAreaHeight);
+
+/// <summary>
 /// Builds the per-tab right-click menu. Attached via
 /// <see cref="TabViewItem.ContextFlyout"/> on each item, not on the
 /// parent <see cref="TabView"/>: that gives an unambiguous target.
@@ -21,7 +30,9 @@ internal static class TabContextMenuBuilder
         TabModel tab,
         Func<TabModel, Task> requestClose,
         Action<TabModel> requestDetachToNewWindow,
-        DialogTracker dialogs)
+        DialogTracker dialogs,
+        Func<SnapZoneSource>? getSnapSource = null,
+        Func<TabModel, SnapZone, Task>? detachWithZoneAsync = null)
     {
         var flyout = new MenuFlyout();
 
@@ -70,12 +81,48 @@ internal static class TabContextMenuBuilder
         detach.Click += (_, _) => requestDetachToNewWindow(tab);
         flyout.Items.Add(detach);
 
+        // "Move Tab to Zone" opens a visual picker for Snap Layouts
+        // zones. Only shown when both snap callbacks are wired and
+        // there is more than one tab (detaching the last tab is a no-op).
+        MenuFlyoutItem? moveToZone = null;
+        if (getSnapSource is not null && detachWithZoneAsync is not null)
+        {
+            moveToZone = new MenuFlyoutItem { Text = "Move Tab to Zone" };
+            moveToZone.IsEnabled = manager.Tabs.Count > 1;
+            moveToZone.Click += (_, _) =>
+            {
+                var target = flyout.Target;
+                if (target?.XamlRoot is null) return;
+
+                var source = getSnapSource();
+                var picker = new SnapZonePicker();
+                picker.Render(source.WorkAreaWidth, source.WorkAreaHeight);
+
+                var pickerFlyout = new Flyout
+                {
+                    Content = picker,
+                    Placement = FlyoutPlacementMode.Bottom,
+                };
+
+                picker.ZoneSelected += async (_, zone) =>
+                {
+                    pickerFlyout.Hide();
+                    await detachWithZoneAsync(tab, zone);
+                };
+
+                pickerFlyout.ShowAt(target);
+            };
+            flyout.Items.Add(moveToZone);
+        }
+
         // Re-evaluate IsEnabled on each open so tabs closed after
         // the flyout was built (but before the user right-clicked)
         // are reflected in the grey state. Matches Windows Terminal.
         flyout.Opening += (_, _) =>
         {
             detach.IsEnabled = manager.Tabs.Count > 1;
+            if (moveToZone is not null)
+                moveToZone.IsEnabled = manager.Tabs.Count > 1;
         };
 
         flyout.Items.Add(new MenuFlyoutSeparator());

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -101,7 +101,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 tab,
                 RequestCloseTabAsync,
                 requestDetachToNewWindow: RequestDetachToNewWindow,
-                _dialogs),
+                _dialogs,
+                getSnapSource: GetSnapSource,
+                detachWithZoneAsync: DetachWithZoneAsync),
             DataContext = tab,
         };
         tab.PropertyChanged += (_, e) =>
@@ -206,6 +208,34 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
         if (App.WindowsByRoot.TryGetValue(xamlRoot, out var main))
             main.DetachTabToNewWindow(tab);
+    }
+
+    /// <summary>
+    /// Resolve the source window's current monitor work area for the
+    /// snap zone picker miniature.
+    /// </summary>
+    private SnapZoneSource GetSnapSource()
+    {
+        var xamlRoot = XamlRoot;
+        if (xamlRoot is not null && App.WindowsByRoot.TryGetValue(xamlRoot, out var main))
+        {
+            var display = SnapPlacement.ResolveDisplayFor(main.AppWindow);
+            var w = display.WorkArea;
+            return new SnapZoneSource(w.Width, w.Height);
+        }
+        // Fallback: standard 1080p.
+        return new SnapZoneSource(1920, 1080);
+    }
+
+    /// <summary>
+    /// Detach a tab into a new window snapped to the chosen zone.
+    /// </summary>
+    private Task DetachWithZoneAsync(TabModel tab, Ghostty.Core.Tabs.SnapZone zone)
+    {
+        var xamlRoot = XamlRoot;
+        if (xamlRoot is not null && App.WindowsByRoot.TryGetValue(xamlRoot, out var main))
+            main.DetachTabToZone(tab, zone);
+        return Task.CompletedTask;
     }
 
     private void OnAddTabButtonClick(TabView sender, object args) => _manager.NewTab();

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -103,7 +103,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 requestDetachToNewWindow: RequestDetachToNewWindow,
                 _dialogs,
                 getSnapSource: GetSnapSource,
-                detachWithZoneAsync: DetachWithZoneAsync),
+                detachWithZone: DetachWithZone),
             DataContext = tab,
         };
         tab.PropertyChanged += (_, e) =>
@@ -230,12 +230,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// <summary>
     /// Detach a tab into a new window snapped to the chosen zone.
     /// </summary>
-    private Task DetachWithZoneAsync(TabModel tab, Ghostty.Core.Tabs.SnapZone zone)
+    private void DetachWithZone(TabModel tab, Ghostty.Core.Tabs.SnapZone zone)
     {
         var xamlRoot = XamlRoot;
         if (xamlRoot is not null && App.WindowsByRoot.TryGetValue(xamlRoot, out var main))
             main.DetachTabToZone(tab, zone);
-        return Task.CompletedTask;
     }
 
     private void OnAddTabButtonClick(TabView sender, object args) => _manager.NewTab();


### PR DESCRIPTION
## Summary

- Adds a snap layout zone picker that lets users detach a tab into a snapped position on the current monitor.
- Pure-logic core: \`SnapZone\`, \`SnapZoneRect\`, \`SnapMonitorShape\`, \`SnapZoneCatalog\`, \`SnapZoneMath\` in \`Ghostty.Core.Tabs\`. Integer math, no float seams.
- Aspect-ratio classification: standard landscape (halves + quarters + maximize = 9 zones), ultra-wide >= 2.1 (halves + thirds + quarters + maximize = 12 zones), portrait (halves + horizontal thirds + maximize = 6 zones).
- \`SnapZonePicker\` UserControl renders a miniature of the current monitor with clickable zones styled like the Windows 11 maximize-button hover flyout.
- Pre-snap placement via \`MainWindow.CreateForAdoption\` (from PR # 199) + \`AppWindow.MoveAndResize\` before activation, avoiding placement flicker.
- \`DisplayArea.GetFromWindowId\` with \`DisplayAreaFallback.Nearest\` (not \`FindAll\`, per known iteration bug).

## Verification

- 14 commits (13 feature + 1 review fix)
- \`dotnet test\`: 187 -> 221 (+34 new tests: 13 SnapZoneCatalogTests + 21 SnapZoneMathTests)
- \`dotnet build\` Debug + Release: clean (2 pre-existing CS0067)
- \`dotnet publish -c Release -r win-x64\` (NativeAOT): clean, ~33.4 MB
- Pending manual smoke: zone picker on landscape/ultra-wide/portrait, multi-monitor placement, drag-out gesture regression, Narrator accessibility

> **IMPORTANT**: stacked PR. Part 7 of 7 in the PR 206 follow-ups chain. Parent: \`windows-tab-detach\`. Stack: # 205 -> # 203 -> # 204 -> # 200 -> # 202 -> # 199 -> # 201.

Refs: # 201