### PR TITLE
feat(windows): settings reorganization phase 2 (color picker)

### DIFF
--- a/windows/Ghostty.Core/Settings/Hsv.cs
+++ b/windows/Ghostty.Core/Settings/Hsv.cs
@@ -1,0 +1,8 @@
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// HSV color used by the picker UI. H is in degrees [0, 360), S and V
+/// are fractions in [0, 1]. Conversion lives on <see cref="Rgb"/> so
+/// consumers can round-trip without reaching across types.
+/// </summary>
+public readonly record struct Hsv(double H, double S, double V);

--- a/windows/Ghostty.Core/Settings/Rgb.cs
+++ b/windows/Ghostty.Core/Settings/Rgb.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Globalization;
+
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// 24-bit sRGB color used by the settings UI. Parses/formats the
+/// "#RRGGBB" hex strings that libghostty config accepts, and converts
+/// to/from <see cref="Hsv"/> for the ColorPickerControl.
+/// </summary>
+public readonly record struct Rgb(byte R, byte G, byte B)
+{
+    public static bool TryParseHex(string value, out Rgb rgb)
+    {
+        rgb = default;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+
+        var s = value.Trim();
+        if (s.StartsWith('#')) s = s[1..];
+
+        if (s.Length == 3)
+        {
+            // Expand "abc" -> "aabbcc" (standard CSS short form).
+            Span<char> expanded = stackalloc char[6];
+            expanded[0] = s[0]; expanded[1] = s[0];
+            expanded[2] = s[1]; expanded[3] = s[1];
+            expanded[4] = s[2]; expanded[5] = s[2];
+            s = new string(expanded);
+        }
+
+        if (s.Length != 6) return false;
+
+        if (!byte.TryParse(s.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r)) return false;
+        if (!byte.TryParse(s.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g)) return false;
+        if (!byte.TryParse(s.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b)) return false;
+
+        rgb = new Rgb(r, g, b);
+        return true;
+    }
+
+    public string ToHex() => $"#{R:X2}{G:X2}{B:X2}";
+
+    /// <summary>
+    /// Unpack a 24-bit RGB value packed as R in the high byte and B in
+    /// the low byte (the layout used by <c>ConfigService</c>'s color
+    /// properties).
+    /// </summary>
+    public static Rgb FromRgb24(uint packed)
+        => new((byte)((packed >> 16) & 0xFF), (byte)((packed >> 8) & 0xFF), (byte)(packed & 0xFF));
+
+    public Hsv ToHsv()
+    {
+        var r = R / 255.0;
+        var g = G / 255.0;
+        var b = B / 255.0;
+
+        var max = Math.Max(r, Math.Max(g, b));
+        var min = Math.Min(r, Math.Min(g, b));
+        var delta = max - min;
+
+        double h;
+        if (delta == 0)
+        {
+            h = 0;
+        }
+        else if (max == r)
+        {
+            var segment = (g - b) / delta;
+            h = 60 * (segment < 0 ? segment + 6 : segment);
+        }
+        else if (max == g)
+        {
+            h = 60 * ((b - r) / delta + 2);
+        }
+        else
+        {
+            h = 60 * ((r - g) / delta + 4);
+        }
+
+        var s = max == 0 ? 0 : delta / max;
+        return new Hsv(h, s, max);
+    }
+
+    public static Rgb FromHsv(Hsv hsv)
+    {
+        var h = hsv.H % 360;
+        if (h < 0) h += 360;
+        var s = Math.Clamp(hsv.S, 0, 1);
+        var v = Math.Clamp(hsv.V, 0, 1);
+
+        var c = v * s;
+        var hp = h / 60.0;
+        var x = c * (1 - Math.Abs((hp % 2) - 1));
+        var m = v - c;
+
+        double r1, g1, b1;
+        switch ((int)hp)
+        {
+            case 0: r1 = c; g1 = x; b1 = 0; break;
+            case 1: r1 = x; g1 = c; b1 = 0; break;
+            case 2: r1 = 0; g1 = c; b1 = x; break;
+            case 3: r1 = 0; g1 = x; b1 = c; break;
+            case 4: r1 = x; g1 = 0; b1 = c; break;
+            default: r1 = c; g1 = 0; b1 = x; break; // hp in [5, 6)
+        }
+
+        return new Rgb(
+            (byte)Math.Round((r1 + m) * 255),
+            (byte)Math.Round((g1 + m) * 255),
+            (byte)Math.Round((b1 + m) * 255));
+    }
+}

--- a/windows/Ghostty.Core/Settings/Rgb.cs
+++ b/windows/Ghostty.Core/Settings/Rgb.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Globalization;
+using Ghostty.Core.Config;
 
 namespace Ghostty.Core.Settings;
 
