### PR TITLE
fix(windows): always copy ghostty.dll in Debug builds

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -89,11 +89,12 @@
   </ItemGroup>
 
   <!--
-    Fallback: copy libghostty.dll for non-AOT builds (dotnet run / Debug).
-    When PublishAot is true and ghostty-static.lib is linked, the DLL is
-    not needed at runtime.
+    Copy libghostty.dll for non-AOT builds (dotnet run / Debug).
+    Always copy regardless of whether the static lib also exists:
+    zig build produces both artifacts, and Debug builds load the DLL
+    at runtime even when the static lib is present on disk.
   -->
-  <ItemGroup Condition="!Exists('..\..\zig-out\lib\ghostty-static.lib')">
+  <ItemGroup>
     <None Include="..\..\zig-out\lib\ghostty.dll" Condition="Exists('..\..\zig-out\lib\ghostty.dll')">
       <Link>native\ghostty.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
## Summary

- `zig build -Dapp-runtime=none` produces both `ghostty-static.lib` and `ghostty.dll`
- The csproj DLL copy was gated on `!Exists(ghostty-static.lib)`, so when the static lib existed the DLL was never copied to the build output
- Debug (non-AOT) builds load the DLL at runtime, causing `EntryPointNotFoundException` for any native function added after the last DLL copy (e.g. `ghostty_cli_set_theme_callback`)
- Remove the condition so `PreserveNewest` always copies the fresh DLL

## Test results

- [x] `dotnet build` copies fresh DLL even with ghostty-static.lib present (same size 30948352, same timestamp)
- [x] `ghostty.exe +list-themes` works (no more EntryPointNotFoundException)
- [x] App starts normally (clean startup, exit 0)