### PR TITLE
refactor(windows): settings reorganization phase 1 (foundation)

### DIFF
--- a/windows/Ghostty.Core/Settings/SettingsEntry.cs
+++ b/windows/Ghostty.Core/Settings/SettingsEntry.cs
@@ -1,0 +1,36 @@
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Shape of a settings control. Used by the future search overlay
+/// to render result rows inline. Phase 1 only needs the values to
+/// exist in the index; no rendering logic consumes this yet.
+/// </summary>
+public enum SettingType
+{
+    Color,
+    Number,
+    Toggle,
+    Combo,
+    Text,
+    Slider,
+    Custom,
+}
+
+/// <summary>
+/// One entry in the hand-maintained settings index. Adding a new
+/// config key to the settings UI requires one new record in
+/// <see cref="SettingsIndex"/>.
+///
+/// This record lives in Ghostty.Core so the index can be unit-tested
+/// without pulling in WinUI 3. The Tags and Description fields drive
+/// the future search overlay; Page and Section drive the current
+/// grouped layout.
+/// </summary>
+public sealed record SettingsEntry(
+    string Key,
+    string Label,
+    string Description,
+    string Page,
+    string Section,
+    string[] Tags,
+    SettingType Type);

--- a/windows/Ghostty.Core/Settings/SettingsEntry.cs
+++ b/windows/Ghostty.Core/Settings/SettingsEntry.cs
@@ -25,6 +25,12 @@ public enum SettingType
 /// without pulling in WinUI 3. The Tags and Description fields drive
 /// the future search overlay; Page and Section drive the current
 /// grouped layout.
