### PR TITLE
refactor(windows): adopt C# 14 features enabled by .NET 10

### DIFF
--- a/windows/Ghostty.Core/Config/ThemeParser.cs
+++ b/windows/Ghostty.Core/Config/ThemeParser.cs
@@ -13,12 +13,13 @@ namespace Ghostty.Core.Config;
 /// </summary>
 public static class ThemeParser
 {
-    // Two-char set, but SearchValues lets the JIT pick the optimal
-    // path (Vector256 on modern x64) without redoing the array setup
-    // on every config parse.
+    // Cached so the collection-expression `[':', '=']` form does not
+    // allocate a fresh char[] every parse. The JIT then dispatches to
+    // the SearchValues two-char scanner (Char2SearchValues path), which
+    // is the same shape as the specialized `IndexOfAny(char, char)`
+    // overload but reachable from the span-based call site below.
     private static readonly SearchValues<char> ThemePairSeparators =
         SearchValues.Create(":=");
-
 
     /// <summary>
     /// Parse a theme config value into light/dark components.

--- a/windows/Ghostty.Core/Config/ThemeParser.cs
+++ b/windows/Ghostty.Core/Config/ThemeParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -12,6 +13,13 @@ namespace Ghostty.Core.Config;
 /// </summary>
 public static class ThemeParser
 {
+    // Two-char set, but SearchValues lets the JIT pick the optimal
+    // path (Vector256 on modern x64) without redoing the array setup
+    // on every config parse.
+    private static readonly SearchValues<char> ThemePairSeparators =
+        SearchValues.Create(":=");
+
+
     /// <summary>
     /// Parse a theme config value into light/dark components.
     /// Handles single ("ThemeName") and pair ("light:X,dark:Y") forms.
@@ -33,7 +41,7 @@ public static class ThemeParser
         {
             // Find the first ':' or '='. Match Zig which tolerates spaces
             // around the separator (e.g. "dark : bar").
-            var sepIdx = part.IndexOfAny([':', '=']);
+            var sepIdx = part.AsSpan().IndexOfAny(ThemePairSeparators);
             if (sepIdx <= 0) continue;
 
             var name = part[..sepIdx].Trim();

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -27,14 +27,13 @@ internal sealed class TabModel : INotifyPropertyChanged
     /// because the config layer does not exist; reserved for plan 3.</summary>
     public string? ProfileId { get; set; }
 
-    private string? _userOverrideTitle;
     public string? UserOverrideTitle
     {
-        get => _userOverrideTitle;
+        get;
         set
         {
-            if (_userOverrideTitle == value) return;
-            _userOverrideTitle = value;
+            if (field == value) return;
+            field = value;
             Raise();
             // EffectiveTitle is computed; classic bindings listen for
             // the exact property name, so raise it explicitly.
@@ -42,27 +41,24 @@ internal sealed class TabModel : INotifyPropertyChanged
         }
     }
 
-    private string? _shellReportedTitle;
     public string? ShellReportedTitle
     {
-        get => _shellReportedTitle;
+        get;
         set
         {
-            if (_shellReportedTitle == value) return;
-            _shellReportedTitle = value;
+            if (field == value) return;
+            field = value;
             Raise();
             Raise(nameof(EffectiveTitle));
         }
     }
 
-    private TabProgressState _progress = TabProgressState.None;
     public TabProgressState Progress
     {
-        get => _progress;
-        set { if (!_progress.Equals(value)) { _progress = value; Raise(); } }
-    }
+        get;
+        set { if (!field.Equals(value)) { field = value; Raise(); } }
+    } = TabProgressState.None;
 
-    private TabColor _color = TabColor.None;
     /// <summary>
     /// Preset tint applied to this tab's header. In-memory only;
     /// resets to <see cref="TabColor.None"/> on app restart. True
@@ -71,9 +67,9 @@ internal sealed class TabModel : INotifyPropertyChanged
     /// </summary>
     public TabColor Color
     {
-        get => _color;
-        set { if (_color != value) { _color = value; Raise(); } }
-    }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
+    } = TabColor.None;
 
     public string EffectiveTitle =>
         UserOverrideTitle ?? ShellReportedTitle ?? "Ghostty";

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -9,9 +9,8 @@ namespace Ghostty.Core.Tabs;
 /// One tab's worth of state. Pure C# (no WinUI types) so the test
 /// project can reference it directly via the Ghostty.Core ProjectReference.
 ///
-/// INPC is hand-rolled here rather than depending on
-/// CommunityToolkit.Mvvm: only two reactive properties, not worth a
-/// NuGet dependency.
+/// INPC is hand-rolled with the C# 14 <c>field</c> keyword: no source
+/// generator dependency, no per-property backing field declarations.
 ///
 /// EffectiveTitle is a computed property; the model raises
 /// PropertyChanged for both UserOverrideTitle and ShellReportedTitle so

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -26,76 +26,67 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
     private readonly bool _groupByCategory;
     private List<CommandItem> _allCommands = [];
 
-    private bool _isOpen;
     public bool IsOpen
     {
-        get => _isOpen;
-        set { if (_isOpen != value) { _isOpen = value; Raise(); } }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
     }
 
-    private string _searchText = "";
     public string SearchText
     {
-        get => _searchText;
+        get;
         set
         {
-            if (_searchText == value) return;
-            _searchText = value;
+            if (field == value) return;
+            field = value;
             Raise();
             OnSearchTextChanged(value);
         }
-    }
+    } = "";
 
