### PR TITLE
feat(windows): tab detach to new window and snap layout zone picker

### DIFF
--- a/windows/Ghostty.Core/Hosting/HostLifetimeState.cs
+++ b/windows/Ghostty.Core/Hosting/HostLifetimeState.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Hosting;
+
+/// <summary>
+/// Ownership-and-lifetime state for a single Ghostty host instance.
+/// Carries the answers to "do I free the app on Dispose" and "have I
+/// been disposed yet" in a pointer-free form so the invariants can be
+/// unit-tested without touching libghostty.
+/// </summary>
+internal sealed class HostLifetimeState
+{
+    public bool IsBootstrap { get; }
+    public bool OwnsApp => IsBootstrap;
+    public bool IsDisposed { get; private set; }
+
+    private HostLifetimeState(bool isBootstrap)
+    {
+        IsBootstrap = isBootstrap;
+    }
+
+    public static HostLifetimeState Bootstrap() => new(isBootstrap: true);
+    public static HostLifetimeState PerWindow() => new(isBootstrap: false);
+
+    /// <summary>Idempotent. Marks the host as disposed.</summary>
+    public void MarkDisposed() => IsDisposed = true;
+}
+
+/// <summary>
+/// Process-level supervisor that enforces the drain-last invariant:
+/// every per-window host must dispose before the bootstrap host.
+/// Injected into <c>GhosttyHost</c> via <see cref="IAppHandleOwnership"/>
+/// so the real dispose path consults this supervisor and the tests
+/// can exercise the transitions against a fake.
+///
+/// Thread safety: UI-thread-only. All NotifyDisposed calls must
+/// originate from the UI dispatcher. GhosttyHost is sealed and has no
+/// finalizer, so disposal from a finalizer thread is not a concern.
+/// </summary>
+internal sealed class HostLifetimeSupervisor
+{
+    private readonly HashSet<HostLifetimeState> _live = new();
+    private HostLifetimeState? _bootstrap;
+
+    public int LivePerWindowCount
+    {
+        get
+        {
+            int n = 0;
+            foreach (var s in _live)
+                if (!s.IsBootstrap && !s.IsDisposed) n++;
+            return n;
+        }
+    }
+
+    public HostLifetimeState RegisterBootstrap()
+    {
+        if (_bootstrap is not null)
+            throw new InvalidOperationException(
+                "HostLifetimeSupervisor: bootstrap already registered.");
+        _bootstrap = HostLifetimeState.Bootstrap();
+        _live.Add(_bootstrap);
+        return _bootstrap;
+    }
+
+    public HostLifetimeState RegisterPerWindow()
+    {
+        var s = HostLifetimeState.PerWindow();
+        _live.Add(s);
+        return s;
+    }
+
+    /// <summary>
+    /// Called from the host's Dispose path. Enforces the drain-last
+    /// invariant. Throws if a per-window host tries to Dispose after
+    /// the bootstrap, or if the bootstrap tries to Dispose while any
+    /// per-window host is still live.
+    /// </summary>
+    public void NotifyDisposed(HostLifetimeState state)
+    {
+        if (state.IsBootstrap)
+        {
+            if (LivePerWindowCount > 0)
+                throw new InvalidOperationException(
+                    "HostLifetimeSupervisor: bootstrap cannot dispose while per-window hosts are live. Drain per-window hosts first.");
+            _live.Remove(state);
+            return;
+        }
+
+        if (_bootstrap is not null && _bootstrap.IsDisposed)
+            throw new InvalidOperationException(
+                "HostLifetimeSupervisor: per-window host cannot dispose after bootstrap has been freed.");
+        _live.Remove(state);
+    }
+}
+
+/// <summary>
+/// Abstraction consulted by <c>GhosttyHost.Dispose</c> to decide
+/// whether to call <c>AppFree</c> and to notify the supervisor that
+/// this host has been disposed. The production implementation is
+/// <see cref="SupervisedOwnership"/>, which wraps a
+/// <see cref="HostLifetimeState"/> and a
+/// <see cref="HostLifetimeSupervisor"/>; tests swap in a fake that
+/// records calls without a real supervisor.
+/// </summary>
+internal interface IAppHandleOwnership
+{
+    HostLifetimeState State { get; }
+    void NotifyDisposed();
+}
+
+/// <summary>
+/// Production <see cref="IAppHandleOwnership"/> backed by a shared
+/// <see cref="HostLifetimeSupervisor"/>. The ctor takes the state
+/// returned by the supervisor's register call and holds on to the
+/// supervisor so <see cref="NotifyDisposed"/> can enforce the
+/// drain-last invariant.
+/// </summary>
+internal sealed class SupervisedOwnership : IAppHandleOwnership
+{
+    private readonly HostLifetimeSupervisor _supervisor;
+    public HostLifetimeState State { get; }
+
+    public SupervisedOwnership(HostLifetimeState state, HostLifetimeSupervisor supervisor)
+    {
+        State = state;
+        _supervisor = supervisor;
+    }
+
+    public void NotifyDisposed() => _supervisor.NotifyDisposed(State);
+}

--- a/windows/Ghostty.Core/Tabs/SnapMonitorShape.cs
+++ b/windows/Ghostty.Core/Tabs/SnapMonitorShape.cs
@@ -1,0 +1,75 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Monitor-shape bucket used by SnapZoneCatalog to choose which
+/// zone set to offer. Mirrors the Windows 11 shell's own heuristic:
+/// the shell swaps to three-column layouts around the 21:9 aspect
+/// ratio boundary, and to vertical thirds on portrait monitors.
+/// </summary>
+internal enum SnapMonitorShape
+{
+    StandardLandscape,
+    UltraWideLandscape,
+    Portrait,
+}
+
+/// <summary>
+/// Pure-logic zone catalog. Given the physical width and height of a
+/// monitor work area, returns the zone set that matches what the
+/// Windows 11 shell would show for that monitor's maximize-button
+/// flyout. SnapZoneCatalog has no WinUI dependency so it is directly
+/// unit-testable from Ghostty.Tests.
+/// </summary>
+internal static partial class SnapZoneCatalog
+{
+    // The Windows 11 shell flips to three-column ultra-wide layouts
+    // around 21:9 (2.333). 16:9 (1.78) and 16:10 (1.6) stay in the
+    // standard bucket. 2.1 is the conventional cut-off.
+    public const double UltraWideAspect = 2.1;
+
+    public static SnapMonitorShape Classify(int width, int height)
+    {
+        if (width < height) return SnapMonitorShape.Portrait;
+        double ratio = width / (double)height;
+        if (ratio >= UltraWideAspect) return SnapMonitorShape.UltraWideLandscape;
+        return SnapMonitorShape.StandardLandscape;
+    }
+
+    // Cached arrays returned via IReadOnlyList so no allocation on
+    // every call (the picker opens on every right-click).
+    private static readonly SnapZone[] StandardLandscapeZones =
+    {
+        SnapZone.LeftHalf, SnapZone.RightHalf,
+        SnapZone.TopHalf, SnapZone.BottomHalf,
+        SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+        SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+        SnapZone.Maximize,
+    };
+
+    private static readonly SnapZone[] UltraWideZones =
+    {
+        SnapZone.LeftHalf, SnapZone.RightHalf,
+        SnapZone.LeftThird, SnapZone.MiddleThird, SnapZone.RightThird,
+        SnapZone.LeftTwoThirds, SnapZone.RightTwoThirds,
+        SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+        SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+        SnapZone.Maximize,
+    };
+
+    private static readonly SnapZone[] PortraitZones =
+    {
+        SnapZone.TopHalf, SnapZone.BottomHalf,
+        SnapZone.TopThird, SnapZone.MiddleThirdHorizontal, SnapZone.BottomThird,
+        SnapZone.Maximize,
+    };
+
+    public static System.Collections.Generic.IReadOnlyList<SnapZone> ZonesFor(int width, int height)
+    {
+        return Classify(width, height) switch
+        {
+            SnapMonitorShape.UltraWideLandscape => UltraWideZones,
+            SnapMonitorShape.Portrait => PortraitZones,
+            _ => StandardLandscapeZones,
+        };
+    }
+}

--- a/windows/Ghostty.Core/Tabs/SnapZone.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZone.cs
@@ -1,0 +1,42 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// The set of Snap Layouts zones Ghostty offers. This is the union of
+/// the zones shown for standard-landscape, ultra-wide, and portrait
+/// monitors; SnapZoneCatalog picks the subset actually rendered by
+/// the picker based on the current monitor's aspect ratio.
+///
+/// Values intentionally mirror the Windows 11 shell's maximize-button
+/// flyout layout. There is no public API to query the shell's own
+/// preset list, so this enum is the source of truth.
+/// </summary>
+internal enum SnapZone
+{
+    Maximize,
+
+    // Halves (landscape and portrait both use these).
+    LeftHalf,
+    RightHalf,
+    TopHalf,
+    BottomHalf,
+
+    // Quarters (standard landscape + ultra-wide).
+    TopLeftQuarter,
+    TopRightQuarter,
+    BottomLeftQuarter,
+    BottomRightQuarter,
+
+    // Ultra-wide vertical thirds.
+    LeftThird,
+    MiddleThird,
+    RightThird,
+    LeftTwoThirds,
+    RightTwoThirds,
+
+    // Portrait horizontal thirds. Named with the "Horizontal" suffix
+    // so the middle row does not collide with the ultra-wide
+    // MiddleThird (vertical column).
+    TopThird,
+    MiddleThirdHorizontal,
+    BottomThird,
+}

--- a/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZoneMath.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Pure rect math for Snap Layouts zones. Integer arithmetic only:
+/// work-area coordinates come from DisplayArea.WorkArea as physical
+/// pixels and go straight to AppWindow.MoveAndResize, so converting
+/// to double and back risks rounding off-by-ones.
+///
+/// The odd-width split always rounds the left half DOWN and gives
+/// the remainder to the right half, keeping left + right equal to
+/// the input width with no seam crossing the mid-line.
+/// </summary>
+internal static class SnapZoneMath
+{
+    public static SnapZoneRect RectFor(SnapZone zone, int x, int y, int w, int h)
+    {
+        int halfW = w / 2;
+        int halfH = h / 2;
+        int restW = w - halfW; // remainder lives in the right/bottom
+        int restH = h - halfH;
+
+        int thirdW = w / 3;
+        int twoThirdW = 2 * thirdW;
+        int restThirdW = w - twoThirdW; // remainder for right third
+
+        int thirdH = h / 3;
+        int twoThirdH = 2 * thirdH;
+        int restThirdH = h - twoThirdH;
+
+        return zone switch
+        {
+            SnapZone.Maximize => new SnapZoneRect(x, y, w, h),
+
+            SnapZone.LeftHalf   => new SnapZoneRect(x,         y,         halfW, h),
+            SnapZone.RightHalf  => new SnapZoneRect(x + halfW, y,         restW, h),
+            SnapZone.TopHalf    => new SnapZoneRect(x,         y,         w,     halfH),
+            SnapZone.BottomHalf => new SnapZoneRect(x,         y + halfH, w,     restH),
+
+            SnapZone.TopLeftQuarter     => new SnapZoneRect(x,         y,         halfW, halfH),
+            SnapZone.TopRightQuarter    => new SnapZoneRect(x + halfW, y,         restW, halfH),
+            SnapZone.BottomLeftQuarter  => new SnapZoneRect(x,         y + halfH, halfW, restH),
+            SnapZone.BottomRightQuarter => new SnapZoneRect(x + halfW, y + halfH, restW, restH),
+
+            SnapZone.LeftThird      => new SnapZoneRect(x,              y, thirdW,     h),
+            SnapZone.MiddleThird    => new SnapZoneRect(x + thirdW,     y, thirdW,     h),
+            SnapZone.RightThird     => new SnapZoneRect(x + twoThirdW,  y, restThirdW, h),
+            SnapZone.LeftTwoThirds  => new SnapZoneRect(x,              y, twoThirdW,  h),
+            SnapZone.RightTwoThirds => new SnapZoneRect(x + thirdW,     y, w - thirdW, h),
+
+            SnapZone.TopThird              => new SnapZoneRect(x, y,             w, thirdH),
+            SnapZone.MiddleThirdHorizontal => new SnapZoneRect(x, y + thirdH,    w, thirdH),
+            SnapZone.BottomThird           => new SnapZoneRect(x, y + twoThirdH, w, restThirdH),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(zone), zone, "Unhandled zone"),
+        };
+    }
+}

--- a/windows/Ghostty.Core/Tabs/SnapZoneRect.cs
+++ b/windows/Ghostty.Core/Tabs/SnapZoneRect.cs
@@ -1,0 +1,9 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Pure-int rectangle for SnapZoneMath. Deliberately does NOT
+/// reference Windows.Graphics.RectInt32 so Ghostty.Core stays free
+/// of the WindowsAppSDK dependency. The WinUI shell converts to
+/// RectInt32 at the call site via SnapZoneRectInterop.
+/// </summary>
+internal readonly record struct SnapZoneRect(int X, int Y, int Width, int Height);

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -54,12 +54,49 @@ internal sealed class TabManager
     public event EventHandler? LastTabClosed;
     public event EventHandler? WindowTitleChanged;
 
+    /// <summary>
+    /// Raised AFTER the tab's manager subscriptions have been unwired
+    /// but BEFORE the tab is removed from <see cref="Tabs"/>. Fired
+    /// from <see cref="DetachTab"/> only; close paths do not fire it.
+    /// </summary>
+    public event EventHandler<TabModel>? TabDetaching;
+
     public TabManager(Func<IPaneHost> paneHostFactory)
+        : this(paneHostFactory, seed: null) { }
+
+    /// <summary>
+    /// Seeded constructor. If <paramref name="seed"/> is non-null the
+    /// manager adopts it as its initial tab and skips the factory call.
+    /// If <paramref name="seed"/> is null the legacy path runs.
+    ///
+    /// Seeded construction does NOT raise <see cref="TabAdded"/> for
+    /// the seed: it is the initial tab, and TabAdded is for growth.
+    /// Both <c>TabHost.xaml.cs</c> and <c>VerticalTabStrip.xaml.cs</c>
+    /// already iterate <see cref="Tabs"/> on construction before they
+    /// subscribe to <see cref="TabAdded"/>, so a seeded tab is visible
+    /// in the window's UI on first render.
+    ///
+    /// Seeded construction also does NOT raise
+    /// <see cref="ActiveTabChanged"/> or <see cref="WindowTitleChanged"/>
+    /// for the seed. This matches the legacy factory path, which
+    /// assigns <see cref="ActiveTab"/> directly without events because
+    /// no listener is wired at ctor time.
+    /// </summary>
+    public TabManager(Func<IPaneHost> paneHostFactory, TabModel? seed)
     {
         _paneHostFactory = paneHostFactory;
-        var first = CreateTab();
-        _tabs.Add(first);
-        _activeTab = first;
+        if (seed is null)
+        {
+            var first = CreateTab();
+            _tabs.Add(first);
+            _activeTab = first;
+        }
+        else
+        {
+            WireAdoptedTab(seed);
+            _tabs.Add(seed);
+            _activeTab = seed;
+        }
     }
 
     public TabModel NewTab()
