### PR TITLE
refactor(windows): adopt Microsoft.Extensions.Logging with [LoggerMessage]

### DIFF
--- a/docs/windows/logging.md
+++ b/docs/windows/logging.md
@@ -1,0 +1,102 @@
+# Windows logging
+
+Ghostty's Windows shell emits diagnostics through `Microsoft.Extensions.Logging`
+with two sinks wired at startup.
+
+## Sinks
+
+### ETW (EventSource)
+
+`Microsoft-Extensions-Logging` EventSource, via the built-in
+`EventSourceLoggerProvider`. Capture with:
+
+```
+dotnet-trace collect -n Ghostty
+```
+
+Add `--providers Microsoft-Extensions-Logging` if you need to narrow the
+trace to just the logging events. The same provider is visible in PerfView
+and Windows Performance Analyzer.
+
+### Rolling file
+
+`%LOCALAPPDATA%\Ghostty\logs\ghostty-YYYYMMDD.log`. One file per UTC day.
+Each file caps at 16 MB; when full, the writer rolls to
+`ghostty-YYYYMMDD-1.log`, `-2.log`, and so on. Files older than 14 days
+are deleted at startup and again whenever the writer crosses a UTC-day
+boundary, so a long-running session prunes itself.
+
+Line format is pipe-separated, easy to grep:
+
+```
+2026-04-17T14:23:17.042Z | Warn  | 2100 | Ghostty.Clipboard.WinUiClipboardBackend | clipboard read failed: 0x8001010E
+```
+
+When a log call includes an exception, the record line is followed by
+indented frames (up to 10) so the stack is readable in the same file.
+
+The writer is backed by a bounded channel with drop-oldest semantics, so
+a logging storm never blocks the UI or termio threads. On overflow a
+synthetic "N log record(s) dropped" warning is flushed at the top of the
+next batch, so drops are visible to operators.
+
+## Config keys
+
+Both keys live in the regular Ghostty config file.
+
+| Key | Type | Default | Values |
+|---|---|---|---|
+| `log-level` | enum | `info` | `trace`, `debug`, `info`, `warn`, `error`, `off` |
+| `log-filter` | list of `CATEGORY=LEVEL` pairs | empty | see below |
+
+`log-filter` lets you override the default level per component:
+
+```
+log-filter = Ghostty.Services.ThemePreviewService=trace, Ghostty.Core.Config=warn
+```
+
+Longest matching category prefix wins, mirroring the
+`Microsoft.Extensions.Logging` filter semantics. Unknown levels in a
+filter pair are silently skipped rather than failing the config load.
+
+Both keys are re-read whenever the config file changes on disk; the
+filter rules rebuild in place via a volatile reference swap, no restart
+needed.
+
+## Event id taxonomy
+
+EventIds are assigned from disjoint per-component ranges so they stay
+stable across renames. You can assert on an id by itself without looking
+at the message text.
+
+| Range | Component |
+|---|---|
+| 1000-1099 | Config (ConfigService, ConfigWriteScheduler, SystemSchedulerTimer) |
+| 1100-1199 | FrecencyStore (command palette history) |
+| 2000-2099 | Startup (AUMID, jump list) |
+| 2100-2199 | Clipboard (backend + bridge + confirm dialog) |
+| 2200-2299 | ThemePreviewService |
+| 2300-2399 | WindowState + WindowStateMigration |
+| 2400-2499 | Shell (taskbar host, backdrop) |
+| 2500-2599 | MainWindow |
+| 2600-2699 | Settings UI |
+
+The constants live in `windows/Ghostty.Core/Logging/LogEvents.cs` (Core
+types) and `windows/Ghostty/Logging/LogEvents.cs` (WinUI shell types).
+Each id appears in exactly two places: the constant definition and one
+`[LoggerMessage(EventId = ...)]` attribute.
+
+## Relationship to instrumentation (#54-#59)
+
+Logging, as described here, is the coarse-grained "what happened" channel
+for diagnostics, errors, and user-reportable events.
+
+The `[Conditional("GHOSTTY_INSTRUMENT")]` trace primitives tracked in
+issues #54-#59 are a separate channel for nanosecond-precision
+performance data. They emit Chrome Tracing JSON, not ETW or file, and
+are compiled out entirely when the symbol is undefined. The two
+channels share nothing at runtime.
+
+When you need to know *what went wrong*, use logging. When you need to
+know *when it happened, to the microsecond*, use the instrumentation
+channel (once it lands).

--- a/docs/windows/logging.md
+++ b/docs/windows/logging.md
@@ -11,12 +11,16 @@ with two sinks wired at startup.
 `EventSourceLoggerProvider`. Capture with:
 
 ```
-dotnet-trace collect -n Ghostty
+dotnet-trace collect -n Ghostty --providers Microsoft-Extensions-Logging
 ```
 
-Add `--providers Microsoft-Extensions-Logging` if you need to narrow the
-trace to just the logging events. The same provider is visible in PerfView
-and Windows Performance Analyzer.
+The same provider is visible in PerfView and Windows Performance Analyzer.
+
+> Known issue (# 269): the provider is registered and the file sink
+> captures events end-to-end, but `dotnet-trace` does not currently
+> surface our events. If you hit empty output, the file sink below is
+> the reliable channel until # 269 lands. PerfView is a useful
+> independent check.
 
 ### Rolling file
 

--- a/windows/Ghostty.Core/AssemblyAttributes.cs
+++ b/windows/Ghostty.Core/AssemblyAttributes.cs
@@ -4,3 +4,10 @@
 // under NativeAOT. Without this guard, a hand-written [DllImport] added
 // later would silently bring back the runtime marshaller.
 [assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+
+// #259 logging: Ghostty (WinUI shell) and Ghostty.Tests both consume
+// internal logging types defined in this assembly (LogEvents constants,
+// LoggingBootstrap, FilterState, CapturingLoggerProvider). Both
+// consumers already reference Ghostty.Core via ProjectReference.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty.Tests")]

--- a/windows/Ghostty.Core/Commands/FrecencyStore.cs
+++ b/windows/Ghostty.Core/Commands/FrecencyStore.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Ghostty.Commands;
 
-internal sealed class FrecencyStore
+internal sealed partial class FrecencyStore
 {
     public Dictionary<string, FrecencyEntry> Entries { get; set; } = [];
 
@@ -55,7 +56,7 @@ internal sealed class FrecencyStore
         }
         catch (JsonException ex)
         {
-            Debug.WriteLine($"FrecencyStore parse failed: {ex.Message}");
+            CoreStaticLoggers.FrecencyStore.LogParseFailed(ex);
             return new FrecencyStore();
         }
     }
@@ -76,7 +77,7 @@ internal sealed class FrecencyStore
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"FrecencyStore load failed: {ex.Message}");
+            CoreStaticLoggers.FrecencyStore.LogLoadFailed(ex);
             return new FrecencyStore();
         }
     }
@@ -91,7 +92,7 @@ internal sealed class FrecencyStore
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"FrecencyStore save failed: {ex.Message}");
+            CoreStaticLoggers.FrecencyStore.LogSaveFailed(ex);
         }
     }
 }
@@ -106,4 +107,25 @@ internal sealed class FrecencyEntry
 [JsonSerializable(typeof(FrecencyStore))]
 internal partial class FrecencyStoreContext : JsonSerializerContext
 {
+}
+
+internal static partial class FrecencyStoreLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Frecency.ParseFailed,
+                   Level = LogLevel.Warning,
+                   Message = "FrecencyStore parse failed")]
+    internal static partial void LogParseFailed(
+        this ILogger<FrecencyStore> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Frecency.LoadFailed,
+                   Level = LogLevel.Warning,
+                   Message = "FrecencyStore load failed")]
+    internal static partial void LogLoadFailed(
+        this ILogger<FrecencyStore> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Frecency.SaveFailed,
+                   Level = LogLevel.Warning,
+                   Message = "FrecencyStore save failed")]
+    internal static partial void LogSaveFailed(
+        this ILogger<FrecencyStore> logger, System.Exception ex);
 }

--- a/windows/Ghostty.Core/Config/ConfigWriteScheduler.cs
+++ b/windows/Ghostty.Core/Config/ConfigWriteScheduler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Ghostty.Core.Config;
 
@@ -13,12 +14,13 @@ namespace Ghostty.Core.Config;
 /// host uses to invoke <see cref="IConfigService.Reload"/> on the
 /// dispatcher queue.
 /// </summary>
-public sealed class ConfigWriteScheduler : IConfigWriteScheduler
+public sealed partial class ConfigWriteScheduler : IConfigWriteScheduler
 {
     private readonly IConfigFileEditor _editor;
     private readonly ISchedulerTimer _timer;
     private readonly TimeSpan _debounce;
     private readonly Action _onFlushed;
+    private readonly ILogger<ConfigWriteScheduler> _logger;
     // OrdinalIgnoreCase matches ghostty's own config parser, so
     // Schedule("vertical-tabs") and Schedule("Vertical-Tabs") coalesce
     // the same way the downstream reader would treat them.
@@ -31,16 +33,19 @@ public sealed class ConfigWriteScheduler : IConfigWriteScheduler
         IConfigFileEditor editor,
         ISchedulerTimer timer,
         TimeSpan debounce,
-        Action onFlushed)
+        Action onFlushed,
+        ILogger<ConfigWriteScheduler> logger)
     {
         ArgumentNullException.ThrowIfNull(editor);
         ArgumentNullException.ThrowIfNull(timer);
         ArgumentNullException.ThrowIfNull(onFlushed);
+        ArgumentNullException.ThrowIfNull(logger);
 
         _editor = editor;
         _timer = timer;
         _debounce = debounce;
         _onFlushed = onFlushed;
+        _logger = logger;
         _timer.Callback = FlushFromTimer;
     }
 
@@ -82,8 +87,7 @@ public sealed class ConfigWriteScheduler : IConfigWriteScheduler
             try { _editor.SetValue(kv.Key, kv.Value); }
             catch (Exception ex)
             {
-                Debug.WriteLine(
-                    $"[ConfigWriteScheduler] SetValue('{kv.Key}') failed: {ex.Message}");
+                LogWriteFailed(ex, kv.Key);
             }
         }
     }
@@ -104,4 +108,9 @@ public sealed class ConfigWriteScheduler : IConfigWriteScheduler
         DrainAndWrite(signal: false);
         _timer.Dispose();
     }
+
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Config.WriteSchedulerErr,
+                   Level = LogLevel.Warning,
+                   Message = "[ConfigWriteScheduler] SetValue('{Key}') failed")]
+    private partial void LogWriteFailed(System.Exception ex, string key);
 }

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -49,6 +49,23 @@ public interface IConfigService : IDisposable
     string CommandPaletteBackground { get; }
 
     /// <summary>
+    /// Minimum log level for the Windows shell's diagnostic logger,
+    /// read from the <c>log-level</c> config key. One of
+    /// <c>trace</c>, <c>debug</c>, <c>info</c>, <c>warn</c>, <c>error</c>,
+    /// <c>off</c>. Defaults to <c>info</c> when unset.
+    /// Parsed into a <c>LoggerFilterOptions.MinLevel</c> by
+    /// <c>Ghostty.Core.Logging.LoggingBootstrap</c>.
+    /// </summary>
+    string LogLevel { get; }
+
+    /// <summary>
+    /// Comma-separated <c>CATEGORY=LEVEL</c> pairs overriding
+    /// <see cref="LogLevel"/> per-category, read from the
+    /// <c>log-filter</c> config key. Empty when unset.
+    /// </summary>
+    string LogFilter { get; }
+
+    /// <summary>
     /// Window theme from config: "light", "dark", "system", "auto", or
     /// "ghostty" (palette-derived chrome). Controls both the XAML
     /// ElementTheme and the DWM title bar chrome.

--- a/windows/Ghostty.Core/Config/SystemSchedulerTimer.cs
+++ b/windows/Ghostty.Core/Config/SystemSchedulerTimer.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Ghostty.Core.Config;
 
@@ -10,12 +11,15 @@ namespace Ghostty.Core.Config;
 /// threadpool thread; the caller is responsible for marshaling onto
 /// the UI thread if needed.
 /// </summary>
-public sealed class SystemSchedulerTimer : ISchedulerTimer
+public sealed partial class SystemSchedulerTimer : ISchedulerTimer
 {
     private readonly Timer _timer;
+    private readonly ILogger<SystemSchedulerTimer> _logger;
 
-    public SystemSchedulerTimer()
+    public SystemSchedulerTimer(ILogger<SystemSchedulerTimer> logger)
     {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
         _timer = new Timer(_ => Callback?.Invoke(), null, Timeout.Infinite, Timeout.Infinite);
     }
 
@@ -42,6 +46,11 @@ public sealed class SystemSchedulerTimer : ISchedulerTimer
         using var done = new ManualResetEvent(false);
         _timer.Dispose(done);
         if (!done.WaitOne(TimeSpan.FromSeconds(2)))
-            Debug.WriteLine("[SystemSchedulerTimer] Dispose timed out waiting for callback");
+            LogDisposeTimedOut();
     }
