### PR TITLE
feat(windows): add tab color palette

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabColor.cs
+++ b/windows/Ghostty.Core/Tabs/TabColor.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Preset tint for a <see cref="TabModel"/>. Ten entries matching
+/// macOS <c>TerminalTabColor</c> one-for-one so multi-platform users
+/// see the same palette. <see cref="None"/> is the default and clears
+/// the tint.
+///
+/// Lives in Ghostty.Core (pure net9.0) so Ghostty.Tests consumes it
+/// directly via ProjectReference without pulling WinUI.
+/// </summary>
+internal enum TabColor
+{
+    None = 0,
+    Blue,
+    Purple,
+    Pink,
+    Red,
+    Orange,
+    Yellow,
+    Green,
+    Teal,
+    Graphite,
+}
+
+/// <summary>
+/// sRGB color values for <see cref="TabColor"/>. Keyed in enum order;
+/// <see cref="TabColor.None"/> has no entry (callers check for it
+/// explicitly and paint transparent).
+///
+/// Hex values picked to match the macOS system* color rendering in
+/// sRGB (approx, since macOS system colors shift slightly across
+/// OS versions). Our values are fixed by design: terminal tab tints
+/// should not drift under the user's feet. Alpha is set by the
+/// painter (see <c>TabHost.AddItem</c>), not here.
+///
+/// macOS source: macos/Sources/Features/Terminal/TerminalTabColor.swift
+/// </summary>
+internal static class TabColorPalette
+{
+    // 2-row x 5-column layout matching macOS TabColorMenuView.paletteRows.
+    // Row 1: None, Blue, Purple, Pink, Red
+    // Row 2: Orange, Yellow, Green, Teal, Graphite
+    public static readonly TabColor[][] PaletteRows =
+    {
+        new[] { TabColor.None, TabColor.Blue, TabColor.Purple, TabColor.Pink, TabColor.Red },
+        new[] { TabColor.Orange, TabColor.Yellow, TabColor.Green, TabColor.Teal, TabColor.Graphite },
+    };
+
+    // sRGB values approximating macOS NSColor.system* at standard
+    // contrast. Source per entry documented inline. Alpha fixed at 255;
+    // callers blend as needed.
+    public static readonly IReadOnlyDictionary<TabColor, Color> Colors =
+        new Dictionary<TabColor, Color>
+        {
+            // NSColor.systemBlue     approx #007AFF
+            [TabColor.Blue]     = Color.FromArgb(255, 0x00, 0x7A, 0xFF),
+            // NSColor.systemPurple   approx #AF52DE
+            [TabColor.Purple]   = Color.FromArgb(255, 0xAF, 0x52, 0xDE),
+            // NSColor.systemPink     approx #FF2D55
+            [TabColor.Pink]     = Color.FromArgb(255, 0xFF, 0x2D, 0x55),
+            // NSColor.systemRed      approx #FF3B30
+            [TabColor.Red]      = Color.FromArgb(255, 0xFF, 0x3B, 0x30),
+            // NSColor.systemOrange   approx #FF9500
+            [TabColor.Orange]   = Color.FromArgb(255, 0xFF, 0x95, 0x00),
+            // NSColor.systemYellow   approx #FFCC00
+            [TabColor.Yellow]   = Color.FromArgb(255, 0xFF, 0xCC, 0x00),
+            // NSColor.systemGreen    approx #34C759
+            [TabColor.Green]    = Color.FromArgb(255, 0x34, 0xC7, 0x59),
+            // NSColor.systemTeal     approx #30B0C7
+            [TabColor.Teal]     = Color.FromArgb(255, 0x30, 0xB0, 0xC7),
+            // NSColor.systemGray     approx #8E8E93
+            [TabColor.Graphite] = Color.FromArgb(255, 0x8E, 0x8E, 0x93),
+        };
+
+    /// <summary>
+    /// Human-readable label. Used for the swatch tooltip (<c>ToolTipService.ToolTip</c>).
+    /// Matches macOS <c>TerminalTabColor.localizedName</c>.
+    /// </summary>
+    public static string LocalizedName(TabColor color) => color switch
+    {
+        TabColor.None     => "None",
+        TabColor.Blue     => "Blue",
+        TabColor.Purple   => "Purple",
+        TabColor.Pink     => "Pink",
+        TabColor.Red      => "Red",
+        TabColor.Orange   => "Orange",
+        TabColor.Yellow   => "Yellow",
+        TabColor.Green    => "Green",
+        TabColor.Teal     => "Teal",
+        TabColor.Graphite => "Graphite",
+        _                 => "None",
+    };
+}

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -62,6 +62,19 @@ internal sealed class TabModel : INotifyPropertyChanged
         set { if (!_progress.Equals(value)) { _progress = value; Raise(); } }
     }
 
