### PR TITLE
refactor(windows): ctor-inject ILogger<T> for components that have a ctor

### DIFF
--- a/windows/Ghostty.Tests/Logging/LogEventsUniquenessTests.cs
+++ b/windows/Ghostty.Tests/Logging/LogEventsUniquenessTests.cs
@@ -13,6 +13,19 @@ namespace Ghostty.Tests.Logging;
 /// and one [LoggerMessage(EventId = ...)] attribute." When someone
 /// renames an event or forgets to migrate a call site, this test fires
 /// before the drift lands on main.
+///
+/// Known edge cases:
+///   - `using static Ghostty.Logging.LogEvents;` would let consumers
+///     write `Clipboard.ReadFailed` without the `LogEvents.` prefix.
+///     The needle here is `.ClassName.ConstName`, so the leading dot
+///     is missing in that form -- the test reports a false 0 and
+///     FAILS rather than silently missing drift, which is the right
+///     failure mode (prompts the author to decide: either drop the
+///     `using static` or update the scanner).
+///   - Computed EventIds like `Clipboard.ReadFailed + 1` are treated
+///     as one reference, not two. The sibling they add to is not
+///     counted. We don't have any such uses today; grep fires if one
+///     lands.
 /// </summary>
 public class LogEventsUniquenessTests
 {
@@ -45,10 +58,13 @@ public class LogEventsUniquenessTests
         // those references are not drift — they are the safety net.
         var ghosttyDir = Path.Combine(windowsRoot, "Ghostty");
         var coreDir = Path.Combine(windowsRoot, "Ghostty.Core");
+        var sep = Path.DirectorySeparatorChar;
+        var objSegment = $"{sep}obj{sep}";
+        var binSegment = $"{sep}bin{sep}";
         var allCsFiles = Directory.EnumerateFiles(ghosttyDir, "*.cs", SearchOption.AllDirectories)
             .Concat(Directory.EnumerateFiles(coreDir, "*.cs", SearchOption.AllDirectories))
-            .Where(p => !p.Contains(Path.Combine("obj", ""), StringComparison.OrdinalIgnoreCase))
-            .Where(p => !p.Contains(Path.Combine("bin", ""), StringComparison.OrdinalIgnoreCase))
+            .Where(p => !p.Contains(objSegment, StringComparison.OrdinalIgnoreCase))
+            .Where(p => !p.Contains(binSegment, StringComparison.OrdinalIgnoreCase))
             .ToArray();
 
         var failures = new List<string>();
@@ -85,9 +101,11 @@ public class LogEventsUniquenessTests
     private static IEnumerable<string> CollectQualifiedConstants(string path)
     {
         var src = File.ReadAllText(path);
-        // Strip block comments before scanning so inline code samples in
-        // docstrings aren't mistaken for definitions.
+        // Strip block AND line comments before scanning so inline code
+        // samples in docstrings and commented-out definitions aren't
+        // mistaken for real `public const int` entries.
         src = Regex.Replace(src, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+        src = Regex.Replace(src, @"//.*$", string.Empty, RegexOptions.Multiline);
 
         string? currentClass = null;
         foreach (var rawLine in src.Split('\n'))

--- a/windows/Ghostty.Tests/Logging/LogEventsUniquenessTests.cs
+++ b/windows/Ghostty.Tests/Logging/LogEventsUniquenessTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+/// <summary>
+/// Enforces the hand-written invariant documented in both LogEvents.cs
+/// files: "Each id appears in exactly two places: the definition here
+/// and one [LoggerMessage(EventId = ...)] attribute." When someone
+/// renames an event or forgets to migrate a call site, this test fires
+/// before the drift lands on main.
+/// </summary>
+public class LogEventsUniquenessTests
+{
+    [Fact]
+    public void EachEventIdConstant_IsReferenced_ExactlyOnce_OutsideItsDefinition()
+    {
+        var windowsRoot = FindWindowsSourceRoot();
+
+        var coreEventsFile = Path.Combine(windowsRoot, "Ghostty.Core", "Logging", "LogEvents.cs");
+        var shellEventsFile = Path.Combine(windowsRoot, "Ghostty", "Logging", "LogEvents.cs");
+
+        Assert.True(File.Exists(coreEventsFile), $"Core LogEvents.cs not found at {coreEventsFile}");
+        Assert.True(File.Exists(shellEventsFile), $"Shell LogEvents.cs not found at {shellEventsFile}");
+
+        // { "Clipboard.ReadFailed", "Config.ReloadFailed", ... }
+        var qualifiedNames = new List<string>();
+        qualifiedNames.AddRange(CollectQualifiedConstants(coreEventsFile));
+        qualifiedNames.AddRange(CollectQualifiedConstants(shellEventsFile));
+        Assert.NotEmpty(qualifiedNames);
+
+        var definitionFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            coreEventsFile,
+            shellEventsFile,
+        };
+
+        // Only scan production projects: Ghostty.Tests legitimately
+        // references the same constant multiple times (one per assertion
+        // that a given call site emitted the expected EventId), and
+        // those references are not drift — they are the safety net.
+        var ghosttyDir = Path.Combine(windowsRoot, "Ghostty");
+        var coreDir = Path.Combine(windowsRoot, "Ghostty.Core");
+        var allCsFiles = Directory.EnumerateFiles(ghosttyDir, "*.cs", SearchOption.AllDirectories)
+            .Concat(Directory.EnumerateFiles(coreDir, "*.cs", SearchOption.AllDirectories))
+            .Where(p => !p.Contains(Path.Combine("obj", ""), StringComparison.OrdinalIgnoreCase))
+            .Where(p => !p.Contains(Path.Combine("bin", ""), StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        var failures = new List<string>();
+        foreach (var qualified in qualifiedNames)
+        {
+            // Match ".Foo.Bar" so substrings like "FooBar" inside an
+            // unrelated identifier don't count. Every [LoggerMessage]
+            // reference is "Ghostty.(Core.)Logging.LogEvents.Class.Name"
+            // which ends in the same ".Class.Name" suffix we collected.
+            var needle = "." + qualified;
+            int usageCount = 0;
+            foreach (var file in allCsFiles)
+            {
+                if (definitionFiles.Contains(file)) continue;
+                var text = File.ReadAllText(file);
+                if (text.Contains(needle, StringComparison.Ordinal))
+                    usageCount++;
+            }
+
+            if (usageCount != 1)
+            {
+                failures.Add($"  {qualified}: found {usageCount} references outside definition (expected 1)");
+            }
+        }
+
+        Assert.True(failures.Count == 0,
+            "LogEvents constant(s) violate the one-reference-per-definition invariant:\n"
+            + string.Join("\n", failures));
+    }
+
+    // Collect "ClassName.ConstantName" strings from the nested-class
+    // LogEvents shape used in the codebase: one `internal static class`
+    // per component range, each holding several `public const int`s.
+    private static IEnumerable<string> CollectQualifiedConstants(string path)
+    {
+        var src = File.ReadAllText(path);
+        // Strip block comments before scanning so inline code samples in
+        // docstrings aren't mistaken for definitions.
+        src = Regex.Replace(src, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+
+        string? currentClass = null;
+        foreach (var rawLine in src.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            var classMatch = Regex.Match(line, @"internal\s+static\s+class\s+(\w+)");
+            if (classMatch.Success && classMatch.Groups[1].Value != "LogEvents")
+            {
+                currentClass = classMatch.Groups[1].Value;
+                continue;
+            }
+
+            if (currentClass is null) continue;
+
+            var constMatch = Regex.Match(line, @"public\s+const\s+int\s+(\w+)\s*=");
+            if (constMatch.Success)
+            {
+                yield return currentClass + "." + constMatch.Groups[1].Value;
+            }
+        }
+    }
+
+    // Walk up from the test's bin directory until we find the windows/
+    // folder by looking for the solution file. Tests run from
+    // windows/Ghostty.Tests/bin/<platform>/<config>/<tfm>/, so the
+    // marker lives a few levels up.
+    private static string FindWindowsSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "Ghostty.sln");
+            if (File.Exists(candidate))
+                return current.FullName;
+            current = current.Parent;
+        }
+        throw new InvalidOperationException(
+            "Could not locate windows/Ghostty.sln by walking up from " + AppContext.BaseDirectory);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -405,11 +405,12 @@ public partial class App : Application
         _bootstrapHost = new GhosttyHost(
             DispatcherQueue.GetForCurrentThread(),
             _configService.ConfigHandle,
-            _lifetimeSupervisor);
+            _lifetimeSupervisor,
+            factory);
         BootstrapHost = _bootstrapHost;
         _configService.SetApp(_bootstrapHost.App);
 
-        var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor);
+        var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor, factory);
         window.Closed += OnAnyWindowClosedInternal;
         window.Activate();
     }

