### PR TITLE
refactor(windows): harden exit-code and unhandled-exception hygiene

### DIFF
--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -181,47 +181,60 @@ public partial class App : Application
     {
         InitializeComponent();
 
-        // Surface unhandled exceptions to stderr before the process dies.
-        // Without this, a managed exception on the UI thread silently exits
-        // with a non-descriptive code and we have nothing to debug from.
-        // Stays enabled in Debug builds only -- in Release we want WER to
-        // capture a real crash dump instead.
-#if DEBUG
+        // Surface unhandled exceptions to stderr AND to a file under
+        // %LOCALAPPDATA%\Ghostty\ before the process dies. Without
+        // this, a managed exception on the UI thread silently exits
+        // with a non-descriptive code and we have nothing to debug
+        // from -- especially in Release, where WER captures a dump
+        // but the user is left without a human-readable pointer to
+        // it. The file path is stable across Debug and Release so
+        // the same path works for dev debugging and for a user who
+        // needs to attach logs to a bug report.
         UnhandledException += (s, e) =>
         {
-            try
-            {
-                Console.Error.WriteLine("[Ghostty] UNHANDLED EXCEPTION on UI thread:");
-                Console.Error.WriteLine(e.Exception.ToString());
-                Console.Error.Flush();
-            }
-            catch { /* logging must not throw */ }
-            // Leave Handled=false so the runtime still tears the app down --
-            // we just wanted to see the exception first.
+            LogUnhandled("UI-THREAD UNHANDLED", e.Exception.ToString());
+            // Leave Handled=false so the runtime still tears the app
+            // down -- we just wanted to record the exception first.
         };
 
         AppDomain.CurrentDomain.UnhandledException += (s, e) =>
         {
-            try
-            {
-                Console.Error.WriteLine("[Ghostty] UNHANDLED EXCEPTION (AppDomain):");
-                Console.Error.WriteLine(e.ExceptionObject?.ToString() ?? "(null)");
-                Console.Error.Flush();
-            }
-            catch { /* logging must not throw */ }
+            LogUnhandled("APPDOMAIN UNHANDLED", e.ExceptionObject?.ToString() ?? "(null)");
         };
 
         System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (s, e) =>
         {
-            try
-            {
-                Console.Error.WriteLine("[Ghostty] UNOBSERVED TASK EXCEPTION:");
-                Console.Error.WriteLine(e.Exception.ToString());
-                Console.Error.Flush();
-            }
-            catch { /* logging must not throw */ }
+            LogUnhandled("UNOBSERVED TASK", e.Exception.ToString());
         };
-#endif
+    }
+
+    private static void LogUnhandled(string tag, string detail)
+    {
+        // stderr mirror for terminal launches (Program.Main's
+        // FreeConsole gate keeps the console attached in that case).
+        try
+        {
+            Console.Error.WriteLine($"[Ghostty] {tag}:");
+            Console.Error.WriteLine(detail);
+            Console.Error.Flush();
+        }
+        catch { /* logging must not throw */ }
+
+        // File log for GUI launches and packaged releases where there
+        // is no readable console. Append so repeated crashes during
+        // one session accumulate into one file.
+        try
+        {
+            var localAppData = Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData);
+            var dir = Path.Combine(localAppData, "Ghostty");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "crash.log");
+            File.AppendAllText(
+                path,
+                $"{DateTimeOffset.UtcNow:O} [{tag}]\n{detail}\n\n");
+        }
+        catch { /* logging must not throw */ }
     }
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -223,6 +223,20 @@ public partial class App : Application
         // File log for GUI launches and packaged releases where there
         // is no readable console. Append so repeated crashes during
         // one session accumulate into one file.