+    private TabColor _color = TabColor.None;
+    /// <summary>
+    /// Preset tint applied to this tab's header. In-memory only;
+    /// resets to <see cref="TabColor.None"/> on app restart. True
+    /// cross-session persistence needs a durable tab id and a
+    /// startup restore hook (out of scope, tracked as a followup).
+    /// </summary>
+    public TabColor Color
+    {
+        get => _color;
+        set { if (_color != value) { _color = value; Raise(); } }
+    }
+
     public string EffectiveTitle =>
         UserOverrideTitle ?? ShellReportedTitle ?? "Ghostty";
 

--- a/windows/Ghostty.Tests/Tabs/TabModelColorTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabModelColorTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class TabModelColorTests
+{
+    [Fact]
+    public void Default_color_is_None()
+    {
+        var mgr = new TabManager(() => new FakePaneHost());
+        Assert.Equal(TabColor.None, mgr.ActiveTab.Color);
+    }
+
+    [Fact]
+    public void Setting_color_raises_PropertyChanged_once()
+    {
+        var mgr = new TabManager(() => new FakePaneHost());
+        var tab = mgr.ActiveTab;
+
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)tab).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        tab.Color = TabColor.Blue;
+
+        Assert.Single(raised);
+        Assert.Equal(nameof(TabModel.Color), raised[0]);
+    }
+
+    [Fact]
+    public void Setting_color_to_same_value_does_not_raise()
+    {
+        var mgr = new TabManager(() => new FakePaneHost());
+        var tab = mgr.ActiveTab;
+        tab.Color = TabColor.Red;
+
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)tab).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        tab.Color = TabColor.Red;
+
+        Assert.Empty(raised);
+    }
+
+    [Fact]
+    public void Palette_contains_every_non_None_enum_value()
+    {
+        foreach (TabColor color in System.Enum.GetValues<TabColor>())
+        {
+            if (color == TabColor.None) continue;
+            Assert.True(
+                TabColorPalette.Colors.ContainsKey(color),
+                $"TabColorPalette.Colors missing entry for {color}");
+        }
+    }
+
+    [Fact]
+    public void Palette_rows_are_five_by_two_matching_macOS()
+    {
+        Assert.Equal(2, TabColorPalette.PaletteRows.Length);
+        Assert.All(TabColorPalette.PaletteRows, row => Assert.Equal(5, row.Length));
+        Assert.Equal(TabColor.None, TabColorPalette.PaletteRows[0][0]);
+    }
+
+    [Fact]
+    public void LocalizedName_covers_all_enum_values()
+    {
+        foreach (TabColor color in System.Enum.GetValues<TabColor>())
+        {
+            var name = TabColorPalette.LocalizedName(color);
+            Assert.False(string.IsNullOrWhiteSpace(name));
+        }
+    }
+}

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Tabs.TabColorPalettePicker"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <StackPanel Orientation="Vertical"
+                Spacing="4"
+                Padding="8">
+        <TextBlock Text="Tab Color"
+                   FontWeight="SemiBold"
+                   Margin="2,0,0,4"/>
+        <!--
+            Rows are built in code-behind from TabColorPalette.PaletteRows
+            so the macOS ordering stays the single source of truth. The
+            StackPanels below are just layout scaffolding.
+        -->
+        <StackPanel x:Name="Row0" Orientation="Horizontal" Spacing="4"/>
+        <StackPanel x:Name="Row1" Orientation="Horizontal" Spacing="4"/>
+    </StackPanel>
+</UserControl>

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
@@ -1,0 +1,125 @@
+using System;
+using Ghostty.Core.Tabs;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Small 2-row, 5-column swatch grid used to pick a preset
+/// <see cref="TabColor"/>. Hosted inside a secondary
+/// <see cref="Flyout"/> anchored to the target <c>TabViewItem</c>.
+///
+/// This is NOT a <c>MenuFlyoutItem</c>-with-templated-content hack.
+/// WinAppSDK 1.6 has known hit-testing quirks when hosting arbitrary
+/// UI inside a menu item; hosting in a separate Flyout sidesteps them
+/// at the cost of one extra click on color change.
+/// </summary>
+internal sealed partial class TabColorPalettePicker : UserControl
+{
+    /// <summary>
+    /// Raised when the user clicks a swatch. The parent flyout is
+    /// responsible for closing itself (the picker does not know about
+    /// its host).
+    /// </summary>
+    public event EventHandler<TabColor>? ColorSelected;
+
+    private readonly TabColor _initial;
+
+    public TabColorPalettePicker(TabColor initial)
+    {
+        _initial = initial;
+        InitializeComponent();
+        BuildSwatches();
+    }
+
+    private void BuildSwatches()
+    {
+        // Render the two rows declared in TabColorPalette.PaletteRows.
+        // We intentionally read the macOS-derived layout from
+        // Ghostty.Core so platform divergence stays in one file.
+        var rows = TabColorPalette.PaletteRows;
+        AddRow(Row0, rows[0]);
+        AddRow(Row1, rows[1]);
+    }
+
+    private void AddRow(StackPanel host, TabColor[] row)
+    {
+        foreach (var color in row)
+            host.Children.Add(BuildSwatch(color));
+    }
+
+    private Border BuildSwatch(TabColor color)
+    {
+        // Each swatch is a 20x20 DIP Ellipse wrapped in a Border that
+        // owns the selection ring (2 DIP, SystemAccentColor). Pointer
+        // input goes on the Border so the whole tile is clickable, not
+        // only the ellipse interior.
+        var ellipse = new Ellipse { Width = 20, Height = 20 };
+
+        if (color == TabColor.None)
+        {
+            // Hollow circle with a diagonal slash, matching the macOS
+            // .circle.slash symbol. Implemented as an Ellipse with
+            // Stroke plus a Line inside a Grid.
+            ellipse.Fill = new SolidColorBrush(Colors.Transparent);
+            ellipse.Stroke =
+                (SolidColorBrush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+            ellipse.StrokeThickness = 1;
+
+            var slash = new Line
+            {
+                X1 = 3, Y1 = 17, X2 = 17, Y2 = 3,
+                StrokeThickness = 1.5,
+                Stroke = (SolidColorBrush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            };
+
+            var grid = new Grid { Width = 20, Height = 20 };
+            grid.Children.Add(ellipse);
+            grid.Children.Add(slash);
+
+            return WrapSwatch(grid, color);
+        }
+        else
+        {
+            var drawing = TabColorPalette.Colors[color];
+            ellipse.Fill = new SolidColorBrush(
+                Windows.UI.Color.FromArgb(255, drawing.R, drawing.G, drawing.B));
+            return WrapSwatch(ellipse, color);
+        }
+    }
+
+    private Border WrapSwatch(FrameworkElement content, TabColor color)
+    {
+        // The border paints the selection ring when this swatch matches
+        // the currently-applied TabColor. 2 DIP ring in SystemAccentColor,
+        // inset so the visual ring sits outside the 20x20 circle.
+        bool selected = color == _initial;
+
+        var border = new Border
+        {
+            Width = 24,
+            Height = 24,
+            CornerRadius = new CornerRadius(12),
+            BorderThickness = new Thickness(selected ? 2 : 0),
+            BorderBrush = selected
+                ? (SolidColorBrush)Application.Current.Resources["SystemControlHighlightAccentBrush"]
+                : new SolidColorBrush(Colors.Transparent),
+            Background = new SolidColorBrush(Colors.Transparent),
+            Padding = new Thickness(2),
+            Child = content,
+        };
+
+        ToolTipService.SetToolTip(border, TabColorPalette.LocalizedName(color));
+        border.Tapped += (_, e) =>
+        {
+            e.Handled = true;
+            ColorSelected?.Invoke(this, color);
+        };
+        return border;
+    }
+}

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
@@ -66,16 +66,16 @@ internal sealed partial class TabColorPalettePicker : UserControl
             // Hollow circle with a diagonal slash, matching the macOS
             // .circle.slash symbol. Implemented as an Ellipse with
             // Stroke plus a Line inside a Grid.
+            var secondaryBrush = GetBrushResource("TextFillColorSecondaryBrush");
             ellipse.Fill = new SolidColorBrush(Colors.Transparent);
-            ellipse.Stroke =
-                (SolidColorBrush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+            ellipse.Stroke = secondaryBrush;
             ellipse.StrokeThickness = 1;
 
             var slash = new Line
             {
                 X1 = 3, Y1 = 17, X2 = 17, Y2 = 3,
                 StrokeThickness = 1.5,
-                Stroke = (SolidColorBrush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                Stroke = secondaryBrush,
             };
 
             var grid = new Grid { Width = 20, Height = 20 };
@@ -107,7 +107,7 @@ internal sealed partial class TabColorPalettePicker : UserControl
             CornerRadius = new CornerRadius(12),
             BorderThickness = new Thickness(selected ? 2 : 0),
             BorderBrush = selected
-                ? (SolidColorBrush)Application.Current.Resources["SystemControlHighlightAccentBrush"]
+                ? GetBrushResource("SystemControlHighlightAccentBrush")
                 : new SolidColorBrush(Colors.Transparent),
             Background = new SolidColorBrush(Colors.Transparent),
             Padding = new Thickness(2),
@@ -121,5 +121,17 @@ internal sealed partial class TabColorPalettePicker : UserControl
             ColorSelected?.Invoke(this, color);
         };
         return border;
+    }
+
+    /// <summary>
+    /// Look up a theme brush resource with a fallback. WinUI 3 theme
+    /// resources are not always <see cref="SolidColorBrush"/>; a raw
+    /// cast would throw on unexpected types or missing keys.
+    /// </summary>
+    private static SolidColorBrush GetBrushResource(string key)
+    {
+        if (Application.Current.Resources.TryGetValue(key, out var value) && value is SolidColorBrush brush)
+            return brush;
+        return new SolidColorBrush(Colors.Gray);
     }
 }

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ghostty.Core.Tabs;
 using Ghostty.Dialogs;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 
 namespace Ghostty.Tabs;
 
@@ -65,7 +67,45 @@ internal static class TabContextMenuBuilder
         dup.Click += (_, _) => manager.NewTab(); // TODO(config): respect ProfileId once profiles exist
         flyout.Items.Add(dup);
 
+        flyout.Items.Add(new MenuFlyoutSeparator());
+
+        // "Tab Color..." opens a secondary Flyout anchored to the
+        // right-clicked TabViewItem. We use a plain MenuFlyoutItem
+        // (not MenuFlyoutSubItem) because the swatch grid needs a
+        // real Flyout host to avoid MenuFlyoutItem hit-testing
+        // quirks on WinAppSDK 1.6.
+        var colorPick = new MenuFlyoutItem { Text = "Tab Color..." };
+        colorPick.Click += (_, _) =>
+        {
+            var target = flyout.Target as FrameworkElement;
+            if (target is null) return;
+            ShowColorPicker(target, tab);
+        };
+        flyout.Items.Add(colorPick);
+
         return flyout;
+    }
+
+    private static void ShowColorPicker(FrameworkElement anchor, TabModel tab)
+    {
+        // Build the secondary flyout fresh each invocation. Cheap, and
+        // avoids any stale selection-ring state from the previous
+        // right-click.
+        var picker = new TabColorPalettePicker(tab.Color);
+        var subFlyout = new Flyout
+        {
+            Content = picker,
+            Placement = FlyoutPlacementMode.Bottom,
+            ShouldConstrainToRootBounds = true,
+        };
+
+        picker.ColorSelected += (_, color) =>
+        {
+            tab.Color = color;
+            subFlyout.Hide();
+        };
+
+        subFlyout.ShowAt(anchor);
     }
 
     private static void CloseOthers(TabManager manager, TabModel keep)

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -86,6 +86,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
         headerPanel.Children.Add(headerText);
         headerPanel.Children.Add(headerBar);
 
