### PR TITLE
feat(windows): settings reorganization phase 3 (search overlay)

### DIFF
--- a/windows/Ghostty.Core/Settings/SettingsSearch.cs
+++ b/windows/Ghostty.Core/Settings/SettingsSearch.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Which tier of match an entry produced. Higher enum value == better
+/// match; results sort by this descending. None is used internally and
+/// never surfaces in <see cref="SearchHit"/>.
+///
+/// Tier order is set by the Phase 3 spec; see
+/// docs/superpowers/specs/2026-04-14-settings-reorganization-design.md.
+/// </summary>
+public enum MatchKind
+{
+    None = 0,
+    FuzzyKey = 1,
+    TagContains = 2,
+    TagExact = 3,
+    DescriptionContains = 4,
+    LabelContains = 5,
+    LabelPrefix = 6,
+    ExactLabel = 7,
+}
+
+public sealed record SearchHit(SettingsEntry Entry, MatchKind Kind);
+
+/// <summary>
+/// Tiered substring + fuzzy search over <see cref="SettingsIndex"/>.
+/// Lives in Ghostty.Core so the ranking is unit-tested without pulling
+/// WinUI 3 into the test assembly.
+/// </summary>
+public static class SettingsSearch
+{
+    public static IReadOnlyList<SearchHit> Search(
+        string? query,
+        IEnumerable<SettingsEntry> entries)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return Array.Empty<SearchHit>();
+        var q = query.Trim().ToLowerInvariant();
+
+        var hits = new List<(int InputIndex, SearchHit Hit)>();
+        int i = 0;
+        foreach (var entry in entries)
+        {
+            var kind = Classify(entry, q);
+            if (kind != MatchKind.None)
+                hits.Add((i, new SearchHit(entry, kind)));
+            i++;
+        }
+
+        // Stable sort: tier desc, then original input order within a tier
+        // so UI grouping (by page/section) stays predictable.
+        return hits
+            .OrderByDescending(x => (int)x.Hit.Kind)
+            .ThenBy(x => x.InputIndex)
+            .Select(x => x.Hit)
+            .ToList();
+    }
+
+    private static MatchKind Classify(SettingsEntry e, string q)
+    {
+        var label = e.Label.ToLowerInvariant();
+        if (label == q) return MatchKind.ExactLabel;
+        if (label.StartsWith(q, StringComparison.Ordinal)) return MatchKind.LabelPrefix;
+        if (label.Contains(q, StringComparison.Ordinal)) return MatchKind.LabelContains;
+
+        if (e.Description.Contains(q, StringComparison.OrdinalIgnoreCase))
+            return MatchKind.DescriptionContains;
+
+        var tagExact = false;
+        var tagContains = false;
+        foreach (var tag in e.Tags)
+        {
+            var t = tag.ToLowerInvariant();
+            if (t == q) { tagExact = true; break; }
+            if (t.Contains(q, StringComparison.Ordinal)) tagContains = true;
+        }
+        if (tagExact) return MatchKind.TagExact;
+        if (tagContains) return MatchKind.TagContains;
+
+        if (IsSubsequence(q, e.Key.ToLowerInvariant())) return MatchKind.FuzzyKey;
+
+        return MatchKind.None;
+    }
+
+    // Characters of needle appear in haystack in order (not necessarily
+    // contiguous). Classic fuzzy-finder primitive, kept under the spec's
+    // "under 50 lines" bar.
+    private static bool IsSubsequence(string needle, string haystack)
+    {
+        if (needle.Length == 0) return true;
+        int ni = 0;
+        foreach (var c in haystack)
+        {
+            if (c == needle[ni])
+            {
+                ni++;
+                if (ni == needle.Length) return true;
+            }
+        }
+        return false;
+    }
+}

