### PR TITLE
fix(windows): skip simdutf no_libcxx mode on MSVC ABI

### DIFF
--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -877,10 +877,23 @@ pub fn addSimd(
     if (b.systemIntegrationOption("simdutf", .{})) {
         m.linkSystemLibrary("simdutf", dynamic_link_opts);
     } else {
+        // Windows MSVC: do NOT pass no_libcxx. Upstream's no_libcxx mode
+        // compiles simdutf with -fno-exceptions -fno-rtti plus
+        // SIMDUTF_NO_LIBCXX, which breaks MSVC C++ static initializers
+        // (the implementation singleton returned by
+        // get_default_implementation() is null on first call, so the
+        // termio thread AVs deep in convert_utf8_to_utf32_with_errors
+        // the first time shell output hits the SIMD decoder).
+        // On MSVC we were already skipping linkLibCpp (see simdutf
+        // build.zig), so the original rationale for no_libcxx
+        // ("libghostty-vt only depends on libc") is already satisfied
+        // here; forcing it on just trips the MSVC static-init path.
+        // Not our bug, but we're the only downstream building Windows.
+        const no_libcxx = target.result.abi != .msvc;
         if (b.lazyDependency("simdutf", .{
             .target = target,
             .optimize = optimize,
-            .no_libcxx = true,
+            .no_libcxx = no_libcxx,
         })) |simdutf_dep| {
             m.linkLibrary(simdutf_dep.artifact("simdutf"));
             if (static_libs) |v| try v.append(
@@ -949,7 +962,11 @@ pub fn addSimd(
         // When using the vendored simdutf, build its headers in no-libcxx
         // mode so we don't need C++ standard library headers at all.
         // System simdutf headers may not support this define.
-        if (!b.systemIntegrationOption("simdutf", .{})) try flags.append(
+        //
+        // Skip on MSVC: matching the simdutf library build above, MSVC
+        // already uses its own C++ headers and static-init machinery,
+        // and SIMDUTF_NO_LIBCXX breaks that path for our vt.cpp too.
+        if (!b.systemIntegrationOption("simdutf", .{}) and target.result.abi != .msvc) try flags.append(
             b.allocator,
             "-DSIMDUTF_NO_LIBCXX",
         );

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -873,27 +873,23 @@ pub fn addSimd(
     const optimize = m.optimize.?;
     const system_highway = b.systemIntegrationOption("highway", .{ .default = false });
 
+    // MSVC's C++ static-init pass populates simdutf's implementation
+    // singleton; the upstream no_libcxx path compiles that out with
+    // -fno-exceptions -fno-rtti, which leaves get_default_implementation()
+    // returning null and AVs on the first UTF-8 decode. Keep no_libcxx
+    // and -DSIMDUTF_NO_LIBCXX off on MSVC; simdutf's own build.zig
+    // already skips linkLibCpp there, so libghostty-vt still depends
+    // only on libc.
+    const is_msvc = target.result.abi == .msvc;
+
     // Simdutf
     if (b.systemIntegrationOption("simdutf", .{})) {
         m.linkSystemLibrary("simdutf", dynamic_link_opts);
     } else {
-        // Windows MSVC: do NOT pass no_libcxx. Upstream's no_libcxx mode
-        // compiles simdutf with -fno-exceptions -fno-rtti plus
-        // SIMDUTF_NO_LIBCXX, which breaks MSVC C++ static initializers
-        // (the implementation singleton returned by
-        // get_default_implementation() is null on first call, so the
-        // termio thread AVs deep in convert_utf8_to_utf32_with_errors
-        // the first time shell output hits the SIMD decoder).
-        // On MSVC we were already skipping linkLibCpp (see simdutf
-        // build.zig), so the original rationale for no_libcxx
-        // ("libghostty-vt only depends on libc") is already satisfied
-        // here; forcing it on just trips the MSVC static-init path.
-        // Not our bug, but we're the only downstream building Windows.
-        const no_libcxx = target.result.abi != .msvc;
         if (b.lazyDependency("simdutf", .{
             .target = target,
             .optimize = optimize,
-            .no_libcxx = no_libcxx,
+            .no_libcxx = !is_msvc,
         })) |simdutf_dep| {
             m.linkLibrary(simdutf_dep.artifact("simdutf"));
             if (static_libs) |v| try v.append(
@@ -961,12 +957,9 @@ pub fn addSimd(
 
         // When using the vendored simdutf, build its headers in no-libcxx
         // mode so we don't need C++ standard library headers at all.
-        // System simdutf headers may not support this define.
-        //
-        // Skip on MSVC: matching the simdutf library build above, MSVC
-        // already uses its own C++ headers and static-init machinery,
-        // and SIMDUTF_NO_LIBCXX breaks that path for our vt.cpp too.
-        if (!b.systemIntegrationOption("simdutf", .{}) and target.result.abi != .msvc) try flags.append(
+        // System simdutf headers may not support this define. Skipped on
+        // MSVC for the same static-init reason as the library build above.
+        if (!b.systemIntegrationOption("simdutf", .{}) and !is_msvc) try flags.append(
             b.allocator,
             "-DSIMDUTF_NO_LIBCXX",
         );


### PR DESCRIPTION
Unblocks \`just run-win\` after the upstream rebase.

## Root cause

Upstream ghostty-org/ghostty#12291 (\"libghostty: Remove all libc++ and libc++ ABI dependencies\", commit e51de8b58) unconditionally passes \`no_libcxx=true\` to the vendored simdutf build and adds \`-DSIMDUTF_NO_LIBCXX\` when compiling our own \`src/simd/*.cpp\`. That compiles simdutf with \`-fno-exceptions -fno-rtti\` + SIMDUTF_NO_LIBCXX.

On the Windows MSVC ABI that combo breaks the C++ static initializer that registers simdutf's implementation singleton. The first call into \`simdutf::convert_utf8_to_utf32_with_errors\` on the termio reader thread dereferences a null \`get_default_implementation()\` and AVs at \`simdutf.cpp:14927\`, killing the whole app the first time shell output hits the SIMD UTF-8 decode path.

Upstream CI does not build libghostty for Windows from this tree, so the regression slipped through.

## Stack

Symbolized from the crash minidump via \`cdb\`:

\`\`\`
simdutf::convert_utf8_to_utf32_with_errors+0x45   pkg/simdutf/vendor/simdutf.cpp:14927
ghostty::N_AVX2::DecodeUTF8+0x76                  src/simd/vt.cpp:177
ghostty::N_AVX2::DecodeUTF8UntilControlSeqImpl    src/simd/vt.cpp:240
ghostty_simd_decode_utf8_until_control_seq        src/simd/vt.cpp:313
utf8DecodeUntilControlSeq                          src/simd/vt.zig:27
processOutputLocked                                src/termio/Termio.zig:692
threadMainWindows                                  src/termio/Exec.zig:1390
\`\`\`

## Fix

Skip \`no_libcxx\` and \`-DSIMDUTF_NO_LIBCXX\` when \`target.result.abi == .msvc\`. The simdutf build.zig already skipped \`linkLibCpp()\` for MSVC (the MSVC SDK headers cover C++ needs), so the original # 12291 motivation (\"libghostty-vt only depends on libc\") is already satisfied on Windows. Non-MSVC targets keep upstream behavior exactly.

Patch surface: two blocks in \`src/build/SharedDeps.zig\`. Both have WHY comments citing the crash site.

## Validation

- \`zig build -Dapp-runtime=none\`: builds cleanly, emits fresh \`zig-out/lib/ghostty.dll\`.
- Debug build: 0 errors, baseline xUnit2013 warnings.
- \`Ghostty.Tests\` 390/390, \`IconGen.Tests\` 19/19.
- \`Ghostty.exe\` launched: survived past the 6+ seconds of shell output that reliably segfaulted before. No AV, no entry in Windows Error Reporting for the new run.
- Verified the verbose zig build log no longer emits \`-DSIMDUTF_NO_LIBCXX\` for our simd sources and that \`simdutf.lib\` builds without the no-libcxx define.

## Not in scope

- Exit-code hygiene (\`FreeConsole\` timing, native-AV bypass, Debug-only unhandled logging, overloaded exit 1). Separate PR.
- Upstream fix. When #12291's no-libcxx path eventually learns to cope with MSVC static init this patch can be dropped; until then this is the minimal local unblock.