### PR TITLE
feat(windows): light/dark conditional theming parity

### DIFF
--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -27,8 +27,9 @@ public interface IConfigService : IDisposable
     double BackgroundOpacity { get; }
 
     /// <summary>
-    /// Window theme from config: "light", "dark", "system", or "auto".
-    /// Controls both the XAML ElementTheme and the DWM title bar chrome.
+    /// Window theme from config: "light", "dark", "system", "auto", or
+    /// "ghostty" (palette-derived chrome). Controls both the XAML
+    /// ElementTheme and the DWM title bar chrome.
     /// </summary>
     string WindowTheme { get; }
 

--- a/windows/Ghostty.Core/Config/ThemeParser.cs
+++ b/windows/Ghostty.Core/Config/ThemeParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Ghostty.Core.Config;
 
@@ -73,17 +74,37 @@ public static class ThemeParser
             var key = trimmed[..eqIndex].Trim();
             if (key != "palette") continue;
 
-            var entry = trimmed[(eqIndex + 1)..].Trim();
-            var entryEq = entry.IndexOf('=');
-            if (entryEq < 0) continue;
-            var idxStr = entry[..entryEq].Trim();
-            if (!int.TryParse(idxStr, out var parsedIdx)) continue;
-            if (parsedIdx is < 0 or >= 16) continue;
-
-            var colorStr = entry[(entryEq + 1)..].Trim();
-            if (TryParseHexRgb(colorStr, out var packed))
-                palette[parsedIdx] = packed;
+            ApplyPaletteEntry(trimmed[(eqIndex + 1)..].Trim(), palette);
         }
+    }
+
+    /// <summary>
+    /// Apply palette entries given as raw "N=#RRGGBB" values (no
+    /// leading "palette =" prefix). Use this when the caller already
+    /// has the values pre-extracted from the config by key and would
+    /// otherwise have to re-prefix them just to let this module
+    /// re-match the key.
+    /// </summary>
+    public static void ApplyPaletteFromValues(IEnumerable<string> values, uint[] palette)
+    {
+        if (palette.Length < 16)
+            throw new ArgumentException("palette must have at least 16 entries", nameof(palette));
+
+        foreach (var value in values)
+            ApplyPaletteEntry(value, palette);
+    }
+
+    private static void ApplyPaletteEntry(string entry, uint[] palette)
+    {
+        var entryEq = entry.IndexOf('=');
+        if (entryEq < 0) return;
+        var idxStr = entry[..entryEq].Trim();
+        if (!int.TryParse(idxStr, out var parsedIdx)) return;
+        if (parsedIdx is < 0 or >= 16) return;
+
+        var colorStr = entry[(entryEq + 1)..].Trim();
+        if (TryParseHexRgb(colorStr, out var packed))
+            palette[parsedIdx] = packed;
     }
 
     /// <summary>
@@ -94,34 +115,54 @@ public static class ThemeParser
     {
         packed = 0;
         if (string.IsNullOrEmpty(value)) return false;
-        var hex = value.TrimStart('#');
-        try
+        var hex = value.AsSpan().TrimStart('#');
+
+        // Uses byte.TryParse over Parse+catch because this runs on
+        // every config reload for up to 16 palette entries plus fg/bg/
+        // cursor; exception-as-control-flow would be wasteful, and
+        // AOT exercises the exception machinery enough as it is.
+        switch (hex.Length)
         {
-            switch (hex.Length)
-            {
-                case 3:
-                    packed = ((uint)byte.Parse(new string(hex[0], 2), System.Globalization.NumberStyles.HexNumber) << 16)
-                           | ((uint)byte.Parse(new string(hex[1], 2), System.Globalization.NumberStyles.HexNumber) << 8)
-                           | byte.Parse(new string(hex[2], 2), System.Globalization.NumberStyles.HexNumber);
-                    return true;
-                case 6:
-                    packed = ((uint)byte.Parse(hex[..2], System.Globalization.NumberStyles.HexNumber) << 16)
-                           | ((uint)byte.Parse(hex[2..4], System.Globalization.NumberStyles.HexNumber) << 8)
-                           | byte.Parse(hex[4..6], System.Globalization.NumberStyles.HexNumber);
-                    return true;
-                case 8:
-                    // #AARRGGBB - drop the alpha
-                    packed = ((uint)byte.Parse(hex[2..4], System.Globalization.NumberStyles.HexNumber) << 16)
-                           | ((uint)byte.Parse(hex[4..6], System.Globalization.NumberStyles.HexNumber) << 8)
-                           | byte.Parse(hex[6..8], System.Globalization.NumberStyles.HexNumber);
-                    return true;
-                default:
-                    return false;
-            }
+            case 3:
+                if (!TryParseHexNibble(hex[0], out var r3)) return false;
+                if (!TryParseHexNibble(hex[1], out var g3)) return false;
+                if (!TryParseHexNibble(hex[2], out var b3)) return false;
+                packed = ((uint)r3 << 16) | ((uint)g3 << 8) | b3;
+                return true;
+            case 6:
+                return TryParseRgbBytes(hex[..2], hex[2..4], hex[4..6], out packed);
+            case 8:
+                // #AARRGGBB -- drop the alpha.
+                return TryParseRgbBytes(hex[2..4], hex[4..6], hex[6..8], out packed);
+            default:
+                return false;
         }
-        catch (FormatException)
+    }
+
+    private static bool TryParseRgbBytes(
+        ReadOnlySpan<char> r, ReadOnlySpan<char> g, ReadOnlySpan<char> b, out uint packed)
+    {
+        packed = 0;
+        if (!byte.TryParse(r, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var rb)) return false;
+        if (!byte.TryParse(g, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var gb)) return false;
+        if (!byte.TryParse(b, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var bb)) return false;
+        packed = ((uint)rb << 16) | ((uint)gb << 8) | bb;
+        return true;
+    }
+
+    private static bool TryParseHexNibble(char c, out byte value)
+    {
+        // Expand a 3-digit hex shorthand (e.g. 'F' -> 0xFF) without
+        // allocating the "FF" string the old code built.
+        int v = c switch
         {
-            return false;
-        }
+            >= '0' and <= '9' => c - '0',
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            _ => -1,
+        };
+        if (v < 0) { value = 0; return false; }
+        value = (byte)(v * 0x11);
+        return true;
     }
 }

