### PR TITLE
fix(windows): terminal foreground color not updating on theme reload

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -123,6 +123,19 @@ public sealed partial class TerminalControl : UserControl
         TitleChanged?.Invoke(this, title);
     }
     internal void RaiseCloseRequested() => CloseRequested?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>
+    /// Ask the renderer thread to repaint this surface. No-op if the
+    /// surface has not been created or has already been disposed.
+    /// Used after config reload to pick up color changes that the
+    /// termio thread applies asynchronously.
+    /// </summary>
+    internal void RequestRedraw()
+    {
+        if (_surface.Handle == IntPtr.Zero) return;
+        NativeMethods.SurfaceDraw(_surface);
+    }
+
     internal void RaiseProgressChanged(Ghostty.Core.Tabs.TabProgressState state)
     {
         CurrentProgress = state;

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -132,7 +132,7 @@ public sealed partial class TerminalControl : UserControl
     /// </summary>
     internal void RequestRedraw()
     {
-        if (_surface.Handle == IntPtr.Zero) return;
+        if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return;
         NativeMethods.SurfaceDraw(_surface);
     }
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -83,6 +83,12 @@ public sealed partial class MainWindow : Window
     private GradientTintVisual? _gradientVisual;
     private Window? _settingsWindow;
 
+    // Cancellation token for the deferred redraw scheduled after a
+    // config reload. If the user reloads config again before the
+    // previous delay fires, the old redraw is cancelled to avoid
+    // stacking up redundant draws.
+    private CancellationTokenSource? _redrawCts;
+
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
     private Controls.TerminalControl? _previousFocusSurface;
@@ -459,6 +465,11 @@ public sealed partial class MainWindow : Window
             // Re-apply shell theme after backdrop style, since
             // ApplyBackdropStyle may override RootGrid.Background.
             ApplyShellTheme();
+
+            // The Zig termio thread updates terminal.colors.foreground
+            // asynchronously after config reload. Schedule a deferred
+            // redraw so the renderer picks up the new palette values.
+            ScheduleDeferredRedraw();
         };
 
         _tabManager.LastTabClosed += (_, _) => Close();
@@ -949,6 +960,38 @@ public sealed partial class MainWindow : Window
 
         _horizontalTabHost.SetAccentColor(wuiColor);
         _verticalTabHost.SetAccentColor(wuiColor);
+    }
+
+    /// <summary>
+    /// Schedule a deferred redraw of every live terminal surface.
+    /// The Zig termio thread processes its change_config message
+    /// asynchronously after the renderer thread has already drawn
+    /// a frame with the old palette. A short delay lets the termio
+    /// thread catch up before we ask each surface to repaint.
+    /// Debounced: rapid config reloads cancel the previous timer.
+    /// </summary>
+    private async void ScheduleDeferredRedraw()
+    {
+        _redrawCts?.Cancel();
+        _redrawCts?.Dispose();
+        var cts = new CancellationTokenSource();
+        _redrawCts = cts;
+
+        try
+        {
+            await Task.Delay(50, cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+
+        foreach (var tab in _tabManager.Tabs)
+        {
+            var paneHost = (PaneHost)tab.PaneHost;
+            foreach (var leaf in PaneTree.Leaves(paneHost.RootNode))
+                leaf.Terminal().RequestRedraw();
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -678,6 +678,11 @@ public sealed partial class MainWindow : Window
         _taskbar.Dispose();
         _themeManager.Dispose();
 
+        // Cancel any pending deferred redraw before freeing surfaces.
+        _redrawCts?.Cancel();
+        _redrawCts?.Dispose();
+        _redrawCts = null;
+
         // Surface lifetime is decoupled from Loaded/Unloaded
         // (see TerminalControl.DisposeSurface), so we have to
         // free every leaf in every tab explicitly before tearing


### PR DESCRIPTION
## Summary

- After config reload, the Zig renderer thread draws a frame before the termio thread updates terminal default colors, so the first frame uses stale palette values
- On macOS this is masked by the 60fps display link; on Windows rendering is event-driven and no second render gets queued
- Schedule a debounced 50ms deferred `SurfaceDraw` on every live terminal surface after `ConfigChanged` fires, giving the termio thread time to process its `change_config`

## Test plan

- [ ] Set `theme = SomeTheme` in config, reload with Ctrl+Shift+, -- foreground color updates
- [ ] Switch between light and dark themes -- both foreground and background update
- [ ] Rapid config reloads don't stack up redundant draws (debounce works)
- [ ] New text after reload also uses correct color

Closes #220