### PR TITLE
feat(windows): add ShellDetector for VT-awareness classification

### DIFF
--- a/windows/Ghostty.Core/Shell/ShellCapability.cs
+++ b/windows/Ghostty.Core/Shell/ShellCapability.cs
@@ -2,8 +2,7 @@ namespace Ghostty.Core.Shell;
 
 /// <summary>
 /// VT/Console-API capability verdict for a Windows shell executable.
-/// Drives the ConPTY-vs-bypass decision in issue # 112. Detection is
-/// a case-insensitive filename heuristic; see <see cref="ShellDetector"/>.
+/// Detection is a case-insensitive filename heuristic; see <see cref="ShellDetector"/>.
 /// </summary>
 public enum ShellCapability
 {

--- a/windows/Ghostty.Core/Shell/ShellCapability.cs
+++ b/windows/Ghostty.Core/Shell/ShellCapability.cs
@@ -1,0 +1,27 @@
+namespace Ghostty.Core.Shell;
+
+/// <summary>
+/// VT/Console-API capability verdict for a Windows shell executable.
+/// Drives the ConPTY-vs-bypass decision in issue # 112. Detection is
+/// a case-insensitive filename heuristic; see <see cref="ShellDetector"/>.
+/// </summary>
+public enum ShellCapability
+{
+    /// <summary>
+    /// Binary is not on the known-shell list. Callers must fall back to
+    /// ConPTY (the safe default) and are expected to log for troubleshooting.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Shell speaks VT natively and is safe to spawn over raw pipes
+    /// (ConPTY bypass). Examples: pwsh, wsl, ssh, bash, nu.
+    /// </summary>
+    VtAware,
+
+    /// <summary>
+    /// Shell uses the Win32 Console API and must be hosted by ConPTY.
+    /// Examples: cmd.exe, Windows PowerShell 5.1 (powershell.exe).
+    /// </summary>
+    ConsoleApi,
+}

--- a/windows/Ghostty.Core/Shell/ShellDetectionResult.cs
+++ b/windows/Ghostty.Core/Shell/ShellDetectionResult.cs
@@ -8,18 +8,16 @@ namespace Ghostty.Core.Shell;
 /// <param name="Capability">VT/Console-API verdict.</param>
 /// <param name="NormalizedFileName">
 /// Lowercase leaf filename (e.g. <c>"pwsh.exe"</c>). Empty string when
-/// the input has no file component. Kept as a stable value so log lines
-/// do not drift with casing (<c>PWSH.EXE</c> and <c>pwsh.exe</c> both
-/// log as <c>pwsh.exe</c>).
+/// the input has no file component. Nullable because <c>default</c>
+/// struct initialization leaves it null; <see cref="ShellDetector.Detect"/>
+/// always returns a non-null value.
 /// </param>
 public readonly record struct ShellDetectionResult(
     ShellCapability Capability,
-    string NormalizedFileName)
+    string? NormalizedFileName)
 {
     /// <summary>
-    /// True if and only if the filename matched the known-shell table
-    /// (equivalently, <see cref="Capability"/> is not <see cref="ShellCapability.Unknown"/>).
-    /// Computed from <see cref="Capability"/> so the two signals cannot drift.
+    /// True when the filename matched the known-shell table.
     /// </summary>
     public bool IsKnown => Capability != ShellCapability.Unknown;
 }

--- a/windows/Ghostty.Core/Shell/ShellDetectionResult.cs
+++ b/windows/Ghostty.Core/Shell/ShellDetectionResult.cs
@@ -1,0 +1,25 @@
+namespace Ghostty.Core.Shell;
+
+/// <summary>
+/// Output of <see cref="ShellDetector.Detect(string)"/>. Structured so
+/// callers do not have to switch on the enum just to decide whether to
+/// log an unrecognized binary: <see cref="IsKnown"/> is the signal.
+/// </summary>
+/// <param name="Capability">VT/Console-API verdict.</param>
+/// <param name="NormalizedFileName">
+/// Lowercase leaf filename (e.g. <c>"pwsh.exe"</c>). Empty string when
+/// the input has no file component. Kept as a stable value so log lines
+/// do not drift with casing (<c>PWSH.EXE</c> and <c>pwsh.exe</c> both
+/// log as <c>pwsh.exe</c>).
+/// </param>
+public readonly record struct ShellDetectionResult(
+    ShellCapability Capability,
+    string NormalizedFileName)
+{
+    /// <summary>
+    /// True if and only if the filename matched the known-shell table
+    /// (equivalently, <see cref="Capability"/> is not <see cref="ShellCapability.Unknown"/>).
+    /// Computed from <see cref="Capability"/> so the two signals cannot drift.
+    /// </summary>
+    public bool IsKnown => Capability != ShellCapability.Unknown;
+}