@@ -95,7 +132,7 @@ internal sealed class TabManager
 
         tab.PaneHost.LeafFocused -= OnLeafFocused;
         tab.PropertyChanged -= OnTabPropertyChanged;
-        tab.OnClose?.Invoke();
+        UnsubscribeProgressForwarder(tab);
         tab.OnClose = null;
         tab.PaneHost.DisposeAllLeaves();
 
@@ -203,5 +240,111 @@ internal sealed class TabManager
         {
             WindowTitleChanged?.Invoke(this, EventArgs.Empty);
         }
+    }
+
+    /// <summary>
+    /// Remove <paramref name="tab"/> from this manager without tearing
+    /// down its pane host. Caller takes ownership of the returned model
+    /// and must hand it to another manager via <see cref="AdoptTab"/>.
+    /// Raises <see cref="TabDetaching"/>, then <see cref="TabRemoved"/>,
+    /// then either <see cref="LastTabClosed"/> (if it was the last tab)
+    /// or <see cref="ActiveTabChanged"/> / <see cref="WindowTitleChanged"/>
+    /// (if it was the active tab of more than one).
+    /// </summary>
+    public TabModel DetachTab(TabModel tab)
+    {
+        if (_tabs.Count <= 1)
+            throw new InvalidOperationException("Cannot detach the last tab.");
+
+        var index = _tabs.IndexOf(tab);
+        if (index < 0)
+            throw new InvalidOperationException(
+                "DetachTab: tab not owned by this manager.");
+
+        TabDetaching?.Invoke(this, tab);
+
+        // Unwire manager-side subscriptions. Intentionally do NOT call
+        // tab.OnClose or tab.PaneHost.DisposeAllLeaves: the tab is
+        // moving, not dying. The progress-forwarder unsubscribe is
+        // shared with the close path via UnsubscribeProgressForwarder
+        // so this detach path never has to name OnClose.
+        tab.PaneHost.LeafFocused -= OnLeafFocused;
+        tab.PropertyChanged -= OnTabPropertyChanged;
+        UnsubscribeProgressForwarder(tab);
+        // tab.OnClose is intentionally LEFT ALONE. WireAdoptedTab on
+        // the destination manager overwrites it as part of adoption.
+
+        _tabs.RemoveAt(index);
+        TabRemoved?.Invoke(this, tab);
+
+        if (_tabs.Count == 0)
+        {
+            LastTabClosed?.Invoke(this, EventArgs.Empty);
+            return tab;
+        }
+
+        if (ReferenceEquals(_activeTab, tab))
+        {
+            var next = _tabs[Math.Min(index, _tabs.Count - 1)];
+            _activeTab = next;
+            ActiveTabChanged?.Invoke(this, next);
+            WindowTitleChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        return tab;
+    }
+
+    /// <summary>
+    /// Attach an externally-sourced <see cref="TabModel"/> to this
+    /// manager. Rewires <see cref="TabModel.OnClose"/>,
+    /// <see cref="IPaneHost.LeafFocused"/>, progress forwarding, and
+    /// property-change forwarding to the adopter's event graph.
+    /// Raises <see cref="TabAdded"/> and activates the tab.
+    /// </summary>
+    public void AdoptTab(TabModel tab)
+    {
+        if (_tabs.Contains(tab))
+            throw new InvalidOperationException("AdoptTab: tab already owned.");
+
+        WireAdoptedTab(tab);
+        _tabs.Add(tab);
+        TabAdded?.Invoke(this, tab);
+        Activate(tab);
+    }
+
+    /// <summary>
+    /// Shared rewire used by both <see cref="AdoptTab"/> and the
+    /// seeded constructor. Does NOT touch _tabs, does NOT raise any
+    /// events; the caller owns activation and TabAdded.
+    /// </summary>
+    private void WireAdoptedTab(TabModel tab)
+    {
+        tab.PaneHost.LeafFocused += OnLeafFocused;
+        EventHandler<TabProgressState> progressHandler = (_, state) => tab.Progress = state;
+        tab.PaneHost.ProgressChanged += progressHandler;
+        // OnClose stores the unsubscribe action so DetachTab /
+        // CloseTab can walk back the progress wiring without needing
+        // to re-capture the handler delegate.
+        tab.OnClose = () => tab.PaneHost.ProgressChanged -= progressHandler;
+        tab.PropertyChanged += OnTabPropertyChanged;
+    }
+
+    /// <summary>
+    /// Walk back the progress-forwarder subscription installed by
+    /// <see cref="CreateTab"/> or <see cref="WireAdoptedTab"/>. Shared
+    /// between <see cref="CloseTab"/> and <see cref="DetachTab"/> so
+    /// neither path has to spell out "invoke OnClose and null it";
+    /// in particular, <see cref="DetachTab"/> must NOT invoke OnClose
+    /// (per spec) because OnClose is the close-signal hook,
+    /// not the detach hook.
+    /// </summary>
+    private void UnsubscribeProgressForwarder(TabModel tab)
+    {
+        // OnClose is the unsubscribe action. Running it detaches the
+        // progress handler from PaneHost.ProgressChanged. On DetachTab
+        // we run this helper instead of tab.OnClose?.Invoke() at the
+        // call site so the semantics are obvious: we are dismantling
+        // ONE specific subscription, not running the full close.
+        tab.OnClose?.Invoke();
     }
 }

--- a/windows/Ghostty.Core/Windows/CursorWindowPlacement.cs
+++ b/windows/Ghostty.Core/Windows/CursorWindowPlacement.cs
@@ -1,0 +1,83 @@
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// Work area rectangle in physical screen pixels. Mirrors the shape of
+/// <c>DisplayArea.WorkArea</c> without pulling in WinAppSDK types, so
+/// the placement math can live in <c>Ghostty.Core</c> and be unit-tested
+/// without a WinUI runtime.
+/// </summary>
+internal readonly record struct WorkAreaRect(int X, int Y, int Width, int Height)
+{
+    public int Right => X + Width;
+    public int Bottom => Y + Height;
+}
+
+/// <summary>
+/// Target placement rectangle for a new window. Mirrors
+/// <c>Windows.Graphics.RectInt32</c>.
+/// </summary>
+internal readonly record struct PlacementRect(int X, int Y, int Width, int Height);
+
+/// <summary>
+/// Cursor-anchored placement math for Move Tab to New Window. Pure.
+/// No Win32, no WinAppSDK. Called from MainWindow.DetachTabToNewWindow
+/// after <c>GetCursorPos</c> and <c>DisplayArea.WorkArea</c> have been
+/// resolved.
+///
+/// Contract:
+///
+///   - Raw anchor is (cursor - (<see cref="OffsetX"/>, <see cref="OffsetY"/>)).
+///     The offset keeps the title bar of the new window under the cursor
+///     without putting the cursor directly on top of a window control.
+///   - If the resulting rect extends past the work area's right or
+///     bottom edge, the top-left is pulled back so the entire window
+///     fits.
+///   - If the window is larger than the work area on either axis, the
+///     top-left is pinned to the work area origin on that axis and the
+///     size is left unchanged. The system will clip; we do not shrink.
+/// </summary>
+internal static class CursorWindowPlacement
+{
+    // TODO(dpi): scale offset constants per monitor DPI. At 100% DPI a
+    // 32px nudge puts the title bar under the cursor; at 200% it feels
+    // half as large. Left as a fixed physical-pixel offset for the
+    // first cut; revisit when the new window's target DisplayArea
+    // reports effective DPI.
+    internal const int OffsetX = 32;
+    internal const int OffsetY = 32;
+
+    public static PlacementRect Compute(
+        int cursorX,
+        int cursorY,
+        int windowWidth,
+        int windowHeight,
+        WorkAreaRect workArea)
+    {
+        int x = cursorX - OffsetX;
+        int y = cursorY - OffsetY;
+
+        // Window wider than the work area: pin left, do not shrink.
+        if (windowWidth >= workArea.Width)
+        {
+            x = workArea.X;
+        }
+        else
+        {
+            // Clamp right edge into work area, then clamp left edge.
+            if (x + windowWidth > workArea.Right) x = workArea.Right - windowWidth;
+            if (x < workArea.X) x = workArea.X;
+        }
+
+        if (windowHeight >= workArea.Height)
+        {
+            y = workArea.Y;
+        }
+        else
+        {
+            if (y + windowHeight > workArea.Bottom) y = workArea.Bottom - windowHeight;
+            if (y < workArea.Y) y = workArea.Y;
+        }
+
+        return new PlacementRect(x, y, windowWidth, windowHeight);
+    }
+}