+///
+/// Tags is a <see cref="string"/>[] which does not participate in
+/// structural value equality -- two entries with the same Key but
+/// different Tags arrays compare as unequal. This is fine because
+/// entries are only ever looked up by Key; the record is not placed
+/// in a hash set and not compared elsewhere.
 /// </summary>
 public sealed record SettingsEntry(
     string Key,

--- a/windows/Ghostty.Core/Settings/SettingsIndex.cs
+++ b/windows/Ghostty.Core/Settings/SettingsIndex.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Hand-maintained registry of every config key the settings UI edits.
+/// Grouped by Page and Section to match the sidebar + sub-section
+/// layout. Tags drive the future search overlay: typing "color" in
+/// search surfaces every entry whose Tags or Label contains "color".
+///
+/// When adding a new setting to the UI: add one entry here AND
+/// (if applicable) to SettingsIndexTests.ExpectedKeys.
+/// </summary>
+public static class SettingsIndex
+{
+    public static readonly IReadOnlyList<SettingsEntry> All = new SettingsEntry[]
+    {
+        // ----- General -----
+        new("auto-reload-config", "Auto-reload config",
+            "Watch the config file for changes and reload automatically.",
+            "General", "App Behavior",
+            new[] { "reload", "watch", "config" },
+            SettingType.Toggle),
+
+        // ----- Appearance / Window Mode -----
+        new("window-theme", "Window mode",
+            "Light, dark, or follow the system theme. Ghostty derives from terminal background.",
+            "Appearance", "Window Mode",
+            new[] { "theme", "dark", "light", "system", "chrome", "titlebar" },
+            SettingType.Combo),
+
+        // ----- Appearance / Font -----
+        new("font-family", "Font family",
+            "Monospace font used for terminal text.",
+            "Appearance", "Font",
+            new[] { "font", "text", "typography" },
+            SettingType.Text),
+        new("font-size", "Font size",
+            "Point size of the terminal font.",
+            "Appearance", "Font",
+            new[] { "font", "size", "text", "zoom" },
+            SettingType.Number),
+
+        // ----- Appearance / Background Material -----
+        new("background-opacity", "Background opacity",
+            "Transparency of the terminal background (0 = fully transparent, 1 = opaque).",
+            "Appearance", "Background Material",
+            new[] { "opacity", "transparency", "alpha", "background" },
+            SettingType.Slider),
+        new("custom-shader", "Custom shader path",
+            "Path to a GLSL post-process shader file.",
+            "Appearance", "Background Material",
+            new[] { "shader", "glsl", "effect", "post-process" },
+            SettingType.Text),
+        new("background-style", "Backdrop preset",
+            "Solid (Mica), Frosted (Acrylic), or Crystal (zero blur).",
+            "Appearance", "Background Material",
+            new[] { "backdrop", "mica", "acrylic", "crystal", "material" },
+            SettingType.Combo),
+        new("background-blur-follows-opacity", "Blur follows opacity",
+            "Automatically reduce blur as opacity increases.",
+            "Appearance", "Background Material",
+            new[] { "blur", "opacity", "acrylic" },
+            SettingType.Toggle),
+        new("background-tint-color", "Tint color",
+            "Color overlaid on the acrylic backdrop.",
+            "Appearance", "Background Material",
+            new[] { "color", "tint", "acrylic", "background" },
+            SettingType.Color),
+        new("background-tint-opacity", "Tint opacity",
+            "Strength of the acrylic tint color.",
+            "Appearance", "Background Material",
+            new[] { "tint", "opacity", "acrylic" },
+            SettingType.Slider),
+        new("background-luminosity-opacity", "Luminosity opacity",
+            "Strength of the acrylic luminosity layer.",
+            "Appearance", "Background Material",
+            new[] { "luminosity", "opacity", "acrylic" },
+            SettingType.Slider),
+
+        // ----- Appearance / Gradient -----
+        new("background-gradient-blend", "Gradient blend mode",
+            "Whether the gradient renders over or under the terminal text.",
+            "Appearance", "Gradient",
+            new[] { "gradient", "blend", "overlay", "underlay" },
+            SettingType.Combo),
+        new("background-gradient-opacity", "Gradient opacity",
+            "Strength of the gradient tint layer.",
+            "Appearance", "Gradient",
+            new[] { "gradient", "opacity" },
+            SettingType.Slider),
+        new("background-gradient-speed", "Gradient speed",
+            "Animation speed multiplier for gradient motion effects.",
+            "Appearance", "Gradient",
+            new[] { "gradient", "speed", "animation" },
+            SettingType.Slider),
+        new("background-gradient-animation", "Gradient animation",
+            "Motion effects applied to gradient points.",
+            "Appearance", "Gradient",
+            new[] { "gradient", "animation", "motion", "drift", "orbit" },
+            SettingType.Custom),
+        new("background-gradient-point", "Gradient points",
+            "Position, color, and radius of each radial gradient source.",
+            "Appearance", "Gradient",
+            new[] { "gradient", "point", "color", "position" },
+            SettingType.Custom),
+
+        // ----- Colors / Theme -----
+        new("theme", "Color theme",
+            "Named theme file loaded from the themes directory. Supports light:X,dark:Y pairs.",
+            "Colors", "Theme",
+            new[] { "theme", "color", "palette", "scheme" },
+            SettingType.Combo),
+
+        // ----- Colors / Terminal Colors -----
+        new("foreground", "Foreground",
+            "Default text color.",
+            "Colors", "Terminal Colors",
+            new[] { "color", "text", "foreground" },
+            SettingType.Color),
+        new("background", "Background",
+            "Default terminal background color.",
+            "Colors", "Terminal Colors",
+            new[] { "color", "background" },
+            SettingType.Color),
+        new("cursor-color", "Cursor color",
+            "Color of the cursor glyph.",
+            "Colors", "Terminal Colors",
+            new[] { "color", "cursor" },
+            SettingType.Color),
+        new("selection-background", "Selection background",
+            "Background color of selected text.",
+            "Colors", "Terminal Colors",
+            new[] { "color", "selection", "highlight" },
+            SettingType.Color),
+
+        // ----- Terminal -----
+        new("scrollback-limit", "Scrollback limit",
+            "Number of lines retained in the scrollback buffer.",
+            "Terminal", "Scrollback",
+            new[] { "scrollback", "buffer", "history", "lines" },
+            SettingType.Number),
+        new("cursor-style", "Cursor style",
+            "Block, bar, or underline cursor shape.",
+            "Terminal", "Cursor",
+            new[] { "cursor", "shape", "style" },
+            SettingType.Combo),
+        new("cursor-style-blink", "Cursor blink",
+            "Whether the cursor blinks.",
+            "Terminal", "Cursor",
+            new[] { "cursor", "blink", "animation" },
+            SettingType.Toggle),
+        new("mouse-hide-while-typing", "Hide mouse while typing",
+            "Hide the mouse cursor during keyboard input.",
+            "Terminal", "Mouse",
+            new[] { "mouse", "cursor", "hide" },
+            SettingType.Toggle),
+    };
+}

--- a/windows/Ghostty.Core/Settings/SettingsIndex.cs
+++ b/windows/Ghostty.Core/Settings/SettingsIndex.cs
@@ -136,9 +136,9 @@ public static class SettingsIndex
 
         // ----- Terminal -----
         new("scrollback-limit", "Scrollback limit",
-            "Number of lines retained in the scrollback buffer.",
+            "Maximum bytes retained per terminal surface for scrollback (default 10 MB).",
             "Terminal", "Scrollback",
-            new[] { "scrollback", "buffer", "history", "lines" },
+            new[] { "scrollback", "buffer", "history", "bytes", "memory" },
             SettingType.Number),
         new("cursor-style", "Cursor style",
             "Block, bar, or underline cursor shape.",

--- a/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+public class SettingsIndexTests
+{
+    // Every config key the settings UI currently edits must have an
+    // index entry. This test is the forcing function: when a new
+    // page handler calls OnValueChanged("some-key", ...), we want
+    // the build to remind the author to register the key here.
+    //
+    // Keys come from hand-inspecting the existing Pages/*.xaml.cs
+    // files as of 2026-04-14. When new config keys are wired up,
+    // add them to this list AND to SettingsIndex.
+    private static readonly string[] ExpectedKeys =
+    {
+        // General
+        "auto-reload-config",
+        // Appearance
+        "window-theme",
+        "font-family",
+        "font-size",
+        "background-opacity",
+        "custom-shader",
+        "background-style",
+        "background-blur-follows-opacity",
+        "background-tint-color",
+        "background-tint-opacity",
+        "background-luminosity-opacity",
+        "background-gradient-blend",
+        "background-gradient-opacity",
+        "background-gradient-speed",
+        "background-gradient-animation",
+        "background-gradient-point",
+        // Colors
+        "theme",
+        "foreground",
+        "background",
+        "cursor-color",
+        "selection-background",
+        // Terminal
+        "scrollback-limit",
+        "cursor-style",
+        "cursor-style-blink",
+        "mouse-hide-while-typing",
+    };
+
+    [Fact]
+    public void All_contains_entry_for_every_expected_key()
+    {
+        var keys = SettingsIndex.All.Select(e => e.Key).ToHashSet();
+        var missing = ExpectedKeys.Where(k => !keys.Contains(k)).ToList();
+        Assert.True(
+            missing.Count == 0,
+            $"SettingsIndex.All is missing entries for: {string.Join(", ", missing)}");
+    }
+
+    [Fact]
+    public void All_has_no_duplicate_keys()
+    {
+        var duplicates = SettingsIndex.All
+            .GroupBy(e => e.Key)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+        Assert.True(
+            duplicates.Count == 0,
+            $"Duplicate keys in SettingsIndex.All: {string.Join(", ", duplicates)}");
+    }
+
+    [Fact]
+    public void Every_entry_has_non_empty_label_page_section()
+    {
+        foreach (var e in SettingsIndex.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(e.Label), $"Label empty for {e.Key}");
+            Assert.False(string.IsNullOrWhiteSpace(e.Page),  $"Page empty for {e.Key}");
+            Assert.False(string.IsNullOrWhiteSpace(e.Section),$"Section empty for {e.Key}");
+        }
+    }
+
+    [Fact]
+    public void Every_entry_has_at_least_one_tag()
+    {
+        foreach (var e in SettingsIndex.All)
+        {
+            Assert.NotEmpty(e.Tags);
+        }
+    }
+}

--- a/windows/Ghostty/Controls/Settings/SettingsCard.xaml
+++ b/windows/Ghostty/Controls/Settings/SettingsCard.xaml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Controls.Settings.SettingsCard"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+      Atomic row of a settings page. Label + description on the left,
+      control slot on the right. Height and spacing are hard-coded here
+      so every row on every page aligns the same way, eliminating the
+      drift we had before where each page used ad-hoc StackPanel Spacing
+      values. The ConfigKey attached property is reserved for Phase 3
+      (search) to scroll to + pulse a specific card.
+    -->
+    <Border
+        Padding="16,10"
+        MinHeight="68"
+        CornerRadius="{ThemeResource ControlCornerRadius}"
+        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+        BorderThickness="1"
+        Margin="0,0,0,6">
+        <Grid ColumnSpacing="16" VerticalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
+                <TextBlock
+                    x:Name="HeaderText"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    x:Name="DescriptionText"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    TextWrapping="Wrap"
+                    Visibility="Collapsed" />
+            </StackPanel>
+
+            <ContentPresenter
+                x:Name="ControlPresenter"
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                HorizontalAlignment="Right" />
+        </Grid>
+    </Border>
+</UserControl>

--- a/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
@@ -1,0 +1,100 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+
+namespace Ghostty.Controls.Settings;
+
+/// <summary>
+/// Atomic row of a settings page: bold label, optional muted
+/// description, and a right-aligned control slot. Consumers put the
+/// actual input control (ToggleSwitch, ComboBox, Slider, ColorPicker,
+/// etc.) inside as child content.
+///
+/// Header and Description are exposed as dependency properties so
+/// XAML consumers can write Header="Font size" without touching
+/// code-behind. ConfigKey is reserved for Phase 3 (search overlay) --
+/// it tags the card for scroll-to and pulse animation.
+/// </summary>
+[ContentProperty(Name = nameof(Control))]
+public sealed partial class SettingsCard : UserControl
+{
+    public SettingsCard()
+    {
+        InitializeComponent();
+    }
+
+    public static readonly DependencyProperty HeaderProperty =
+        DependencyProperty.Register(
+            nameof(Header),
+            typeof(string),
+            typeof(SettingsCard),
+            new PropertyMetadata(string.Empty, OnHeaderChanged));
+
+    public string Header
+    {
+        get => (string)GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    private static void OnHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var card = (SettingsCard)d;
+        card.HeaderText.Text = (string)(e.NewValue ?? string.Empty);
+    }
+
+    public static readonly DependencyProperty DescriptionProperty =
+        DependencyProperty.Register(
+            nameof(Description),
+            typeof(string),
+            typeof(SettingsCard),
+            new PropertyMetadata(string.Empty, OnDescriptionChanged));
+
+    public string Description
+    {
+        get => (string)GetValue(DescriptionProperty);
+        set => SetValue(DescriptionProperty, value);
+    }
+
+    private static void OnDescriptionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var card = (SettingsCard)d;
+        var text = (string)(e.NewValue ?? string.Empty);
+        card.DescriptionText.Text = text;
+        card.DescriptionText.Visibility =
+            string.IsNullOrWhiteSpace(text) ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    public static readonly DependencyProperty ControlProperty =
+        DependencyProperty.Register(
+            nameof(Control),
+            typeof(object),
+            typeof(SettingsCard),
+            new PropertyMetadata(null, OnControlChanged));
+
+    public object? Control
+    {
+        get => GetValue(ControlProperty);
+        set => SetValue(ControlProperty, value);
+    }
+
+    private static void OnControlChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var card = (SettingsCard)d;
+        card.ControlPresenter.Content = e.NewValue;
+    }
+
+    // Reserved for Phase 3: search scroll + pulse animation targets
+    // this attached property to find the card for a given config key.
+    public static readonly DependencyProperty ConfigKeyProperty =
+        DependencyProperty.RegisterAttached(
+            "ConfigKey",
+            typeof(string),
+            typeof(SettingsCard),
+            new PropertyMetadata(string.Empty));
+
+    public static string GetConfigKey(DependencyObject obj) =>
+        (string)obj.GetValue(ConfigKeyProperty);
+
+    public static void SetConfigKey(DependencyObject obj, string value) =>
+        obj.SetValue(ConfigKeyProperty, value);
+}

