### PR TITLE
refactor(windows): drop CommunityToolkit.Mvvm dependency

### DIFF
--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -70,8 +70,10 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
     private List<CommandItem> _filteredCommands = [];
     public List<CommandItem> FilteredCommands
     {
+        // Always a fresh list from ApplyFilter/ApplyCommandLineFilter,
+        // so no reference-equality guard: it would always pass anyway.
         get => _filteredCommands;
-        set { if (_filteredCommands != value) { _filteredCommands = value; Raise(); } }
+        set { _filteredCommands = value; Raise(); }
     }
 
     private string? _ghostText;

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
+using System.Runtime.CompilerServices;
 
 namespace Ghostty.Commands;
 
@@ -12,10 +12,7 @@ internal enum PaletteMode
     CommandLine,
 }
 
-// Suppress MVVMTK0045: this ViewModel is internal and accessed from code-behind,
-// never directly x:Bind'd from XAML, so the WinRT-marshalling AOT concern does not apply.
-#pragma warning disable MVVMTK0045
-internal partial class CommandPaletteViewModel : ObservableObject
+internal class CommandPaletteViewModel : INotifyPropertyChanged
 {
     private readonly IReadOnlyList<ICommandSource> _sources;
     private readonly FrecencyStore _frecency;
@@ -23,32 +20,74 @@ internal partial class CommandPaletteViewModel : ObservableObject
     private readonly bool _groupByCategory;
     private List<CommandItem> _allCommands = [];
 
-    [ObservableProperty]
     private bool _isOpen;
+    public bool IsOpen
+    {
+        get => _isOpen;
+        set { if (_isOpen != value) { _isOpen = value; Raise(); } }
+    }
 
-    [ObservableProperty]
     private string _searchText = "";
+    public string SearchText
+    {
+        get => _searchText;
+        set
+        {
+            if (_searchText == value) return;
+            _searchText = value;
+            Raise();
+            OnSearchTextChanged(value);
+        }
+    }
 
-    [ObservableProperty]
     private PaletteMode _mode = PaletteMode.Search;
+    public PaletteMode Mode
+    {
+        get => _mode;
+        set { if (_mode != value) { _mode = value; Raise(); } }
+    }
 
-    [ObservableProperty]
     private bool _isPinned;
+    public bool IsPinned
+    {
+        get => _isPinned;
+        set { if (_isPinned != value) { _isPinned = value; Raise(); } }
+    }
 
-    [ObservableProperty]
     private CommandItem? _selectedCommand;
+    public CommandItem? SelectedCommand
+    {
+        get => _selectedCommand;
+        set { if (_selectedCommand != value) { _selectedCommand = value; Raise(); } }
+    }
 
-    [ObservableProperty]
     private List<CommandItem> _filteredCommands = [];
+    public List<CommandItem> FilteredCommands
+    {
+        get => _filteredCommands;
+        set { if (_filteredCommands != value) { _filteredCommands = value; Raise(); } }
+    }
 
-    [ObservableProperty]
     private string? _ghostText;
+    public string? GhostText
+    {
+        get => _ghostText;
+        set { if (_ghostText != value) { _ghostText = value; Raise(); } }
+    }
 
-    [ObservableProperty]
     private string _statusText = "";
+    public string StatusText
+    {
+        get => _statusText;
+        set { if (_statusText != value) { _statusText = value; Raise(); } }
+    }
 
-    [ObservableProperty]
     private string _modeLabel = "Search";
+    public string ModeLabel
+    {
+        get => _modeLabel;
+        set { if (_modeLabel != value) { _modeLabel = value; Raise(); } }
+    }
 
     public CommandPaletteViewModel(
         IReadOnlyList<ICommandSource> sources,
@@ -92,7 +131,6 @@ internal partial class CommandPaletteViewModel : ObservableObject
         else Open();
     }
 
-    [RelayCommand]
     public void ExecuteSelectedCommand()
     {
         if (SelectedCommand is null) return;
@@ -111,7 +149,7 @@ internal partial class CommandPaletteViewModel : ObservableObject
         }
     }
 
-    partial void OnSearchTextChanged(string value)
+    private void OnSearchTextChanged(string value)
     {
         if (value.StartsWith('>'))
         {
@@ -218,5 +256,10 @@ internal partial class CommandPaletteViewModel : ObservableObject
         idx = Math.Min(FilteredCommands.Count - 1, idx + 1);
         SelectedCommand = FilteredCommands[idx];
     }
+
+    // ── INotifyPropertyChanged ───────────────────────────────────────────────
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void Raise([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }
-#pragma warning restore MVVMTK0045

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -12,6 +12,12 @@ internal enum PaletteMode
     CommandLine,
 }
 
+/// <summary>
+/// Backs the command palette control. Pure code-behind binding
+/// (see <c>CommandPaletteControl.Bind</c>), so the type stays internal
+/// and INPC is hand-rolled for the same reason as <c>TabModel</c>:
+/// not worth a NuGet dependency for one consumer.
+/// </summary>
 internal class CommandPaletteViewModel : INotifyPropertyChanged
 {
     private readonly IReadOnlyList<ICommandSource> _sources;

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -64,7 +64,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes # 253.

CommandPaletteViewModel was the sole consumer of CommunityToolkit.Mvvm. Hand-rolls INotifyPropertyChanged to match the existing TabModel pattern.

## Commits

- refactor: hand-roll INPC in CommandPaletteViewModel
- chore: remove CommunityToolkit.Mvvm package reference
- docs: explain hand-rolled INPC choice

## Notes

- MVVMTK0045 pragma is gone along with the package, trimming graph simpler for NativeAOT
- Non-`>` fuzzy search manually verified
- Pre-existing `>` command execution bug filed separately as # 255

## Test plan

- [x] Build clean (0 warnings, 0 errors)
- [x] Fuzzy search manual smoke test