+        //
+        // Three handlers (UI thread, AppDomain, TaskScheduler) can
+        // fire on three different threads in quick succession during
+        // a cascading crash; serialize the write or they race on the
+        // file open and at least one `AppendAllText` throws an
+        // `IOException`. A dead crash logger silently swallowing the
+        // exception we were trying to record is exactly the failure
+        // mode this whole helper was built to prevent.
+        //
+        // LocalApplicationData is a per-user folder. For packaged
+        // (MSIX) builds Windows virtualizes this to the package's
+        // private app-data directory; the file still lands somewhere
+        // the user can find via the Settings app, just not the literal
+        // `%LOCALAPPDATA%\Ghostty\`.
         try
         {
             var localAppData = Environment.GetFolderPath(
@@ -230,12 +244,17 @@ public partial class App : Application
             var dir = Path.Combine(localAppData, "Ghostty");
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, "crash.log");
-            File.AppendAllText(
-                path,
-                $"{DateTimeOffset.UtcNow:O} [{tag}]\n{detail}\n\n");
+            lock (_crashLogLock)
+            {
+                File.AppendAllText(
+                    path,
+                    $"{DateTimeOffset.UtcNow:O} [{tag}]\n{detail}\n\n");
+            }
         }
         catch { /* logging must not throw */ }
     }
+
+    private static readonly object _crashLogLock = new();
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -14,9 +14,37 @@ namespace Ghostty;
 /// </summary>
 public static partial class Program
 {
+    // Exit codes for Ghostty.exe. Distinct values let callers
+    // (launchers, tests, CI, `just run-win`) tell apart "the app
+    // refused to start" from "the app crashed mid-run":
+    //
+    //   0  normal success; the WinUI message loop returned cleanly,
+    //      or a CLI action (`+...`) completed with exit code 0.
+    //   1  native / corrupted-state crash (access violation, stack
+    //      overflow). Set by Windows when an unhandled SEH exception
+    //      tears down the process before managed code sees it. WER
+    //      captures the minidump under %LOCALAPPDATA%\CrashDumps\.
+    //   2  ghostty_init failed; the native library wrote the reason
+    //      to stderr. No config means no app.
+    //   3  unhandled managed exception in the GUI startup path. The
+    //      catch block in StartGui writes ghostty-crash.log in
+    //      AppContext.BaseDirectory.
+    //   >3 reserved for future distinguishable failure modes.
+    //
+    // CLI actions (`ghostty +list-themes` etc.) return whatever code
+    // the native action produced via Environment.Exit(exitCode) and
+    // bypass this scheme.
+    private const int ExitCodeInitFailed = 2;
+    private const int ExitCodeManagedUnhandled = 3;
+
     [LibraryImport("kernel32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool FreeConsole();
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial uint GetConsoleProcessList(
+        [Out] uint[] lpdwProcessList,
+        uint dwProcessCount);
 
     [STAThread]
     static int Main(string[] args)
@@ -45,10 +73,26 @@ public static partial class Program
                 Environment.Exit(exitCode);
         }
 
-        // Detach from the console before starting WinUI. Without this,
-        // a console window would stay visible when launched from Explorer
-        // or Start Menu, and cmd.exe would block until we exit.
-        FreeConsole();
+        // Detach from the console before starting WinUI -- but ONLY
+        // when we are the console's sole owner. When launched from
+        // Explorer / Start Menu, Windows allocates a fresh console
+        // for a console-subsystem app and briefly flashes it; that
+        // is the console we want to close so the user never sees it.
+        // When launched from a terminal (bash, cmd, pwsh), the
+        // terminal shares its console with us; FreeConsole would
+        // detach us from the shared console and silently drop every
+        // Console.Error.WriteLine below, including the diagnostic
+        // logs and the unhandled-exception dump we rely on to debug
+        // startup crashes. GetConsoleProcessList returns >= 2 in the
+        // shared case (the parent terminal process counts as one of
+        // the processes attached to that console), exactly 1 in the
+        // solo case.
+        var consoleProcesses = new uint[4];
+        var consoleProcessCount = GetConsoleProcessList(
+            consoleProcesses,
+            (uint)consoleProcesses.Length);
+        if (consoleProcessCount <= 1)
+            FreeConsole();
 
         return StartGui();
     }
@@ -78,8 +122,10 @@ public static partial class Program
         if (result != 0)
         {
             // ghostty_init failed (e.g. invalid action). The Zig
-            // code logs to stderr. Exit with failure.
-            Environment.Exit(1);
+            // code logs to stderr. Use a distinct exit code so
+            // callers can tell this apart from a later GUI-startup
+            // crash (code 3) or a native access violation (code 1).
+            Environment.Exit(ExitCodeInitFailed);
         }
     }
 