--- a/windows/Ghostty.Core/Shell/ShellDetector.cs
+++ b/windows/Ghostty.Core/Shell/ShellDetector.cs
@@ -1,0 +1,77 @@
+using System.Collections.Frozen;
+
+namespace Ghostty.Core.Shell;
+
+/// <summary>
+/// Pure-logic classifier for Windows shell executables. Given an
+/// executable path, returns whether the shell is known to speak VT
+/// natively (safe to bypass ConPTY), uses the Console API (must use
+/// ConPTY), or is unrecognized (fall back to ConPTY + log).
+///
+/// No I/O: the path is not resolved on disk, no process is spawned,
+/// no registry is read. Consumers in issue # 112 will combine this
+/// verdict with the <c>conpty-mode</c> config switch.
+/// </summary>
+public static class ShellDetector
+{
+    // Lookup uses OrdinalIgnoreCase because Windows filenames are
+    // case-insensitive. Keys include the ".exe" suffix so the lookup
+    // key is exactly the output of Path.GetFileName -- no suffix
+    // stripping, no ambiguity between "pwsh" and "pwsh.exe".
+    private static readonly FrozenDictionary<string, ShellCapability> KnownShells =
+        new Dictionary<string, ShellCapability>(StringComparer.OrdinalIgnoreCase)
+        {
+            // VT-aware: safe to bypass ConPTY.
+            ["pwsh.exe"]   = ShellCapability.VtAware,   // PowerShell 7+
+            ["wsl.exe"]    = ShellCapability.VtAware,   // WSL launcher (distro owns its PTY)
+            ["ssh.exe"]    = ShellCapability.VtAware,   // OpenSSH client
+            ["bash.exe"]   = ShellCapability.VtAware,   // Git Bash / MSYS2 / Cygwin / legacy WSL1 stub
+            ["nu.exe"]     = ShellCapability.VtAware,   // Nushell
+            ["zsh.exe"]    = ShellCapability.VtAware,   // MSYS2 / Cygwin
+            ["fish.exe"]   = ShellCapability.VtAware,   // MSYS2 / Cygwin
+            ["elvish.exe"] = ShellCapability.VtAware,   // Elvish
+            ["xonsh.exe"]  = ShellCapability.VtAware,   // Xonsh
+
+            // Console-API: must use ConPTY.
+            ["cmd.exe"]        = ShellCapability.ConsoleApi, // Command Prompt
+            ["powershell.exe"] = ShellCapability.ConsoleApi, // Windows PowerShell 5.1
+        }
+        .ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Classify the given executable path. Safe on null, empty, or
+    /// whitespace inputs: returns <see cref="ShellCapability.Unknown"/>
+    /// with an empty <see cref="ShellDetectionResult.NormalizedFileName"/>.
+    /// </summary>
+    /// <param name="exePath">
+    /// Executable path as passed to a spawner (e.g. <c>ProcessStartInfo.FileName</c>).
+    /// Only the leaf filename is inspected; directory components are ignored.
+    /// </param>
+    public static ShellDetectionResult Detect(string exePath)
+    {
+        if (string.IsNullOrWhiteSpace(exePath))
+            return new ShellDetectionResult(ShellCapability.Unknown, string.Empty);
+
+        string fileName;
+        try
+        {
+            fileName = Path.GetFileName(exePath);
+        }
+        catch (ArgumentException)
+        {
+            // Path.GetFileName stopped throwing on invalid chars in
+            // modern .NET, but guarding is cheap and keeps us safe if
+            // a future runtime reintroduces stricter validation.
+            return new ShellDetectionResult(ShellCapability.Unknown, string.Empty);
+        }
+
+        if (string.IsNullOrEmpty(fileName))
+            return new ShellDetectionResult(ShellCapability.Unknown, string.Empty);
+
+        var normalized = fileName.ToLowerInvariant();
+
+        return KnownShells.TryGetValue(fileName, out var capability)
+            ? new ShellDetectionResult(capability, normalized)
+            : new ShellDetectionResult(ShellCapability.Unknown, normalized);
+    }
+}