+
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Config.TimerDisposeSlow,
+                   Level = LogLevel.Warning,
+                   Message = "[SystemSchedulerTimer] Dispose timed out waiting for callback")]
+    private partial void LogDisposeTimedOut();
 }

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -43,6 +43,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="9.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/windows/Ghostty.Core/Logging/CoreStaticLoggers.cs
+++ b/windows/Ghostty.Core/Logging/CoreStaticLoggers.cs
@@ -1,0 +1,68 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Static accessor for <see cref="ILogger{T}"/> instances used by
+/// Core types whose call sites are static methods or otherwise
+/// cannot receive a logger through a constructor argument.
+///
+/// Populated once from <c>App.OnLaunched</c> via
+/// <see cref="Initialize(ILoggerFactory)"/>. Before that call, all
+/// accessors return <see cref="NullLogger{T}"/>, so early / test
+/// call sites are safe no-ops.
+///
+/// Tests should use <see cref="Install"/> instead of Initialize so
+/// the static state is restored to the pre-test NullLogger baseline
+/// on scope disposal. Without that, test-owned CapturingLoggerProvider
+/// factories get disposed while CoreStaticLoggers still holds their
+/// loggers, producing stale captures or ObjectDisposedException in any
+/// subsequent test that transitively triggers a Core log site.
+/// </summary>
+internal static class CoreStaticLoggers
+{
+    private static ILogger<Ghostty.Commands.FrecencyStore>? _frecencyStore;
+
+    internal static ILogger<Ghostty.Commands.FrecencyStore> FrecencyStore
+        => _frecencyStore ?? NullLogger<Ghostty.Commands.FrecencyStore>.Instance;
+
+    /// <summary>
+    /// Populate the static accessors from the process-wide factory.
+    /// Safe to call more than once - each call atomically swaps the
+    /// cached loggers. Used by <c>App.OnLaunched</c> in production.
+    /// </summary>
+    internal static void Initialize(ILoggerFactory factory)
+    {
+        _frecencyStore = factory.CreateLogger<Ghostty.Commands.FrecencyStore>();
+    }
+
+    /// <summary>
+    /// Test-side scope: installs loggers from <paramref name="factory"/>
+    /// and returns an <see cref="IDisposable"/> that restores the static
+    /// accessors to their pre-install state on disposal. Use with
+    /// <c>using var _ = CoreStaticLoggers.Install(factory);</c> in tests.
+    /// </summary>
+    internal static IDisposable Install(ILoggerFactory factory)
+    {
+        var priorFrecencyStore = _frecencyStore;
+        Initialize(factory);
+        return new Scope(priorFrecencyStore);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly ILogger<Ghostty.Commands.FrecencyStore>? _priorFrecencyStore;
+
+        public Scope(ILogger<Ghostty.Commands.FrecencyStore>? priorFrecencyStore)
+        {
+            _priorFrecencyStore = priorFrecencyStore;
+        }
+
+        public void Dispose()
+        {
+            _frecencyStore = _priorFrecencyStore;
+        }
+    }
+}

--- a/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
@@ -1,0 +1,16 @@
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Knobs for <see cref="FileLoggerProvider"/>. Path defaults to
+/// <c>%LOCALAPPDATA%\Ghostty\logs</c>; size cap to 16 MB; retention to
+/// 14 days. Tests inject narrower values and a temp dir.
+/// </summary>
+internal sealed record FileLoggerOptions
+{
+    public required string Directory { get; init; }
+    public long MaxBytesPerFile { get; init; } = 16 * 1024 * 1024;
+    public int RetentionDays { get; init; } = 14;
+    public int ChannelCapacity { get; init; } = 4096;
+    public int BatchMaxRecords { get; init; } = 64;
+    public int BatchMaxMs { get; init; } = 250;
+}

--- a/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
@@ -12,5 +12,4 @@ internal sealed record FileLoggerOptions
     public int RetentionDays { get; init; } = 14;
     public int ChannelCapacity { get; init; } = 4096;
     public int BatchMaxRecords { get; init; } = 64;
-    public int BatchMaxMs { get; init; } = 250;
 }

--- a/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
@@ -34,6 +34,12 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
 
     private long _droppedCount;
 
+    // Reused across FormatRecord calls on the single writer task. Not
+    // thread-safe, which is fine: only WriterLoopAsync touches it.
+    // Caching it removes the per-record StringBuilder allocation the
+    // previous implementation paid.
+    private readonly StringBuilder _formatBuilder = new(256);
+
     public FileLoggerProvider(FileLoggerOptions options)
         : this(options, SystemClock.Instance, RealFileSystem.Instance) { }
 
@@ -59,8 +65,14 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         _writer = _channel.Writer;
         _reader = _channel.Reader;
 
-        _fs.CreateDirectory(_opts.Directory);
-        SweepRetention();
+        // Best-effort directory prep + startup retention sweep. A locked
+        // stale log file (second Ghostty instance running, revoked ACLs)
+        // would throw IOException/UnauthorizedAccessException out of the
+        // ctor and crash App.OnLaunched for a non-critical cleanup task.
+        // Log retention is not worth failing app startup for; mirror the
+        // writer-loop rollover sweep which is already try/catched.
+        try { _fs.CreateDirectory(_opts.Directory); } catch { /* best-effort */ }
+        try { SweepRetention(); } catch { /* best-effort */ }
         _writerTask = Task.Run(WriterLoopAsync);
     }
 
@@ -210,11 +222,17 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
                         // Shutdown signal: let it propagate to the outer handler.
                         throw;
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
                         // Last-resort guard: a record-level failure (broken
                         // Exception.Message getter, formatter bug, etc.) must
-                        // never kill the writer loop.
+                        // never kill the writer loop. We can't log through
+                        // ILogger here without recursing back into ourselves,
+                        // but Debug.WriteLine surfaces the detail when a
+                        // debugger is attached so infra failures aren't 100%
+                        // silent during development.
+                        System.Diagnostics.Debug.WriteLine(
+                            $"[FileLoggerProvider] record-level failure: {ex}");
                     }
                 }
                 try { stream?.Flush(); } catch (IOException) { /* drop */ }
@@ -253,12 +271,16 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         return Path.Combine(_opts.Directory, name);
     }
 
-    private static int FormatRecord(in LogRecord r, byte[] buffer)
+    private int FormatRecord(in LogRecord r, byte[] buffer)
     {
         // 2026-04-17T14:23:17.042Z | Warn  | 2100 | Category | Message\r\n
         //   [indented stack lines on exception]
-        var sb = new StringBuilder(256);
-        sb.Append(r.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture))
+        var sb = _formatBuilder;
+        sb.Clear();
+        // AppendFormat writes the timestamp directly into sb's buffer,
+        // skipping the intermediate DateTime.ToString() allocation the
+        // previous implementation paid per record.
+        sb.AppendFormat(CultureInfo.InvariantCulture, "{0:yyyy-MM-ddTHH:mm:ss.fffZ}", r.Timestamp)
           .Append(" | ")
           .Append(LevelTag(r.Level))
           .Append(" | ")