--- a/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
@@ -64,16 +64,20 @@ public sealed partial class SettingsCard : UserControl
             string.IsNullOrWhiteSpace(text) ? Visibility.Collapsed : Visibility.Visible;
     }
 
+    // Typed as UIElement (not object) so passing a plain string or a
+    // view-model is a compile error instead of silently rendering as
+    // text inside the ContentPresenter. XAML children still flow in
+    // through the ContentProperty attribute.
     public static readonly DependencyProperty ControlProperty =
         DependencyProperty.Register(
             nameof(Control),
-            typeof(object),
+            typeof(UIElement),
             typeof(SettingsCard),
             new PropertyMetadata(null, OnControlChanged));
 
-    public object? Control
+    public UIElement? Control
     {
-        get => GetValue(ControlProperty);
+        get => (UIElement?)GetValue(ControlProperty);
         set => SetValue(ControlProperty, value);
     }
 

--- a/windows/Ghostty/Controls/Settings/SettingsGroup.xaml
+++ b/windows/Ghostty/Controls/Settings/SettingsGroup.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Controls.Settings.SettingsGroup"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+      Vertical section: bold section title, optional muted subtitle,
+      then a stack of SettingsCard children. The container itself is
+      an ItemsControl so XAML consumers can drop cards directly as
+      children without nesting in a StackPanel.
+    -->
+    <StackPanel Spacing="4" Margin="0,0,0,20">
+        <TextBlock
+            x:Name="HeaderText"
+            Style="{StaticResource BodyStrongTextBlockStyle}"
+            FontSize="16"
+            Margin="0,0,0,2" />
+        <TextBlock
+            x:Name="DescriptionText"
+            Style="{StaticResource CaptionTextBlockStyle}"
+            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+            TextWrapping="Wrap"
+            Margin="0,0,0,4"
+            Visibility="Collapsed" />
+        <ItemsControl x:Name="CardsPresenter" />
+    </StackPanel>
+</UserControl>

--- a/windows/Ghostty/Controls/Settings/SettingsGroup.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/SettingsGroup.xaml.cs
@@ -1,0 +1,71 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using System.Collections.ObjectModel;
+
+namespace Ghostty.Controls.Settings;
+
+/// <summary>
+/// Section heading with a vertical list of settings cards.
+/// Header and Description are dependency properties; child cards
+/// are the Content (Items) of an inner ItemsControl.
+///
+/// Matches the Section field of <see cref="Ghostty.Core.Settings.SettingsEntry"/>
+/// so the page layout mirrors the index exactly.
+/// </summary>
+[ContentProperty(Name = nameof(Cards))]
+public sealed partial class SettingsGroup : UserControl
+{
+    public SettingsGroup()
+    {
+        InitializeComponent();
+        Cards = new ObservableCollection<object>();
+        CardsPresenter.ItemsSource = Cards;
+    }
+
+    public static readonly DependencyProperty HeaderProperty =
+        DependencyProperty.Register(
+            nameof(Header),
+            typeof(string),
+            typeof(SettingsGroup),
+            new PropertyMetadata(string.Empty, OnHeaderChanged));
+
+    public string Header
+    {
+        get => (string)GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    private static void OnHeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var g = (SettingsGroup)d;
+        g.HeaderText.Text = (string)(e.NewValue ?? string.Empty);
+    }
+
+    public static readonly DependencyProperty DescriptionProperty =
+        DependencyProperty.Register(
+            nameof(Description),
+            typeof(string),
+            typeof(SettingsGroup),
+            new PropertyMetadata(string.Empty, OnDescriptionChanged));
+
+    public string Description
+    {
+        get => (string)GetValue(DescriptionProperty);
+        set => SetValue(DescriptionProperty, value);
+    }
+
+    private static void OnDescriptionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var g = (SettingsGroup)d;
+        var text = (string)(e.NewValue ?? string.Empty);
+        g.DescriptionText.Text = text;
+        g.DescriptionText.Visibility =
+            string.IsNullOrWhiteSpace(text) ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    // Observable so adding cards at runtime repaints. Typed as object
+    // rather than SettingsCard so a Task (future) could embed a
+    // custom control directly without wrapping it.
+    public ObservableCollection<object> Cards { get; }
+}

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -60,7 +60,9 @@ internal sealed class ConfigService : IConfigService
     public string CursorStyle { get; private set; } = "block";
     public bool CursorBlink { get; private set; }
     public bool MouseHideWhileTyping { get; private set; }
-    public int ScrollbackLimit { get; private set; } = 10000;
+    // scrollback-limit is bytes in ghostty, not lines. Zig default is
+    // 10_000_000 (10 MB) per terminal surface -- see Config.zig.
+    public int ScrollbackLimit { get; private set; } = 10_000_000;
 
     // Font settings snapshot (for settings UI to display current values).
     public string FontFamily { get; private set; } = "";
@@ -314,16 +316,20 @@ internal sealed class ConfigService : IConfigService
             GetFileValue("mouse-hide-while-typing", "false"),
             "true", StringComparison.OrdinalIgnoreCase);
         if (int.TryParse(
-                GetFileValue("scrollback-limit", "10000"),
+                GetFileValue("scrollback-limit", "10000000"),
                 System.Globalization.NumberStyles.Integer,
                 System.Globalization.CultureInfo.InvariantCulture,
                 out var scrollback))
         {
-            ScrollbackLimit = Math.Clamp(scrollback, 0, 1_000_000);
+            // Upper bound is int.MaxValue (~2 GB) so we don't silently
+            // truncate realistic byte values. Zig uses usize which is
+            // wider, but the settings UI only needs to display what the
+            // user typed; anything bigger than 2 GB is exotic.
+            ScrollbackLimit = Math.Clamp(scrollback, 0, int.MaxValue);
         }
         else
         {
-            ScrollbackLimit = 10000;
+            ScrollbackLimit = 10_000_000;
         }
 
         // Font settings (used by settings UI for initial display).

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -56,6 +56,16 @@ internal sealed class ConfigService : IConfigService
     public uint[] AnsiPalette { get; private set; } = new uint[16];
     public string CurrentTheme { get; private set; } = "";
 
+    // Terminal settings snapshot (for settings UI to display current values).
+    public string CursorStyle { get; private set; } = "block";
+    public bool CursorBlink { get; private set; }
+    public bool MouseHideWhileTyping { get; private set; }
+    public int ScrollbackLimit { get; private set; } = 10000;
+
+    // Font settings snapshot (for settings UI to display current values).
+    public string FontFamily { get; private set; } = "";
+    public double FontSize { get; private set; } = 13.0;
+
     /// <summary>
     /// Parsed light theme name from a conditional theme pair, or null
     /// if the theme is a single (non-conditional) value.
@@ -291,6 +301,16 @@ internal sealed class ConfigService : IConfigService
         var (parsedLight, parsedDark) = ThemeParser.ParseThemePair(CurrentTheme);
         LightTheme = parsedLight;
         DarkTheme = parsedDark;