--- a/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
+++ b/windows/Ghostty/Clipboard/DialogClipboardConfirmer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
-using Ghostty.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -26,12 +25,17 @@ internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
 
     private readonly DispatcherQueue _dispatcher;
     private readonly Func<IntPtr, XamlRoot?> _xamlRootProvider;
+    private readonly ILogger<DialogClipboardConfirmer> _logger;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    public DialogClipboardConfirmer(DispatcherQueue dispatcher, Func<IntPtr, XamlRoot?> xamlRootProvider)
+    public DialogClipboardConfirmer(
+        DispatcherQueue dispatcher,
+        Func<IntPtr, XamlRoot?> xamlRootProvider,
+        ILogger<DialogClipboardConfirmer> logger)
     {
         _dispatcher = dispatcher;
         _xamlRootProvider = xamlRootProvider;
+        _logger = logger;
     }
 
     public async ValueTask<bool> ConfirmAsync(string preview, ClipboardConfirmRequest request, IntPtr originSurface)
@@ -95,7 +99,7 @@ internal sealed class DialogClipboardConfirmer : IClipboardConfirmer
                 }
                 catch (Exception ex)
                 {
-                    StaticLoggers.DialogClipboardConfirmer.LogConfirmDialogFailed(ex);
+                    _logger.LogConfirmDialogFailed(ex);
                     tcs.TrySetResult(false);
                 }
             });

--- a/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
+++ b/windows/Ghostty/Clipboard/WinUiClipboardBackend.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
-using Ghostty.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Windows.ApplicationModel.DataTransfer;
@@ -24,10 +23,12 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
     private const int CO_E_NOTINITIALIZED = unchecked((int)0x800401F0);
 
     private readonly DispatcherQueue _dispatcher;
+    private readonly ILogger<WinUiClipboardBackend> _logger;
 
-    public WinUiClipboardBackend(DispatcherQueue dispatcher)
+    public WinUiClipboardBackend(DispatcherQueue dispatcher, ILogger<WinUiClipboardBackend> logger)
     {
         _dispatcher = dispatcher;
+        _logger = logger;
     }
 
     public async ValueTask<string?> ReadTextAsync()