@@ -329,6 +351,11 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         }
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        // Per-category level filtering is applied upstream by the
+        // LoggerFactory filter delegate wired in LoggingBootstrap.Build.
+        // By the time this is called, the call has already passed the
+        // configured threshold, so we only reject the explicit off level.
         public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
 
         public void Log<TState>(

--- a/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Buffers;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Rolling-file sink for the Windows tree's <see cref="ILoggerFactory"/>.
+/// Producer side is lock-free; writes go onto a bounded
+/// <see cref="Channel{T}"/> with drop-oldest semantics so a logging storm
+/// never blocks UI or termio threads. A single background task drains
+/// the channel in batches, formats each record as one pipe-separated
+/// line, rotates on UTC day change and on 16 MB size, and prunes files
+/// older than 14 days at startup.
+/// </summary>
+internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
+{
+    private readonly FileLoggerOptions _opts;
+    private readonly IClock _clock;
+    private readonly IFileSystem _fs;
+
+    private readonly Channel<LogRecord> _channel;
+    private readonly ChannelWriter<LogRecord> _writer;
+    private readonly ChannelReader<LogRecord> _reader;
+
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _writerTask;
+
+    private long _droppedCount;
+
+    public FileLoggerProvider(FileLoggerOptions options)
+        : this(options, SystemClock.Instance, RealFileSystem.Instance) { }
+
+    internal FileLoggerProvider(FileLoggerOptions options, IClock clock, IFileSystem fs)
+    {
+        _opts = options;
+        _clock = clock;
+        _fs = fs;
+
+        // DropOldest causes TryWrite to always return true (the oldest
+        // queued record is silently evicted to make room). To surface
+        // those evictions we count them in the ItemDropped callback;
+        // the writer loop later flushes the count as one synthetic
+        // "LogRecordsDropped" warning record per batch.
+        _channel = Channel.CreateBounded<LogRecord>(
+            new BoundedChannelOptions(options.ChannelCapacity)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false,
+            },
+            _ => Interlocked.Increment(ref _droppedCount));
+        _writer = _channel.Writer;
+        _reader = _channel.Reader;
+
+        _fs.CreateDirectory(_opts.Directory);
+        SweepRetention();
+        _writerTask = Task.Run(WriterLoopAsync);
+    }
+
+    public ILogger CreateLogger(string categoryName)
+        => new FileLogger(categoryName, this);
+
+    /// <summary>
+    /// Public writer entry so follow-up work (crash-log path convergence)
+    /// can drive records straight onto the channel without going through
+    /// <see cref="ILogger"/>. Not part of this PR's consumer surface;
+    /// kept public to avoid a breaking change when the follow-up lands.
+    /// </summary>
+    public bool TryWrite(LogRecord record)
+    {
+        if (_writer.TryWrite(record))
+            return true;
+
+        Interlocked.Increment(ref _droppedCount);
+        return false;
+    }
+
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    public async ValueTask DisposeAsync()
+    {
+        _writer.TryComplete();
+        try
+        {
+            await _writerTask.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // Writer stuck; force-cancel and wait for unwind so _cts.Dispose()
+            // below doesn't race the still-propagating OperationCanceledException.
+            _cts.Cancel();
+            try { await _writerTask.ConfigureAwait(false); }
+            catch { /* expected OperationCanceledException */ }
+        }
+        _cts.Dispose();
+    }
+
+    private void SweepRetention()
+    {
+        if (!_fs.DirectoryExists(_opts.Directory))
+            return;
+
+        var cutoff = _clock.UtcToday.AddDays(-_opts.RetentionDays);
+        foreach (var path in _fs.EnumerateFiles(_opts.Directory, "ghostty-*.log"))
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            var datePart = name.Length >= "ghostty-YYYYMMDD".Length
+                ? name.Substring("ghostty-".Length, 8)
+                : null;
+            if (datePart is null)
+                continue;
+            if (!DateOnly.TryParseExact(datePart, "yyyyMMdd", CultureInfo.InvariantCulture,
+                    DateTimeStyles.None, out var fileDate))
+                continue;
+            if (fileDate < cutoff)
+                _fs.DeleteFile(path);
+        }
+    }
+
+    private async Task WriterLoopAsync()
+    {
+        DateOnly openDate = default;
+        int rollCounter = 0;
+        Stream? stream = null;
+
+        var buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            while (await _reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            {
+                var batch = DrainBatch();
+                if (batch.Count == 0)
+                    continue;
+
+                var dropped = Interlocked.Exchange(ref _droppedCount, 0);
+                if (dropped > 0)
+                    batch.Insert(0, SyntheticDroppedRecord(dropped));
+
+                foreach (var record in batch)
+                {
+                    try
+                    {
+                        var today = DateOnly.FromDateTime(record.Timestamp);
+                        if (stream is null || today != openDate)
+                        {
+                            try { stream?.Flush(); } catch (IOException) { /* drop */ }
+                            stream?.Dispose();
+
+                            // On UTC-day rollover (not the first-open case), sweep
+                            // retention so long-running sessions don't accumulate
+                            // stale files past the retention window. Startup sweep
+                            // already ran in the ctor, so guard on openDate.
+                            var previousDate = openDate;
+                            openDate = today;
+                            rollCounter = 0;
+                            if (previousDate != default)
+                            {
+                                try { SweepRetention(); } catch { /* best-effort */ }
+                            }
+
+                            try
+                            {
+                                stream = _fs.OpenAppend(PathFor(openDate, rollCounter));
+                            }
+                            catch (IOException)
+                            {
+                                // Path gone, ACL revoked, etc. Skip this record;
+                                // the next batch will retry.
+                                stream = null;
+                                continue;
+                            }
+                        }
+
+                        var len = FormatRecord(record, buffer);
+                        try
+                        {
+                            stream.Write(buffer, 0, len);
+                        }
+                        catch (IOException)
+                        {
+                            // Disk full, ACL revoked, handle invalidated: drop
+                            // record rather than letting the writer task die.
+                            continue;
+                        }
+
+                        if (stream.Position >= _opts.MaxBytesPerFile)
+                        {
+                            try
+                            {
+                                stream.Flush();
+                                stream.Dispose();
+                                rollCounter++;
+                                stream = _fs.OpenAppend(PathFor(openDate, rollCounter));
+                            }
+                            catch (IOException)
+                            {
+                                stream = null;
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Shutdown signal: let it propagate to the outer handler.
+                        throw;
+                    }
+                    catch (Exception)
+                    {
+                        // Last-resort guard: a record-level failure (broken
+                        // Exception.Message getter, formatter bug, etc.) must
+                        // never kill the writer loop.
+                    }
+                }
+                try { stream?.Flush(); } catch (IOException) { /* drop */ }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        finally
+        {
+            stream?.Dispose();
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private System.Collections.Generic.List<LogRecord> DrainBatch()
+    {
+        var list = new System.Collections.Generic.List<LogRecord>(_opts.BatchMaxRecords);
+        while (list.Count < _opts.BatchMaxRecords && _reader.TryRead(out var rec))
+            list.Add(rec);
+        return list;
+    }
+
+    private LogRecord SyntheticDroppedRecord(long count)
+        => new(
+            Timestamp: _clock.UtcNow,
+            Level: LogLevel.Warning,
+            EventId: new EventId(0, "LogRecordsDropped"),
+            Category: "Ghostty.Core.Logging",
+            Message: $"{count} log record(s) dropped due to channel overflow",
+            Exception: null);
+
+    private string PathFor(DateOnly date, int rollCounter)
+    {
+        var name = rollCounter == 0
+            ? $"ghostty-{date:yyyyMMdd}.log"
+            : $"ghostty-{date:yyyyMMdd}-{rollCounter}.log";
+        return Path.Combine(_opts.Directory, name);
+    }
+
+    private static int FormatRecord(in LogRecord r, byte[] buffer)
+    {
+        // 2026-04-17T14:23:17.042Z | Warn  | 2100 | Category | Message\r\n
+        //   [indented stack lines on exception]
+        var sb = new StringBuilder(256);
+        sb.Append(r.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture))
+          .Append(" | ")
+          .Append(LevelTag(r.Level))
+          .Append(" | ")
+          .Append(r.EventId.Id)
+          .Append(" | ")
+          .Append(r.Category)
+          .Append(" | ")
+          .Append(r.Message)
+          .Append('\n');
+
+        if (r.Exception is not null)
+        {
+            // Write the exception type + message, then up to 10 Ghostty.* frames.
+            sb.Append("  ").Append(r.Exception.GetType().FullName)
+              .Append(": ").Append(r.Exception.Message).Append('\n');
+
+            var trace = r.Exception.StackTrace;
+            if (trace is not null)
+            {
+                int frame = 0;
+                foreach (var line in trace.Split('\n'))
+                {
+                    if (frame >= 10) break;
+                    var trimmed = line.TrimEnd();
+                    if (trimmed.Length == 0) continue;
+                    sb.Append("    ").Append(trimmed).Append('\n');
+                    frame++;
+                }
+            }
+        }
+
+        var text = sb.ToString();
+
+        // Guard against pathological record sizes that would overflow the
+        // rented buffer. UTF-8 worst case is 4 bytes per char, so cap the
+        // character count to buffer.Length / 4 and append a truncation
+        // marker. Keeps one record from killing the writer task.
+        var maxChars = buffer.Length / 4;
+        if (text.Length > maxChars)
+        {
+            const string suffix = "...[truncated]\n";
+            text = string.Concat(text.AsSpan(0, maxChars - suffix.Length), suffix);
+        }
+
+        return Encoding.UTF8.GetBytes(text, buffer);
+    }
+
+    private static string LevelTag(LogLevel l) => l switch
+    {
+        LogLevel.Trace       => "Trce ",
+        LogLevel.Debug       => "Dbug ",
+        LogLevel.Information => "Info ",
+        LogLevel.Warning     => "Warn ",
+        LogLevel.Error       => "Err  ",
+        LogLevel.Critical    => "Crit ",
+        _                    => "None ",
+    };
+
+    private sealed class FileLogger : ILogger
+    {
+        private readonly string _category;
+        private readonly FileLoggerProvider _parent;
+
+        public FileLogger(string category, FileLoggerProvider parent)
+        {
+            _category = category;
+            _parent = parent;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            _parent.TryWrite(new LogRecord(
+                Timestamp: _parent._clock.UtcNow,
+                Level: logLevel,
+                EventId: eventId,
+                Category: _category,
+                Message: formatter(state, exception),
+                Exception: exception));
+        }
+    }
+}

--- a/windows/Ghostty.Core/Logging/FilterState.cs
+++ b/windows/Ghostty.Core/Logging/FilterState.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 
 namespace Ghostty.Core.Logging;
@@ -7,16 +8,38 @@ namespace Ghostty.Core.Logging;
 /// <c>volatile</c> field so <see cref="LoggingBootstrap.ApplyFilters"/>
 /// can atomically swap in a rebuilt rules set on config reload without
 /// tearing down the factory or providers.
+///
+/// Also owns a per-category resolved-threshold cache. MEL invokes the
+/// filter delegate on every log call per (provider, category) pair, so
+/// repeating the StartsWith scan over the rules list at that frequency
+/// is wasteful once the answer is stable. <see cref="Replace"/> swaps
+/// in a fresh cache instance so the old decisions cannot leak into the
+/// post-reload rule set.
 /// </summary>
 internal sealed class FilterState
 {
     // Reference writes are atomic in .NET. `volatile` additionally
     // prevents the filter delegate from observing a stale reference.
     private volatile LoggerFilterOptions _options;
+    private volatile ConcurrentDictionary<string, LogLevel> _cache = new();
 
     public FilterState(LoggerFilterOptions initial) => _options = initial;
 
     public LoggerFilterOptions Options => _options;
 
-    public void Replace(LoggerFilterOptions next) => _options = next;
+    /// <summary>
+    /// Per-category resolved threshold cache. Read by the filter
+    /// delegate; invalidated by <see cref="Replace"/>.
+    /// </summary>
+    public ConcurrentDictionary<string, LogLevel> Cache => _cache;
+
+    public void Replace(LoggerFilterOptions next)
+    {
+        _options = next;
+        // Swap to a fresh cache instance. A racing log-call on the old
+        // reference at worst populates a dictionary that is already
+        // unreferenced; the next lookup will hit the new (empty) cache
+        // and recompute against the updated rules.
+        _cache = new ConcurrentDictionary<string, LogLevel>();
+    }
 }

--- a/windows/Ghostty.Core/Logging/FilterState.cs
+++ b/windows/Ghostty.Core/Logging/FilterState.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Holds the current <see cref="LoggerFilterOptions"/> behind a
+/// <c>volatile</c> field so <see cref="LoggingBootstrap.ApplyFilters"/>
+/// can atomically swap in a rebuilt rules set on config reload without
+/// tearing down the factory or providers.
+/// </summary>
+internal sealed class FilterState
+{
+    // Reference writes are atomic in .NET. `volatile` additionally
+    // prevents the filter delegate from observing a stale reference.
+    private volatile LoggerFilterOptions _options;
+
+    public FilterState(LoggerFilterOptions initial) => _options = initial;
+
+    public LoggerFilterOptions Options => _options;
+
+    public void Replace(LoggerFilterOptions next) => _options = next;
+}

--- a/windows/Ghostty.Core/Logging/IClock.cs
+++ b/windows/Ghostty.Core/Logging/IClock.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Minimal UTC clock abstraction so day-rollover and retention tests
+/// can control time. Production impl is <see cref="SystemClock"/>.
+/// </summary>
+internal interface IClock
+{
+    DateTime UtcNow { get; }
+    DateOnly UtcToday => DateOnly.FromDateTime(UtcNow);
+}

--- a/windows/Ghostty.Core/Logging/IFileSystem.cs
+++ b/windows/Ghostty.Core/Logging/IFileSystem.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Minimal filesystem abstraction so rotation and retention tests can
+/// observe behavior without touching the real disk. Production impl is
+/// <see cref="RealFileSystem"/>.
+/// </summary>
+internal interface IFileSystem
+{
+    void CreateDirectory(string path);
+    bool DirectoryExists(string path);
+
+    /// <summary>
+    /// Returns full paths of files in <paramref name="path"/> matching
+    /// <paramref name="searchPattern"/>. Consumers pass the returned
+    /// strings to <see cref="DeleteFile"/> and to
+    /// <see cref="Path.GetFileNameWithoutExtension(string)"/>; fakes
+    /// MUST return full paths, not bare file names.
+    /// </summary>
+    IEnumerable<string> EnumerateFiles(string path, string searchPattern);
+
+    void DeleteFile(string path);
+    Stream OpenAppend(string path);
+    long FileLength(string path);
+}

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -1,0 +1,22 @@
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// EventId constants for <c>Ghostty.Core</c>-resident components.
+/// Id ranges are disjoint per component. Each id appears in exactly two
+/// places: the definition here and one <c>[LoggerMessage(EventId = ...)]</c>
+/// attribute - `grep` for the constant name should return exactly two hits.
+/// </summary>
+internal static class LogEvents
+{
+    // 1000-1099: Config
+    internal static class Config
+    {
+        // Populated in Task 2.3 / 2.4.
+    }
+
+    // 1100-1199: Frecency / command history
+    internal static class Frecency
+    {
+        // Populated in Task 2.2.
+    }
+}

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -11,12 +11,16 @@ internal static class LogEvents
     // 1000-1099: Config
     internal static class Config
     {
-        // Populated in Task 2.3 / 2.4.
+        public const int ReloadFailed      = 1000; // reserved, populated in Phase 3 (ConfigService)
+        public const int WriteSchedulerErr = 1001;
+        public const int TimerDisposeSlow  = 1002;
     }
 
     // 1100-1199: Frecency / command history
     internal static class Frecency
     {
-        // Populated in Task 2.2.
+        public const int ParseFailed = 1100;
+        public const int LoadFailed  = 1101;
+        public const int SaveFailed  = 1102;
     }
 }

--- a/windows/Ghostty.Core/Logging/LogRecord.cs
+++ b/windows/Ghostty.Core/Logging/LogRecord.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Record carried through <see cref="FileLoggerProvider"/>'s channel.
+/// Kept as a readonly struct so the producer path is allocation-free
+/// except for the string message the ILogger formatter produces.
+/// </summary>
+internal readonly record struct LogRecord(
+    DateTime Timestamp,
+    LogLevel Level,
+    EventId EventId,
+    string Category,
+    string Message,
+    Exception? Exception);

--- a/windows/Ghostty.Core/Logging/LoggingBootstrap.cs
+++ b/windows/Ghostty.Core/Logging/LoggingBootstrap.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Logging;
+
+internal static class LoggingBootstrap
+{
+    /// <summary>
+    /// Parses Ghostty config keys <c>log-level</c> and <c>log-filter</c>
+    /// into a <see cref="LoggerFilterOptions"/> carrying a default minimum
+    /// plus per-category override rules.
+    /// </summary>
+    /// <param name="logLevel">
+    /// Default minimum level; one of trace / debug / info / warn / error / off.
+    /// Case-insensitive. Null or empty falls back to Information.
+    /// </param>
+    /// <param name="logFilter">
+    /// Comma-separated <c>CATEGORY=LEVEL</c> pairs. Category match uses
+    /// standard Microsoft.Extensions.Logging prefix semantics: the longest
+    /// category prefix wins. Unknown level names are skipped with no
+    /// effect on the returned options.
+    /// </param>
+    internal static LoggerFilterOptions ParseFilterOptions(
+        string? logLevel, string? logFilter)
+    {
+        var options = new LoggerFilterOptions
+        {
+            MinLevel = ParseLevelOrDefault(logLevel, LogLevel.Information),
+        };
+
+        if (!string.IsNullOrWhiteSpace(logFilter))
+        {
+            foreach (var rawPair in logFilter.Split(
+                         ',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var eq = rawPair.IndexOf('=');
+                if (eq <= 0 || eq == rawPair.Length - 1)
+                    continue; // malformed; skip
+
+                var category = rawPair[..eq].Trim();
+                var levelText = rawPair[(eq + 1)..].Trim();
+
+                if (!TryParseLevel(levelText, out var level))
+                    continue; // unknown level; skip
+
+                options.Rules.Add(new LoggerFilterRule(
+                    providerName: null,
+                    categoryName: category,
+                    logLevel: level,
+                    filter: null));
+            }
+        }
+
+        return options;
+    }
+
+    private static LogLevel ParseLevelOrDefault(string? text, LogLevel fallback)
+        => TryParseLevel(text, out var level) ? level : fallback;
+
+    private static bool TryParseLevel(string? text, out LogLevel level)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            level = default;
+            return false;
+        }
+
+        // Map Ghostty config vocabulary to Microsoft.Extensions.Logging levels.
+        switch (text.Trim().ToLowerInvariant())
+        {
+            case "trace": level = LogLevel.Trace; return true;
+            case "debug": level = LogLevel.Debug; return true;
+            case "info":
+            case "information": level = LogLevel.Information; return true;
+            case "warn":
+            case "warning": level = LogLevel.Warning; return true;
+            case "error": level = LogLevel.Error; return true;
+            case "off":
+            case "none": level = LogLevel.None; return true;
+            default: level = default; return false;
+        }
+    }
+
+    /// <summary>
+    /// Constructs the process-wide <see cref="ILoggerFactory"/> wired to
+    /// the ETW EventSource provider and the rolling-file sink. Returns
+    /// the factory plus the file sink so the caller can dispose the
+    /// file sink with an await-able teardown.
+    /// </summary>
+    internal static (ILoggerFactory Factory, FileLoggerProvider FileSink, FilterState Filters) Build(
+        string? logLevel,
+        string? logFilter,
+        string fileLogDirectory)
+    {
+        var filters = new FilterState(ParseFilterOptions(logLevel, logFilter));
+        var fileSink = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = fileLogDirectory,
+        });
+
+        var factory = LoggerFactory.Create(builder =>
+        {
+            // Single filter delegate closes over FilterState so
+            // ApplyFilters(filters, ...) can swap in a new rule set
+            // without rebuilding the factory.
+            builder.AddFilter((providerName, category, level) =>
+            {
+                if (category is null) return level >= filters.Options.MinLevel;
+
+                // Longest matching category prefix wins; falls back to MinLevel.
+                LoggerFilterRule? best = null;
+                foreach (var rule in filters.Options.Rules)
+                {
+                    if (rule.CategoryName is null) continue;
+                    if (!category.StartsWith(rule.CategoryName, StringComparison.Ordinal))
+                        continue;
+                    if (best is null || rule.CategoryName.Length > best.CategoryName!.Length)
+                        best = rule;
+                }
+                var threshold = best?.LogLevel ?? filters.Options.MinLevel;
+                return level >= threshold;
+            });
+            builder.AddEventSourceLogger();
+            builder.AddProvider(fileSink);
+        });
+
+        return (factory, fileSink, filters);
+    }
+
+    /// <summary>
+    /// Rebuilds the filter rule set in place so a live config reload
+    /// takes effect without tearing down the factory. Safe to call from
+    /// the dispatcher thread that owns <see cref="FilterState"/>.
+    /// </summary>
+    internal static void ApplyFilters(FilterState filters, string? logLevel, string? logFilter)
+        => filters.Replace(ParseFilterOptions(logLevel, logFilter));
+}

--- a/windows/Ghostty.Core/Logging/LoggingBootstrap.cs
+++ b/windows/Ghostty.Core/Logging/LoggingBootstrap.cs
@@ -103,24 +103,11 @@ internal static class LoggingBootstrap
         {
             // Single filter delegate closes over FilterState so
             // ApplyFilters(filters, ...) can swap in a new rule set
-            // without rebuilding the factory.
-            builder.AddFilter((providerName, category, level) =>
-            {
-                if (category is null) return level >= filters.Options.MinLevel;
-
-                // Longest matching category prefix wins; falls back to MinLevel.
-                LoggerFilterRule? best = null;
-                foreach (var rule in filters.Options.Rules)
-                {
-                    if (rule.CategoryName is null) continue;
-                    if (!category.StartsWith(rule.CategoryName, StringComparison.Ordinal))
-                        continue;
-                    if (best is null || rule.CategoryName.Length > best.CategoryName!.Length)
-                        best = rule;
-                }
-                var threshold = best?.LogLevel ?? filters.Options.MinLevel;
-                return level >= threshold;
-            });
+            // without rebuilding the factory. The per-category resolve
+            // result is memoized in FilterState.Cache; Replace() swaps
+            // the cache instance so stale thresholds cannot outlive a
+            // config reload.
+            builder.AddFilter((providerName, category, level) => IsEnabled(filters, category, level));
             builder.AddEventSourceLogger();
             builder.AddProvider(fileSink);
         });
@@ -135,4 +122,40 @@ internal static class LoggingBootstrap
     /// </summary>
     internal static void ApplyFilters(FilterState filters, string? logLevel, string? logFilter)
         => filters.Replace(ParseFilterOptions(logLevel, logFilter));