--- a/windows/Ghostty.Core/Shell/ShellDetector.cs
+++ b/windows/Ghostty.Core/Shell/ShellDetector.cs
@@ -9,8 +9,7 @@ namespace Ghostty.Core.Shell;
 /// ConPTY), or is unrecognized (fall back to ConPTY + log).
 ///
 /// No I/O: the path is not resolved on disk, no process is spawned,
-/// no registry is read. Consumers in issue # 112 will combine this
-/// verdict with the <c>conpty-mode</c> config switch.
+/// no registry is read.
 /// </summary>
 public static class ShellDetector
 {
@@ -19,7 +18,7 @@ public static class ShellDetector
     // key is exactly the output of Path.GetFileName -- no suffix
     // stripping, no ambiguity between "pwsh" and "pwsh.exe".
     private static readonly FrozenDictionary<string, ShellCapability> KnownShells =
-        new Dictionary<string, ShellCapability>(StringComparer.OrdinalIgnoreCase)
+        new Dictionary<string, ShellCapability>
         {
             // VT-aware: safe to bypass ConPTY.
             ["pwsh.exe"]   = ShellCapability.VtAware,   // PowerShell 7+
@@ -52,25 +51,16 @@ public static class ShellDetector
         if (string.IsNullOrWhiteSpace(exePath))
             return new ShellDetectionResult(ShellCapability.Unknown, string.Empty);
 
-        string fileName;
-        try
-        {
-            fileName = Path.GetFileName(exePath);
-        }
-        catch (ArgumentException)
-        {
-            // Path.GetFileName stopped throwing on invalid chars in
-            // modern .NET, but guarding is cheap and keeps us safe if
-            // a future runtime reintroduces stricter validation.
-            return new ShellDetectionResult(ShellCapability.Unknown, string.Empty);
-        }
-
+        var fileName = Path.GetFileName(exePath);
         if (string.IsNullOrEmpty(fileName))
             return new ShellDetectionResult(ShellCapability.Unknown, string.Empty);
 
+        // Normalize unconditionally so NormalizedFileName is stable
+        // regardless of input casing. Callers log this verbatim; cheap
+        // cost on a cold path for predictable output.
         var normalized = fileName.ToLowerInvariant();
 
-        return KnownShells.TryGetValue(fileName, out var capability)
+        return KnownShells.TryGetValue(normalized, out var capability)
             ? new ShellDetectionResult(capability, normalized)
             : new ShellDetectionResult(ShellCapability.Unknown, normalized);
     }

--- a/windows/Ghostty.Tests/Shell/ShellDetectorTests.cs
+++ b/windows/Ghostty.Tests/Shell/ShellDetectorTests.cs
@@ -1,0 +1,119 @@
+using Ghostty.Core.Shell;
+using Xunit;
+
+namespace Ghostty.Tests.Shell;
+
+/// <summary>
+/// Unit tests for <see cref="ShellDetector"/>. The classifier is pure
+/// logic (no I/O); tests exhaustively cover the recognition table,
+/// boundary inputs, case-insensitivity, and path-shape invariance.
+/// </summary>
+public sealed class ShellDetectorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Boundary_inputs_return_unknown_with_empty_name(string? input)
+    {
+        var result = ShellDetector.Detect(input!);
+
+        Assert.Equal(ShellCapability.Unknown, result.Capability);
+        Assert.Equal(string.Empty, result.NormalizedFileName);
+        Assert.False(result.IsKnown);
+    }
+
+    [Theory]
+    [InlineData("customshell.exe", "customshell.exe")]
+    [InlineData("C:\\tools\\customshell.exe", "customshell.exe")]
+    [InlineData(".\\customshell.exe", "customshell.exe")]
+    [InlineData("mybin", "mybin")]
+    [InlineData("C:\\Windows\\System32\\", "")]
+    public void Unknown_binary_returns_unknown_with_normalized_name(string input, string expectedName)
+    {
+        var result = ShellDetector.Detect(input);
+
+        Assert.Equal(ShellCapability.Unknown, result.Capability);
+        Assert.Equal(expectedName, result.NormalizedFileName);
+        Assert.False(result.IsKnown);
+    }
+
+    [Theory]
+    [InlineData("pwsh.exe")]
+    [InlineData("wsl.exe")]
+    [InlineData("ssh.exe")]
+    [InlineData("bash.exe")]
+    [InlineData("nu.exe")]
+    [InlineData("zsh.exe")]
+    [InlineData("fish.exe")]
+    [InlineData("elvish.exe")]
+    [InlineData("xonsh.exe")]
+    public void Vt_aware_shells_classify_as_vt_aware(string fileName)
+    {
+        var result = ShellDetector.Detect(fileName);
+
+        Assert.Equal(ShellCapability.VtAware, result.Capability);
+        Assert.Equal(fileName, result.NormalizedFileName);
+        Assert.True(result.IsKnown);
+    }
+
+    [Theory]
+    [InlineData("cmd.exe")]
+    [InlineData("powershell.exe")]
+    public void Console_api_shells_classify_as_console_api(string fileName)
+    {
+        var result = ShellDetector.Detect(fileName);
+
+        Assert.Equal(ShellCapability.ConsoleApi, result.Capability);
+        Assert.Equal(fileName, result.NormalizedFileName);
+        Assert.True(result.IsKnown);
+    }
+
+    [Theory]
+    [InlineData("PWSH.EXE")]
+    [InlineData("Pwsh.Exe")]
+    [InlineData("pwsh.EXE")]
+    [InlineData("CMD.EXE")]
+    [InlineData("Cmd.Exe")]
+    public void Classification_is_case_insensitive_and_normalizes_to_lowercase(string fileName)
+    {
+        var result = ShellDetector.Detect(fileName);
+
+        Assert.True(result.IsKnown);
+        Assert.NotEqual(ShellCapability.Unknown, result.Capability);
+        Assert.Equal(fileName.ToLowerInvariant(), result.NormalizedFileName);
+    }
+
+    [Theory]
+    [InlineData("pwsh.exe")]
+    [InlineData("C:\\Program Files\\PowerShell\\7\\pwsh.exe")]
+    [InlineData(".\\pwsh.exe")]
+    [InlineData("..\\bin\\pwsh.exe")]
+    [InlineData("C:/Program Files/PowerShell/7/pwsh.exe")]
+    [InlineData("\\\\server\\share\\pwsh.exe")]
+    public void Path_shape_does_not_affect_classification(string path)
+    {
+        var result = ShellDetector.Detect(path);
+
+        Assert.Equal(ShellCapability.VtAware, result.Capability);
+        Assert.Equal("pwsh.exe", result.NormalizedFileName);
+        Assert.True(result.IsKnown);
+    }
+
+    [Theory]
+    [InlineData("powershell_ise.exe")]
+    [InlineData("git-bash.exe")]
+    [InlineData("ubuntu.exe")]
+    [InlineData("debian.exe")]
+    [InlineData("notepad.exe")]
+    public void Unsupported_binaries_classify_as_unknown(string fileName)
+    {
+        var result = ShellDetector.Detect(fileName);
+
+        Assert.Equal(ShellCapability.Unknown, result.Capability);
+        Assert.Equal(fileName, result.NormalizedFileName);
+        Assert.False(result.IsKnown);
+    }
+
+}