+        // Tab color tint. We paint headerPanel.Background, not
+        // TabViewItem.Background: the WinUI 3 TabView template layers
+        // its own brushes over the item background and the tint gets
+        // composited away on 1.6. The header panel is our own XAML so
+        // we own the paint surface outright.
+        ApplyTabColor(headerPanel, tab.Color, selected: false);
+
         var item = new TabViewItem
         {
             Header = headerPanel,
@@ -110,6 +117,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 headerBar.IsIndeterminate = p.State == TabProgressState.Kind.Indeterminate;
                 if (p.State != TabProgressState.Kind.Indeterminate)
                     headerBar.Value = p.Percent;
+            }
+            else if (e.PropertyName == nameof(TabModel.Color))
+            {
+                var selected = ReferenceEquals(_manager.ActiveTab, tab);
+                ApplyTabColor(headerPanel, tab.Color, selected);
             }
         };
         _itemByModel[tab] = item;
@@ -139,10 +151,42 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // shared container (see #171). This method only syncs the
         // TabView strip selection.
         if (!_itemByModel.TryGetValue(_manager.ActiveTab, out var item)) return;
+
+        // Re-apply tab color tints so the selected tab gets the
+        // stronger alpha (0.6) and the others get 0.35. The previous
+        // selected tab's header will flip from 0.6 to 0.35 here.
+        foreach (var (model, viewItem) in _itemByModel)
+        {
+            if (viewItem.Header is StackPanel headerPanel)
+            {
+                var isSelected = ReferenceEquals(model, _manager.ActiveTab);
+                ApplyTabColor(headerPanel, model.Color, isSelected);
+            }
+        }
+
         if (ReferenceEquals(TabViewControl.SelectedItem, item)) return;
         _suppressSelectionEvent = true;
         TabViewControl.SelectedItem = item;
         _suppressSelectionEvent = false;