@@ -42,7 +43,7 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
         catch (COMException ex)
         {
             // Clipboard locked by another process. Treated as "no text".
-            StaticLoggers.WinUiClipboardBackend.LogReadFailed(ex, ex.HResult);
+            _logger.LogReadFailed(ex, ex.HResult);
             return null;
         }
     }
@@ -55,7 +56,7 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
         }
         catch (COMException ex)
         {
-            StaticLoggers.WinUiClipboardBackend.LogWriteFailed(ex, ex.HResult);
+            _logger.LogWriteFailed(ex, ex.HResult);
 
             // CO_E_NOTINITIALIZED is a known WinUI 3 startup race: the
             // clipboard broker is not ready yet. Retry once on the next
@@ -73,7 +74,7 @@ internal sealed class WinUiClipboardBackend : IClipboardBackend
                     try { WinClipboard.SetContent(BuildPackage(payloads)); }
                     catch (COMException retryEx)
                     {
-                        StaticLoggers.WinUiClipboardBackend.LogWriteRetryFailed(retryEx, retryEx.HResult);
+                        _logger.LogWriteRetryFailed(retryEx, retryEx.HResult);
                     }
                 });
             }

--- a/windows/Ghostty/Hosting/ClipboardBridge.cs
+++ b/windows/Ghostty/Hosting/ClipboardBridge.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
 using Ghostty.Interop;
-using Ghostty.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 
@@ -38,17 +37,20 @@ internal sealed class ClipboardBridge
     private readonly ClipboardService _service;
     private readonly Func<IntPtr, IntPtr> _resolveSurface;   // userdata -> surface
     private readonly Func<IntPtr, bool> _isSurfaceAlive;     // surface  -> alive?
+    private readonly ILogger<ClipboardBridge> _logger;
 
     public ClipboardBridge(
         DispatcherQueue dispatcher,
         ClipboardService service,
         Func<IntPtr, IntPtr> resolveSurface,
-        Func<IntPtr, bool> isSurfaceAlive)
+        Func<IntPtr, bool> isSurfaceAlive,
+        ILogger<ClipboardBridge> logger)
     {
         _dispatcher = dispatcher;
         _service = service;
         _resolveSurface = resolveSurface;
         _isSurfaceAlive = isSurfaceAlive;
+        _logger = logger;
     }
 
     // read_clipboard_cb
@@ -73,7 +75,7 @@ internal sealed class ClipboardBridge
             }
             catch (Exception ex)
             {
-                StaticLoggers.ClipboardBridge.LogReadHandlerFailed(ex);
+                _logger.LogReadHandlerFailed(ex);
             }
             finally
             {
@@ -121,7 +123,7 @@ internal sealed class ClipboardBridge
             }
             catch (Exception ex)
             {
-                StaticLoggers.ClipboardBridge.LogConfirmHandlerFailed(ex);
+                _logger.LogConfirmHandlerFailed(ex);
             }
             finally
             {
@@ -166,7 +168,7 @@ internal sealed class ClipboardBridge
             }
             catch (Exception ex)
             {
-                StaticLoggers.ClipboardBridge.LogWriteHandlerFailed(ex);
+                _logger.LogWriteHandlerFailed(ex);
             }
         });
     }

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -8,6 +8,7 @@ using Ghostty.Core.Clipboard;
 using Ghostty.Core.Hosting;
 using Ghostty.Core.Interop;
 using Ghostty.Interop;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Windows.Win32;
@@ -111,7 +112,11 @@ internal sealed class GhosttyHost : IDisposable
     /// <see cref="App.TryGetHostForSurface"/> to forward to whichever
     /// per-window host owns the target surface.
     /// </summary>
-    public GhosttyHost(DispatcherQueue dispatcher, GhosttyConfig config, HostLifetimeSupervisor supervisor)
+    public GhosttyHost(
+        DispatcherQueue dispatcher,
+        GhosttyConfig config,
+        HostLifetimeSupervisor supervisor,
+        ILoggerFactory loggerFactory)
     {
         _dispatcher = dispatcher;
         _ownership = new SupervisedOwnership(
@@ -127,16 +132,20 @@ internal sealed class GhosttyHost : IDisposable
         _closeSurfaceCb = OnCloseSurface;
 
         // Build the clipboard bridge after all delegate fields are assigned.
-        var clipboardBackend = new WinUiClipboardBackend(_dispatcher);
+        var clipboardBackend = new WinUiClipboardBackend(
+            _dispatcher,
+            loggerFactory.CreateLogger<WinUiClipboardBackend>());
         var clipboardConfirmer = new DialogClipboardConfirmer(
             _dispatcher,
-            xamlRootProvider: ResolveXamlRootForSurface);
+            xamlRootProvider: ResolveXamlRootForSurface,
+            loggerFactory.CreateLogger<DialogClipboardConfirmer>());
         var clipboardService = new ClipboardService(clipboardBackend, clipboardConfirmer);
         _clipboardBridge = new ClipboardBridge(
             _dispatcher,
             clipboardService,
             resolveSurface: ResolveSurfaceFromUserdata,
-            isSurfaceAlive: IsSurfaceAlive);
+            isSurfaceAlive: IsSurfaceAlive,
+            loggerFactory.CreateLogger<ClipboardBridge>());
 
         var runtime = new GhosttyRuntimeConfig
         {
@@ -170,7 +179,8 @@ internal sealed class GhosttyHost : IDisposable
     public GhosttyHost(
         DispatcherQueue dispatcher,
         IntPtr sharedApp,
-        HostLifetimeSupervisor supervisor)
+        HostLifetimeSupervisor supervisor,
+        ILoggerFactory loggerFactory)
     {
         _dispatcher = dispatcher;
         _ownership = new SupervisedOwnership(
@@ -184,16 +194,20 @@ internal sealed class GhosttyHost : IDisposable
         // docstring above for the full reason. Libghostty calls the
         // bootstrap host's _actionCb etc, not ours.
 
-        var clipboardBackend = new WinUiClipboardBackend(_dispatcher);
+        var clipboardBackend = new WinUiClipboardBackend(
+            _dispatcher,
+            loggerFactory.CreateLogger<WinUiClipboardBackend>());
         var clipboardConfirmer = new DialogClipboardConfirmer(
             _dispatcher,
-            xamlRootProvider: ResolveXamlRootForSurface);
+            xamlRootProvider: ResolveXamlRootForSurface,
+            loggerFactory.CreateLogger<DialogClipboardConfirmer>());
         var clipboardService = new ClipboardService(clipboardBackend, clipboardConfirmer);
         _clipboardBridge = new ClipboardBridge(
             _dispatcher,
             clipboardService,
             resolveSurface: ResolveSurfaceFromUserdata,
-            isSurfaceAlive: IsSurfaceAlive);
+            isSurfaceAlive: IsSurfaceAlive,
+            loggerFactory.CreateLogger<ClipboardBridge>());
     }
 
     /// <summary>

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -6,10 +6,11 @@ namespace Ghostty.Logging;
 
 /// <summary>
 /// Static accessor for <see cref="ILogger{T}"/> instances used by