--- a/windows/Ghostty.Tests/Hosting/HostLifetimeStateTests.cs
+++ b/windows/Ghostty.Tests/Hosting/HostLifetimeStateTests.cs
@@ -1,0 +1,69 @@
+using System;
+using Ghostty.Core.Hosting;
+using Xunit;
+
+namespace Ghostty.Tests.Hosting;
+
+public sealed class HostLifetimeStateTests
+{
+    [Fact]
+    public void Bootstrap_OwnsApp_AndIsNotDisposedInitially()
+    {
+        var s = HostLifetimeState.Bootstrap();
+        Assert.True(s.IsBootstrap);
+        Assert.True(s.OwnsApp);
+        Assert.False(s.IsDisposed);
+    }
+
+    [Fact]
+    public void PerWindow_DoesNotOwnApp()
+    {
+        var s = HostLifetimeState.PerWindow();
+        Assert.False(s.IsBootstrap);
+        Assert.False(s.OwnsApp);
+        Assert.False(s.IsDisposed);
+    }
+
+    [Fact]
+    public void MarkDisposed_IsIdempotent()
+    {
+        var s = HostLifetimeState.PerWindow();
+        s.MarkDisposed();
+        s.MarkDisposed();
+        Assert.True(s.IsDisposed);
+    }
+
+    [Fact]
+    public void Supervisor_RequiresBootstrapDrainLast()
+    {
+        var supervisor = new HostLifetimeSupervisor();
+        var bootstrap = supervisor.RegisterBootstrap();
+        var perWindow1 = supervisor.RegisterPerWindow();
+        var perWindow2 = supervisor.RegisterPerWindow();
+
+        perWindow1.MarkDisposed();
+        supervisor.NotifyDisposed(perWindow1);
+        perWindow2.MarkDisposed();
+        supervisor.NotifyDisposed(perWindow2);
+
+        // Bootstrap CAN dispose now; nothing should throw.
+        bootstrap.MarkDisposed();
+        supervisor.NotifyDisposed(bootstrap);
+
+        Assert.True(bootstrap.IsDisposed);
+        Assert.Equal(0, supervisor.LivePerWindowCount);
+    }
+
+    [Fact]
+    public void Supervisor_BootstrapDispose_ThrowsIfPerWindowStillAlive()
+    {
+        var supervisor = new HostLifetimeSupervisor();
+        var bootstrap = supervisor.RegisterBootstrap();
+        _ = supervisor.RegisterPerWindow();
+
+        // Attempt to dispose the bootstrap while a per-window host
+        // is still live violates the drain-last invariant.
+        Assert.Throws<InvalidOperationException>(
+            () => supervisor.NotifyDisposed(bootstrap));
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/SnapZoneCatalogTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneCatalogTests.cs
@@ -1,0 +1,76 @@
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class SnapZoneCatalogTests
+{
+    [Theory]
+    [InlineData(1920, 1080, (int)SnapMonitorShape.StandardLandscape)] // 16:9
+    [InlineData(2560, 1600, (int)SnapMonitorShape.StandardLandscape)] // 16:10
+    [InlineData(1920, 1200, (int)SnapMonitorShape.StandardLandscape)] // 16:10
+    [InlineData(3440, 1440, (int)SnapMonitorShape.UltraWideLandscape)] // 21:9 = 2.388
+    [InlineData(5120, 1440, (int)SnapMonitorShape.UltraWideLandscape)] // 32:9 = 3.555
+    [InlineData(1080, 1920, (int)SnapMonitorShape.Portrait)]
+    [InlineData(1200, 1920, (int)SnapMonitorShape.Portrait)]
+    [InlineData(1000, 1000, (int)SnapMonitorShape.StandardLandscape)] // square -> landscape
+    public void Classify_returns_expected_shape(int w, int h, int expected)
+    {
+        Assert.Equal((SnapMonitorShape)expected, SnapZoneCatalog.Classify(w, h));
+    }
+
+    [Fact]
+    public void Classify_threshold_2point1_exact_is_ultrawide()
+    {
+        // 2100 x 1000 = 2.1 exact -> ultra-wide (>= 2.1)
+        Assert.Equal(SnapMonitorShape.UltraWideLandscape, SnapZoneCatalog.Classify(2100, 1000));
+    }
+
+    [Fact]
+    public void Classify_just_below_threshold_is_standard()
+    {
+        // 2099 x 1000 = 2.099 -> standard
+        Assert.Equal(SnapMonitorShape.StandardLandscape, SnapZoneCatalog.Classify(2099, 1000));
+    }
+
+    [Fact]
+    public void ZonesFor_standard_landscape_returns_halves_quarters_plus_maximize()
+    {
+        var zones = SnapZoneCatalog.ZonesFor(1920, 1080);
+        Assert.Equal(new[]
+        {
+            SnapZone.LeftHalf, SnapZone.RightHalf,
+            SnapZone.TopHalf, SnapZone.BottomHalf,
+            SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+            SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+            SnapZone.Maximize,
+        }, zones);
+    }
+
+    [Fact]
+    public void ZonesFor_ultrawide_returns_halves_thirds_quarters_plus_maximize()
+    {
+        var zones = SnapZoneCatalog.ZonesFor(3440, 1440);
+        Assert.Equal(new[]
+        {
+            SnapZone.LeftHalf, SnapZone.RightHalf,
+            SnapZone.LeftThird, SnapZone.MiddleThird, SnapZone.RightThird,
+            SnapZone.LeftTwoThirds, SnapZone.RightTwoThirds,
+            SnapZone.TopLeftQuarter, SnapZone.TopRightQuarter,
+            SnapZone.BottomLeftQuarter, SnapZone.BottomRightQuarter,
+            SnapZone.Maximize,
+        }, zones);
+    }
+
+    [Fact]
+    public void ZonesFor_portrait_returns_halves_horizontal_thirds_plus_maximize()
+    {
+        var zones = SnapZoneCatalog.ZonesFor(1080, 1920);
+        Assert.Equal(new[]
+        {
+            SnapZone.TopHalf, SnapZone.BottomHalf,
+            SnapZone.TopThird, SnapZone.MiddleThirdHorizontal, SnapZone.BottomThird,
+            SnapZone.Maximize,
+        }, zones);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
+++ b/windows/Ghostty.Tests/Tabs/SnapZoneMathTests.cs
@@ -1,0 +1,185 @@
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class SnapZoneMathTests
+{
+    [Fact]
+    public void Maximize_returns_input_rect()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.Maximize, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 1920, 1080), r);
+    }
+
+    [Fact]
+    public void LeftHalf_splits_even_width_in_half()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.LeftHalf, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 960, 1080), r);
+    }
+
+    [Fact]
+    public void RightHalf_has_matching_offset_and_remainder_width()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.RightHalf, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(960, 0, 960, 1080), r);
+    }
+
+    [Fact]
+    public void TopHalf_and_BottomHalf_split_height()
+    {
+        var top = SnapZoneMath.RectFor(SnapZone.TopHalf, 0, 0, 1920, 1080);
+        var bot = SnapZoneMath.RectFor(SnapZone.BottomHalf, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 1920, 540), top);
+        Assert.Equal(new SnapZoneRect(0, 540, 1920, 540), bot);
+    }
+
+    [Fact]
+    public void RespectsNonZeroOrigin_including_negative_left()
+    {
+        // Secondary monitor left of primary, taskbar at top.
+        var r = SnapZoneMath.RectFor(SnapZone.LeftHalf, -1920, 100, 1920, 1040);
+        Assert.Equal(new SnapZoneRect(-1920, 100, 960, 1040), r);
+    }
+
+    [Fact]
+    public void OddWidth_rounds_LeftHalf_down_RightHalf_takes_remainder()
+    {
+        // Width 1921 -> left 960, right 961, right origin at 960. Sum 1921.
+        var left = SnapZoneMath.RectFor(SnapZone.LeftHalf, 0, 0, 1921, 1080);
+        var right = SnapZoneMath.RectFor(SnapZone.RightHalf, 0, 0, 1921, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 960, 1080), left);
+        Assert.Equal(new SnapZoneRect(960, 0, 961, 1080), right);
+        Assert.Equal(1921, left.Width + right.Width);
+    }
+
+    [Fact]
+    public void TopLeftQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.TopLeftQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 0, 960, 540), r);
+    }
+
+    [Fact]
+    public void TopRightQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.TopRightQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(960, 0, 960, 540), r);
+    }
+
+    [Fact]
+    public void BottomLeftQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.BottomLeftQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(0, 540, 960, 540), r);
+    }
+
+    [Fact]
+    public void BottomRightQuarter_1920x1080()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.BottomRightQuarter, 0, 0, 1920, 1080);
+        Assert.Equal(new SnapZoneRect(960, 540, 960, 540), r);
+    }
+
+    [Fact]
+    public void Quarters_odd_dimensions_cover_input_without_seam()
+    {
+        var tl = SnapZoneMath.RectFor(SnapZone.TopLeftQuarter, 0, 0, 1921, 1081);
+        var tr = SnapZoneMath.RectFor(SnapZone.TopRightQuarter, 0, 0, 1921, 1081);
+        var bl = SnapZoneMath.RectFor(SnapZone.BottomLeftQuarter, 0, 0, 1921, 1081);
+        var br = SnapZoneMath.RectFor(SnapZone.BottomRightQuarter, 0, 0, 1921, 1081);
+
+        // Widths sum to 1921 on top row.
+        Assert.Equal(1921, tl.Width + tr.Width);
+        // Heights sum to 1081 on left column.
+        Assert.Equal(1081, tl.Height + bl.Height);
+        // BR starts exactly where TL ends.
+        Assert.Equal(tl.X + tl.Width, br.X);
+        Assert.Equal(tl.Y + tl.Height, br.Y);
+    }
+
+    [Fact]
+    public void LeftThird_of_3440_wide()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.LeftThird, 0, 0, 3440, 1440);
+        // 3440 / 3 = 1146 (int)
+        Assert.Equal(new SnapZoneRect(0, 0, 1146, 1440), r);
+    }
+
+    [Fact]
+    public void MiddleThird_of_3440_wide()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.MiddleThird, 0, 0, 3440, 1440);
+        Assert.Equal(new SnapZoneRect(1146, 0, 1146, 1440), r);
+    }
+
+    [Fact]
+    public void RightThird_of_3440_wide_absorbs_remainder()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.RightThird, 0, 0, 3440, 1440);
+        // Starts at 2*1146 = 2292, width = 3440 - 2292 = 1148.
+        Assert.Equal(new SnapZoneRect(2292, 0, 1148, 1440), r);
+    }
+
+    [Fact]
+    public void Thirds_cover_input_without_seam()
+    {
+        var l = SnapZoneMath.RectFor(SnapZone.LeftThird, 0, 0, 3440, 1440);
+        var m = SnapZoneMath.RectFor(SnapZone.MiddleThird, 0, 0, 3440, 1440);
+        var r = SnapZoneMath.RectFor(SnapZone.RightThird, 0, 0, 3440, 1440);
+        Assert.Equal(3440, l.Width + m.Width + r.Width);
+        Assert.Equal(l.X + l.Width, m.X);
+        Assert.Equal(m.X + m.Width, r.X);
+    }
+
+    [Fact]
+    public void LeftTwoThirds_matches_LeftThird_plus_MiddleThird()
+    {
+        var lt = SnapZoneMath.RectFor(SnapZone.LeftTwoThirds, 0, 0, 3440, 1440);
+        // 2 * (3440/3) = 2292
+        Assert.Equal(new SnapZoneRect(0, 0, 2292, 1440), lt);
+    }
+
+    [Fact]
+    public void RightTwoThirds_matches_MiddleThird_plus_RightThird()
+    {
+        var rt = SnapZoneMath.RectFor(SnapZone.RightTwoThirds, 0, 0, 3440, 1440);
+        // Starts at w/3 = 1146, width = 3440 - 1146 = 2294.
+        Assert.Equal(new SnapZoneRect(1146, 0, 2294, 1440), rt);
+    }
+
+    [Fact]
+    public void TopThird_of_1080x1920_portrait()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.TopThird, 0, 0, 1080, 1920);
+        // 1920 / 3 = 640
+        Assert.Equal(new SnapZoneRect(0, 0, 1080, 640), r);
+    }
+
+    [Fact]
+    public void MiddleThirdHorizontal_of_1080x1920_portrait()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.MiddleThirdHorizontal, 0, 0, 1080, 1920);
+        Assert.Equal(new SnapZoneRect(0, 640, 1080, 640), r);
+    }
+
+    [Fact]
+    public void BottomThird_of_1080x1920_portrait_absorbs_remainder()
+    {
+        var r = SnapZoneMath.RectFor(SnapZone.BottomThird, 0, 0, 1080, 1920);
+        // 2*640 = 1280, remainder = 640
+        Assert.Equal(new SnapZoneRect(0, 1280, 1080, 640), r);
+    }
+
+    [Fact]
+    public void Horizontal_thirds_cover_input_without_seam()
+    {
+        var t = SnapZoneMath.RectFor(SnapZone.TopThird, 0, 0, 1080, 1921);
+        var m = SnapZoneMath.RectFor(SnapZone.MiddleThirdHorizontal, 0, 0, 1080, 1921);
+        var b = SnapZoneMath.RectFor(SnapZone.BottomThird, 0, 0, 1080, 1921);
+        Assert.Equal(1921, t.Height + m.Height + b.Height);
+        Assert.Equal(t.Y + t.Height, m.Y);
+        Assert.Equal(m.Y + m.Height, b.Y);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabManagerDetachTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerDetachTests.cs
@@ -1,0 +1,162 @@
+using System;
+using Ghostty.Core.Panes;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public sealed class TabManagerDetachTests
+{
+    private static TabManager NewManager(out FakePaneHost first)
+    {
+        FakePaneHost? captured = null;
+        var mgr = new TabManager(() =>
+        {
+            var h = new FakePaneHost();
+            captured ??= h;
+            return h;
+        });
+        first = captured!;
+        return mgr;
+    }
+
+    [Fact]
+    public void DetachTab_RemovesFromTabs_PreservesPaneHostIdentity()
+    {
+        var src = NewManager(out _);
+        src.NewTab();
+        src.NewTab();
+        Assert.Equal(3, src.Tabs.Count);
+
+        var target = src.Tabs[1];
+        var paneHostBefore = target.PaneHost;
+
+        var detached = src.DetachTab(target);
+
+        Assert.Equal(2, src.Tabs.Count);
+        Assert.DoesNotContain(target, src.Tabs);
+        Assert.Same(target, detached);
+        Assert.Same(paneHostBefore, detached.PaneHost);
+    }
+
+    [Fact]
+    public void DetachTab_RaisesTabDetachingExactlyOnceBeforeRemoval()
+    {
+        var src = NewManager(out _);
+        src.NewTab();
+        var target = src.Tabs[1];
+
+        int detachingCount = 0;
+        int countAtDetachingTime = -1;
+        src.TabDetaching += (_, t) =>
+        {
+            detachingCount++;
+            Assert.Same(target, t);
+            countAtDetachingTime = src.Tabs.Count;
+        };
+
+        src.DetachTab(target);
+
+        Assert.Equal(1, detachingCount);
+        Assert.Equal(2, countAtDetachingTime); // fires BEFORE removal
+    }
+
+    [Fact]
+    public void DetachTab_DoesNotCallDisposeAllLeaves()
+    {
+        var src = NewManager(out var host);
+        var target = src.Tabs[0];
+        // Seed a second tab so the detach does not trip LastTabClosed.
+        src.NewTab();
+
+        src.DetachTab(target);
+
+        Assert.Equal(0, host.DisposeAllCalls);
+    }
+
+    [Fact]
+    public void DetachTab_LastTab_ThrowsInvalidOperation()
+    {
+        var src = NewManager(out _);
+        Assert.Equal(1, src.Tabs.Count);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => src.DetachTab(src.Tabs[0]));
+
+        Assert.Contains("Cannot detach the last tab", ex.Message);
+    }
+
+    [Fact]
+    public void DetachTab_OfActiveTab_PicksNextActiveTab()
+    {
+        var src = NewManager(out _);
+        src.NewTab(); // index 1, becomes active
+        src.NewTab(); // index 2, becomes active
+        var active = src.ActiveTab;
+
+        src.DetachTab(active);
+
+        Assert.Equal(2, src.Tabs.Count);
+        Assert.NotSame(active, src.ActiveTab);
+    }
+
+    [Fact]
+    public void AdoptTab_AddsToTargetManager_FiresTabAddedAndActivates()
+    {
+        var src = NewManager(out _);
+        src.NewTab();
+        var detached = src.DetachTab(src.Tabs[1]);
+
+        var dst = NewManager(out _);
+        Assert.Equal(1, dst.Tabs.Count);
+
+        int tabAdded = 0;
+        dst.TabAdded += (_, _) => tabAdded++;
+
+        dst.AdoptTab(detached);
+
+        Assert.Equal(2, dst.Tabs.Count);
+        Assert.Contains(detached, dst.Tabs);
+        Assert.Same(detached, dst.ActiveTab);
+        Assert.Equal(1, tabAdded);
+    }
+
+    [Fact]
+    public void SeededCtor_UsesSeed_DoesNotCallFactory()
+    {
+        int factoryCalls = 0;
+        var seedHost = new FakePaneHost();
+        var seed = new TabModel(seedHost);
+
+        var dst = new TabManager(
+            () => { factoryCalls++; return new FakePaneHost(); },
+            seed);
+
+        Assert.Equal(0, factoryCalls);
+        Assert.Equal(1, dst.Tabs.Count);
+        Assert.Same(seed, dst.Tabs[0]);
+        Assert.Same(seed, dst.ActiveTab);
+    }
+
+    [Fact]
+    public void DetachAdoptRoundTrip_ProgressRoutesToNewManager()
+    {
+        var src = NewManager(out var srcHost);
+        src.NewTab();
+        var target = src.Tabs[1];
+
+        var detached = src.DetachTab(target);
+
+        var dst = NewManager(out _);
+        dst.AdoptTab(detached);
+
+        // Simulate active leaf progress on the source host. Because
+        // AdoptTab rebinds the progress handler, detached.Progress must
+        // follow the host it now lives under.
+        var hostOfDetached = (FakePaneHost)detached.PaneHost;
+        hostOfDetached.RaiseProgressChanged(TabProgressState.Normal(42));
+
+        Assert.Equal(TabProgressState.Kind.Normal, detached.Progress.State);
+        Assert.Equal(42, detached.Progress.Percent);
+    }
+}