--- a/windows/Ghostty.Core/Settings/SettingsSearch.cs
+++ b/windows/Ghostty.Core/Settings/SettingsSearch.cs
@@ -38,7 +38,9 @@ public static class SettingsSearch
         IEnumerable<SettingsEntry> entries)
     {
         if (string.IsNullOrWhiteSpace(query)) return Array.Empty<SearchHit>();
-        var q = query.Trim().ToLowerInvariant();
+        // Only trim; comparisons below use OrdinalIgnoreCase so we don't
+        // need to lowercase the query or the entry fields on every hit.
+        var q = query.Trim();
 
         var hits = new List<(int InputIndex, SearchHit Hit)>();
         int i = 0;
@@ -61,10 +63,9 @@ public static class SettingsSearch
 
     private static MatchKind Classify(SettingsEntry e, string q)
     {
-        var label = e.Label.ToLowerInvariant();
-        if (label == q) return MatchKind.ExactLabel;
-        if (label.StartsWith(q, StringComparison.Ordinal)) return MatchKind.LabelPrefix;
-        if (label.Contains(q, StringComparison.Ordinal)) return MatchKind.LabelContains;
+        if (e.Label.Equals(q, StringComparison.OrdinalIgnoreCase)) return MatchKind.ExactLabel;
+        if (e.Label.StartsWith(q, StringComparison.OrdinalIgnoreCase)) return MatchKind.LabelPrefix;
+        if (e.Label.Contains(q, StringComparison.OrdinalIgnoreCase)) return MatchKind.LabelContains;
 
         if (e.Description.Contains(q, StringComparison.OrdinalIgnoreCase))
             return MatchKind.DescriptionContains;
@@ -73,28 +74,28 @@ public static class SettingsSearch
         var tagContains = false;
         foreach (var tag in e.Tags)
         {
-            var t = tag.ToLowerInvariant();
-            if (t == q) { tagExact = true; break; }
-            if (t.Contains(q, StringComparison.Ordinal)) tagContains = true;
+            if (tag.Equals(q, StringComparison.OrdinalIgnoreCase)) { tagExact = true; break; }
+            if (tag.Contains(q, StringComparison.OrdinalIgnoreCase)) tagContains = true;
         }
         if (tagExact) return MatchKind.TagExact;
         if (tagContains) return MatchKind.TagContains;
 
-        if (IsSubsequence(q, e.Key.ToLowerInvariant())) return MatchKind.FuzzyKey;
+        if (IsSubsequenceIgnoreCase(q, e.Key)) return MatchKind.FuzzyKey;
 
         return MatchKind.None;
     }
 
     // Characters of needle appear in haystack in order (not necessarily
     // contiguous). Classic fuzzy-finder primitive, kept under the spec's
-    // "under 50 lines" bar.
-    private static bool IsSubsequence(string needle, string haystack)
+    // "under 50 lines" bar. Case-insensitive via char.ToLowerInvariant so
+    // callers don't have to pre-lowercase the inputs.
+    private static bool IsSubsequenceIgnoreCase(string needle, string haystack)
     {
         if (needle.Length == 0) return true;
         int ni = 0;
         foreach (var c in haystack)
         {
-            if (c == needle[ni])
+            if (char.ToLowerInvariant(c) == char.ToLowerInvariant(needle[ni]))
             {
                 ni++;
                 if (ni == needle.Length) return true;

--- a/windows/Ghostty.Tests/Settings/SettingsSearchTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsSearchTests.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+public class SettingsSearchTests
+{
+    // Match tiers, best → worst, per Phase 3 spec
+    // (docs/superpowers/specs/2026-04-14-settings-reorganization-design.md#matching):
+    //   1. ExactLabel        2. LabelPrefix      3. LabelContains
+    //   4. DescriptionContains  5. TagExact      6. TagContains
+    //   7. FuzzyKey
+    //
+    // Tests use tiny per-test corpora so each assertion isolates one
+    // tier boundary without accidental cross-field hits.
+
+    private static SettingsEntry Make(
+        string key,
+        string label = "Label",
+        string description = "Description.",
+        string[]? tags = null) =>
+        new(key, label, description, "Page", "Section",
+            tags ?? new[] { "misc" }, SettingType.Text);
+
+    [Fact]
+    public void Empty_query_returns_no_hits()
+    {
+        var corpus = new[] { Make("a", label: "Alpha") };
+        Assert.Empty(SettingsSearch.Search("", corpus));
+        Assert.Empty(SettingsSearch.Search("   ", corpus));
+        Assert.Empty(SettingsSearch.Search(null!, corpus));
+    }
+
+    [Fact]
+    public void Exact_label_beats_label_prefix()
+    {
+        var exact  = Make("a", label: "Font");
+        var prefix = Make("b", label: "Font family");
+        var hits = SettingsSearch.Search("Font", new[] { prefix, exact });
+        Assert.Equal("a", hits[0].Entry.Key);
+        Assert.Equal(MatchKind.ExactLabel, hits[0].Kind);
+        Assert.Equal("b", hits[1].Entry.Key);
+        Assert.Equal(MatchKind.LabelPrefix, hits[1].Kind);
+    }
+
+    [Fact]
+    public void Label_prefix_beats_label_contains()
+    {
+        var prefix   = Make("a", label: "Cursor style");
+        var contains = Make("b", label: "Hide cursor while typing");
+        var hits = SettingsSearch.Search("cursor", new[] { contains, prefix });
+        Assert.Equal("a", hits[0].Entry.Key);
+        Assert.Equal(MatchKind.LabelPrefix, hits[0].Kind);
+        Assert.Equal("b", hits[1].Entry.Key);
+        Assert.Equal(MatchKind.LabelContains, hits[1].Kind);
+    }
+
+    [Fact]
+    public void Label_contains_beats_description_contains()
+    {
+        var label = Make("a", label: "Bar foo baz");
+        var desc  = Make("b", label: "Unrelated", description: "Contains foo inside.");
+        var hits = SettingsSearch.Search("foo", new[] { desc, label });
+        Assert.Equal("a", hits[0].Entry.Key);
+        Assert.Equal(MatchKind.LabelContains, hits[0].Kind);
+        Assert.Equal("b", hits[1].Entry.Key);
+        Assert.Equal(MatchKind.DescriptionContains, hits[1].Kind);
+    }
+
+    [Fact]
+    public void Description_contains_beats_tag_exact()
+    {
+        var desc = Make("a", label: "Unrelated", description: "foo appears here.");
+        var tag  = Make("b", label: "Other", description: "Nothing.", tags: new[] { "foo" });
+        var hits = SettingsSearch.Search("foo", new[] { tag, desc });
+        Assert.Equal("a", hits[0].Entry.Key);
+        Assert.Equal(MatchKind.DescriptionContains, hits[0].Kind);
+        Assert.Equal("b", hits[1].Entry.Key);
+        Assert.Equal(MatchKind.TagExact, hits[1].Kind);
+    }
+
+    [Fact]
+    public void Tag_exact_beats_tag_contains()
+    {
+        var exact    = Make("a", tags: new[] { "foo" });
+        var contains = Make("b", tags: new[] { "foobar" });
+        var hits = SettingsSearch.Search("foo", new[] { contains, exact });
+        Assert.Equal("a", hits[0].Entry.Key);
+        Assert.Equal(MatchKind.TagExact, hits[0].Kind);
+        Assert.Equal("b", hits[1].Entry.Key);
+        Assert.Equal(MatchKind.TagContains, hits[1].Kind);
+    }
+
+    [Fact]
+    public void Fuzzy_key_match_is_last_resort()
+    {
+        // "bgop" isn't a substring of any label, description, or tag,
+        // but the characters appear in order in "background-opacity".
+        var entry = Make("background-opacity", label: "Opac", description: "x", tags: new[] { "xxx" });
+        var other = Make("scrollback-limit", label: "Scroll", description: "x", tags: new[] { "yyy" });
+        var hits = SettingsSearch.Search("bgop", new[] { other, entry });
+        Assert.Single(hits);
+        Assert.Equal("background-opacity", hits[0].Entry.Key);
+        Assert.Equal(MatchKind.FuzzyKey, hits[0].Kind);
+    }
+
+    [Fact]
+    public void Fuzzy_key_requires_characters_in_order()
+    {
+        // "ob" is not a subsequence of "abc" (no 'o' before 'b').
+        var entry = Make("abc");
+        Assert.Empty(SettingsSearch.Search("ob", new[] { entry }));
+    }
+
+    [Fact]
+    public void No_match_returns_empty()
+    {
+        var corpus = new[] { Make("a", label: "Alpha") };
+        Assert.Empty(SettingsSearch.Search("zzzqqq", corpus));
+    }
+
+    [Fact]
+    public void Matching_is_case_insensitive()
+    {
+        var corpus = new[]
+        {
+            Make("a", label: "Background"),
+            Make("b", label: "Other", tags: new[] { "BACKGROUND" }),
+        };
+        var lower = SettingsSearch.Search("background", corpus).Select(h => h.Entry.Key);
+        var upper = SettingsSearch.Search("BACKGROUND", corpus).Select(h => h.Entry.Key);
+        Assert.Equal(lower, upper);
+    }
+
+    [Fact]
+    public void Results_are_ordered_by_match_tier_descending()
+    {
+        var entries = new[]
+        {
+            Make("a", label: "Background"),                                     // ExactLabel
+            Make("b", label: "Background opacity"),                             // LabelPrefix
+            Make("c", label: "Colors", description: "background tint layer."),  // DescriptionContains
+            Make("d", label: "Other", tags: new[] { "background" }),            // TagExact
+        };
+        var hits = SettingsSearch.Search("background", entries);
+        var tiers = hits.Select(h => (int)h.Kind).ToList();
+        for (int i = 1; i < tiers.Count; i++)
+        {
+            Assert.True(
+                tiers[i - 1] >= tiers[i],
+                $"tier dropped then rose: {string.Join(", ", tiers)}");
+        }
+    }
+
+    [Fact]
+    public void Each_entry_appears_at_most_once_at_best_tier()
+    {
+        // "foo" matches tag "foo" (exact) AND description ("foo sits...").
+        // Description is a higher tier; only one hit, at that tier.
+        var e = Make("a", label: "Other", description: "foo sits here.", tags: new[] { "foo" });
+        var hits = SettingsSearch.Search("foo", new[] { e });
+        Assert.Single(hits);
+        Assert.Equal(MatchKind.DescriptionContains, hits[0].Kind);
+    }
+
+    [Fact]
+    public void Ties_within_tier_preserve_input_order()
+    {
+        var first  = Make("first",  label: "Background A");
+        var second = Make("second", label: "Background B");
+        var hits = SettingsSearch.Search("background", new[] { first, second });
+        Assert.Equal("first",  hits[0].Entry.Key);
+        Assert.Equal("second", hits[1].Entry.Key);
+    }
+}

--- a/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml
@@ -1,0 +1,38 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.SearchResultsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+      Search results pane, shown in place of a regular page whenever the
+      AutoSuggestBox has a non-empty query. The visible children are
+      built in code-behind (SearchResultsPage.xaml.cs) from
+      SettingsSearch hits, because the groupings are dynamic and
+      a XAML DataTemplateSelector would be heavier than the one-off
+      layout needs.
+    -->
+    <ScrollViewer Padding="24">
+        <StackPanel MaxWidth="800">
+            <TextBlock
+                x:Name="TitleText"
+                Style="{StaticResource TitleTextBlockStyle}"
+                Margin="0,0,0,20" />
+
+            <!-- Filled imperatively with group headers + result rows. -->
+            <StackPanel x:Name="ResultsPanel" />
+
+            <!-- Empty state: "No settings match 'xyz'. [Clear search]". -->
+            <StackPanel
+                x:Name="EmptyPanel"
+                Visibility="Collapsed"
+                Spacing="12"
+                Margin="0,24,0,0">
+                <TextBlock
+                    x:Name="EmptyText"
+                    Style="{StaticResource BodyTextBlockStyle}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                <Button x:Name="ClearButton" Content="Clear search" Click="ClearButton_Click" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Settings;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Settings.Pages;
+
+internal sealed partial class SearchResultsPage : Page
+{
+    private string _query = string.Empty;
+    private Action<string>? _onChosen;
+    private Action? _onClear;
+
+    public SearchResultsPage()
+    {
+        InitializeComponent();
+    }
+
+    public void Show(
+        string query,
+        IReadOnlyList<SearchHit> hits,
+        Action<string> onChosen,
+        Action onClear)
+    {
+        _query = query;
+        _onChosen = onChosen;
+        _onClear = onClear;
+
+        TitleText.Text = hits.Count == 0
+            ? "Search"
+            : $"{hits.Count} result{(hits.Count == 1 ? "" : "s")} for \"{query}\"";
+
+        ResultsPanel.Children.Clear();
+
+        if (hits.Count == 0)
+        {
+            EmptyText.Text = $"No settings match \"{query}\".";
+            EmptyPanel.Visibility = Visibility.Visible;
+            return;
+        }
+
+        EmptyPanel.Visibility = Visibility.Collapsed;
+        BuildGroupedResults(hits);
+    }
+
+    private void BuildGroupedResults(IReadOnlyList<SearchHit> hits)
+    {
+        // Group by Page then Section. Ordering comes from the first
+        // hit seen in each bucket, which preserves the scorer's
+        // tier-desc sort at the top level -- the best page for the
+        // query floats to the top of the results.
+        var byPage = new List<(string Page, List<(string Section, List<SearchHit> Hits)> Sections)>();
+        foreach (var hit in hits)
+        {
+            var pageBucket = byPage.FirstOrDefault(p => p.Page == hit.Entry.Page);
+            if (pageBucket.Page == null)
+            {
+                pageBucket = (hit.Entry.Page, new List<(string, List<SearchHit>)>());
+                byPage.Add(pageBucket);
+            }
+            var sectionBucket = pageBucket.Sections.FirstOrDefault(s => s.Section == hit.Entry.Section);
+            if (sectionBucket.Section == null)
+            {
+                sectionBucket = (hit.Entry.Section, new List<SearchHit>());
+                pageBucket.Sections.Add(sectionBucket);
+            }
+            sectionBucket.Hits.Add(hit);
+        }
+
+        foreach (var (page, sections) in byPage)
+        {
+            ResultsPanel.Children.Add(new TextBlock
+            {
+                Text = page,
+                Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"],
+                FontSize = 16,
+                Margin = new Thickness(0, 12, 0, 4),
+            });
+            foreach (var (section, sectionHits) in sections)
+            {
+                ResultsPanel.Children.Add(new TextBlock
+                {
+                    Text = section,
+                    Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                    Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                    Margin = new Thickness(0, 4, 0, 4),
+                });
+                foreach (var hit in sectionHits)
+                {
+                    ResultsPanel.Children.Add(BuildRow(hit));
+                }
+            }
+        }
+    }
+
+    private UIElement BuildRow(SearchHit hit)
+    {
+        // Rows are buttons so keyboard focus + Enter work out of the
+        // box. The row itself is a Border inside the Button content;
+        // ButtonPadding="0" keeps the visual padding on the Border.
+        var header = new TextBlock
+        {
+            Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"],
+        };
+        AppendHighlighted(header.Inlines, hit.Entry.Label, _query);
+
+        var description = new TextBlock
+        {
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+        AppendHighlighted(description.Inlines, hit.Entry.Description, _query);
+
+        var breadcrumb = new TextBlock
+        {
+            Text = $"{hit.Entry.Page} > {hit.Entry.Section}",
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
+            Margin = new Thickness(0, 4, 0, 0),
+        };
+
+        var panel = new StackPanel { Spacing = 0 };
+        panel.Children.Add(header);
+        panel.Children.Add(description);
+        panel.Children.Add(breadcrumb);
+
+        var border = new Border
+        {
+            Padding = new Thickness(16, 10, 16, 10),
+            MinHeight = 68,
+            CornerRadius = new CornerRadius(4),
+            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"],
+            BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+            BorderThickness = new Thickness(1),
+            Margin = new Thickness(0, 0, 0, 6),
+            Child = panel,
+        };
+
+        var button = new Button
+        {
+            Padding = new Thickness(0),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            BorderThickness = new Thickness(0),
+            Content = border,
+        };
+        button.Click += (_, _) => _onChosen?.Invoke(hit.Entry.Key);
+        ToolTipService.SetToolTip(button, $"Open in {hit.Entry.Page}");
+        return button;
+    }
+
+    // Split `text` around each case-insensitive occurrence of `query`
+    // and render matches bolded with accent foreground. Inline spans
+    // avoid re-measuring a child TextBlock for every match.
+    private static void AppendHighlighted(InlineCollection inlines, string text, string query)
+    {
+        inlines.Clear();
+        if (string.IsNullOrEmpty(query) || string.IsNullOrEmpty(text))
+        {
+            inlines.Add(new Run { Text = text });
+            return;
+        }
+
+        var accent = (Brush)Application.Current.Resources["AccentTextFillColorPrimaryBrush"];
+        int cursor = 0;
+        while (cursor < text.Length)
+        {
+            var idx = text.IndexOf(query, cursor, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0)
+            {
+                inlines.Add(new Run { Text = text[cursor..] });
+                return;
+            }
+            if (idx > cursor)
+                inlines.Add(new Run { Text = text[cursor..idx] });
+            inlines.Add(new Run
+            {
+                Text = text.Substring(idx, query.Length),
+                Foreground = accent,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            });
+            cursor = idx + query.Length;
+        }
+    }
+
+    private void ClearButton_Click(object sender, RoutedEventArgs e) => _onClear?.Invoke();
+}

--- a/windows/Ghostty/Settings/SettingsCardLocator.cs
+++ b/windows/Ghostty/Settings/SettingsCardLocator.cs
@@ -68,7 +68,15 @@ internal static class SettingsCardLocator
         pulse.InsertKeyFrame(0.0f, new Vector3(1.0f, 1.0f, 1.0f));
         pulse.InsertKeyFrame(0.35f, new Vector3(1.02f, 1.02f, 1.0f));
         pulse.InsertKeyFrame(1.0f, new Vector3(1.0f, 1.0f, 1.0f));
+
+        // Wrap in a scoped batch so we can release the compositor's hold
+        // on the Scale property once the keyframes finish. Without the
+        // StopAnimation, setting visual.Scale from code later would be
+        // silently ignored -- the expression system keeps ownership.
+        var batch = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
         visual.StartAnimation("Scale", pulse);
+        batch.End();
+        batch.Completed += (_, _) => visual.StopAnimation("Scale");
     }
 
     private static T? FindAncestor<T>(DependencyObject start) where T : class

--- a/windows/Ghostty/Settings/SettingsCardLocator.cs
+++ b/windows/Ghostty/Settings/SettingsCardLocator.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Numerics;
+using Ghostty.Controls.Settings;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Settings;
+
+/// <summary>
+/// Helpers used by the search results pane to scroll a target card
+/// into view and pulse it briefly. Keeps the visual-tree walk and the
+/// composition animation in one place so SettingsWindow stays focused
+/// on routing.
+/// </summary>
+internal static class SettingsCardLocator
+{
+    public static SettingsCard? FindByConfigKey(DependencyObject root, string key)
+    {
+        int childCount = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < childCount; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is SettingsCard card && SettingsCard.GetConfigKey(card) == key)
+                return card;
+            var nested = FindByConfigKey(child, key);
+            if (nested != null) return nested;
+        }
+        return null;
+    }
+
+    public static void ScrollIntoView(FrameworkElement target)
+    {
+        // Walk ancestors to find the enclosing ScrollViewer so we
+        // translate the target's bounds into scroll-viewer coordinates.
+        var scroller = FindAncestor<ScrollViewer>(target);
+        if (scroller == null) return;
+
+        var transform = target.TransformToVisual(scroller);
+        var point = transform.TransformPoint(new Windows.Foundation.Point(0, 0));
+        // Leave a small top margin so the pulsed card isn't flush
+        // against the ScrollViewer edge.
+        double offset = Math.Max(0, scroller.VerticalOffset + point.Y - 24);
+        scroller.ChangeView(null, offset, null, disableAnimation: false);
+    }
+
+    /// <summary>
+    /// Brief accent-tinted scale+glow pulse. Uses composition animations
+    /// so it runs on the compositor and doesn't fight layout. The card
+    /// is left untouched afterward.
+    /// </summary>
+    public static void Pulse(FrameworkElement target)
+    {
+        var visual = ElementCompositionPreview.GetElementVisual(target);
+        var compositor = visual.Compositor;
+
+        // Center the scale on the card so it grows outward evenly.
+        target.UpdateLayout();
+        visual.CenterPoint = new Vector3(
+            (float)target.ActualWidth / 2f,
+            (float)target.ActualHeight / 2f,
+            0f);
+
+        var pulse = compositor.CreateVector3KeyFrameAnimation();
+        pulse.Duration = TimeSpan.FromMilliseconds(520);
+        pulse.InsertKeyFrame(0.0f, new Vector3(1.0f, 1.0f, 1.0f));
+        pulse.InsertKeyFrame(0.35f, new Vector3(1.02f, 1.02f, 1.0f));
+        pulse.InsertKeyFrame(1.0f, new Vector3(1.0f, 1.0f, 1.0f));
+        visual.StartAnimation("Scale", pulse);
+    }
+
+    private static T? FindAncestor<T>(DependencyObject start) where T : class
+    {
+        var current = VisualTreeHelper.GetParent(start);
+        while (current != null)
+        {
+            if (current is T t) return t;
+            current = VisualTreeHelper.GetParent(current);
+        }
+        return null;
+    }
+}

--- a/windows/Ghostty/Settings/SettingsWindow.xaml
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml
@@ -12,33 +12,48 @@
         PaneDisplayMode="Left"
         SelectionChanged="NavView_SelectionChanged">
 
+        <NavigationView.AutoSuggestBox>
+            <!--
+              Standard WinUI 3 pattern: NavigationView renders an
+              AutoSuggestBox at the top of the pane. Used here as a
+              plain search field (QueryIcon, no suggestions). Ctrl+F
+              focuses it; Esc clears it and restores the previous page.
+            -->
+            <AutoSuggestBox
+                x:Name="SearchBox"
+                PlaceholderText="Search settings"
+                QueryIcon="Find"
+                TextChanged="SearchBox_TextChanged"
+                KeyDown="SearchBox_KeyDown" />
+        </NavigationView.AutoSuggestBox>
+
         <NavigationView.MenuItems>
-            <NavigationViewItem Content="General" Tag="general">
+            <NavigationViewItem x:Name="NavGeneral" Content="General" Tag="general">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Setting" />
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem Content="Appearance" Tag="appearance">
+            <NavigationViewItem x:Name="NavAppearance" Content="Appearance" Tag="appearance">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Font" />
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem Content="Colors" Tag="colors">
+            <NavigationViewItem x:Name="NavColors" Content="Colors" Tag="colors">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Highlight" />
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem Content="Terminal" Tag="terminal">
+            <NavigationViewItem x:Name="NavTerminal" Content="Terminal" Tag="terminal">
                 <NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE756;" />
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem Content="Keybindings" Tag="keybindings">
+            <NavigationViewItem x:Name="NavKeybindings" Content="Keybindings" Tag="keybindings">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Keyboard" />
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem Content="Advanced" Tag="advanced">
+            <NavigationViewItem x:Name="NavAdvanced" Content="Advanced" Tag="advanced">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Repair" />
                 </NavigationViewItem.Icon>
@@ -46,17 +61,31 @@
 
             <NavigationViewItemSeparator />
 
-            <NavigationViewItem Content="Raw Editor" Tag="raw">
+            <NavigationViewItem x:Name="NavRaw" Content="Raw Editor" Tag="raw">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Edit" />
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem Content="Diagnostics" Tag="diagnostics">
+            <NavigationViewItem x:Name="NavDiagnostics" Content="Diagnostics" Tag="diagnostics">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Important" />
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
         </NavigationView.MenuItems>
+
+        <NavigationView.PaneFooter>
+            <!--
+              Only visible while searching. Spec: "Total result count at
+              the bottom of the sidebar." Hidden when no query; pane
+              footer layout collapses cleanly with zero-opacity text.
+            -->
+            <TextBlock
+                x:Name="ResultCountText"
+                Margin="12,4,12,12"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Visibility="Collapsed" />
+        </NavigationView.PaneFooter>
 
         <Frame x:Name="ContentFrame" />
     </NavigationView>

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Ghostty.Core.Config;
+using Ghostty.Core.Settings;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using WinRT.Interop;
 
@@ -12,11 +15,20 @@ namespace Ghostty.Settings;
 
 internal sealed partial class SettingsWindow : Window
 {
+    // 150ms matches the spec; longer than keystroke bursts, shorter
+    // than perceptible lag on a sub-30-item index.
+    private static readonly TimeSpan SearchDebounce = TimeSpan.FromMilliseconds(150);
+
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
     private readonly IKeyBindingsProvider _keybindings;
     private readonly IThemeProvider _theme;
     private readonly Dictionary<string, Page> _pageCache = new();
+    private readonly DispatcherTimer _searchTimer;
+
+    private Pages.SearchResultsPage? _resultsPage;
+    private string _pendingQuery = string.Empty;
+    private string? _prePrevSelectedTag;  // restored when Esc clears search
 
     public SettingsWindow(
         IConfigService configService,
@@ -44,13 +56,21 @@ internal sealed partial class SettingsWindow : Window
         // NSScreen.mainScreen and handles multi-monitor correctly.
         const int width = 1100;
         const int height = 750;
-        var display = Microsoft.UI.Windowing.DisplayArea.GetFromWindowId(
-            windowId,
-            Microsoft.UI.Windowing.DisplayAreaFallback.Primary);
+        var display = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Primary);
         var work = display.WorkArea;
         var x = work.X + (work.Width - width) / 2;
         var y = work.Y + (work.Height - height) / 2;
         appWindow.MoveAndResize(new Windows.Graphics.RectInt32(x, y, width, height));
+
+        _searchTimer = new DispatcherTimer { Interval = SearchDebounce };
+        _searchTimer.Tick += OnSearchTimerTick;
+
+        // Ctrl+F from anywhere in the window focuses the search box.
+        // Keyboard accelerator on the root element so it still fires
+        // when focus is inside a Page loaded into ContentFrame.
+        var ctrlF = new KeyboardAccelerator { Key = Windows.System.VirtualKey.F, Modifiers = Windows.System.VirtualKeyModifiers.Control };
+        ctrlF.Invoked += (_, args) => { args.Handled = true; SearchBox.Focus(FocusState.Keyboard); };
+        NavView.KeyboardAccelerators.Add(ctrlF);
 
         Closed += OnClosed;
         NavView.SelectedItem = NavView.MenuItems[0];
@@ -58,6 +78,8 @@ internal sealed partial class SettingsWindow : Window
 
     private void OnClosed(object sender, WindowEventArgs args)
     {
+        _searchTimer.Stop();
+
         // Unsubscribe providers from ConfigChanged to avoid leaking
         // event subscriptions back to the long-lived ConfigService.
         (_keybindings as IDisposable)?.Dispose();
@@ -69,8 +91,17 @@ internal sealed partial class SettingsWindow : Window
         NavigationView sender,
         NavigationViewSelectionChangedEventArgs args)
     {
+        // Suppress during search: the sidebar stays visible so users
+        // can still read match counts, but a click on a menu item
+        // while searching should leave the results pane alone.
+        if (!string.IsNullOrEmpty(_pendingQuery)) return;
+
         if (args.SelectedItem is not NavigationViewItem item) return;
-        var tag = item.Tag?.ToString();
+        ShowPage(item.Tag?.ToString());
+    }
+
+    private void ShowPage(string? tag)
+    {
         if (tag == null) return;
 
         if (!_pageCache.TryGetValue(tag, out var page))
@@ -92,4 +123,206 @@ internal sealed partial class SettingsWindow : Window
 
         ContentFrame.Content = page;
     }
+
+    // ---- Search ----
+
+    private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+        _pendingQuery = sender.Text ?? string.Empty;
+        _searchTimer.Stop();
+        _searchTimer.Start();
+    }
+
+    private void SearchBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != Windows.System.VirtualKey.Escape) return;
+        e.Handled = true;
+        ClearSearch();
+    }
+
+    private void OnSearchTimerTick(object? sender, object e)
+    {
+        _searchTimer.Stop();
+        ApplyQuery(_pendingQuery);
+    }
+
+    private void ApplyQuery(string query)
+    {
+        var trimmed = query.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            ExitSearchMode();
+            return;
+        }
+
+        var hits = SettingsSearch.Search(trimmed, SettingsIndex.All);
+        UpdateSidebarCounts(hits);
+        UpdateResultsPane(trimmed, hits);
+
+        ResultCountText.Text = $"{hits.Count} result{(hits.Count == 1 ? "" : "s")}";
+        ResultCountText.Visibility = Visibility.Visible;
+    }
+
+    private void ExitSearchMode()
+    {
+        _pendingQuery = string.Empty;
+        ClearSidebarCounts();
+        ResultCountText.Visibility = Visibility.Collapsed;
+
+        // Restore the page the user was on before searching.
+        if (_prePrevSelectedTag != null && FindNavItem(_prePrevSelectedTag) is { } prev)
+        {
+            NavView.SelectedItem = prev;
+            ShowPage(_prePrevSelectedTag);
+            _prePrevSelectedTag = null;
+        }
+        else if (NavView.SelectedItem is NavigationViewItem current)
+        {
+            ShowPage(current.Tag?.ToString());
+        }
+    }
+
+    private void ClearSearch()
+    {
+        // Programmatic text change won't re-raise TextChanged with
+        // reason=UserInput, so ExitSearchMode must be called directly.
+        SearchBox.Text = string.Empty;
+        _searchTimer.Stop();
+        ExitSearchMode();
+    }
+
+    private void UpdateResultsPane(string query, IReadOnlyList<SearchHit> hits)
+    {
+        _resultsPage ??= new Pages.SearchResultsPage();
+
+        // Remember where the user was so Esc can restore it.
+        if (_prePrevSelectedTag == null && NavView.SelectedItem is NavigationViewItem current)
+            _prePrevSelectedTag = current.Tag?.ToString();
+
+        _resultsPage.Show(query, hits, OnResultChosen, ClearSearch);
+        ContentFrame.Content = _resultsPage;
+    }
+
+    private void OnResultChosen(string configKey)
+    {
+        // Resolve the entry to its owning page.
+        var entry = SettingsIndex.All.FirstOrDefault(x => x.Key == configKey);
+        if (entry == null) return;
+        var tag = PageTagFor(entry.Page);
+        if (tag == null) return;
+
+        // Leave search mode; select the target nav item; load the page.
+        SearchBox.Text = string.Empty;
+        _pendingQuery = string.Empty;
+        _searchTimer.Stop();
+        ClearSidebarCounts();
+        ResultCountText.Visibility = Visibility.Collapsed;
+        _prePrevSelectedTag = null;
+
+        if (FindNavItem(tag) is { } item)
+            NavView.SelectedItem = item;
+        ShowPage(tag);
+
+        // Defer card discovery until the page has loaded and measured;
+        // on first navigation the visual tree won't exist yet.
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (ContentFrame.Content is not FrameworkElement root) return;
+            ScrollAndPulseAfterLoad(root, configKey);
+        });
+    }
+
+    private static void ScrollAndPulseAfterLoad(FrameworkElement root, string configKey)
+    {
+        // The page is already measured if it was cached, but not if
+        // this is the first time it's been navigated to. Hook Loaded
+        // once and defer to DispatcherQueue to run after first layout.
+        if (root.IsLoaded)
+        {
+            DoScrollAndPulse(root, configKey);
+            return;
+        }
+
+        void Handler(object? s, RoutedEventArgs e)
+        {
+            root.Loaded -= Handler;
+            root.DispatcherQueue.TryEnqueue(() => DoScrollAndPulse(root, configKey));
+        }
+        root.Loaded += Handler;
+    }
+
+    private static void DoScrollAndPulse(FrameworkElement root, string configKey)
+    {
+        var card = SettingsCardLocator.FindByConfigKey(root, configKey);
+        if (card == null) return;
+        SettingsCardLocator.ScrollIntoView(card);
+        SettingsCardLocator.Pulse(card);
+    }
+
+    // ---- Sidebar match counts ----
+
+    private void UpdateSidebarCounts(IReadOnlyList<SearchHit> hits)
+    {
+        var counts = hits.GroupBy(h => h.Entry.Page)
+                         .ToDictionary(g => g.Key, g => g.Count());
+
+        SetCount(NavGeneral, "General", counts);
+        SetCount(NavAppearance, "Appearance", counts);
+        SetCount(NavColors, "Colors", counts);
+        SetCount(NavTerminal, "Terminal", counts);
+        SetCount(NavKeybindings, "Keybindings", counts);
+        SetCount(NavAdvanced, "Advanced", counts);
+        // Raw Editor + Diagnostics don't host index entries yet.
+        SetCount(NavRaw, null, counts);
+        SetCount(NavDiagnostics, null, counts);
+    }
+
+    private static void SetCount(NavigationViewItem item, string? pageName, Dictionary<string, int> counts)
+    {
+        int n = pageName != null && counts.TryGetValue(pageName, out var c) ? c : 0;
+        // Dim pages with zero matches rather than collapsing, so the
+        // sidebar layout stays stable while the user edits the query.
+        item.Opacity = n > 0 ? 1.0 : 0.4;
+        item.InfoBadge = n > 0
+            ? new InfoBadge
+            {
+                Value = n,
+                Style = (Style)Application.Current.Resources["AttentionValueInfoBadgeStyle"],
+            }
+            : null;
+    }
+
+    private void ClearSidebarCounts()
+    {
+        foreach (var item in new[] { NavGeneral, NavAppearance, NavColors, NavTerminal, NavKeybindings, NavAdvanced, NavRaw, NavDiagnostics })
+        {
+            item.Opacity = 1.0;
+            item.InfoBadge = null;
+        }
+    }
+
+    private NavigationViewItem? FindNavItem(string tag) => tag switch
+    {
+        "general" => NavGeneral,
+        "appearance" => NavAppearance,
+        "colors" => NavColors,
+        "terminal" => NavTerminal,
+        "keybindings" => NavKeybindings,
+        "advanced" => NavAdvanced,
+        "raw" => NavRaw,
+        "diagnostics" => NavDiagnostics,
+        _ => null,
+    };
+
+    private static string? PageTagFor(string indexPageName) => indexPageName switch
+    {
+        "General" => "general",
+        "Appearance" => "appearance",
+        "Colors" => "colors",
+        "Terminal" => "terminal",
+        "Keybindings" => "keybindings",
+        "Advanced" => "advanced",
+        _ => null,
+    };
 }

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -19,16 +19,28 @@ internal sealed partial class SettingsWindow : Window
     // than perceptible lag on a sub-30-item index.
     private static readonly TimeSpan SearchDebounce = TimeSpan.FromMilliseconds(150);
 