@@ -10,31 +10,16 @@ namespace Ghostty.Core.Settings;
 /// </summary>
 public readonly record struct Rgb(byte R, byte G, byte B)
 {
+    // Delegate to ThemeParser so the two hex parsers in Ghostty.Core
+    // don't drift. ThemeParser additionally accepts #AARRGGBB (dropping
+    // alpha); HexBox.MaxLength filters that out at the UI, so the
+    // behavior difference is inert for current callers.
     public static bool TryParseHex(string value, out Rgb rgb)
     {
         rgb = default;
         if (string.IsNullOrWhiteSpace(value)) return false;
-
-        var s = value.Trim();
-        if (s.StartsWith('#')) s = s[1..];
-
-        if (s.Length == 3)
-        {
-            // Expand "abc" -> "aabbcc" (standard CSS short form).
-            Span<char> expanded = stackalloc char[6];
-            expanded[0] = s[0]; expanded[1] = s[0];
-            expanded[2] = s[1]; expanded[3] = s[1];
-            expanded[4] = s[2]; expanded[5] = s[2];
-            s = new string(expanded);
-        }
-
-        if (s.Length != 6) return false;
-
-        if (!byte.TryParse(s.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r)) return false;
-        if (!byte.TryParse(s.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g)) return false;
-        if (!byte.TryParse(s.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b)) return false;
-
-        rgb = new Rgb(r, g, b);
+        if (!ThemeParser.TryParseHexRgb(value.Trim(), out var packed)) return false;
+        rgb = FromRgb24(packed);
         return true;
     }
 
@@ -47,6 +32,12 @@ public readonly record struct Rgb(byte R, byte G, byte B)
     /// </summary>
     public static Rgb FromRgb24(uint packed)
         => new((byte)((packed >> 16) & 0xFF), (byte)((packed >> 8) & 0xFF), (byte)(packed & 0xFF));
+
+    /// <summary>
+    /// Pack into the 0x00RRGGBB layout used by <c>ConfigService</c>'s
+    /// color properties. Inverse of <see cref="FromRgb24"/>.
+    /// </summary>
+    public uint ToRgb24() => ((uint)R << 16) | ((uint)G << 8) | B;
 
     public Hsv ToHsv()
     {

--- a/windows/Ghostty.Tests/Settings/ColorConversionTests.cs
+++ b/windows/Ghostty.Tests/Settings/ColorConversionTests.cs
@@ -59,6 +59,18 @@ public class ColorConversionTests
         Assert.Equal(new Rgb((byte)r, (byte)g, (byte)b), Rgb.FromRgb24(packed));
     }
 
+    [Theory]
+    [InlineData(0xFF, 0x6B, 0x35, 0x00FF6B35u)]
+    [InlineData(0x1E, 0x1E, 0x2E, 0x001E1E2Eu)]
+    [InlineData(0, 0, 0, 0x00000000u)]
+    [InlineData(0xFF, 0xFF, 0xFF, 0x00FFFFFFu)]
+    public void ToRgb24_RoundTripsFromRgb24(int r, int g, int b, uint expected)
+    {
+        var rgb = new Rgb((byte)r, (byte)g, (byte)b);
+        Assert.Equal(expected, rgb.ToRgb24());
+        Assert.Equal(rgb, Rgb.FromRgb24(rgb.ToRgb24()));
+    }
+
     // ---------- HSV <-> RGB ----------
 
     [Theory]

--- a/windows/Ghostty.Tests/Settings/ColorConversionTests.cs
+++ b/windows/Ghostty.Tests/Settings/ColorConversionTests.cs
@@ -1,0 +1,106 @@
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+public class ColorConversionTests
+{
+    // ---------- Hex parsing ----------
+
+    [Theory]
+    [InlineData("#FF6B35", 0xFF, 0x6B, 0x35)]
+    [InlineData("#ff6b35", 0xFF, 0x6B, 0x35)]
+    [InlineData("FF6B35", 0xFF, 0x6B, 0x35)]
+    [InlineData("#000000", 0, 0, 0)]
+    [InlineData("#FFFFFF", 0xFF, 0xFF, 0xFF)]
+    public void TryParseHex_SixDigit_Succeeds(string input, int r, int g, int b)
+    {
+        Assert.True(Rgb.TryParseHex(input, out var rgb));
+        Assert.Equal(new Rgb((byte)r, (byte)g, (byte)b), rgb);
+    }
+
+    [Theory]
+    [InlineData("#abc", 0xAA, 0xBB, 0xCC)]
+    [InlineData("abc", 0xAA, 0xBB, 0xCC)]
+    [InlineData("#f0a", 0xFF, 0x00, 0xAA)]
+    public void TryParseHex_ThreeDigit_ExpandsToSixDigit(string input, int r, int g, int b)
+    {
+        Assert.True(Rgb.TryParseHex(input, out var rgb));
+        Assert.Equal(new Rgb((byte)r, (byte)g, (byte)b), rgb);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("#")]
+    [InlineData("not-a-color")]
+    [InlineData("#12345")]      // wrong length
+    [InlineData("#1234567")]    // wrong length
+    [InlineData("#xyz123")]     // bad digits
+    [InlineData(null)]
+    public void TryParseHex_Invalid_ReturnsFalse(string? input)
+    {
+        Assert.False(Rgb.TryParseHex(input!, out _));
+    }
+
+    [Fact]
+    public void ToHex_EmitsUppercaseWithHash()
+    {
+        Assert.Equal("#FF6B35", new Rgb(0xFF, 0x6B, 0x35).ToHex());
+        Assert.Equal("#000000", new Rgb(0, 0, 0).ToHex());
+    }
+
+    [Theory]
+    [InlineData(0x00FF6B35u, 0xFF, 0x6B, 0x35)]
+    [InlineData(0x001E1E2Eu, 0x1E, 0x1E, 0x2E)]
+    [InlineData(0x00000000u, 0, 0, 0)]
+    [InlineData(0x00FFFFFFu, 0xFF, 0xFF, 0xFF)]
+    public void FromRgb24_UnpacksHighByteFirst(uint packed, int r, int g, int b)
+    {
+        Assert.Equal(new Rgb((byte)r, (byte)g, (byte)b), Rgb.FromRgb24(packed));
+    }
+
+    // ---------- HSV <-> RGB ----------
+
+    [Theory]
+    [InlineData(0xFF, 0x00, 0x00,   0.0, 1.0, 1.0)] // red
+    [InlineData(0x00, 0xFF, 0x00, 120.0, 1.0, 1.0)] // green
+    [InlineData(0x00, 0x00, 0xFF, 240.0, 1.0, 1.0)] // blue
+    [InlineData(0xFF, 0xFF, 0xFF,   0.0, 0.0, 1.0)] // white
+    [InlineData(0x00, 0x00, 0x00,   0.0, 0.0, 0.0)] // black
+    [InlineData(0x80, 0x80, 0x80,   0.0, 0.0, 0.5019608)] // gray
+    public void RgbToHsv_KnownColors(int r, int g, int b, double h, double s, double v)
+    {
+        var hsv = new Rgb((byte)r, (byte)g, (byte)b).ToHsv();
+        Assert.Equal(h, hsv.H, 1);
+        Assert.Equal(s, hsv.S, 3);
+        Assert.Equal(v, hsv.V, 3);
+    }
+
+    [Theory]
+    [InlineData(  0.0, 1.0, 1.0, 0xFF, 0x00, 0x00)]
+    [InlineData(120.0, 1.0, 1.0, 0x00, 0xFF, 0x00)]
+    [InlineData(240.0, 1.0, 1.0, 0x00, 0x00, 0xFF)]
+    [InlineData( 60.0, 1.0, 1.0, 0xFF, 0xFF, 0x00)] // yellow
+    [InlineData(180.0, 1.0, 1.0, 0x00, 0xFF, 0xFF)] // cyan
+    [InlineData(300.0, 1.0, 1.0, 0xFF, 0x00, 0xFF)] // magenta
+    public void HsvToRgb_KnownColors(double h, double s, double v, int r, int g, int b)
+    {
+        var rgb = Rgb.FromHsv(new Hsv(h, s, v));
+        Assert.Equal((byte)r, rgb.R);
+        Assert.Equal((byte)g, rgb.G);
+        Assert.Equal((byte)b, rgb.B);
+    }
+
+    [Theory]
+    [InlineData(0xFF, 0x6B, 0x35)]
+    [InlineData(0xF7, 0xC9, 0x48)]
+    [InlineData(0xCD, 0xD6, 0xF4)]
+    [InlineData(0x1E, 0x1E, 0x2E)]
+    [InlineData(0x12, 0x34, 0x56)]
+    public void RgbHsvRgb_RoundTrip(int r, int g, int b)
+    {
+        var original = new Rgb((byte)r, (byte)g, (byte)b);
+        var roundTrip = Rgb.FromHsv(original.ToHsv());
+        Assert.Equal(original, roundTrip);
+    }
+}

--- a/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml
+++ b/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Controls.Settings.ColorPickerControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+      Inline swatch + hex TextBox + dropdown chevron. The flyout hosts
+      the WinUI ColorPicker (HSV square, hue slider, RGB/hex inputs).
+      Consumers see a Color property (#RRGGBB string) and a ColorChanged
+      event fired only on commit (flyout close or hex box LostFocus),
+      not on every pointer move inside the picker.
+    -->
+    <StackPanel Orientation="Horizontal" Spacing="8">
+        <DropDownButton x:Name="PickerButton" Padding="8,4">
+            <Border x:Name="SwatchBorder" Width="20" Height="20" CornerRadius="2"
+                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                    BorderThickness="1" />
+            <DropDownButton.Flyout>
+                <Flyout x:Name="PickerFlyout" Closed="PickerFlyout_Closed">
+                    <ColorPicker x:Name="Picker"
+                                 IsMoreButtonVisible="False"
+                                 IsHexInputVisible="True"
+                                 IsAlphaEnabled="False"
+                                 ColorChanged="Picker_ColorChanged" />
+                </Flyout>
+            </DropDownButton.Flyout>
+        </DropDownButton>
+        <TextBox x:Name="HexBox"
+                 MinWidth="110"
+                 MaxLength="7"
+                 VerticalAlignment="Center"
+                 LostFocus="HexBox_LostFocus" />
+    </StackPanel>
+</UserControl>

--- a/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml
+++ b/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml
@@ -17,7 +17,9 @@
                     BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                     BorderThickness="1" />
             <DropDownButton.Flyout>
-                <Flyout x:Name="PickerFlyout" Closed="PickerFlyout_Closed">
+                <Flyout x:Name="PickerFlyout"
+                        Opening="PickerFlyout_Opening"
+                        Closed="PickerFlyout_Closed">
                     <ColorPicker x:Name="Picker"
                                  IsMoreButtonVisible="False"
                                  IsHexInputVisible="True"
@@ -30,6 +32,7 @@
                  MinWidth="110"
                  MaxLength="7"
                  VerticalAlignment="Center"
+                 KeyDown="HexBox_KeyDown"
                  LostFocus="HexBox_LostFocus" />
     </StackPanel>
 </UserControl>

--- a/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml.cs
@@ -1,0 +1,169 @@
+using System;
+using Ghostty.Core.Settings;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using WindowsColor = Windows.UI.Color;
+using WindowsColors = Microsoft.UI.Colors;
+
+namespace Ghostty.Controls.Settings;
+
+/// <summary>
+/// Inline color picker: swatch + hex TextBox + flyout with the WinUI
+/// ColorPicker (HSV square, hue slider, RGB/hex inputs). Consumers see
+/// a single <see cref="Color"/> dependency property (a "#RRGGBB"
+/// string) and a <see cref="ColorChanged"/> event that fires only when
+/// the user commits -- flyout close or hex box LostFocus -- so config
+/// writes are not spammed on every pointer move inside the picker.
+///
+/// Windows.UI.Color is aliased to WindowsColor because the control's
+/// own Color dependency property (a string) would otherwise shadow
+/// the type name everywhere in this file.
+/// </summary>
+public sealed partial class ColorPickerControl : UserControl
+{
+    public ColorPickerControl()
+    {
+        InitializeComponent();
+    }
+
+    public static readonly DependencyProperty ColorProperty =
+        DependencyProperty.Register(
+            nameof(Color),
+            typeof(string),
+            typeof(ColorPickerControl),
+            new PropertyMetadata(string.Empty, OnColorPropertyChanged));
+
+    /// <summary>
+    /// Hex color string in "#RRGGBB" form. Setting this externally
+    /// updates the swatch, hex TextBox, and built-in ColorPicker
+    /// without firing <see cref="ColorChanged"/> (reserved for user
+    /// edits only).
+    /// </summary>
+    public string Color
+    {
+        get => (string)GetValue(ColorProperty);
+        set => SetValue(ColorProperty, value);
+    }
+
+    /// <summary>
+    /// Raised when the user commits a new color via the flyout closing
+    /// or the hex box losing focus with a valid value. The argument is
+    /// the new hex string in "#RRGGBB" form.
+    /// </summary>
+    public event EventHandler<string>? ColorChanged;
+
+    // Guards against re-entrancy when the picker or hex box drives the
+    // Color DP: skip pushing the value back into the control that just
+    // raised it (would reset caret position in HexBox etc.).
+    private bool _suppressPush;
+
+    // Null until the user moves something inside the flyout. On first
+    // Picker_ColorChanged we capture the pre-edit Color (which can be
+    // empty -- "no override set"); on flyout close we fire only if the
+    // user actually interacted, regardless of whether the starting
+    // value was empty.
+    private string? _valueAtFlyoutOpen;
+
+    private static void OnColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var control = (ColorPickerControl)d;
+        var hex = (string?)e.NewValue ?? string.Empty;
+        control.ApplyHex(hex, pushToPicker: !control._suppressPush, pushToHexBox: !control._suppressPush);
+    }
+
+    private void ApplyHex(string hex, bool pushToPicker, bool pushToHexBox)
+    {
+        if (!Rgb.TryParseHex(hex, out var rgb))
+        {
+            // Unparseable input. Clear the swatch in every case; only
+            // clear the hex TextBox when we were asked to push (i.e.
+            // the consumer set Color = "" to mean "no override"). When
+            // pushToHexBox is false we're reacting to the user mid-edit
+            // and overwriting their text would steal the caret.
+            SwatchBorder.Background = new SolidColorBrush(WindowsColors.Transparent);
+            if (pushToHexBox) HexBox.Text = string.Empty;
+            return;
+        }
+
+        var normalized = rgb.ToHex();
+        var color = WindowsColor.FromArgb(0xFF, rgb.R, rgb.G, rgb.B);
+        SwatchBorder.Background = new SolidColorBrush(color);
+
+        if (pushToHexBox && HexBox.Text != normalized)
+        {
+            HexBox.Text = normalized;
+        }
+
+        if (pushToPicker)
+        {
+            Picker.Color = color;
+        }
+    }
+
+    private void HexBox_LostFocus(object sender, RoutedEventArgs e)
+    {
+        var input = HexBox.Text;
+        if (!Rgb.TryParseHex(input, out var rgb))
+        {
+            // Revert to last valid value.
+            ApplyHex(Color, pushToPicker: false, pushToHexBox: true);
+            return;
+        }
+
+        var normalized = rgb.ToHex();
+        if (string.Equals(normalized, Color, StringComparison.OrdinalIgnoreCase))
+        {
+            // Value unchanged; still normalize casing in the box.
+            if (HexBox.Text != normalized) HexBox.Text = normalized;
+            return;
+        }
+
+        _suppressPush = true;
+        try
+        {
+            Color = normalized;
+            HexBox.Text = normalized;
+            Picker.Color = WindowsColor.FromArgb(0xFF, rgb.R, rgb.G, rgb.B);
+        }
+        finally
+        {
+            _suppressPush = false;
+        }
+
+        ColorChanged?.Invoke(this, normalized);
+    }
+
+    private void Picker_ColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+    {
+        // Live preview: swatch and hex box reflect the in-progress
+        // pick so the user sees both representations while dragging.
+        // The ColorChanged event itself is deferred to flyout close.
+        // Capture the pre-edit value the first time the picker fires
+        // during this flyout session, even if Color is currently "".
+        _valueAtFlyoutOpen ??= Color;
+
+        var c = args.NewColor;
+        var rgb = new Rgb(c.R, c.G, c.B);
+        var hex = rgb.ToHex();
+
+        SwatchBorder.Background = new SolidColorBrush(c);
+        if (HexBox.Text != hex) HexBox.Text = hex;
+
+        _suppressPush = true;
+        try { Color = hex; }
+        finally { _suppressPush = false; }
+    }
+
+    private void PickerFlyout_Closed(object sender, object e)
+    {
+        if (_valueAtFlyoutOpen is null) return; // never interacted
+
+        var before = _valueAtFlyoutOpen;
+        _valueAtFlyoutOpen = null;
+        if (!string.Equals(Color, before, StringComparison.OrdinalIgnoreCase))
+        {
+            ColorChanged?.Invoke(this, Color);
+        }
+    }
+}

--- a/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/ColorPickerControl.xaml.cs
@@ -2,7 +2,9 @@ using System;
 using Ghostty.Core.Settings;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
+using Windows.System;
 using WindowsColor = Windows.UI.Color;
 using WindowsColors = Microsoft.UI.Colors;
 
@@ -13,8 +15,9 @@ namespace Ghostty.Controls.Settings;
 /// ColorPicker (HSV square, hue slider, RGB/hex inputs). Consumers see
 /// a single <see cref="Color"/> dependency property (a "#RRGGBB"
 /// string) and a <see cref="ColorChanged"/> event that fires only when
-/// the user commits -- flyout close or hex box LostFocus -- so config
-/// writes are not spammed on every pointer move inside the picker.
+/// the user commits -- flyout close, hex box LostFocus, or Enter in
+/// the hex box -- so config writes are not spammed on every pointer
+/// move inside the picker.
 ///
 /// Windows.UI.Color is aliased to WindowsColor because the control's
 /// own Color dependency property (a string) would otherwise shadow
@@ -55,15 +58,17 @@ public sealed partial class ColorPickerControl : UserControl
 
     // Guards against re-entrancy when the picker or hex box drives the
     // Color DP: skip pushing the value back into the control that just
-    // raised it (would reset caret position in HexBox etc.).
+    // raised it (would reset caret position in HexBox etc.). Also
+    // suppresses the picker's ColorChanged side effects (swatch/hex
+    // mirroring) when ApplyHex is the one pushing Picker.Color.
     private bool _suppressPush;
 
-    // Null until the user moves something inside the flyout. On first
-    // Picker_ColorChanged we capture the pre-edit Color (which can be
-    // empty -- "no override set"); on flyout close we fire only if the
-    // user actually interacted, regardless of whether the starting
-    // value was empty.
-    private string? _valueAtFlyoutOpen;
+    // Pre-edit color captured when the flyout actually opens. Null
+    // outside an open flyout session; on close we compare Color
+    // against this to decide whether to fire ColorChanged. Capturing
+    // on Opening (rather than on the first Picker_ColorChanged) keeps
+    // external Color sets from polluting the baseline.
+    private string? _colorAtFlyoutOpen;
 
     private static void OnColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -97,11 +102,25 @@ public sealed partial class ColorPickerControl : UserControl
 
         if (pushToPicker)
         {
-            Picker.Color = color;
+            // Mark this assignment as programmatic so Picker_ColorChanged
+            // ignores the resulting event (mirrors what HexBox_LostFocus
+            // already does for the same reason).
+            _suppressPush = true;
+            try { Picker.Color = color; }
+            finally { _suppressPush = false; }
         }
     }
 