-/// <c>Ghostty</c>-project types whose call sites are static methods
-/// or whose construction happens before the logger factory exists
-/// (see <c>ConfigService</c>, which the factory reads its filter
-/// config from at build time).
+/// <c>Ghostty</c>-project types whose call sites genuinely cannot
+/// receive a logger through a constructor argument. Every remaining
+/// entry here has a documented reason below; new components should
+/// take <c>ILogger&lt;T&gt;</c> in their ctor via the <see cref="ILoggerFactory"/>
+/// threaded through <see cref="App.OnLaunched"/>, not grow this class.
 ///
 /// Populated once from <c>App.OnLaunched</c> via
 /// <see cref="Initialize(ILoggerFactory)"/>. Before that call every
@@ -18,9 +19,28 @@ namespace Ghostty.Logging;
 /// <see cref="WindowStateMigration"/> entry), so early call sites
 /// are safe no-ops.
 ///
-/// Tests (if any are added in the future) should use
-/// <see cref="Install"/> which returns an <see cref="IDisposable"/>
-/// scope that restores the pre-install state on disposal.
+/// Why each remaining site stays here:
+///   - <see cref="App"/>: logs AUMID/jump-list failures in
+///     <c>App.OnLaunched</c> BEFORE the factory is built. No ctor
+///     available in the early-startup scope.
+///   - <see cref="ConfigService"/>: constructed before the factory
+///     exists because the factory reads <c>log-level</c> /
+///     <c>log-filter</c> off <c>ConfigService</c>. Chicken-and-egg,
+///     so ctor injection is impossible.
+///   - <see cref="WindowStateMigration"/>: <c>static class</c>, so
+///     there is no ctor to inject into.
+///   - <see cref="WindowState"/>: data class deserialized by
+///     <c>System.Text.Json</c> via a static <c>Load()</c> method.
+///     Ctor injection would require threading a logger through
+///     every deserialization site.
+///   - <see cref="GeneralPage"/>: XAML page constructed by the
+///     WinUI 3 Frame via a parameterless ctor; ctor injection
+///     requires a DI-enabled <c>Frame</c> which is a larger
+///     refactor than this slot is worth.
+///
+/// Tests should use <see cref="Install"/> which returns an
+/// <see cref="IDisposable"/> scope that restores the pre-install
+/// state on disposal.
 ///
 /// Note: <c>Ghostty.Settings.WindowStateMigration</c> is a
 /// <c>static class</c> so it cannot appear as a type argument to
