### PR TITLE
feat(windows): visual gradient points editor (phase 4)

### DIFF
--- a/windows/Ghostty.Core/Settings/GradientPointsLogic.cs
+++ b/windows/Ghostty.Core/Settings/GradientPointsLogic.cs
@@ -12,4 +12,27 @@ public static class GradientPointsLogic
 {
     public static (float X, float Y) Clamp(float x, float y) =>
         (Math.Clamp(x, 0f, 1f), Math.Clamp(y, 0f, 1f));
+
+    /// <summary>
+    /// Returns the index of the topmost point whose center lies within
+    /// <paramref name="handleRadius"/> of (<paramref name="px"/>,
+    /// <paramref name="py"/>), or null if none match. Later points draw
+    /// above earlier, so the scan runs from end to start.
+    /// All values are in normalized [0,1] canvas space.
+    /// </summary>
+    public static int? HitTest(
+        IReadOnlyList<(float X, float Y)> points,
+        float px,
+        float py,
+        float handleRadius)
+    {
+        var r2 = handleRadius * handleRadius;
+        for (int i = points.Count - 1; i >= 0; i--)
+        {
+            var dx = points[i].X - px;
+            var dy = points[i].Y - py;
+            if (dx * dx + dy * dy <= r2) return i;
+        }
+        return null;
+    }
 }

--- a/windows/Ghostty.Core/Settings/GradientPointsLogic.cs
+++ b/windows/Ghostty.Core/Settings/GradientPointsLogic.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Settings;
+
+/// <summary>
+/// Pure positional helpers for <c>GradientPointsEditor</c>. Lives in
+/// Ghostty.Core so it can be unit-tested without a XAML test host.
+/// All coordinates are in normalized [0,1] canvas space.
+/// </summary>
+public static class GradientPointsLogic
+{
+    public static (float X, float Y) Clamp(float x, float y) =>
+        (Math.Clamp(x, 0f, 1f), Math.Clamp(y, 0f, 1f));
+}

--- a/windows/Ghostty.Tests/Settings/GradientPointsLogicTests.cs
+++ b/windows/Ghostty.Tests/Settings/GradientPointsLogicTests.cs
@@ -1,0 +1,19 @@
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+public class GradientPointsLogicTests
+{
+    [Theory]
+    [InlineData(0.5f, 0.5f, 0.5f, 0.5f)]
+    [InlineData(-0.1f, 0.4f, 0.0f, 0.4f)]
+    [InlineData(0.4f, 1.2f, 0.4f, 1.0f)]
+    [InlineData(2.0f, -3.0f, 1.0f, 0.0f)]
+    public void Clamp_ClampsXAndY(float x, float y, float expectedX, float expectedY)
+    {
+        var (cx, cy) = GradientPointsLogic.Clamp(x, y);
+        Assert.Equal(expectedX, cx);
+        Assert.Equal(expectedY, cy);
+    }
+}

--- a/windows/Ghostty.Tests/Settings/GradientPointsLogicTests.cs
+++ b/windows/Ghostty.Tests/Settings/GradientPointsLogicTests.cs
@@ -16,4 +16,49 @@ public class GradientPointsLogicTests
         Assert.Equal(expectedX, cx);
         Assert.Equal(expectedY, cy);
     }
