### PR TITLE
chore(windows): treeshake NativeAOT publish

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -39,11 +39,15 @@
       NativeAOT treeshaking: drop BCL features this app never uses so the
       linker can eliminate their implementations and data tables. Each
       flag below encodes an assumption about our runtime surface; revisit
-      if any of them become false. Issue # 258.
+      if any of them become false. Closes # 258.
     -->
     <!-- Desktop GUI talks to libghostty via P/Invoke and does not route
          user text through managed culture-sensitive APIs (string compare,
-         ToUpper, DateTime parsing, etc.). Drops the ICU data payload. -->
+         ToUpper, DateTime parsing, etc.). Drops the ICU data payload.
+         Any new parsing added to this app MUST pass
+         CultureInfo.InvariantCulture explicitly: under invariant mode
+         the current culture IS invariant, so culture-sensitive calls
+         silently take the invariant path with no warning. -->
     <InvariantGlobalization>true</InvariantGlobalization>
     <!-- No ETW / EventSource providers are consumed or emitted by this
          app; libghostty has its own logging and we do not subscribe to

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -35,6 +35,27 @@
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <!--
+      NativeAOT treeshaking: drop BCL features this app never uses so the
+      linker can eliminate their implementations and data tables. Each
+      flag below encodes an assumption about our runtime surface; revisit
+      if any of them become false. Issue # 258.
+    -->
+    <!-- Desktop GUI talks to libghostty via P/Invoke and does not route
+         user text through managed culture-sensitive APIs (string compare,
+         ToUpper, DateTime parsing, etc.). Drops the ICU data payload. -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- No ETW / EventSource providers are consumed or emitted by this
+         app; libghostty has its own logging and we do not subscribe to
+         runtime event sources. -->
+    <EventSourceSupport>false</EventSourceSupport>
+    <!-- No outbound HTTP today. When the sponsor-gated update channel
+         lands it will use WinHTTP directly, not HttpClient with
+         DiagnosticSource activity propagation. -->
+    <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
+    <!-- No System.Diagnostics.Metrics instruments are registered; we
+         have no OpenTelemetry / metrics pipeline. -->
+    <MetricsSupport>false</MetricsSupport>
     <!-- Use our own Program.Main with diagnostic error capture instead
          of the XAML-generated entry point (App.g.i.cs). This lets us
          catch NativeAOT startup failures that would otherwise exit


### PR DESCRIPTION
Apply four AOT feature switches in `Ghostty.csproj` so the linker can drop BCL subsystems this app does not exercise. Each switch encodes an assumption, documented inline in the csproj so future reviewers can revisit if any of them stops holding.

## Properties and why each is safe

- `InvariantGlobalization=true`. The shell talks to libghostty via P/Invoke; no user text is routed through culture-sensitive managed APIs (string compare, `ToUpper`, `DateTime.Parse`, etc.). Drops the ICU data payload.
- `EventSourceSupport=false`. No ETW / EventSource providers are consumed or emitted. libghostty owns its own logging.
- `HttpActivityPropagationSupport=false`. No outbound HTTP today. The future sponsor-gated update channel will use WinHTTP directly, not `HttpClient` with DiagnosticSource activity propagation.
- `MetricsSupport=false`. No `System.Diagnostics.Metrics` instruments are registered; no OpenTelemetry / metrics pipeline.

## Measured impact

Release publish, `-r win-x64 -p:PublishAot=true`, same machine, back-to-back builds:

- `Ghostty.exe`: 38,145,024 -> 37,914,112 bytes. -230,912 bytes, -0.22 MB, -0.61%.
- Publish directory total: 200,880,017 -> 199,870,865 bytes. -1,009,152 bytes, -0.96 MB (mostly symbol files for trimmed code).

## Warnings

Both baseline and treeshake AOT publishes emit 0 warnings. No new `IL*` / `Trim*` / `AOT*` diagnostics appear. Debug build retains the same 3 pre-existing `xUnit2013` warnings in `TabManagerDetachTests.cs` carried from Phase 1/2 of the net10 migration.

## Validation

- `dotnet build windows/Ghostty/Ghostty.sln -c Debug -p:Platform=x64` -> 0 errors, 3 expected warnings.
- `dotnet test windows/Ghostty.Tests -c Debug -p:Platform=x64 --no-build` -> 390/390 pass.
- `dotnet test dist/windows/IconGen.Tests -c Debug` -> 19/19 pass.
- `dotnet publish windows/Ghostty/Ghostty.csproj -c Release -r win-x64 -p:PublishAot=true` -> 0 warnings.
- Manual launch of the published exe: not verified from this session.

Closes #258