+    }
+
+    /// <summary>
+    /// Paint the tab header background from a <see cref="TabColor"/>.
+    /// None clears to transparent. Non-None uses fixed sRGB at alpha
+    /// 0.35 unselected / 0.6 selected so Mica/acrylic shows through
+    /// and the text foreground stays readable on both themes.
+    /// </summary>
+    private static void ApplyTabColor(StackPanel headerPanel, TabColor color, bool selected)
+    {
+        if (color == TabColor.None)
+        {
+            headerPanel.Background = null;
+            return;
+        }
+        var drawing = TabColorPalette.Colors[color];
+        var alpha = (byte)(selected ? 153 : 89); // 0.6 and 0.35 of 255
+        headerPanel.Background = new SolidColorBrush(
+            Windows.UI.Color.FromArgb(alpha, drawing.R, drawing.G, drawing.B));
     }
 
     private void OnAddTabButtonClick(TabView sender, object args) => _manager.NewTab();

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -170,6 +170,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
         _suppressSelectionEvent = false;
     }
 
+    // Tab color alpha values. Selected tabs use a stronger tint so
+    // the color is clearly visible; unselected tabs use a lighter
+    // tint so Mica/acrylic shows through and text stays readable.
+    private const byte SelectedTabAlpha = 153;   // ~0.6 of 255
+    private const byte UnselectedTabAlpha = 89;  // ~0.35 of 255
+
     /// <summary>
     /// Paint the tab header background from a <see cref="TabColor"/>.
     /// None clears to transparent. Non-None uses fixed sRGB at alpha
@@ -184,7 +190,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
             return;
         }
         var drawing = TabColorPalette.Colors[color];
-        var alpha = (byte)(selected ? 153 : 89); // 0.6 and 0.35 of 255
+        var alpha = selected ? SelectedTabAlpha : UnselectedTabAlpha;
         headerPanel.Background = new SolidColorBrush(
             Windows.UI.Color.FromArgb(alpha, drawing.R, drawing.G, drawing.B));
     }


### PR DESCRIPTION
## Summary

- Adds a v1 tab color palette: preset swatches only, no custom picker, no cross-session persistence.
- TabColor enum + TabColorPalette live in Ghostty.Core.Tabs so tests can exercise them directly.
- Palette matches macOS TerminalTabColor: None, Blue, Purple, Pink, Red, Orange, Yellow, Green, Teal, Graphite.
- Context menu opens a secondary Flyout with a TabColorPalettePicker user control.
- TabHost paints headerPanel.Background at alpha 0.35 unselected / 0.6 selected.

> **IMPORTANT**: stacked PR. Part 4 of 5 in the stack. Parent: windows-aot-analyzers (#212). Stack: #210 -> #211 -> #212 -> this -> #215.

Replaces closed #213.