+
+    [Fact]
+    public void HitTest_ReturnsNullWhenEmpty()
+    {
+        var result = GradientPointsLogic.HitTest(
+            System.Array.Empty<(float, float)>(), 0.5f, 0.5f, 0.05f);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HitTest_ReturnsNullWhenNoneInRange()
+    {
+        var points = new (float, float)[] { (0.1f, 0.1f), (0.9f, 0.9f) };
+        var result = GradientPointsLogic.HitTest(points, 0.5f, 0.5f, 0.05f);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HitTest_ReturnsIndexOfPointInRange()
+    {
+        var points = new (float, float)[] { (0.5f, 0.5f) };
+        var result = GradientPointsLogic.HitTest(points, 0.52f, 0.48f, 0.05f);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void HitTest_PrefersLaterPointOnOverlap()
+    {
+        // Later points render on top, so hit-test walks from the end.
+        var points = new (float, float)[] { (0.5f, 0.5f), (0.5f, 0.5f) };
+        var result = GradientPointsLogic.HitTest(points, 0.5f, 0.5f, 0.05f);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void HitTest_BoundaryAtRadius_IsIncluded()
+    {
+        // Uses exactly-IEEE-754-representable values so distance equals
+        // radius to the bit: point (0,0), pointer (0.5, 0), radius 0.5.
+        // dx^2 + dy^2 = 0.25 exactly; r^2 = 0.25 exactly; <= holds.
+        // This proves the implementation is inclusive (<=) not exclusive (<).
+        var points = new (float, float)[] { (0f, 0f) };
+        var result = GradientPointsLogic.HitTest(points, 0.5f, 0f, 0.5f);
+        Assert.Equal(0, result);
+    }
 }

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Controls.Settings.GradientPointsEditor"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="8">
+        <TextBlock Text="Gradient points"
+                   Style="{StaticResource BodyStrongTextBlockStyle}" />
+        <TextBlock Text="Drag dots on the canvas. Double-click empty space to add. Up to 5 points."
+                   Style="{StaticResource CaptionTextBlockStyle}"
+                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+        <!-- 2D canvas. Aspect is enforced in code-behind in a later task. -->
+        <Border x:Name="CanvasBorder"
+                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="4"
+                Background="#111827">
+            <Canvas x:Name="PointsCanvas"
+                    Height="220"
+                    HorizontalAlignment="Stretch"
+                    IsDoubleTapEnabled="True" />
+        </Border>
+
+        <!-- Compact rows per point. Built imperatively in code-behind. -->
+        <StackPanel x:Name="RowsPanel" Spacing="4" />
+
+        <Button x:Name="AddPointButton" Content="Add point" />
+    </StackPanel>
+</UserControl>

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Ghostty.Core.Settings;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI;
@@ -27,6 +28,15 @@ public sealed partial class GradientPointsEditor : UserControl
     // Guard to suppress echo when we programmatically change row inputs
     // (e.g. during drag) so NumberBox.ValueChanged doesn't loop back.
     private bool _suppressRowEcho;
+
+    // -1 means no drag in progress; set to the handle index being dragged.
+    private int _dragIndex = -1;
+
+    // Element instances currently in PointsCanvas.Children, parallel to
+    // _points. RenderCanvas clears and repopulates these. MovePoint
+    // mutates existing instances in place so pointer capture survives.
+    private readonly List<Microsoft.UI.Xaml.Shapes.Ellipse> _falloffs = new();
+    private readonly List<Microsoft.UI.Xaml.Shapes.Ellipse> _handles = new();
 
     public event EventHandler<IReadOnlyList<GradientPointModel>>? PointsChanged;
 
@@ -180,6 +190,8 @@ public sealed partial class GradientPointsEditor : UserControl
     private void RenderCanvas()
     {
         PointsCanvas.Children.Clear();
+        _falloffs.Clear();
+        _handles.Clear();
         var w = PointsCanvas.ActualWidth;
         var h = PointsCanvas.ActualHeight;
         if (w <= 0 || h <= 0) return;
@@ -201,6 +213,7 @@ public sealed partial class GradientPointsEditor : UserControl
             Canvas.SetLeft(falloff, p.X * w - falloffSize / 2);
             Canvas.SetTop(falloff, p.Y * h - falloffSize / 2);
             PointsCanvas.Children.Add(falloff);
+            _falloffs.Add(falloff);
 
             // Handle: a small white-bordered solid dot above the falloff.
             var handle = new Microsoft.UI.Xaml.Shapes.Ellipse
@@ -213,9 +226,87 @@ public sealed partial class GradientPointsEditor : UserControl
                 StrokeThickness = 2,
                 Tag = i,
             };
+            int capturedIndex = i;
+            handle.PointerPressed += (s, e) =>
+            {
+                if (s is not Microsoft.UI.Xaml.Shapes.Ellipse el) return;
+                el.CapturePointer(e.Pointer);
+                _dragIndex = capturedIndex;
+                e.Handled = true;
+            };
+            handle.PointerMoved += (s, e) =>
+            {
+                if (_dragIndex != capturedIndex) return;
+                var pos = e.GetCurrentPoint(PointsCanvas).Position;
+                var w = PointsCanvas.ActualWidth;
+                var h = PointsCanvas.ActualHeight;
+                if (w <= 0 || h <= 0) return;
+                var (nx, ny) = GradientPointsLogic.Clamp(
+                    (float)(pos.X / w), (float)(pos.Y / h));
+                var cur = _points[capturedIndex];
+                _points[capturedIndex] = cur with { X = nx, Y = ny };
+                MovePoint(capturedIndex);
+                SyncRowNumbers(capturedIndex);
+                RaisePointsChanged();
+            };
+            handle.PointerReleased += (s, e) =>
+            {
+                if (_dragIndex == capturedIndex && s is Microsoft.UI.Xaml.Shapes.Ellipse el)
+                    el.ReleasePointerCapture(e.Pointer);
+                _dragIndex = -1;
+            };
+            handle.PointerCaptureLost += (_, _) => _dragIndex = -1;
             Canvas.SetLeft(handle, p.X * w - HandleDiameter / 2);
             Canvas.SetTop(handle, p.Y * h - HandleDiameter / 2);
             PointsCanvas.Children.Add(handle);
+            _handles.Add(handle);
+        }
+    }
+
+    /// <summary>
+    /// Update the visual position (and falloff size) of a single point
+    /// in place, without rebuilding the canvas. Used during drag so
+    /// pointer capture on the handle Ellipse survives the mutation.
+    /// </summary>
+    private void MovePoint(int index)
+    {
+        if (index < 0 || index >= _points.Count) return;
+        if (index >= _handles.Count || index >= _falloffs.Count) return;
+        var w = PointsCanvas.ActualWidth;
+        var h = PointsCanvas.ActualHeight;
+        if (w <= 0 || h <= 0) return;
+
+        var p = _points[index];
+        var falloffSize = 2.0 * p.Radius * Math.Min(w, h);
+
+        var falloff = _falloffs[index];
+        falloff.Width = falloffSize;
+        falloff.Height = falloffSize;
+        Canvas.SetLeft(falloff, p.X * w - falloffSize / 2);
+        Canvas.SetTop(falloff, p.Y * h - falloffSize / 2);
+
+        var handle = _handles[index];
+        Canvas.SetLeft(handle, p.X * w - HandleDiameter / 2);
+        Canvas.SetTop(handle, p.Y * h - HandleDiameter / 2);
+    }
+
+    // Updates the X/Y/R NumberBoxes in a row to match _points[index]
+    // after a canvas drag, without triggering the ValueChanged -> RenderCanvas loop.
+    private void SyncRowNumbers(int index)
+    {
+        if (index < 0 || index >= RowsPanel.Children.Count) return;
+        if (RowsPanel.Children[index] is not StackPanel row) return;
+        _suppressRowEcho = true;
+        try
+        {
+            // Row layout is: swatch, X nb, Y nb, R nb, remove. Indexes 1..3.
+            if (row.Children[1] is NumberBox xn) xn.Value = _points[index].X;
+            if (row.Children[2] is NumberBox yn) yn.Value = _points[index].Y;
+            if (row.Children[3] is NumberBox rn) rn.Value = _points[index].Radius;
+        }
+        finally
+        {
+            _suppressRowEcho = false;
         }
     }
 

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using Ghostty.Core.Settings;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Shapes;
 using Windows.UI;
 
 namespace Ghostty.Controls.Settings;
@@ -263,22 +265,32 @@ public sealed partial class GradientPointsEditor : UserControl
             PointsCanvas.Children.Add(falloff);
             _falloffs.Add(falloff);
 
-            // Handle: a small white-bordered circular button above the falloff.
-            // Using Button (a Control) instead of Ellipse (a Shape) so that
-            // IsTabStop and KeyDown are available for keyboard nudge + delete.
-            // CornerRadius = (HandleDiameter + 4) / 2 makes it visually circular.
+            // Handle: a small circular drag target above the falloff.
+            // ContentControl (not Button) so Button's internal pointer template
+            // does not steal PointerPressed before our drag handler can run.
+            // XY focus nav is disabled so Up/Down reach our KeyDown instead of
+            // moving focus to the next control outside the canvas.
             var handleSize = HandleDiameter + 4;
-            var handle = new Button
+            var handle = new ContentControl
             {
                 Width = handleSize,
                 Height = handleSize,
                 Padding = new Microsoft.UI.Xaml.Thickness(0),
-                Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(p.Color),
-                BorderBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    Microsoft.UI.Colors.White),
-                BorderThickness = new Microsoft.UI.Xaml.Thickness(2),
-                CornerRadius = new Microsoft.UI.Xaml.CornerRadius(handleSize / 2),
+                IsTabStop = true,
+                XYFocusKeyboardNavigation = XYFocusKeyboardNavigationMode.Disabled,
                 Tag = i,
+                Content = new Ellipse
+                {
+                    Width = HandleDiameter,
+                    Height = HandleDiameter,
+                    Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(p.Color),
+                    Stroke = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                        Microsoft.UI.Colors.White),
+                    StrokeThickness = 2,
+                    IsHitTestVisible = false,
+                },
+                HorizontalContentAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+                VerticalContentAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center,
             };
             int capturedIndex = i;
             handle.KeyDown += (s, e) =>
@@ -317,7 +329,7 @@ public sealed partial class GradientPointsEditor : UserControl
             };
             handle.PointerPressed += (s, e) =>
             {
-                if (s is not Button btn) return;
+                if (s is not ContentControl btn) return;
                 btn.CapturePointer(e.Pointer);
                 _dragIndex = capturedIndex;
                 e.Handled = true;
@@ -339,7 +351,7 @@ public sealed partial class GradientPointsEditor : UserControl
             };
             handle.PointerReleased += (s, e) =>
             {
-                if (_dragIndex == capturedIndex && s is Button btn)
+                if (_dragIndex == capturedIndex && s is ContentControl btn)
                     btn.ReleasePointerCapture(e.Pointer);
                 _dragIndex = -1;
             };

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -17,6 +17,10 @@ public sealed partial class GradientPointsEditor : UserControl
     // Maximum gradient points supported by libghostty's config.
     public const int MaxPoints = 5;
 
+    // Handle dot is 14 px diameter (normalized coords computed per-frame
+    // based on actual canvas pixel size).
+    private const double HandleDiameter = 14.0;
+
     private readonly List<GradientPointModel> _points = new();
 
     public event EventHandler<IReadOnlyList<GradientPointModel>>? PointsChanged;
@@ -26,6 +30,7 @@ public sealed partial class GradientPointsEditor : UserControl
     public GradientPointsEditor()
     {
         InitializeComponent();
+        PointsCanvas.SizeChanged += (_, _) => RenderCanvas();
     }
 
     /// <summary>