--- a/windows/Ghostty.Tests/Shell/ShellDetectorTests.cs
+++ b/windows/Ghostty.Tests/Shell/ShellDetectorTests.cs
@@ -81,7 +81,6 @@ public sealed class ShellDetectorTests
         var result = ShellDetector.Detect(fileName);
 
         Assert.True(result.IsKnown);
-        Assert.NotEqual(ShellCapability.Unknown, result.Capability);
         Assert.Equal(fileName.ToLowerInvariant(), result.NormalizedFileName);
     }
 


### PR DESCRIPTION
First piece of the #263 umbrella work. Pure-logic classifier in `Ghostty.Core`
that maps a Windows executable path to `VtAware` / `ConsoleApi` / `Unknown`.

The consumer (#112 `conpty-mode = auto|always|never`) is not in this PR --
classification is a standalone prerequisite so the bypass logic can land
clean on top of tested pure logic. No runtime behavior change here.

Recognition table (case-insensitive filename match against the leaf):
- VT-aware: `pwsh.exe`, `wsl.exe`, `ssh.exe`, `bash.exe`, `nu.exe`,
  `zsh.exe`, `fish.exe`, `elvish.exe`, `xonsh.exe`
- Console-API: `cmd.exe`, `powershell.exe`
- Everything else: `Unknown`, caller falls back to ConPTY and logs

## Validation

- `Ghostty.Tests` 426/426 green (390 baseline + 36 new across 7 methods).
- `FrozenDictionary` + `OrdinalIgnoreCase`; no new package references.
- `IsKnown` is a computed property so the enum verdict and the "should I
  log this?" signal cannot drift out of sync.
- AOT / trim / single-file analyzers clean.

Refs #263, prereq #112