--- a/windows/Ghostty.Core/Config/ThemeParser.cs
+++ b/windows/Ghostty.Core/Config/ThemeParser.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Pure-logic parsing for ghostty theme configuration values.
+/// Mirrors the Zig parser in Config.zig (Theme.parseCLI) for the
+/// conditional theme syntax, and parses palette entries from theme
+/// files for the C# side that needs them for UI accents.
+/// </summary>
+public static class ThemeParser
+{
+    /// <summary>
+    /// Parse a theme config value into light/dark components.
+    /// Handles single ("ThemeName") and pair ("light:X,dark:Y") forms.
+    /// Returns (null, null) for single themes or empty input. Both
+    /// light and dark must be present for a pair; partial pairs (only
+    /// light: or only dark:) return (null, null) to match the Zig
+    /// parser which treats those as InvalidValue errors.
+    /// </summary>
+    public static (string? light, string? dark) ParseThemePair(string theme)
+    {
+        if (string.IsNullOrWhiteSpace(theme))
+            return (null, null);
+
+        var parts = theme.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        string? light = null;
+        string? dark = null;
+
+        foreach (var part in parts)
+        {
+            // Find the first ':' or '='. Match Zig which tolerates spaces
+            // around the separator (e.g. "dark : bar").
+            var sepIdx = part.IndexOfAny([':', '=']);
+            if (sepIdx <= 0) continue;
+
+            var name = part[..sepIdx].Trim();
+            var value = part[(sepIdx + 1)..].Trim();
+            if (value.Length == 0) continue;
+
+            if (string.Equals(name, "light", StringComparison.OrdinalIgnoreCase))
+                light = value;
+            else if (string.Equals(name, "dark", StringComparison.OrdinalIgnoreCase))
+                dark = value;
+        }
+
+        // Zig's Theme.parseCLI requires both light and dark to be present;
+        // a partial pair (e.g. "light:X" alone) is an error. Match that here.
+        if (light is not null && dark is not null)
+            return (light, dark);
+
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Parse "palette = N=#RRGGBB" lines and write into the supplied
+    /// 16-entry palette array. Lines that aren't palette entries are
+    /// ignored, so this can be pointed at a full theme file or the
+    /// user's main config file.
+    /// </summary>
+    public static void ApplyPaletteFromLines(IEnumerable<string> lines, uint[] palette)
+    {
+        if (palette.Length < 16)
+            throw new ArgumentException("palette must have at least 16 entries", nameof(palette));
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith('#')) continue;
+            var eqIndex = trimmed.IndexOf('=');
+            if (eqIndex < 0) continue;
+            var key = trimmed[..eqIndex].Trim();
+            if (key != "palette") continue;
+
+            var entry = trimmed[(eqIndex + 1)..].Trim();
+            var entryEq = entry.IndexOf('=');
+            if (entryEq < 0) continue;
+            var idxStr = entry[..entryEq].Trim();
+            if (!int.TryParse(idxStr, out var parsedIdx)) continue;
+            if (parsedIdx is < 0 or >= 16) continue;
+
+            var colorStr = entry[(entryEq + 1)..].Trim();
+            if (TryParseHexRgb(colorStr, out var packed))
+                palette[parsedIdx] = packed;
+        }
+    }
+
+    /// <summary>
+    /// Parse a hex color string (#RGB, #RRGGBB, or #AARRGGBB) into
+    /// a packed 0x00RRGGBB uint. Returns false on invalid input.
+    /// </summary>
+    public static bool TryParseHexRgb(string value, out uint packed)
+    {
+        packed = 0;
+        if (string.IsNullOrEmpty(value)) return false;
+        var hex = value.TrimStart('#');
+        try
+        {
+            switch (hex.Length)
+            {
+                case 3:
+                    packed = ((uint)byte.Parse(new string(hex[0], 2), System.Globalization.NumberStyles.HexNumber) << 16)
+                           | ((uint)byte.Parse(new string(hex[1], 2), System.Globalization.NumberStyles.HexNumber) << 8)
+                           | byte.Parse(new string(hex[2], 2), System.Globalization.NumberStyles.HexNumber);
+                    return true;
+                case 6:
+                    packed = ((uint)byte.Parse(hex[..2], System.Globalization.NumberStyles.HexNumber) << 16)
+                           | ((uint)byte.Parse(hex[2..4], System.Globalization.NumberStyles.HexNumber) << 8)
+                           | byte.Parse(hex[4..6], System.Globalization.NumberStyles.HexNumber);
+                    return true;
+                case 8:
+                    // #AARRGGBB - drop the alpha
+                    packed = ((uint)byte.Parse(hex[2..4], System.Globalization.NumberStyles.HexNumber) << 16)
+                           | ((uint)byte.Parse(hex[4..6], System.Globalization.NumberStyles.HexNumber) << 8)
+                           | byte.Parse(hex[6..8], System.Globalization.NumberStyles.HexNumber);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Config/ThemeParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ThemeParserTests.cs
@@ -1,0 +1,295 @@
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public class ThemeParserTests
+{
+    // ===== ParseThemePair =====
+
+    [Fact]
+    public void ParseThemePair_Empty_ReturnsNullPair()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair("");
+        Assert.Null(light);
+        Assert.Null(dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_Whitespace_ReturnsNullPair()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair("   ");
+        Assert.Null(light);
+        Assert.Null(dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_SingleTheme_ReturnsNullPair()
+    {
+        // Single theme name (no light:/dark: prefix) is not a pair.
+        var (light, dark) = ThemeParser.ParseThemePair("Tokyo Night");
+        Assert.Null(light);
+        Assert.Null(dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_FullPair_ReturnsBoth()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair("light:Catppuccin Latte,dark:Catppuccin Mocha");
+        Assert.Equal("Catppuccin Latte", light);
+        Assert.Equal("Catppuccin Mocha", dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_OrderInsensitive_ReturnsBoth()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair("dark:Mocha,light:Latte");
+        Assert.Equal("Latte", light);
+        Assert.Equal("Mocha", dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_TrimsWhitespace()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair(" light : Latte , dark : Mocha ");
+        Assert.Equal("Latte", light);
+        Assert.Equal("Mocha", dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_PartialLightOnly_ReturnsNullPair()
+    {
+        // Match Zig: a partial pair returns InvalidValue. We return (null, null).
+        var (light, dark) = ThemeParser.ParseThemePair("light:Latte");
+        Assert.Null(light);
+        Assert.Null(dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_PartialDarkOnly_ReturnsNullPair()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair("dark:Mocha");
+        Assert.Null(light);
+        Assert.Null(dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_EqualsSeparator_AccepteForTypoTolerance()
+    {
+        // Zig accepts "=" as a typo-tolerance path. We do too on the read side.
+        var (light, dark) = ThemeParser.ParseThemePair("light=Latte,dark=Mocha");
+        Assert.Equal("Latte", light);
+        Assert.Equal("Mocha", dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_CaseInsensitivePrefix()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair("LIGHT:Latte,Dark:Mocha");
+        Assert.Equal("Latte", light);
+        Assert.Equal("Mocha", dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_SameLightAndDark_ReturnsBoth()
+    {
+        // Caller (UI) is responsible for collapsing same-value pairs to single.
+        var (light, dark) = ThemeParser.ParseThemePair("light:Tokyo,dark:Tokyo");
+        Assert.Equal("Tokyo", light);
+        Assert.Equal("Tokyo", dark);
+    }
+
+    [Fact]
+    public void ParseThemePair_ThemeNameWithSpaces_PreservesSpaces()
+    {
+        var (light, dark) = ThemeParser.ParseThemePair("light:Rose Pine Dawn,dark:Rose Pine");
+        Assert.Equal("Rose Pine Dawn", light);
+        Assert.Equal("Rose Pine", dark);
+    }
+
+    // ===== ApplyPaletteFromLines =====
+
+    [Fact]
+    public void ApplyPaletteFromLines_EmptyInput_LeavesPaletteUnchanged()
+    {
+        var palette = new uint[16];
+        for (uint i = 0; i < 16; i++) palette[i] = 0xABABAB;
+
+        ThemeParser.ApplyPaletteFromLines(System.Array.Empty<string>(), palette);
+
+        for (uint i = 0; i < 16; i++)
+            Assert.Equal(0xABABABu, palette[i]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_SetsByIndex()
+    {
+        var palette = new uint[16];
+        var lines = new[]
+        {
+            "palette = 0=#112233",
+            "palette = 7=#aabbcc",
+        };
+
+        ThemeParser.ApplyPaletteFromLines(lines, palette);
+
+        Assert.Equal(0x112233u, palette[0]);
+        Assert.Equal(0xAABBCCu, palette[7]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_OverridesPriorValue()
+    {
+        var palette = new uint[16];
+        palette[0] = 0xFFFFFF;
+
+        ThemeParser.ApplyPaletteFromLines(new[] { "palette = 0=#112233" }, palette);
+
+        Assert.Equal(0x112233u, palette[0]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_LayeringSimulatesUserOverridesTheme()
+    {
+        // Simulates: theme file sets a palette, user config overrides one entry.
+        var palette = new uint[16];
+
+        var themeLines = new[]
+        {
+            "palette = 0=#000000",
+            "palette = 1=#cc0000",
+            "palette = 2=#00cc00",
+        };
+        ThemeParser.ApplyPaletteFromLines(themeLines, palette);
+
+        var userLines = new[]
+        {
+            "palette = 1=#ff0000", // user overrides red
+        };
+        ThemeParser.ApplyPaletteFromLines(userLines, palette);
+
+        Assert.Equal(0x000000u, palette[0]);
+        Assert.Equal(0xFF0000u, palette[1]); // overridden
+        Assert.Equal(0x00CC00u, palette[2]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_IgnoresComments()
+    {
+        var palette = new uint[16];
+
+        ThemeParser.ApplyPaletteFromLines(new[]
+        {
+            "# palette = 0=#ffffff",
+            "palette = 0=#112233",
+        }, palette);
+
+        Assert.Equal(0x112233u, palette[0]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_IgnoresUnrelatedKeys()
+    {
+        var palette = new uint[16];
+        var lines = new[]
+        {
+            "background = #1e1e2e",
+            "foreground = #cdd6f4",
+            "cursor-color = #f5e0dc",
+            "palette = 0=#112233",
+        };
+
+        ThemeParser.ApplyPaletteFromLines(lines, palette);
+
+        Assert.Equal(0x112233u, palette[0]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_SkipsOutOfRangeIndices()
+    {
+        var palette = new uint[16];
+        var lines = new[]
+        {
+            "palette = -1=#112233",
+            "palette = 16=#445566",
+            "palette = 99=#778899",
+        };
+
+        ThemeParser.ApplyPaletteFromLines(lines, palette);
+
+        for (uint i = 0; i < 16; i++)
+            Assert.Equal(0u, palette[i]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_SkipsMalformedEntries()
+    {
+        var palette = new uint[16];
+        palette[0] = 0xDEADBEEF;
+        var lines = new[]
+        {
+            "palette",                  // no =
+            "palette = ",               // no entry
+            "palette = =#112233",       // no index
+            "palette = abc=#112233",    // non-numeric index
+            "palette = 0=notahex",      // bad color
+        };
+
+        ThemeParser.ApplyPaletteFromLines(lines, palette);
+
+        Assert.Equal(0xDEADBEEFu, palette[0]);
+    }
+
+    [Fact]
+    public void ApplyPaletteFromLines_TooSmallPalette_Throws()
+    {
+        var palette = new uint[8];
+        Assert.Throws<System.ArgumentException>(() =>
+            ThemeParser.ApplyPaletteFromLines(System.Array.Empty<string>(), palette));
+    }
+
+    // ===== TryParseHexRgb =====
+
+    [Fact]
+    public void TryParseHexRgb_ShortForm_Expands()
+    {
+        Assert.True(ThemeParser.TryParseHexRgb("#abc", out var rgb));
+        Assert.Equal(0xAABBCCu, rgb);
+    }
+
+    [Fact]
+    public void TryParseHexRgb_FullForm()
+    {
+        Assert.True(ThemeParser.TryParseHexRgb("#112233", out var rgb));
+        Assert.Equal(0x112233u, rgb);
+    }
+
+    [Fact]
+    public void TryParseHexRgb_WithAlpha_DropsAlpha()
+    {
+        Assert.True(ThemeParser.TryParseHexRgb("#FF112233", out var rgb));
+        Assert.Equal(0x112233u, rgb);
+    }
+
+    [Fact]
+    public void TryParseHexRgb_NoLeadingHash()
+    {
+        Assert.True(ThemeParser.TryParseHexRgb("112233", out var rgb));
+        Assert.Equal(0x112233u, rgb);
+    }
+
+    [Fact]
+    public void TryParseHexRgb_Empty_ReturnsFalse()
+    {
+        Assert.False(ThemeParser.TryParseHexRgb("", out var rgb));
+        Assert.Equal(0u, rgb);
+    }
+
+    [Fact]
+    public void TryParseHexRgb_Invalid_ReturnsFalse()
+    {
+        Assert.False(ThemeParser.TryParseHexRgb("not-a-color", out _));
+        Assert.False(ThemeParser.TryParseHexRgb("#xyz", out _));
+        Assert.False(ThemeParser.TryParseHexRgb("#1234", out _)); // wrong length
+    }
+}

--- a/windows/Ghostty.Tests/Config/ThemeParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ThemeParserTests.cs
@@ -74,7 +74,7 @@ public class ThemeParserTests
     }
 
     [Fact]
-    public void ParseThemePair_EqualsSeparator_AccepteForTypoTolerance()
+    public void ParseThemePair_EqualsSeparator_AcceptedForTypoTolerance()
     {
         // Zig accepts "=" as a typo-tolerance path. We do too on the read side.
         var (light, dark) = ThemeParser.ParseThemePair("light=Latte,dark=Mocha");

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -266,6 +266,13 @@ internal sealed class GhosttyHost : IDisposable
     /// changed. Mirrors GTK's handleStyleManagerDark which calls
     /// surface.core().colorSchemeCallback() for each surface after
     /// the app-level colorSchemeEvent.
+    ///
+    /// UI thread only. <see cref="Adopt"/> / <see cref="Detach"/>
+    /// mutate <see cref="_surfaces"/> on the UI thread by contract; the
+    /// only background-thread writers that can coexist are the
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/>'s own snapshot
+    /// enumerator guarantees. Called from <c>MainWindow</c> inside a
+    /// <c>DispatcherQueue.TryEnqueue</c> after <c>UISettings.ColorValuesChanged</c>.
     /// </summary>
     internal void NotifyColorSchemeChanged(GhosttyColorScheme scheme)
     {

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -262,6 +262,21 @@ internal sealed class GhosttyHost : IDisposable
     }
 
     /// <summary>
+    /// Notify all surfaces owned by this host that the OS color scheme
+    /// changed. Mirrors GTK's handleStyleManagerDark which calls
+    /// surface.core().colorSchemeCallback() for each surface after
+    /// the app-level colorSchemeEvent.
+    /// </summary>
+    internal void NotifyColorSchemeChanged(GhosttyColorScheme scheme)
+    {
+        foreach (var (handle, _) in _surfaces)
+        {
+            var surface = new GhosttySurface(handle);
+            NativeMethods.SurfaceSetColorScheme(surface, scheme);
+        }
+    }
+
+    /// <summary>
     /// Bootstrap/per-window dispose invariant: the bootstrap host
     /// (<see cref="IAppHandleOwnership.State"/>.<c>IsBootstrap</c>)
     /// MUST be disposed LAST, after every per-window host. App.xaml.cs's

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -369,6 +369,10 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void AppSetColorScheme(GhosttyApp app, GhosttyColorScheme scheme);
 
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_set_color_scheme")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void SurfaceSetColorScheme(GhosttySurface surface, GhosttyColorScheme scheme);
+
     [LibraryImport(Dll, EntryPoint = "ghostty_app_update_config")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void AppUpdateConfig(GhosttyApp app, GhosttyConfig config);

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -903,15 +903,8 @@ public sealed partial class MainWindow : Window
     {
         if (!_shellTheme.IsEnabled)
         {
-            // Revert to standard chrome. Clear custom title bar
-            // button colors back to null (system default).
-            ApplyButtonColors(
-                bg: null, fg: null,
-                inactiveBg: null, inactiveFg: null,
-                hoverBg: null, hoverFg: null,
-                pressedBg: null, pressedFg: null);
-
-            // Reset VerticalTitleText to theme default.
+            // Revert to standard chrome. Reset VerticalTitleText so
+            // it picks up the element-theme default again.
             VerticalTitleText.ClearValue(TextBlock.ForegroundProperty);
 
             // Force ApplyBackdropStyle to re-run by clearing its
@@ -919,6 +912,12 @@ public sealed partial class MainWindow : Window
             // SetTransparentChrome/SetOpaqueChrome.
             _currentBackdropStyle = "";
             ApplyBackdropStyle();
+
+            // Let ApplyTheme write the standard caption-button colors
+            // directly. Pre-clearing the buttons to null here would
+            // briefly show the system accent (blue) on close/min/max
+            // before ApplyTheme overwrites them, producing a visible
+            // flash on every config reload.
             ApplyTheme();
 
             _horizontalTabHost.ClearShellTheme();

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -80,6 +80,15 @@ public sealed partial class MainWindow : Window
     // redundant SystemBackdrop swaps on config reload.
     private string _currentBackdropStyle = "";
 
+    // Tracks the last applied caption-button colors so we can skip
+    // redundant TitleBar property writes. WinUI 3 marshals each
+    // property setter to DWM separately, and rapid sequential writes
+    // can cause a brief flash to the system accent color (blue) while
+    // DWM is between updates.
+    private (Windows.UI.Color? Bg, Windows.UI.Color? Fg, Windows.UI.Color? InactiveBg,
+             Windows.UI.Color? InactiveFg, Windows.UI.Color? HoverBg, Windows.UI.Color? HoverFg,
+             Windows.UI.Color? PressedBg, Windows.UI.Color? PressedFg) _lastButtonColors;
+
     private GradientTintVisual? _gradientVisual;
     private Window? _settingsWindow;
 
@@ -854,25 +863,28 @@ public sealed partial class MainWindow : Window
         // Caption button colors must be set explicitly when
         // ExtendsContentIntoTitleBar is true, otherwise WinUI 3
         // fills them with the system accent color.
-        var tb = AppWindow.TitleBar;
         var fg = _themeManager.IsDarkMode
             ? Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0xFF, 0x00, 0x00, 0x00);
         var fgInactive = _themeManager.IsDarkMode
             ? Windows.UI.Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0x66, 0x00, 0x00, 0x00);
-        tb.ButtonBackgroundColor = Windows.UI.Color.FromArgb(0, 0, 0, 0);
-        tb.ButtonInactiveBackgroundColor = Windows.UI.Color.FromArgb(0, 0, 0, 0);
-        tb.ButtonForegroundColor = fg;
-        tb.ButtonInactiveForegroundColor = fgInactive;
-        tb.ButtonHoverBackgroundColor = _themeManager.IsDarkMode
+        var hoverBg = _themeManager.IsDarkMode
             ? Windows.UI.Color.FromArgb(0x33, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0x33, 0x00, 0x00, 0x00);
-        tb.ButtonHoverForegroundColor = fg;
-        tb.ButtonPressedBackgroundColor = _themeManager.IsDarkMode
+        var pressedBg = _themeManager.IsDarkMode
             ? Windows.UI.Color.FromArgb(0x22, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0x22, 0x00, 0x00, 0x00);
-        tb.ButtonPressedForegroundColor = fg;
+
+        ApplyButtonColors(
+            bg: Windows.UI.Color.FromArgb(0, 0, 0, 0),
+            fg: fg,
+            inactiveBg: Windows.UI.Color.FromArgb(0, 0, 0, 0),
+            inactiveFg: fgInactive,
+            hoverBg: hoverBg,
+            hoverFg: fg,
+            pressedBg: pressedBg,
+            pressedFg: fg);
 
         // Propagate theme to tab hosts so their text/icons adapt.
         // Guard: tab hosts are created after the first ApplyTheme call.
@@ -893,13 +905,11 @@ public sealed partial class MainWindow : Window
         {
             // Revert to standard chrome. Clear custom title bar
             // button colors back to null (system default).
-            var titleBar = AppWindow.TitleBar;
-            titleBar.ButtonBackgroundColor = null;
-            titleBar.ButtonForegroundColor = null;
-            titleBar.ButtonInactiveBackgroundColor = null;
-            titleBar.ButtonInactiveForegroundColor = null;
-            titleBar.ButtonHoverBackgroundColor = null;
-            titleBar.ButtonHoverForegroundColor = null;
+            ApplyButtonColors(
+                bg: null, fg: null,
+                inactiveBg: null, inactiveFg: null,
+                hoverBg: null, hoverFg: null,
+                pressedBg: null, pressedFg: null);
 
             // Reset VerticalTitleText to theme default.
             VerticalTitleText.ClearValue(TextBlock.ForegroundProperty);
@@ -916,18 +926,19 @@ public sealed partial class MainWindow : Window
             return;
         }
 
-        var tb = AppWindow.TitleBar;
         // Transparent backgrounds let the caption buttons blend
         // with whatever backdrop (Mica/Acrylic) is behind them.
-        tb.ButtonBackgroundColor = Windows.UI.Color.FromArgb(0, 0, 0, 0);
-        tb.ButtonForegroundColor = _shellTheme.TitleBarForeground;
-        tb.ButtonInactiveBackgroundColor = Windows.UI.Color.FromArgb(0, 0, 0, 0);
-        tb.ButtonInactiveForegroundColor = Windows.UI.Color.FromArgb(
-            128, _shellTheme.TitleBarForeground.R,
-            _shellTheme.TitleBarForeground.G,
-            _shellTheme.TitleBarForeground.B);
-        tb.ButtonHoverBackgroundColor = _shellTheme.TabBarBackground;
-        tb.ButtonHoverForegroundColor = _shellTheme.TitleBarForeground;
+        var fg = _shellTheme.TitleBarForeground;
+        var fgInactive = Windows.UI.Color.FromArgb(128, fg.R, fg.G, fg.B);
+        ApplyButtonColors(
+            bg: Windows.UI.Color.FromArgb(0, 0, 0, 0),
+            fg: fg,
+            inactiveBg: Windows.UI.Color.FromArgb(0, 0, 0, 0),
+            inactiveFg: fgInactive,
+            hoverBg: _shellTheme.TabBarBackground,
+            hoverFg: fg,
+            pressedBg: _shellTheme.TabBarBackground,
+            pressedFg: fg);
 
         // When a transparent backdrop (frosted/crystal) is active, the
         // RootGrid must stay transparent so the SystemBackdrop shows
@@ -952,6 +963,41 @@ public sealed partial class MainWindow : Window
         // Push theme to both tab hosts.
         _horizontalTabHost.ApplyShellTheme(_shellTheme);
         _verticalTabHost.ApplyShellTheme(_shellTheme);
+    }
+
+    /// <summary>
+    /// Apply caption-button colors only when they actually change, and
+    /// write each property only when its individual value changed.
+    /// WinUI 3 marshals each TitleBar property setter to DWM separately;
+    /// rapid sequential writes cause a brief flash to the system accent
+    /// color (blue) on the close/min/max buttons while DWM is between
+    /// updates. Skipping no-op writes minimizes that window.
+    /// </summary>
+    private void ApplyButtonColors(
+        Windows.UI.Color? bg, Windows.UI.Color? fg,
+        Windows.UI.Color? inactiveBg, Windows.UI.Color? inactiveFg,
+        Windows.UI.Color? hoverBg, Windows.UI.Color? hoverFg,
+        Windows.UI.Color? pressedBg, Windows.UI.Color? pressedFg)
+    {
+        var next = (bg, fg, inactiveBg, inactiveFg, hoverBg, hoverFg, pressedBg, pressedFg);
+        if (next == _lastButtonColors) return;
+
+        var prev = _lastButtonColors;
+        _lastButtonColors = next;
+
+        var tb = AppWindow.TitleBar;
+        // Only write properties that actually changed. WinUI 3 sends each
+        // setter individually to DWM and each write can trigger a brief
+        // redraw with default (system accent) colors before the new value
+        // takes effect.
+        if (prev.Bg != bg) tb.ButtonBackgroundColor = bg;
+        if (prev.InactiveBg != inactiveBg) tb.ButtonInactiveBackgroundColor = inactiveBg;
+        if (prev.HoverBg != hoverBg) tb.ButtonHoverBackgroundColor = hoverBg;
+        if (prev.PressedBg != pressedBg) tb.ButtonPressedBackgroundColor = pressedBg;
+        if (prev.Fg != fg) tb.ButtonForegroundColor = fg;
+        if (prev.InactiveFg != inactiveFg) tb.ButtonInactiveForegroundColor = inactiveFg;
+        if (prev.HoverFg != hoverFg) tb.ButtonHoverForegroundColor = hoverFg;
+        if (prev.PressedFg != pressedFg) tb.ButtonPressedForegroundColor = pressedFg;
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -204,9 +204,11 @@ public sealed partial class MainWindow : Window
         _systemUiSettings = new Windows.UI.ViewManagement.UISettings();
         var initialFg = _systemUiSettings.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
         var initialDark = initialFg.R > 128;
-        Ghostty.Interop.NativeMethods.AppSetColorScheme(
-            _host.App,
-            initialDark ? Ghostty.Interop.GhosttyColorScheme.Dark : Ghostty.Interop.GhosttyColorScheme.Light);
+        var initialScheme = initialDark
+            ? Ghostty.Interop.GhosttyColorScheme.Dark
+            : Ghostty.Interop.GhosttyColorScheme.Light;
+        Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, initialScheme);
+        _host.NotifyColorSchemeChanged(initialScheme);
 
         // Subscribe to runtime theme changes. ColorValuesChanged fires on a
         // background thread, so dispatch back to the UI thread before calling
@@ -216,9 +218,13 @@ public sealed partial class MainWindow : Window
             var fg = s.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
             var dark = fg.R > 128;
             DispatcherQueue.TryEnqueue(() =>
-                Ghostty.Interop.NativeMethods.AppSetColorScheme(
-                    _host.App,
-                    dark ? Ghostty.Interop.GhosttyColorScheme.Dark : Ghostty.Interop.GhosttyColorScheme.Light));
+            {
+                var scheme = dark
+                    ? Ghostty.Interop.GhosttyColorScheme.Dark
+                    : Ghostty.Interop.GhosttyColorScheme.Light;
+                Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, scheme);
+                _host.NotifyColorSchemeChanged(scheme);
+            });
         };
 
         // Apply initial backdrop (Mica when opaque, transparent when

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -208,7 +208,10 @@ public sealed partial class MainWindow : Window
             ? Ghostty.Interop.GhosttyColorScheme.Dark
             : Ghostty.Interop.GhosttyColorScheme.Light;
         Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, initialScheme);
-        _host.NotifyColorSchemeChanged(initialScheme);
+        // NotifyColorSchemeChanged is not called here because no surfaces
+        // exist yet at window construction time. Each surface picks up the
+        // app-level scheme when it initializes. The runtime handler below
+        // covers post-init OS theme changes.
 
         // Subscribe to runtime theme changes. ColorValuesChanged fires on a
         // background thread, so dispatch back to the UI thread before calling

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -882,7 +882,7 @@ public sealed partial class MainWindow : Window
 
     /// <summary>
     /// Apply palette-derived colors to the window chrome when
-    /// windows-shell-theme is enabled.
+    /// window-theme=ghostty is set.
     /// </summary>
     private void ApplyShellTheme()
     {

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -53,7 +53,6 @@ internal sealed class ConfigService : IConfigService
     public uint? CursorColor { get; private set; }
     public uint? CursorTextColor { get; private set; }
     public uint[] AnsiPalette { get; private set; } = new uint[16];
-    public bool ShellThemeEnabled { get; private set; }
     public string CurrentTheme { get; private set; } = "";
     public int DiagnosticsCount { get; private set; }
 
@@ -225,9 +224,6 @@ internal sealed class ConfigService : IConfigService
             CursorTextColor = BackgroundColor;
         }
 
-        ShellThemeEnabled = string.Equals(
-            GetFileValue("windows-shell-theme", "false"),
-            "true", StringComparison.OrdinalIgnoreCase);
         CurrentTheme = GetFileValue("theme", "");
 
         AnsiPalette = GetAllPaletteColors();

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -54,6 +54,19 @@ internal sealed class ConfigService : IConfigService
     public uint? CursorTextColor { get; private set; }
     public uint[] AnsiPalette { get; private set; } = new uint[16];
     public string CurrentTheme { get; private set; } = "";
+
+    /// <summary>
+    /// Parsed light theme name from a conditional theme pair, or null
+    /// if the theme is a single (non-conditional) value.
+    /// </summary>
+    public string? LightTheme { get; private set; }
+
+    /// <summary>
+    /// Parsed dark theme name from a conditional theme pair, or null
+    /// if the theme is a single (non-conditional) value.
+    /// </summary>
+    public string? DarkTheme { get; private set; }
+
     public int DiagnosticsCount { get; private set; }
 
     /// <summary>
@@ -225,6 +238,9 @@ internal sealed class ConfigService : IConfigService
         }
 
         CurrentTheme = GetFileValue("theme", "");
+        var (parsedLight, parsedDark) = ParseThemePair(CurrentTheme);
+        LightTheme = parsedLight;
+        DarkTheme = parsedDark;
 
         AnsiPalette = GetAllPaletteColors();
     }
@@ -494,6 +510,38 @@ internal sealed class ConfigService : IConfigService
             };
         }
         catch (FormatException) { return null; }
+    }
+
+    /// <summary>
+    /// Parse a theme config value into light/dark components.
+    /// Handles: "ThemeName" (single), "light:X,dark:Y" (pair).
+    /// Matches the Zig parser in Config.zig Theme.parseCLI.
+    /// </summary>
+    internal static (string? light, string? dark) ParseThemePair(string theme)
+    {
+        if (string.IsNullOrWhiteSpace(theme))
+            return (null, null);
+
+        var parts = theme.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        string? light = null;
+        string? dark = null;
+
+        foreach (var part in parts)
+        {
+            if (part.StartsWith("light:", StringComparison.OrdinalIgnoreCase))
+                light = part[6..].Trim();
+            else if (part.StartsWith("light=", StringComparison.OrdinalIgnoreCase))
+                light = part[6..].Trim();
+            else if (part.StartsWith("dark:", StringComparison.OrdinalIgnoreCase))
+                dark = part[5..].Trim();
+            else if (part.StartsWith("dark=", StringComparison.OrdinalIgnoreCase))
+                dark = part[5..].Trim();
+        }
+
+        if (light is not null || dark is not null)
+            return (light, dark);
+
+        return (null, null);
     }
 
     private static float? ParseFloat(string value)

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -538,7 +538,9 @@ internal sealed class ConfigService : IConfigService
                 dark = part[5..].Trim();
         }
 
-        if (light is not null || dark is not null)
+        // Zig's Theme.parseCLI requires both light and dark to be present;
+        // a partial pair (e.g. "light:X" alone) is an error. Match that here.
+        if (light is not null && dark is not null)
             return (light, dark);
 
         return (null, null);

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Ghostty.Core.Config;
@@ -205,8 +206,14 @@ internal sealed class ConfigService : IConfigService
         GradientBlend = GetFileValue("background-gradient-blend", "overlay");
         GradientOpacity = ParseFloat(GetFileValue("background-gradient-opacity", "")) ?? 0.05f;
         WindowTheme = GetString("window-theme", "auto");
-        BackgroundColor = GetColor("background", 0x001E1E2E);
-        ForegroundColor = GetColor("foreground", 0x00FFFFFF);
+
+        // For background and foreground we go through GetThemeValue first
+        // because libghostty's _config was finalized with the default
+        // (.light) conditional state, so for a pair theme in dark mode
+        // it would return the LIGHT theme's colors. GetThemeValue resolves
+        // the active theme name (light vs dark) based on OS state.
+        BackgroundColor = ResolveThemedColor("background", 0x001E1E2E);
+        ForegroundColor = ResolveThemedColor("foreground", 0x00FFFFFF);
 
         // cursor-color is a TerminalColor (tagged union) in the Zig
         // config, so it can't be read via ghostty_config_get as a
@@ -323,17 +330,85 @@ internal sealed class ConfigService : IConfigService
         var userVal = GetFileValue(key, "");
         if (!string.IsNullOrEmpty(userVal)) return userVal;
 
-        // Check the active theme file.
-        var theme = GetFileValue("theme", "");
+        // Resolve the active theme name (handles light:X,dark:Y pairs).
+        var theme = ResolveActiveThemeName();
         if (string.IsNullOrEmpty(theme)) return null;
 
+        var themePath = ResolveThemePath(theme);
+        return themePath is null ? null : ReadKeyFromFile(themePath, key);
+    }
+
+    /// <summary>
+    /// Resolve the active theme name from the config file. For a
+    /// conditional theme (light:X,dark:Y), picks X or Y based on the
+    /// current OS color scheme. For a single theme, returns it as-is.
+    /// </summary>
+    private string ResolveActiveThemeName()
+    {
+        var raw = GetFileValue("theme", "");
+        if (string.IsNullOrEmpty(raw)) return "";
+
+        var (light, dark) = ParseThemePair(raw);
+        if (light is null || dark is null) return raw;
+
+        return IsOsDark() ? dark : light;
+    }
+
+    /// <summary>
+    /// Find the theme file on disk by name. Looks in the user themes
+    /// directory next to the config file. Returns null if not found.
+    /// </summary>
+    private string? ResolveThemePath(string themeName)
+    {
         var configDir = Path.GetDirectoryName(ConfigFilePath);
         if (string.IsNullOrEmpty(configDir)) return null;
+        var themePath = Path.Combine(configDir, "themes", themeName);
+        return File.Exists(themePath) ? themePath : null;
+    }
 
-        var themePath = Path.Combine(configDir, "themes", theme);
-        if (!File.Exists(themePath)) return null;
+    /// <summary>
+    /// Read a color, preferring user config over the active theme file
+    /// over the libghostty default. This is needed because libghostty's
+    /// _config is finalized with the default (.light) conditional state,
+    /// so for pair themes in dark mode it returns the wrong colors.
+    /// </summary>
+    private uint ResolveThemedColor(string key, uint defaultValue)
+    {
+        // 1. User config override.
+        var userVal = GetFileValue(key, "");
+        if (!string.IsNullOrEmpty(userVal))
+        {
+            if (ThemeParser.TryParseHexRgb(userVal, out var packed))
+                return packed;
+        }
 
-        foreach (var line in File.ReadLines(themePath))
+        // 2. Active theme file (resolves light:X,dark:Y by OS state).
+        var themeName = ResolveActiveThemeName();
+        if (!string.IsNullOrEmpty(themeName))
+        {
+            var themePath = ResolveThemePath(themeName);
+            if (themePath is not null)
+            {
+                var themeVal = ReadKeyFromFile(themePath, key);
+                if (!string.IsNullOrEmpty(themeVal)
+                    && ThemeParser.TryParseHexRgb(themeVal, out var packed))
+                    return packed;
+            }
+        }
+
+        // 3. Fall back to libghostty's resolved value (light variant or
+        // hard default).
+        return GetColor(key, defaultValue);
+    }
+
+    /// <summary>
+    /// Read a single config key's value from a file. Returns null when
+    /// the key is not found or the file is unreadable.
+    /// </summary>
+    private static string? ReadKeyFromFile(string path, string key)
+    {
+        if (!File.Exists(path)) return null;
+        foreach (var line in File.ReadLines(path))
         {
             var trimmed = line.TrimStart();
             if (trimmed.StartsWith('#')) continue;
@@ -345,6 +420,24 @@ internal sealed class ConfigService : IConfigService
             if (v.Length > 0) return v;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Detect OS dark mode the same way WindowThemeManager does:
+    /// UISettings.Foreground is white in dark mode, black in light.
+    /// </summary>
+    private static bool IsOsDark()
+    {
+        try
+        {
+            var ui = new Windows.UI.ViewManagement.UISettings();
+            var fg = ui.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
+            return fg.R > 128;
+        }
+        catch
+        {
+            return true;
+        }
     }
 
     /// <summary>
@@ -444,9 +537,10 @@ internal sealed class ConfigService : IConfigService
     }
 
     /// <summary>
-    /// Read all 16 palette colors. Reads the config file once and
-    /// parses all "palette = N=#COLOR" entries, falling back to
-    /// xterm defaults for missing indices.
+    /// Read all 16 palette colors. Loads the active theme's palette
+    /// first (resolving light:X,dark:Y to the OS-active variant), then
+    /// applies user-config overrides on top. Falls back to xterm
+    /// defaults for indices that neither source sets.
     /// </summary>
     private uint[] GetAllPaletteColors()
     {
@@ -458,21 +552,19 @@ internal sealed class ConfigService : IConfigService
             0x0000FF, 0xFF00FF, 0x00FFFF, 0xFFFFFF,
         ];
 
-        var allPalette = GetAllFileValues("palette");
-        foreach (var entry in allPalette)
+        // Apply theme palette first (lower priority).
+        var themeName = ResolveActiveThemeName();
+        if (!string.IsNullOrEmpty(themeName))
         {
-            var eqIdx = entry.IndexOf('=');
-            if (eqIdx < 0) continue;
-            var idxStr = entry[..eqIdx].Trim();
-            if (!int.TryParse(idxStr, out var parsedIdx)) continue;
-            if (parsedIdx is < 0 or >= 16) continue;
-            var colorStr = entry[(eqIdx + 1)..].Trim();
-            var parsed = ParseHexColor(colorStr);
-            if (parsed is not null)
-                defaults[parsedIdx] = ((uint)parsed.Value.R << 16)
-                                    | ((uint)parsed.Value.G << 8)
-                                    | parsed.Value.B;
+            var themePath = ResolveThemePath(themeName);
+            if (themePath is not null)
+                ThemeParser.ApplyPaletteFromLines(File.ReadLines(themePath), defaults);
         }
+
+        // Then apply user-config palette overrides on top.
+        ThemeParser.ApplyPaletteFromLines(
+            GetAllFileValues("palette").Select(v => "palette = " + v),
+            defaults);
 
         return defaults;
     }
@@ -514,37 +606,10 @@ internal sealed class ConfigService : IConfigService
 
     /// <summary>
     /// Parse a theme config value into light/dark components.
-    /// Handles: "ThemeName" (single), "light:X,dark:Y" (pair).
-    /// Matches the Zig parser in Config.zig Theme.parseCLI.
+    /// Delegates to <see cref="ThemeParser.ParseThemePair"/>.
     /// </summary>
     internal static (string? light, string? dark) ParseThemePair(string theme)
-    {
-        if (string.IsNullOrWhiteSpace(theme))
-            return (null, null);
-
-        var parts = theme.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-        string? light = null;
-        string? dark = null;
-
-        foreach (var part in parts)
-        {
-            if (part.StartsWith("light:", StringComparison.OrdinalIgnoreCase))
-                light = part[6..].Trim();
-            else if (part.StartsWith("light=", StringComparison.OrdinalIgnoreCase))
-                light = part[6..].Trim();
-            else if (part.StartsWith("dark:", StringComparison.OrdinalIgnoreCase))
-                dark = part[5..].Trim();
-            else if (part.StartsWith("dark=", StringComparison.OrdinalIgnoreCase))
-                dark = part[5..].Trim();
-        }
-
-        // Zig's Theme.parseCLI requires both light and dark to be present;
-        // a partial pair (e.g. "light:X" alone) is an error. Match that here.
-        if (light is not null && dark is not null)
-            return (light, dark);
-
-        return (null, null);
-    }
+        => ThemeParser.ParseThemePair(theme);
 
     private static float? ParseFloat(string value)
     {

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -423,22 +423,11 @@ internal sealed class ConfigService : IConfigService
     }
 
     /// <summary>
-    /// Detect OS dark mode the same way WindowThemeManager does:
-    /// UISettings.Foreground is white in dark mode, black in light.
+    /// Detect OS dark mode via the shared <see cref="OsTheme"/> helper
+    /// so this and <see cref="WindowThemeManager"/> can't drift on the
+    /// "which byte means dark" heuristic.
     /// </summary>
-    private static bool IsOsDark()
-    {
-        try
-        {
-            var ui = new Windows.UI.ViewManagement.UISettings();
-            var fg = ui.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
-            return fg.R > 128;
-        }
-        catch
-        {
-            return true;
-        }
-    }
+    private static bool IsOsDark() => OsTheme.IsDark();
 
     /// <summary>
     /// Read a Windows-only config key directly from the config file.
@@ -561,10 +550,11 @@ internal sealed class ConfigService : IConfigService
                 ThemeParser.ApplyPaletteFromLines(File.ReadLines(themePath), defaults);
         }
 
-        // Then apply user-config palette overrides on top.
-        ThemeParser.ApplyPaletteFromLines(
-            GetAllFileValues("palette").Select(v => "palette = " + v),
-            defaults);
+        // Then apply user-config palette overrides on top. The values
+        // from GetAllFileValues are already raw "N=#RRGGBB" entries,
+        // so use the Values overload instead of re-prefixing every
+        // entry with "palette = " just to let the parser re-match it.
+        ThemeParser.ApplyPaletteFromValues(GetAllFileValues("palette"), defaults);
 
         return defaults;
     }

--- a/windows/Ghostty/Services/OsTheme.cs
+++ b/windows/Ghostty/Services/OsTheme.cs
@@ -1,0 +1,24 @@
+using Windows.UI.ViewManagement;
+
+namespace Ghostty.Services;
+
+/// <summary>
+/// Detect the current OS light/dark mode. Centralised here so the
+/// "which byte of which color means dark" rule can't drift between
+/// callers -- <see cref="WindowThemeManager"/> and
+/// <see cref="ConfigService"/> historically had two copies.
+/// </summary>
+internal static class OsTheme
+{
+    /// <summary>
+    /// True when the OS is currently in dark mode.
+    /// UISettings.Foreground is white (R greater than 128) in dark
+    /// mode (light text on dark background) and black in light mode.
+    /// </summary>
+    public static bool IsDark()
+    {
+        var ui = new UISettings();
+        var fg = ui.GetColorValue(UIColorType.Foreground);
+        return fg.R > 128;
+    }
+}

--- a/windows/Ghostty/Services/ShellThemeService.cs
+++ b/windows/Ghostty/Services/ShellThemeService.cs
@@ -22,7 +22,7 @@ internal sealed class ShellThemeService
     public Windows.UI.Color ScrollbarTrack { get; private set; }
     public Windows.UI.Color ScrollbarThumb { get; private set; }
 
-    public bool IsEnabled => _configService.ShellThemeEnabled;
+    public bool IsEnabled => _configService.WindowTheme == "ghostty";
 
     private bool _wasEnabled;
 

--- a/windows/Ghostty/Services/ShellThemeService.cs
+++ b/windows/Ghostty/Services/ShellThemeService.cs
@@ -22,7 +22,7 @@ internal sealed class ShellThemeService
     public Windows.UI.Color ScrollbarTrack { get; private set; }
     public Windows.UI.Color ScrollbarThumb { get; private set; }
 
-    public bool IsEnabled => _configService.WindowTheme == "ghostty";
+    public bool IsEnabled => string.Equals(_configService.WindowTheme, "ghostty", StringComparison.OrdinalIgnoreCase);
 
     private bool _wasEnabled;
 

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -39,12 +39,6 @@ internal sealed class WindowThemeManager : IDisposable
     /// </summary>
     public ElementTheme ElementTheme => IsDarkMode ? ElementTheme.Dark : ElementTheme.Light;
 
-    /// <summary>
-    /// True when window-theme is "ghostty", meaning ShellThemeService
-    /// should derive chrome colors from the terminal palette.
-    /// </summary>
-    public bool IsGhosttyMode { get; private set; }
-
     public WindowThemeManager(IConfigService configService, DispatcherQueue dispatcher)
     {
         _configService = configService;
@@ -105,10 +99,7 @@ internal sealed class WindowThemeManager : IDisposable
 
     private void Resolve()
     {
-        var theme = _configService.WindowTheme;
-        IsGhosttyMode = theme == "ghostty";
-
-        IsDarkMode = theme switch
+        IsDarkMode = _configService.WindowTheme switch
         {
             "light" => false,
             "dark" => true,

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -39,6 +39,12 @@ internal sealed class WindowThemeManager : IDisposable
     /// </summary>
     public ElementTheme ElementTheme => IsDarkMode ? ElementTheme.Dark : ElementTheme.Light;
 
+    /// <summary>
+    /// True when window-theme is "ghostty", meaning ShellThemeService
+    /// should derive chrome colors from the terminal palette.
+    /// </summary>
+    public bool IsGhosttyMode { get; private set; }
+
     public WindowThemeManager(IConfigService configService, DispatcherQueue dispatcher)
     {
         _configService = configService;
@@ -99,12 +105,16 @@ internal sealed class WindowThemeManager : IDisposable
 
     private void Resolve()
     {
-        IsDarkMode = _configService.WindowTheme switch
+        var theme = _configService.WindowTheme;
+        IsGhosttyMode = theme == "ghostty";
+
+        IsDarkMode = theme switch
         {
             "light" => false,
             "dark" => true,
             "system" => IsSystemDark(),
             "auto" => IsBackgroundDark(),
+            "ghostty" => IsBackgroundDark(),
             _ => true, // default to dark
         };
     }

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -113,16 +113,13 @@ internal sealed class WindowThemeManager : IDisposable
     }
 
     /// <summary>
-    /// Check whether the OS is currently in dark mode by reading
-    /// the foreground color from UISettings. White foreground means
-    /// dark mode (light text on dark background).
+    /// Check whether the OS is currently in dark mode. Uses the
+    /// shared <see cref="OsTheme"/> helper; we keep the
+    /// <see cref="_uiSettings"/> instance for the ColorValuesChanged
+    /// subscription but route the actual dark-mode read through the
+    /// shared heuristic so it can't diverge from ConfigService.
     /// </summary>
-    private bool IsSystemDark()
-    {
-        var fg = _uiSettings.GetColorValue(
-            Windows.UI.ViewManagement.UIColorType.Foreground);
-        return fg.R > 128;
-    }
+    private static bool IsSystemDark() => OsTheme.IsDark();
 
     /// <summary>
     /// Derive theme from the terminal background color luminance,

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -105,6 +105,8 @@ internal sealed class WindowThemeManager : IDisposable
             "dark" => true,
             "system" => IsSystemDark(),
             "auto" => IsBackgroundDark(),
+            // ghostty: chrome colors come from the palette via ShellThemeService,
+            // so XAML theme follows palette luminance just like "auto".
             "ghostty" => IsBackgroundDark(),
             _ => true, // default to dark
         };

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -15,12 +15,8 @@
                 <ComboBoxItem Content="System" Tag="system" />
                 <ComboBoxItem Content="Light" Tag="light" />
                 <ComboBoxItem Content="Dark" Tag="dark" />
+                <ComboBoxItem Content="Ghostty" Tag="ghostty" />
             </ComboBox>
-
-            <ToggleSwitch
-                x:Name="ShellThemeToggle"
-                Header="Shell follows terminal theme"
-                Toggled="ShellTheme_Toggled" />
 
             <AutoSuggestBox
                 x:Name="FontFamilySearch"

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -33,7 +33,6 @@ internal sealed partial class AppearancePage : Page
         // runtime type is different (e.g. in tests).
         if (configService is ConfigService cs)
         {
-            ShellThemeToggle.IsOn = cs.ShellThemeEnabled;
             SelectComboByTag(BackgroundStyleCombo, cs.BackgroundStyle);
             BlurFollowsOpacityToggle.IsOn = cs.BackgroundBlurFollowsOpacity;
             if (cs.BackgroundTintColor.HasValue)
@@ -197,12 +196,6 @@ internal sealed partial class AppearancePage : Page
     {
         if (sender is ToggleSwitch ts)
             OnValueChanged("background-blur-follows-opacity", ts.IsOn ? "true" : "false");
-    }
-
-    private void ShellTheme_Toggled(object sender, RoutedEventArgs e)
-    {
-        if (sender is ToggleSwitch ts)
-            OnValueChanged("windows-shell-theme", ts.IsOn ? "true" : "false");
     }
 
     private void TintColor_LostFocus(object sender, RoutedEventArgs e)

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml
@@ -7,11 +7,38 @@
         <StackPanel Spacing="8" MaxWidth="600">
             <TextBlock Text="Colors" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
 
+            <!-- Theme mode selector: single theme or separate light/dark -->
+            <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,0,4">
+                <TextBlock Text="Theme" VerticalAlignment="Center"
+                           Style="{StaticResource BodyStrongTextBlockStyle}" />
+                <RadioButton x:Name="SingleModeRadio" Content="Single"
+                             GroupName="ThemeMode" IsChecked="True"
+                             Checked="ThemeMode_Changed" />
+                <RadioButton x:Name="PairModeRadio" Content="Light &amp; Dark"
+                             GroupName="ThemeMode"
+                             Checked="ThemeMode_Changed" />
+            </StackPanel>
+
+            <!-- Single theme picker (visible in single mode) -->
             <AutoSuggestBox
                 x:Name="ThemeSearch"
                 Header="Theme"
                 PlaceholderText="Search themes..."
                 QueryIcon="Find" />
+
+            <!-- Light/dark theme pickers (visible in pair mode) -->
+            <StackPanel x:Name="PairThemePanel" Spacing="8" Visibility="Collapsed">
+                <AutoSuggestBox
+                    x:Name="LightThemeSearch"
+                    Header="Light theme"
+                    PlaceholderText="Search themes..."
+                    QueryIcon="Find" />
+                <AutoSuggestBox
+                    x:Name="DarkThemeSearch"
+                    Header="Dark theme"
+                    PlaceholderText="Search themes..."
+                    QueryIcon="Find" />
+            </StackPanel>
 
             <TextBox Header="Foreground" PlaceholderText="#cdd6f4" LostFocus="Foreground_LostFocus" />
             <TextBox Header="Background" PlaceholderText="#1e1e2e" LostFocus="Background_LostFocus" />

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Ghostty.Core.Config;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
@@ -10,6 +11,8 @@ internal sealed partial class ColorsPage : Page
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
     private readonly SearchableList _themeList;
+    private readonly SearchableList _lightThemeList;
+    private readonly SearchableList _darkThemeList;
     private bool _loading = true;
 
     public ColorsPage(IConfigService configService, IConfigFileEditor editor, IThemeProvider theme)
@@ -17,14 +20,84 @@ internal sealed partial class ColorsPage : Page
         _configService = configService;
         _editor = editor;
         InitializeComponent();
-        _themeList = new SearchableList(ThemeSearch, chosen => OnValueChanged("theme", chosen));
-        _themeList.SetItems(theme.AvailableThemes);
 
-        // Show the current theme in the search box.
-        if (configService is ConfigService cs && !string.IsNullOrEmpty(cs.CurrentTheme))
-            ThemeSearch.Text = cs.CurrentTheme;
+        _themeList = new SearchableList(ThemeSearch, chosen => OnThemeChosen(chosen));
+        _lightThemeList = new SearchableList(LightThemeSearch, _ => OnPairThemeChosen());
+        _darkThemeList = new SearchableList(DarkThemeSearch, _ => OnPairThemeChosen());
+
+        var themes = theme.AvailableThemes;
+        _themeList.SetItems(themes);
+        _lightThemeList.SetItems(themes);
+        _darkThemeList.SetItems(themes);
+
+        // Determine initial mode from current config.
+        if (configService is ConfigService cs)
+        {
+            var currentTheme = cs.CurrentTheme;
+            if (cs.LightTheme is not null || cs.DarkTheme is not null)
+            {
+                // Pair mode.
+                SingleModeRadio.IsChecked = false;
+                PairModeRadio.IsChecked = true;
+                ThemeSearch.Visibility = Visibility.Collapsed;
+                PairThemePanel.Visibility = Visibility.Visible;
+                if (cs.LightTheme is not null)
+                    LightThemeSearch.Text = cs.LightTheme;
+                if (cs.DarkTheme is not null)
+                    DarkThemeSearch.Text = cs.DarkTheme;
+            }
+            else
+            {
+                // Single mode (default).
+                if (!string.IsNullOrEmpty(currentTheme))
+                    ThemeSearch.Text = currentTheme;
+            }
+        }
 
         _loading = false;
+    }
+
+    private void ThemeMode_Changed(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+
+        if (PairModeRadio.IsChecked == true)
+        {
+            ThemeSearch.Visibility = Visibility.Collapsed;
+            PairThemePanel.Visibility = Visibility.Visible;
+            ThemeSearch.Text = "";
+        }
+        else
+        {
+            ThemeSearch.Visibility = Visibility.Visible;
+            PairThemePanel.Visibility = Visibility.Collapsed;
+            LightThemeSearch.Text = "";
+            DarkThemeSearch.Text = "";
+        }
+    }
+
+    private void OnThemeChosen(string theme)
+    {
+        OnValueChanged("theme", theme);
+    }
+
+    private void OnPairThemeChosen()
+    {
+        var light = LightThemeSearch.Text.Trim();
+        var dark = DarkThemeSearch.Text.Trim();
+
+        // Need both to write a pair.
+        if (string.IsNullOrEmpty(light) || string.IsNullOrEmpty(dark))
+            return;
+
+        // If both are the same, collapse to single theme.
+        if (string.Equals(light, dark, StringComparison.OrdinalIgnoreCase))
+        {
+            OnValueChanged("theme", light);
+            return;
+        }
+
+        OnValueChanged("theme", $"light:{light},dark:{dark}");
     }
 
     private void OnValueChanged(string key, string value)

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -40,10 +40,8 @@ internal sealed partial class ColorsPage : Page
                 PairModeRadio.IsChecked = true;
                 ThemeSearch.Visibility = Visibility.Collapsed;
                 PairThemePanel.Visibility = Visibility.Visible;
-                if (cs.LightTheme is not null)
-                    LightThemeSearch.Text = cs.LightTheme;
-                if (cs.DarkTheme is not null)
-                    DarkThemeSearch.Text = cs.DarkTheme;
+                LightThemeSearch.Text = cs.LightTheme;
+                DarkThemeSearch.Text = cs.DarkTheme;
             }
             else
             {

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -33,7 +33,7 @@ internal sealed partial class ColorsPage : Page
         if (configService is ConfigService cs)
         {
             var currentTheme = cs.CurrentTheme;
-            if (cs.LightTheme is not null || cs.DarkTheme is not null)
+            if (cs.LightTheme is not null && cs.DarkTheme is not null)
             {
                 // Pair mode.
                 SingleModeRadio.IsChecked = false;
@@ -62,24 +62,28 @@ internal sealed partial class ColorsPage : Page
 
         if (PairModeRadio.IsChecked == true)
         {
+            // Switching to pair mode: seed both boxes from the current
+            // single theme so the user sees their selection carried over.
+            var current = ThemeSearch.Text.Trim();
+            if (!string.IsNullOrEmpty(current))
+            {
+                LightThemeSearch.Text = current;
+                DarkThemeSearch.Text = current;
+            }
+
             ThemeSearch.Visibility = Visibility.Collapsed;
             PairThemePanel.Visibility = Visibility.Visible;
-            ThemeSearch.Text = "";
         }
         else
         {
-            ThemeSearch.Visibility = Visibility.Visible;
-            PairThemePanel.Visibility = Visibility.Collapsed;
-
-            // Collapse back to single: pick the dark theme as the default
-            // (most users run dark mode). Clear the pair boxes so re-entering
-            // pair mode starts fresh.
+            // Switching to single mode: pick the dark theme as default
+            // (most users run dark mode), falling back to light.
             var fallback = DarkThemeSearch.Text.Trim();
             if (string.IsNullOrEmpty(fallback))
                 fallback = LightThemeSearch.Text.Trim();
 
-            LightThemeSearch.Text = "";
-            DarkThemeSearch.Text = "";
+            ThemeSearch.Visibility = Visibility.Visible;
+            PairThemePanel.Visibility = Visibility.Collapsed;
 
             if (!string.IsNullOrEmpty(fallback))
             {

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -1,4 +1,3 @@
-using System;
 using Ghostty.Core.Config;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
@@ -71,8 +70,22 @@ internal sealed partial class ColorsPage : Page
         {
             ThemeSearch.Visibility = Visibility.Visible;
             PairThemePanel.Visibility = Visibility.Collapsed;
+
+            // Collapse back to single: pick the dark theme as the default
+            // (most users run dark mode). Clear the pair boxes so re-entering
+            // pair mode starts fresh.
+            var fallback = DarkThemeSearch.Text.Trim();
+            if (string.IsNullOrEmpty(fallback))
+                fallback = LightThemeSearch.Text.Trim();
+
             LightThemeSearch.Text = "";
             DarkThemeSearch.Text = "";
+
+            if (!string.IsNullOrEmpty(fallback))
+            {
+                ThemeSearch.Text = fallback;
+                OnValueChanged("theme", fallback);
+            }
         }
     }
 

--- a/windows/Ghostty/Shell/AcrylicBackdrop.cs
+++ b/windows/Ghostty/Shell/AcrylicBackdrop.cs
@@ -99,6 +99,12 @@ internal sealed partial class AcrylicBackdrop : SystemBackdrop
     /// base class's default-config plumbing. Skipping it avoids the
     /// crash and is safe: our controller is reconfigured whenever the
     /// app state that actually matters to us changes.
+    ///
+    /// We intentionally do not react to XamlRoot theme transitions here
+    /// either -- our tint color and luminosity come from the user's
+    /// config (tint color, tint opacity, luminosity opacity) not from
+    /// system theme resources. A theme change does not change what the
+    /// acrylic should look like.
     /// </summary>
     protected override void OnDefaultSystemBackdropConfigurationChanged(
         ICompositionSupportsSystemBackdrop target,

--- a/windows/Ghostty/Shell/AcrylicBackdrop.cs
+++ b/windows/Ghostty/Shell/AcrylicBackdrop.cs
@@ -81,4 +81,29 @@ internal sealed partial class AcrylicBackdrop : SystemBackdrop
         _controller = null;
         _config = null;
     }
+
+    /// <summary>
+    /// WinUI 3 invokes this when it wants subclasses to refresh the
+    /// default <see cref="SystemBackdropConfiguration"/> (typically on
+    /// XamlRoot theme transitions). The base implementation forwards
+    /// the target to native and throws <c>ArgumentException("parameter
+    /// is incorrect")</c> if the target isn't a valid backdrop
+    /// composition root -- which is the case when this fires before
+    /// <see cref="OnTargetConnected"/> has run (e.g. when the backdrop
+    /// is assigned during window construction, before the XAML content
+    /// is attached and the target is wired up).
+    ///
+    /// Since we manage our own <see cref="SystemBackdropConfiguration"/>
+    /// in <see cref="OnTargetConnected"/> and drive tint/luminosity via
+    /// <see cref="UpdateTuning"/> from config reload, we don't need the
+    /// base class's default-config plumbing. Skipping it avoids the
+    /// crash and is safe: our controller is reconfigured whenever the
+    /// app state that actually matters to us changes.
+    /// </summary>
+    protected override void OnDefaultSystemBackdropConfigurationChanged(
+        ICompositionSupportsSystemBackdrop target,
+        XamlRoot xamlRoot)
+    {
+        // Intentionally do not call base. See remarks above.
+    }
 }


### PR DESCRIPTION
## Summary

- Wire per-surface `colorSchemeCallback` so each terminal surface gets notified on OS theme changes (enables per-surface mode 2031 reporting)
- Add `window-theme=ghostty` value that activates palette-derived chrome colors via ShellThemeService, replacing the `windows-shell-theme` config key
- Add conditional theme UI to Colors settings page with Single / Light & Dark mode selector for `theme=light:X,dark:Y` pairs
- Fix AcrylicBackdrop crash when `window-theme=ghostty` combined with `background-style=frosted` (Fixes #234)

## IMPORTANT

This PR is part of a stack. It targets `windows` and should be reviewed independently.

## Changes

12 files changed across 3 logical slices plus the #234 crash fix:

**Slice 1 -- per-surface color scheme callback:**
- `NativeMethods.cs`: add `SurfaceSetColorScheme` P/Invoke
- `GhosttyHost.cs`: add `NotifyColorSchemeChanged()` to iterate surfaces
- `MainWindow.xaml.cs`: call both app-level and per-surface on OS theme change

**Slice 2 -- window-theme=ghostty + deprecate windows-shell-theme:**
- `WindowThemeManager.cs`: add "ghostty" case using bg luminance
- `ShellThemeService.cs`: activate via `WindowTheme == "ghostty"` only
- `ConfigService.cs`: remove `ShellThemeEnabled` and `windows-shell-theme` reading
- `AppearancePage.xaml/.cs`: add Ghostty combo item, remove shell theme toggle

**Slice 3 -- conditional theme UI:**
- `ConfigService.cs`: add `ParseThemePair()`, `LightTheme`/`DarkTheme` properties
- `ColorsPage.xaml/.cs`: radio button mode selector + dual AutoSuggestBox for light/dark theme pairs

**Crash fix:**
- `AcrylicBackdrop.cs`: override `OnDefaultSystemBackdropConfigurationChanged` so WinUI 3's base impl doesn't throw when fired before `OnTargetConnected` has run

## Test plan

- [x] Toggle Windows dark/light mode, verify terminal colors update
- [x] Set `window-theme=ghostty`, verify palette-derived chrome activates (tested with `background-style=solid` end-to-end, and with `frosted` after the #234 crash fix)
- [x] Set `theme=light:Rose Pine Dawn,dark:Rose Pine`, verify correct theme loads per OS mode
- [x] Open settings Colors page, verify mode selector shows correct state
- [x] Pick same theme for both light and dark, verify collapses to single

## Followups

Cosmetic issues surfaced during `window-theme=ghostty` verification, tracked separately:

- #233: acrylic tint should follow terminal bg when `window-theme=ghostty`
- #236: command palette popup ignores window element theme
- #237: tab title low contrast on frosted acrylic with `window-theme=ghostty`

OSC 11 / OSC 10 response verification was dropped from the test plan: Windows ConPTY intercepts dynamic-color queries before they reach Ghostty's VT parser (confirmed via instrumented `processOutput` -- only OSC 0 title arrives; OSC 10/11/12 queries never do). A proper fix requires ConPTY bypass, out of scope here.

Closes deblasis/ghostty#231