@@ -36,7 +41,74 @@ public sealed partial class GradientPointsEditor : UserControl
     {
         _points.Clear();
         _points.AddRange(points.Take(MaxPoints));
-        // Rendering + rows wired in a later task.
+        RenderCanvas();
+    }
+
+    private void RenderCanvas()
+    {
+        PointsCanvas.Children.Clear();
+        var w = PointsCanvas.ActualWidth;
+        var h = PointsCanvas.ActualHeight;
+        if (w <= 0 || h <= 0) return;
+
+        for (int i = 0; i < _points.Count; i++)
+        {
+            var p = _points[i];
+            // Falloff: an Ellipse sized to 2*Radius in normalized space,
+            // filled with a RadialGradientBrush from opaque center to
+            // transparent edge.
+            var falloffSize = 2.0 * p.Radius * Math.Min(w, h);
+            var falloff = new Microsoft.UI.Xaml.Shapes.Ellipse
+            {
+                Width = falloffSize,
+                Height = falloffSize,
+                IsHitTestVisible = false,
+                Fill = BuildFalloffBrush(p.Color),
+            };
+            Canvas.SetLeft(falloff, p.X * w - falloffSize / 2);
+            Canvas.SetTop(falloff, p.Y * h - falloffSize / 2);
+            PointsCanvas.Children.Add(falloff);
+
+            // Handle: a small white-bordered solid dot above the falloff.
+            var handle = new Microsoft.UI.Xaml.Shapes.Ellipse
+            {
+                Width = HandleDiameter,
+                Height = HandleDiameter,
+                Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(p.Color),
+                Stroke = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    Microsoft.UI.Colors.White),
+                StrokeThickness = 2,
+                Tag = i,
+            };
+            Canvas.SetLeft(handle, p.X * w - HandleDiameter / 2);
+            Canvas.SetTop(handle, p.Y * h - HandleDiameter / 2);
+            PointsCanvas.Children.Add(handle);
+        }
+    }
+
+    private static Microsoft.UI.Xaml.Media.Brush BuildFalloffBrush(Color c)
+    {
+        // RadialGradientBrush: opaque at center, transparent at edge.
+        // This is a visual editor aid ONLY -- it does not reflect blend
+        // mode, opacity, or animation of the real gradient.
+        var brush = new Microsoft.UI.Xaml.Media.RadialGradientBrush
+        {
+            Center = new Windows.Foundation.Point(0.5, 0.5),
+            GradientOrigin = new Windows.Foundation.Point(0.5, 0.5),
+            RadiusX = 0.5,
+            RadiusY = 0.5,
+        };
+        brush.GradientStops.Add(new Microsoft.UI.Xaml.Media.GradientStop
+        {
+            Color = Color.FromArgb(0xCC, c.R, c.G, c.B),
+            Offset = 0.0,
+        });
+        brush.GradientStops.Add(new Microsoft.UI.Xaml.Media.GradientStop
+        {
+            Color = Color.FromArgb(0x00, c.R, c.G, c.B),
+            Offset = 1.0,
+        });
+        return brush;
     }
 }
 

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -129,15 +129,10 @@ public sealed partial class GradientPointsEditor : UserControl
             Tag = index,
         };
 
-        var swatch = new Button
-        {
-            Width = 24,
-            Height = 24,
-            Padding = new Thickness(0),
-            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                _points[index].Color),
-        };
-        // Reuse the existing ColorPickerControl flyout from Phase 2.
+        // ColorPickerControl provides its own swatch and flyout -- no outer
+        // wrapper needed. Wrapping it in a second Flyout caused the inner
+        // WinUI ColorPicker flyout to light-dismiss whenever the user dragged
+        // a slider past the outer flyout boundary.
         var picker = new ColorPickerControl
         {
             Color = ColorToHex(_points[index].Color),
@@ -157,13 +152,10 @@ public sealed partial class GradientPointsEditor : UserControl
                     return;
                 var p = _points[index];
                 _points[index] = p with { Color = c };
-                swatch.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(c);
                 RenderCanvas();
                 RaisePointsChanged();
             });