+
+        // Terminal settings (used by settings UI for initial display).
+        CursorStyle = GetString("cursor-style", "block");
+        CursorBlink = GetBool("cursor-style-blink");
+        MouseHideWhileTyping = GetBool("mouse-hide-while-typing");
+        ScrollbackLimit = (int)Math.Clamp(GetDouble("scrollback-limit", 10000.0), 0, 1_000_000);
+
+        // Font settings (used by settings UI for initial display).
+        FontFamily = GetString("font-family", "");
+        FontSize = Math.Clamp(GetDouble("font-size", 13.0), 6.0, 72.0);
 
         AnsiPalette = GetAllPaletteColors();
     }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -303,14 +303,47 @@ internal sealed class ConfigService : IConfigService
         DarkTheme = parsedDark;
 
         // Terminal settings (used by settings UI for initial display).
-        CursorStyle = GetString("cursor-style", "block");
-        CursorBlink = GetBool("cursor-style-blink");
-        MouseHideWhileTyping = GetBool("mouse-hide-while-typing");
-        ScrollbackLimit = (int)Math.Clamp(GetDouble("scrollback-limit", 10000.0), 0, 1_000_000);
+        // Read from the config file cache instead of ghostty_config_get:
+        // some keys (booleans, enums, repeatable lists like font-family)
+        // don't round-trip cleanly through the native getter.
+        CursorStyle = GetFileValue("cursor-style", "block");
+        CursorBlink = string.Equals(
+            GetFileValue("cursor-style-blink", "false"),
+            "true", StringComparison.OrdinalIgnoreCase);
+        MouseHideWhileTyping = string.Equals(
+            GetFileValue("mouse-hide-while-typing", "false"),
+            "true", StringComparison.OrdinalIgnoreCase);
+        if (int.TryParse(
+                GetFileValue("scrollback-limit", "10000"),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var scrollback))
+        {
+            ScrollbackLimit = Math.Clamp(scrollback, 0, 1_000_000);
+        }
+        else
+        {
+            ScrollbackLimit = 10000;
+        }
 
         // Font settings (used by settings UI for initial display).
-        FontFamily = GetString("font-family", "");
-        FontSize = Math.Clamp(GetDouble("font-size", 13.0), 6.0, 72.0);
+        // font-family is a repeatable list in Zig; the file cache gives
+        // us the first user-set value, which is what the settings UI
+        // wants to display. font-size is f32 in Zig, but we parse the
+        // raw string to avoid the f32/f64 reinterpret pitfall.
+        FontFamily = GetFileValue("font-family", "");
+        if (double.TryParse(
+                GetFileValue("font-size", "13"),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var fontSize))
+        {
+            FontSize = Math.Clamp(fontSize, 6.0, 72.0);
+        }
+        else
+        {
+            FontSize = 13.0;
+        }
 
         AnsiPalette = GetAllPaletteColors();
     }

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -1,153 +1,168 @@
 <Page
     x:Class="Ghostty.Settings.Pages.AppearancePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Ghostty.Controls.Settings">
 
     <ScrollViewer Padding="24">
-        <StackPanel Spacing="8" MaxWidth="600">
-            <TextBlock Text="Appearance" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+        <StackPanel MaxWidth="800">
+            <TextBlock Text="Appearance" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,20" />
 
-            <ComboBox
-                x:Name="WindowThemeCombo"
-                Header="Window theme"
-                SelectionChanged="WindowTheme_SelectionChanged">
-                <ComboBoxItem Content="Auto" Tag="auto" />
-                <ComboBoxItem Content="System" Tag="system" />
-                <ComboBoxItem Content="Light" Tag="light" />
-                <ComboBoxItem Content="Dark" Tag="dark" />
-                <ComboBoxItem Content="Ghostty" Tag="ghostty" />
-            </ComboBox>
+            <ctrl:SettingsGroup Header="Window Mode"
+                                Description="How the window chrome and title bar look.">
+                <ctrl:SettingsCard Header="Window mode"
+                                   Description="Auto derives from background luminosity. Ghostty colors the title bar from the terminal palette."
+                                   ctrl:SettingsCard.ConfigKey="window-theme">
+                    <ComboBox x:Name="WindowThemeCombo" MinWidth="160"
+                              SelectionChanged="WindowTheme_SelectionChanged">
+                        <ComboBoxItem Content="Auto" Tag="auto" />
+                        <ComboBoxItem Content="System" Tag="system" />
+                        <ComboBoxItem Content="Light" Tag="light" />
+                        <ComboBoxItem Content="Dark" Tag="dark" />
+                        <ComboBoxItem Content="Ghostty" Tag="ghostty" />
+                    </ComboBox>
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
 
-            <AutoSuggestBox
-                x:Name="FontFamilySearch"
-                Header="Font family"
-                PlaceholderText="Search fonts..."
-                QueryIcon="Find" />
+            <ctrl:SettingsGroup Header="Font"
+                                Description="Typography used by terminal content.">
+                <ctrl:SettingsCard Header="Font family"
+                                   ctrl:SettingsCard.ConfigKey="font-family">
+                    <AutoSuggestBox x:Name="FontFamilySearch"
+                                    PlaceholderText="Search fonts..."
+                                    QueryIcon="Find"
+                                    MinWidth="260" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Font size"
+                                   ctrl:SettingsCard.ConfigKey="font-size">
+                    <NumberBox x:Name="FontSizeBox" Value="13"
+                               Minimum="6" Maximum="72"
+                               SpinButtonPlacementMode="Compact"
+                               MinWidth="100"
+                               ValueChanged="FontSize_ValueChanged" />
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
 
-            <NumberBox
-                x:Name="FontSizeBox"
-                Header="Font size"
-                Value="13"
-                Minimum="6"
-                Maximum="72"
-                SpinButtonPlacementMode="Compact"
-                ValueChanged="FontSize_ValueChanged" />
+            <ctrl:SettingsGroup Header="Background Material"
+                                Description="Window transparency, blur, and tint.">
+                <ctrl:SettingsCard Header="Background opacity"
+                                   Description="0 is fully transparent, 1 is opaque."
+                                   ctrl:SettingsCard.ConfigKey="background-opacity">
+                    <Slider x:Name="OpacitySlider"
+                            Minimum="0" Maximum="1" StepFrequency="0.05"
+                            TickFrequency="0.1" TickPlacement="BottomRight"
+                            Value="1" MinWidth="240"
+                            ValueChanged="Opacity_ValueChanged" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Custom shader"
+                                   Description="Path to a GLSL post-process shader."
+                                   ctrl:SettingsCard.ConfigKey="custom-shader">
+                    <TextBox x:Name="ShaderPathBox"
+                             PlaceholderText="Path to .glsl shader file"
+                             MinWidth="300"
+                             LostFocus="ShaderPath_LostFocus" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Backdrop preset"
+                                   Description="Mica, Acrylic, or no-blur Crystal."
+                                   ctrl:SettingsCard.ConfigKey="background-style">
+                    <ComboBox x:Name="BackgroundStyleCombo" MinWidth="180"
+                              SelectionChanged="BackgroundStyle_SelectionChanged">
+                        <ComboBoxItem Content="Solid (Mica)" Tag="solid" />
+                        <ComboBoxItem Content="Frosted (Acrylic)" Tag="frosted" />
+                        <ComboBoxItem Content="Crystal (Zero blur)" Tag="crystal" />
+                    </ComboBox>
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Blur follows opacity"
+                                   Description="Reduce blur automatically as opacity rises."
+                                   ctrl:SettingsCard.ConfigKey="background-blur-follows-opacity">
+                    <ToggleSwitch x:Name="BlurFollowsOpacityToggle"
+                                  Toggled="BlurFollowsOpacity_Toggled" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Acrylic tint color"
+                                   ctrl:SettingsCard.ConfigKey="background-tint-color">
+                    <TextBox x:Name="TintColorBox" PlaceholderText="#RRGGBB"
+                             MinWidth="160" LostFocus="TintColor_LostFocus" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Acrylic tint opacity"
+                                   ctrl:SettingsCard.ConfigKey="background-tint-opacity">
+                    <Slider x:Name="TintOpacitySlider"
+                            Minimum="0" Maximum="1" StepFrequency="0.05"
+                            TickFrequency="0.1" TickPlacement="BottomRight"
+                            Value="0.3" MinWidth="240"
+                            ValueChanged="TintOpacity_ValueChanged" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Acrylic luminosity opacity"
+                                   ctrl:SettingsCard.ConfigKey="background-luminosity-opacity">
+                    <Slider x:Name="LuminosityOpacitySlider"
+                            Minimum="0" Maximum="1" StepFrequency="0.05"
+                            TickFrequency="0.1" TickPlacement="BottomRight"
+                            Value="0.3" MinWidth="240"
+                            ValueChanged="LuminosityOpacity_ValueChanged" />
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
 