@@ -31,17 +51,8 @@ namespace Ghostty.Logging;
 /// </summary>
 internal static class StaticLoggers
 {
-    // Phase 3 (this file's initial population)
-    private static ILogger<Ghostty.Clipboard.WinUiClipboardBackend>? _winUiClipboardBackend;
-    private static ILogger<Ghostty.Clipboard.DialogClipboardConfirmer>? _dialogClipboardConfirmer;
-    private static ILogger<Ghostty.Hosting.ClipboardBridge>? _clipboardBridge;
-    private static ILogger<Ghostty.MainWindow>? _mainWindow;
-    private static ILogger<Ghostty.Shell.TaskbarHost>? _taskbarHost;
-    private static ILogger<Ghostty.Shell.AcrylicBackdrop>? _acrylicBackdrop;
-    private static ILogger<Ghostty.Services.ThemePreviewService>? _themePreviewService;
     private static ILogger<Ghostty.Services.ConfigService>? _configService;
 
-    // Phase 4 (prefilled so Phase 4 is a drop-in migration).
     // WindowStateMigration is a static class, so it uses the non-generic
     // ILogger with an explicit category name; see class docstring.
     private const string WindowStateMigrationCategory = "Ghostty.Settings.WindowStateMigration";
@@ -50,20 +61,6 @@ internal static class StaticLoggers
     private static ILogger<Ghostty.Settings.Pages.GeneralPage>? _generalPage;
     private static ILogger<App>? _app;
 
-    internal static ILogger<Ghostty.Clipboard.WinUiClipboardBackend> WinUiClipboardBackend
-        => _winUiClipboardBackend ?? NullLogger<Ghostty.Clipboard.WinUiClipboardBackend>.Instance;
-    internal static ILogger<Ghostty.Clipboard.DialogClipboardConfirmer> DialogClipboardConfirmer
-        => _dialogClipboardConfirmer ?? NullLogger<Ghostty.Clipboard.DialogClipboardConfirmer>.Instance;
-    internal static ILogger<Ghostty.Hosting.ClipboardBridge> ClipboardBridge
-        => _clipboardBridge ?? NullLogger<Ghostty.Hosting.ClipboardBridge>.Instance;
-    internal static ILogger<Ghostty.MainWindow> MainWindow
-        => _mainWindow ?? NullLogger<Ghostty.MainWindow>.Instance;
-    internal static ILogger<Ghostty.Shell.TaskbarHost> TaskbarHost
-        => _taskbarHost ?? NullLogger<Ghostty.Shell.TaskbarHost>.Instance;
-    internal static ILogger<Ghostty.Shell.AcrylicBackdrop> AcrylicBackdrop
-        => _acrylicBackdrop ?? NullLogger<Ghostty.Shell.AcrylicBackdrop>.Instance;
-    internal static ILogger<Ghostty.Services.ThemePreviewService> ThemePreviewService
-        => _themePreviewService ?? NullLogger<Ghostty.Services.ThemePreviewService>.Instance;
     internal static ILogger<Ghostty.Services.ConfigService> ConfigService
         => _configService ?? NullLogger<Ghostty.Services.ConfigService>.Instance;
     internal static ILogger WindowStateMigration
@@ -77,13 +74,6 @@ internal static class StaticLoggers
 
     internal static void Initialize(ILoggerFactory factory)
     {
-        _winUiClipboardBackend = factory.CreateLogger<Ghostty.Clipboard.WinUiClipboardBackend>();
-        _dialogClipboardConfirmer = factory.CreateLogger<Ghostty.Clipboard.DialogClipboardConfirmer>();
-        _clipboardBridge = factory.CreateLogger<Ghostty.Hosting.ClipboardBridge>();
-        _mainWindow = factory.CreateLogger<Ghostty.MainWindow>();
-        _taskbarHost = factory.CreateLogger<Ghostty.Shell.TaskbarHost>();
-        _acrylicBackdrop = factory.CreateLogger<Ghostty.Shell.AcrylicBackdrop>();
-        _themePreviewService = factory.CreateLogger<Ghostty.Services.ThemePreviewService>();
         _configService = factory.CreateLogger<Ghostty.Services.ConfigService>();
         _windowStateMigration = factory.CreateLogger(WindowStateMigrationCategory);
         _windowState = factory.CreateLogger<Ghostty.Settings.WindowState>();
@@ -99,19 +89,9 @@ internal static class StaticLoggers
     }
 
     private static Snapshot CaptureSnapshot() => new(
-        _winUiClipboardBackend, _dialogClipboardConfirmer, _clipboardBridge,
-        _mainWindow, _taskbarHost, _acrylicBackdrop,
-        _themePreviewService, _configService,
-        _windowStateMigration, _windowState, _generalPage, _app);
+        _configService, _windowStateMigration, _windowState, _generalPage, _app);
 
     private readonly record struct Snapshot(
-        ILogger<Ghostty.Clipboard.WinUiClipboardBackend>? WinUiClipboardBackend,
-        ILogger<Ghostty.Clipboard.DialogClipboardConfirmer>? DialogClipboardConfirmer,
-        ILogger<Ghostty.Hosting.ClipboardBridge>? ClipboardBridge,
-        ILogger<Ghostty.MainWindow>? MainWindow,
-        ILogger<Ghostty.Shell.TaskbarHost>? TaskbarHost,
-        ILogger<Ghostty.Shell.AcrylicBackdrop>? AcrylicBackdrop,
-        ILogger<Ghostty.Services.ThemePreviewService>? ThemePreviewService,
         ILogger<Ghostty.Services.ConfigService>? ConfigService,
         ILogger? WindowStateMigration,
         ILogger<Ghostty.Settings.WindowState>? WindowState,
@@ -125,13 +105,6 @@ internal static class StaticLoggers
 
         public void Dispose()
         {
-            _winUiClipboardBackend = _prior.WinUiClipboardBackend;
-            _dialogClipboardConfirmer = _prior.DialogClipboardConfirmer;
-            _clipboardBridge = _prior.ClipboardBridge;
-            _mainWindow = _prior.MainWindow;
-            _taskbarHost = _prior.TaskbarHost;
-            _acrylicBackdrop = _prior.AcrylicBackdrop;
-            _themePreviewService = _prior.ThemePreviewService;
             _configService = _prior.ConfigService;
             _windowStateMigration = _prior.WindowStateMigration;
             _windowState = _prior.WindowState;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -65,6 +65,10 @@ public sealed partial class MainWindow : Window
     // so anything in this window that needs to mutate the config file
     // goes through App.ConfigFileEditor rather than building its own.
     private readonly IConfigFileEditor _configEditor;
+    // Held so AcrylicBackdrop rebuilds in ApplyBackdropStyle() can get a
+    // fresh ILogger<T> without reaching into static accessors.
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<MainWindow> _logger;
     private readonly PaneHostFactory _factory;
     private readonly TabManager _tabManager;
     private readonly PaneActionRouter _router;
@@ -200,8 +204,12 @@ public sealed partial class MainWindow : Window
     // WinUI 3 tears Content down before Closed fires.
     internal XamlRoot? RegisteredRoot { get; private set; }
 
-    internal MainWindow(ConfigService configService, GhosttyHost bootstrapHost, HostLifetimeSupervisor supervisor)
-        : this(configService, bootstrapHost, supervisor, seedTab: null)
+    internal MainWindow(
+        ConfigService configService,
+        GhosttyHost bootstrapHost,
+        HostLifetimeSupervisor supervisor,
+        ILoggerFactory loggerFactory)
+        : this(configService, bootstrapHost, supervisor, loggerFactory, seedTab: null)
     {
     }
 
@@ -212,12 +220,17 @@ public sealed partial class MainWindow : Window
     /// factory" path runs. <paramref name="bootstrapHost"/> is the
     /// app-owning GhosttyHost built once in App.xaml.cs; this window
     /// constructs its OWN per-window GhosttyHost from it using the
-    /// shared-app ctor.
+    /// shared-app ctor. <paramref name="loggerFactory"/> is the
+    /// process-wide factory built in App.OnLaunched; MainWindow holds
+    /// it to construct loggers for the per-window components it owns
+    /// (GhosttyHost's clipboard trio, TaskbarHost, AcrylicBackdrop,
+    /// ThemePreviewService).
     /// </summary>
     private MainWindow(
         ConfigService configService,
         GhosttyHost bootstrapHost,
         HostLifetimeSupervisor supervisor,
+        ILoggerFactory loggerFactory,
         TabModel? seedTab)
     {
         InitializeComponent();
@@ -227,6 +240,8 @@ public sealed partial class MainWindow : Window
             ?? throw new InvalidOperationException(
                 "MainWindow: App.ConfigFileEditor is null. " +
                 "App.OnLaunched must initialize it before constructing a window.");
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<MainWindow>();
 
         // Build this window's per-window GhosttyHost around the shared
         // app. Each per-window host has its OWN per-window surface
@@ -236,7 +251,8 @@ public sealed partial class MainWindow : Window
         _host = new GhosttyHost(
             DispatcherQueue,
             bootstrapHost.App.Handle,
-            supervisor);
+            supervisor,
+            loggerFactory);
         // NOTE: configService.SetApp is already done by App.xaml.cs on
         // the bootstrap host. We do NOT call it again here.
 
@@ -318,7 +334,10 @@ public sealed partial class MainWindow : Window
 
         _shellTheme = new ShellThemeService(configService);
         _shellTheme.ThemeChanged += OnShellThemeChanged;
-        _themePreview = new ThemePreviewService(configService, DispatcherQueue);
+        _themePreview = new ThemePreviewService(
+            configService,
+            DispatcherQueue,
+            loggerFactory.CreateLogger<ThemePreviewService>());
         _themePreview.ListThemesRequested += OnListThemesRequested;
 
         _factory = new PaneHostFactory(_host);
@@ -411,7 +430,7 @@ public sealed partial class MainWindow : Window
         _titleBar.ApplyForCurrentMode();
         _titleBar.SyncCaptionInset();
 
-        _taskbar = new TaskbarHost(this, _tabManager);
+        _taskbar = new TaskbarHost(this, _tabManager, loggerFactory.CreateLogger<TaskbarHost>());
 
         AppWindow.Changed += (_, _) =>
         {
@@ -521,7 +540,7 @@ public sealed partial class MainWindow : Window
                 }
                 catch (System.Exception ex)
                 {
-                    StaticLoggers.MainWindow.LogConfigOpenFailed(ex);
+                    _logger.LogConfigOpenFailed(ex);
                 }
             };
 
@@ -617,9 +636,10 @@ public sealed partial class MainWindow : Window
         ConfigService configService,
         GhosttyHost bootstrapHost,
         HostLifetimeSupervisor supervisor,
+        ILoggerFactory loggerFactory,
         TabModel adoptedTab)
     {
-        return new MainWindow(configService, bootstrapHost, supervisor, seedTab: adoptedTab);
+        return new MainWindow(configService, bootstrapHost, supervisor, loggerFactory, seedTab: adoptedTab);
     }
 
     /// <summary>