-        var flyout = new Flyout { Content = picker };
-        swatch.Flyout = flyout;
-        row.Children.Add(swatch);
+        row.Children.Add(picker);
 
         row.Children.Add(BuildNumberBox("X", _points[index].X, v =>
         {
@@ -407,7 +399,7 @@ public sealed partial class GradientPointsEditor : UserControl
         _suppressRowEcho = true;
         try
         {
-            // Row layout is: swatch, X nb, Y nb, R nb, remove. Indexes 1..3.
+            // Row layout is: picker, X nb, Y nb, R nb, remove. Indexes 1..3.
             if (row.Children[1] is NumberBox xn) xn.Value = _points[index].X;
             if (row.Children[2] is NumberBox yn) yn.Value = _points[index].Y;
             if (row.Children[3] is NumberBox rn) rn.Value = _points[index].Radius;

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -46,6 +46,27 @@ public sealed partial class GradientPointsEditor : UserControl
     {
         InitializeComponent();
         PointsCanvas.SizeChanged += (_, _) => RenderCanvas();
+        AddPointButton.Click += (_, _) => TryAdd(0.5f, 0.5f);
+        PointsCanvas.DoubleTapped += (_, e) =>
+        {
+            var pos = e.GetPosition(PointsCanvas);
+            var w = PointsCanvas.ActualWidth;
+            var h = PointsCanvas.ActualHeight;
+            if (w <= 0 || h <= 0) return;
+            var (x, y) = GradientPointsLogic.Clamp(
+                (float)(pos.X / w), (float)(pos.Y / h));
+
+            // Don't stack a new point directly on top of an existing handle.
+            // Hit-test in normalized space using the handle's on-canvas radius.
+            var handleNorm = (float)(HandleDiameter / 2.0 / Math.Min(w, h));
+            var existing = _points
+                .Select(p => (p.X, p.Y))
+                .ToList();
+            if (GradientPointsLogic.HitTest(existing, x, y, handleNorm) is not null)
+                return;
+
+            TryAdd(x, y);
+        };
     }
 
     /// <summary>
@@ -58,6 +79,18 @@ public sealed partial class GradientPointsEditor : UserControl
         _points.AddRange(points.Take(MaxPoints));
         RenderCanvas();
         RebuildRows();
+    }
+
+    private void TryAdd(float x, float y)
+    {
+        if (_points.Count >= MaxPoints) return;
+        // Default new point: mid-radius, neutral amber so it's visible
+        // even against dark backgrounds. Consumers can re-color via the row.
+        var color = Color.FromArgb(0xFF, 0xF7, 0xC9, 0x48);
+        _points.Add(new GradientPointModel(x, y, color, 0.4f));
+        RenderCanvas();
+        RebuildRows();
+        RaisePointsChanged();
     }
 
     private void RebuildRows()

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI;
+
+namespace Ghostty.Controls.Settings;
+
+/// <summary>
+/// Visual 2D editor for background-gradient-point values. Position
+/// editing via drag on the canvas; radius via numeric input below.
+/// The editor is stateless from the config perspective: consumers
+/// call SetPoints to load, then listen for PointsChanged to persist.
+/// </summary>
+public sealed partial class GradientPointsEditor : UserControl
+{
+    // Maximum gradient points supported by libghostty's config.
+    public const int MaxPoints = 5;
+
+    private readonly List<GradientPointModel> _points = new();
+
+    public event EventHandler<IReadOnlyList<GradientPointModel>>? PointsChanged;
+
+    public GradientPointsEditor()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Replaces the editor state. Does NOT raise PointsChanged --
+    /// this is the load path, not a user edit.
+    /// </summary>
+    public void SetPoints(IReadOnlyList<GradientPointModel> points)
+    {
+        _points.Clear();
+        _points.AddRange(points.Take(MaxPoints));
+        // Rendering + rows wired in a later task.
+    }
+}
+
+/// <summary>
+/// Editor-local DTO for a gradient point. Maps 1:1 to
+/// <c>Ghostty.Services.GradientPoint</c>; the control does not
+/// reference the service layer.
+/// </summary>
+public readonly record struct GradientPointModel(
+    float X, float Y, Color Color, float Radius);

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -247,6 +247,10 @@ public sealed partial class GradientPointsEditor : UserControl
         var h = PointsCanvas.ActualHeight;
         if (w <= 0 || h <= 0) return;
 
+        CanvasBorder.Visibility = _points.Count == 0
+            ? Microsoft.UI.Xaml.Visibility.Collapsed
+            : Microsoft.UI.Xaml.Visibility.Visible;
+
         for (int i = 0; i < _points.Count; i++)
         {
             var p = _points[i];

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -75,6 +75,10 @@ public sealed partial class GradientPointsEditor : UserControl
     /// </summary>
     public void SetPoints(IReadOnlyList<GradientPointModel> points)
     {
+        // Guard against external re-seeds (e.g. ConfigChanged handler)
+        // happening in the middle of an active drag. A rebuild would
+        // destroy the captured handle and stall the drag.
+        if (_dragIndex != -1) return;
         _points.Clear();
         _points.AddRange(points.Take(MaxPoints));
         RenderCanvas();

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -21,6 +21,8 @@ public sealed partial class GradientPointsEditor : UserControl
 
     public event EventHandler<IReadOnlyList<GradientPointModel>>? PointsChanged;
 
+    public IReadOnlyList<GradientPointModel> Points => _points;
+
     public GradientPointsEditor()
     {
         InitializeComponent();

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -142,16 +142,25 @@ public sealed partial class GradientPointsEditor : UserControl
         {
             Color = ColorToHex(_points[index].Color),
         };
-        picker.ColorChanged += (_, _) =>
-        {
-            if (_suppressRowEcho) return;
-            var c = HexToColor(picker.Color) ?? _points[index].Color;
-            var p = _points[index];
-            _points[index] = p with { Color = c };
-            swatch.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(c);
-            RenderCanvas();
-            RaisePointsChanged();
-        };
+        // Subscribe to the picker's Color DependencyProperty so slider
+        // drags inside the flyout update the point live. (The
+        // ColorChanged event itself only fires on flyout close.)
+        picker.RegisterPropertyChangedCallback(
+            ColorPickerControl.ColorProperty,
+            (sender, _) =>
+            {
+                if (_suppressRowEcho) return;
+                if (sender is not ColorPickerControl cp) return;
+                var c = HexToColor(cp.Color) ?? _points[index].Color;
+                var existing = _points[index].Color;
+                if (existing.R == c.R && existing.G == c.G && existing.B == c.B)
+                    return;
+                var p = _points[index];
+                _points[index] = p with { Color = c };
+                swatch.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(c);
+                RenderCanvas();
+                RaisePointsChanged();
+            });
         var flyout = new Flyout { Content = picker };
         swatch.Flyout = flyout;
         row.Children.Add(swatch);
@@ -287,7 +296,6 @@ public sealed partial class GradientPointsEditor : UserControl
                     Stroke = new Microsoft.UI.Xaml.Media.SolidColorBrush(
                         Microsoft.UI.Colors.White),
                     StrokeThickness = 2,
-                    IsHitTestVisible = false,
                 },
                 HorizontalContentAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
                 VerticalContentAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center,
@@ -327,10 +335,9 @@ public sealed partial class GradientPointsEditor : UserControl
                 RaisePointsChanged();
                 e.Handled = true;
             };
-            handle.PointerPressed += (s, e) =>
+            handle.PointerPressed += (_, e) =>
             {
-                if (s is not ContentControl btn) return;
-                btn.CapturePointer(e.Pointer);
+                handle.CapturePointer(e.Pointer);
                 _dragIndex = capturedIndex;
                 e.Handled = true;
             };
@@ -349,10 +356,10 @@ public sealed partial class GradientPointsEditor : UserControl
                 SyncRowNumbers(capturedIndex);
                 RaisePointsChanged();
             };
-            handle.PointerReleased += (s, e) =>
+            handle.PointerReleased += (_, e) =>
             {
-                if (_dragIndex == capturedIndex && s is ContentControl btn)
-                    btn.ReleasePointerCapture(e.Pointer);
+                if (_dragIndex == capturedIndex)
+                    handle.ReleasePointerCapture(e.Pointer);
                 _dragIndex = -1;
             };
             handle.PointerCaptureLost += (_, _) => _dragIndex = -1;

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI;
 
@@ -23,6 +24,10 @@ public sealed partial class GradientPointsEditor : UserControl
 
     private readonly List<GradientPointModel> _points = new();
 
+    // Guard to suppress echo when we programmatically change row inputs
+    // (e.g. during drag) so NumberBox.ValueChanged doesn't loop back.
+    private bool _suppressRowEcho;
+
     public event EventHandler<IReadOnlyList<GradientPointModel>>? PointsChanged;
 
     public IReadOnlyList<GradientPointModel> Points => _points;
@@ -42,7 +47,135 @@ public sealed partial class GradientPointsEditor : UserControl
         _points.Clear();
         _points.AddRange(points.Take(MaxPoints));
         RenderCanvas();
+        RebuildRows();
     }
+
+    private void RebuildRows()
+    {
+        RowsPanel.Children.Clear();
+        for (int i = 0; i < _points.Count; i++)
+        {
+            RowsPanel.Children.Add(BuildRow(i));
+        }
+        AddPointButton.IsEnabled = _points.Count < MaxPoints;
+    }
+
+    private StackPanel BuildRow(int index)
+    {
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            Tag = index,
+        };
+
+        var swatch = new Button
+        {
+            Width = 24,
+            Height = 24,
+            Padding = new Thickness(0),
+            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                _points[index].Color),
+        };
+        // Reuse the existing ColorPickerControl flyout from Phase 2.
+        var picker = new ColorPickerControl
+        {
+            Color = ColorToHex(_points[index].Color),
+        };
+        picker.ColorChanged += (_, _) =>
+        {
+            if (_suppressRowEcho) return;
+            var c = HexToColor(picker.Color) ?? _points[index].Color;
+            var p = _points[index];
+            _points[index] = p with { Color = c };
+            swatch.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(c);
+            RenderCanvas();
+            RaisePointsChanged();
+        };
+        var flyout = new Flyout { Content = picker };
+        swatch.Flyout = flyout;
+        row.Children.Add(swatch);
+
+        row.Children.Add(BuildNumberBox("X", _points[index].X, v =>
+        {
+            var p = _points[index];
+            _points[index] = p with { X = (float)v };
+        }));
+        row.Children.Add(BuildNumberBox("Y", _points[index].Y, v =>
+        {
+            var p = _points[index];
+            _points[index] = p with { Y = (float)v };
+        }));
+        row.Children.Add(BuildNumberBox("R", _points[index].Radius, v =>
+        {
+            var p = _points[index];
+            _points[index] = p with { Radius = (float)v };
+        }));
+
+        var remove = new Button
+        {
+            Content = "\u2715",
+            Padding = new Thickness(6, 2, 6, 2),
+        };
+        remove.Click += (_, _) =>
+        {
+            _points.RemoveAt(index);
+            RenderCanvas();
+            RebuildRows();
+            RaisePointsChanged();
+        };
+        row.Children.Add(remove);
+
+        return row;
+    }
+
+    private NumberBox BuildNumberBox(string header, double value, Action<double> onChanged)
+    {
+        var nb = new NumberBox
+        {
+            Header = header,
+            Minimum = 0,
+            Maximum = 1,
+            SmallChange = 0.05,
+            LargeChange = 0.1,
+            SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Hidden,
+            Width = 80,
+            Value = value,
+        };
+        nb.ValueChanged += (_, args) =>
+        {
+            if (_suppressRowEcho) return;
+            if (double.IsNaN(args.NewValue)) return;
+            var clamped = Math.Clamp(args.NewValue, 0.0, 1.0);
+            onChanged(clamped);
+            RenderCanvas();
+            RaisePointsChanged();
+        };
+        return nb;
+    }
+
+    private static string ColorToHex(Color c) =>
+        $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
+    private static Color? HexToColor(string hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex)) return null;
+        var s = hex.TrimStart('#');
+        if (s.Length != 6) return null;
+        if (!byte.TryParse(s.AsSpan(0, 2),
+            System.Globalization.NumberStyles.HexNumber,
+            System.Globalization.CultureInfo.InvariantCulture, out var r)) return null;
+        if (!byte.TryParse(s.AsSpan(2, 2),
+            System.Globalization.NumberStyles.HexNumber,
+            System.Globalization.CultureInfo.InvariantCulture, out var g)) return null;
+        if (!byte.TryParse(s.AsSpan(4, 2),
+            System.Globalization.NumberStyles.HexNumber,
+            System.Globalization.CultureInfo.InvariantCulture, out var b)) return null;
+        return Color.FromArgb(0xFF, r, g, b);
+    }
+
+    private void RaisePointsChanged() =>
+        PointsChanged?.Invoke(this, _points.AsReadOnly());
 
     private void RenderCanvas()
     {

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -45,7 +45,18 @@ public sealed partial class GradientPointsEditor : UserControl
     public GradientPointsEditor()
     {
         InitializeComponent();
-        PointsCanvas.SizeChanged += (_, _) => RenderCanvas();
+        PointsCanvas.SizeChanged += (_, _) =>
+        {
+            if (_dragIndex != -1)
+            {
+                // Mid-drag: reposition in place so pointer capture survives.
+                MovePoint(_dragIndex);
+            }
+            else
+            {
+                RenderCanvas();
+            }
+        };
         AddPointButton.Click += (_, _) => TryAdd(0.5f, 0.5f);
         PointsCanvas.DoubleTapped += (_, e) =>
         {
@@ -272,7 +283,7 @@ public sealed partial class GradientPointsEditor : UserControl
             int capturedIndex = i;
             handle.KeyDown += (s, e) =>
             {
-                if (_points.Count == 0) return;
+                if (capturedIndex >= _points.Count) return;
                 const float step = 0.01f;
                 var cur = _points[capturedIndex];
                 switch (e.Key)

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class GradientPointsEditor : UserControl
     // _points. RenderCanvas clears and repopulates these. MovePoint
     // mutates existing instances in place so pointer capture survives.
     private readonly List<Microsoft.UI.Xaml.Shapes.Ellipse> _falloffs = new();
-    private readonly List<Microsoft.UI.Xaml.Shapes.Ellipse> _handles = new();
+    private readonly List<Microsoft.UI.Xaml.UIElement> _handles = new();
 
     public event EventHandler<IReadOnlyList<GradientPointModel>>? PointsChanged;
 
@@ -248,22 +248,62 @@ public sealed partial class GradientPointsEditor : UserControl
             PointsCanvas.Children.Add(falloff);
             _falloffs.Add(falloff);
 
-            // Handle: a small white-bordered solid dot above the falloff.
-            var handle = new Microsoft.UI.Xaml.Shapes.Ellipse
+            // Handle: a small white-bordered circular button above the falloff.
+            // Using Button (a Control) instead of Ellipse (a Shape) so that
+            // IsTabStop and KeyDown are available for keyboard nudge + delete.
+            // CornerRadius = (HandleDiameter + 4) / 2 makes it visually circular.
+            var handleSize = HandleDiameter + 4;
+            var handle = new Button
             {
-                Width = HandleDiameter,
-                Height = HandleDiameter,
-                Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(p.Color),
-                Stroke = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                Width = handleSize,
+                Height = handleSize,
+                Padding = new Microsoft.UI.Xaml.Thickness(0),
+                Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(p.Color),
+                BorderBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(
                     Microsoft.UI.Colors.White),
-                StrokeThickness = 2,
+                BorderThickness = new Microsoft.UI.Xaml.Thickness(2),
+                CornerRadius = new Microsoft.UI.Xaml.CornerRadius(handleSize / 2),
                 Tag = i,
             };
             int capturedIndex = i;
+            handle.KeyDown += (s, e) =>
+            {
+                if (_points.Count == 0) return;
+                const float step = 0.01f;
+                var cur = _points[capturedIndex];
+                switch (e.Key)
+                {
+                    case Windows.System.VirtualKey.Left:
+                        _points[capturedIndex] = cur with { X = Math.Clamp(cur.X - step, 0f, 1f) };
+                        break;
+                    case Windows.System.VirtualKey.Right:
+                        _points[capturedIndex] = cur with { X = Math.Clamp(cur.X + step, 0f, 1f) };
+                        break;
+                    case Windows.System.VirtualKey.Up:
+                        _points[capturedIndex] = cur with { Y = Math.Clamp(cur.Y - step, 0f, 1f) };
+                        break;
+                    case Windows.System.VirtualKey.Down:
+                        _points[capturedIndex] = cur with { Y = Math.Clamp(cur.Y + step, 0f, 1f) };
+                        break;
+                    case Windows.System.VirtualKey.Delete:
+                        _points.RemoveAt(capturedIndex);
+                        RenderCanvas();
+                        RebuildRows();
+                        RaisePointsChanged();
+                        e.Handled = true;
+                        return;
+                    default:
+                        return;
+                }
+                RenderCanvas();
+                SyncRowNumbers(capturedIndex);
+                RaisePointsChanged();
+                e.Handled = true;
+            };
             handle.PointerPressed += (s, e) =>
             {
-                if (s is not Microsoft.UI.Xaml.Shapes.Ellipse el) return;
-                el.CapturePointer(e.Pointer);
+                if (s is not Button btn) return;
+                btn.CapturePointer(e.Pointer);
                 _dragIndex = capturedIndex;
                 e.Handled = true;
             };
@@ -284,13 +324,13 @@ public sealed partial class GradientPointsEditor : UserControl
             };
             handle.PointerReleased += (s, e) =>
             {
-                if (_dragIndex == capturedIndex && s is Microsoft.UI.Xaml.Shapes.Ellipse el)
-                    el.ReleasePointerCapture(e.Pointer);
+                if (_dragIndex == capturedIndex && s is Button btn)
+                    btn.ReleasePointerCapture(e.Pointer);
                 _dragIndex = -1;
             };
             handle.PointerCaptureLost += (_, _) => _dragIndex = -1;
-            Canvas.SetLeft(handle, p.X * w - HandleDiameter / 2);
-            Canvas.SetTop(handle, p.Y * h - HandleDiameter / 2);
+            Canvas.SetLeft(handle, p.X * w - handleSize / 2);
+            Canvas.SetTop(handle, p.Y * h - handleSize / 2);
             PointsCanvas.Children.Add(handle);
             _handles.Add(handle);
         }
@@ -319,8 +359,9 @@ public sealed partial class GradientPointsEditor : UserControl
         Canvas.SetTop(falloff, p.Y * h - falloffSize / 2);
 
         var handle = _handles[index];
-        Canvas.SetLeft(handle, p.X * w - HandleDiameter / 2);
-        Canvas.SetTop(handle, p.Y * h - HandleDiameter / 2);
+        var handleSize = HandleDiameter + 4;
+        Canvas.SetLeft(handle, p.X * w - handleSize / 2);
+        Canvas.SetTop(handle, p.Y * h - handleSize / 2);
     }
 
     // Updates the X/Y/R NumberBoxes in a row to match _points[index]

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -186,16 +186,9 @@
                             Value="1"
                             ValueChanged="GradientSpeed_ValueChanged" />
 
-                    <!-- Gradient points editor -->
-                    <TextBlock Text="Gradient points" Margin="0,12,0,4" />
-                    <TextBlock Text="Up to 5 color points. Each has position (x,y), color, and radius."
-                               Style="{StaticResource CaptionTextBlockStyle}"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-
-                    <StackPanel x:Name="PointsPanel" Spacing="8" />
-
-                    <Button Content="Add point" Click="AddPoint_Click"
-                            x:Name="AddPointButton" />
+                    <!-- Gradient points editor (Phase 4): visual 2D canvas. -->
+                    <ctrl:GradientPointsEditor x:Name="GradientEditor"
+                                               ctrl:SettingsCard.ConfigKey="background-gradient-point" />
                 </StackPanel>
             </ctrl:SettingsGroup>
         </StackPanel>

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -151,40 +151,49 @@
                 -->
                 <StackPanel x:Name="GradientSettingsPanel" Spacing="8" Visibility="Collapsed">
 
-                    <ComboBox x:Name="GradientBlendCombo" Header="Blend mode"
-                              SelectionChanged="GradientBlend_SelectionChanged">
-                        <ComboBoxItem Content="Overlay (on top of content)" Tag="overlay" />
-                        <ComboBoxItem Content="Underlay (behind content)" Tag="underlay" />
-                    </ComboBox>
+                    <ctrl:SettingsCard Header="Blend mode"
+                                       ctrl:SettingsCard.ConfigKey="background-gradient-blend-mode">
+                        <ComboBox x:Name="GradientBlendCombo"
+                                  SelectionChanged="GradientBlend_SelectionChanged">
+                            <ComboBoxItem Content="Overlay (on top of content)" Tag="overlay" />
+                            <ComboBoxItem Content="Underlay (behind content)" Tag="underlay" />
+                        </ComboBox>
+                    </ctrl:SettingsCard>
 
-                    <Slider x:Name="GradientOpacitySlider"
-                            Header="Gradient opacity"
-                            Minimum="0" Maximum="1" StepFrequency="0.01"
-                            TickFrequency="0.1" TickPlacement="BottomRight"
-                            Value="0.05"
-                            ValueChanged="GradientOpacity_ValueChanged" />
+                    <ctrl:SettingsCard Header="Gradient opacity"
+                                       ctrl:SettingsCard.ConfigKey="background-gradient-opacity">
+                        <Slider x:Name="GradientOpacitySlider"
+                                Minimum="0" Maximum="1" StepFrequency="0.01"
+                                TickFrequency="0.1" TickPlacement="BottomRight"
+                                Value="0.05"
+                                ValueChanged="GradientOpacity_ValueChanged" />
+                    </ctrl:SettingsCard>
 
                     <!-- Animation mode picker -->
-                    <TextBlock Text="Position animation" Margin="0,8,0,4" />
-                    <RadioButtons x:Name="PositionAnimRadio" SelectedIndex="0"
-                                  SelectionChanged="AnimationMode_Changed">
-                        <RadioButton Content="None" Tag="" />
-                        <RadioButton Content="Drift (subtle)" Tag="drift" />
-                        <RadioButton Content="Orbit (circular)" Tag="orbit" />
-                        <RadioButton Content="Wander (random)" Tag="wander" />
-                        <RadioButton Content="Bounce (edges)" Tag="bounce" />
-                    </RadioButtons>
+                    <ctrl:SettingsCard Header="Position animation"
+                                       ctrl:SettingsCard.ConfigKey="background-gradient-animation">
+                        <RadioButtons x:Name="PositionAnimRadio" SelectedIndex="0"
+                                      SelectionChanged="AnimationMode_Changed">
+                            <RadioButton Content="None" Tag="" />
+                            <RadioButton Content="Drift (subtle)" Tag="drift" />
+                            <RadioButton Content="Orbit (circular)" Tag="orbit" />
+                            <RadioButton Content="Wander (random)" Tag="wander" />
+                            <RadioButton Content="Bounce (edges)" Tag="bounce" />
+                        </RadioButtons>
+                    </ctrl:SettingsCard>
 
                     <CheckBox x:Name="BreatheCheck" Content="Breathe (pulsing size)"
                               Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
                     <CheckBox x:Name="ColorCycleCheck" Content="Color cycle (hue rotation)"
                               Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
 
-                    <Slider x:Name="GradientSpeedSlider"
-                            Header="Animation speed"
-                            Minimum="0.1" Maximum="3" StepFrequency="0.1"
-                            Value="1"
-                            ValueChanged="GradientSpeed_ValueChanged" />
+                    <ctrl:SettingsCard Header="Animation speed"
+                                       ctrl:SettingsCard.ConfigKey="background-gradient-speed">
+                        <Slider x:Name="GradientSpeedSlider"
+                                Minimum="0.1" Maximum="3" StepFrequency="0.1"
+                                Value="1"
+                                ValueChanged="GradientSpeed_ValueChanged" />
+                    </ctrl:SettingsCard>
 
                     <!-- Gradient points editor (Phase 4): visual 2D canvas. -->
                     <ctrl:GradientPointsEditor x:Name="GradientEditor"

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -163,6 +163,7 @@
                     <ctrl:SettingsCard Header="Gradient opacity"
                                        ctrl:SettingsCard.ConfigKey="background-gradient-opacity">
                         <Slider x:Name="GradientOpacitySlider"
+                                Width="240"
                                 Minimum="0" Maximum="1" StepFrequency="0.01"
                                 TickFrequency="0.1" TickPlacement="BottomRight"
                                 Value="0.05"
@@ -182,15 +183,22 @@
                         </RadioButtons>
                     </ctrl:SettingsCard>
 
-                    <CheckBox x:Name="BreatheCheck" Content="Breathe (pulsing size)"
-                              Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
-                    <CheckBox x:Name="ColorCycleCheck" Content="Color cycle (hue rotation)"
-                              Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
+                    <ctrl:SettingsCard Header="Additional effects"
+                                       Description="Combine with any position animation above.">
+                        <StackPanel Spacing="4">
+                            <CheckBox x:Name="BreatheCheck" Content="Breathe (pulsing size)"
+                                      Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
+                            <CheckBox x:Name="ColorCycleCheck" Content="Color cycle (hue rotation)"
+                                      Checked="AnimationMode_Changed" Unchecked="AnimationMode_Changed" />
+                        </StackPanel>
+                    </ctrl:SettingsCard>
 
                     <ctrl:SettingsCard Header="Animation speed"
                                        ctrl:SettingsCard.ConfigKey="background-gradient-speed">
                         <Slider x:Name="GradientSpeedSlider"
+                                Width="240"
                                 Minimum="0.1" Maximum="3" StepFrequency="0.1"
+                                TickFrequency="0.5" TickPlacement="BottomRight"
                                 Value="1"
                                 ValueChanged="GradientSpeed_ValueChanged" />
                     </ctrl:SettingsCard>

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -281,15 +281,30 @@ internal sealed partial class AppearancePage : Page
     private void WriteAllPoints()
     {
         if (_loading) return;
-        var values = GradientEditor.Points
-            .Select(p => string.Create(
-                System.Globalization.CultureInfo.InvariantCulture,
-                $"{p.X:0.###},{p.Y:0.###},#{p.Color.R:X2}{p.Color.G:X2}{p.Color.B:X2},{p.Radius:0.###}"))
-            .ToArray();
-        _configService.SuppressWatcher(true);
-        try { _editor.SetRepeatableValues("background-gradient-point", values); }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        // Suppress the re-seed that OnConfigChanged would otherwise do
+        // when our own Reload() fires ConfigChanged synchronously. The
+        // editor already reflects the values we are about to write, so
+        // re-seeding would just rebuild rows and destroy any open flyout
+        // (e.g. the color picker the user is dragging). Inner try/finally
+        // on SuppressWatcher keeps the watcher flag balanced if
+        // SetRepeatableValues throws.
+        _loading = true;
+        try
+        {
+            var values = GradientEditor.Points
+                .Select(p => string.Create(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    $"{p.X:0.###},{p.Y:0.###},#{p.Color.R:X2}{p.Color.G:X2}{p.Color.B:X2},{p.Radius:0.###}"))
+                .ToArray();
+            _configService.SuppressWatcher(true);
+            try { _editor.SetRepeatableValues("background-gradient-point", values); }
+            finally { _configService.SuppressWatcher(false); }
+            _configService.Reload();
+        }
+        finally
+        {
+            _loading = false;
+        }
     }
 
     private void AnimationMode_Changed(object sender, object e)

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -19,6 +19,12 @@ internal sealed partial class AppearancePage : Page
     private readonly IConfigFileEditor _editor;
     private readonly SearchableList _fontList;
     private bool _loading = true;
+    // Counts Reload() invocations we initiated ourselves. Each one will
+    // eventually re-enter OnConfigChanged via the dispatcher queue; we
+    // decrement to skip that re-seed (the editor already has the values
+    // we just wrote). External config file edits never touch this so they
+    // still re-seed normally.
+    private int _expectingOwnReloads;
 
     public AppearancePage(IConfigService configService, IConfigFileEditor editor)
     {
@@ -281,29 +287,22 @@ internal sealed partial class AppearancePage : Page
     private void WriteAllPoints()
     {
         if (_loading) return;
-        // Suppress the re-seed that OnConfigChanged would otherwise do
-        // when our own Reload() fires ConfigChanged synchronously. The
-        // editor already reflects the values we are about to write, so
-        // re-seeding would just rebuild rows and destroy any open flyout
-        // (e.g. the color picker the user is dragging). Inner try/finally
+        // Reload() fires ConfigChanged synchronously; OnConfigChanged
+        // decrements _expectingOwnReloads and skips the re-seed so an
+        // in-progress picker flyout isn't torn down. Inner try/finally
         // on SuppressWatcher keeps the watcher flag balanced if
         // SetRepeatableValues throws.
-        _loading = true;
-        try
+        var values = GradientEditor.Points
+            .Select(p => string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"{p.X:0.###},{p.Y:0.###},#{p.Color.R:X2}{p.Color.G:X2}{p.Color.B:X2},{p.Radius:0.###}"))
+            .ToArray();
+        _configService.SuppressWatcher(true);
+        try { _editor.SetRepeatableValues("background-gradient-point", values); }
+        finally { _configService.SuppressWatcher(false); }
+        if (_configService.Reload())
         {
-            var values = GradientEditor.Points
-                .Select(p => string.Create(
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    $"{p.X:0.###},{p.Y:0.###},#{p.Color.R:X2}{p.Color.G:X2}{p.Color.B:X2},{p.Radius:0.###}"))
-                .ToArray();
-            _configService.SuppressWatcher(true);
-            try { _editor.SetRepeatableValues("background-gradient-point", values); }
-            finally { _configService.SuppressWatcher(false); }
-            _configService.Reload();
-        }
-        finally
-        {
-            _loading = false;
+            _expectingOwnReloads++;
         }
     }
 
@@ -328,6 +327,14 @@ internal sealed partial class AppearancePage : Page
 
     private void OnConfigChanged(IConfigService svc)
     {
+        // Echo from our own Reload(): editor already reflects these
+        // values, so skip the rebuild (which would tear down any open
+        // row, like a color picker flyout the user is dragging).
+        if (_expectingOwnReloads > 0)
+        {
+            _expectingOwnReloads--;
+            return;
+        }
         if (_loading) return;
         // GradientPoints is on the concrete ConfigService, not the interface.
         // Bail silently for any other runtime type (e.g. test fakes).

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -95,6 +95,8 @@ internal sealed partial class AppearancePage : Page
             SelectComboByTag(GradientBlendCombo, configSvc.GradientBlend);
         }
 
+        GradientEditor.PointsChanged += (_, _) => WriteAllPoints();
+
         _loading = false;
 
         // Re-seed the gradient editor when the config file changes on disk.

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -96,6 +96,13 @@ internal sealed partial class AppearancePage : Page
         }
 
         _loading = false;