-            <Slider
-                x:Name="OpacitySlider"
-                Header="Background opacity"
-                Minimum="0"
-                Maximum="1"
-                StepFrequency="0.05"
-                TickFrequency="0.1"
-                TickPlacement="BottomRight"
-                Value="1"
-                ValueChanged="Opacity_ValueChanged" />
+            <ctrl:SettingsGroup Header="Gradient"
+                                Description="Optional animated radial gradient overlay.">
+                <ctrl:SettingsCard Header="Enable gradient tint">
+                    <ToggleSwitch x:Name="GradientEnabledToggle"
+                                  IsOn="False"
+                                  Toggled="GradientEnabled_Toggled" />
+                </ctrl:SettingsCard>
 
-            <TextBox
-                x:Name="ShaderPathBox"
-                Header="Custom shader path"
-                PlaceholderText="Path to .glsl shader file"
-                LostFocus="ShaderPath_LostFocus" />
+                <!--
+                  The gradient sub-panel is preserved from the original
+                  AppearancePage. The numeric-only gradient point editor
+                  is slated for replacement in Phase 4 with a visual editor.
+                -->
+                <StackPanel x:Name="GradientSettingsPanel" Spacing="8" Visibility="Collapsed">
 
-            <TextBlock Text="Background Style" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,24,0,8" />
+                    <ComboBox x:Name="GradientBlendCombo" Header="Blend mode"
+                              SelectionChanged="GradientBlend_SelectionChanged">
+                        <ComboBoxItem Content="Overlay (on top of content)" Tag="overlay" />
+                        <ComboBoxItem Content="Underlay (behind content)" Tag="underlay" />
+                    </ComboBox>
 
-            <ComboBox x:Name="BackgroundStyleCombo" Header="Backdrop preset"
-                      SelectionChanged="BackgroundStyle_SelectionChanged">
-                <ComboBoxItem Content="Solid (Mica)" Tag="solid" />
-                <ComboBoxItem Content="Frosted (Acrylic)" Tag="frosted" />
-                <ComboBoxItem Content="Crystal (Zero blur)" Tag="crystal" />
-            </ComboBox>
+                    <Slider x:Name="GradientOpacitySlider"
+                            Header="Gradient opacity"
+                            Minimum="0" Maximum="1" StepFrequency="0.01"
+                            TickFrequency="0.1" TickPlacement="BottomRight"
+                            Value="0.05"
+                            ValueChanged="GradientOpacity_ValueChanged" />
 
-            <ToggleSwitch
-                x:Name="BlurFollowsOpacityToggle"
-                Header="Background blur follows opacity"
-                Toggled="BlurFollowsOpacity_Toggled" />
+                    <!-- Animation mode picker -->
+                    <TextBlock Text="Position animation" Margin="0,8,0,4" />
+                    <RadioButtons x:Name="PositionAnimRadio" SelectedIndex="0"
+                                  SelectionChanged="AnimationMode_Changed">
+                        <RadioButton Content="None" Tag="" />
+                        <RadioButton Content="Drift (subtle)" Tag="drift" />
+                        <RadioButton Content="Orbit (circular)" Tag="orbit" />
+                        <RadioButton Content="Wander (random)" Tag="wander" />
+                        <RadioButton Content="Bounce (edges)" Tag="bounce" />
+                    </RadioButtons>
 
-            <TextBox
-                x:Name="TintColorBox"
-                Header="Acrylic tint color"
-                PlaceholderText="#RRGGBB"
-                LostFocus="TintColor_LostFocus" />
+                    <CheckBox x:Name="BreatheCheck" Content="Breathe (pulsing size)"
+                              Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
+                    <CheckBox x:Name="ColorCycleCheck" Content="Color cycle (hue rotation)"
+                              Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
 
-            <Slider
-                x:Name="TintOpacitySlider"
-                Header="Acrylic tint opacity"
-                Minimum="0"
-                Maximum="1"
-                StepFrequency="0.05"
-                TickFrequency="0.1"
-                TickPlacement="BottomRight"
-                Value="0.3"
-                ValueChanged="TintOpacity_ValueChanged" />
+                    <Slider x:Name="GradientSpeedSlider"
+                            Header="Animation speed"
+                            Minimum="0.1" Maximum="3" StepFrequency="0.1"
+                            Value="1"
+                            ValueChanged="GradientSpeed_ValueChanged" />
 
-            <Slider
-                x:Name="LuminosityOpacitySlider"
-                Header="Acrylic luminosity opacity"
-                Minimum="0"
-                Maximum="1"
-                StepFrequency="0.05"
-                TickFrequency="0.1"
-                TickPlacement="BottomRight"
-                Value="0.3"
-                ValueChanged="LuminosityOpacity_ValueChanged" />
+                    <!-- Gradient points editor -->
+                    <TextBlock Text="Gradient points" Margin="0,12,0,4" />
+                    <TextBlock Text="Up to 5 color points. Each has position (x,y), color, and radius."
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
 
-            <TextBlock Text="Gradient Tint" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,24,0,8" />
+                    <StackPanel x:Name="PointsPanel" Spacing="8" />
 
-            <ToggleSwitch x:Name="GradientEnabledToggle"
-                          Header="Enable gradient tint"
-                          IsOn="False"
-                          Toggled="GradientEnabled_Toggled" />
-
-            <!-- Gradient settings panel, visible only when enabled -->
-            <StackPanel x:Name="GradientSettingsPanel" Spacing="8" Visibility="Collapsed">
-
-                <ComboBox x:Name="GradientBlendCombo" Header="Blend mode"
-                          SelectionChanged="GradientBlend_SelectionChanged">
-                    <ComboBoxItem Content="Overlay (on top of content)" Tag="overlay" />
-                    <ComboBoxItem Content="Underlay (behind content)" Tag="underlay" />
-                </ComboBox>
-
-                <Slider x:Name="GradientOpacitySlider"
-                        Header="Gradient opacity"
-                        Minimum="0" Maximum="1" StepFrequency="0.01"
-                        TickFrequency="0.1" TickPlacement="BottomRight"
-                        Value="0.05"
-                        ValueChanged="GradientOpacity_ValueChanged" />
-
-                <!-- Animation mode picker -->
-                <TextBlock Text="Position animation" Margin="0,8,0,4" />
-                <RadioButtons x:Name="PositionAnimRadio" SelectedIndex="0"
-                              SelectionChanged="AnimationMode_Changed">
-                    <RadioButton Content="None" Tag="" />
-                    <RadioButton Content="Drift (subtle)" Tag="drift" />
-                    <RadioButton Content="Orbit (circular)" Tag="orbit" />
-                    <RadioButton Content="Wander (random)" Tag="wander" />
-                    <RadioButton Content="Bounce (edges)" Tag="bounce" />
-                </RadioButtons>
-
-                <CheckBox x:Name="BreatheCheck" Content="Breathe (pulsing size)"
-                          Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
-                <CheckBox x:Name="ColorCycleCheck" Content="Color cycle (hue rotation)"
-                          Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
-
-                <Slider x:Name="GradientSpeedSlider"
-                        Header="Animation speed"
-                        Minimum="0.1" Maximum="3" StepFrequency="0.1"
-                        Value="1"
-                        ValueChanged="GradientSpeed_ValueChanged" />
-
-                <!-- Gradient points editor -->
-                <TextBlock Text="Gradient points" Margin="0,12,0,4" />
-                <TextBlock Text="Up to 5 color points. Each has position (x,y), color, and radius."
-                           Style="{StaticResource CaptionTextBlockStyle}"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-
-                <StackPanel x:Name="PointsPanel" Spacing="8" />
-
-                <Button Content="Add point" Click="AddPoint_Click"
-                        x:Name="AddPointButton" />
-            </StackPanel>
+                    <Button Content="Add point" Click="AddPoint_Click"
+                            x:Name="AddPointButton" />
+                </StackPanel>
+            </ctrl:SettingsGroup>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -13,13 +13,48 @@
                 <ctrl:SettingsCard Header="Window mode"
                                    Description="Auto derives from background luminosity. Ghostty colors the title bar from the terminal palette."
                                    ctrl:SettingsCard.ConfigKey="window-theme">