@@ -697,7 +717,8 @@ public sealed partial class MainWindow : Window
         // built inside the new window. RehostTo is what actually moves
         // the surface entries out of this window's _surfaces into the
         // new window's _surfaces AND rewrites App._hostBySurface.
-        var newWindow = MainWindow.CreateForAdoption(_configService, bootstrap, supervisor, detached);
+        var newWindow = MainWindow.CreateForAdoption(
+            _configService, bootstrap, supervisor, _loggerFactory, detached);
         var newHost = newWindow._host;
         ((Panes.PaneHost)detached.PaneHost).RehostTo(newHost);
 
@@ -805,7 +826,7 @@ public sealed partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            StaticLoggers.MainWindow.LogDialogDrainFailed(ex);
+            _logger.LogDialogDrainFailed(ex);
         }
 
         _gradientVisual?.Dispose();
@@ -1136,7 +1157,8 @@ public sealed partial class MainWindow : Window
             case BackdropStyles.Frosted:
                 if (DesktopAcrylicController.IsSupported())
                     SystemBackdrop = new AcrylicBackdrop(
-                        tintColor, tintOpacity, luminosityOpacity);
+                        tintColor, tintOpacity, luminosityOpacity,
+                        _loggerFactory.CreateLogger<AcrylicBackdrop>());
                 else
                     goto case BackdropStyles.Solid;
                 ApplyWindowClassBrush(ClassBrushKind.Transparent);

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -65,9 +65,16 @@ public sealed partial class MainWindow : Window
     // so anything in this window that needs to mutate the config file
     // goes through App.ConfigFileEditor rather than building its own.
     private readonly IConfigFileEditor _configEditor;