+
+        // Re-seed the gradient editor when the config file changes on disk.
+        // The editor's own writes set _loading/SuppressWatcher, so this only
+        // fires for genuine external edits.
+        _configService.ConfigChanged += OnConfigChanged;
+        Unloaded += (_, _) => _configService.ConfigChanged -= OnConfigChanged;
+
         LoadFontsAsync();
     }
 
@@ -300,6 +307,26 @@ internal sealed partial class AppearancePage : Page
 
         var value = parts.Count > 0 ? string.Join(",", parts) : "static";
         OnValueChanged("background-gradient-animation", value);
+    }
+
+    private void OnConfigChanged(IConfigService svc)
+    {
+        if (_loading) return;
+        // GradientPoints is on the concrete ConfigService, not the interface.
+        // Bail silently for any other runtime type (e.g. test fakes).
+        if (svc is not ConfigService cs) return;
+        _loading = true;
+        try
+        {
+            GradientEditor.SetPoints(cs.GradientPoints
+                .Select(p => new Controls.Settings.GradientPointModel(
+                    p.X, p.Y, p.Color, p.Radius))
+                .ToList());
+        }
+        finally
+        {
+            _loading = false;
+        }
     }
 
 }

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -19,7 +19,6 @@ internal sealed partial class AppearancePage : Page
     private readonly IConfigFileEditor _editor;
     private readonly SearchableList _fontList;
     private bool _loading = true;