+
+    /// <summary>
+    /// Evaluates whether a log call should pass through, using the
+    /// memoized per-category cache on <see cref="FilterState"/>. Shared
+    /// by the production filter delegate in <see cref="Build"/> and by
+    /// tests so any regression in cache invalidation surfaces through
+    /// the same code path as production.
+    /// </summary>
+    internal static bool IsEnabled(FilterState filters, string? category, LogLevel level)
+    {
+        if (category is null) return level >= filters.Options.MinLevel;
+        var threshold = filters.Cache.GetOrAdd(category, ResolveThreshold, filters);
+        return level >= threshold;
+    }
+
+    /// <summary>
+    /// Longest matching category prefix wins; falls back to
+    /// <see cref="LoggerFilterOptions.MinLevel"/>. Called once per
+    /// previously-unseen category per filter-rule set via
+    /// <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd"/>. Kept
+    /// as a <c>static</c> method so the delegate is cached and the
+    /// dictionary doesn't close over the delegate instance.
+    /// </summary>
+    private static LogLevel ResolveThreshold(string category, FilterState state)
+    {
+        LoggerFilterRule? best = null;
+        foreach (var rule in state.Options.Rules)
+        {
+            if (rule.CategoryName is null) continue;
+            if (!category.StartsWith(rule.CategoryName, StringComparison.Ordinal))
+                continue;
+            if (best is null || rule.CategoryName.Length > best.CategoryName!.Length)
+                best = rule;
+        }
+        return best?.LogLevel ?? state.Options.MinLevel;
+    }
 }

--- a/windows/Ghostty.Core/Logging/RealFileSystem.cs
+++ b/windows/Ghostty.Core/Logging/RealFileSystem.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Ghostty.Core.Logging;
+
+internal sealed class RealFileSystem : IFileSystem
+{
+    public static readonly RealFileSystem Instance = new();
+
+    public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+    public bool DirectoryExists(string path) => Directory.Exists(path);
+
+    public IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+        => Directory.EnumerateFiles(path, searchPattern);
+
+    public void DeleteFile(string path) => File.Delete(path);
+
+    public Stream OpenAppend(string path)
+        => new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+
+    public long FileLength(string path) => new FileInfo(path).Length;
+}

--- a/windows/Ghostty.Core/Logging/SystemClock.cs
+++ b/windows/Ghostty.Core/Logging/SystemClock.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Ghostty.Core.Logging;
+
+internal sealed class SystemClock : IClock
+{
+    public static readonly SystemClock Instance = new();
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/windows/Ghostty.Core/Logging/Testing/CapturingLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/Testing/CapturingLoggerProvider.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Logging.Testing;
+
+/// <summary>
+/// In-memory <see cref="ILoggerProvider"/> that captures every emitted
+/// entry. Used by contract tests to assert that a specific component
+/// emits a specific <see cref="EventId"/> on a given code path.
+///
+/// This is NOT a test stub - it is a real <see cref="ILoggerProvider"/>
+/// implementation. It lives in <c>Ghostty.Core</c> so both
+/// <c>Ghostty.Tests</c> and any future Core-referencing test project can
+/// use it without duplication.
+/// </summary>
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly ConcurrentQueue<CapturedEntry> _entries = new();
+
+    public IReadOnlyList<CapturedEntry> Entries => _entries.ToArray();
+
+    public ILogger CreateLogger(string categoryName)
+        => new CapturingLogger(categoryName, _entries);
+
+    public void Dispose() { }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly string _category;
+        private readonly ConcurrentQueue<CapturedEntry> _sink;
+
+        public CapturingLogger(string category, ConcurrentQueue<CapturedEntry> sink)
+        {
+            _category = category;
+            _sink = sink;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _sink.Enqueue(new CapturedEntry(
+                _category, logLevel, eventId, formatter(state, exception), exception));
+        }
+    }
+}
+
+internal readonly record struct CapturedEntry(
+    string Category,
+    LogLevel Level,
+    EventId EventId,
+    string Message,
+    Exception? Exception);

--- a/windows/Ghostty.Tests/Config/ConfigWriteSchedulerTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigWriteSchedulerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Ghostty.Core.Config;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Ghostty.Tests.Config;
@@ -39,7 +40,8 @@ public class ConfigWriteSchedulerTests
         var editor = new FakeEditor();
         var onFlush = 0;
         using var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(200), () => onFlush++);
+            editor, timer, TimeSpan.FromMilliseconds(200), () => onFlush++,
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Schedule("vertical-tabs", "true");
         scheduler.Schedule("vertical-tabs", "false");
@@ -61,7 +63,8 @@ public class ConfigWriteSchedulerTests
         var timer = new FakeTimer();
         var editor = new FakeEditor();
         using var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(100), () => { });
+            editor, timer, TimeSpan.FromMilliseconds(100), () => { },
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Schedule("vertical-tabs", "true");
         scheduler.Schedule("command-palette-background", "mica");
@@ -84,7 +87,8 @@ public class ConfigWriteSchedulerTests
         var timer = new FakeTimer();
         var editor = new FakeEditor();
         using var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(100), () => { });
+            editor, timer, TimeSpan.FromMilliseconds(100), () => { },
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         // Ghostty's config parser is case-insensitive, so the two
         // spellings must land on the same pending entry with last-wins.
@@ -103,7 +107,8 @@ public class ConfigWriteSchedulerTests
         var editor = new FakeEditor();
         var onFlush = 0;
         var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(200), () => onFlush++);
+            editor, timer, TimeSpan.FromMilliseconds(200), () => onFlush++,
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Schedule("vertical-tabs", "true");
         scheduler.Dispose();
@@ -123,7 +128,8 @@ public class ConfigWriteSchedulerTests
         var editor = new ThrowingEditor(throwOnKey: "vertical-tabs");
         var onFlush = 0;
         using var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(50), () => onFlush++);
+            editor, timer, TimeSpan.FromMilliseconds(50), () => onFlush++,
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Schedule("vertical-tabs", "true");    // will throw
         scheduler.Schedule("command-palette-background", "mica"); // must still land
@@ -156,7 +162,8 @@ public class ConfigWriteSchedulerTests
         var timer = new FakeTimer();
         var editor = new FakeEditor();
         using var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(200), () => { });
+            editor, timer, TimeSpan.FromMilliseconds(200), () => { },
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Schedule("vertical-tabs", "true");
         scheduler.Flush();
@@ -171,7 +178,8 @@ public class ConfigWriteSchedulerTests
         var timer = new FakeTimer();
         var editor = new FakeEditor();
         var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(200), () => { });
+            editor, timer, TimeSpan.FromMilliseconds(200), () => { },
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Schedule("vertical-tabs", "true");
         scheduler.Dispose();
@@ -187,7 +195,8 @@ public class ConfigWriteSchedulerTests
         var editor = new FakeEditor();
         var onFlush = 0;
         using var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(200), () => onFlush++);
+            editor, timer, TimeSpan.FromMilliseconds(200), () => onFlush++,
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Flush();
 
@@ -202,7 +211,8 @@ public class ConfigWriteSchedulerTests
         var timer = new FakeTimer();
         var editor = new FakeEditor();
         var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(200), () => { });
+            editor, timer, TimeSpan.FromMilliseconds(200), () => { },
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Dispose();
         scheduler.Schedule("vertical-tabs", "true");
@@ -217,7 +227,8 @@ public class ConfigWriteSchedulerTests
         var timer = new FakeTimer();
         var editor = new FakeEditor();
         var scheduler = new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(200), () => { });
+            editor, timer, TimeSpan.FromMilliseconds(200), () => { },
+            NullLogger<ConfigWriteScheduler>.Instance);
 
         scheduler.Dispose();
         scheduler.Dispose();   // second call must not re-dispose the timer
@@ -231,12 +242,15 @@ public class ConfigWriteSchedulerTests
         var timer = new FakeTimer();
         var editor = new FakeEditor();
         Action noop = () => { };
+        var logger = NullLogger<ConfigWriteScheduler>.Instance;
 
         Assert.Throws<ArgumentNullException>(() => new ConfigWriteScheduler(
-            null!, timer, TimeSpan.FromMilliseconds(1), noop));
+            null!, timer, TimeSpan.FromMilliseconds(1), noop, logger));
         Assert.Throws<ArgumentNullException>(() => new ConfigWriteScheduler(
-            editor, null!, TimeSpan.FromMilliseconds(1), noop));
+            editor, null!, TimeSpan.FromMilliseconds(1), noop, logger));
         Assert.Throws<ArgumentNullException>(() => new ConfigWriteScheduler(
-            editor, timer, TimeSpan.FromMilliseconds(1), null!));
+            editor, timer, TimeSpan.FromMilliseconds(1), null!, logger));
+        Assert.Throws<ArgumentNullException>(() => new ConfigWriteScheduler(
+            editor, timer, TimeSpan.FromMilliseconds(1), noop, null!));
     }
 }

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/windows/Ghostty.Tests/Logging/ConfigWriteSchedulerLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/ConfigWriteSchedulerLoggingTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using Ghostty.Core.Config;
+using Ghostty.Core.Logging;
+using Ghostty.Core.Logging.Testing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+public class ConfigWriteSchedulerLoggingTests
+{
+    [Fact]
+    public void WriteBatch_ItemThatThrows_EmitsWarningWithWriteSchedulerErrEventId()
+    {
+        var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var editor = new ThrowingEditor();
+        var timer = new ManualTimer();
+        using var scheduler = new ConfigWriteScheduler(
+            editor, timer, TimeSpan.FromMilliseconds(1),
+            onFlushed: () => { },
+            logger: factory.CreateLogger<ConfigWriteScheduler>());
+
+        scheduler.Schedule("vertical-tabs", "true");
+        scheduler.Flush();
+
+        var warnings = capture.Entries.Where(e => e.Level == LogLevel.Warning).ToArray();
+        Assert.Contains(warnings, e => e.EventId.Id == LogEvents.Config.WriteSchedulerErr);
+    }
+
+    private sealed class ThrowingEditor : IConfigFileEditor
+    {
+        public string FilePath => "throwing";
+        public string ReadAll() => string.Empty;
+        public void SetValue(string key, string value)
+            => throw new System.IO.IOException($"injected: {key}");
+        public void RemoveValue(string key) { }
+        public void WriteRaw(string content) { }
+        public void SetRepeatableValues(string key, string[] values) { }
+    }
+
+    private sealed class ManualTimer : ISchedulerTimer
+    {
+        public Action? Callback { get; set; }
+        public void Schedule(TimeSpan delay) { }
+        public void Cancel() { }
+        public void Dispose() { }
+    }
+}