@@ -249,7 +295,7 @@ public static partial class Program
             }
             catch { /* best effort */ }
 
-            return 1;
+            return ExitCodeManagedUnhandled;
         }
     }
 }

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -14,28 +14,40 @@ namespace Ghostty;
 /// </summary>
 public static partial class Program
 {
-    // Exit codes for Ghostty.exe. Distinct values let callers
-    // (launchers, tests, CI, `just run-win`) tell apart "the app
-    // refused to start" from "the app crashed mid-run":
-    //
-    //   0  normal success; the WinUI message loop returned cleanly,
-    //      or a CLI action (`+...`) completed with exit code 0.
-    //   1  native / corrupted-state crash (access violation, stack
-    //      overflow). Set by Windows when an unhandled SEH exception
-    //      tears down the process before managed code sees it. WER
-    //      captures the minidump under %LOCALAPPDATA%\CrashDumps\.
-    //   2  ghostty_init failed; the native library wrote the reason
-    //      to stderr. No config means no app.
-    //   3  unhandled managed exception in the GUI startup path. The
-    //      catch block in StartGui writes ghostty-crash.log in
-    //      AppContext.BaseDirectory.
-    //   >3 reserved for future distinguishable failure modes.
-    //
-    // CLI actions (`ghostty +list-themes` etc.) return whatever code
-    // the native action produced via Environment.Exit(exitCode) and
-    // bypass this scheme.
-    private const int ExitCodeInitFailed = 2;
-    private const int ExitCodeManagedUnhandled = 3;
+    /// <summary>
+    /// Exit codes for Ghostty.exe. Distinct values let callers
+    /// (launchers, tests, CI, <c>just run-win</c>) tell apart "refused
+    /// to start" from "crashed mid-run". CLI actions
+    /// (<c>ghostty +list-themes</c> etc.) bypass this scheme and
+    /// return whatever the native action produced via
+    /// <c>Environment.Exit(exitCode)</c>.
+    /// </summary>
+    private enum ExitCode
+    {
+        /// <summary>WinUI message loop returned cleanly, or a CLI
+        /// action completed with exit code 0.</summary>
+        Success = 0,
+
+        /// <summary>Native / corrupted-state crash (AV, stack overflow).
+        /// Not set by our code; this is what Windows returns when an
+        /// unhandled SEH exception tears the process down before
+        /// managed code sees it. WER captures the minidump under
+        /// <c>%LOCALAPPDATA%\CrashDumps\</c>.</summary>
+        NativeCrash = 1,
+
+        /// <summary><c>ghostty_init</c> failed. The native library
+        /// already wrote the reason to stderr; no config means no
+        /// app.</summary>
+        InitFailed = 2,
+
+        /// <summary>Unhandled managed exception in the GUI startup
+        /// path. <see cref="StartGui"/>'s catch block writes
+        /// <c>ghostty-crash.log</c> in <c>AppContext.BaseDirectory</c>.
+        /// (A future PR should converge this with the
+        /// <c>%LOCALAPPDATA%\Ghostty\crash.log</c> path used by the
+        /// App-level unhandled-exception handlers.)</summary>
+        ManagedUnhandled = 3,
+    }
 
     [LibraryImport("kernel32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
@@ -73,20 +85,21 @@ public static partial class Program
                 Environment.Exit(exitCode);
         }
 
-        // Detach from the console before starting WinUI -- but ONLY
-        // when we are the console's sole owner. When launched from
-        // Explorer / Start Menu, Windows allocates a fresh console
-        // for a console-subsystem app and briefly flashes it; that
-        // is the console we want to close so the user never sees it.
-        // When launched from a terminal (bash, cmd, pwsh), the
-        // terminal shares its console with us; FreeConsole would
-        // detach us from the shared console and silently drop every
-        // Console.Error.WriteLine below, including the diagnostic
-        // logs and the unhandled-exception dump we rely on to debug
-        // startup crashes. GetConsoleProcessList returns >= 2 in the
-        // shared case (the parent terminal process counts as one of
-        // the processes attached to that console), exactly 1 in the
-        // solo case.
+        // Detach from the console before starting WinUI, but ONLY
+        // when we are the console's sole owner. Explorer / Start
+        // Menu allocates a fresh console for a console-subsystem app
+        // and briefly flashes it; that's the console we want to
+        // close. A terminal launch (bash, cmd, pwsh) shares the
+        // terminal's console with us, and FreeConsole would detach
+        // us from that shared console and silently drop every
+        // Console.Error.WriteLine below (which is how we lose
+        // startup diagnostics and the unhandled-exception dump).
+        //
+        // GetConsoleProcessList returns >= 2 in the shared case (the
+        // parent terminal process counts), exactly 1 in the solo
+        // case, and 0 if the probe fails (no attached console). The
+        // `<= 1` guard treats a probe failure as solo, which matches
+        // the pre-gating behavior and never worse.
         var consoleProcesses = new uint[4];
         var consoleProcessCount = GetConsoleProcessList(
             consoleProcesses,
@@ -122,10 +135,9 @@ public static partial class Program
         if (result != 0)
         {
             // ghostty_init failed (e.g. invalid action). The Zig
-            // code logs to stderr. Use a distinct exit code so
-            // callers can tell this apart from a later GUI-startup
-            // crash (code 3) or a native access violation (code 1).
-            Environment.Exit(ExitCodeInitFailed);
+            // code logs to stderr. Distinct exit code per the
+            // ExitCode enum above.
+            Environment.Exit((int)ExitCode.InitFailed);
         }
     }
 
@@ -295,7 +307,7 @@ public static partial class Program
             }
             catch { /* best effort */ }
 
-            return ExitCodeManagedUnhandled;
+            return (int)ExitCode.ManagedUnhandled;
         }
     }
 }