-    private readonly List<GradientPointEditor> _pointEditors = [];
 
     public AppearancePage(IConfigService configService, IConfigFileEditor editor)
     {
@@ -66,12 +65,10 @@ internal sealed partial class AppearancePage : Page
             GradientSettingsPanel.Visibility = points.Count > 0
                 ? Visibility.Visible : Visibility.Collapsed;
 
-            // Load existing points into editors.
-            foreach (var pt in points)
-            {
-                AddPointEditor(pt.X, pt.Y,
-                    $"#{pt.Color.R:X2}{pt.Color.G:X2}{pt.Color.B:X2}", pt.Radius);
-            }
+            // Load existing points into editor.
+            GradientEditor.SetPoints(points
+                .Select(p => new GradientPointModel(p.X, p.Y, p.Color, p.Radius))
+                .ToList());
 
             // Parse animation mode into radio + checkboxes.
             var anim = configSvc.GradientAnimation;
@@ -98,7 +95,6 @@ internal sealed partial class AppearancePage : Page
             SelectComboByTag(GradientBlendCombo, configSvc.GradientBlend);
         }
 
-        UpdateAddButtonVisibility();
         _loading = false;
         LoadFontsAsync();
     }
@@ -259,74 +255,32 @@ internal sealed partial class AppearancePage : Page
             try { _editor.RemoveValue("background-gradient-point"); }
             finally { _configService.SuppressWatcher(false); }
             _configService.Reload();