--- a/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
+++ b/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
@@ -86,7 +86,7 @@ public class FileLoggerProviderTests : IDisposable
     {
         var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
         // Capacity=1 so any burst overflows (DropOldest discards the oldest).
-        var opts = NewOptions(_tempDir) with { ChannelCapacity = 1, BatchMaxRecords = 1, BatchMaxMs = 1 };
+        var opts = NewOptions(_tempDir) with { ChannelCapacity = 1, BatchMaxRecords = 1 };
         await using var sink = new FileLoggerProvider(opts, clock, RealFileSystem.Instance);
         var logger = sink.CreateLogger("Cat");
 
@@ -143,7 +143,6 @@ public class FileLoggerProviderTests : IDisposable
     {
         Directory = dir,
         BatchMaxRecords = 64,
-        BatchMaxMs = 25,
         RetentionDays = 14,
         ChannelCapacity = 4096,
         MaxBytesPerFile = 16 * 1024 * 1024,

--- a/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
+++ b/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+public class FileLoggerProviderTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public FileLoggerProviderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "GhosttyLogTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task OpensFileUnderExpectedName_OnFirstWrite()
+    {
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 14, 0, 0, DateTimeKind.Utc));
+        await using var sink = new FileLoggerProvider(
+            NewOptions(_tempDir), clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("TestCategory");
+
+        logger.LogWarning(new EventId(42, "TestEvent"), "hello");
+
+        await DrainAsync(sink);
+        var files = Directory.EnumerateFiles(_tempDir).ToArray();
+        Assert.Single(files);
+        Assert.Equal("ghostty-20260417.log", Path.GetFileName(files[0]));
+        var body = ReadAllTextShared(files[0]);
+        Assert.Contains(" | Warn  | 42 | TestCategory | hello", body);
+    }
+
+    [Fact]
+    public async Task RollsToNewFile_OnUtcDayChange()
+    {
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 23, 59, 0, DateTimeKind.Utc));
+        await using var sink = new FileLoggerProvider(
+            NewOptions(_tempDir), clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("TestCategory");
+
+        logger.LogInformation(new EventId(1, "First"), "first day");
+        await DrainAsync(sink);
+
+        clock.Set(new DateTime(2026, 4, 18, 0, 1, 0, DateTimeKind.Utc));
+        logger.LogInformation(new EventId(2, "Second"), "second day");
+        await DrainAsync(sink);
+
+        var files = Directory.EnumerateFiles(_tempDir).Select(Path.GetFileName).OrderBy(n => n).ToArray();
+        Assert.Equal(new[] { "ghostty-20260417.log", "ghostty-20260418.log" }, files);
+    }
+
+    [Fact]
+    public async Task RollsToSuffixedFile_WhenSizeCapExceeded()
+    {
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
+        // Tiny cap so one small log line rolls immediately.
+        var opts = NewOptions(_tempDir) with { MaxBytesPerFile = 50 };
+        await using var sink = new FileLoggerProvider(opts, clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("Cat");
+
+        for (int i = 0; i < 5; i++)
+            logger.LogWarning(new EventId(i, "E"), "message-{Index}", i);
+
+        await DrainAsync(sink);
+        var files = Directory.EnumerateFiles(_tempDir).Select(Path.GetFileName).OrderBy(n => n).ToArray();
+        Assert.Contains("ghostty-20260417.log", files);
+        Assert.Contains("ghostty-20260417-1.log", files); // at least one roll happened
+    }
+
+    [Fact]
+    public async Task EmitsSyntheticDroppedRecord_WhenChannelOverflows()
+    {
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
+        // Capacity=1 so any burst overflows (DropOldest discards the oldest).
+        var opts = NewOptions(_tempDir) with { ChannelCapacity = 1, BatchMaxRecords = 1, BatchMaxMs = 1 };
+        await using var sink = new FileLoggerProvider(opts, clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("Cat");
+
+        for (int i = 0; i < 20; i++)
+            logger.LogWarning(new EventId(i, "E"), "burst-{Index}", i);
+
+        await DrainAsync(sink);
+        var body = ReadAllTextShared(Path.Combine(_tempDir, "ghostty-20260417.log"));
+        // The synthetic "LogRecordsDropped" warning emits category
+        // Ghostty.Core.Logging and its message contains the overflow
+        // phrase. The format line writes Category and Message but not
+        // the EventId name, so we assert on both signals that are
+        // actually emitted.
+        Assert.Contains("Ghostty.Core.Logging", body);
+        Assert.Contains("dropped due to channel overflow", body);
+    }
+
+    [Fact]
+    public void RetentionSweep_DeletesFilesOlderThanCutoff_OnConstruction()
+    {
+        // Today = 2026-04-17. Retention 14 days => cutoff 2026-04-03.
+        WriteStub("ghostty-20260301.log"); // very old, should be deleted
+        WriteStub("ghostty-20260402.log"); // day before cutoff, should be deleted
+        WriteStub("ghostty-20260404.log"); // after cutoff, should remain
+        WriteStub("ghostty-20260417.log"); // today, should remain
+        WriteStub("not-a-log.txt");       // unrelated, should remain
+
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
+        using var sink = new FileLoggerProvider(NewOptions(_tempDir), clock, RealFileSystem.Instance);
+
+        var remaining = Directory.EnumerateFiles(_tempDir).Select(Path.GetFileName).OrderBy(n => n).ToArray();
+        Assert.DoesNotContain("ghostty-20260301.log", remaining);
+        Assert.DoesNotContain("ghostty-20260402.log", remaining);
+        Assert.Contains("ghostty-20260404.log", remaining);
+        Assert.Contains("ghostty-20260417.log", remaining);
+        Assert.Contains("not-a-log.txt", remaining);
+    }
+
+    // ----- helpers -----
+
+    private void WriteStub(string name) => File.WriteAllText(Path.Combine(_tempDir, name), "");
+
+    // Read a file that may still be held open for appending by the
+    // writer task. Production side opens with FileShare.Read, so a
+    // concurrent reader must pass FileShare.ReadWrite to coexist.
+    private static string ReadAllTextShared(string path)
+    {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private static FileLoggerOptions NewOptions(string dir) => new()
+    {
+        Directory = dir,
+        BatchMaxRecords = 64,
+        BatchMaxMs = 25,
+        RetentionDays = 14,
+        ChannelCapacity = 4096,
+        MaxBytesPerFile = 16 * 1024 * 1024,
+    };
+
+    private static async Task DrainAsync(FileLoggerProvider sink)
+    {
+        // Give the writer loop one scheduling slice to flush the batch.
+        for (int i = 0; i < 50; i++)
+        {
+            await Task.Delay(20);
+        }
+    }
+
+    private sealed class FakeClock : IClock
+    {
+        private DateTime _now;
+        public FakeClock(DateTime utcNow) => _now = utcNow;
+        public void Set(DateTime utcNow) => _now = utcNow;
+        public DateTime UtcNow => _now;
+    }
+}

--- a/windows/Ghostty.Tests/Logging/FrecencyStoreLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/FrecencyStoreLoggingTests.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using Ghostty.Commands;
+using Ghostty.Core.Logging;
+using Ghostty.Core.Logging.Testing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+public class FrecencyStoreLoggingTests
+{
+    [Fact]
+    public void FromJson_WithMalformedJson_EmitsWarningWithParseFailedEventId()
+    {
+        var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+        using var scope = CoreStaticLoggers.Install(factory);
+
+        FrecencyStore.FromJson("this is not json");
+
+        var warnings = capture.Entries.Where(e => e.Level == LogLevel.Warning).ToArray();
+        Assert.Contains(warnings, e => e.EventId.Id == LogEvents.Frecency.ParseFailed);
+    }
+}

--- a/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
+++ b/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Linq;
 using Ghostty.Core.Logging;
+using Ghostty.Core.Logging.Testing;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -85,5 +88,108 @@ public class LoggingBootstrapTests
 
         Assert.Single(opts.Rules);
         Assert.Equal("Ghostty.Core", opts.Rules[0].CategoryName);
+    }
+
+    // Regression: proves the live-reload filter swap actually takes
+    // effect on subsequent log calls. MEL caches per-(provider, category)
+    // thresholds internally; the filter delegate closed over FilterState
+    // must be consulted on every log call (not just once at builder
+    // time), otherwise ApplyFilters is a no-op in practice.
+    [Fact]
+    public void ApplyFilters_SwappingInPlace_AppliesToSubsequentLogCalls()
+    {
+        var filters = new FilterState(
+            LoggingBootstrap.ParseFilterOptions("error", null));
+
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b =>
+        {
+            b.AddProvider(capture);
+            b.AddFilter((providerName, category, level) =>
+            {
+                if (category is null) return level >= filters.Options.MinLevel;
+
+                LoggerFilterRule? best = null;
+                foreach (var rule in filters.Options.Rules)
+                {
+                    if (rule.CategoryName is null) continue;
+                    if (!category.StartsWith(rule.CategoryName, StringComparison.Ordinal))
+                        continue;
+                    if (best is null || rule.CategoryName.Length > best.CategoryName!.Length)
+                        best = rule;
+                }
+                var threshold = best?.LogLevel ?? filters.Options.MinLevel;
+                return level >= threshold;
+            });
+        });
+        var logger = factory.CreateLogger("Ghostty.Services.ThemePreviewService");
+
+        // Baseline: log-level=error suppresses Warning.
+        logger.LogWarning(new EventId(99, "Before"), "warning-before-swap");
+        Assert.Empty(capture.Entries);
+
+        // Live swap to info.
+        LoggingBootstrap.ApplyFilters(filters, "info", null);
+
+        // Now Warning must pass through.
+        logger.LogWarning(new EventId(99, "After"), "warning-after-swap");
+
+        var entries = capture.Entries.Where(e => e.Level == LogLevel.Warning).ToArray();
+        Assert.Single(entries);
+        Assert.Equal("warning-after-swap", entries[0].Message);
+    }
+
+    // Regression: per-category filter rules must also live-swap.
+    [Fact]
+    public void ApplyFilters_AddingPerCategoryOverride_AppliesToSubsequentLogCalls()
+    {
+        var filters = new FilterState(
+            LoggingBootstrap.ParseFilterOptions("info", null));
+
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b =>
+        {
+            b.AddProvider(capture);
+            b.AddFilter((providerName, category, level) =>
+            {
+                if (category is null) return level >= filters.Options.MinLevel;
+
+                LoggerFilterRule? best = null;
+                foreach (var rule in filters.Options.Rules)
+                {
+                    if (rule.CategoryName is null) continue;
+                    if (!category.StartsWith(rule.CategoryName, StringComparison.Ordinal))
+                        continue;
+                    if (best is null || rule.CategoryName.Length > best.CategoryName!.Length)
+                        best = rule;
+                }
+                var threshold = best?.LogLevel ?? filters.Options.MinLevel;
+                return level >= threshold;
+            });
+        });
+        var logger = factory.CreateLogger("Ghostty.Services.ThemePreviewService");
+
+        // Baseline: log-level=info suppresses Debug.
+        logger.LogDebug(new EventId(100, "Debug1"), "debug-before");
+        Assert.DoesNotContain(capture.Entries, e => e.Level == LogLevel.Debug);
+
+        // Live-swap: add a per-category override for this category to debug.
+        LoggingBootstrap.ApplyFilters(
+            filters, "info", "Ghostty.Services.ThemePreviewService=debug");
+
+        // Now Debug must pass through for this category.
+        logger.LogDebug(new EventId(100, "Debug2"), "debug-after");
+
+        var debugEntries = capture.Entries
+            .Where(e => e.Level == LogLevel.Debug && e.Category == "Ghostty.Services.ThemePreviewService")
+            .ToArray();
+        Assert.Single(debugEntries);
+        Assert.Equal("debug-after", debugEntries[0].Message);
+
+        // Unrelated category must still be suppressed at Debug level.
+        var otherLogger = factory.CreateLogger("Ghostty.Core.Config.SomeOtherType");
+        otherLogger.LogDebug(new EventId(101, "Other"), "other-debug");
+        Assert.DoesNotContain(capture.Entries, e =>
+            e.Category == "Ghostty.Core.Config.SomeOtherType" && e.Level == LogLevel.Debug);
     }
 }

--- a/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
+++ b/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
@@ -1,0 +1,89 @@
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+public class LoggingBootstrapTests
+{
+    [Fact]
+    public void ParseFilterOptions_DefaultsToInformation_WhenLevelEmpty()
+    {
+        var opts = LoggingBootstrap.ParseFilterOptions(logLevel: null, logFilter: null);
+
+        Assert.Equal(LogLevel.Information, opts.MinLevel);
+        Assert.Empty(opts.Rules);
+    }
+
+    [Theory]
+    [InlineData("trace", LogLevel.Trace)]
+    [InlineData("TRACE", LogLevel.Trace)]
+    [InlineData("debug", LogLevel.Debug)]
+    [InlineData("info", LogLevel.Information)]
+    [InlineData("information", LogLevel.Information)]
+    [InlineData("warn", LogLevel.Warning)]
+    [InlineData("warning", LogLevel.Warning)]
+    [InlineData("error", LogLevel.Error)]
+    [InlineData("off", LogLevel.None)]
+    [InlineData("none", LogLevel.None)]
+    public void ParseFilterOptions_ParsesLevelCaseInsensitively(string input, LogLevel expected)
+    {
+        var opts = LoggingBootstrap.ParseFilterOptions(input, null);
+        Assert.Equal(expected, opts.MinLevel);
+    }
+
+    [Fact]
+    public void ParseFilterOptions_UnknownLevel_FallsBackToInformation()
+    {
+        var opts = LoggingBootstrap.ParseFilterOptions("bogus", null);
+        Assert.Equal(LogLevel.Information, opts.MinLevel);
+    }
+
+    [Fact]
+    public void ParseFilterOptions_SingleFilterRule_IsApplied()
+    {
+        var opts = LoggingBootstrap.ParseFilterOptions(
+            "info",
+            "Ghostty.Services.ThemePreviewService=trace");
+
+        Assert.Single(opts.Rules);
+        Assert.Equal("Ghostty.Services.ThemePreviewService", opts.Rules[0].CategoryName);
+        Assert.Equal(LogLevel.Trace, opts.Rules[0].LogLevel);
+    }
+
+    [Fact]
+    public void ParseFilterOptions_MultipleCommaSeparatedRules_AreAllApplied()
+    {
+        var opts = LoggingBootstrap.ParseFilterOptions(
+            "info",
+            "Ghostty.Services.ThemePreviewService=trace, Ghostty.Core.Config=warn");
+
+        Assert.Equal(2, opts.Rules.Count);
+        Assert.Contains(opts.Rules, r =>
+            r.CategoryName == "Ghostty.Services.ThemePreviewService" && r.LogLevel == LogLevel.Trace);
+        Assert.Contains(opts.Rules, r =>
+            r.CategoryName == "Ghostty.Core.Config" && r.LogLevel == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void ParseFilterOptions_MalformedPair_IsSkipped()
+    {
+        var opts = LoggingBootstrap.ParseFilterOptions(
+            "info",
+            "Ghostty.Services=warn, NoEqualsSign, =warn, Ghostty.Core=");
+
+        Assert.Single(opts.Rules);
+        Assert.Equal("Ghostty.Services", opts.Rules[0].CategoryName);
+    }
+
+    [Fact]
+    public void ParseFilterOptions_UnknownLevelInRule_IsSkipped()
+    {
+        var opts = LoggingBootstrap.ParseFilterOptions(
+            "info",
+            "Ghostty.Services=bogus, Ghostty.Core=warn");
+
+        Assert.Single(opts.Rules);
+        Assert.Equal("Ghostty.Core", opts.Rules[0].CategoryName);
+    }
+}

--- a/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
+++ b/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
@@ -105,22 +105,11 @@ public class LoggingBootstrapTests
         using var factory = LoggerFactory.Create(b =>
         {
             b.AddProvider(capture);
+            // Go through the production filter path so a regression in
+            // FilterState.Replace cache invalidation or the shared
+            // LoggingBootstrap.IsEnabled helper surfaces here.
             b.AddFilter((providerName, category, level) =>
-            {
-                if (category is null) return level >= filters.Options.MinLevel;
-
-                LoggerFilterRule? best = null;
-                foreach (var rule in filters.Options.Rules)
-                {
-                    if (rule.CategoryName is null) continue;
-                    if (!category.StartsWith(rule.CategoryName, StringComparison.Ordinal))
-                        continue;
-                    if (best is null || rule.CategoryName.Length > best.CategoryName!.Length)
-                        best = rule;
-                }
-                var threshold = best?.LogLevel ?? filters.Options.MinLevel;
-                return level >= threshold;
-            });
+                LoggingBootstrap.IsEnabled(filters, category, level));
         });
         var logger = factory.CreateLogger("Ghostty.Services.ThemePreviewService");
 
@@ -150,22 +139,11 @@ public class LoggingBootstrapTests
         using var factory = LoggerFactory.Create(b =>
         {
             b.AddProvider(capture);
+            // Go through the production filter path so a regression in
+            // FilterState.Replace cache invalidation or the shared
+            // LoggingBootstrap.IsEnabled helper surfaces here.
             b.AddFilter((providerName, category, level) =>
-            {
-                if (category is null) return level >= filters.Options.MinLevel;
-
-                LoggerFilterRule? best = null;
-                foreach (var rule in filters.Options.Rules)
-                {
-                    if (rule.CategoryName is null) continue;
-                    if (!category.StartsWith(rule.CategoryName, StringComparison.Ordinal))
-                        continue;
-                    if (best is null || rule.CategoryName.Length > best.CategoryName!.Length)
-                        best = rule;
-                }
-                var threshold = best?.LogLevel ?? filters.Options.MinLevel;
-                return level >= threshold;
-            });
+                LoggingBootstrap.IsEnabled(filters, category, level));
         });
         var logger = factory.CreateLogger("Ghostty.Services.ThemePreviewService");
 

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -280,7 +280,14 @@ public partial class App : Application
         }
         catch (System.Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Failed to set AUMID: {ex.Message}");
+            // StaticLoggers.App is NullLogger until Initialize(factory)
+            // runs further down in OnLaunched; AUMID + jump-list both
+            // run before the factory exists (AUMID must be set before
+            // any shell interop per the MSDN contract above), so these
+            // warnings are silently dropped until the factory is built.
+            // Same behavior as the pre-migration trace-only path which
+            // only wrote to the IDE output window.
+            Ghostty.Logging.StaticLoggers.App.LogAumidFailed(ex);
         }
 
         // Build the jump list once at startup.
@@ -300,7 +307,8 @@ public partial class App : Application
         }
         catch (System.Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Failed to build jump list: {ex.Message}");
+            // See AumidFailed above: NullLogger until factory builds.
+            Ghostty.Logging.StaticLoggers.App.LogJumpListFailed(ex);
         }
 
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
@@ -493,4 +501,19 @@ public partial class App : Application
             }
         }
     }
