### PR TITLE
fix(windows): backdrop style switching not applying visually

### DIFF
--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -920,12 +920,18 @@ public sealed partial class MainWindow : Window
         tb.ButtonHoverBackgroundColor = _shellTheme.TabBarBackground;
         tb.ButtonHoverForegroundColor = _shellTheme.TitleBarForeground;
 
+        // When a transparent backdrop (frosted/crystal) is active, the
+        // RootGrid must stay transparent so the SystemBackdrop shows
+        // through. An opaque shell theme background would mask it.
+        var needsTransparent = _currentBackdropStyle is "frosted" or "crystal";
         RootGrid.Background = new SolidColorBrush(
-            Microsoft.UI.ColorHelper.FromArgb(
-                _shellTheme.TitleBarBackground.A,
-                _shellTheme.TitleBarBackground.R,
-                _shellTheme.TitleBarBackground.G,
-                _shellTheme.TitleBarBackground.B));
+            needsTransparent
+                ? Windows.UI.Color.FromArgb(0, 0, 0, 0)
+                : Microsoft.UI.ColorHelper.FromArgb(
+                    _shellTheme.TitleBarBackground.A,
+                    _shellTheme.TitleBarBackground.R,
+                    _shellTheme.TitleBarBackground.G,
+                    _shellTheme.TitleBarBackground.B));
 
         VerticalTitleText.Foreground = new SolidColorBrush(
             Microsoft.UI.ColorHelper.FromArgb(

--- a/windows/Ghostty/Shell/CrystalBackdrop.cs
+++ b/windows/Ghostty/Shell/CrystalBackdrop.cs
@@ -62,6 +62,18 @@ internal sealed partial class CrystalBackdrop : SystemBackdrop
     {
         base.OnTargetDisconnected(target);
 
+        // Disable DWM blur-behind so switching to a different backdrop
+        // (solid/frosted) doesn't leave stale transparency state.
+        if (_hwnd != 0)
+        {
+            var bb = new Win32Interop.DWM_BLURBEHIND
+            {
+                DwFlags = Win32Interop.DWM_BLURBEHIND.DWM_BB_ENABLE,
+                FEnable = 0,
+            };
+            Win32Interop.DwmEnableBlurBehindWindow(_hwnd, ref bb);
+        }
+
         if (_blurRegion != 0)
         {
             Win32Interop.DeleteObject(_blurRegion);


### PR DESCRIPTION
## Summary

- Fix backdrop style switching (frosted/crystal/solid) not applying visually on config reload.
- Two root causes: `ApplyShellTheme()` unconditionally painted an opaque `RootGrid.Background` masking transparent backdrops, and `CrystalBackdrop.OnTargetDisconnected` never disabled DWM blur-behind leaving stale compositor state.

## What changed

**MainWindow.xaml.cs**: `ApplyShellTheme()` now checks `_currentBackdropStyle` -- when the active backdrop is "frosted" or "crystal", `RootGrid.Background` stays transparent instead of using the opaque shell theme color.

**CrystalBackdrop.cs**: `OnTargetDisconnected` now calls `DwmEnableBlurBehindWindow` with `FEnable = 0` to disable DWM blur-behind before cleaning up the GDI region.

## Test plan

- [ ] Switch between frosted/crystal/solid in Settings UI, verify visual changes apply immediately
- [ ] Toggle shell theme on/off while using frosted or crystal backdrop
- [ ] Change backdrop style while shell theme is enabled
- [ ] Verify solid backdrop still gets the shell theme background color

Closes #229