-            _pointEditors.Clear();
-            PointsPanel.Children.Clear();
+            GradientEditor.SetPoints(System.Array.Empty<GradientPointModel>());
         }
-        else if (_pointEditors.Count == 0)
+        else if (GradientEditor.Points.Count == 0)
         {
-            // Add a default point when enabling.
-            AddPointEditor(0.5f, 0.5f, "#FF6B35", 0.5f);
+            // Seed a default point when enabling for the first time.
+            GradientEditor.SetPoints(new[]
+            {
+                new GradientPointModel(
+                    0.5f, 0.5f, Windows.UI.Color.FromArgb(0xFF, 0xFF, 0x6B, 0x35), 0.5f),
+            });
             WriteAllPoints();
-        }
-    }
-
-    private void AddPoint_Click(object sender, RoutedEventArgs e)
-    {
-        if (_pointEditors.Count >= 5) return;
-        AddPointEditor(0.5f, 0.5f, "#F7C948", 0.4f);
-        WriteAllPoints();
-        UpdateAddButtonVisibility();
-    }
-
-    private void AddPointEditor(float x, float y, string color, float radius)
-    {
-        var editor = new GradientPointEditor(
-            _pointEditors.Count,
-            () => { if (!_loading) WriteAllPoints(); },
-            RemovePointEditor);
-        editor.XSlider.Value = x;
-        editor.YSlider.Value = y;
-        editor.ColorPicker.Color = color;
-        editor.RadiusSlider.Value = radius;
-        _pointEditors.Add(editor);
-        PointsPanel.Children.Add(editor.Panel);
-        UpdateAddButtonVisibility();
-    }
-
-    private void RemovePointEditor(GradientPointEditor editor)
-    {
-        _pointEditors.Remove(editor);
-        PointsPanel.Children.Remove(editor.Panel);
-        // Renumber remaining points.
-        for (int i = 0; i < _pointEditors.Count; i++)
-        {
-            var header = _pointEditors[i].Panel.Children[0] as StackPanel;
-            if (header?.Children[0] is TextBlock tb)
-                tb.Text = $"Point {i + 1}";
-        }
-        WriteAllPoints();
-        UpdateAddButtonVisibility();
-
-        if (_pointEditors.Count == 0)
-        {
-            GradientEnabledToggle.IsOn = false;
-            GradientSettingsPanel.Visibility = Visibility.Collapsed;
         }
     }
 
     private void WriteAllPoints()
     {
         if (_loading) return;
-        var values = _pointEditors.Select(e => e.ToConfigValue()).ToArray();
+        var values = GradientEditor.Points
+            .Select(p => string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"{p.X:0.###},{p.Y:0.###},#{p.Color.R:X2}{p.Color.G:X2}{p.Color.B:X2},{p.Radius:0.###}"))
+            .ToArray();
         _configService.SuppressWatcher(true);
         try { _editor.SetRepeatableValues("background-gradient-point", values); }
         finally { _configService.SuppressWatcher(false); }
         _configService.Reload();