+}
+
+internal static partial class AppLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.AumidFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to set AUMID")]
+    internal static partial void LogAumidFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.JumpListFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to build jump list")]
+    internal static partial void LogJumpListFailed(
+        this ILogger<App> logger, System.Exception ex);
 }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -10,6 +10,7 @@ using Ghostty.Core.Config;
 using Ghostty.Core.Hosting;
 using Ghostty.Hosting;
 using Ghostty.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 
@@ -305,6 +306,29 @@ public partial class App : Application
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
         ConfigService = _configService;
 
+        // #259 logging: build the factory from Ghostty config before any
+        // other service constructs an ILogger<T>. Log directory under the
+        // same %LOCALAPPDATA%\Ghostty root that App.LogUnhandled already
+        // uses for crash.log, so a user reporting a bug only has one
+        // folder to attach.
+        var logDir = System.IO.Path.Combine(
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
+            "Ghostty", "logs");
+        var (factory, fileSink, filters) = Ghostty.Core.Logging.LoggingBootstrap.Build(
+            logLevel: _configService.LogLevel,
+            logFilter: _configService.LogFilter,
+            fileLogDirectory: logDir);
+        _loggerFactory = factory;
+        _fileLogSink = fileSink;
+        _logFilters = filters;
+        LoggerFactory = factory;
+        _configService.ConfigChanged += OnConfigChanged_ApplyLogFilters;
+
+        // #259 logging: populate Core-side static logger accessors
+        // for types whose call sites are static (e.g., FrecencyStore
+        // static methods that can't take a ctor-injected logger).
+        Ghostty.Core.Logging.CoreStaticLoggers.Initialize(factory);
+
         // One editor + one scheduler per process. Keeping them here
         // (instead of per-settings-window) means rapid edits coalesce
         // across window lifetimes and the file watcher sees a single
@@ -317,7 +341,7 @@ public partial class App : Application
         var uiDispatcher = DispatcherQueue.GetForCurrentThread();
         _configWriteScheduler = new ConfigWriteScheduler(
             _configEditor,
-            new SystemSchedulerTimer(),
+            new SystemSchedulerTimer(factory.CreateLogger<SystemSchedulerTimer>()),
             debounce: TimeSpan.FromMilliseconds(150),
             onFlushed: () =>
             {
@@ -341,7 +365,8 @@ public partial class App : Application
                     try { cs.Reload(); }
                     finally { cs.SuppressWatcher(false); }
                 });
-            });
+            },
+            logger: factory.CreateLogger<ConfigWriteScheduler>());
         ConfigWriteScheduler = _configWriteScheduler;
 
         // One-shot migration of the legacy ui-settings.json into the
@@ -361,23 +386,6 @@ public partial class App : Application
         // host libghostty invokes. Its callback bodies consult
         // _hostBySurface to forward to whichever per-window host owns
         // the target surface.
-        // #259 logging: build the factory from Ghostty config before any
-        // other service constructs an ILogger<T>. Log directory under the
-        // same %LOCALAPPDATA%\Ghostty root that App.LogUnhandled already
-        // uses for crash.log, so a user reporting a bug only has one
-        // folder to attach.
-        var logDir = System.IO.Path.Combine(
-            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
-            "Ghostty", "logs");
-        var (factory, fileSink, filters) = Ghostty.Core.Logging.LoggingBootstrap.Build(
-            logLevel: _configService.LogLevel,
-            logFilter: _configService.LogFilter,
-            fileLogDirectory: logDir);
-        _loggerFactory = factory;
-        _fileLogSink = fileSink;
-        _logFilters = filters;
-        LoggerFactory = factory;
-        _configService.ConfigChanged += OnConfigChanged_ApplyLogFilters;
 
         _bootstrapHost = new GhosttyHost(
             DispatcherQueue.GetForCurrentThread(),

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -51,6 +51,9 @@ public partial class App : Application
     private ConfigWriteScheduler? _configWriteScheduler;
     private GhosttyHost? _bootstrapHost;
     private HostLifetimeSupervisor? _lifetimeSupervisor;
+    private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
+    private Ghostty.Core.Logging.FileLoggerProvider? _fileLogSink;
+    private Ghostty.Core.Logging.FilterState? _logFilters;
 
     // Top-level window registry keyed by XamlRoot. Replaces the old
     // singular RootWindow and the earlier List<Window> draft: XamlRoot
@@ -70,6 +73,13 @@ public partial class App : Application
 
     internal static GhosttyHost? BootstrapHost { get; private set; }
     internal static ConfigService? ConfigService { get; private set; }
+
+    /// <summary>
+    /// Process-wide logger factory built at startup from Ghostty config.
+    /// Null before OnLaunched runs; null after OnAnyWindowClosedInternal
+    /// tears services down.
+    /// </summary>
+    internal static Microsoft.Extensions.Logging.ILoggerFactory? LoggerFactory { get; private set; }
 
     /// <summary>
     /// Process-wide debounced config write scheduler. All settings-UI
@@ -351,6 +361,24 @@ public partial class App : Application
         // host libghostty invokes. Its callback bodies consult
         // _hostBySurface to forward to whichever per-window host owns
         // the target surface.
+        // #259 logging: build the factory from Ghostty config before any
+        // other service constructs an ILogger<T>. Log directory under the
+        // same %LOCALAPPDATA%\Ghostty root that App.LogUnhandled already
+        // uses for crash.log, so a user reporting a bug only has one
+        // folder to attach.
+        var logDir = System.IO.Path.Combine(
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
+            "Ghostty", "logs");
+        var (factory, fileSink, filters) = Ghostty.Core.Logging.LoggingBootstrap.Build(
+            logLevel: _configService.LogLevel,
+            logFilter: _configService.LogFilter,
+            fileLogDirectory: logDir);
+        _loggerFactory = factory;
+        _fileLogSink = fileSink;
+        _logFilters = filters;
+        LoggerFactory = factory;
+        _configService.ConfigChanged += OnConfigChanged_ApplyLogFilters;
+
         _bootstrapHost = new GhosttyHost(
             DispatcherQueue.GetForCurrentThread(),
             _configService.ConfigHandle,
@@ -361,6 +389,13 @@ public partial class App : Application
         var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor);
         window.Closed += OnAnyWindowClosedInternal;
         window.Activate();
+    }
+
+    private void OnConfigChanged_ApplyLogFilters(Ghostty.Core.Config.IConfigService cfg)
+    {
+        if (_logFilters is null) return;
+        Ghostty.Core.Logging.LoggingBootstrap.ApplyFilters(
+            _logFilters, cfg.LogLevel, cfg.LogFilter);
     }
 
     /// <summary>
@@ -408,6 +443,19 @@ public partial class App : Application
                 // the libghostty config struct symmetrically with
                 // ConfigNew + ConfigLoadDefaultFiles.
                 _configService?.Dispose();
+
+                // #259 logging: dispose the factory after the config
+                // service so any ConfigChanged callbacks fired during
+                // ConfigService.Dispose don't race a disposed factory.
+                // FileLoggerProvider.DisposeAsync flushes its channel
+                // with a 2-second cap; block synchronously so the final
+                // batch of log records lands on disk before process exit.
+                if (_fileLogSink is not null)
+                {
+                    try { _fileLogSink.DisposeAsync().AsTask().GetAwaiter().GetResult(); }
+                    catch { /* best-effort */ }
+                }
+                _loggerFactory?.Dispose();
             }
             finally
             {
@@ -421,6 +469,11 @@ public partial class App : Application
                 LifetimeSupervisor = null;
                 _configService = null;
                 ConfigService = null;
+
+                _fileLogSink = null;
+                _loggerFactory = null;
+                LoggerFactory = null;
+
                 Exit();
             }
         }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -473,6 +473,11 @@ public partial class App : Application
                 // FileLoggerProvider.DisposeAsync flushes its channel
                 // with a 2-second cap; block synchronously so the final
                 // batch of log records lands on disk before process exit.
+                //
+                // Sync-over-async here is intentional and deadlock-free:
+                // FileLoggerProvider's writer loop runs on Task.Run and
+                // awaits throughout with ConfigureAwait(false), so no
+                // continuation resumes on this UI SynchronizationContext.
                 if (_fileLogSink is not null)
                 {
                     try { _fileLogSink.DisposeAsync().AsTask().GetAwaiter().GetResult(); }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -329,6 +329,13 @@ public partial class App : Application
         // static methods that can't take a ctor-injected logger).
         Ghostty.Core.Logging.CoreStaticLoggers.Initialize(factory);
 
+        // #259 logging: populate Ghostty-project static logger accessors
+        // for types that construct before ctor-injection is possible
+        // (e.g., ConfigService is built above BEFORE the factory exists,
+        // and cannot receive a logger through its ctor) and for call
+        // sites inside static scopes.
+        Ghostty.Logging.StaticLoggers.Initialize(factory);
+
         // One editor + one scheduler per process. Keeping them here
         // (instead of per-settings-window) means rapid edits coalesce
         // across window lifetimes and the file watcher sees a single

--- a/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
+++ b/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
@@ -1,8 +1,9 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -94,7 +95,7 @@ internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine($"[clipboard] confirm dialog failed: {ex.Message}");
+                    StaticLoggers.DialogClipboardConfirmer.LogConfirmDialogFailed(ex);
                     tcs.TrySetResult(false);
                 }
             });
@@ -123,4 +124,13 @@ internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
             "A terminal application is asking to write the following text to your clipboard."),
         _ => ("Clipboard", "Confirm clipboard access."),
     };
+}
+
+internal static partial class DialogClipboardConfirmerLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Clipboard.ConfirmDialogErr,
+                   Level = LogLevel.Warning,
+                   Message = "[clipboard] confirm dialog failed")]
+    internal static partial void LogConfirmDialogFailed(
+        this ILogger<DialogClipboardConfirmer> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
+++ b/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
@@ -1,19 +1,15 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Windows.ApplicationModel.DataTransfer;
 using WinClipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
 
 namespace Ghostty.Clipboard;
-
-// TODO(logging): replace Debug.WriteLine with ILogger<T> once the
-// Windows port has structured logging infrastructure. Debug.WriteLine
-// disappears in Release builds, so production failures here are
-// currently invisible.
 
 /// <summary>
 /// Production IClipboardBackend backed by Windows.ApplicationModel.
@@ -46,7 +42,7 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
         catch (COMException ex)
         {
             // Clipboard locked by another process. Treated as "no text".
-            Debug.WriteLine($"[clipboard] read failed: 0x{ex.HResult:X8}");
+            StaticLoggers.WinUiClipboardBackend.LogReadFailed(ex, ex.HResult);
             return null;
         }
     }
@@ -59,7 +55,7 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
         }
         catch (COMException ex)
         {
-            Debug.WriteLine($"[clipboard] write failed: 0x{ex.HResult:X8}");
+            StaticLoggers.WinUiClipboardBackend.LogWriteFailed(ex, ex.HResult);
 
             // CO_E_NOTINITIALIZED is a known WinUI 3 startup race: the
             // clipboard broker is not ready yet. Retry once on the next
@@ -77,7 +73,7 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
                     try { WinClipboard.SetContent(BuildPackage(payloads)); }
                     catch (COMException retryEx)
                     {
-                        Debug.WriteLine($"[clipboard] write retry failed: 0x{retryEx.HResult:X8}");
+                        StaticLoggers.WinUiClipboardBackend.LogWriteRetryFailed(retryEx, retryEx.HResult);
                     }
                 });
             }
@@ -109,4 +105,25 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
         }
         return package;
     }
+}
+
+internal static partial class WinUiClipboardBackendLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Clipboard.ReadFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[clipboard] read failed: 0x{HResult:X8}")]
+    internal static partial void LogReadFailed(
+        this ILogger<WinUiClipboardBackend> logger, System.Exception ex, int hresult);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Clipboard.WriteFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[clipboard] write failed: 0x{HResult:X8}")]
+    internal static partial void LogWriteFailed(
+        this ILogger<WinUiClipboardBackend> logger, System.Exception ex, int hresult);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Clipboard.WriteRetryFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[clipboard] write retry failed: 0x{HResult:X8}")]
+    internal static partial void LogWriteRetryFailed(
+        this ILogger<WinUiClipboardBackend> logger, System.Exception ex, int hresult);
 }

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -49,10 +49,11 @@
          the current culture IS invariant, so culture-sensitive calls
          silently take the invariant path with no warning. -->
     <InvariantGlobalization>true</InvariantGlobalization>
-    <!-- No ETW / EventSource providers are consumed or emitted by this
-         app; libghostty has its own logging and we do not subscribe to
-         runtime event sources. -->
-    <EventSourceSupport>false</EventSourceSupport>
+    <!-- ETW support is required by Microsoft.Extensions.Logging.EventSource,
+         the Windows-native diagnostic sink adopted in #259. Capture via
+         the Microsoft-Extensions-Logging provider. Previous assumption
+         (#258) that this app emits no EventSources is now false. -->
+    <EventSourceSupport>true</EventSourceSupport>
     <!-- No outbound HTTP today. When the sponsor-gated update channel
          lands it will use WinHTTP directly, not HttpClient with
          DiagnosticSource activity propagation. -->

--- a/windows/Ghostty/Hosting/ClipboardBridge.cs
+++ b/windows/Ghostty/Hosting/ClipboardBridge.cs
@@ -1,9 +1,10 @@
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
 using Ghostty.Interop;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 
 namespace Ghostty.Hosting;
@@ -31,8 +32,6 @@ namespace Ghostty.Hosting;
 /// shortly after, and libghostty cleans up the request state via the
 /// surface destroy path.
 /// </summary>
-// TODO(logging): replace Debug.WriteLine with ILogger<T> once the
-// Windows port has structured logging infrastructure.
 internal sealed class ClipboardBridge
 {
     private readonly DispatcherQueue _dispatcher;
@@ -74,7 +73,7 @@ internal sealed class ClipboardBridge
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[clipboard] read handler failed: {ex.Message}");
+                StaticLoggers.ClipboardBridge.LogReadHandlerFailed(ex);
             }
             finally
             {
@@ -122,7 +121,7 @@ internal sealed class ClipboardBridge
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[clipboard] confirm handler failed: {ex.Message}");
+                StaticLoggers.ClipboardBridge.LogConfirmHandlerFailed(ex);
             }
             finally
             {
@@ -167,8 +166,29 @@ internal sealed class ClipboardBridge
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[clipboard] write handler failed: {ex.Message}");
+                StaticLoggers.ClipboardBridge.LogWriteHandlerFailed(ex);
             }
         });
     }