+    // One row per nav item. Drives three lookups (tag -> NavigationViewItem,
+    // index-page-name -> tag, iteration for sidebar counts) so that page
+    // renames don't require editing three parallel switch statements.
+    // IndexName is null for nav items that don't host SettingsIndex entries.
+    private readonly record struct PageMapping(string Tag, string? IndexName, NavigationViewItem Item);
+
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
     private readonly IKeyBindingsProvider _keybindings;
     private readonly IThemeProvider _theme;
     private readonly Dictionary<string, Page> _pageCache = new();
     private readonly DispatcherTimer _searchTimer;
+    private readonly IReadOnlyList<PageMapping> _pageMappings;
 
     private Pages.SearchResultsPage? _resultsPage;
     private string _pendingQuery = string.Empty;
-    private string? _prePrevSelectedTag;  // restored when Esc clears search
+    private string? _preSearchSelectedTag;  // restored when Esc clears search
+
+    // Set while programmatically changing NavView.SelectedItem from search
+    // flows so NavView_SelectionChanged doesn't redundantly call ShowPage
+    // (the caller drives navigation explicitly).
+    private bool _suppressNavSelection;
 
     public SettingsWindow(
         IConfigService configService,
@@ -65,6 +77,19 @@ internal sealed partial class SettingsWindow : Window
         _searchTimer = new DispatcherTimer { Interval = SearchDebounce };
         _searchTimer.Tick += OnSearchTimerTick;
 
+        _pageMappings = new[]
+        {
+            new PageMapping("general", "General", NavGeneral),
+            new PageMapping("appearance", "Appearance", NavAppearance),
+            new PageMapping("colors", "Colors", NavColors),
+            new PageMapping("terminal", "Terminal", NavTerminal),
+            new PageMapping("keybindings", "Keybindings", NavKeybindings),
+            new PageMapping("advanced", "Advanced", NavAdvanced),
+            // Raw Editor + Diagnostics don't host SettingsIndex entries yet.
+            new PageMapping("raw", null, NavRaw),
+            new PageMapping("diagnostics", null, NavDiagnostics),
+        };
+
         // Ctrl+F from anywhere in the window focuses the search box.
         // Keyboard accelerator on the root element so it still fires
         // when focus is inside a Page loaded into ContentFrame.
@@ -95,6 +120,10 @@ internal sealed partial class SettingsWindow : Window
         // can still read match counts, but a click on a menu item
         // while searching should leave the results pane alone.
         if (!string.IsNullOrEmpty(_pendingQuery)) return;
+
+        // Skip when a search-exit flow is driving the selection itself;
+        // that caller calls ShowPage explicitly so we'd otherwise navigate twice.
+        if (_suppressNavSelection) return;
 
         if (args.SelectedItem is not NavigationViewItem item) return;
         ShowPage(item.Tag?.ToString());
@@ -171,11 +200,14 @@ internal sealed partial class SettingsWindow : Window
         ResultCountText.Visibility = Visibility.Collapsed;
 
         // Restore the page the user was on before searching.
-        if (_prePrevSelectedTag != null && FindNavItem(_prePrevSelectedTag) is { } prev)
+        if (_preSearchSelectedTag != null && FindNavItem(_preSearchSelectedTag) is { } prev)
         {
-            NavView.SelectedItem = prev;
-            ShowPage(_prePrevSelectedTag);
-            _prePrevSelectedTag = null;
+            var tag = _preSearchSelectedTag;
+            _preSearchSelectedTag = null;
+            _suppressNavSelection = true;
+            try { NavView.SelectedItem = prev; }
+            finally { _suppressNavSelection = false; }
+            ShowPage(tag);
         }
         else if (NavView.SelectedItem is NavigationViewItem current)
         {
@@ -197,8 +229,8 @@ internal sealed partial class SettingsWindow : Window
         _resultsPage ??= new Pages.SearchResultsPage();
 
         // Remember where the user was so Esc can restore it.
-        if (_prePrevSelectedTag == null && NavView.SelectedItem is NavigationViewItem current)
-            _prePrevSelectedTag = current.Tag?.ToString();
+        if (_preSearchSelectedTag == null && NavView.SelectedItem is NavigationViewItem current)
+            _preSearchSelectedTag = current.Tag?.ToString();
 
         _resultsPage.Show(query, hits, OnResultChosen, ClearSearch);
         ContentFrame.Content = _resultsPage;
@@ -218,10 +250,14 @@ internal sealed partial class SettingsWindow : Window
         _searchTimer.Stop();
         ClearSidebarCounts();
         ResultCountText.Visibility = Visibility.Collapsed;
-        _prePrevSelectedTag = null;
+        _preSearchSelectedTag = null;
 
         if (FindNavItem(tag) is { } item)
-            NavView.SelectedItem = item;
+        {
+            _suppressNavSelection = true;
+            try { NavView.SelectedItem = item; }
+            finally { _suppressNavSelection = false; }
+        }
         ShowPage(tag);
 
         // Defer card discovery until the page has loaded and measured;
@@ -267,62 +303,42 @@ internal sealed partial class SettingsWindow : Window
         var counts = hits.GroupBy(h => h.Entry.Page)
                          .ToDictionary(g => g.Key, g => g.Count());
 
-        SetCount(NavGeneral, "General", counts);
-        SetCount(NavAppearance, "Appearance", counts);
-        SetCount(NavColors, "Colors", counts);
-        SetCount(NavTerminal, "Terminal", counts);
-        SetCount(NavKeybindings, "Keybindings", counts);
-        SetCount(NavAdvanced, "Advanced", counts);
-        // Raw Editor + Diagnostics don't host index entries yet.
-        SetCount(NavRaw, null, counts);
-        SetCount(NavDiagnostics, null, counts);
-    }
-
-    private static void SetCount(NavigationViewItem item, string? pageName, Dictionary<string, int> counts)
-    {
-        int n = pageName != null && counts.TryGetValue(pageName, out var c) ? c : 0;
-        // Dim pages with zero matches rather than collapsing, so the
-        // sidebar layout stays stable while the user edits the query.
-        item.Opacity = n > 0 ? 1.0 : 0.4;
-        item.InfoBadge = n > 0
-            ? new InfoBadge
-            {
-                Value = n,
-                Style = (Style)Application.Current.Resources["AttentionValueInfoBadgeStyle"],
-            }
-            : null;
+        foreach (var m in _pageMappings)
+        {
+            int n = m.IndexName != null && counts.TryGetValue(m.IndexName, out var c) ? c : 0;
+            // Dim pages with zero matches rather than collapsing, so the
+            // sidebar layout stays stable while the user edits the query.
+            m.Item.Opacity = n > 0 ? 1.0 : 0.4;
+            m.Item.InfoBadge = n > 0
+                ? new InfoBadge
+                {
+                    Value = n,
+                    Style = (Style)Application.Current.Resources["AttentionValueInfoBadgeStyle"],
+                }
+                : null;
+        }
     }
 
     private void ClearSidebarCounts()
     {
-        foreach (var item in new[] { NavGeneral, NavAppearance, NavColors, NavTerminal, NavKeybindings, NavAdvanced, NavRaw, NavDiagnostics })
+        foreach (var m in _pageMappings)
         {
-            item.Opacity = 1.0;
-            item.InfoBadge = null;
+            m.Item.Opacity = 1.0;
+            m.Item.InfoBadge = null;
         }
     }
 
-    private NavigationViewItem? FindNavItem(string tag) => tag switch
+    private NavigationViewItem? FindNavItem(string tag)
     {
-        "general" => NavGeneral,
-        "appearance" => NavAppearance,
-        "colors" => NavColors,
-        "terminal" => NavTerminal,
-        "keybindings" => NavKeybindings,
-        "advanced" => NavAdvanced,
-        "raw" => NavRaw,
-        "diagnostics" => NavDiagnostics,
-        _ => null,
-    };
+        foreach (var m in _pageMappings)
+            if (m.Tag == tag) return m.Item;
+        return null;
+    }
 