-    }
-
-    private void UpdateAddButtonVisibility()
-    {
-        AddPointButton.IsEnabled = _pointEditors.Count < 5;
     }
 
     private void AnimationMode_Changed(object sender, object e)
@@ -348,90 +302,4 @@ internal sealed partial class AppearancePage : Page
         OnValueChanged("background-gradient-animation", value);
     }
 
-    private sealed class GradientPointEditor
-    {
-        public Slider XSlider { get; }
-        public Slider YSlider { get; }
-        public ColorPickerControl ColorPicker { get; }
-        public Slider RadiusSlider { get; }
-        public Button RemoveButton { get; }
-        public StackPanel Panel { get; }
-
-        public GradientPointEditor(int index, Action onChanged, Action<GradientPointEditor> onRemove)
-        {
-            Panel = new StackPanel
-            {
-                Spacing = 4,
-                Padding = new Thickness(8),
-                BorderBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray),
-                BorderThickness = new Thickness(1),
-                CornerRadius = new CornerRadius(4)
-            };
-
-            var header = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
-            header.Children.Add(new TextBlock
-            {
-                Text = $"Point {index + 1}",
-                VerticalAlignment = VerticalAlignment.Center
-            });
-            RemoveButton = new Button { Content = "Remove", Padding = new Thickness(4, 2, 4, 2) };
-            RemoveButton.Click += (_, _) => onRemove(this);
-            header.Children.Add(RemoveButton);
-            Panel.Children.Add(header);
-
-            XSlider = new Slider
-            {
-                Header = "X position",
-                Minimum = 0,
-                Maximum = 1,
-                StepFrequency = 0.05,
-                Value = 0.5
-            };
-            XSlider.ValueChanged += (_, _) => onChanged();
-            Panel.Children.Add(XSlider);
-
-            YSlider = new Slider
-            {
-                Header = "Y position",
-                Minimum = 0,
-                Maximum = 1,
-                StepFrequency = 0.05,
-                Value = 0.5
-            };
-            YSlider.ValueChanged += (_, _) => onChanged();
-            Panel.Children.Add(YSlider);
-
-            // ColorPickerControl has no built-in Header property like TextBox
-            // does, so emit a small caption above it to match the surrounding
-            // sliders' "X position", "Y position" labels.
-            Panel.Children.Add(new TextBlock
-            {
-                Text = "Color",
-                Style = (Style)Microsoft.UI.Xaml.Application.Current.Resources["CaptionTextBlockStyle"],
-                Margin = new Thickness(0, 4, 0, 2)
-            });
-            ColorPicker = new ColorPickerControl { Color = "#FF6B35" };
-            ColorPicker.ColorChanged += (_, _) => onChanged();
-            Panel.Children.Add(ColorPicker);
-
-            RadiusSlider = new Slider
-            {
-                Header = "Radius",
-                Minimum = 0.1,
-                Maximum = 1,
-                StepFrequency = 0.05,
-                Value = 0.5
-            };
-            RadiusSlider.ValueChanged += (_, _) => onChanged();
-            Panel.Children.Add(RadiusSlider);
-        }
-
-        public string ToConfigValue()
-        {
-            var color = ColorPicker.Color;
-            if (string.IsNullOrEmpty(color)) color = "#FF6B35";
-            if (!color.StartsWith('#')) color = "#" + color;
-            return $"{XSlider.Value:F2},{YSlider.Value:F2},{color},{RadiusSlider.Value:F2}";
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Phase 4 of the settings reorganization. Replaces the numeric-only gradient point stack on the Appearance page with a 2D visual editor: drag dots on a canvas, soft radial falloffs for radius feedback, compact numeric rows below, and keyboard support for accessibility.

## IMPORTANT: stacked PR

Part of the settings reorganization stack. Merge order:

1. #245 (phase 1 foundation) -> windows
2. #246 (phase 2 color picker) -> #245
3. #247 (phase 3 search overlay) -> #246
4. **this PR** (phase 4 gradient editor) -> #247
5. #252 (phase 5 raw editor + diagnostics) -> this PR

GitHub auto-retargets child PRs when parents merge.

## In scope

- Draggable dot per gradient point, clamped to [0, 1].
- Soft radial falloff around each dot as a visual editor aid. Rendered with a local RadialGradientBrush, not the real GradientTintVisual, so it will not reflect blend mode, opacity, or animation of the final output.
- Compact per-point row: ColorPickerControl swatch + X/Y/R NumberBoxes + remove.
- Double-click empty canvas to add a point. "Add point" button as fallback. 5-point cap.
- Keyboard: arrow-key nudge by 0.01 and Delete on a focused handle. XY focus navigation disabled on the handle so Up/Down reach the handler.
- ConfigKey tags on blend mode, opacity, position animation, speed, and gradient points so the phase 3 search pulse targets them.
- Breathe / color cycle wrapped in an "Additional effects" SettingsCard so the multi-select nature is visible.
- Canvas hides when no points; speed slider gets an explicit width.

## Out of scope

- Live preview via GradientTintVisual in a canvas corner (deferred).
- Drag-to-resize-radius by the falloff edge (deferred; radius stays numeric).
- Runtime reapply of other UiSettings toggles (vertical-tabs etc.) tracked separately under # 244.

## Test plan

- [ ] Open Settings with a pre-existing 3-point gradient config; editor renders all three dots at correct positions.
- [ ] Drag a dot on the canvas; terminal background follows live.
- [ ] Open the color picker on a row; drag HSV slider; terminal and canvas falloff update live without the flyout closing.
- [ ] Double-click empty canvas to add a point; double-click on an existing handle is a no-op; "Add point" button also works; 5-point cap disables both paths.
- [ ] Tab to a handle, arrow-nudge, Delete.
- [ ] Edit config file externally while the editor is open; editor re-seeds.
- [ ] Search "gradient" in Settings; click each result; the card pulses.
- [ ] dotnet test windows/Ghostty.Tests passes (319 tests).