+}
+
+internal static partial class ClipboardBridgeLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Clipboard.ReadHandlerErr,
+                   Level = LogLevel.Warning,
+                   Message = "[clipboard] read handler failed")]
+    internal static partial void LogReadHandlerFailed(
+        this ILogger<ClipboardBridge> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Clipboard.ConfirmHandlerErr,
+                   Level = LogLevel.Warning,
+                   Message = "[clipboard] confirm handler failed")]
+    internal static partial void LogConfirmHandlerFailed(
+        this ILogger<ClipboardBridge> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Clipboard.WriteHandlerErr,
+                   Level = LogLevel.Warning,
+                   Message = "[clipboard] write handler failed")]
+    internal static partial void LogWriteHandlerFailed(
+        this ILogger<ClipboardBridge> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -9,7 +9,8 @@ internal static class LogEvents
     // 2000-2099: Startup
     internal static class Startup
     {
-        // Populated in Task 4.5.
+        public const int AumidFailed    = 2000;
+        public const int JumpListFailed = 2001;
     }
 
     // 2100-2199: Clipboard
@@ -38,7 +39,11 @@ internal static class LogEvents
     // 2300-2399: WindowState + migration
     internal static class WindowState
     {
-        // Populated in Tasks 4.3 / 4.4.
+        public const int LoadFailed                    = 2300;
+        public const int SaveFailed                    = 2301;
+        public const int MigrationFailed               = 2302;
+        public const int MigrationLegacyDeleteFailed   = 2303;
+        public const int MigrationScanFailed           = 2304;
     }
 
     // 2400-2499: Shell (taskbar, backdrop)
@@ -58,6 +63,6 @@ internal static class LogEvents
     // 2600-2699: Settings UI
     internal static class SettingsUi
     {
-        // Populated in Task 4.6.
+        public const int ConfigOpenFailed = 2600;
     }
 }

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -1,0 +1,50 @@
+namespace Ghostty.Logging;
+
+/// <summary>
+/// EventId constants for components resident in the WinUI shell
+/// (<c>Ghostty</c> project). Disjoint from <c>Ghostty.Core.Logging.LogEvents</c>.
+/// </summary>
+internal static class LogEvents
+{
+    // 2000-2099: Startup
+    internal static class Startup
+    {
+        // Populated in Task 4.5.
+    }
+
+    // 2100-2199: Clipboard
+    internal static class Clipboard
+    {
+        // Populated in Tasks 3.1 / 3.2 / 3.3.
+    }
+
+    // 2200-2299: ThemePreview
+    internal static class ThemePreview
+    {
+        // Populated in Task 3.6.
+    }
+
+    // 2300-2399: WindowState + migration
+    internal static class WindowState
+    {
+        // Populated in Tasks 4.3 / 4.4.
+    }
+
+    // 2400-2499: Shell (taskbar, backdrop)
+    internal static class Shell
+    {
+        // Populated in Tasks 3.5 / 3.7.
+    }
+
+    // 2500-2599: MainWindow
+    internal static class MainWindow
+    {
+        // Populated in Task 3.4.
+    }
+
+    // 2600-2699: Settings UI
+    internal static class SettingsUi
+    {
+        // Populated in Task 4.6.
+    }
+}

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -15,13 +15,24 @@ internal static class LogEvents
     // 2100-2199: Clipboard
     internal static class Clipboard
     {
-        // Populated in Tasks 3.1 / 3.2 / 3.3.
+        public const int ReadFailed         = 2100;
+        public const int WriteFailed        = 2101;
+        public const int WriteRetryFailed   = 2102;
+        public const int ConfirmDialogErr   = 2103; // DialogClipboardConfirmer
+        public const int ReadHandlerErr     = 2104; // ClipboardBridge
+        public const int ConfirmHandlerErr  = 2105; // ClipboardBridge
+        public const int WriteHandlerErr    = 2106; // ClipboardBridge
     }
 
     // 2200-2299: ThemePreview
     internal static class ThemePreview
     {
-        // Populated in Task 3.6.
+        public const int PipeWaiting       = 2200;
+        public const int ClientConnected   = 2201;
+        public const int PreviewCancelled  = 2202;
+        public const int PreviewConfirmed  = 2203;
+        public const int PipeError         = 2204;
+        public const int InvalidThemeName  = 2205;
     }
 
     // 2300-2399: WindowState + migration
@@ -33,13 +44,15 @@ internal static class LogEvents
     // 2400-2499: Shell (taskbar, backdrop)
     internal static class Shell
     {
-        // Populated in Tasks 3.5 / 3.7.
+        public const int TaskbarWiringFailed      = 2400;
+        public const int AcrylicDefaultConfigFired = 2401;
     }
 
     // 2500-2599: MainWindow
     internal static class MainWindow
     {
-        // Populated in Task 3.4.
+        public const int ConfigOpenFailed  = 2500;
+        public const int DialogDrainFailed = 2501;
     }
 
     // 2600-2699: Settings UI

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -1,0 +1,142 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ghostty.Logging;
+
+/// <summary>
+/// Static accessor for <see cref="ILogger{T}"/> instances used by
+/// <c>Ghostty</c>-project types whose call sites are static methods
+/// or whose construction happens before the logger factory exists
+/// (see <c>ConfigService</c>, which the factory reads its filter
+/// config from at build time).
+///
+/// Populated once from <c>App.OnLaunched</c> via
+/// <see cref="Initialize(ILoggerFactory)"/>. Before that call every
+/// accessor returns <see cref="NullLogger{T}"/> (or
+/// <see cref="NullLogger.Instance"/> for the string-category
+/// <see cref="WindowStateMigration"/> entry), so early call sites
+/// are safe no-ops.
+///
+/// Tests (if any are added in the future) should use
+/// <see cref="Install"/> which returns an <see cref="IDisposable"/>
+/// scope that restores the pre-install state on disposal.
+///
+/// Note: <c>Ghostty.Settings.WindowStateMigration</c> is a
+/// <c>static class</c> so it cannot appear as a type argument to
+/// <see cref="ILogger{T}"/>. Its accessor uses the non-generic
+/// <see cref="ILogger"/> bound to the same category name the
+/// generic path would have produced, so filter rules keyed on
+/// "Ghostty.Settings.WindowStateMigration" behave identically.
+/// </summary>
+internal static class StaticLoggers
+{
+    // Phase 3 (this file's initial population)
+    private static ILogger<Ghostty.Clipboard.WinUiClipboardBackend>? _winUiClipboardBackend;
+    private static ILogger<Ghostty.Clipboard.DialogClipboardConfirmer>? _dialogClipboardConfirmer;
+    private static ILogger<Ghostty.Hosting.ClipboardBridge>? _clipboardBridge;
+    private static ILogger<Ghostty.MainWindow>? _mainWindow;
+    private static ILogger<Ghostty.Shell.TaskbarHost>? _taskbarHost;
+    private static ILogger<Ghostty.Shell.AcrylicBackdrop>? _acrylicBackdrop;
+    private static ILogger<Ghostty.Services.ThemePreviewService>? _themePreviewService;
+    private static ILogger<Ghostty.Services.ConfigService>? _configService;
+
+    // Phase 4 (prefilled so Phase 4 is a drop-in migration).
+    // WindowStateMigration is a static class, so it uses the non-generic
+    // ILogger with an explicit category name; see class docstring.
+    private const string WindowStateMigrationCategory = "Ghostty.Settings.WindowStateMigration";
+    private static ILogger? _windowStateMigration;
+    private static ILogger<Ghostty.Settings.WindowState>? _windowState;
+    private static ILogger<Ghostty.Settings.Pages.GeneralPage>? _generalPage;
+    private static ILogger<App>? _app;
+
+    internal static ILogger<Ghostty.Clipboard.WinUiClipboardBackend> WinUiClipboardBackend
+        => _winUiClipboardBackend ?? NullLogger<Ghostty.Clipboard.WinUiClipboardBackend>.Instance;
+    internal static ILogger<Ghostty.Clipboard.DialogClipboardConfirmer> DialogClipboardConfirmer
+        => _dialogClipboardConfirmer ?? NullLogger<Ghostty.Clipboard.DialogClipboardConfirmer>.Instance;
+    internal static ILogger<Ghostty.Hosting.ClipboardBridge> ClipboardBridge
+        => _clipboardBridge ?? NullLogger<Ghostty.Hosting.ClipboardBridge>.Instance;
+    internal static ILogger<Ghostty.MainWindow> MainWindow
+        => _mainWindow ?? NullLogger<Ghostty.MainWindow>.Instance;
+    internal static ILogger<Ghostty.Shell.TaskbarHost> TaskbarHost
+        => _taskbarHost ?? NullLogger<Ghostty.Shell.TaskbarHost>.Instance;
+    internal static ILogger<Ghostty.Shell.AcrylicBackdrop> AcrylicBackdrop
+        => _acrylicBackdrop ?? NullLogger<Ghostty.Shell.AcrylicBackdrop>.Instance;
+    internal static ILogger<Ghostty.Services.ThemePreviewService> ThemePreviewService
+        => _themePreviewService ?? NullLogger<Ghostty.Services.ThemePreviewService>.Instance;
+    internal static ILogger<Ghostty.Services.ConfigService> ConfigService
+        => _configService ?? NullLogger<Ghostty.Services.ConfigService>.Instance;
+    internal static ILogger WindowStateMigration
+        => _windowStateMigration ?? NullLogger.Instance;
+    internal static ILogger<Ghostty.Settings.WindowState> WindowState
+        => _windowState ?? NullLogger<Ghostty.Settings.WindowState>.Instance;
+    internal static ILogger<Ghostty.Settings.Pages.GeneralPage> GeneralPage
+        => _generalPage ?? NullLogger<Ghostty.Settings.Pages.GeneralPage>.Instance;
+    internal static ILogger<App> App
+        => _app ?? NullLogger<App>.Instance;
+
+    internal static void Initialize(ILoggerFactory factory)
+    {
+        _winUiClipboardBackend = factory.CreateLogger<Ghostty.Clipboard.WinUiClipboardBackend>();
+        _dialogClipboardConfirmer = factory.CreateLogger<Ghostty.Clipboard.DialogClipboardConfirmer>();
+        _clipboardBridge = factory.CreateLogger<Ghostty.Hosting.ClipboardBridge>();
+        _mainWindow = factory.CreateLogger<Ghostty.MainWindow>();
+        _taskbarHost = factory.CreateLogger<Ghostty.Shell.TaskbarHost>();
+        _acrylicBackdrop = factory.CreateLogger<Ghostty.Shell.AcrylicBackdrop>();
+        _themePreviewService = factory.CreateLogger<Ghostty.Services.ThemePreviewService>();
+        _configService = factory.CreateLogger<Ghostty.Services.ConfigService>();
+        _windowStateMigration = factory.CreateLogger(WindowStateMigrationCategory);
+        _windowState = factory.CreateLogger<Ghostty.Settings.WindowState>();
+        _generalPage = factory.CreateLogger<Ghostty.Settings.Pages.GeneralPage>();
+        _app = factory.CreateLogger<App>();
+    }
+
+    internal static IDisposable Install(ILoggerFactory factory)
+    {
+        var prior = CaptureSnapshot();
+        Initialize(factory);
+        return new Scope(prior);
+    }
+
+    private static Snapshot CaptureSnapshot() => new(
+        _winUiClipboardBackend, _dialogClipboardConfirmer, _clipboardBridge,
+        _mainWindow, _taskbarHost, _acrylicBackdrop,
+        _themePreviewService, _configService,
+        _windowStateMigration, _windowState, _generalPage, _app);
+
+    private readonly record struct Snapshot(
+        ILogger<Ghostty.Clipboard.WinUiClipboardBackend>? WinUiClipboardBackend,
+        ILogger<Ghostty.Clipboard.DialogClipboardConfirmer>? DialogClipboardConfirmer,
+        ILogger<Ghostty.Hosting.ClipboardBridge>? ClipboardBridge,
+        ILogger<Ghostty.MainWindow>? MainWindow,
+        ILogger<Ghostty.Shell.TaskbarHost>? TaskbarHost,
+        ILogger<Ghostty.Shell.AcrylicBackdrop>? AcrylicBackdrop,
+        ILogger<Ghostty.Services.ThemePreviewService>? ThemePreviewService,
+        ILogger<Ghostty.Services.ConfigService>? ConfigService,
+        ILogger? WindowStateMigration,
+        ILogger<Ghostty.Settings.WindowState>? WindowState,
+        ILogger<Ghostty.Settings.Pages.GeneralPage>? GeneralPage,
+        ILogger<App>? App);
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly Snapshot _prior;
+        public Scope(Snapshot prior) => _prior = prior;
+
+        public void Dispose()
+        {
+            _winUiClipboardBackend = _prior.WinUiClipboardBackend;
+            _dialogClipboardConfirmer = _prior.DialogClipboardConfirmer;
+            _clipboardBridge = _prior.ClipboardBridge;
+            _mainWindow = _prior.MainWindow;
+            _taskbarHost = _prior.TaskbarHost;
+            _acrylicBackdrop = _prior.AcrylicBackdrop;
+            _themePreviewService = _prior.ThemePreviewService;
+            _configService = _prior.ConfigService;
+            _windowStateMigration = _prior.WindowStateMigration;
+            _windowState = _prior.WindowState;
+            _generalPage = _prior.GeneralPage;
+            _app = _prior.App;
+        }
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -16,10 +16,12 @@ using Ghostty.Input;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Shell;
 using Ghostty.Services;
+using Ghostty.Logging;
 using Ghostty.Panes;
 using Ghostty.Settings;
 using Ghostty.Shell;
 using Ghostty.Tabs;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -519,7 +521,7 @@ public sealed partial class MainWindow : Window
                 }
                 catch (System.Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[MainWindow] Failed to open config file: {ex.Message}");
+                    StaticLoggers.MainWindow.LogConfigOpenFailed(ex);
                 }
             };
 
@@ -803,7 +805,7 @@ public sealed partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"DialogTracker drain failed: {ex.Message}");
+            StaticLoggers.MainWindow.LogDialogDrainFailed(ex);
         }
 
         _gradientVisual?.Dispose();
@@ -1598,4 +1600,19 @@ public sealed partial class MainWindow : Window
         };
         timer.Start();
     }