-                    <ComboBox x:Name="WindowThemeCombo" MinWidth="160"
+                    <ComboBox x:Name="WindowThemeCombo" MinWidth="260"
                               SelectionChanged="WindowTheme_SelectionChanged">
-                        <ComboBoxItem Content="Auto" Tag="auto" />
-                        <ComboBoxItem Content="System" Tag="system" />
-                        <ComboBoxItem Content="Light" Tag="light" />
-                        <ComboBoxItem Content="Dark" Tag="dark" />
-                        <ComboBoxItem Content="Ghostty" Tag="ghostty" />
+                        <ComboBoxItem Tag="auto">
+                            <StackPanel>
+                                <TextBlock Text="Auto" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <TextBlock Text="Derive from terminal background luminosity."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </ComboBoxItem>
+                        <ComboBoxItem Tag="system">
+                            <StackPanel>
+                                <TextBlock Text="System" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <TextBlock Text="Follow Windows light/dark setting."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </ComboBoxItem>
+                        <ComboBoxItem Tag="light">
+                            <StackPanel>
+                                <TextBlock Text="Light" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <TextBlock Text="Force light title bar and chrome."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </ComboBoxItem>
+                        <ComboBoxItem Tag="dark">
+                            <StackPanel>
+                                <TextBlock Text="Dark" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <TextBlock Text="Force dark title bar and chrome."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </ComboBoxItem>
+                        <ComboBoxItem Tag="ghostty">
+                            <StackPanel>
+                                <TextBlock Text="Ghostty" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <TextBlock Text="Color title bar from the terminal palette."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </StackPanel>
+                        </ComboBoxItem>
                     </ComboBox>
                 </ctrl:SettingsCard>
             </ctrl:SettingsGroup>

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -28,6 +28,14 @@ internal sealed partial class AppearancePage : Page
         OpacitySlider.Value = configService.BackgroundOpacity;
         SelectWindowTheme(configService.WindowTheme);
 
+        // Seed font size from current config before the loading guard
+        // flips off so the ValueChanged handler doesn't fire a redundant
+        // write back to disk.
+        if (configService is ConfigService csFont)
+        {
+            FontSizeBox.Value = csFont.FontSize;
+        }
+
         // Windows-only properties are on the concrete ConfigService, not IConfigService.
         // Cast to read current values for initialization; fall back to defaults if the
         // runtime type is different (e.g. in tests).
@@ -131,6 +139,15 @@ internal sealed partial class AppearancePage : Page
             {
                 _fontList.SetItems(fonts);
                 FontFamilySearch.PlaceholderText = $"Search {fonts.Count} fonts...";
+
+                // Display the currently-configured font so the user sees
+                // what's in use, not an empty placeholder. Reading from
+                // the concrete ConfigService since font-family isn't on
+                // IConfigService.
+                if (_configService is ConfigService cs && !string.IsNullOrEmpty(cs.FontFamily))
+                {
+                    FontFamilySearch.Text = cs.FontFamily;
+                }
             });
         });
     }

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml
@@ -1,49 +1,89 @@
 <Page
     x:Class="Ghostty.Settings.Pages.ColorsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Ghostty.Controls.Settings">
 
     <ScrollViewer Padding="24">
-        <StackPanel Spacing="8" MaxWidth="600">
-            <TextBlock Text="Colors" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+        <StackPanel MaxWidth="800">
+            <TextBlock Text="Colors" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,20" />
 
-            <!-- Theme mode selector: single theme or separate light/dark -->
-            <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,0,4">
-                <TextBlock Text="Theme" VerticalAlignment="Center"
-                           Style="{StaticResource BodyStrongTextBlockStyle}" />
-                <RadioButton x:Name="SingleModeRadio" Content="Single"
-                             GroupName="ThemeMode" IsChecked="True"
-                             Checked="ThemeMode_Changed" />
-                <RadioButton x:Name="PairModeRadio" Content="Light &amp; Dark"
-                             GroupName="ThemeMode"
-                             Checked="ThemeMode_Changed" />
-            </StackPanel>
+            <ctrl:SettingsGroup Header="Theme"
+                                Description="Choose a single palette or separate light and dark themes that follow the system.">
+                <!--
+                  Theme mode radios are a mini section header rather than a
+                  control-in-a-card because they govern which picker below
+                  is visible, not a single config value.
+                -->
+                <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,0,8">
+                    <RadioButton x:Name="SingleModeRadio" Content="Single"
+                                 GroupName="ThemeMode" IsChecked="True"
+                                 Checked="ThemeMode_Changed" />
+                    <RadioButton x:Name="PairModeRadio" Content="Light &amp; Dark"
+                                 GroupName="ThemeMode"
+                                 Checked="ThemeMode_Changed" />
+                </StackPanel>
 
-            <!-- Single theme picker (visible in single mode) -->
-            <AutoSuggestBox
-                x:Name="ThemeSearch"
-                Header="Theme"
-                PlaceholderText="Search themes..."
-                QueryIcon="Find" />
+                <ctrl:SettingsCard
+                    x:Name="SingleThemeCard"
+                    Header="Theme"
+                    Description="Named theme file loaded from the themes directory."
+                    ctrl:SettingsCard.ConfigKey="theme">
+                    <AutoSuggestBox
+                        x:Name="ThemeSearch"
+                        PlaceholderText="Search themes..."
+                        QueryIcon="Find"
+                        MinWidth="260" />
+                </ctrl:SettingsCard>
 
-            <!-- Light/dark theme pickers (visible in pair mode) -->
-            <StackPanel x:Name="PairThemePanel" Spacing="8" Visibility="Collapsed">
-                <AutoSuggestBox
-                    x:Name="LightThemeSearch"
+                <ctrl:SettingsCard
+                    x:Name="LightThemeCard"
                     Header="Light theme"
-                    PlaceholderText="Search themes..."
-                    QueryIcon="Find" />
-                <AutoSuggestBox
-                    x:Name="DarkThemeSearch"
-                    Header="Dark theme"
-                    PlaceholderText="Search themes..."
-                    QueryIcon="Find" />
-            </StackPanel>
+                    Description="Used when the system is in light mode."
+                    Visibility="Collapsed">
+                    <AutoSuggestBox
+                        x:Name="LightThemeSearch"
+                        PlaceholderText="Search themes..."
+                        QueryIcon="Find"
+                        MinWidth="260" />
+                </ctrl:SettingsCard>
 
