### PR TITLE
chore(windows): migrate C# tree to .NET 10

### DIFF
--- a/dist/windows/IconGen.Tests/IconGen.Tests.csproj
+++ b/dist/windows/IconGen.Tests/IconGen.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/dist/windows/IconGen/IconGen.csproj
+++ b/dist/windows/IconGen/IconGen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.312",
+    "version": "10.0.202",
     "rollForward": "latestPatch"
   }
 }

--- a/justfile
+++ b/justfile
@@ -110,7 +110,7 @@ build-win:
 # Build the DLL and the shell, then launch it.
 [windows]
 run-win: build-dll build-win
-    ./windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/Ghostty.exe
+    ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.exe
 
 # === Upstream Sync ===
 

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -10,7 +10,7 @@
       hand-written stubs that drift. The previous PaneStubs.cs +
       Compile Include trick is replaced by this assembly.
     -->
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Ghostty.Core</RootNamespace>
     <AssemblyName>Ghostty.Core</AssemblyName>
     <Nullable>enable</Nullable>

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -12,7 +12,7 @@
       are explicit fakes that live in this project; they are NOT parallel
       type definitions of production types.
     -->
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Ghostty.Tests</RootNamespace>
     <AssemblyName>Ghostty.Tests</AssemblyName>
     <Nullable>enable</Nullable>

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <!--
       WinUI 3 + Windows App SDK does not support AnyCPU because the

--- a/windows/Ghostty/global.json
+++ b/windows/Ghostty/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.312",
+    "version": "10.0.202",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Migrates the Windows C# tree from .NET 9 to .NET 10. Zero semantic source changes.

## What changed

- `global.json` and `windows/Ghostty/global.json`: SDK 9.0.312 to 10.0.202 (`rollForward` values preserved).
- Five csprojs: TargetFramework net9.0 to net10.0 (Ghostty, Ghostty.Core, Ghostty.Tests, IconGen, IconGen.Tests).
- `justfile` line 113: bin path updated to `net10.0-windows10.0.19041.0`.

`LangVersion` stays `latest`; the net10 SDK picks C# 14, but no C# 14 features are used in this PR. Adoption is a separate stacked PR.

## Validation

| Check | Result |
|---|---|
| Debug build | 0 errors, 3 warnings (pre-existing xUnit2013 in TabManagerDetachTests.cs lines 81/111/136) |
| Ghostty.Tests | 390 / 390 pass |
| IconGen.Tests | 19 / 19 pass |
| `just run-win` | launches, tab opens, cmd.exe responsive, closes cleanly |
| AOT publish | clean, 0 IL/CsWinRT/Trim warnings (same as net9 baseline) |

Warning sets compared file-by-file against the pre-bump `windows` HEAD baseline. No new, no regressed, no cleared.

## Exe size

NativeAOT publish: 34.72 MB (net9) to 36.38 MB (net10). +1.66 MB / +4.78%.

Normal for a major .NET bump (the BCL grows and gets statically linked). The usual shrink levers (`InvariantGlobalization`, `EventSourceSupport=false`, etc.) are out of scope here and can be tuned in a follow-up if desired.

## Why bump now

.NET 9 is STS, EOL May 2026. .NET 10 is LTS (GA Nov 2025). Local SDK 10.0.202 is already installed.