+}
+
+internal static partial class MainWindowLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.MainWindow.ConfigOpenFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[MainWindow] Failed to open config file")]
+    internal static partial void LogConfigOpenFailed(
+        this ILogger<MainWindow> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.MainWindow.DialogDrainFailed,
+                   Level = LogLevel.Warning,
+                   Message = "DialogTracker drain failed")]
+    internal static partial void LogDialogDrainFailed(
+        this ILogger<MainWindow> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -47,6 +47,8 @@ internal sealed class ConfigService : IConfigService
     public bool VerticalTabs { get; private set; }
     public bool CommandPaletteGroupCommands { get; private set; }
     public string CommandPaletteBackground { get; private set; } = "acrylic";
+    public string LogLevel { get; private set; } = "info";
+    public string LogFilter { get; private set; } = string.Empty;
 
     private static readonly string[] CommandPaletteBackgroundAllowed =
         { "acrylic", "mica", "opaque" };
@@ -310,6 +312,11 @@ internal sealed class ConfigService : IConfigService
             GetFileValue("command-palette-background", ""),
             allowed: CommandPaletteBackgroundAllowed,
             defaultValue: "acrylic");
+        // Windows-only logger keys. Parsing into LogLevel/filter rules
+        // happens in LoggingBootstrap; here we just surface the raw
+        // strings so reloads can re-read them without parser knowledge.
+        LogLevel = GetFileValue("log-level", "info");
+        LogFilter = GetFileValue("log-filter", string.Empty);
 
         // background-style is a Windows-only key not in the Zig config
         // schema, so we read it directly from the config file.

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Ghostty.Core.Config;
 using Ghostty.Interop;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 
 namespace Ghostty.Services;
@@ -197,7 +198,7 @@ internal sealed class ConfigService : IConfigService
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"[ConfigService] Reload failed to create new config: {ex.Message}");
+            StaticLoggers.ConfigService.LogReloadFailed(ex);
             return false;
         }
 
@@ -858,4 +859,16 @@ internal sealed class ConfigService : IConfigService
         if (_config.Handle != IntPtr.Zero)
             NativeMethods.ConfigFree(_config);
     }
+}
+
+internal static partial class ConfigServiceLogExtensions
+{
+    // LogLevel.Error (not Warning) because a failed reload leaves the
+    // previous config in place; the user's edit silently stops being
+    // applied, which is a genuine functional degradation.
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Config.ReloadFailed,
+                   Level = LogLevel.Error,
+                   Message = "[ConfigService] Reload failed to create new config")]
+    internal static partial void LogReloadFailed(
+        this ILogger<ConfigService> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 
 namespace Ghostty.Services;
@@ -91,9 +92,9 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
                     PipeTransmissionMode.Byte,
                     PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance);
 
-                Debug.WriteLine($"[theme-preview] pipe server waiting: \\\\.\\pipe\\{PipeName}");
+                StaticLoggers.ThemePreviewService.LogPipeWaiting(PipeName);
                 await server.WaitForConnectionAsync(ct);
-                Debug.WriteLine("[theme-preview] client connected");
+                StaticLoggers.ThemePreviewService.LogClientConnected();
 
                 // Snapshot current colors for revert on cancel.
                 SaveCurrentColors();
@@ -130,12 +131,12 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
 
                 if (!confirmed)
                 {
-                    Debug.WriteLine("[theme-preview] cancelled, reverting");
+                    StaticLoggers.ThemePreviewService.LogPreviewCancelled();
                     RevertColors();
                 }
                 else
                 {
-                    Debug.WriteLine("[theme-preview] confirmed");
+                    StaticLoggers.ThemePreviewService.LogPreviewConfirmed();
                 }
             }
             catch (OperationCanceledException)
@@ -146,7 +147,7 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
             {
                 // Pipe broken, client disconnected. Loop back to accept
                 // next connection.
-                Debug.WriteLine($"[theme-preview] pipe error: {ex.Message}");
+                StaticLoggers.ThemePreviewService.LogPipeError(ex);
             }
         }
     }
@@ -177,7 +178,7 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
             themeName.Contains("..") ||
             themeName.AsSpan().IndexOfAny(InvalidFileNameChars) >= 0)
         {
-            Debug.WriteLine($"[theme-preview] rejected invalid name: {themeName}");
+            StaticLoggers.ThemePreviewService.LogInvalidThemeName(themeName);
             return;
         }
 
@@ -246,4 +247,47 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
         return s.Length == 6 &&
             uint.TryParse(s, System.Globalization.NumberStyles.HexNumber, null, out color);
     }
+}
+
+internal static partial class ThemePreviewServiceLogExtensions
+{
+    // Message keeps the pipe name as a structured parameter; the UNC
+    // prefix (\\.\pipe\) is documented here rather than in the text so
+    // the Microsoft.Extensions.Logging source generator does not have
+    // to re-emit a backslash-heavy format string (CS1009 escape errors).
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.PipeWaiting,
+                   Level = LogLevel.Debug,
+                   Message = "[theme-preview] pipe server waiting (pipe name={PipeName})")]
+    internal static partial void LogPipeWaiting(
+        this ILogger<ThemePreviewService> logger, string pipeName);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.ClientConnected,
+                   Level = LogLevel.Debug,
+                   Message = "[theme-preview] client connected")]
+    internal static partial void LogClientConnected(
+        this ILogger<ThemePreviewService> logger);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.PreviewCancelled,
+                   Level = LogLevel.Debug,
+                   Message = "[theme-preview] cancelled, reverting")]
+    internal static partial void LogPreviewCancelled(
+        this ILogger<ThemePreviewService> logger);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.PreviewConfirmed,
+                   Level = LogLevel.Debug,
+                   Message = "[theme-preview] confirmed")]
+    internal static partial void LogPreviewConfirmed(
+        this ILogger<ThemePreviewService> logger);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.PipeError,
+                   Level = LogLevel.Warning,
+                   Message = "[theme-preview] pipe error")]
+    internal static partial void LogPipeError(
+        this ILogger<ThemePreviewService> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.InvalidThemeName,
+                   Level = LogLevel.Warning,
+                   Message = "[theme-preview] rejected invalid name: {ThemeName}")]
+    internal static partial void LogInvalidThemeName(
+        this ILogger<ThemePreviewService> logger, string themeName);
 }

--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using Ghostty.Core.Config;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -77,7 +79,16 @@ internal sealed partial class GeneralPage : Page
         }
         catch (System.Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Failed to open config file: {ex.Message}");
+            StaticLoggers.GeneralPage.LogConfigOpenFailed(ex);
         }
     }
+}
+
+internal static partial class GeneralPageLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SettingsUi.ConfigOpenFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to open config file")]
+    internal static partial void LogConfigOpenFailed(
+        this ILogger<GeneralPage> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Settings/WindowState.cs
+++ b/windows/Ghostty/Settings/WindowState.cs
@@ -1,8 +1,9 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Ghostty.Settings;
 
@@ -73,7 +74,7 @@ internal sealed class WindowState
         {
             // A malformed or inaccessible state file must never block
             // startup. Fall back to defaults and trace for post-mortem.
-            Debug.WriteLine($"WindowState load failed, using defaults: {ex.Message}");
+            StaticLoggers.WindowState.LogLoadFailed(ex);
             return new WindowState();
         }
     }
@@ -87,7 +88,7 @@ internal sealed class WindowState
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"WindowState save failed: {ex.Message}");
+            StaticLoggers.WindowState.LogSaveFailed(ex);
         }
     }
 }
@@ -96,4 +97,19 @@ internal sealed class WindowState
 [JsonSerializable(typeof(WindowState))]
 internal partial class WindowStateContext : JsonSerializerContext
 {
+}
+
+internal static partial class WindowStateLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.WindowState.LoadFailed,
+                   Level = LogLevel.Warning,
+                   Message = "WindowState load failed, using defaults")]
+    internal static partial void LogLoadFailed(
+        this ILogger<WindowState> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.WindowState.SaveFailed,
+                   Level = LogLevel.Warning,
+                   Message = "WindowState save failed")]
+    internal static partial void LogSaveFailed(
+        this ILogger<WindowState> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Settings/WindowStateMigration.cs
+++ b/windows/Ghostty/Settings/WindowStateMigration.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using Ghostty.Core.Config;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Ghostty.Settings;
 
@@ -110,11 +111,11 @@ internal static class WindowStateMigration
             // does not block startup. WindowState.Load already prefers
             // the new path when both exist.
             try { File.Delete(legacyPath); }
-            catch (Exception ex) { Debug.WriteLine($"WindowStateMigration: legacy delete failed: {ex.Message}"); }
+            catch (Exception ex) { StaticLoggers.WindowStateMigration.LogLegacyDeleteFailed(ex); }
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"WindowStateMigration failed: {ex.Message}");
+            StaticLoggers.WindowStateMigration.LogMigrationFailed(ex);
         }
     }
 
@@ -150,8 +151,29 @@ internal static class WindowStateMigration
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"WindowStateMigration: config scan failed: {ex.Message}");
+            StaticLoggers.WindowStateMigration.LogScanFailed(ex);
         }
         return set;
     }
+}
+
+internal static partial class WindowStateMigrationLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.WindowState.MigrationFailed,
+                   Level = LogLevel.Warning,
+                   Message = "WindowStateMigration failed")]
+    internal static partial void LogMigrationFailed(
+        this ILogger logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.WindowState.MigrationLegacyDeleteFailed,
+                   Level = LogLevel.Warning,
+                   Message = "WindowStateMigration: legacy delete failed")]
+    internal static partial void LogLegacyDeleteFailed(
+        this ILogger logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.WindowState.MigrationScanFailed,
+                   Level = LogLevel.Warning,
+                   Message = "WindowStateMigration: config scan failed")]
+    internal static partial void LogScanFailed(
+        this ILogger logger, System.Exception ex);
 }

--- a/windows/Ghostty/Shell/AcrylicBackdrop.cs
+++ b/windows/Ghostty/Shell/AcrylicBackdrop.cs
@@ -1,4 +1,5 @@
-using System.Diagnostics;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
@@ -122,10 +123,21 @@ internal sealed partial class AcrylicBackdrop : SystemBackdrop
         if (!_defaultConfigWarnedOnce)
         {
             _defaultConfigWarnedOnce = true;
-            Debug.WriteLine(
-                "[AcrylicBackdrop] OnDefaultSystemBackdropConfigurationChanged fired; "
-              + $"controllerConnected={_controller is not null}, targetNull={target is null}. "
-                + "The override is suppressing the base impl to avoid the WinUI 3 ArgumentException.");
+            StaticLoggers.AcrylicBackdrop.LogDefaultConfigFired(
+                _controller is not null, target is null);
         }
     }
+}
+
+internal static partial class AcrylicBackdropLogExtensions
+{
+    // Logged once per instance on the first OnDefaultSystemBackdropConfigurationChanged
+    // callback. See the method docstring for why the base implementation is skipped.
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Shell.AcrylicDefaultConfigFired,
+                   Level = LogLevel.Warning,
+                   Message = "[AcrylicBackdrop] OnDefaultSystemBackdropConfigurationChanged fired; " +
+                             "controllerConnected={ControllerConnected}, targetNull={TargetNull}. " +
+                             "The override is suppressing the base impl to avoid the WinUI 3 ArgumentException.")]
+    internal static partial void LogDefaultConfigFired(
+        this ILogger<AcrylicBackdrop> logger, bool controllerConnected, bool targetNull);
 }

--- a/windows/Ghostty/Shell/TaskbarHost.cs
+++ b/windows/Ghostty/Shell/TaskbarHost.cs
@@ -1,8 +1,9 @@
 using System;
-using System.Diagnostics;
 using Ghostty.Core.Tabs;
 using Ghostty.Core.Taskbar;
+using Ghostty.Logging;
 using Ghostty.Taskbar;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -47,7 +48,7 @@ internal sealed class TaskbarHost : IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Taskbar progress wiring failed: {ex.Message}");
+            StaticLoggers.TaskbarHost.LogTaskbarWiringFailed(ex);
         }
     }
 
@@ -72,4 +73,13 @@ internal sealed class TaskbarHost : IDisposable
     {
         _tickTimer?.Stop();
     }
+}
+
+internal static partial class TaskbarHostLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Shell.TaskbarWiringFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Taskbar progress wiring failed")]
+    internal static partial void LogTaskbarWiringFailed(
+        this ILogger<TaskbarHost> logger, System.Exception ex);
 }


### PR DESCRIPTION
Closes # 259.

Adds `Microsoft.Extensions.Logging` and migrates the 31 `Debug.WriteLine`
sites in the Windows C# tree to `[LoggerMessage]` source-gen partials
with stable EventIds. Both `TODO(logging)` comments are gone; grep
`Debug.WriteLine` on `windows/` returns zero hits.

Two sinks wired at startup: ETW via the built-in `EventSourceLoggerProvider`
and a custom rolling-file provider at `%LOCALAPPDATA%\Ghostty\logs\`
(16 MB per file, 14-day retention, lock-free bounded channel so a
logging storm never blocks UI or termio). Two new Ghostty config keys
drive runtime filtering: `log-level` and `log-filter`. Filter rules
rebuild in place on config reload.

Not in this PR, stacked for follow-up:
- crash-log path convergence (route App.LogUnhandled through the file
  sink so crash.log and ghostty-YYYYMMDD.log share one folder)
- # 55 conditional trace primitives (separate nanosecond-precision
  channel, documented in docs/windows/logging.md as distinct from this
  PR's diagnostics channel)
- ergonomics: optional console provider, JSON line format, `log-file`
  config override
- # 269 ETW visibility: the provider is registered and the file sink
  captures events end-to-end, but dotnet-trace does not currently
  surface our events. Needs a follow-up investigation (PerfView,
  minimal reproducer, debugger attach).

## Verification

- grep `Debug.WriteLine windows/` empty in source.
- 415/415 in Ghostty.Tests (+25 from 390 baseline), 19/19 in IconGen.Tests.
- AOT publish clean: 0 trim warnings, 0 AOT warnings.
- Exe size: 38,866,432 bytes (+930 KB vs post-# 261 baseline). Mostly
  the `EventSourceSupport=true` re-enable and M.E.Logging transitives.
- Manual: file sink produces the expected line format and config-read
  suppression confirmed via A/B pair (no-filter run at 09:12:05 landed
  Warning # 2401; same environment with `log-level = error` landed nothing).
  Live-swap mechanism covered by two regression tests:
  `ApplyFilters_SwappingInPlace_AppliesToSubsequentLogCalls` and
  `ApplyFilters_AddingPerCategoryOverride_AppliesToSubsequentLogCalls`.
- ETW sink wiring verified in code but event visibility from dotnet-trace
  unresolved (see # 269).

See `docs/windows/logging.md` for the user-facing guide.