-            <TextBox Header="Foreground" PlaceholderText="#cdd6f4" LostFocus="Foreground_LostFocus" />
-            <TextBox Header="Background" PlaceholderText="#1e1e2e" LostFocus="Background_LostFocus" />
-            <TextBox Header="Cursor color" PlaceholderText="#f5e0dc" LostFocus="CursorColor_LostFocus" />
-            <TextBox Header="Selection color" PlaceholderText="#585b70" LostFocus="SelectionColor_LostFocus" />
+                <ctrl:SettingsCard
+                    x:Name="DarkThemeCard"
+                    Header="Dark theme"
+                    Description="Used when the system is in dark mode."
+                    Visibility="Collapsed">
+                    <AutoSuggestBox
+                        x:Name="DarkThemeSearch"
+                        PlaceholderText="Search themes..."
+                        QueryIcon="Find"
+                        MinWidth="260" />
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
+
+            <ctrl:SettingsGroup Header="Terminal Colors"
+                                Description="Override individual colors. Takes precedence over the theme.">
+                <ctrl:SettingsCard Header="Foreground"
+                                   Description="Default text color."
+                                   ctrl:SettingsCard.ConfigKey="foreground">
+                    <TextBox x:Name="ForegroundBox" PlaceholderText="#cdd6f4" MinWidth="160" LostFocus="Foreground_LostFocus" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Background"
+                                   Description="Default background color."
+                                   ctrl:SettingsCard.ConfigKey="background">
+                    <TextBox x:Name="BackgroundBox" PlaceholderText="#1e1e2e" MinWidth="160" LostFocus="Background_LostFocus" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Cursor color"
+                                   Description="Color of the cursor glyph."
+                                   ctrl:SettingsCard.ConfigKey="cursor-color">
+                    <TextBox x:Name="CursorColorBox" PlaceholderText="#f5e0dc" MinWidth="160" LostFocus="CursorColor_LostFocus" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Selection background"
+                                   Description="Background color of selected text."
+                                   ctrl:SettingsCard.ConfigKey="selection-background">
+                    <TextBox x:Name="SelectionColorBox" PlaceholderText="#585b70" MinWidth="160" LostFocus="SelectionColor_LostFocus" />
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml
@@ -63,25 +63,31 @@
 
             <ctrl:SettingsGroup Header="Terminal Colors"
                                 Description="Override individual colors. Takes precedence over the theme.">
+                <!--
+                  Color boxes are unnamed on purpose: seeding them with
+                  current values is deferred to Phase 2 (ColorPickerControl).
+                  Until then the placeholder text hints at the expected
+                  hex format.
+                -->
                 <ctrl:SettingsCard Header="Foreground"
                                    Description="Default text color."
                                    ctrl:SettingsCard.ConfigKey="foreground">
-                    <TextBox x:Name="ForegroundBox" PlaceholderText="#cdd6f4" MinWidth="160" LostFocus="Foreground_LostFocus" />
+                    <TextBox PlaceholderText="#cdd6f4" MinWidth="160" LostFocus="Foreground_LostFocus" />
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Background"
                                    Description="Default background color."
                                    ctrl:SettingsCard.ConfigKey="background">
-                    <TextBox x:Name="BackgroundBox" PlaceholderText="#1e1e2e" MinWidth="160" LostFocus="Background_LostFocus" />
+                    <TextBox PlaceholderText="#1e1e2e" MinWidth="160" LostFocus="Background_LostFocus" />
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Cursor color"
                                    Description="Color of the cursor glyph."
                                    ctrl:SettingsCard.ConfigKey="cursor-color">
-                    <TextBox x:Name="CursorColorBox" PlaceholderText="#f5e0dc" MinWidth="160" LostFocus="CursorColor_LostFocus" />
+                    <TextBox PlaceholderText="#f5e0dc" MinWidth="160" LostFocus="CursorColor_LostFocus" />
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Selection background"
                                    Description="Background color of selected text."
                                    ctrl:SettingsCard.ConfigKey="selection-background">
-                    <TextBox x:Name="SelectionColorBox" PlaceholderText="#585b70" MinWidth="160" LostFocus="SelectionColor_LostFocus" />
+                    <TextBox PlaceholderText="#585b70" MinWidth="160" LostFocus="SelectionColor_LostFocus" />
                 </ctrl:SettingsCard>
             </ctrl:SettingsGroup>
         </StackPanel>

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -38,8 +38,9 @@ internal sealed partial class ColorsPage : Page
                 // Pair mode.
                 SingleModeRadio.IsChecked = false;
                 PairModeRadio.IsChecked = true;
-                ThemeSearch.Visibility = Visibility.Collapsed;
-                PairThemePanel.Visibility = Visibility.Visible;
+                SingleThemeCard.Visibility = Visibility.Collapsed;
+                LightThemeCard.Visibility = Visibility.Visible;
+                DarkThemeCard.Visibility = Visibility.Visible;
                 LightThemeSearch.Text = cs.LightTheme;
                 DarkThemeSearch.Text = cs.DarkTheme;
             }
@@ -76,8 +77,9 @@ internal sealed partial class ColorsPage : Page
                 DarkThemeSearch.Text = current;
             }
 