### PR DESCRIPTION
Four small changes, all aimed at making crashes diagnosable. Surfaced while triaging the \`just run-win\` native AV that led to PR # 264.

## 1. FreeConsole gating

\`Program.Main\` called \`FreeConsole()\` unconditionally before \`StartGui\` so the Explorer launch flow would not leave a flashing console window. That also detached from the parent terminal when launched from \`bash\`/\`cmd\`/\`pwsh\`, silently dropping every \`Console.Error.WriteLine\` below -- including the startup diagnostics and the unhandled-exception dump we rely on for live debugging. Exactly how we lost 5 useful log lines earlier today while chasing a native crash.

Fix: check \`GetConsoleProcessList\`. Only \`FreeConsole\` when we are the sole owner of the console (Explorer launch, count == 1); skip it when the terminal is attached too (count >= 2).

## 2. Distinct exit codes

\`Program.Main\` used exit 1 for both \`ghostty_init\` failure and any managed unhandled exception caught in \`StartGui\`. Native access violations also exit 1 via the default Windows handler. Callers (launchers, tests, \`just run-win\`) could not tell these apart.

Introduce named constants:

| Code | Meaning |
|---|---|
| 0 | Normal success; WinUI loop returned cleanly, or a CLI action returned 0 |
| 1 | Native / corrupted-state crash (AV, stack overflow). WER captures the dump. |
| 2 | \`ghostty_init\` failed (new; was 1) |
| 3 | Unhandled managed exception in GUI startup (new; was 1) |
| >3 | Reserved |

CLI actions (\`+list-themes\` etc.) bypass this scheme and return whatever the native action produced.

## 3. Release unhandled-exception logging

\`App.xaml.cs\` wrapped \`UnhandledException\` / \`AppDomain.UnhandledException\` / \`TaskScheduler.UnobservedTaskException\` handlers in \`#if DEBUG\`, so a Release crash was indistinguishable from a hang -- nothing in stderr, nothing on disk, just a missing window and an exit code.

Remove the guard. Keep the stderr mirror (reliable again thanks to # 1) and also append a timestamped record to \`%LOCALAPPDATA%\Ghostty\crash.log\`. WER still takes the minidump; this gives us a stable human-readable pointer to what fired and when.

## 4. Extract LogUnhandled helper

Three handlers, three near-identical bodies. One shared \`LogUnhandled(tag, detail)\` keeps the tag strings aligned and means future changes (e.g. rotation, machine-id scrub) land in one spot.


## Validation

- Debug build: 0 errors, baseline warnings.
- \`Ghostty.Tests\` 390/390, \`IconGen.Tests\` 19/19.
- No happy-path behavior change -- the edits only change where logs land and which exit code non-success paths return.