-    // Held so AcrylicBackdrop rebuilds in ApplyBackdropStyle() can get a
-    // fresh ILogger<T> without reaching into static accessors.
-    private readonly ILoggerFactory _loggerFactory;
+    // Narrower than holding ILoggerFactory: AcrylicBackdrop is rebuilt
+    // per backdrop-style change in ApplyBackdropStyle(), and that is
+    // the ONLY reason this window needed a way to mint loggers after
+    // construction. Capturing the delegate once keeps the logger
+    // surface on MainWindow honest about its scope and avoids a
+    // field that a future reader could reach into for unrelated
+    // things. The detach-to-new-window path reads App.LoggerFactory
+    // statically (same shape as App.BootstrapHost / App.LifetimeSupervisor
+    // just above it in DetachTabToNewWindow).
+    private readonly Func<ILogger<AcrylicBackdrop>> _newAcrylicLogger;
     private readonly ILogger<MainWindow> _logger;
     private readonly PaneHostFactory _factory;
     private readonly TabManager _tabManager;
@@ -240,7 +247,7 @@ public sealed partial class MainWindow : Window
             ?? throw new InvalidOperationException(
                 "MainWindow: App.ConfigFileEditor is null. " +
                 "App.OnLaunched must initialize it before constructing a window.");
-        _loggerFactory = loggerFactory;
+        _newAcrylicLogger = loggerFactory.CreateLogger<AcrylicBackdrop>;
         _logger = loggerFactory.CreateLogger<MainWindow>();
 
         // Build this window's per-window GhosttyHost around the shared
@@ -717,8 +724,15 @@ public sealed partial class MainWindow : Window
         // built inside the new window. RehostTo is what actually moves
         // the surface entries out of this window's _surfaces into the
         // new window's _surfaces AND rewrites App._hostBySurface.
+        // Same App.* static-read shape as the bootstrap/supervisor
+        // pulls just above: the detach path is an App-level concern
+        // (moves a tab between windows that the App owns), so reaching
+        // into App for the process-wide factory is consistent.
+        var factory = App.LoggerFactory
+            ?? throw new InvalidOperationException(
+                "DetachTabToWindow: no logger factory; App.OnLaunched did not run.");
         var newWindow = MainWindow.CreateForAdoption(
-            _configService, bootstrap, supervisor, _loggerFactory, detached);
+            _configService, bootstrap, supervisor, factory, detached);
         var newHost = newWindow._host;
         ((Panes.PaneHost)detached.PaneHost).RehostTo(newHost);
 
@@ -1158,7 +1172,7 @@ public sealed partial class MainWindow : Window
                 if (DesktopAcrylicController.IsSupported())
                     SystemBackdrop = new AcrylicBackdrop(
                         tintColor, tintOpacity, luminosityOpacity,
-                        _loggerFactory.CreateLogger<AcrylicBackdrop>());
+                        _newAcrylicLogger());
                 else
                     goto case BackdropStyles.Solid;
                 ApplyWindowClassBrush(ClassBrushKind.Transparent);

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
-using Ghostty.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 
@@ -32,6 +31,7 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
 
     private readonly ConfigService _configService;
     private readonly DispatcherQueue _dispatcher;
+    private readonly ILogger<ThemePreviewService> _logger;
     private readonly CancellationTokenSource _cts = new();
     private Task? _serverTask;
 
@@ -51,10 +51,12 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
 
     public ThemePreviewService(
         ConfigService configService,
-        DispatcherQueue dispatcher)
+        DispatcherQueue dispatcher,
+        ILogger<ThemePreviewService> logger)
     {
         _configService = configService;
         _dispatcher = dispatcher;
+        _logger = logger;
         _serverTask = Task.Run(() => RunServer(_cts.Token));
     }
 
@@ -92,9 +94,9 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
                     PipeTransmissionMode.Byte,
                     PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance);
 
-                StaticLoggers.ThemePreviewService.LogPipeWaiting(PipeName);
+                _logger.LogPipeWaiting(PipeName);
                 await server.WaitForConnectionAsync(ct);
-                StaticLoggers.ThemePreviewService.LogClientConnected();
+                _logger.LogClientConnected();
 
                 // Snapshot current colors for revert on cancel.
                 SaveCurrentColors();
@@ -131,12 +133,12 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
 
                 if (!confirmed)
                 {
-                    StaticLoggers.ThemePreviewService.LogPreviewCancelled();
+                    _logger.LogPreviewCancelled();
                     RevertColors();
                 }
                 else
                 {
-                    StaticLoggers.ThemePreviewService.LogPreviewConfirmed();
+                    _logger.LogPreviewConfirmed();
                 }
             }
             catch (OperationCanceledException)
@@ -147,7 +149,7 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
             {
                 // Pipe broken, client disconnected. Loop back to accept
                 // next connection.
-                StaticLoggers.ThemePreviewService.LogPipeError(ex);
+                _logger.LogPipeError(ex);
             }
         }
     }
@@ -178,7 +180,7 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
             themeName.Contains("..") ||
             themeName.AsSpan().IndexOfAny(InvalidFileNameChars) >= 0)
         {
-            StaticLoggers.ThemePreviewService.LogInvalidThemeName(themeName);
+            _logger.LogInvalidThemeName(themeName);
             return;
         }
 