-            ThemeSearch.Visibility = Visibility.Collapsed;
-            PairThemePanel.Visibility = Visibility.Visible;
+            SingleThemeCard.Visibility = Visibility.Collapsed;
+            LightThemeCard.Visibility = Visibility.Visible;
+            DarkThemeCard.Visibility = Visibility.Visible;
         }
         else if (rb == SingleModeRadio)
         {
@@ -87,8 +89,9 @@ internal sealed partial class ColorsPage : Page
             if (string.IsNullOrEmpty(fallback))
                 fallback = LightThemeSearch.Text.Trim();
 
-            ThemeSearch.Visibility = Visibility.Visible;
-            PairThemePanel.Visibility = Visibility.Collapsed;
+            SingleThemeCard.Visibility = Visibility.Visible;
+            LightThemeCard.Visibility = Visibility.Collapsed;
+            DarkThemeCard.Visibility = Visibility.Collapsed;
 
             if (!string.IsNullOrEmpty(fallback))
             {

--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml
@@ -1,28 +1,43 @@
 <Page
     x:Class="Ghostty.Settings.Pages.GeneralPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Ghostty.Controls.Settings">
 
     <ScrollViewer Padding="24">
-        <StackPanel Spacing="8" MaxWidth="600">
-            <TextBlock Text="General" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+        <StackPanel MaxWidth="800">
+            <TextBlock Text="General" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,20" />
 
-            <ToggleSwitch
-                x:Name="AutoReloadToggle"
-                Header="Auto-reload config"
-                OffContent="Manual reload only"
-                OnContent="Watch file for changes"
-                Toggled="AutoReloadToggle_Toggled" />
+            <ctrl:SettingsGroup Header="App Behavior">
+                <ctrl:SettingsCard
+                    Header="Auto-reload config"
+                    Description="Watch the config file for changes and reload automatically."
+                    ctrl:SettingsCard.ConfigKey="auto-reload-config">
+                    <ToggleSwitch
+                        x:Name="AutoReloadToggle"
+                        OffContent="Manual reload only"
+                        OnContent="Watch file for changes"
+                        Toggled="AutoReloadToggle_Toggled" />
+                </ctrl:SettingsCard>
 
-            <ToggleSwitch
-                x:Name="VerticalTabsToggle"
-                Header="Vertical tabs"
-                OffContent="Horizontal tab bar"
-                OnContent="Vertical tab sidebar"
-                Toggled="VerticalTabsToggle_Toggled" />
+                <ctrl:SettingsCard
+                    Header="Vertical tabs"
+                    Description="Arrange tabs in a sidebar instead of a horizontal bar.">
+                    <ToggleSwitch
+                        x:Name="VerticalTabsToggle"
+                        OffContent="Horizontal tab bar"
+                        OnContent="Vertical tab sidebar"
+                        Toggled="VerticalTabsToggle_Toggled" />
+                </ctrl:SettingsCard>
 
-            <Button Content="Reload Configuration" Click="ReloadButton_Click" Margin="0,16,0,0" />
-            <Button Content="Open Config File" Click="OpenFileButton_Click" />
+                <ctrl:SettingsCard Header="Configuration"
+                                   Description="Reload from disk or open the config file in your default editor.">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Button Content="Reload" Click="ReloadButton_Click" />
+                        <Button Content="Open File" Click="OpenFileButton_Click" />
+                    </StackPanel>
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml
@@ -1,36 +1,57 @@
 <Page
     x:Class="Ghostty.Settings.Pages.TerminalPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Ghostty.Controls.Settings">
 
     <ScrollViewer Padding="24">
-        <StackPanel Spacing="8" MaxWidth="600">
-            <TextBlock Text="Terminal" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
+        <StackPanel MaxWidth="800">
+            <TextBlock Text="Terminal" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,20" />
 
-            <NumberBox
-                x:Name="ScrollbackBox"
-                Header="Scrollback limit"
-                Value="10000"
-                Minimum="0"
-                Maximum="1000000"
-                SpinButtonPlacementMode="Compact"
-                ValueChanged="Scrollback_ValueChanged" />
+            <ctrl:SettingsGroup Header="Scrollback">
+                <ctrl:SettingsCard
+                    Header="Scrollback limit"
+                    Description="Number of lines retained in the scrollback buffer."
+                    ctrl:SettingsCard.ConfigKey="scrollback-limit">
+                    <NumberBox
+                        x:Name="ScrollbackBox"
+                        Value="10000"
+                        Minimum="0"
+                        Maximum="1000000"
+                        SpinButtonPlacementMode="Compact"
+                        MinWidth="140"
+                        ValueChanged="Scrollback_ValueChanged" />
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
 
-            <ComboBox
-                x:Name="CursorStyleBox"
-                Header="Cursor style"
-                PlaceholderText="Select..."
-                SelectionChanged="CursorStyle_SelectionChanged" />
+            <ctrl:SettingsGroup Header="Cursor">
+                <ctrl:SettingsCard
+                    Header="Cursor style"
+                    Description="Shape of the text cursor."
+                    ctrl:SettingsCard.ConfigKey="cursor-style">
+                    <ComboBox
+                        x:Name="CursorStyleBox"
+                        PlaceholderText="Select..."
+                        MinWidth="140"
+                        SelectionChanged="CursorStyle_SelectionChanged" />
+                </ctrl:SettingsCard>
 
-            <ToggleSwitch
-                x:Name="CursorBlinkToggle"
-                Header="Cursor blink"
-                Toggled="CursorBlink_Toggled" />
+                <ctrl:SettingsCard
+                    Header="Cursor blink"
+                    Description="Blink the cursor when it has focus."
+                    ctrl:SettingsCard.ConfigKey="cursor-style-blink">
+                    <ToggleSwitch x:Name="CursorBlinkToggle" Toggled="CursorBlink_Toggled" />
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
 
-            <ToggleSwitch
-                x:Name="MouseHideToggle"
-                Header="Hide mouse while typing"
-                Toggled="MouseHide_Toggled" />
+            <ctrl:SettingsGroup Header="Mouse">
+                <ctrl:SettingsCard
+                    Header="Hide mouse while typing"
+                    Description="Hide the pointer during keyboard input."
+                    ctrl:SettingsCard.ConfigKey="mouse-hide-while-typing">
+                    <ToggleSwitch x:Name="MouseHideToggle" Toggled="MouseHide_Toggled" />
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml
@@ -10,16 +10,16 @@
 
             <ctrl:SettingsGroup Header="Scrollback">
                 <ctrl:SettingsCard
-                    Header="Scrollback limit"
-                    Description="Number of lines retained in the scrollback buffer."
+                    Header="Scrollback limit (bytes)"
+                    Description="Maximum bytes retained per surface. Ghostty default is 10 MB (10000000)."
                     ctrl:SettingsCard.ConfigKey="scrollback-limit">
                     <NumberBox
                         x:Name="ScrollbackBox"
-                        Value="10000"
+                        Value="10000000"
                         Minimum="0"
-                        Maximum="1000000"
+                        Maximum="2147483647"
                         SpinButtonPlacementMode="Compact"
-                        MinWidth="140"
+                        MinWidth="160"
                         ValueChanged="Scrollback_ValueChanged" />
                 </ctrl:SettingsCard>
             </ctrl:SettingsGroup>

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
@@ -16,6 +16,19 @@ internal sealed partial class TerminalPage : Page
         _editor = editor;
         InitializeComponent();
         CursorStyleBox.ItemsSource = new[] { "block", "bar", "underline" };
+
+        // Load current values so the UI reflects config on open, not
+        // hard-coded defaults. Windows-only terminal properties are on
+        // the concrete ConfigService; fall back to schema defaults if
+        // the runtime type is different (e.g. in tests).
+        if (configService is Ghostty.Services.ConfigService cs)
+        {
+            ScrollbackBox.Value = cs.ScrollbackLimit;
+            CursorStyleBox.SelectedItem = cs.CursorStyle;
+            CursorBlinkToggle.IsOn = cs.CursorBlink;
+            MouseHideToggle.IsOn = cs.MouseHideWhileTyping;
+        }
+
         _loading = false;
     }
 

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -38,7 +38,19 @@ internal sealed partial class SettingsWindow : Window
         var hwnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
         var appWindow = AppWindow.GetFromWindowId(windowId);
-        appWindow.Resize(new Windows.Graphics.SizeInt32(900, 650));
+        // Settings window is centered on the display the cursor is on,
+        // sized to give room for the new sub-sectioned pages. The
+        // DisplayArea API is the WinUI 3 equivalent of macOS's
+        // NSScreen.mainScreen and handles multi-monitor correctly.
+        const int width = 1100;
+        const int height = 750;
+        var display = Microsoft.UI.Windowing.DisplayArea.GetFromWindowId(
+            windowId,
+            Microsoft.UI.Windowing.DisplayAreaFallback.Primary);
+        var work = display.WorkArea;
+        var x = work.X + (work.Width - width) / 2;
+        var y = work.Y + (work.Height - height) / 2;
+        appWindow.MoveAndResize(new Windows.Graphics.RectInt32(x, y, width, height));
 
         Closed += OnClosed;
         NavView.SelectedItem = NavView.MenuItems[0];


### PR DESCRIPTION
IMPORTANT: Phase 1 of a 5-phase sequence. Each phase is its own PR.

Foundation for the settings reorganization:

- Resize settings window to 1100x750, centered on the active display
- Add reusable SettingsCard and SettingsGroup WinUI controls
- Add SettingsIndex in Ghostty.Core with entries for every current config key (drives future search and section layout)
- Migrate General, Appearance, Colors, Terminal pages to the new card/group layout
- Settings UI now shows current values on open (not hardcoded defaults) for font family, font size, cursor style/blink, scrollback, mouse hide
- Window Mode combo now has two-line items with descriptions for each value

No behavior changes to the config write path. Every event handler and x:Name is preserved.

Runtime application of some terminal-behavior settings (cursor style/blink, mouse-hide-while-typing) remains deferred; tracked in #244.

## Phases

1. Foundation (this PR)
2. ColorPickerControl
3. Search overlay
4. GradientPointsEditor
5. Raw Editor + Diagnostics merge