### PR TITLE
fix(windows): wire ToggleFullscreen through PaneActionRouter

### DIFF
--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -83,6 +83,9 @@ internal sealed class PaneActionRouter
             case PaneAction.ToggleCommandPalette:
                 CommandPaletteToggleRequested?.Invoke(this, EventArgs.Empty);
                 return;
+            case PaneAction.ToggleFullscreen:
+                ToggleFullscreenRequested?.Invoke(this, EventArgs.Empty);
+                return;
         }
 
         var pane = _tabs.ActiveTab.PaneHost;


### PR DESCRIPTION
## Summary

- Add the missing `PaneAction.ToggleFullscreen` case to the event-only switch in `PaneActionRouter.Invoke()`
- The event was declared and subscribed to in MainWindow but never raised -- pressing F11 threw `ArgumentOutOfRangeException`
- Eliminates CS0067 compiler warning on every build

Closes #221