-    private PaletteMode _mode = PaletteMode.Search;
     public PaletteMode Mode
     {
-        get => _mode;
-        set { if (_mode != value) { _mode = value; Raise(); } }
-    }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
+    } = PaletteMode.Search;
 
-    private bool _isPinned;
     public bool IsPinned
     {
-        get => _isPinned;
-        set { if (_isPinned != value) { _isPinned = value; Raise(); } }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
     }
 
-    private CommandItem? _selectedCommand;
     public CommandItem? SelectedCommand
     {
-        get => _selectedCommand;
-        set { if (_selectedCommand != value) { _selectedCommand = value; Raise(); } }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
     }
 
-    private List<CommandItem> _filteredCommands = [];
     public List<CommandItem> FilteredCommands
     {
         // Always a fresh list from ApplyFilter/ApplyCommandLineFilter,
         // so no reference-equality guard: it would always pass anyway.
-        get => _filteredCommands;
-        set { _filteredCommands = value; Raise(); }
-    }
+        get;
+        set { field = value; Raise(); }
+    } = [];
 
-    private string? _ghostText;
     public string? GhostText
     {
-        get => _ghostText;
-        set { if (_ghostText != value) { _ghostText = value; Raise(); } }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
     }
 
-    private string _statusText = "";
     public string StatusText
     {
-        get => _statusText;
-        set { if (_statusText != value) { _statusText = value; Raise(); } }
-    }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
+    } = "";
 