-    private static string? PageTagFor(string indexPageName) => indexPageName switch
+    private string? PageTagFor(string indexPageName)
     {
-        "General" => "general",
-        "Appearance" => "appearance",
-        "Colors" => "colors",
-        "Terminal" => "terminal",
-        "Keybindings" => "keybindings",
-        "Advanced" => "advanced",
-        _ => null,
-    };
+        foreach (var m in _pageMappings)
+            if (m.IndexName == indexPageName) return m.Tag;
+        return null;
+    }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR. Merge order: #245 →  #246 → **this** → (phase 4) → (phase 5).
> Base is \`feature/settings-color-picker\` (#246). GitHub will auto-retarget to \`windows\` when the parents merge.

Phase 3 of the settings reorganization. Adds a search overlay that filters the settings index, transforms the sidebar into a result navigator, and pulses the target card on navigation.

## What's here

- \`SettingsSearch\` in \`Ghostty.Core.Settings\` — pure-logic tiered scorer (exact label / label prefix / label contains / description contains / tag exact / tag contains / fuzzy key). 13 xUnit tests.
- \`AutoSuggestBox\` in the NavigationView pane header. 150ms debounce. Ctrl+F focuses; Esc clears.
- On non-empty query: \`ContentFrame\` shows \`SearchResultsPage\`; each \`NavigationViewItem\` gets a match-count \`InfoBadge\`; pages with zero matches dim to 0.4 opacity (layout stays stable); pane footer shows the total.
- Clicking a result clears the search, selects the owning nav item, navigates to the page, scrolls the matching \`SettingsCard\` into view, and runs a ~520ms composition scale pulse.
- Empty state: "No settings match <query>" with a Clear button.

## Known gap (not a regression)

Gradient rows (\`background-gradient-*\`) aren't \`ConfigKey\`-tagged yet; phase 4 rebuilds that section. Those results currently navigate to Appearance without a pulse. No existing behavior changes.

## Test plan

- [ ] Type \`opacity\` — Appearance shows a 3-count badge, other pages dim
- [ ] Click \"Background opacity\" — jumps to Appearance, scrolls, pulses
- [ ] Ctrl+F — focuses the search box
- [ ] Type \`bgop\` — fuzzy match surfaces \`background-opacity\`
- [ ] Esc — restores the prior page
- [ ] \`dotnet test windows/Ghostty.Tests\` — 310 pass (13 new)