-    private void HexBox_LostFocus(object sender, RoutedEventArgs e)
+    private void HexBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != VirtualKey.Enter) return;
+        CommitHexBox();
+        e.Handled = true;
+    }
+
+    private void HexBox_LostFocus(object sender, RoutedEventArgs e) => CommitHexBox();
+
+    private void CommitHexBox()
     {
         var input = HexBox.Text;
         if (!Rgb.TryParseHex(input, out var rgb))
@@ -136,13 +155,15 @@ public sealed partial class ColorPickerControl : UserControl
 
     private void Picker_ColorChanged(ColorPicker sender, ColorChangedEventArgs args)
     {
+        // Suppress side effects when ApplyHex or CommitHexBox pushed
+        // Picker.Color themselves -- the swatch/hex box are already in
+        // sync, and bouncing through Color = hex here would latch
+        // _colorAtFlyoutOpen to the programmatic value.
+        if (_suppressPush) return;
+
         // Live preview: swatch and hex box reflect the in-progress
         // pick so the user sees both representations while dragging.
         // The ColorChanged event itself is deferred to flyout close.
-        // Capture the pre-edit value the first time the picker fires
-        // during this flyout session, even if Color is currently "".
-        _valueAtFlyoutOpen ??= Color;
-
         var c = args.NewColor;
         var rgb = new Rgb(c.R, c.G, c.B);
         var hex = rgb.ToHex();
@@ -155,12 +176,17 @@ public sealed partial class ColorPickerControl : UserControl
         finally { _suppressPush = false; }
     }
 
+    private void PickerFlyout_Opening(object sender, object e)
+    {
+        _colorAtFlyoutOpen = Color;
+    }
+
     private void PickerFlyout_Closed(object sender, object e)
     {
-        if (_valueAtFlyoutOpen is null) return; // never interacted
+        if (_colorAtFlyoutOpen is null) return;
 
-        var before = _valueAtFlyoutOpen;
-        _valueAtFlyoutOpen = null;
+        var before = _colorAtFlyoutOpen;
+        _colorAtFlyoutOpen = null;
         if (!string.Equals(Color, before, StringComparison.OrdinalIgnoreCase))
         {
             ColorChanged?.Invoke(this, Color);

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -524,6 +524,16 @@ internal sealed class ConfigService : IConfigService
             : defaultValue;
 
     /// <summary>
+    /// True iff the user's config file actually sets a value for this
+    /// key. Distinguishes a user-authored override from an inherited
+    /// theme/default value, which the typed accessors above conflate.
+    /// </summary>
+    public bool IsConfiguredInFile(string key)
+        => _configFileCache is not null
+            && _configFileCache.TryGetValue(key, out var list)
+            && list.Count > 0;
+
+    /// <summary>
     /// Read all values for a repeatable Windows-only config key from
     /// the cached snapshot. Returns each matching line's value in file
     /// order.

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -534,6 +534,14 @@ internal sealed class ConfigService : IConfigService
             && list.Count > 0;
 
     /// <summary>
+    /// Raw cached first-line value for a config key, or empty if not
+    /// set in the user's file. For UI paths that need to display a
+    /// user-authored override for a key without a typed accessor on
+    /// this service (e.g. selection-background).
+    /// </summary>
+    public string GetRawFileValue(string key) => GetFileValue(key, string.Empty);
+
+    /// <summary>
     /// Read all values for a repeatable Windows-only config key from
     /// the cached snapshot. Returns each matching line's value in file
     /// order.

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -115,8 +115,8 @@
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Acrylic tint color"
                                    ctrl:SettingsCard.ConfigKey="background-tint-color">
-                    <TextBox x:Name="TintColorBox" PlaceholderText="#RRGGBB"
-                             MinWidth="160" LostFocus="TintColor_LostFocus" />
+                    <ctrl:ColorPickerControl x:Name="TintColorPicker"
+                                             ColorChanged="TintColor_ColorChanged" />
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Acrylic tint opacity"
                                    ctrl:SettingsCard.ConfigKey="background-tint-opacity">

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Ghostty.Controls.Settings;
 using Ghostty.Core.Config;
 using Ghostty.Core.DirectWrite;
+using Ghostty.Core.Settings;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -46,7 +48,7 @@ internal sealed partial class AppearancePage : Page
             if (cs.BackgroundTintColor.HasValue)
             {
                 var c = cs.BackgroundTintColor.Value;
-                TintColorBox.Text = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+                TintColorPicker.Color = new Rgb(c.R, c.G, c.B).ToHex();
             }
             TintOpacitySlider.Value = cs.BackgroundTintOpacity ?? 0.3;
             LuminosityOpacitySlider.Value = cs.BackgroundLuminosityOpacity ?? 0.3;
@@ -215,10 +217,8 @@ internal sealed partial class AppearancePage : Page
             OnValueChanged("background-blur-follows-opacity", ts.IsOn ? "true" : "false");
     }
 
-    private void TintColor_LostFocus(object sender, RoutedEventArgs e)
-    {
-        if (sender is TextBox tb) OnValueChanged("background-tint-color", tb.Text);
-    }
+    private void TintColor_ColorChanged(object? sender, string hex)
+        => OnValueChanged("background-tint-color", hex);
 
     private void TintOpacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
@@ -286,7 +286,7 @@ internal sealed partial class AppearancePage : Page
             RemovePointEditor);
         editor.XSlider.Value = x;
         editor.YSlider.Value = y;
-        editor.ColorBox.Text = color;
+        editor.ColorPicker.Color = color;
         editor.RadiusSlider.Value = radius;
         _pointEditors.Add(editor);
         PointsPanel.Children.Add(editor.Panel);
@@ -352,7 +352,7 @@ internal sealed partial class AppearancePage : Page
     {
         public Slider XSlider { get; }
         public Slider YSlider { get; }
-        public TextBox ColorBox { get; }
+        public ColorPickerControl ColorPicker { get; }
         public Slider RadiusSlider { get; }
         public Button RemoveButton { get; }
         public StackPanel Panel { get; }
@@ -401,9 +401,18 @@ internal sealed partial class AppearancePage : Page
             YSlider.ValueChanged += (_, _) => onChanged();
             Panel.Children.Add(YSlider);
 
-            ColorBox = new TextBox { Header = "Color", PlaceholderText = "#RRGGBB", Text = "#FF6B35" };
-            ColorBox.LostFocus += (_, _) => onChanged();
-            Panel.Children.Add(ColorBox);
+            // ColorPickerControl has no built-in Header property like TextBox
+            // does, so emit a small caption above it to match the surrounding
+            // sliders' "X position", "Y position" labels.
+            Panel.Children.Add(new TextBlock
+            {
+                Text = "Color",
+                Style = (Style)Microsoft.UI.Xaml.Application.Current.Resources["CaptionTextBlockStyle"],
+                Margin = new Thickness(0, 4, 0, 2)
+            });
+            ColorPicker = new ColorPickerControl { Color = "#FF6B35" };
+            ColorPicker.ColorChanged += (_, _) => onChanged();
+            Panel.Children.Add(ColorPicker);
 
             RadiusSlider = new Slider
             {
@@ -419,7 +428,8 @@ internal sealed partial class AppearancePage : Page
 
         public string ToConfigValue()
         {
-            var color = ColorBox.Text.Trim();
+            var color = ColorPicker.Color;
+            if (string.IsNullOrEmpty(color)) color = "#FF6B35";
             if (!color.StartsWith('#')) color = "#" + color;
             return $"{XSlider.Value:F2},{YSlider.Value:F2},{color},{RadiusSlider.Value:F2}";
         }

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -179,8 +179,8 @@ internal sealed partial class AppearancePage : Page
     {
         if (_loading) return;
         _configService.SuppressWatcher(true);
-        _editor.SetValue(key, value);
-        _configService.SuppressWatcher(false);
+        try { _editor.SetValue(key, value); }
+        finally { _configService.SuppressWatcher(false); }
         _configService.Reload();
     }
 
@@ -256,8 +256,8 @@ internal sealed partial class AppearancePage : Page
         if (!enabled)
         {
             _configService.SuppressWatcher(true);
-            _editor.RemoveValue("background-gradient-point");
-            _configService.SuppressWatcher(false);
+            try { _editor.RemoveValue("background-gradient-point"); }
+            finally { _configService.SuppressWatcher(false); }
             _configService.Reload();
             _pointEditors.Clear();
             PointsPanel.Children.Clear();
@@ -319,8 +319,8 @@ internal sealed partial class AppearancePage : Page
         if (_loading) return;
         var values = _pointEditors.Select(e => e.ToConfigValue()).ToArray();
         _configService.SuppressWatcher(true);
-        _editor.SetRepeatableValues("background-gradient-point", values);
-        _configService.SuppressWatcher(false);
+        try { _editor.SetRepeatableValues("background-gradient-point", values); }
+        finally { _configService.SuppressWatcher(false); }
         _configService.Reload();
     }
 

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml
@@ -63,31 +63,65 @@
 
             <ctrl:SettingsGroup Header="Terminal Colors"
                                 Description="Override individual colors. Takes precedence over the theme.">
-                <!--
-                  Color boxes are unnamed on purpose: seeding them with
-                  current values is deferred to Phase 2 (ColorPickerControl).
-                  Until then the placeholder text hints at the expected
-                  hex format.
-                -->
                 <ctrl:SettingsCard Header="Foreground"
                                    Description="Default text color."
                                    ctrl:SettingsCard.ConfigKey="foreground">
-                    <TextBox PlaceholderText="#cdd6f4" MinWidth="160" LostFocus="Foreground_LostFocus" />
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <ctrl:ColorPickerControl x:Name="ForegroundPicker"
+                                                 ColorChanged="Foreground_ColorChanged" />
+                        <Button x:Name="ForegroundResetButton"
+                                Click="Foreground_Reset"
+                                ToolTipService.ToolTip="Use the theme's value"
+                                Padding="6,4"
+                                Visibility="Collapsed">
+                            <FontIcon Glyph="&#xE894;" FontSize="12" />
+                        </Button>
+                    </StackPanel>
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Background"
                                    Description="Default background color."
                                    ctrl:SettingsCard.ConfigKey="background">
-                    <TextBox PlaceholderText="#1e1e2e" MinWidth="160" LostFocus="Background_LostFocus" />
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <ctrl:ColorPickerControl x:Name="BackgroundPicker"
+                                                 ColorChanged="Background_ColorChanged" />
+                        <Button x:Name="BackgroundResetButton"
+                                Click="Background_Reset"
+                                ToolTipService.ToolTip="Use the theme's value"
+                                Padding="6,4"
+                                Visibility="Collapsed">
+                            <FontIcon Glyph="&#xE894;" FontSize="12" />
+                        </Button>
+                    </StackPanel>
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Cursor color"
                                    Description="Color of the cursor glyph."
                                    ctrl:SettingsCard.ConfigKey="cursor-color">
-                    <TextBox PlaceholderText="#f5e0dc" MinWidth="160" LostFocus="CursorColor_LostFocus" />
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <ctrl:ColorPickerControl x:Name="CursorColorPicker"
+                                                 ColorChanged="CursorColor_ColorChanged" />
+                        <Button x:Name="CursorColorResetButton"
+                                Click="CursorColor_Reset"
+                                ToolTipService.ToolTip="Use the theme's value"
+                                Padding="6,4"
+                                Visibility="Collapsed">
+                            <FontIcon Glyph="&#xE894;" FontSize="12" />
+                        </Button>
+                    </StackPanel>
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Selection background"
                                    Description="Background color of selected text."
                                    ctrl:SettingsCard.ConfigKey="selection-background">
-                    <TextBox PlaceholderText="#585b70" MinWidth="160" LostFocus="SelectionColor_LostFocus" />
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <ctrl:ColorPickerControl x:Name="SelectionColorPicker"
+                                                 ColorChanged="SelectionColor_ColorChanged" />
+                        <Button x:Name="SelectionColorResetButton"
+                                Click="SelectionColor_Reset"
+                                ToolTipService.ToolTip="Use the theme's value"
+                                Padding="6,4"
+                                Visibility="Collapsed">
+                            <FontIcon Glyph="&#xE894;" FontSize="12" />
+                        </Button>
+                    </StackPanel>
                 </ctrl:SettingsCard>
             </ctrl:SettingsGroup>
         </StackPanel>

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -45,10 +45,14 @@ internal sealed partial class ColorsPage : Page
                 () => Rgb.FromRgb24(cs.BackgroundColor).ToHex());
             SyncColorOverride("cursor-color", CursorColorPicker, CursorColorResetButton,
                 () => cs.CursorColor is uint cursor ? Rgb.FromRgb24(cursor).ToHex() : "");
-            // selection-background has no typed accessor on ConfigService;
-            // the user's raw file value is enough to seed the picker.
+            // selection-background has no typed accessor on ConfigService,
+            // so parse the user's raw file value directly. Falls back to
+            // empty if the entry is present but unparseable -- same UX
+            // as "unset" -- rather than crashing the settings page.
             SyncColorOverride("selection-background", SelectionColorPicker, SelectionColorResetButton,
-                () => "");
+                () => ThemeParser.TryParseHexRgb(cs.GetRawFileValue("selection-background"), out var packed)
+                    ? Rgb.FromRgb24(packed).ToHex()
+                    : "");
 
             var currentTheme = cs.CurrentTheme;
             if (cs.LightTheme is not null && cs.DarkTheme is not null)
@@ -147,8 +151,8 @@ internal sealed partial class ColorsPage : Page
     {
         if (_loading) return;
         _configService.SuppressWatcher(true);
-        _editor.SetValue(key, value);
-        _configService.SuppressWatcher(false);
+        try { _editor.SetValue(key, value); }
+        finally { _configService.SuppressWatcher(false); }
         _configService.Reload();
     }
 
@@ -198,8 +202,8 @@ internal sealed partial class ColorsPage : Page
     {
         if (_loading) return;
         _configService.SuppressWatcher(true);
-        _editor.RemoveValue(key);
-        _configService.SuppressWatcher(false);
+        try { _editor.RemoveValue(key); }
+        finally { _configService.SuppressWatcher(false); }
         _configService.Reload();
 
         _loading = true;

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -1,4 +1,7 @@
+using System;
+using Ghostty.Controls.Settings;
 using Ghostty.Core.Config;
+using Ghostty.Core.Settings;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -29,9 +32,24 @@ internal sealed partial class ColorsPage : Page
         _lightThemeList.SetItems(themes);
         _darkThemeList.SetItems(themes);
 
-        // Determine initial mode from current config.
+        // Determine initial mode from current config and seed the
+        // color pickers only for keys the user has actually overridden
+        // in their config file. Inherited theme/default colors should
+        // read as "unset" in the UI so the user can tell at a glance
+        // whether they're customizing or accepting the theme.
         if (configService is ConfigService cs)
         {
+            SyncColorOverride("foreground", ForegroundPicker, ForegroundResetButton,
+                () => Rgb.FromRgb24(cs.ForegroundColor).ToHex());
+            SyncColorOverride("background", BackgroundPicker, BackgroundResetButton,
+                () => Rgb.FromRgb24(cs.BackgroundColor).ToHex());
+            SyncColorOverride("cursor-color", CursorColorPicker, CursorColorResetButton,
+                () => cs.CursorColor is uint cursor ? Rgb.FromRgb24(cursor).ToHex() : "");
+            // selection-background has no typed accessor on ConfigService;
+            // the user's raw file value is enough to seed the picker.
+            SyncColorOverride("selection-background", SelectionColorPicker, SelectionColorResetButton,
+                () => "");
+
             var currentTheme = cs.CurrentTheme;
             if (cs.LightTheme is not null && cs.DarkTheme is not null)
             {
@@ -134,23 +152,77 @@ internal sealed partial class ColorsPage : Page
         _configService.Reload();
     }
 
-    private void Foreground_LostFocus(object sender, RoutedEventArgs e)
+    private void Foreground_ColorChanged(object? sender, string hex)
     {
-        if (sender is TextBox tb) OnValueChanged("foreground", tb.Text);
+        OnValueChanged("foreground", hex);
+        ForegroundResetButton.Visibility = Visibility.Visible;
     }
 
-    private void Background_LostFocus(object sender, RoutedEventArgs e)
+    private void Background_ColorChanged(object? sender, string hex)
     {
-        if (sender is TextBox tb) OnValueChanged("background", tb.Text);
+        OnValueChanged("background", hex);
+        BackgroundResetButton.Visibility = Visibility.Visible;
     }
 
-    private void CursorColor_LostFocus(object sender, RoutedEventArgs e)
+    private void CursorColor_ColorChanged(object? sender, string hex)
     {
-        if (sender is TextBox tb) OnValueChanged("cursor-color", tb.Text);
+        OnValueChanged("cursor-color", hex);
+        CursorColorResetButton.Visibility = Visibility.Visible;
     }
 
-    private void SelectionColor_LostFocus(object sender, RoutedEventArgs e)
+    private void SelectionColor_ColorChanged(object? sender, string hex)
     {
-        if (sender is TextBox tb) OnValueChanged("selection-background", tb.Text);
+        OnValueChanged("selection-background", hex);
+        SelectionColorResetButton.Visibility = Visibility.Visible;
+    }
+
+    private void Foreground_Reset(object sender, RoutedEventArgs e)
+        => ResetColorOverride("foreground", ForegroundPicker, ForegroundResetButton);
+
+    private void Background_Reset(object sender, RoutedEventArgs e)
+        => ResetColorOverride("background", BackgroundPicker, BackgroundResetButton);
+
+    private void CursorColor_Reset(object sender, RoutedEventArgs e)
+        => ResetColorOverride("cursor-color", CursorColorPicker, CursorColorResetButton);
+
+    private void SelectionColor_Reset(object sender, RoutedEventArgs e)
+        => ResetColorOverride("selection-background", SelectionColorPicker, SelectionColorResetButton);
+
+    // Drop the override key from the config file, then clear the picker
+    // and hide the reset button so the row reads as "no override set".
+    // Suppressing the watcher keeps the file-change event from racing
+    // the explicit Reload below; setting Color under the loading guard
+    // blocks the picker's ColorChanged handler from firing a stray
+    // OnValueChanged write back to disk.
+    private void ResetColorOverride(string key, ColorPickerControl picker, Button resetButton)
+    {
+        if (_loading) return;
+        _configService.SuppressWatcher(true);
+        _editor.RemoveValue(key);
+        _configService.SuppressWatcher(false);
+        _configService.Reload();
+
+        _loading = true;
+        try { picker.Color = ""; }
+        finally { _loading = false; }
+        resetButton.Visibility = Visibility.Collapsed;
+    }
+
+    // Seed one color row from the cached config: if the user has actually
+    // set this key in their file, fill the picker and show the reset
+    // button; otherwise leave both empty so the row reads as "unset".
+    private void SyncColorOverride(string key, ColorPickerControl picker, Button resetButton, Func<string> resolvedValue)
+    {
+        if (_configService is not ConfigService cs) return;
+        if (cs.IsConfiguredInFile(key))
+        {
+            picker.Color = resolvedValue();
+            resetButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            picker.Color = "";
+            resetButton.Visibility = Visibility.Collapsed;
+        }
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #245 (phase 1, foundation). Targets `feature/settings-reorganization`; GitHub auto-retargets to `windows` when #245 merges.
>
> Stack order: #245 (phase 1) -> THIS (phase 2) -> phase 3 (search) -> phase 4 (gradient editor) -> phase 5 (raw editor merge).

## What changes

- New `ColorPickerControl` (UserControl) under `Controls/Settings/`. Inline swatch + dropdown chevron + hex TextBox; flyout hosts the WinUI `ColorPicker` (HSV square, hue slider, RGB/hex inputs).
- `ColorsPage` and `AppearancePage` (tint color, gradient points) drop their bare hex TextBoxes for the new control.
- Per-row reset (`x`) on `ColorsPage` color overrides. Drops the key from the config file so the theme's value applies again. Visible only when the key is actually overridden.
- New `Rgb`/`Hsv` types in `Ghostty.Core.Settings` (hex parse + format, HSV<->RGB round-trips, `FromRgb24` to unpack the packed-uint format used on the `ConfigService` color properties). xUnit coverage in `Ghostty.Tests`.
- New `ConfigService.IsConfiguredInFile(key)` distinguishes user overrides from inherited theme/default values. Drives the conditional reset button.

## Out of scope

- Selection background still has no typed accessor on `ConfigService`; the picker just stays empty when unset.
- Gradient point color UX is the same numeric stack as today, just with the new picker per row. The visual 2D editor is phase 4.
- Runtime re-application of color changes is not handled here (same gap as the color overrides had before this PR).

## Test plan

- [x] `dotnet test` (297 pass, +21 new)
- [x] Manual: open Settings -> Colors and Appearance, pick colors via flyout and via hex box.
- [x] Manual: starting from no overrides, pick a color, verify it writes; press `x`, verify the override is removed and the input clears.
- [x] Manual: tint color and gradient point colors edit through the flyout.