-    private string _modeLabel = "Search";
     public string ModeLabel
     {
-        get => _modeLabel;
-        set { if (_modeLabel != value) { _modeLabel = value; Raise(); } }
-    }
+        get;
+        set { if (field != value) { field = value; Raise(); } }
+    } = "Search";
 
     public CommandPaletteViewModel(
         IReadOnlyList<ICommandSource> sources,

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -14,9 +14,9 @@ internal enum PaletteMode
 
 /// <summary>
 /// Backs the command palette control. Pure code-behind binding
-/// (see <c>CommandPaletteControl.Bind</c>), so the type stays internal
-/// and INPC is hand-rolled for the same reason as <c>TabModel</c>:
-/// not worth a NuGet dependency for one consumer.
+/// (see <c>CommandPaletteControl.Bind</c>), so the type stays internal.
+/// INPC is hand-rolled with the C# 14 <c>field</c> keyword for the
+/// same reason as <c>TabModel</c>: no source generator dependency.
 /// </summary>
 internal class CommandPaletteViewModel : INotifyPropertyChanged
 {

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -45,6 +45,9 @@ internal sealed partial class CommandPaletteControl : UserControl
     {
         _vm?.PropertyChanged -= OnViewModelPropertyChanged;
 
+        // The subscribe below skips ?. on purpose: _vm was just
+        // assigned the non-nullable viewModel parameter on the
+        // previous line.
         _vm = viewModel;
         _vm.PropertyChanged += OnViewModelPropertyChanged;
 

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -43,8 +43,7 @@ internal sealed partial class CommandPaletteControl : UserControl
     /// </summary>
     public void Bind(CommandPaletteViewModel viewModel)
     {
-        if (_vm is not null)
-            _vm.PropertyChanged -= OnViewModelPropertyChanged;
+        _vm?.PropertyChanged -= OnViewModelPropertyChanged;
 
         _vm = viewModel;
         _vm.PropertyChanged += OnViewModelPropertyChanged;
@@ -371,12 +370,12 @@ internal sealed partial class CommandPaletteControl : UserControl
 
     private void OnPinChecked(object sender, RoutedEventArgs e)
     {
-        if (_vm is not null) _vm.IsPinned = true;
+        _vm?.IsPinned = true;
     }
 
     private void OnPinUnchecked(object sender, RoutedEventArgs e)
     {
-        if (_vm is not null) _vm.IsPinned = false;
+        _vm?.IsPinned = false;
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -106,8 +106,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     {
         var next = _activeLeaf.Terminal();
         if (ReferenceEquals(next, _progressBoundTerminal)) return;
-        if (_progressBoundTerminal is not null)
-            _progressBoundTerminal.ProgressChanged -= OnActiveLeafProgressChanged;
+        _progressBoundTerminal?.ProgressChanged -= OnActiveLeafProgressChanged;
         _progressBoundTerminal = next;
         next.ProgressChanged += OnActiveLeafProgressChanged;
         // Re-emit the new leaf's last known state so subscribers see

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
@@ -22,6 +23,12 @@ namespace Ghostty.Services;
 /// </summary>
 internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
 {
+    // Path.GetInvalidFileNameChars() allocates a fresh char[] on each
+    // call; SearchValues caches the set once and picks an optimal
+    // scanner for the ~41 invalid chars on Windows.
+    private static readonly SearchValues<char> InvalidFileNameChars =
+        SearchValues.Create(Path.GetInvalidFileNameChars());
+
     private readonly ConfigService _configService;
     private readonly DispatcherQueue _dispatcher;
     private readonly CancellationTokenSource _cts = new();
@@ -168,7 +175,7 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
         // Validate: theme names are filenames, reject anything suspicious.
         if (themeName.Length > 255 ||
             themeName.Contains("..") ||
-            themeName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            themeName.AsSpan().IndexOfAny(InvalidFileNameChars) >= 0)
         {
             Debug.WriteLine($"[theme-preview] rejected invalid name: {themeName}");
             return;

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -24,8 +24,8 @@ namespace Ghostty.Services;
 internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
 {
     // Path.GetInvalidFileNameChars() allocates a fresh char[] on each
-    // call; SearchValues caches the set once and picks an optimal
-    // scanner for the ~41 invalid chars on Windows.
+    // call (defensive copy); SearchValues caches the set once and picks
+    // an optimal scanner for the 41 invalid chars on Windows.
     private static readonly SearchValues<char> InvalidFileNameChars =
         SearchValues.Create(Path.GetInvalidFileNameChars());
 

--- a/windows/Ghostty/Shell/GradientTintVisual.cs
+++ b/windows/Ghostty/Shell/GradientTintVisual.cs
@@ -149,8 +149,7 @@ internal sealed class GradientTintVisual : IDisposable
     /// </summary>
     internal void SetOverlayOpacity(float opacity)
     {
-        if (_overlayCanvas is not null)
-            _overlayCanvas.Opacity = opacity;
+        _overlayCanvas?.Opacity = opacity;
     }
 
     /// <summary>

--- a/windows/Ghostty/Shell/TitleBarCoordinator.cs
+++ b/windows/Ghostty/Shell/TitleBarCoordinator.cs
@@ -112,11 +112,9 @@ internal sealed class TitleBarCoordinator
 
     private void RebindVerticalTitle()
     {
-        if (_boundTab is not null)
-            _boundTab.PropertyChanged -= OnBoundTabPropertyChanged;
+        _boundTab?.PropertyChanged -= OnBoundTabPropertyChanged;
         _boundTab = _tabs.ActiveTab;
-        if (_boundTab is not null)
-            _boundTab.PropertyChanged += OnBoundTabPropertyChanged;
+        _boundTab?.PropertyChanged += OnBoundTabPropertyChanged;
         UpdateVerticalTitleText();
     }
 

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -21,7 +21,6 @@ internal sealed partial class VerticalTabStrip : UserControl
 {
     private readonly TabManager _manager;
     private bool _syncing;
-    private bool _isExpanded;
 
     /// <summary>Raised when the user clicks the chevron toggle.</summary>
     public event EventHandler? ChevronToggled;
@@ -42,11 +41,11 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     public bool IsExpanded
     {
-        get => _isExpanded;
+        get;
         set
         {
-            if (_isExpanded == value) return;
-            _isExpanded = value;
+            if (field == value) return;
+            field = value;
             TabList.ItemTemplate = (DataTemplate)Resources[
                 value ? "ExpandedRowTemplate" : "CollapsedRowTemplate"];
             // Chevron points in the direction the strip will go on


### PR DESCRIPTION
Second PR in the .NET 10 migration stack. Covers the C# 14 language features that became available once the Windows C# tree moved to the net10 SDK in # 257.

## IMPORTANT: stack order

1. #257  chore(windows): migrate C# tree to .NET 10 (TFM bump)
2. #260  **this PR**  refactor(windows): adopt C# 14 features enabled by .NET 10

Base is `chore/net10-migration` (parent in the stack). When #257 merges GitHub retargets this to `windows` automatically.

## Scope (three commits, one theme each)

1. `refactor(windows): adopt C# 14 field keyword in INPC properties` -- TabModel (4 props), CommandPaletteViewModel (9 props), VerticalTabStrip (1 prop). 14 hand-rolled backing fields collapsed. The hand-rolled-INPC comments in those files pointed at exactly this language feature.
2. `refactor(windows): adopt C# 14 null-conditional assignment` -- 5 sites in CommandPaletteControl, TitleBarCoordinator, GradientTintVisual, PaneHost. Covers event `+=` / `-=` as well as plain `=`.
3. `perf(windows): adopt SearchValues<char> for constant char sets` -- ThemeParser (`:` / `=` pair separators) and ThemePreviewService (cached `Path.GetInvalidFileNameChars()`).

## Not in scope

Scan targets rejected or deferred during the Phase 2 report:

- Extension blocks: only 2 extension methods across 2 single-method static classes, no density.
- Implicit span conversions: 1 intentional `.AsSpan()` call, no meaningful targets.
- FrozenDictionary: only remaining candidate is `TabColor.Colors` (9 entries, cold path); WindowsOnlyKeys already adopted it where it matters.
- `[LoggerMessage]` source generator: codebase has no `ILogger` wiring. Tracked as # 259.
- NativeAOT size tuning: tracked independently as #258 (InvariantGlobalization, EventSourceSupport, MetricsSupport levers).

## Validation

- Debug build: 0 errors, 3 pre-existing xUnit2013 warnings (= baseline).
- Ghostty.Tests 390/390, IconGen.Tests 19/19.
- AOT publish: 0 warnings, `Ghostty.exe` 36.38 MB (unchanged vs # 257 baseline).