--- a/windows/Ghostty.Tests/Windows/CursorWindowPlacementTests.cs
+++ b/windows/Ghostty.Tests/Windows/CursorWindowPlacementTests.cs
@@ -1,0 +1,96 @@
+using Ghostty.Core.Windows;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+public sealed class CursorWindowPlacementTests
+{
+    private static readonly WorkAreaRect WorkArea = new(X: 0, Y: 0, Width: 1920, Height: 1080);
+
+    [Fact]
+    public void CursorAtOrigin_PlacesAtCursorMinusOffset_ClampedIntoWorkArea()
+    {
+        // Offset is 32,32. Cursor (0,0) minus offset is (-32,-32).
+        // Clamp pulls X and Y back to the work area top-left.
+        var rect = CursorWindowPlacement.Compute(
+            cursorX: 0, cursorY: 0,
+            windowWidth: 800, windowHeight: 600,
+            workArea: WorkArea);
+
+        Assert.Equal(0, rect.X);
+        Assert.Equal(0, rect.Y);
+        Assert.Equal(800, rect.Width);
+        Assert.Equal(600, rect.Height);
+    }
+
+    [Fact]
+    public void CursorInInterior_PlacesWithOffset()
+    {
+        var rect = CursorWindowPlacement.Compute(
+            cursorX: 500, cursorY: 400,
+            windowWidth: 800, windowHeight: 600,
+            workArea: WorkArea);
+
+        // 500 - 32 = 468, 400 - 32 = 368.
+        Assert.Equal(468, rect.X);
+        Assert.Equal(368, rect.Y);
+    }
+
+    [Fact]
+    public void CursorNearRightEdge_ClampsSoWindowFitsInsideWorkArea()
+    {
+        // cursor at x=1900, window 800 wide: raw X would be 1868,
+        // right edge = 2668, outside work area (right=1920). Clamp
+        // so right edge == 1920: X = 1920 - 800 = 1120.
+        var rect = CursorWindowPlacement.Compute(
+            cursorX: 1900, cursorY: 500,
+            windowWidth: 800, windowHeight: 600,
+            workArea: WorkArea);
+
+        Assert.Equal(1120, rect.X);
+    }
+
+    [Fact]
+    public void CursorNearBottomEdge_ClampsSoWindowFitsInsideWorkArea()
+    {
+        var rect = CursorWindowPlacement.Compute(
+            cursorX: 500, cursorY: 1070,
+            windowWidth: 800, windowHeight: 600,
+            workArea: WorkArea);
+
+        // raw Y = 1038, bottom = 1638 > 1080. Clamp: Y = 1080 - 600 = 480.
+        Assert.Equal(480, rect.Y);
+    }
+
+    [Fact]
+    public void WindowLargerThanWorkArea_AlignsTopLeftToWorkArea()
+    {
+        // If the requested window is bigger than the work area, we
+        // can't fit it. Contract: pin top-left to work area origin
+        // and let the system clip.
+        var rect = CursorWindowPlacement.Compute(
+            cursorX: 500, cursorY: 500,
+            windowWidth: 3000, windowHeight: 2000,
+            workArea: WorkArea);
+
+        Assert.Equal(0, rect.X);
+        Assert.Equal(0, rect.Y);
+        Assert.Equal(3000, rect.Width);
+        Assert.Equal(2000, rect.Height);
+    }
+
+    [Fact]
+    public void SecondaryMonitor_UsesWorkAreaOrigin()
+    {
+        // Secondary monitor to the right at (1920,0) 1920x1080.
+        var secondary = new WorkAreaRect(X: 1920, Y: 0, Width: 1920, Height: 1080);
+        var rect = CursorWindowPlacement.Compute(
+            cursorX: 2500, cursorY: 500,
+            windowWidth: 800, windowHeight: 600,
+            workArea: secondary);
+
+        // raw = (2468, 468); both inside secondary.
+        Assert.Equal(2468, rect.X);
+        Assert.Equal(468, rect.Y);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -38,6 +38,13 @@ public partial class App : Application
     //   2. When WindowsByRoot is empty, bootstrap host disposes: it
     //      calls AppFree (its HostLifetimeState.OwnsApp is true).
     //   3. ConfigService disposal is handled by process exit.
+    // Instance fields for the App's own lifecycle (assigned in
+    // OnLaunched, cleared in OnAnyWindowClosedInternal). The matching
+    // static properties below expose the same references to types
+    // (MainWindow, GhosttyHost) that do not hold a reference to the
+    // App instance. WinUI 3's Application is a process singleton so
+    // both always agree; the duplication is the lesser evil compared
+    // to casting Application.Current everywhere.
     private ConfigService? _configService;
     private GhosttyHost? _bootstrapHost;
     private HostLifetimeSupervisor? _lifetimeSupervisor;

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -1,6 +1,13 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using Ghostty.Controls;
+using Ghostty.Core.Hosting;
+using Ghostty.Hosting;
 using Ghostty.Services;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -8,18 +15,120 @@ using Microsoft.UI.Xaml;
 namespace Ghostty;
 
 /// <summary>
-/// Application entry point. Keeps a strong reference to the main window so
-/// it is not collected while the message loop is running.
+/// Application entry point. Owns the single <c>ghostty_app_t</c>
+/// (via the bootstrap <see cref="GhosttyHost"/>), the shared
+/// <see cref="ConfigService"/>, and the process-wide window registry
+/// (<see cref="WindowsByRoot"/>). Callback routing from libghostty is
+/// centralized here via the static <see cref="_hostBySurface"/> map.
 /// </summary>
 public partial class App : Application
 {
-    // TODO(multi-window, #161): replace with an XamlRoot -> Window
-    // registry once the shell supports multiple top-level windows
-    // (Move Tab to New Window, Settings window, etc.). Single-window
-    // assumption is only safe while there is exactly one root.
-    public static Window? RootWindow { get; internal set; }
+    // -- Option (b) hoist: process-global libghostty ownership. --
+    //
+    // Single ghostty_app_t across all top-level windows. The bootstrap
+    // GhosttyHost owns the runtime callback function pointers libghostty
+    // was given in AppNew, so it must stay alive until the last window
+    // closes. Every MainWindow builds its own per-window GhosttyHost
+    // with its own per-window _surfaces dictionary.
+    //
+    // Dispose order at shutdown (OnAnyWindowClosedInternal handler):
+    //   1. Per-window host for the closing window disposes first, as
+    //      part of MainWindow.OnClosed, and removes itself from
+    //      _hostBySurface via GhosttyHost.Dispose -> UnregisterHostSurfaces.
+    //   2. When WindowsByRoot is empty, bootstrap host disposes: it
+    //      calls AppFree (its HostLifetimeState.OwnsApp is true).
+    //   3. ConfigService disposal is handled by process exit.
+    private ConfigService? _configService;
+    private GhosttyHost? _bootstrapHost;
+    private HostLifetimeSupervisor? _lifetimeSupervisor;
 
-    private Window? _window;
+    // Top-level window registry keyed by XamlRoot. Replaces the old
+    // singular RootWindow and the earlier List<Window> draft: XamlRoot
+    // is the identity every UserControl already has in hand, so
+    // lookups from a TabHost or dialog code become O(1). UI-thread-
+    // only access. Insert on MainWindow content Loaded (since the
+    // XamlRoot is not available before then), remove on Closed.
+    internal static readonly Dictionary<XamlRoot, MainWindow> WindowsByRoot = new();
+
+    /// <summary>
+    /// Live top-level window list view. Equivalent to
+    /// <c>WindowsByRoot.Values</c>. Kept as a convenience for callers
+    /// that want to iterate all windows without caring about lookup
+    /// keys.
+    /// </summary>
+    internal static IEnumerable<MainWindow> AllWindows => WindowsByRoot.Values;
+
+    internal static GhosttyHost? BootstrapHost { get; private set; }
+    internal static ConfigService? ConfigService { get; private set; }
+    internal static HostLifetimeSupervisor? LifetimeSupervisor { get; private set; }
+
+    // Process-wide callback routing: surface handle -> per-window host.
+    // Inserted/removed by GhosttyHost.Register/Unregister/Adopt/Detach.
+    // Consulted by the bootstrap host's libghostty callbacks to forward
+    // to whichever per-window host currently owns the surface.
+    //
+    // ConcurrentDictionary because bootstrap host's libghostty callbacks
+    // (OnCloseSurface, OnWakeup, OnAction, OnReadClipboard, OnConfirmReadClipboard,
+    // OnWriteClipboard) may be invoked from libghostty's thread and consult
+    // this map before dispatcher-hopping. Once the owning host is found,
+    // the callback hops to that host's dispatcher for any UI work.
+    private static readonly ConcurrentDictionary<IntPtr, GhosttyHost> _hostBySurface = new();
+
+    internal static int HostBySurfaceCount => _hostBySurface.Count;
+
+    internal static void RegisterSurfaceRoute(IntPtr handle, GhosttyHost host)
+        => _hostBySurface[handle] = host;
+
+    internal static void UnregisterSurfaceRoute(IntPtr handle, GhosttyHost host)
+    {
+        // Only remove if we still own this entry. Guards against a
+        // double-adopt path where the target host already overwrote.
+        ((ICollection<KeyValuePair<IntPtr, GhosttyHost>>)_hostBySurface)
+            .Remove(new KeyValuePair<IntPtr, GhosttyHost>(handle, host));
+    }
+
+    internal static bool TryGetHostForSurface(IntPtr handle, out GhosttyHost? host)
+    {
+        if (_hostBySurface.TryGetValue(handle, out var h)) { host = h; return true; }
+        host = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Search for a <see cref="TerminalControl"/> across all per-window
+    /// hosts. Used by <see cref="GhosttyHost.IsRegistered"/> when the
+    /// bootstrap host's own dictionary misses (the control may have
+    /// moved to a different window's host).
+    /// </summary>
+    internal static bool TryFindHostForControl(TerminalControl control, [NotNullWhen(true)] out GhosttyHost? host)
+    {
+        foreach (var candidate in _hostBySurface.Values.Distinct())
+        {
+            if (candidate.ContainsControl(control))
+            {
+                host = candidate;
+                return true;
+            }
+        }
+        host = null;
+        return false;
+    }
+
+    internal static void UnregisterHostSurfaces(GhosttyHost host)
+    {
+        // Drain every entry whose value equals `host`. Called from
+        // GhosttyHost.Dispose to clean up routing without requiring the
+        // host to remember every handle it ever saw. Snapshot the keys
+        // first so we do not mutate the dictionary while enumerating it.
+        foreach (var kv in _hostBySurface.ToArray())
+        {
+            if (ReferenceEquals(kv.Value, host))
+            {
+                ((ICollection<KeyValuePair<IntPtr, GhosttyHost>>)_hostBySurface)
+                    .Remove(kv);
+            }
+        }
+    }
 
     static App()
     {
@@ -92,10 +201,7 @@ public partial class App : Application
     {
         // Set the explicit AppUserModelID. This MUST happen before
         // any shell interop call (jump list registration, taskbar
-        // icon operations, toast notifications) — the Shell caches
-        // the process-to-AUMID association on first use and reads
-        // the jump list from a per-AUMID store. Without this, the
-        // jump list silently no-ops on unpackaged exes.
+        // icon operations, toast notifications).
         const string AppUserModelId = "com.deblasis.ghostty";
         try
         {
@@ -105,24 +211,17 @@ public partial class App : Application
         catch (System.Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Failed to set AUMID: {ex.Message}");
-            // Continue anyway; app still functions, just without jump list.
         }
 
-        // Build the jump list once at startup. Rebuilds happen when
-        // the profile list changes (TODO(config): hook a config event).
+        // Build the jump list once at startup.
         try
         {
-            // Environment.ProcessPath points to the apphost .exe, which
-            // is what we want the shell to invoke from the jump list.
-            // Assembly.GetEntryAssembly().Location returns the managed
-            // .dll on single-file apphost layouts, so prefer ProcessPath.
             var exePath = System.Environment.ProcessPath ?? string.Empty;
             if (!string.IsNullOrEmpty(exePath))
             {
                 var facade = new Ghostty.JumpList.CustomDestinationListFacade();
                 var builder = new Ghostty.Core.JumpList.JumpListBuilder(
                     facade,
-                    // TODO(config): profiles — swap for config-driven list
                     profilesProvider: () => System.Array.Empty<Ghostty.Core.JumpList.ProfileEntry>(),
                     exePath: exePath,
                     appId: AppUserModelId);
@@ -132,13 +231,72 @@ public partial class App : Application
         catch (System.Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Failed to build jump list: {ex.Message}");
-            // Jump list is nice-to-have; failure here does not block startup.
         }
 
-        var configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
+        _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
+        ConfigService = _configService;
 
-        _window = new MainWindow(configService);
-        RootWindow = _window;
-        _window.Activate();
+        // One supervisor per process. Threads lifecycle invariants
+        // through every host that ever lives, including the bootstrap.
+        _lifetimeSupervisor = new HostLifetimeSupervisor();
+        LifetimeSupervisor = _lifetimeSupervisor;
+
+        // Build the bootstrap host. This is the one host that owns the
+        // ghostty_app_t (via the legacy ctor's AppNew call) and the one
+        // host libghostty invokes. Its callback bodies consult
+        // _hostBySurface to forward to whichever per-window host owns
+        // the target surface.
+        _bootstrapHost = new GhosttyHost(
+            DispatcherQueue.GetForCurrentThread(),
+            _configService.ConfigHandle,
+            _lifetimeSupervisor);
+        BootstrapHost = _bootstrapHost;
+        _configService.SetApp(_bootstrapHost.App);
+
+        var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor);
+        window.Closed += OnAnyWindowClosedInternal;
+        window.Activate();
+    }
+
+    /// <summary>
+    /// Called when ANY top-level <see cref="MainWindow"/> closes. The
+    /// per-window <see cref="GhosttyHost"/> is already disposed by
+    /// this point (via the window's own Closed path). When
+    /// <see cref="WindowsByRoot"/> hits zero we dispose the bootstrap
+    /// host last; its drain-last supervisor guard asserts that every
+    /// per-window host already disposed in order.
+    ///
+    /// Visibility is <c>internal</c> so <c>MainWindow.DetachTabToNewWindow</c>
+    /// can subscribe freshly-built windows to the same handler.
+    /// </summary>
+    internal void OnAnyWindowClosedInternal(object sender, WindowEventArgs args)
+    {
+        // Use the XamlRoot captured at registration time (stored on the
+        // MainWindow instance) rather than re-reading w.Content.XamlRoot
+        // here. By the time Window.Closed fires in WinUI 3, Content may
+        // already have a null XamlRoot, so re-reading would silently
+        // skip the removal and leak the entry.
+        if (sender is MainWindow w && w.RegisteredRoot is { } root)
+            WindowsByRoot.Remove(root);
+
+        if (WindowsByRoot.Count == 0)
+        {
+            try
+            {
+                // Bootstrap host is the LAST host. Its Dispose drains
+                // _hostBySurface (asserts empty), notifies the
+                // supervisor (which throws if anything is still live),
+                // and calls AppFree.
+                _bootstrapHost?.Dispose();
+            }
+            finally
+            {
+                _bootstrapHost = null;
+                BootstrapHost = null;
+                _lifetimeSupervisor = null;
+                LifetimeSupervisor = null;
+                Exit();
+            }
+        }
     }
 }

--- a/windows/Ghostty/Branding/WindowHelper.cs
+++ b/windows/Ghostty/Branding/WindowHelper.cs
@@ -7,23 +7,23 @@ namespace Ghostty.Branding;
 /// AppIconBadge so the click handler can hand the Window to the
 /// system-menu interop helper.
 ///
-/// This is a single-root resolver: it returns <see cref="App.RootWindow"/>
-/// (the one main window Ghostty currently creates) after verifying the
-/// element is actually attached to a XamlRoot. WinUI 3 desktop does not
-/// expose Window.Current and FrameworkElement does not surface its owning
-/// Window, so this is the simplest reliable path today.
-///
-/// TODO(multi-window, #161): when the shell supports multiple top-level
-/// windows (Move Tab to New Window, Settings window, etc.), replace this
-/// with an XamlRoot -> Window registry maintained by App so the badge
-/// routes system-menu clicks to the correct window instead of always
-/// the main one.
+/// Multi-window aware: looks up the element's XamlRoot in
+/// <see cref="App.WindowsByRoot"/> to find the correct owning window.
+/// Falls back to the first window in the registry if the XamlRoot
+/// lookup misses (e.g. element not yet loaded).
 /// </summary>
 internal static class WindowHelper
 {
     public static Window? GetWindow(FrameworkElement element)
     {
-        if (element.XamlRoot is null) return null;
-        return App.RootWindow;
+        if (element.XamlRoot is { } root &&
+            App.WindowsByRoot.TryGetValue(root, out var window))
+            return window;
+
+        // Fallback: return the first window if available.
+        foreach (var w in App.AllWindows)
+            return w;
+
+        return null;
     }
 }

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using Ghostty.Clipboard;
 using Ghostty.Controls;
 using Ghostty.Core.Clipboard;
+using Ghostty.Core.Hosting;
 using Ghostty.Core.Interop;
 using Ghostty.Interop;
 using Microsoft.UI.Dispatching;
@@ -15,21 +16,37 @@ using Windows.Win32.UI.WindowsAndMessaging;
 namespace Ghostty.Hosting;
 
 /// <summary>
-/// Per-window owner of the libghostty config + app handles and the
-/// runtime callback surface. Holds a dictionary mapping
-/// <see cref="GhosttySurface"/> handles to the <see cref="TerminalControl"/>
-/// that owns them so action-callback <c>target</c> arguments can be routed
-/// to the correct leaf.
+/// Per-window owner of the libghostty surface registry and the runtime
+/// callback surface. Each host has its OWN per-window
+/// <see cref="_surfaces"/> dictionary. The bootstrap host additionally
+/// owns the libghostty callback delegates and the <c>ghostty_app_t</c>.
 ///
-/// Lifetime: created once by <see cref="MainWindow"/> before any terminal
-/// surface is constructed, disposed when the window closes. The app handle
-/// is passed to each <see cref="TerminalControl"/> via its
-/// <see cref="TerminalControl.Host"/> property before it is loaded.
+/// Bootstrap vs per-window:
+///   - Bootstrap host: created once by <see cref="App.OnLaunched"/> via
+///     the legacy ctor. Owns the <c>_wakeupCb</c>, <c>_actionCb</c>,
+///     etc. delegate fields. Libghostty calls these. Their bodies
+///     consult <see cref="App.TryGetHostForSurface"/> to find the
+///     per-window host that currently owns a given surface, then forward
+///     there. Owns <c>ghostty_app_t</c> and calls <c>AppFree</c> on
+///     Dispose.
+///   - Per-window host: created by each <see cref="MainWindow"/> via
+///     the shared-app ctor. Has NO delegate fields, NO <c>AppNew</c>
+///     call. Wraps the same <c>ghostty_app_t</c> (borrowed, not owned).
+///     Dispose does NOT call <c>AppFree</c>.
+///
+/// Lifetime: the <see cref="HostLifetimeSupervisor"/> enforces the
+/// drain-last invariant -- every per-window host must Dispose before
+/// the bootstrap host.
 /// </summary>
 internal sealed class GhosttyHost : IDisposable
 {
     private GhosttyConfig _config;
     private GhosttyApp _app;
+
+    // Lifetime state. The bootstrap host gets a HostLifetimeState
+    // marked IsBootstrap = true; per-window hosts get PerWindow().
+    // Dispose consults this instead of a bare _sharesApp bool.
+    private readonly IAppHandleOwnership _ownership;
 
     /// <summary>
     /// UTC timestamp of the most recent key event seen by any
@@ -68,7 +85,8 @@ internal sealed class GhosttyHost : IDisposable
     private ClipboardBridge? _clipboardBridge;
 
     // Delegates must be retained as fields; P/Invoke hands out native
-    // function pointers the GC cannot track.
+    // function pointers the GC cannot track. Only the BOOTSTRAP host
+    // assigns these; per-window hosts leave them null.
     private GhosttyWakeupCb? _wakeupCb;
     private GhosttyActionCb? _actionCb;
     private GhosttyReadClipboardCb? _readClipboardCb;
@@ -76,17 +94,29 @@ internal sealed class GhosttyHost : IDisposable
     private GhosttyWriteClipboardCb? _writeClipboardCb;
     private GhosttyCloseSurfaceCb? _closeSurfaceCb;
 
-    // ConcurrentDictionary: Register/Unregister run on the UI thread but
-    // lookups happen on libghostty's callback thread in OnAction and
-    // OnCloseSurface. A plain Dictionary would race here.
+    // Per-window surface dictionary. ALWAYS per-host, never shared.
+    // Callbacks routed to this host (by App.xaml.cs's _hostBySurface
+    // map) consult this dictionary to resolve XamlRoot and dispatcher.
+    // The legacy ctor and the shared-app ctor both create a fresh
+    // dictionary; nothing is passed in.
     private readonly ConcurrentDictionary<IntPtr, TerminalControl> _surfaces = new();
     private readonly DispatcherQueue _dispatcher;
 
     public GhosttyApp App => _app;
 
-    public GhosttyHost(DispatcherQueue dispatcher, GhosttyConfig config)
+    /// <summary>
+    /// Bootstrap ctor: owns <c>ghostty_app_t</c>, used by
+    /// <c>App.OnLaunched</c> exactly once. This is the one host
+    /// libghostty invokes. Its callback bodies consult
+    /// <see cref="App.TryGetHostForSurface"/> to forward to whichever
+    /// per-window host owns the target surface.
+    /// </summary>
+    public GhosttyHost(DispatcherQueue dispatcher, GhosttyConfig config, HostLifetimeSupervisor supervisor)
     {
         _dispatcher = dispatcher;
+        _ownership = new SupervisedOwnership(
+            supervisor.RegisterBootstrap(),
+            supervisor);
         _config = config;
 
         _wakeupCb = OnWakeup;
@@ -97,10 +127,6 @@ internal sealed class GhosttyHost : IDisposable
         _closeSurfaceCb = OnCloseSurface;
 
         // Build the clipboard bridge after all delegate fields are assigned.
-        // The bridge takes lambdas that close over `this`, so the delegates
-        // themselves are not captured -- the ordering relative to the runtime
-        // config struct does not matter for correctness, but keeping it here
-        // makes the construction visually adjacent to the callbacks it serves.
         var clipboardBackend = new WinUiClipboardBackend(_dispatcher);
         var clipboardConfirmer = new DialogClipboardConfirmer(
             _dispatcher,
@@ -127,25 +153,151 @@ internal sealed class GhosttyHost : IDisposable
         _app = NativeMethods.AppNew(runtime, _config);
     }
 
+    /// <summary>
+    /// Construct a per-window GhosttyHost that wraps an existing
+    /// process-global <see cref="GhosttyApp"/> owned by
+    /// <c>App.xaml.cs</c>. Each per-window host has its OWN per-window
+    /// <see cref="_surfaces"/> dictionary. The app handle is NOT freed
+    /// on <see cref="Dispose"/>.
+    ///
+    /// CRITICAL: This ctor does NOT assign callback delegates
+    /// (<c>_wakeupCb</c>, <c>_actionCb</c>, etc). Libghostty's
+    /// <c>AppNew</c> was called in the BOOTSTRAP host and bound to the
+    /// bootstrap's delegate instances. The bootstrap host is the
+    /// callback receiver; it forwards to the correct per-window host
+    /// via <c>App._hostBySurface</c>.
+    /// </summary>
+    public GhosttyHost(
+        DispatcherQueue dispatcher,
+        IntPtr sharedApp,
+        HostLifetimeSupervisor supervisor)
+    {
+        _dispatcher = dispatcher;
+        _ownership = new SupervisedOwnership(
+            supervisor.RegisterPerWindow(),
+            supervisor);
+        _app = new GhosttyApp(sharedApp);
+        // Per-window hosts do not own or read _config; the bootstrap host
+        // manages the single GhosttyConfig. Left as default intentionally.
+
+        // NOTE: NO callback delegate assignments here. See the ctor
+        // docstring above for the full reason. Libghostty calls the
+        // bootstrap host's _actionCb etc, not ours.
+
+        var clipboardBackend = new WinUiClipboardBackend(_dispatcher);
+        var clipboardConfirmer = new DialogClipboardConfirmer(
+            _dispatcher,
+            xamlRootProvider: ResolveXamlRootForSurface);
+        var clipboardService = new ClipboardService(clipboardBackend, clipboardConfirmer);
+        _clipboardBridge = new ClipboardBridge(
+            _dispatcher,
+            clipboardService,
+            resolveSurface: ResolveSurfaceFromUserdata,
+            isSurfaceAlive: IsSurfaceAlive);
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="control"/> is registered in this
+    /// host's per-window surface dictionary. Used by the process-wide
+    /// <see cref="App.TryFindHostForControl"/> search.
+    /// </summary>
+    internal bool ContainsControl(TerminalControl control)
+    {
+        foreach (var tc in _surfaces.Values)
+        {
+            if (ReferenceEquals(tc, control))
+                return true;
+        }
+        return false;
+    }
+
     public void Register(GhosttySurface surface, TerminalControl control)
     {
         if (surface.Handle == IntPtr.Zero) return;
         var added = _surfaces.TryAdd(surface.Handle, control);
         Debug.Assert(added, "surface handle collision in GhosttyHost registry");
+        Ghostty.App.RegisterSurfaceRoute(surface.Handle, this);
     }
 
     public void Unregister(GhosttySurface surface)
     {
         if (surface.Handle == IntPtr.Zero) return;
         _surfaces.TryRemove(surface.Handle, out _);
+        Ghostty.App.UnregisterSurfaceRoute(surface.Handle, this);
     }
 
+    /// <summary>
+    /// Move a surface-handle registration into this host's per-window
+    /// dictionary, and update the process-wide routing map so the
+    /// bootstrap host's callbacks will route to this host next. Mirror
+    /// of <see cref="Unregister"/> on the source host plus
+    /// <see cref="Register"/> on this one, intended for cross-window
+    /// pane reparenting via <see cref="Ghostty.Panes.PaneHost.RehostTo"/>.
+    /// UI thread only.
+    ///
+    /// Race window: between the source host's <see cref="Detach"/> and
+    /// this host's <see cref="Adopt"/>, a libghostty callback for the
+    /// moving surface can arrive, consult <see cref="App.TryGetHostForSurface"/>,
+    /// miss, and silently drop. The spec (Risk 3) already accepts this:
+    /// "one update lost is tolerable". An async progress state will
+    /// resynchronize on the next OSC 9;4.
+    /// </summary>
+    public void Adopt(GhosttySurface surface, TerminalControl control)
+    {
+        if (surface.Handle == IntPtr.Zero) return;
+        _surfaces[surface.Handle] = control;
+        Ghostty.App.RegisterSurfaceRoute(surface.Handle, this);
+    }
+
+    /// <summary>
+    /// Remove a surface-handle registration from this host's per-window
+    /// dictionary and the process-wide routing map. Pair with
+    /// <see cref="Adopt"/> on the target host. UI thread only.
+    /// </summary>
+    public void Detach(GhosttySurface surface)
+    {
+        if (surface.Handle == IntPtr.Zero) return;
+        _surfaces.TryRemove(surface.Handle, out _);
+        Ghostty.App.UnregisterSurfaceRoute(surface.Handle, this);
+    }
+
+    /// <summary>
+    /// Bootstrap/per-window dispose invariant: the bootstrap host
+    /// (<see cref="IAppHandleOwnership.State"/>.<c>IsBootstrap</c>)
+    /// MUST be disposed LAST, after every per-window host. App.xaml.cs's
+    /// <c>OnAnyWindowClosedInternal</c> handler enforces this by only
+    /// disposing the bootstrap host when <c>WindowsByRoot</c> is empty.
+    /// Disposing out of order trips the
+    /// <see cref="HostLifetimeSupervisor.NotifyDisposed"/> guard.
+    /// </summary>
     public void Dispose()
     {
-        // Clear before AppFree so any late callbacks libghostty emits during
-        // teardown miss the lookup and become harmless no-ops.
+        // Clear this host's surfaces before touching the app.
         _surfaces.Clear();
-        if (_app.Handle != IntPtr.Zero) NativeMethods.AppFree(_app);
+
+        // Remove any entries we own from the process-wide routing map.
+        Ghostty.App.UnregisterHostSurfaces(this);
+
+        // Notify the supervisor. Throws on drain-last violation.
+        _ownership.NotifyDisposed();
+        _ownership.State.MarkDisposed();
+
+        // Only the bootstrap host frees the app. The drain-last
+        // invariant (enforced by _ownership.NotifyDisposed above)
+        // guarantees every per-window host has already cleared its
+        // _surfaces and its _hostBySurface entries by the time we
+        // reach this line, so AppFree is safe.
+        if (_ownership.State.OwnsApp && _app.Handle != IntPtr.Zero)
+        {
+            // Hard assert: no stray surface entries remain in the
+            // routing map. If this fires, some per-window host
+            // leaked a Register without a matching Detach.
+            Debug.Assert(
+                Ghostty.App.HostBySurfaceCount == 0,
+                "Bootstrap host disposing with live routing entries.");
+            NativeMethods.AppFree(_app);
+        }
+
         // Config lifetime is owned by ConfigService; do not free here.
         _app = default;
         _config = default;
@@ -172,38 +324,35 @@ internal sealed class GhosttyHost : IDisposable
     private const int GhosttyTargetApp = 0;
     private const int GhosttyTargetSurface = 1;
 
+    /// <summary>
+    /// Try to resolve the per-window host that currently owns the
+    /// given surface handle. Checks this host's own _surfaces first
+    /// (fast path for single-window), then falls back to the
+    /// process-wide App._hostBySurface routing map.
+    /// </summary>
+    private bool TryResolveControl(IntPtr surfaceHandle, out TerminalControl? control)
+    {
+        // Fast path: surface is in this host's own dictionary.
+        if (_surfaces.TryGetValue(surfaceHandle, out control))
+            return true;
+
+        // Multi-window path: consult the process-wide routing map.
+        if (Ghostty.App.TryGetHostForSurface(surfaceHandle, out var targetHost) && targetHost is not null)
+        {
+            if (targetHost._surfaces.TryGetValue(surfaceHandle, out control))
+                return true;
+        }
+
+        control = null;
+        return false;
+    }
+
     private byte OnAction(GhosttyApp _, IntPtr targetPtr, IntPtr actionPtr)
     {
-        // ABI note: ghostty_runtime_action_cb is declared as
-        //
-        //   bool action_cb(ghostty_app_t, ghostty_target_s, ghostty_action_s);
-        //
-        // Both target and action are passed BY VALUE in C, but on the Windows
-        // x64 calling convention any struct larger than 8 bytes is passed via
-        // a hidden pointer to a caller-allocated copy. ghostty_target_s is
-        // 16 bytes:
-        //
-        //   struct ghostty_target_s {
-        //     ghostty_target_tag_e tag;   // int32 at offset 0
-        //     // 4 bytes padding
-        //     union {                     // 8-byte aligned
-        //       ghostty_surface_t surface; // pointer at offset 8
-        //     } target;
-        //   };
-        //
-        // ghostty_action_s is similarly oversized. The C# delegate therefore
-        // declares both as IntPtr - the actual pointers we receive point at
-        // ephemeral stack copies of the structs and must be DEREFERENCED to
-        // get at their contents. Treating targetPtr as if it were the surface
-        // handle silently misses every dictionary lookup.
         if (actionPtr == IntPtr.Zero || targetPtr == IntPtr.Zero) return 0;
 
-        // ghostty_action_s layout: { int32 tag; <union> action; }
-        // Union starts at offset 8 (8-byte aligned on x64).
         var tag = (GhosttyActionTag)Marshal.ReadInt32(actionPtr);
         var targetTag = Marshal.ReadInt32(targetPtr);
-        // App-level actions (target = GHOSTTY_TARGET_APP) don't carry
-        // a surface handle. Handle them before the surface lookup.
         if (targetTag == GhosttyTargetApp)
         {
             switch (tag)
@@ -225,7 +374,7 @@ internal sealed class GhosttyHost : IDisposable
 
         if (targetTag != GhosttyTargetSurface) return 0;
         var surfaceHandle = Marshal.ReadIntPtr(targetPtr, 8);
-        if (!_surfaces.TryGetValue(surfaceHandle, out var control)) return 0;
+        if (!TryResolveControl(surfaceHandle, out var control) || control is null) return 0;
 
         switch (tag)
         {
@@ -238,12 +387,9 @@ internal sealed class GhosttyHost : IDisposable
             {
                 var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
                 var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
-                // Capture the surface handle, not `control`: by the time the
-                // dispatched lambda runs the control may have unregistered
-                // and torn down. Re-check the dictionary on the UI thread.
                 _dispatcher.TryEnqueue(() =>
                 {
-                    if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                    if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                         c.RaiseTitleChanged(title);
                 });
                 return 1;
@@ -259,7 +405,7 @@ internal sealed class GhosttyHost : IDisposable
             {
                 _dispatcher.TryEnqueue(() =>
                 {
-                    if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                    if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                         c.RaiseCloseRequested();
                 });
                 return 1;
@@ -267,11 +413,6 @@ internal sealed class GhosttyHost : IDisposable
 
             case GhosttyActionTag.Scrollbar:
             {
-                // ghostty_action_scrollbar_s sits at union offset 8.
-                // Layout is authoritative in GhosttyActionScrollbar;
-                // read it as a single blit instead of three offset
-                // reads so the struct declaration is the single source
-                // of truth.
                 GhosttyActionScrollbar s;
                 unsafe
                 {
@@ -279,22 +420,13 @@ internal sealed class GhosttyHost : IDisposable
                         (void*)(actionPtr + 8));
                 }
 
-                // TerminalControl coalesces updates on its own side
-                // and hops to the UI thread with a cached delegate,
-                // so we don't need the dispatcher here — just resolve
-                // the surface and hand off. If the surface has already
-                // been disposed we silently drop the update.
-                if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                     c.QueueScrollbarChanged(s.Total, s.Offset, s.Len);
                 return 1;
             }
 
             case GhosttyActionTag.ProgressReport:
             {
-                // ghostty_action_progress_report_s sits at union offset 8
-                // inside ghostty_action_s. Layout:
-                //   int32 state  @ +8
-                //   int8  prog   @ +12  (-1 sentinel when no percent)
                 var state = (GhosttyProgressState)Marshal.ReadInt32(actionPtr, 8);
                 var rawPct = (sbyte)Marshal.ReadByte(actionPtr, 12);
                 int pct = rawPct < 0 ? 0 : rawPct;
@@ -309,7 +441,7 @@ internal sealed class GhosttyHost : IDisposable
                 };
                 _dispatcher.TryEnqueue(() =>
                 {
-                    if (_surfaces.TryGetValue(surfaceHandle, out var c))
+                    if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                         c.RaiseProgressChanged(tabState);
                 });
                 return 1;
@@ -331,27 +463,8 @@ internal sealed class GhosttyHost : IDisposable
 
     private void OnCloseSurface(IntPtr userdata, byte processAlive)
     {
-        // userdata is the GCHandle.ToIntPtr value the owning TerminalControl
-        // pinned for itself before SurfaceNew. Decode it back to the managed
-        // control and raise CloseRequested on the UI thread; MainWindow's
-        // CloseRequested handler is what actually closes the window.
-        //
-        // This callback fires from libghostty's thread on two paths today:
-        // (1) the user typed `exit` in the shell and then pressed any key,
-        //     which makes Surface.zig encode the keystroke, notice
-        //     child_exited, and call self.close().
-        // (2) a binding action ran .close_surface or .close_window.
-        //
-        // We deliberately ignore processAlive here. Confirm-on-close lives
-        // at the libghostty layer and only invokes us once the user has
-        // already agreed (or wait_after_command was off).
         if (userdata == IntPtr.Zero) return;
 
-        // Decode the GCHandle, then confirm the resulting control is still
-        // registered. If Unregister already ran on the UI thread the surface
-        // is being torn down and this callback is a late arrival we drop.
-        // Using the thread-safe ConcurrentDictionary lookup avoids a race
-        // with a GCHandle that has been freed by OnUnloaded.
         var control = GCHandle.FromIntPtr(userdata).Target as TerminalControl;
         if (control is null) return;
         if (!IsRegistered(control)) return;
@@ -363,8 +476,16 @@ internal sealed class GhosttyHost : IDisposable
 
     private bool IsRegistered(TerminalControl control)
     {
+        // Check this host's own _surfaces first.
         foreach (var c in _surfaces.Values)
             if (ReferenceEquals(c, control)) return true;
+
+        // Check all per-window hosts via the process-wide routing map.
+        // This handles the case where a surface was moved to another
+        // window's host but the callback still arrived on the bootstrap.
+        if (Ghostty.App.TryFindHostForControl(control, out _))
+            return true;
+
         return false;
     }
 
@@ -385,32 +506,37 @@ internal sealed class GhosttyHost : IDisposable
 
     private bool IsSurfaceAlive(IntPtr surface)
     {
-        // The _surfaces dictionary is the authoritative live-surface registry.
-        // Checking it here is cheap (ConcurrentDictionary ContainsKey), and
-        // guards against a TerminalControl whose DisposeSurface() ran between
-        // the bridge's dispatch and the async continuation completing.
-        return surface != IntPtr.Zero && _surfaces.ContainsKey(surface);
+        if (surface == IntPtr.Zero) return false;
+        // Check this host's own dictionary first.
+        if (_surfaces.ContainsKey(surface)) return true;
+        // Fall back to process-wide routing map for multi-window.
+        return Ghostty.App.TryGetHostForSurface(surface, out _);
     }
 
     private XamlRoot? ResolveXamlRootForSurface(IntPtr surface)
     {
         // Look up the TerminalControl that owns this specific surface so
-        // the confirmation dialog lands on the originating window. In a
-        // multi-window host, falling back to any live XamlRoot would put
-        // an OSC 52 dialog from a background window on top of the
-        // foreground one.
-        //
-        // If the surface is not (or no longer) registered, fall back to
-        // any live control so a request during a focus-change race still
-        // gets a dialog rather than silently auto-denying. If nothing is
-        // live, return null and let DialogClipboardConfirmer auto-deny --
-        // the safe fallback for a security-relevant dialog.
-        if (surface != IntPtr.Zero && _surfaces.TryGetValue(surface, out var owner))
+        // the confirmation dialog lands on the originating window.
+        if (surface != IntPtr.Zero)
         {
-            var ownerRoot = owner.XamlRoot;
-            if (ownerRoot is not null) return ownerRoot;
+            // Check this host first.
+            if (_surfaces.TryGetValue(surface, out var owner))
+            {
+                var ownerRoot = owner.XamlRoot;
+                if (ownerRoot is not null) return ownerRoot;
+            }
+            // Fall back to process-wide routing.
+            if (Ghostty.App.TryGetHostForSurface(surface, out var targetHost) && targetHost is not null)
+            {
+                if (targetHost._surfaces.TryGetValue(surface, out var remoteOwner))
+                {
+                    var remoteRoot = remoteOwner.XamlRoot;
+                    if (remoteRoot is not null) return remoteRoot;
+                }
+            }
         }
 
+        // Last resort: any live control in this host.
         foreach (var ctrl in _surfaces.Values)
         {
             var root = ctrl.XamlRoot;

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -278,9 +278,11 @@ internal sealed class GhosttyHost : IDisposable
         // Remove any entries we own from the process-wide routing map.
         Ghostty.App.UnregisterHostSurfaces(this);
 
-        // Notify the supervisor. Throws on drain-last violation.
-        _ownership.NotifyDisposed();
+        // Mark disposed BEFORE notifying the supervisor. If
+        // NotifyDisposed throws (drain-last violation), the state
+        // is still correctly flagged as disposed.
         _ownership.State.MarkDisposed();
+        _ownership.NotifyDisposed();
 
         // Only the bootstrap host frees the app. The drain-last
         // invariant (enforced by _ownership.NotifyDisposed above)

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Ghostty.Commands;
 using Ghostty.Controls;
+using Ghostty.Core.Hosting;
 using Ghostty.Core.Tabs;
 using Ghostty.Dialogs;
 using Ghostty.Hosting;
@@ -132,15 +133,68 @@ public sealed partial class MainWindow : Window
     // GetWindowLong, GetWindowPlacement, ShowWindow, WINDOWPLACEMENT,
     // WINDOW_STYLE, and SHOW_WINDOW_CMD are provided by CsWin32.
 
-    internal MainWindow(ConfigService configService)
+    // Captured from Content.XamlRoot at registration time (in the
+    // one-shot Content.Loaded handler). Read by App.OnAnyWindowClosedInternal
+    // on Window.Closed to remove the WindowsByRoot entry; reading
+    // Content.XamlRoot directly at Closed time can return null because
+    // WinUI 3 tears Content down before Closed fires.
+    internal XamlRoot? RegisteredRoot { get; private set; }
+
+    internal MainWindow(ConfigService configService, GhosttyHost bootstrapHost, HostLifetimeSupervisor supervisor)
+        : this(configService, bootstrapHost, supervisor, seedTab: null)
+    {
+    }
+
+    /// <summary>
+    /// Full ctor. <paramref name="seedTab"/>, when non-null, is
+    /// adopted as the sole initial tab (used by Move Tab to New
+    /// Window); when null, the normal "create a fresh tab via the
+    /// factory" path runs. <paramref name="bootstrapHost"/> is the
+    /// app-owning GhosttyHost built once in App.xaml.cs; this window
+    /// constructs its OWN per-window GhosttyHost from it using the
+    /// shared-app ctor.
+    /// </summary>
+    private MainWindow(
+        ConfigService configService,
+        GhosttyHost bootstrapHost,
+        HostLifetimeSupervisor supervisor,
+        TabModel? seedTab)
     {
         InitializeComponent();
 
         _configService = configService;
         _configEditor = new ConfigFileEditor(configService.ConfigFilePath);
 
-        _host = new GhosttyHost(DispatcherQueue, configService.ConfigHandle);
-        configService.SetApp(_host.App);
+        // Build this window's per-window GhosttyHost around the shared
+        // app. Each per-window host has its OWN per-window surface
+        // dictionary; routing to this host from the bootstrap host's
+        // libghostty callbacks happens via App._hostBySurface (populated
+        // by the per-window host's Register / Adopt paths).
+        _host = new GhosttyHost(
+            DispatcherQueue,
+            bootstrapHost.App.Handle,
+            supervisor);
+        // NOTE: configService.SetApp is already done by App.xaml.cs on
+        // the bootstrap host. We do NOT call it again here.
+
+        // Register with App.WindowsByRoot once the XamlRoot is live.
+        // We capture the XamlRoot into RegisteredRoot so the
+        // App.OnAnyWindowClosedInternal handler can remove the entry on
+        // Window.Closed even if Content.XamlRoot has gone null by then
+        // (which WinUI 3 does during window teardown).
+        if (Content is FrameworkElement fe)
+        {
+            fe.Loaded += OnContentLoadedOnce;
+            void OnContentLoadedOnce(object s, RoutedEventArgs e)
+            {
+                fe.Loaded -= OnContentLoadedOnce;
+                RegisteredRoot = fe.XamlRoot;
+                if (RegisteredRoot != null)
+                {
+                    App.WindowsByRoot[RegisteredRoot] = this;
+                }
+            }
+        }
 
         // Detect initial system theme and notify libghostty so conditional
         // config blocks (e.g. palette dark/light) take effect immediately.
@@ -196,7 +250,9 @@ public sealed partial class MainWindow : Window
         _themePreview.ListThemesRequested += OnListThemesRequested;
 
         _factory = new PaneHostFactory(_host);
-        _tabManager = new TabManager(() => _factory.Create());
+        _tabManager = new TabManager(
+            () => _factory.Create(),
+            seed: seedTab);
         _router = new PaneActionRouter(_tabManager);
         _uiSettings = UiSettings.Load();
         RestoreWindowPlacement();
@@ -308,10 +364,6 @@ public sealed partial class MainWindow : Window
                 CommandPalettePopup.IsOpen = false;
                 SetCommandPaletteOpenOnAllTerminals(false);
                 _frecencyStore?.Save();
-
-                // Don't focus a surface that may have just been disposed
-                // by the command we executed (e.g. close pane).
-                // Let the tab/pane system handle focus naturally.
             }
             finally
             {
@@ -330,9 +382,6 @@ public sealed partial class MainWindow : Window
                 var wasOpen = _commandPaletteVm.IsOpen;
                 _commandPaletteVm.Close();
                 SetCommandPaletteOpenOnAllTerminals(false);
-                // Only restore previous focus for light-dismiss (Escape, click outside).
-                // For command execution, let the command's own focus handling win
-                // (e.g., PaneHost focuses the new split pane).
                 if (wasOpen)
                     _previousFocusSurface?.Focus(FocusState.Programmatic);
             }
@@ -417,6 +466,152 @@ public sealed partial class MainWindow : Window
         Closed += OnClosedAsync;
     }
 
+    /// <summary>
+    /// Build a <see cref="MainWindow"/> that adopts an existing
+    /// <see cref="TabModel"/> as its sole initial tab, WITHOUT
+    /// activating. Caller is responsible for positioning the window
+    /// (via <see cref="Microsoft.UI.Windowing.AppWindow.MoveAndResize"/>
+    /// or the like) and then calling <see cref="Window.Activate"/>.
+    ///
+    /// Used today by <see cref="DetachTabToNewWindow"/> for cursor-
+    /// anchored placement. PR 201 Snap Layouts will call this same
+    /// factory to install a snap rect before first activation so there
+    /// is no visible placement flicker.
+    /// </summary>
+    internal static MainWindow CreateForAdoption(
+        ConfigService configService,
+        GhosttyHost bootstrapHost,
+        HostLifetimeSupervisor supervisor,
+        TabModel adoptedTab)
+    {
+        return new MainWindow(configService, bootstrapHost, supervisor, seedTab: adoptedTab);
+    }
+
+    /// <summary>
+    /// Pre-activation hook for Snap Layouts placement. PR 199's
+    /// detach flow constructs a MainWindow but MUST NOT call
+    /// Activate until any snap target has been applied, otherwise
+    /// the window flashes at the wrong origin. Call this once
+    /// placement is done.
+    /// </summary>
+    internal void ActivateAfterPlacement() => Activate();
+
+    /// <summary>
+    /// Move <paramref name="tab"/> out of this window into a brand
+    /// new <see cref="MainWindow"/>. The new window is positioned
+    /// near the current mouse cursor on the monitor the cursor is
+    /// currently on. Disabled (via the menu <c>IsEnabled</c> guard)
+    /// when this window has only one tab, because moving the sole
+    /// tab into a new window would be a no-op.
+    /// </summary>
+    internal void DetachTabToNewWindow(TabModel tab)
+    {
+        DetachTabToWindow(tab, newWindow =>
+        {
+            // Cursor-anchored placement. Size = this window's current size
+            // so there is no jarring resize.
+            var placement = ComputeCursorAnchoredPlacement(newWindow);
+            var rect = new Windows.Graphics.RectInt32(
+                placement.X, placement.Y, placement.Width, placement.Height);
+            newWindow.AppWindow.MoveAndResize(rect);
+        });
+    }
+
+    /// <summary>
+    /// Detach <paramref name="tab"/> into a new window and snap it to
+    /// the given <paramref name="zone"/> on the current monitor BEFORE
+    /// activation, so there is no visible placement flicker.
+    /// </summary>
+    internal void DetachTabToZone(TabModel tab, Ghostty.Core.Tabs.SnapZone zone)
+    {
+        DetachTabToWindow(tab, newWindow =>
+        {
+            // Snap to zone on the source window's monitor. MoveAndResize
+            // BEFORE Activate so the window never flashes at the default
+            // origin.
+            var display = Tabs.SnapPlacement.ResolveDisplayFor(AppWindow);
+            Tabs.SnapPlacement.ApplyZone(newWindow.AppWindow, display, zone);
+        });
+    }
+
+    /// <summary>
+    /// Shared detach-rehost-activate logic. Detaches <paramref name="tab"/>
+    /// from this window, creates a new <see cref="MainWindow"/>, rehosts
+    /// the pane tree, runs <paramref name="placementAction"/> for
+    /// positioning, then activates the new window.
+    /// </summary>
+    private void DetachTabToWindow(TabModel tab, Action<MainWindow> placementAction)
+    {
+        if (_tabManager.Tabs.Count <= 1)
+            throw new InvalidOperationException(
+                "DetachTabToWindow: guarded menu fired on single-tab window.");
+
+        // Source-side: detach the model. The manager's TabRemoved
+        // subscribers already drain visual state (RemovePaneHost in
+        // this MainWindow, RemoveItem in each tab host).
+        var detached = _tabManager.DetachTab(tab);
+
+        var bootstrap = App.BootstrapHost
+            ?? throw new InvalidOperationException(
+                "DetachTabToWindow: no bootstrap host; App.OnLaunched did not run.");
+        var supervisor = App.LifetimeSupervisor
+            ?? throw new InvalidOperationException(
+                "DetachTabToWindow: no lifetime supervisor; App.OnLaunched did not run.");
+
+        // Rehost the pane tree's terminals to a fresh per-window host
+        // built inside the new window. RehostTo is what actually moves
+        // the surface entries out of this window's _surfaces into the
+        // new window's _surfaces AND rewrites App._hostBySurface.
+        var newWindow = MainWindow.CreateForAdoption(_configService, bootstrap, supervisor, detached);
+        var newHost = newWindow._host;
+        ((Panes.PaneHost)detached.PaneHost).RehostTo(newHost);
+
+        placementAction(newWindow);
+
+        // Subscribe the new window to the process-wide last-window-exit
+        // handler. WindowsByRoot insertion happens inside the new
+        // window's own Content.Loaded handler.
+        newWindow.Closed += ((App)Application.Current).OnAnyWindowClosedInternal;
+
+        newWindow.Activate();
+    }
+
+    /// <summary>
+    /// Compute the cursor-anchored target rect for a newly built
+    /// <see cref="MainWindow"/>. Queries <c>GetCursorPos</c> (via
+    /// CsWin32), resolves the monitor the cursor is on via
+    /// <see cref="Microsoft.UI.Windowing.DisplayArea.GetFromPoint"/>,
+    /// and delegates the clamping math to
+    /// <see cref="Ghostty.Core.Windows.CursorWindowPlacement.Compute"/>.
+    ///
+    /// DPI contract: <c>GetCursorPos</c> returns physical pixel
+    /// coordinates in virtual desktop space. <c>DisplayArea.GetFromPoint</c>
+    /// consumes physical pixels. The two line up without scaling.
+    /// </summary>
+    private Ghostty.Core.Windows.PlacementRect ComputeCursorAnchoredPlacement(MainWindow target)
+    {
+        PInvoke.GetCursorPos(out var pt);
+
+        var cursorPoint = new Windows.Graphics.PointInt32(pt.X, pt.Y);
+        var display = Microsoft.UI.Windowing.DisplayArea.GetFromPoint(
+            cursorPoint,
+            Microsoft.UI.Windowing.DisplayAreaFallback.Nearest);
+
+        var work = display?.WorkArea
+            ?? new Windows.Graphics.RectInt32(0, 0, 1920, 1080);
+
+        // Inherit the source window's current size.
+        var size = AppWindow.Size;
+
+        return Ghostty.Core.Windows.CursorWindowPlacement.Compute(
+            cursorX: pt.X,
+            cursorY: pt.Y,
+            windowWidth: size.Width,
+            windowHeight: size.Height,
+            workArea: new Ghostty.Core.Windows.WorkAreaRect(
+                work.X, work.Y, work.Width, work.Height));
+    }
+
     private async void OnClosedAsync(object sender, WindowEventArgs args)
     {
         // Persist window placement for next launch. Skip when
@@ -455,7 +650,7 @@ public sealed partial class MainWindow : Window
         _settingsWindow = null;
 
         // Let any in-flight ContentDialog complete before tearing
-        // down the libghostty host. files-community/Files #17363
+        // down the libghostty host. files-community/Files # 17363
         // documents the COMException that fires otherwise.
         try
         {
@@ -600,7 +795,7 @@ public sealed partial class MainWindow : Window
         // Listen for keyboard-driven full-tab close. Route through
         // TabHost.RequestCloseTabAsync so the confirmation dialog
         // is the same code path as the per-tab X button and the
-        // context-menu Close item — single source of truth for
+        // context-menu Close item -- single source of truth for
         // close confirmation lives in TabHost, which has XamlRoot.
         _router.TabCloseRequestedFromKeyboard += async (_, _) =>
         {
@@ -608,7 +803,7 @@ public sealed partial class MainWindow : Window
         };
 
         // Vertical-tabs pinned toggle via Ctrl+Shift+Space. No-op
-        // when the layout is horizontal (TabHost) — the chord is
+        // when the layout is horizontal (TabHost) -- the chord is
         // registered globally but only VerticalTabHost responds.
         _router.ToggleVerticalTabsPinnedRequested += (_, _) =>
         {

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -8,6 +8,7 @@
 
 // user32
 ClientToScreen
+GetCursorPos
 GetKeyState
 GetSystemMenu
 GetWindowLong

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -39,6 +39,9 @@ namespace Ghostty.Panes;
 /// </summary>
 internal sealed partial class PaneHost : UserControl, IPaneHost
 {
+    // Not readonly: RehostTo writes this during cross-window tab
+    // detach. UI-thread-only -- all reads and writes happen on the
+    // dispatcher queue, so no synchronization is needed.
     private GhosttyHost _host;
     private readonly Func<TerminalControl> _terminalFactory;
 

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -39,7 +39,7 @@ namespace Ghostty.Panes;
 /// </summary>
 internal sealed partial class PaneHost : UserControl, IPaneHost
 {
-    private readonly GhosttyHost _host;
+    private GhosttyHost _host;
     private readonly Func<TerminalControl> _terminalFactory;
 
     // Pane highlight system, rendered as an overlay Canvas above the
@@ -313,6 +313,35 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     }
 
     /// <summary>
+    /// Switch every <see cref="TerminalControl"/> leaf in this tree to
+    /// report to <paramref name="newHost"/>. Called by
+    /// <see cref="MainWindow.DetachTabToNewWindow"/> after the PaneHost
+    /// has been removed from the old window's visual parent and before
+    /// it is added to the new window's. UI thread only.
+    ///
+    /// Per-leaf Detach-then-Adopt moves each surface handle between
+    /// the two hosts' per-window <c>_surfaces</c> dictionaries AND
+    /// rewrites the process-wide <c>_hostBySurface</c> routing map so
+    /// libghostty callbacks post-move reach the destination host. The
+    /// spec accepts the one-update-lost race (Risk 3): a callback
+    /// arriving between Detach and Adopt for the same handle looks up,
+    /// misses, drops. An async progress state resyncs on the next
+    /// OSC 9;4.
+    /// </summary>
+    internal void RehostTo(GhosttyHost newHost)
+    {
+        foreach (var leaf in PaneTree.Leaves(_root))
+        {
+            var terminal = leaf.Terminal();
+            var surface = new Interop.GhosttySurface(terminal.SurfaceHandle);
+            _host.Detach(surface);
+            newHost.Adopt(surface, terminal);
+            terminal.Host = newHost;
+        }
+        _host = newHost;
+    }
+
+    /// <summary>
     /// Tear down every leaf's libghostty surface. Called by
     /// <see cref="MainWindow"/> when the window is closing, since
     /// surface lifetime is decoupled from <c>Unloaded</c> events and
@@ -393,7 +422,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     public void EqualizeSplits()
     {
         PaneTree.Equalize(_root);
-        // When zoomed, only update ratios � ToggleSplitZoom.Rebuild()
+        // When zoomed, only update ratios - ToggleSplitZoom.Rebuild()
         // will apply them when the user unzooms.
         if (_zoomedLeaf is not null) return;
         Rebuild();

--- a/windows/Ghostty/Tabs/SnapPlacement.cs
+++ b/windows/Ghostty/Tabs/SnapPlacement.cs
@@ -1,0 +1,33 @@
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Windowing;
+using Windows.Graphics;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Resolves the target display for a source window and applies a
+/// Snap Layouts zone to a target window via
+/// <see cref="AppWindow.MoveAndResize(RectInt32, DisplayArea)"/>.
+///
+/// Uses <see cref="DisplayArea.GetFromWindowId"/> with
+/// <see cref="DisplayAreaFallback.Nearest"/> so a monitor disconnect
+/// between menu open and menu click degrades gracefully to the
+/// nearest available display. Never calls
+/// <see cref="DisplayArea.FindAll"/> (known iteration bug in the
+/// microsoft-ui-xaml repo).
+/// </summary>
+internal static class SnapPlacement
+{
+    public static DisplayArea ResolveDisplayFor(AppWindow source) =>
+        DisplayArea.GetFromWindowId(source.Id, DisplayAreaFallback.Nearest);
+
+    public static void ApplyZone(AppWindow target, DisplayArea display, SnapZone zone)
+    {
+        var work = display.WorkArea; // RectInt32
+        var rect = SnapZoneMath.RectFor(zone, work.X, work.Y, work.Width, work.Height);
+        // Two-argument MoveAndResize takes absolute screen coordinates.
+        // SnapZoneMath.RectFor already produces absolute coords because
+        // we pass the work area's origin (work.X, work.Y) above.
+        target.MoveAndResize(rect.ToRectInt32(), display);
+    }
+}

--- a/windows/Ghostty/Tabs/SnapZonePicker.xaml
+++ b/windows/Ghostty/Tabs/SnapZonePicker.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Tabs.SnapZonePicker"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <!--
+        The picker is a fixed-pixel miniature of the current monitor.
+        Width/Height are set from code-behind so the miniature matches
+        the monitor's aspect ratio exactly; the Canvas is the layout
+        surface for zone Buttons positioned by SetLeft/SetTop.
+    -->
+    <Border
+        x:Name="PickerBorder"
+        Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
+        BorderBrush="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
+        BorderThickness="1"
+        CornerRadius="8"
+        Padding="12">
+        <Canvas
+            x:Name="PickerCanvas"
+            Width="220"
+            Height="140" />
+    </Border>
+</UserControl>

--- a/windows/Ghostty/Tabs/SnapZonePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/SnapZonePicker.xaml.cs
@@ -1,0 +1,125 @@
+using System;
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Visual picker for Snap Layouts zones. Renders a miniature of the
+/// current monitor with a clickable Button per zone, styled to
+/// resemble the Windows 11 maximize-button hover flyout.
+///
+/// The picker does NOT query DisplayArea itself: the caller passes
+/// the work-area width and height so this control stays unit-testable
+/// in principle and lets the detach flow resolve the monitor on the
+/// source window side (so the new window lands on the same monitor).
+/// </summary>
+internal sealed partial class SnapZonePicker : UserControl
+{
+    /// <summary>Raised when the user clicks a zone. Caller must
+    /// close the owning Flyout and run the detach-with-placement
+    /// flow. Never raised more than once per picker instance.</summary>
+    public event EventHandler<SnapZone>? ZoneSelected;
+
+    // Miniature dimensions. The Canvas Width and Height are reset
+    // from Render() so the miniature's aspect ratio matches the real
+    // monitor's aspect. These defaults are only the initial XAML
+    // values so Blend/design-time rendering has something to draw.
+    private const double MaxMiniatureWidth = 220.0;
+    private const double MaxMiniatureHeight = 140.0;
+
+    public SnapZonePicker()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Populate the canvas with one Button per zone returned by
+    /// <see cref="SnapZoneCatalog"/>. Must be called before the
+    /// picker is added to the visual tree.
+    /// </summary>
+    public void Render(int workAreaWidth, int workAreaHeight)
+    {
+        // Guard against degenerate monitors (DisplayArea fallback).
+        if (workAreaWidth <= 0 || workAreaHeight <= 0)
+        {
+            workAreaWidth = 1920;
+            workAreaHeight = 1080;
+        }
+
+        // Fit the monitor into the miniature bounds while preserving
+        // aspect ratio. Landscape monitors use the full width; portrait
+        // monitors use the full height. Ultra-wide monitors pick the
+        // smaller scale factor so neither dimension exceeds the max.
+        double scaleW = MaxMiniatureWidth / workAreaWidth;
+        double scaleH = MaxMiniatureHeight / workAreaHeight;
+        double scale = Math.Min(scaleW, scaleH);
+
+        double miniW = workAreaWidth * scale;
+        double miniH = workAreaHeight * scale;
+
+        PickerCanvas.Width = miniW;
+        PickerCanvas.Height = miniH;
+        PickerCanvas.Children.Clear();
+
+        var zones = SnapZoneCatalog.ZonesFor(workAreaWidth, workAreaHeight);
+        foreach (var zone in zones)
+        {
+            // Use a synthetic 0-origin work area so the rect fractions
+            // map linearly to the miniature. The real window placement
+            // uses the true work-area origin later.
+            var rect = SnapZoneMath.RectFor(zone, 0, 0, workAreaWidth, workAreaHeight);
+            var btn = MakeZoneButton(zone, rect, scale);
+            PickerCanvas.Children.Add(btn);
+        }
+    }
+
+    private Button MakeZoneButton(SnapZone zone, SnapZoneRect rect, double scale)
+    {
+        var btn = new Button
+        {
+            Width = Math.Max(1.0, rect.Width * scale),
+            Height = Math.Max(1.0, rect.Height * scale),
+            Padding = new Thickness(0),
+            CornerRadius = new CornerRadius(2),
+            Margin = new Thickness(1),
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            BorderBrush = (Brush)Application.Current.Resources[
+                "SystemControlForegroundBaseMediumBrush"],
+            BorderThickness = new Thickness(1),
+        };
+        AutomationProperties.SetName(btn, ReadableName(zone));
+        ToolTipService.SetToolTip(btn, ReadableName(zone));
+
+        Canvas.SetLeft(btn, rect.X * scale);
+        Canvas.SetTop(btn, rect.Y * scale);
+
+        btn.Click += (_, _) => ZoneSelected?.Invoke(this, zone);
+        return btn;
+    }
+
+    private static string ReadableName(SnapZone zone) => zone switch
+    {
+        SnapZone.Maximize => "Maximize",
+        SnapZone.LeftHalf => "Left half",
+        SnapZone.RightHalf => "Right half",
+        SnapZone.TopHalf => "Top half",
+        SnapZone.BottomHalf => "Bottom half",
+        SnapZone.TopLeftQuarter => "Top-left quarter",
+        SnapZone.TopRightQuarter => "Top-right quarter",
+        SnapZone.BottomLeftQuarter => "Bottom-left quarter",
+        SnapZone.BottomRightQuarter => "Bottom-right quarter",
+        SnapZone.LeftThird => "Left third",
+        SnapZone.MiddleThird => "Middle third",
+        SnapZone.RightThird => "Right third",
+        SnapZone.LeftTwoThirds => "Left two-thirds",
+        SnapZone.RightTwoThirds => "Right two-thirds",
+        SnapZone.TopThird => "Top third",
+        SnapZone.MiddleThirdHorizontal => "Middle third",
+        SnapZone.BottomThird => "Bottom third",
+        _ => throw new ArgumentOutOfRangeException(nameof(zone), zone, null),
+    };
+}

--- a/windows/Ghostty/Tabs/SnapZoneRectInterop.cs
+++ b/windows/Ghostty/Tabs/SnapZoneRectInterop.cs
@@ -1,0 +1,18 @@
+using Ghostty.Core.Tabs;
+using Windows.Graphics;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Adapts the WinUI-free <see cref="SnapZoneRect"/> to
+/// <see cref="RectInt32"/>, the type required by
+/// <see cref="Microsoft.UI.Windowing.AppWindow.MoveAndResize"/>.
+///
+/// Lives in the WinUI project (not Ghostty.Core) so Ghostty.Core
+/// does not have to reference the WindowsAppSDK.
+/// </summary>
+internal static class SnapZoneRectInterop
+{
+    public static RectInt32 ToRectInt32(this SnapZoneRect r) =>
+        new(r.X, r.Y, r.Width, r.Height);
+}

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -10,14 +10,18 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 namespace Ghostty.Tabs;
 
 /// <summary>
+/// Information the picker needs when "Move Tab to Zone" is clicked.
+/// Supplied by the TabHost caller so TabContextMenuBuilder does not
+/// have to reach into WinUI windowing APIs itself.
+/// </summary>
+internal readonly record struct SnapZoneSource(
+    int WorkAreaWidth,
+    int WorkAreaHeight);
+
+/// <summary>
 /// Builds the per-tab right-click menu. Attached via
 /// <see cref="TabViewItem.ContextFlyout"/> on each item, not on the
 /// parent <see cref="TabView"/>: that gives an unambiguous target.
-///
-/// "Move to New Window" is intentionally absent. It needs reparent-
-/// safe PaneHost work and a cross-window GhosttyHost handoff; that
-/// is a follow-up PR.
-/// TODO(tabs): detach-to-new-window
 /// </summary>
 internal static class TabContextMenuBuilder
 {
@@ -25,7 +29,10 @@ internal static class TabContextMenuBuilder
         TabManager manager,
         TabModel tab,
         Func<TabModel, Task> requestClose,
-        DialogTracker dialogs)
+        Action<TabModel> requestDetachToNewWindow,
+        DialogTracker dialogs,
+        Func<SnapZoneSource>? getSnapSource = null,
+        Action<TabModel, SnapZone>? detachWithZone = null)
     {
         var flyout = new MenuFlyout();
 
@@ -66,6 +73,57 @@ internal static class TabContextMenuBuilder
         var dup = new MenuFlyoutItem { Text = "Duplicate Tab" };
         dup.Click += (_, _) => manager.NewTab(); // TODO(config): respect ProfileId once profiles exist
         flyout.Items.Add(dup);
+
+        flyout.Items.Add(new MenuFlyoutSeparator());
+
+        var detach = new MenuFlyoutItem { Text = "Move Tab to New Window" };
+        detach.IsEnabled = manager.Tabs.Count > 1;
+        detach.Click += (_, _) => requestDetachToNewWindow(tab);
+        flyout.Items.Add(detach);
+
+        // "Move Tab to Zone" opens a visual picker for Snap Layouts
+        // zones. Only shown when both snap callbacks are wired and
+        // there is more than one tab (detaching the last tab is a no-op).
+        MenuFlyoutItem? moveToZone = null;
+        if (getSnapSource is not null && detachWithZone is not null)
+        {
+            moveToZone = new MenuFlyoutItem { Text = "Move Tab to Zone" };
+            moveToZone.IsEnabled = manager.Tabs.Count > 1;
+            moveToZone.Click += (_, _) =>
+            {
+                var target = flyout.Target;
+                if (target?.XamlRoot is null) return;
+
+                var source = getSnapSource();
+                var picker = new SnapZonePicker();
+                picker.Render(source.WorkAreaWidth, source.WorkAreaHeight);
+
+                var pickerFlyout = new Flyout
+                {
+                    Content = picker,
+                    Placement = FlyoutPlacementMode.Bottom,
+                };
+
+                picker.ZoneSelected += (_, zone) =>
+                {
+                    pickerFlyout.Hide();
+                    detachWithZone(tab, zone);
+                };
+
+                pickerFlyout.ShowAt(target);
+            };
+            flyout.Items.Add(moveToZone);
+        }
+
+        // Re-evaluate IsEnabled on each open so tabs closed after
+        // the flyout was built (but before the user right-clicked)
+        // are reflected in the grey state. Matches Windows Terminal.
+        flyout.Opening += (_, _) =>
+        {
+            detach.IsEnabled = manager.Tabs.Count > 1;
+            if (moveToZone is not null)
+                moveToZone.IsEnabled = manager.Tabs.Count > 1;
+        };
 
         flyout.Items.Add(new MenuFlyoutSeparator());
 

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -97,7 +97,14 @@ internal sealed partial class TabHost : UserControl, ITabHost
         {
             Header = headerPanel,
             Content = null,
-            ContextFlyout = TabContextMenuBuilder.Build(_manager, tab, RequestCloseTabAsync, _dialogs),
+            ContextFlyout = TabContextMenuBuilder.Build(
+                _manager,
+                tab,
+                RequestCloseTabAsync,
+                requestDetachToNewWindow: RequestDetachToNewWindow,
+                _dialogs,
+                getSnapSource: GetSnapSource,
+                detachWithZone: DetachWithZone),
             DataContext = tab,
         };
         tab.PropertyChanged += (_, e) =>
@@ -193,6 +200,48 @@ internal sealed partial class TabHost : UserControl, ITabHost
         var alpha = selected ? SelectedTabAlpha : UnselectedTabAlpha;
         headerPanel.Background = new SolidColorBrush(
             Windows.UI.Color.FromArgb(alpha, drawing.R, drawing.G, drawing.B));
+    }
+
+    /// <summary>
+    /// Route a per-tab "Move Tab to New Window" click back to the
+    /// owning <see cref="MainWindow"/>. TabHost is a UserControl with
+    /// no direct MainWindow reference; <see cref="App.WindowsByRoot"/>
+    /// is keyed by <see cref="XamlRoot"/>, so the lookup is O(1).
+    /// </summary>
+    private void RequestDetachToNewWindow(TabModel tab)
+    {
+        var xamlRoot = XamlRoot;
+        if (xamlRoot is null) return;
+
+        if (App.WindowsByRoot.TryGetValue(xamlRoot, out var main))
+            main.DetachTabToNewWindow(tab);
+    }
+
+    /// <summary>
+    /// Resolve the source window's current monitor work area for the
+    /// snap zone picker miniature.
+    /// </summary>
+    private SnapZoneSource GetSnapSource()
+    {
+        var xamlRoot = XamlRoot;
+        if (xamlRoot is not null && App.WindowsByRoot.TryGetValue(xamlRoot, out var main))
+        {
+            var display = SnapPlacement.ResolveDisplayFor(main.AppWindow);
+            var w = display.WorkArea;
+            return new SnapZoneSource(w.Width, w.Height);
+        }
+        // Fallback: standard 1080p.
+        return new SnapZoneSource(1920, 1080);
+    }
+
+    /// <summary>
+    /// Detach a tab into a new window snapped to the chosen zone.
+    /// </summary>
+    private void DetachWithZone(TabModel tab, Ghostty.Core.Tabs.SnapZone zone)
+    {
+        var xamlRoot = XamlRoot;
+        if (xamlRoot is not null && App.WindowsByRoot.TryGetValue(xamlRoot, out var main))
+            main.DetachTabToZone(tab, zone);
     }
 
     private void OnAddTabButtonClick(TabView sender, object args) => _manager.NewTab();


### PR DESCRIPTION
## Summary

- Hoists `ghostty_app_t` ownership from `MainWindow` to `App.xaml.cs` so multiple windows share one app handle. Each `MainWindow` gets a per-window `GhosttyHost` with its own surface dictionary, routed via `App._hostBySurface`.
- Tab detach: `TabManager.DetachTab`/`AdoptTab`, `PaneHost.RehostTo` for cross-window surface transfer, cursor-anchored window placement. Context menu entry gated on `Tabs.Count > 1`.
- Snap layout zone picker: aspect-ratio-classified zones (landscape 9, ultra-wide 12, portrait 6) rendered as a miniature monitor overlay. Pre-snap placement via `CreateForAdoption` + `AppWindow.MoveAndResize` before activation.
- Pure-logic types in `Ghostty.Core`: `HostLifetimeState`, `CursorWindowPlacement`, `SnapZone`/`SnapZoneRect`/`SnapZoneMath`/`SnapMonitorShape`. 53 new tests (221 total).

## Pending manual verification

- SwapChainPanel cross-XamlRoot survival: structural code is in place but the DX12 swap chain reparent needs interactive testing before merge.
- Zone picker on landscape/ultra-wide/portrait, multi-monitor placement.

> **IMPORTANT**: stacked PR. Part 6 of 6 in the windows stack. Parent: `windows-interop-cswin32`. Stack: # 210 -> # 211 -> # 212 -> # 222 -> # 215 -> this PR.

Replaces # 216 and # 217.