--- a/windows/Ghostty/Shell/AcrylicBackdrop.cs
+++ b/windows/Ghostty/Shell/AcrylicBackdrop.cs
@@ -1,4 +1,3 @@
-using Ghostty.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Composition.SystemBackdrops;
@@ -20,6 +19,8 @@ internal sealed partial class AcrylicBackdrop : SystemBackdrop
     private DesktopAcrylicController? _controller;
     private SystemBackdropConfiguration? _config;
 
+    private readonly ILogger<AcrylicBackdrop> _logger;
+
     // Logged once per instance the first time the broken base hook
     // fires, so when a future WinUI 3 update changes that behaviour we
     // can tell at a glance (the trace will either stop appearing or
@@ -30,14 +31,17 @@ internal sealed partial class AcrylicBackdrop : SystemBackdrop
     /// <param name="tintColor">Tint overlay color.</param>
     /// <param name="tintOpacity">0.0 = no tint, 1.0 = full tint color.</param>
     /// <param name="luminosityOpacity">0.0 = no luminosity, 1.0 = full luminosity layer.</param>
+    /// <param name="logger">Logger for the OnDefaultSystemBackdropConfigurationChanged diagnostic.</param>
     internal AcrylicBackdrop(
         Windows.UI.Color tintColor,
         float tintOpacity,
-        float luminosityOpacity)
+        float luminosityOpacity,
+        ILogger<AcrylicBackdrop> logger)
     {
         _tintColor = tintColor;
         _tintOpacity = tintOpacity;
         _luminosityOpacity = luminosityOpacity;
+        _logger = logger;
     }
 
     protected override void OnTargetConnected(
@@ -123,7 +127,7 @@ internal sealed partial class AcrylicBackdrop : SystemBackdrop
         if (!_defaultConfigWarnedOnce)
         {
             _defaultConfigWarnedOnce = true;
-            StaticLoggers.AcrylicBackdrop.LogDefaultConfigFired(
+            _logger.LogDefaultConfigFired(
                 _controller is not null, target is null);
         }
     }

--- a/windows/Ghostty/Shell/TaskbarHost.cs
+++ b/windows/Ghostty/Shell/TaskbarHost.cs
@@ -1,7 +1,6 @@
 using System;
 using Ghostty.Core.Tabs;
 using Ghostty.Core.Taskbar;
-using Ghostty.Logging;
 using Ghostty.Taskbar;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
@@ -29,7 +28,7 @@ internal sealed class TaskbarHost : IDisposable
 
     public bool IsAvailable => _coordinator is not null;
 
-    public TaskbarHost(Window window, TabManager tabs)
+    public TaskbarHost(Window window, TabManager tabs, ILogger<TaskbarHost> logger)
     {
         try
         {
@@ -48,7 +47,7 @@ internal sealed class TaskbarHost : IDisposable
         }
         catch (Exception ex)
         {
-            StaticLoggers.TaskbarHost.LogTaskbarWiringFailed(ex);
+            logger.LogTaskbarWiringFailed(ex);
         }
     }
 


### PR DESCRIPTION
Follow-up to # 268 review feedback. The initial migration used a
static-accessor service-locator (`StaticLoggers`, `CoreStaticLoggers`)
for every call site because it kept the diff flat across a five-phase
migration. This PR rewrites the six sites whose construction we
actually own to take `ILogger<T>` in their ctor, and lets the
remaining static entries be the ones that genuinely cannot take one.

## What changed

Ctor-injected now:
- `WinUiClipboardBackend`, `DialogClipboardConfirmer`, `ClipboardBridge` (both `GhosttyHost` ctors build them)
- `TaskbarHost`, `ThemePreviewService`, `AcrylicBackdrop` (`MainWindow` builds them)
- `MainWindow` itself

To make that possible, `ILoggerFactory` is threaded through the two
construction seams the WinUI shell already had:
- `GhosttyHost`: both ctors take `ILoggerFactory` and call `CreateLogger<T>()` for the clipboard trio
- `MainWindow`: ctor + `CreateForAdoption` take `ILoggerFactory`; held as `_loggerFactory` so `ApplyBackdropStyle` can build a fresh `AcrylicBackdrop` logger on each style swap

`StaticLoggers` shrinks from 12 entries to 5. The five that remain
have a documented reason each, in the class docstring:
- `App` logs AUMID / jump-list failures before the factory is built
- `ConfigService` constructs before the factory exists (chicken-and-egg: factory reads `log-level` off it)
- `WindowStateMigration` is a `static class`
- `WindowState` is JSON-deserialized via a static `Load()`
- `GeneralPage` is framework-constructed via a parameterless ctor

## New test

`LogEventsUniquenessTests` enforces the hand-written invariant both
`LogEvents.cs` files carry in their docstring: "Each id appears in
exactly two places: the definition here and one
`[LoggerMessage(EventId = ...)]` attribute." Scans `Ghostty/` and
`Ghostty.Core/` .cs files, skips the test tree, asserts each defined
constant has exactly one reference outside its definition. Catches
the drift the docstring was asking us to catch by hand.

## Verification

- 452/452 in `Ghostty.Tests` (green)
- `dotnet build windows/Ghostty/Ghostty.csproj /p:Platform=x64` clean
- No runtime behavior change intended; every migrated site logs through
  the same `[LoggerMessage]` partials as before, just via a ctor-held
  `ILogger<T>` instead of a `StaticLoggers` property.