### PR TITLE
fix(bench): honest conpty-throughput probes with paired ingest+emit rates

### DIFF
--- a/windows/Ghostty.Bench.EchoChild/Program.cs
+++ b/windows/Ghostty.Bench.EchoChild/Program.cs
@@ -61,7 +61,23 @@ try
 {
     using var stdin = Console.OpenStandardInput();
     using var stdout = Console.OpenStandardOutput();
-    stdin.CopyTo(stdout);
+
+    // Manual copy loop with an explicit Flush after each Write, rather than
+    // Stream.CopyTo. Under ConPTY, Console.OpenStandardOutput's stream can
+    // hold the final partial chunk of a large burst (e.g., the ~31-byte
+    // terminator after a 1 MB throughput payload) in an internal buffer
+    // until the next full block or process exit. That delays the parent's
+    // terminator observation past the probe's wall-clock budget. DirectPipe
+    // does not exhibit this because its anonymous pipe backing is unbuffered.
+    // 81920 is Stream.CopyTo's default buffer size; keep parity for round-
+    // trip throughput characteristics.
+    byte[] buf = new byte[81920];
+    int n;
+    while ((n = stdin.Read(buf, 0, buf.Length)) > 0)
+    {
+        stdout.Write(buf, 0, n);
+        stdout.Flush();
+    }
 }
 catch (IOException)
 {

--- a/windows/Ghostty.Bench.EchoChild/Program.cs
+++ b/windows/Ghostty.Bench.EchoChild/Program.cs
@@ -7,14 +7,11 @@
 // GetConsoleMode fails cleanly so we skip both steps and behave as a
 // plain byte-for-byte echo.
 //
-// Spec: docs/superpowers/specs/2026-04-17-conpty-bench-probe-protocol-design.md
-//
-// The throughput probe protocol (spec 2026-04-17-conpty-throughput-probe-
-// protocol-design.md) requires no active participation here: its terminator
+// Throughput probes require no active participation here: the terminator
 // travels through this raw-mode CopyTo byte-for-byte, and under ConPTY
-// conhost renders the trailing "~ENDOFBURST_<nonce>~" onto its screen buffer
-// and re-emits it on hOutput as part of the next refresh cycle. No barrier-
-// response logic lives in EchoChild.
+// conhost renders the trailing "~ENDOFBURST_<nonce>~" onto its screen
+// buffer and re-emits it on hOutput as part of the next refresh cycle.
+// No barrier-response logic lives in EchoChild.
 using System.Runtime.InteropServices;
 
 const uint STD_INPUT_HANDLE = unchecked((uint)-10);

--- a/windows/Ghostty.Bench.EchoChild/Program.cs
+++ b/windows/Ghostty.Bench.EchoChild/Program.cs
@@ -8,6 +8,13 @@
 // plain byte-for-byte echo.
 //
 // Spec: docs/superpowers/specs/2026-04-17-conpty-bench-probe-protocol-design.md
+//
+// The throughput probe protocol (spec 2026-04-17-conpty-throughput-probe-
+// protocol-design.md) requires no active participation here: its terminator
+// travels through this raw-mode CopyTo byte-for-byte, and under ConPTY
+// conhost renders the trailing "~ENDOFBURST_<nonce>~" onto its screen buffer
+// and re-emits it on hOutput as part of the next refresh cycle. No barrier-
+// response logic lives in EchoChild.
 using System.Runtime.InteropServices;
 
 const uint STD_INPUT_HANDLE = unchecked((uint)-10);

--- a/windows/Ghostty.Bench/Harness/Runner.cs
+++ b/windows/Ghostty.Bench/Harness/Runner.cs
@@ -103,13 +103,13 @@ public static class Runner
     // transport, reads output until the terminator substring is observed in
     // the return stream, returns (elapsedTicks, emitBytes). Emit counts every
     // byte read during the window including the terminator and any bytes
-    // that arrived in the same read as the terminator's last byte; at 100 MB
+    // that arrived in the same read as the terminator's last byte; at 1 MB
     // payload scale this is ~31 bytes of noise.
     //
     // `scratch` is caller-owned and reused across iterations. The method
     // uses the first (terminator.Length - 1) bytes of scratch as cross-read
     // carryover storage, so scratch.Length must be > terminator.Length. The
-    // recommended size is 64 KB to amortize Read syscalls over 100 MB
+    // recommended size is 64 KB to amortize Read syscalls over 1 MB
     // payloads.
     //
     // Throws:

--- a/windows/Ghostty.Bench/Harness/Runner.cs
+++ b/windows/Ghostty.Bench/Harness/Runner.cs
@@ -161,10 +161,12 @@ public static class Runner
                 if (idx >= 0)
                     return emit;
 
-                // Carry over the last (terminator.Length - 1) bytes so a
-                // terminator that straddles the boundary between this read
-                // and the next is still detectable. Span.CopyTo is memmove-
-                // safe for overlapping source/destination in the same buffer.
+                // Carry over the last (terminator.Length - 1) bytes: that is
+                // the largest suffix that could form the prefix of a terminator
+                // straddling this read and the next. Anything shorter loses
+                // cross-boundary matches; anything longer wastes space.
+                // Span.CopyTo is memmove-safe for overlapping source and
+                // destination in the same buffer.
                 int keep = Math.Min(tailLen, scanLen);
                 if (keep > 0)
                     scratch.AsSpan(scanLen - keep, keep).CopyTo(scratch.AsSpan(0, keep));
@@ -180,10 +182,21 @@ public static class Runner
         long emitBytes;
         try
         {
+            // GetResult is safe here: Task.Run dispatches the async lambda on
+            // the threadpool with no captured SynchronizationContext, so no
+            // deadlock can form regardless of the caller's context. xunit's
+            // test host has no context, console / bench host has none either.
             emitBytes = reader.GetAwaiter().GetResult();
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
+            // Only convert cancellations caused by OUR deadline CTS. The guard
+            // isn't perfect: any OCE raised after the CTS has fired looks the
+            // same from here. In practice, ReadAsync on NamedPipeClientStream /
+            // anonymous pipes only cancels via the caller's token, so the
+            // conversion is correct. If a future transport raises OCE for a
+            // different reason, revisit: split the wait into a timeout vs
+            // exception path using `cts.Token.WaitHandle`.
             throw new TimeoutException(
                 $"throughput terminator not observed within {deadline.TotalSeconds:F1}s");
         }

--- a/windows/Ghostty.Bench/Harness/Runner.cs
+++ b/windows/Ghostty.Bench/Harness/Runner.cs
@@ -98,4 +98,97 @@ public static class Runner
 
     public static double TicksToMicroseconds(long ticks) =>
         ticks * 1_000_000.0 / Stopwatch.Frequency;
+
+    // Runs one timed throughput iteration: writes payload + terminator to the
+    // transport, reads output until the terminator substring is observed in
+    // the return stream, returns (elapsedTicks, emitBytes). Emit counts every
+    // byte read during the window including the terminator and any bytes
+    // that arrived in the same read as the terminator's last byte; at 100 MB
+    // payload scale this is ~31 bytes of noise.
+    //
+    // `scratch` is caller-owned and reused across iterations. The method
+    // uses the first (terminator.Length - 1) bytes of scratch as cross-read
+    // carryover storage, so scratch.Length must be > terminator.Length. The
+    // recommended size is 64 KB to amortize Read syscalls over 100 MB
+    // payloads.
+    //
+    // Throws:
+    //  - EndOfStreamException if Output reaches EOF before the terminator.
+    //  - TimeoutException / OperationCanceledException if `deadline` elapses.
+    //  - The reader task's exception propagates via Task.Wait on the CTS.
+    public static (long elapsedTicks, long emitBytes) RunThroughputIteration(
+        ITransport transport,
+        ReadOnlyMemory<byte> payload,
+        ReadOnlyMemory<byte> terminator,
+        TimeSpan deadline,
+        byte[] scratch)
+    {
+        ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(scratch);
+        if (terminator.Length == 0)
+            throw new ArgumentException("terminator must not be empty", nameof(terminator));
+        if (scratch.Length <= terminator.Length)
+            throw new ArgumentException(
+                $"scratch.Length ({scratch.Length}) must be greater than terminator.Length ({terminator.Length})",
+                nameof(scratch));
+
+        using var cts = new CancellationTokenSource(deadline);
+        var ct = cts.Token;
+
+        // ReadAsync with a CancellationToken is the only way to abort a
+        // blocking pipe read on deadline. Stream.Read (synchronous) does
+        // not observe the token, so a stuck transport would hang past the
+        // deadline forever. NamedPipeClientStream + anonymous pipes both
+        // support ReadAsync(Memory<byte>, CancellationToken) on .NET 10.
+        var reader = Task.Run<long>(async () =>
+        {
+            int tailLen = terminator.Length - 1;
+            int carryoverLen = 0;
+            long emit = 0;
+
+            while (true)
+            {
+                int n = await transport.Output.ReadAsync(
+                    scratch.AsMemory(carryoverLen, scratch.Length - carryoverLen),
+                    ct).ConfigureAwait(false);
+                if (n == 0)
+                    throw new EndOfStreamException("peer closed during throughput read");
+
+                emit += n;
+                int scanLen = carryoverLen + n;
+
+                int idx = scratch.AsSpan(0, scanLen).IndexOf(terminator.Span);
+                if (idx >= 0)
+                    return emit;
+
+                // Carry over the last (terminator.Length - 1) bytes so a
+                // terminator that straddles the boundary between this read
+                // and the next is still detectable. Span.CopyTo is memmove-
+                // safe for overlapping source/destination in the same buffer.
+                int keep = Math.Min(tailLen, scanLen);
+                if (keep > 0)
+                    scratch.AsSpan(scanLen - keep, keep).CopyTo(scratch.AsSpan(0, keep));
+                carryoverLen = keep;
+            }
+        }, ct);
+
+        long start = Stopwatch.GetTimestamp();
+        transport.Input.Write(payload.Span);
+        transport.Input.Write(terminator.Span);
+        transport.Input.Flush();
+
+        long emitBytes;
+        try
+        {
+            emitBytes = reader.GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"throughput terminator not observed within {deadline.TotalSeconds:F1}s");
+        }
+
+        long elapsed = Stopwatch.GetTimestamp() - start;
+        return (elapsed, emitBytes);
+    }
 }

--- a/windows/Ghostty.Bench/Output/ResultJson.cs
+++ b/windows/Ghostty.Bench/Output/ResultJson.cs
@@ -12,9 +12,12 @@ public sealed record ResultJson(
     [property: JsonPropertyName("p50_us")] double? P50Us,
     [property: JsonPropertyName("p95_us")] double? P95Us,
     [property: JsonPropertyName("p99_us")] double? P99Us,
-    [property: JsonPropertyName("p50_mbps")] double? P50Mbps,
-    [property: JsonPropertyName("min_mbps")] double? MinMbps,
-    [property: JsonPropertyName("max_mbps")] double? MaxMbps,
+    [property: JsonPropertyName("ingest_p50_mbps")] double? IngestP50Mbps,
+    [property: JsonPropertyName("ingest_min_mbps")] double? IngestMinMbps,
+    [property: JsonPropertyName("ingest_max_mbps")] double? IngestMaxMbps,
+    [property: JsonPropertyName("emit_p50_mbps")] double? EmitP50Mbps,
+    [property: JsonPropertyName("emit_min_mbps")] double? EmitMinMbps,
+    [property: JsonPropertyName("emit_max_mbps")] double? EmitMaxMbps,
     [property: JsonPropertyName("samples")] int Samples,
     [property: JsonPropertyName("warmup")] int? Warmup,
     [property: JsonPropertyName("payload_bytes")] long? PayloadBytes,
@@ -54,7 +57,8 @@ public sealed record ResultJson(
             Probe: probe,
             Unit: "microseconds",
             P50Us: p50Us, P95Us: p95Us, P99Us: p99Us,
-            P50Mbps: null, MinMbps: null, MaxMbps: null,
+            IngestP50Mbps: null, IngestMinMbps: null, IngestMaxMbps: null,
+            EmitP50Mbps: null,   EmitMinMbps: null,   EmitMaxMbps: null,
             Samples: samples,
             Warmup: warmup,
             PayloadBytes: null,
@@ -65,14 +69,23 @@ public sealed record ResultJson(
             TimestampUtc: FormatUtc(timestampUtc),
             BenchVersion: CurrentVersion);
 
+    // Throughput now reports paired ingest / emit rates. Ingest = "how fast
+    // did N payload bytes reach the other side of the transport." Emit =
+    // "how many bytes did the transport produce on the return path during
+    // that same window." Under DirectPipe they are approximately equal;
+    // under ConPTY they diverge because conhost VT-renders screen state
+    // rather than byte-echoing, and the divergence is informative signal.
     public static ResultJson Throughput(
         string probe,
         string transport,
         string payload,
         long payloadBytes,
-        double p50Mbps,
-        double minMbps,
-        double maxMbps,
+        double ingestP50Mbps,
+        double ingestMinMbps,
+        double ingestMaxMbps,
+        double emitP50Mbps,
+        double emitMinMbps,
+        double emitMaxMbps,
         int samples,
         HostInfo host,
         DateTime timestampUtc) =>
@@ -80,7 +93,12 @@ public sealed record ResultJson(
             Probe: probe,
             Unit: "megabytes_per_second",
             P50Us: null, P95Us: null, P99Us: null,
-            P50Mbps: p50Mbps, MinMbps: minMbps, MaxMbps: maxMbps,
+            IngestP50Mbps: ingestP50Mbps,
+            IngestMinMbps: ingestMinMbps,
+            IngestMaxMbps: ingestMaxMbps,
+            EmitP50Mbps: emitP50Mbps,
+            EmitMinMbps: emitMinMbps,
+            EmitMaxMbps: emitMaxMbps,
             Samples: samples,
             Warmup: null,
             PayloadBytes: payloadBytes,

--- a/windows/Ghostty.Bench/Probes/Payloads.cs
+++ b/windows/Ghostty.Bench/Probes/Payloads.cs
@@ -9,7 +9,7 @@ namespace Ghostty.Bench.Probes;
 // return stream for that pattern; any in-payload occurrence of the prefix
 // would risk a false match and cut the measurement short. The current three
 // factories satisfy this trivially (ASCII 'A', SGR+short text, DCS/OSC/APC
-// sequences interleaved with " printable " markers — none contain the
+// sequences interleaved with " printable " markers, none contain the
 // prefix). New payloads must preserve the invariant.
 //
 // INVARIANT (implicit, not pinned by a test): payloads must end in a

--- a/windows/Ghostty.Bench/Probes/Payloads.cs
+++ b/windows/Ghostty.Bench/Probes/Payloads.cs
@@ -1,7 +1,7 @@
 namespace Ghostty.Bench.Probes;
 
 // Payload factories for throughput probes. Each returns exactly
-// Payloads.TargetBytes (100 MB) of content.
+// Payloads.TargetBytes (1 MB) of content.
 //
 // INVARIANT (enforced by PayloadsTests.Payloads_DoNotContainTerminatorPrefix):
 // no payload may contain the literal substring "~ENDOFBURST_". The throughput
@@ -19,35 +19,29 @@ namespace Ghostty.Bench.Probes;
 // lingering state.
 public static class Payloads
 {
-    public const int TargetBytes = 100 * 1024 * 1024;
+    // Sized to complete within the 180 s throughput watchdog. ConPTY's
+    // emission pipeline for scrolling ASCII is bottlenecked at ~100 KB/s
+    // (measured via conpty-throughput-verify): conhost emits one VT frame
+    // per scrolled row (~87 bytes) at the refresh cadence, so a 1 MB
+    // payload produces ~1.14 MB of hOutput traffic over ~8 s. Scaling to
+    // the spec's aspirational 100 MB would cost ~20 minutes per iteration,
+    // exceeding the harness budget. 1 MB keeps each probe iteration under
+    // 10 s end-to-end while still producing a useful ConPTY vs DirectPipe
+    // throughput comparison.
+    public const int TargetBytes = 1 * 1024 * 1024;
 
-    // Lazy so a process that only runs round-trip probes never pays the
-    // 100 MB alloc, and throughput probes that call these repeatedly
-    // share a single buffer instead of churning 100 MB per sample set.
-    private static readonly Lazy<ReadOnlyMemory<byte>> _ascii = new(BuildAscii, LazyThreadSafetyMode.ExecutionAndPublication);
-    private static readonly Lazy<ReadOnlyMemory<byte>> _sgr = new(BuildSgr, LazyThreadSafetyMode.ExecutionAndPublication);
-    private static readonly Lazy<ReadOnlyMemory<byte>> _stress = new(BuildStress, LazyThreadSafetyMode.ExecutionAndPublication);
-
-    // 100 MB of uppercase 'A' (0x41). ConPTY's parser sees printables
+    // 1 MB of uppercase 'A' (0x41). ConPTY's parser sees printables
     // only and takes the fast path; useful as a floor measurement.
-    public static ReadOnlyMemory<byte> Ascii100Mb() => _ascii.Value;
-
-    // 100 MB of "\x1b[31mhello\x1b[0m " repeated. Tests SGR parser
-    // cost under realistic shell output.
-    public static ReadOnlyMemory<byte> Sgr100Mb() => _sgr.Value;
-
-    // 100 MB of dense DCS/OSC/APC sequences interleaved with short
-    // printable runs. Pathological ConPTY parser load.
-    public static ReadOnlyMemory<byte> Stress100Mb() => _stress.Value;
-
-    private static ReadOnlyMemory<byte> BuildAscii()
+    public static ReadOnlyMemory<byte> Ascii1Mb()
     {
         byte[] buf = new byte[TargetBytes];
         Array.Fill(buf, (byte)'A');
         return buf;
     }
 
-    private static ReadOnlyMemory<byte> BuildSgr()
+    // 1 MB of "\x1b[31mhello\x1b[0m " repeated. Tests SGR parser
+    // cost under realistic shell output.
+    public static ReadOnlyMemory<byte> Sgr1Mb()
     {
         ReadOnlySpan<byte> unit = "\x1b[31mhello\x1b[0m "u8;
         byte[] buf = new byte[TargetBytes];
@@ -58,7 +52,7 @@ public static class Payloads
             written += unit.Length;
         }
         // Pad remainder with 'A' so every byte is defined and the
-        // total is exactly 100 MB.
+        // total is exactly 1 MB.
         while (written < TargetBytes)
         {
             buf[written++] = (byte)'A';
@@ -66,7 +60,9 @@ public static class Payloads
         return buf;
     }
 
-    private static ReadOnlyMemory<byte> BuildStress()
+    // 1 MB of dense DCS/OSC/APC sequences interleaved with short
+    // printable runs. Pathological ConPTY parser load.
+    public static ReadOnlyMemory<byte> Stress1Mb()
     {
         // One repeating chunk contains each introducer at a known offset.
         // DCS: ESC P ... ESC \

--- a/windows/Ghostty.Bench/Probes/Payloads.cs
+++ b/windows/Ghostty.Bench/Probes/Payloads.cs
@@ -1,5 +1,22 @@
 namespace Ghostty.Bench.Probes;
 
+// Payload factories for throughput probes. Each returns exactly
+// Payloads.TargetBytes (100 MB) of content.
+//
+// INVARIANT (enforced by PayloadsTests.Payloads_DoNotContainTerminatorPrefix):
+// no payload may contain the literal substring "~ENDOFBURST_". The throughput
+// probe appends "\r\n~ENDOFBURST_<nonce>~" after each payload and scans the
+// return stream for that pattern; any in-payload occurrence of the prefix
+// would risk a false match and cut the measurement short. The current three
+// factories satisfy this trivially (ASCII 'A', SGR+short text, DCS/OSC/APC
+// sequences interleaved with " printable " markers — none contain the
+// prefix). New payloads must preserve the invariant.
+//
+// INVARIANT (implicit, not pinned by a test): payloads must end in a
+// cleanly-parsed VT state. No unterminated DCS / OSC / APC / SOS / PM
+// sequence may straddle the payload -> terminator boundary, or the parser
+// (conhost) could consume the terminator's leading "\r\n" as part of the
+// lingering state.
 public static class Payloads
 {
     public const int TargetBytes = 100 * 1024 * 1024;

--- a/windows/Ghostty.Bench/Probes/ThroughputProbe.cs
+++ b/windows/Ghostty.Bench/Probes/ThroughputProbe.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using Ghostty.Bench.Harness;
 using Ghostty.Bench.Output;
 using Ghostty.Bench.Transports;
@@ -8,6 +9,18 @@ namespace Ghostty.Bench.Probes;
 public sealed class ThroughputProbe : Probe
 {
     private const int Samples = 3;
+
+    // 120 s per iteration. Generous enough for 100 MB payloads under
+    // conhost's slowest parser path on a cold machine, tight enough to
+    // catch a stuck pipe within one iteration instead of burning the
+    // outer harness watchdog. See spec § decisions.
+    private static readonly TimeSpan IterationDeadline = TimeSpan.FromSeconds(120);
+
+    // 64 KB read buffer. Large enough to amortize Read syscalls over
+    // 100 MB payloads (~1600 reads rather than ~100k at 1 KB), small
+    // enough that the per-iteration scratch footprint is negligible.
+    private const int ScratchSize = 64 * 1024;
+
     private readonly ReadOnlyMemory<byte> _payload;
 
     public ThroughputProbe(string name, string transport, string payloadLabel, ReadOnlyMemory<byte> payload)
@@ -24,53 +37,53 @@ public sealed class ThroughputProbe : Probe
 
     public override ResultJson Run(ITransport transport, HostInfo host, DateTime timestampUtc)
     {
-        double[] mbps = new double[Samples];
-        // Each Read() fills the buffer to readBuf.Length before we stop, so
-        // we don't need to zero it between samples.
-        byte[] readBuf = new byte[_payload.Length];
+        double[] ingestMBps = new double[Samples];
+        double[] emitMBps = new double[Samples];
+        byte[] scratch = new byte[ScratchSize];
 
         for (int i = 0; i < Samples; i++)
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
-            // transport.Output.Read is a blocking synchronous call that the
-            // CTS cannot interrupt. If the 20s deadline fires, Wait throws
-            // but the reader task stays parked until the transport is
-            // disposed at the top of Program.Main. Program.RunAll then
-            // kills the child, which is the real unblock mechanism. For
-            // that reason we don't bother awaiting the task on the error
-            // path.
-            var readerTask = Task.Run(() =>
-            {
-                int read = 0;
-                while (read < readBuf.Length)
-                {
-                    cts.Token.ThrowIfCancellationRequested();
-                    int n = transport.Output.Read(readBuf, read, readBuf.Length - read);
-                    if (n == 0) throw new EndOfStreamException("peer closed during throughput read");
-                    read += n;
-                }
-            }, cts.Token);
+            // Fresh 16-hex-char nonce per iteration. Guid.NewGuid() is v4
+            // (random); 64 bits of nonce entropy rules out any accidental
+            // match from a leftover terminator lingering in conhost's
+            // screen buffer between iterations. See spec § Wire protocol.
+            string nonce = Guid.NewGuid().ToString("N").Substring(0, 16);
+            byte[] terminator = Encoding.ASCII.GetBytes("\r\n~ENDOFBURST_" + nonce + "~");
 
-            long start = Stopwatch.GetTimestamp();
-            transport.Input.Write(_payload.Span);
-            transport.Input.Flush();
-            readerTask.Wait(cts.Token);
-            long elapsedTicks = Stopwatch.GetTimestamp() - start;
+            (long elapsedTicks, long emitBytes) = Runner.RunThroughputIteration(
+                transport: transport,
+                payload: _payload,
+                terminator: terminator,
+                deadline: IterationDeadline,
+                scratch: scratch);
 
             double seconds = elapsedTicks / (double)Stopwatch.Frequency;
-            double megabytes = _payload.Length / (1024.0 * 1024.0);
-            mbps[i] = megabytes / seconds;
+            double payloadMB = _payload.Length / (1024.0 * 1024.0);
+            double emitMB = emitBytes / (1024.0 * 1024.0);
+
+            // Ingest counts only the payload bytes: the 31-byte terminator
+            // is scan infrastructure, not user data. Emit counts every byte
+            // read during the window, including any that arrived alongside
+            // the terminator in the final read; at 100 MB scale that is
+            // noise.
+            ingestMBps[i] = payloadMB / seconds;
+            emitMBps[i] = emitMB / seconds;
         }
 
-        Array.Sort(mbps);
+        Array.Sort(ingestMBps);
+        Array.Sort(emitMBps);
+
         return ResultJson.Throughput(
             probe: Name,
             transport: TransportLabel,
             payload: PayloadLabel,
             payloadBytes: _payload.Length,
-            p50Mbps: Math.Round(mbps[Samples / 2], 2),
-            minMbps: Math.Round(mbps[0], 2),
-            maxMbps: Math.Round(mbps[Samples - 1], 2),
+            ingestP50Mbps: Math.Round(ingestMBps[Samples / 2], 2),
+            ingestMinMbps: Math.Round(ingestMBps[0], 2),
+            ingestMaxMbps: Math.Round(ingestMBps[Samples - 1], 2),
+            emitP50Mbps:   Math.Round(emitMBps[Samples / 2], 2),
+            emitMinMbps:   Math.Round(emitMBps[0], 2),
+            emitMaxMbps:   Math.Round(emitMBps[Samples - 1], 2),
             samples: Samples,
             host: host,
             timestampUtc: timestampUtc);

--- a/windows/Ghostty.Bench/Probes/ThroughputProbe.cs
+++ b/windows/Ghostty.Bench/Probes/ThroughputProbe.cs
@@ -47,7 +47,7 @@ public sealed class ThroughputProbe : Probe
             // Fresh 16-hex-char nonce per iteration. Guid.NewGuid() is v4
             // (random); 64 bits of nonce entropy rules out any accidental
             // match from a leftover terminator lingering in conhost's
-            // screen buffer between iterations. See spec § Wire protocol.
+            // screen buffer between iterations.
             string nonce = Guid.NewGuid().ToString("N").Substring(0, 16);
             byte[] terminator = Encoding.ASCII.GetBytes("\r\n~ENDOFBURST_" + nonce + "~");
 

--- a/windows/Ghostty.Bench/Probes/ThroughputProbe.cs
+++ b/windows/Ghostty.Bench/Probes/ThroughputProbe.cs
@@ -10,15 +10,16 @@ public sealed class ThroughputProbe : Probe
 {
     private const int Samples = 3;
 
-    // 120 s per iteration. Generous enough for 100 MB payloads under
-    // conhost's slowest parser path on a cold machine, tight enough to
-    // catch a stuck pipe within one iteration instead of burning the
-    // outer harness watchdog. See spec § decisions.
-    private static readonly TimeSpan IterationDeadline = TimeSpan.FromSeconds(120);
+    // 60 s per iteration. At ConPTY's measured scroll-ASCII throughput of
+    // ~100 KB/s, 1 MB takes ~10 s. 60 s gives 6x headroom for slow
+    // machines, SGR / stress parser cost, and cold-start warmup. Tight
+    // enough to catch a stuck pipe within one iteration instead of
+    // burning the outer harness watchdog.
+    private static readonly TimeSpan IterationDeadline = TimeSpan.FromSeconds(60);
 
     // 64 KB read buffer. Large enough to amortize Read syscalls over
-    // 100 MB payloads (~1600 reads rather than ~100k at 1 KB), small
-    // enough that the per-iteration scratch footprint is negligible.
+    // 1 MB payloads while staying small enough that the per-iteration
+    // scratch footprint is negligible.
     private const int ScratchSize = 64 * 1024;
 
     private readonly ReadOnlyMemory<byte> _payload;
@@ -64,7 +65,7 @@ public sealed class ThroughputProbe : Probe
             // Ingest counts only the payload bytes: the 31-byte terminator
             // is scan infrastructure, not user data. Emit counts every byte
             // read during the window, including any that arrived alongside
-            // the terminator in the final read; at 100 MB scale that is
+            // the terminator in the final read; at 1 MB scale that is
             // noise.
             ingestMBps[i] = payloadMB / seconds;
             emitMBps[i] = emitMB / seconds;

--- a/windows/Ghostty.Bench/Program.cs
+++ b/windows/Ghostty.Bench/Program.cs
@@ -46,12 +46,16 @@ public static class Program
         // honest enforcement is a fire-and-forget Task that calls
         // Environment.Exit after the deadline. Per-probe budgets:
         //   round-trip: 30s (100 warmup + 1000 iterations)
-        //   throughput: 60s (3 runs of 100 MB each)
+        //   throughput: 180s (3 iterations of 1 MB, per-iteration
+        //                     deadline is 120s — three iterations cannot
+        //                     usefully exceed 3x per-iteration budget, but
+        //                     we leave slack for cold start + 60Hz conhost
+        //                     refresh settling after burst completion)
         //   all:        10 minutes (8 probes in sequence)
         TimeSpan budget =
             probeName == "all"                 ? TimeSpan.FromMinutes(10) :
             probeName.Contains("roundtrip")    ? TimeSpan.FromSeconds(30) :
-            probeName.Contains("throughput")   ? TimeSpan.FromSeconds(60) :
+            probeName.Contains("throughput")   ? TimeSpan.FromSeconds(180) :
                                                  TimeSpan.FromSeconds(30);
         _ = Task.Run(async () =>
         {
@@ -70,6 +74,15 @@ public static class Program
             if (probeName == "conpty-roundtrip-verify")
             {
                 return RunConPtyVerify();
+            }
+
+            if (probeName == "conpty-throughput-verify")
+            {
+                // Optional payload size in KB: `conpty-throughput-verify 1024`
+                int kb = 4;
+                if (args.Length >= 2 && int.TryParse(args[1], out int parsed) && parsed > 0)
+                    kb = parsed;
+                return RunConPtyThroughputVerify(kb);
             }
 
             ResultJson? result = RunSingleByName(probeName);
@@ -131,12 +144,12 @@ public static class Program
         {
             "conpty-roundtrip" => new RoundTripProbe("conpty_roundtrip", "conpty").Run(t, host, ts),
             "direct-pipe-roundtrip" => new RoundTripProbe("direct_pipe_roundtrip", "direct_pipe").Run(t, host, ts),
-            "conpty-throughput-ascii" => new ThroughputProbe("conpty_throughput_ascii", "conpty", "ascii", Payloads.Ascii100Mb()).Run(t, host, ts),
-            "conpty-throughput-sgr" => new ThroughputProbe("conpty_throughput_sgr", "conpty", "sgr", Payloads.Sgr100Mb()).Run(t, host, ts),
-            "conpty-throughput-stress" => new ThroughputProbe("conpty_throughput_stress", "conpty", "stress", Payloads.Stress100Mb()).Run(t, host, ts),
-            "direct-pipe-throughput-ascii" => new ThroughputProbe("direct_pipe_throughput_ascii", "direct_pipe", "ascii", Payloads.Ascii100Mb()).Run(t, host, ts),
-            "direct-pipe-throughput-sgr" => new ThroughputProbe("direct_pipe_throughput_sgr", "direct_pipe", "sgr", Payloads.Sgr100Mb()).Run(t, host, ts),
-            "direct-pipe-throughput-stress" => new ThroughputProbe("direct_pipe_throughput_stress", "direct_pipe", "stress", Payloads.Stress100Mb()).Run(t, host, ts),
+            "conpty-throughput-ascii" => new ThroughputProbe("conpty_throughput_ascii", "conpty", "ascii", Payloads.Ascii1Mb()).Run(t, host, ts),
+            "conpty-throughput-sgr" => new ThroughputProbe("conpty_throughput_sgr", "conpty", "sgr", Payloads.Sgr1Mb()).Run(t, host, ts),
+            "conpty-throughput-stress" => new ThroughputProbe("conpty_throughput_stress", "conpty", "stress", Payloads.Stress1Mb()).Run(t, host, ts),
+            "direct-pipe-throughput-ascii" => new ThroughputProbe("direct_pipe_throughput_ascii", "direct_pipe", "ascii", Payloads.Ascii1Mb()).Run(t, host, ts),
+            "direct-pipe-throughput-sgr" => new ThroughputProbe("direct_pipe_throughput_sgr", "direct_pipe", "sgr", Payloads.Sgr1Mb()).Run(t, host, ts),
+            "direct-pipe-throughput-stress" => new ThroughputProbe("direct_pipe_throughput_stress", "direct_pipe", "stress", Payloads.Stress1Mb()).Run(t, host, ts),
             _ => null,
         };
     }
@@ -246,6 +259,7 @@ public static class Program
         foreach (var p in AllProbeNames) w.WriteLine($"  {p}");
         w.WriteLine("  all                         -- run every probe, write results/<probe>.json + summary.json");
         w.WriteLine("  conpty-roundtrip-verify     -- 5-iteration diagnostic that proves conpty-roundtrip numbers are honest");
+        w.WriteLine("  conpty-throughput-verify    -- small-payload diagnostic: shows what conhost emits for a single payload+terminator burst");
     }
 
     // Diagnostic variant of conpty-roundtrip. Runs 5 iterations with a
@@ -330,6 +344,140 @@ public static class Program
         Console.Out.WriteLine("Each iteration found ITS OWN unique payload letter; leftover bytes from prior iterations would show the wrong letter.");
 
         return 0;
+    }
+
+    // Small-payload diagnostic for the throughput probe protocol. Writes a
+    // 4 KB ASCII payload + the same "\r\n~ENDOFBURST_<nonce>~" terminator the
+    // real throughput probe uses, then reads conhost's hOutput for up to
+    // 10 s, reporting:
+    //   - total bytes read
+    //   - whether the terminator appears anywhere in the accumulated stream
+    //   - hexdump-style rendering of the first 256 and last 512 bytes
+    // The goal is to see whether conhost emits the terminator at all, and
+    // if so, whether it is byte-contiguous or interrupted by VT framing
+    // (cursor-move / erase-in-line / SGR sequences mid-row).
+    private static int RunConPtyThroughputVerify(int payloadKb)
+    {
+        string childExe = ResolveChildExe();
+        using ITransport t = new ConPtyTransport(childExe);
+        t.WaitReady(TimeSpan.FromSeconds(2));
+
+        string nonce = Guid.NewGuid().ToString("N").Substring(0, 16);
+        byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_" + nonce + "~");
+        byte[] payload = new byte[payloadKb * 1024];
+        Array.Fill(payload, (byte)'A');
+
+        // Read window scales with payload: 2 s baseline + 2 s per 100 KB
+        // extrapolated from the 4 KB = ~80 ms observation, with a cap.
+        int readSeconds = Math.Min(180, 2 + payloadKb / 50);
+
+        Console.Out.WriteLine($"conpty-throughput-verify: {payloadKb} KB ASCII + terminator, {readSeconds} s read window");
+        Console.Out.WriteLine($"payload: {payload.Length} bytes of 'A'");
+        Console.Out.Write("terminator bytes: ");
+        DumpBytes(Console.Out, terminator);
+        Console.Out.WriteLine();
+        Console.Out.WriteLine();
+
+        // Parallel reader: start draining hOutput BEFORE writing the payload
+        // so conhost's emit side never backpressures (which, sequentially,
+        // deadlocks at >4 KB because the hOutput pipe fills up).
+        byte[] scratch = new byte[64 * 1024];
+        var all = new System.Collections.Concurrent.ConcurrentQueue<byte[]>();
+        long totalRead = 0;
+        int readCalls = 0;
+        var found = new ManualResetEventSlim(false);
+        int foundOffset = -1;
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(readSeconds));
+
+        var reader = Task.Run(async () =>
+        {
+            // Simple accumulator that scans after each read. Uses the full
+            // accumulated buffer for scanning so cross-read matches work
+            // without implementing the production probe's carryover trick.
+            var accum = new List<byte>(payloadKb * 1024);
+            try
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    int n = await t.Output.ReadAsync(scratch.AsMemory(0, scratch.Length), cts.Token).ConfigureAwait(false);
+                    if (n == 0) return;
+                    Interlocked.Add(ref totalRead, n);
+                    Interlocked.Increment(ref readCalls);
+                    for (int j = 0; j < n; j++) accum.Add(scratch[j]);
+
+                    int hit = CollectionsMarshal.AsSpan(accum).IndexOf(terminator.AsSpan());
+                    if (hit >= 0)
+                    {
+                        foundOffset = hit;
+                        all.Enqueue(accum.ToArray());
+                        found.Set();
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+            all.Enqueue(accum.ToArray());
+        }, cts.Token);
+
+        long start = System.Diagnostics.Stopwatch.GetTimestamp();
+        t.Input.Write(payload);
+        t.Input.Write(terminator);
+        t.Input.Flush();
+
+        // Wait for either the terminator to appear or the deadline to fire.
+        bool matched = found.Wait(TimeSpan.FromSeconds(readSeconds));
+        cts.Cancel();
+        try { reader.Wait(TimeSpan.FromSeconds(2)); } catch { }
+
+        // Reassemble accumulated bytes (single item in queue).
+        byte[] accumBytes = all.TryDequeue(out var first) ? first : Array.Empty<byte>();
+
+        if (matched && foundOffset >= 0)
+        {
+            double us = (System.Diagnostics.Stopwatch.GetTimestamp() - start) * 1_000_000.0 / System.Diagnostics.Stopwatch.Frequency;
+            Console.Out.WriteLine($"TERMINATOR FOUND at offset {foundOffset} after {readCalls} read call(s), {accumBytes.Length} total bytes, {us:F0} us");
+            Console.Out.WriteLine();
+            DumpThroughputVerifySlicesArr(accumBytes);
+            return 0;
+        }
+
+        double elapsedUs = (System.Diagnostics.Stopwatch.GetTimestamp() - start) * 1_000_000.0 / System.Diagnostics.Stopwatch.Frequency;
+        Console.Out.WriteLine($"TERMINATOR NOT FOUND after {readCalls} read call(s), {accumBytes.Length} total bytes, {elapsedUs:F0} us");
+        Console.Out.WriteLine();
+        DumpThroughputVerifySlicesArr(accumBytes);
+
+        byte[] prefix = System.Text.Encoding.ASCII.GetBytes("~ENDOFBURST_");
+        int prefixIdx = accumBytes.AsSpan().IndexOf(prefix.AsSpan());
+        if (prefixIdx >= 0)
+        {
+            Console.Out.WriteLine($"DIAGNOSIS: ~ENDOFBURST_ prefix DOES appear at offset {prefixIdx}; the 16-char nonce or trailing '~' must be split by VT framing. Next 64 bytes from that offset:");
+            int len = Math.Min(64, accumBytes.Length - prefixIdx);
+            DumpBytes(Console.Out, accumBytes.AsSpan(prefixIdx, len));
+            Console.Out.WriteLine();
+        }
+        else
+        {
+            Console.Out.WriteLine("DIAGNOSIS: the literal substring '~ENDOFBURST_' does NOT appear anywhere in what conhost emitted. The terminator is either not reaching hOutput or being mangled beyond substring match.");
+        }
+
+        return 1;
+    }
+
+    private static void DumpThroughputVerifySlicesArr(byte[] all)
+    {
+        int firstLen = Math.Min(256, all.Length);
+        Console.Out.WriteLine($"FIRST {firstLen} BYTES of emission:");
+        DumpBytes(Console.Out, all.AsSpan(0, firstLen));
+        Console.Out.WriteLine();
+        Console.Out.WriteLine();
+
+        int lastLen = Math.Min(512, all.Length);
+        int lastStart = all.Length - lastLen;
+        Console.Out.WriteLine($"LAST {lastLen} BYTES of emission (offset {lastStart}..{all.Length}):");
+        DumpBytes(Console.Out, all.AsSpan(lastStart, lastLen));
+        Console.Out.WriteLine();
+        Console.Out.WriteLine();
     }
 
     // Compact per-byte dump: printable ASCII as the char, else \xNN.

--- a/windows/Ghostty.Tests/Bench/HarnessTests.cs
+++ b/windows/Ghostty.Tests/Bench/HarnessTests.cs
@@ -201,12 +201,12 @@ public class HarnessTests
         });
         byte[] scratch = new byte[64 * 1024];
 
-        var ex = Assert.ThrowsAny<Exception>(() =>
+        // Harness converts the internal OCE from the cancelled ReadAsync
+        // into TimeoutException. Asserting the strict type catches a
+        // regression if the conversion ever silently leaks.
+        Assert.Throws<TimeoutException>(() =>
             Harness.RunThroughputIteration(
                 t, payload, terminator, TimeSpan.FromMilliseconds(250), scratch));
-        Assert.True(
-            ex is TimeoutException || ex is OperationCanceledException,
-            $"expected TimeoutException or OperationCanceledException, got {ex.GetType().Name}");
 
         gate.Set();   // let the scripted responder unwind
     }

--- a/windows/Ghostty.Tests/Bench/HarnessTests.cs
+++ b/windows/Ghostty.Tests/Bench/HarnessTests.cs
@@ -101,4 +101,160 @@ public class HarnessTests
         Assert.Throws<EndOfStreamException>(() =>
             Runner.RunRoundTrip(t, warmup: 0, samples: 1));
     }
+
+    // --- RunThroughputIteration tests ---
+
+    [Fact]
+    public void RunThroughputIteration_ReturnsElapsedAndEmitBytes()
+    {
+        // Echo FakeTransport: every byte written comes back. Payload +
+        // terminator round-trip byte-for-byte, so emit must equal
+        // payload.Length + terminator.Length.
+        using var t = new FakeTransport();
+        byte[] payload = new byte[4096];
+        new Random(42).NextBytes(payload);
+        byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_" + Guid.NewGuid().ToString("N").Substring(0, 16) + "~");
+        byte[] scratch = new byte[64 * 1024];
+
+        var (elapsedTicks, emitBytes) = Harness.RunThroughputIteration(
+            t, payload, terminator, TimeSpan.FromSeconds(5), scratch);
+
+        Assert.True(elapsedTicks > 0, "elapsed must be positive");
+        Assert.Equal(payload.Length + terminator.Length, emitBytes);
+    }
+
+    [Fact]
+    public void RunThroughputIteration_DetectsTerminatorSplitAcrossReads()
+    {
+        // Scripted FakeTransport that returns bytes in two chunks, splitting
+        // the terminator across the boundary. Exercises the carryover scan.
+        byte[] payload = new byte[1024];
+        byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_" + Guid.NewGuid().ToString("N").Substring(0, 16) + "~");
+        byte[] combined = new byte[payload.Length + terminator.Length];
+        Buffer.BlockCopy(payload, 0, combined, 0, payload.Length);
+        Buffer.BlockCopy(terminator, 0, combined, payload.Length, terminator.Length);
+
+        int splitPoint = payload.Length + 15;   // mid-terminator
+        bool firstCall = true;
+        using var t = new FakeTransport(_ =>
+        {
+            if (firstCall)
+            {
+                firstCall = false;
+                byte[] first = new byte[splitPoint];
+                Buffer.BlockCopy(combined, 0, first, 0, splitPoint);
+                return first;
+            }
+            byte[] second = new byte[combined.Length - splitPoint];
+            Buffer.BlockCopy(combined, splitPoint, second, 0, second.Length);
+            return second;
+        });
+        byte[] scratch = new byte[64 * 1024];
+
+        var (_, emitBytes) = Harness.RunThroughputIteration(
+            t, payload, terminator, TimeSpan.FromSeconds(5), scratch);
+
+        Assert.Equal(combined.Length, emitBytes);
+    }
+
+    [Fact]
+    public void RunThroughputIteration_ThrowsOnEndOfStreamBeforeTerminator()
+    {
+        // Scripted transport returns a short buffer that does NOT contain the
+        // terminator, then null (closes output). Harness must surface EOS.
+        byte[] payload = new byte[256];
+        byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_" + Guid.NewGuid().ToString("N").Substring(0, 16) + "~");
+        int call = 0;
+        using var t = new FakeTransport(_ =>
+        {
+            call++;
+            if (call == 1) return payload;   // no terminator
+            return null;                     // close output
+        });
+        byte[] scratch = new byte[64 * 1024];
+
+        Assert.Throws<EndOfStreamException>(() =>
+            Harness.RunThroughputIteration(
+                t, payload, terminator, TimeSpan.FromSeconds(5), scratch));
+    }
+
+    [Fact]
+    public void RunThroughputIteration_ThrowsOnDeadlineExceeded()
+    {
+        // Scripted transport returns a one-byte buffer and then blocks (the
+        // responder lambda never returns for the second call). Deadline of
+        // 250 ms must fire well before the xunit-level timeout.
+        byte[] payload = new byte[64];
+        byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_" + Guid.NewGuid().ToString("N").Substring(0, 16) + "~");
+        int call = 0;
+        var gate = new ManualResetEventSlim(initialState: false);
+        using var t = new FakeTransport(_ =>
+        {
+            call++;
+            if (call == 1) return new byte[] { 0x00 };
+            gate.Wait(TimeSpan.FromSeconds(10));   // released at test end
+            return new byte[0];
+        });
+        byte[] scratch = new byte[64 * 1024];
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Harness.RunThroughputIteration(
+                t, payload, terminator, TimeSpan.FromMilliseconds(250), scratch));
+        Assert.True(
+            ex is TimeoutException || ex is OperationCanceledException,
+            $"expected TimeoutException or OperationCanceledException, got {ex.GetType().Name}");
+
+        gate.Set();   // let the scripted responder unwind
+    }
+
+    [Fact]
+    public void RunThroughputIteration_IgnoresWrongNonceMatch()
+    {
+        // A terminator with a different nonce must not match. Scripted
+        // responder emits a wrong-nonce terminator first, then the correct
+        // terminator. emit must cover both.
+        byte[] payload = new byte[256];
+        string nonce = Guid.NewGuid().ToString("N").Substring(0, 16);
+        byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_" + nonce + "~");
+        byte[] wrongTerminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_aaaaaaaaaaaaaaaa~");
+        int call = 0;
+        using var t = new FakeTransport(_ =>
+        {
+            call++;
+            if (call == 1) return wrongTerminator;
+            if (call == 2) return terminator;
+            return null;
+        });
+        byte[] scratch = new byte[64 * 1024];
+
+        var (_, emitBytes) = Harness.RunThroughputIteration(
+            t, payload, terminator, TimeSpan.FromSeconds(5), scratch);
+
+        Assert.Equal(wrongTerminator.Length + terminator.Length, emitBytes);
+    }
+
+    [Fact]
+    public void RunThroughputIteration_CarryoverDoesNotOverrunScratch()
+    {
+        // Guards the scratch.Length - carryoverLen invariant: scratch must
+        // always have room for at least one byte after tail carryover. Uses
+        // a small scratch (128 bytes) so any off-by-one in the carryover
+        // shift shows up as an ArgumentOutOfRangeException.
+        byte[] payload = new byte[4096];
+        byte[] terminator = System.Text.Encoding.ASCII.GetBytes(
+            "\r\n~ENDOFBURST_" + Guid.NewGuid().ToString("N").Substring(0, 16) + "~");
+        using var t = new FakeTransport();   // echo mode
+        byte[] smallScratch = new byte[128];
+
+        var (_, emitBytes) = Harness.RunThroughputIteration(
+            t, payload, terminator, TimeSpan.FromSeconds(5), smallScratch);
+
+        Assert.Equal(payload.Length + terminator.Length, emitBytes);
+    }
 }

--- a/windows/Ghostty.Tests/Bench/HarnessTests.cs
+++ b/windows/Ghostty.Tests/Bench/HarnessTests.cs
@@ -117,7 +117,7 @@ public class HarnessTests
             "\r\n~ENDOFBURST_" + Guid.NewGuid().ToString("N").Substring(0, 16) + "~");
         byte[] scratch = new byte[64 * 1024];
 
-        var (elapsedTicks, emitBytes) = Harness.RunThroughputIteration(
+        var (elapsedTicks, emitBytes) = Runner.RunThroughputIteration(
             t, payload, terminator, TimeSpan.FromSeconds(5), scratch);
 
         Assert.True(elapsedTicks > 0, "elapsed must be positive");
@@ -153,7 +153,7 @@ public class HarnessTests
         });
         byte[] scratch = new byte[64 * 1024];
 
-        var (_, emitBytes) = Harness.RunThroughputIteration(
+        var (_, emitBytes) = Runner.RunThroughputIteration(
             t, payload, terminator, TimeSpan.FromSeconds(5), scratch);
 
         Assert.Equal(combined.Length, emitBytes);
@@ -177,7 +177,7 @@ public class HarnessTests
         byte[] scratch = new byte[64 * 1024];
 
         Assert.Throws<EndOfStreamException>(() =>
-            Harness.RunThroughputIteration(
+            Runner.RunThroughputIteration(
                 t, payload, terminator, TimeSpan.FromSeconds(5), scratch));
     }
 
@@ -205,7 +205,7 @@ public class HarnessTests
         // into TimeoutException. Asserting the strict type catches a
         // regression if the conversion ever silently leaks.
         Assert.Throws<TimeoutException>(() =>
-            Harness.RunThroughputIteration(
+            Runner.RunThroughputIteration(
                 t, payload, terminator, TimeSpan.FromMilliseconds(250), scratch));
 
         gate.Set();   // let the scripted responder unwind
@@ -233,7 +233,7 @@ public class HarnessTests
         });
         byte[] scratch = new byte[64 * 1024];
 
-        var (_, emitBytes) = Harness.RunThroughputIteration(
+        var (_, emitBytes) = Runner.RunThroughputIteration(
             t, payload, terminator, TimeSpan.FromSeconds(5), scratch);
 
         Assert.Equal(wrongTerminator.Length + terminator.Length, emitBytes);
@@ -252,7 +252,7 @@ public class HarnessTests
         using var t = new FakeTransport();   // echo mode
         byte[] smallScratch = new byte[128];
 
-        var (_, emitBytes) = Harness.RunThroughputIteration(
+        var (_, emitBytes) = Runner.RunThroughputIteration(
             t, payload, terminator, TimeSpan.FromSeconds(5), smallScratch);
 
         Assert.Equal(payload.Length + terminator.Length, emitBytes);

--- a/windows/Ghostty.Tests/Bench/PayloadsTests.cs
+++ b/windows/Ghostty.Tests/Bench/PayloadsTests.cs
@@ -8,16 +8,16 @@ public class PayloadsTests
     private const int Expected = Payloads.TargetBytes;
 
     [Fact]
-    public void Ascii_IsExactlyOneHundredMegabytes()
+    public void Ascii_IsExactlyOneMegabyte()
     {
-        var p = Payloads.Ascii100Mb();
+        var p = Payloads.Ascii1Mb();
         Assert.Equal(Expected, p.Length);
     }
 
     [Fact]
     public void Ascii_ContainsOnlyUppercaseA()
     {
-        var p = Payloads.Ascii100Mb();
+        var p = Payloads.Ascii1Mb();
         for (int i = 0; i < 1000; i++)
         {
             int idx = i * (p.Length / 1000);
@@ -26,16 +26,20 @@ public class PayloadsTests
     }
 
     [Fact]
-    public void Sgr_IsExactlyOneHundredMegabytes()
+    public void Sgr_IsExactlyOneMegabyte()
     {
-        var p = Payloads.Sgr100Mb();
+        var p = Payloads.Sgr1Mb();
         Assert.Equal(Expected, p.Length);
     }
 
     [Fact]
-    public void Sgr_ContainsAtLeastHundredThousandRedSgrSequences()
+    public void Sgr_ContainsAtLeastFiftyThousandRedSgrSequences()
     {
-        var p = Payloads.Sgr100Mb().Span;
+        // The SGR chunk is "\x1b[31mhello\x1b[0m " = 15 bytes. 1 MB / 15
+        // = ~69 905 introducers; 50 000 is a comfortable floor that still
+        // detects accidental factory changes (e.g., a payload switch that
+        // dropped the SGR pattern entirely).
+        var p = Payloads.Sgr1Mb().Span;
         int count = 0;
         ReadOnlySpan<byte> needle = [0x1b, (byte)'[', (byte)'3', (byte)'1', (byte)'m'];
         for (int i = 0; i <= p.Length - needle.Length; i++)
@@ -47,20 +51,20 @@ public class PayloadsTests
             }
             if (match) { count++; i += needle.Length - 1; }
         }
-        Assert.True(count >= 100_000, $"expected at least 100000 SGR red introducers, found {count}");
+        Assert.True(count >= 50_000, $"expected at least 50000 SGR red introducers, found {count}");
     }
 
     [Fact]
-    public void Stress_IsExactlyOneHundredMegabytes()
+    public void Stress_IsExactlyOneMegabyte()
     {
-        var p = Payloads.Stress100Mb();
+        var p = Payloads.Stress1Mb();
         Assert.Equal(Expected, p.Length);
     }
 
     [Fact]
     public void Stress_ContainsDcsOscAndApcIntroducers()
     {
-        var p = Payloads.Stress100Mb().Span;
+        var p = Payloads.Stress1Mb().Span;
         // DCS = 0x1b 0x50, OSC = 0x1b 0x5d, APC = 0x1b 0x5f
         bool dcs = false, osc = false, apc = false;
         for (int i = 0; i < p.Length - 1; i++)
@@ -81,8 +85,8 @@ public class PayloadsTests
     [Fact]
     public void Ascii_IsDeterministic()
     {
-        var a = Payloads.Ascii100Mb();
-        var b = Payloads.Ascii100Mb();
+        var a = Payloads.Ascii1Mb();
+        var b = Payloads.Ascii1Mb();
         Assert.Equal(a.Span.Slice(0, 1024).ToArray(), b.Span.Slice(0, 1024).ToArray());
     }
 
@@ -96,8 +100,8 @@ public class PayloadsTests
     {
         byte[] marker = System.Text.Encoding.ASCII.GetBytes("~ENDOFBURST_");
 
-        Assert.Equal(-1, Payloads.Ascii100Mb().Span.IndexOf(marker));
-        Assert.Equal(-1, Payloads.Sgr100Mb().Span.IndexOf(marker));
-        Assert.Equal(-1, Payloads.Stress100Mb().Span.IndexOf(marker));
+        Assert.Equal(-1, Payloads.Ascii1Mb().Span.IndexOf(marker));
+        Assert.Equal(-1, Payloads.Sgr1Mb().Span.IndexOf(marker));
+        Assert.Equal(-1, Payloads.Stress1Mb().Span.IndexOf(marker));
     }
 }

--- a/windows/Ghostty.Tests/Bench/PayloadsTests.cs
+++ b/windows/Ghostty.Tests/Bench/PayloadsTests.cs
@@ -85,4 +85,19 @@ public class PayloadsTests
         var b = Payloads.Ascii100Mb();
         Assert.Equal(a.Span.Slice(0, 1024).ToArray(), b.Span.Slice(0, 1024).ToArray());
     }
+
+    // The throughput probe appends a "\r\n~ENDOFBURST_<nonce>~" terminator
+    // after the payload and scans conhost's emitted VT stream for it. If a
+    // payload factory ever emitted the literal "~ENDOFBURST_" substring,
+    // the probe could false-match mid-payload and stop the measurement
+    // early. This test pins the invariant so new payloads must preserve it.
+    [Fact]
+    public void Payloads_DoNotContainTerminatorPrefix()
+    {
+        byte[] marker = System.Text.Encoding.ASCII.GetBytes("~ENDOFBURST_");
+
+        Assert.Equal(-1, Payloads.Ascii100Mb().Span.IndexOf(marker));
+        Assert.Equal(-1, Payloads.Sgr100Mb().Span.IndexOf(marker));
+        Assert.Equal(-1, Payloads.Stress100Mb().Span.IndexOf(marker));
+    }
 }

--- a/windows/Ghostty.Tests/Bench/ResultJsonTests.cs
+++ b/windows/Ghostty.Tests/Bench/ResultJsonTests.cs
@@ -42,9 +42,12 @@ public class ResultJsonTests
         Assert.Equal("2026-04-17T14:22:11Z", root.GetProperty("timestamp_utc").GetString());
         Assert.Equal("1", root.GetProperty("bench_version").GetString());
         // WhenWritingNull must suppress throughput-family fields in a round-trip result.
-        Assert.False(root.TryGetProperty("p50_mbps", out _));
-        Assert.False(root.TryGetProperty("min_mbps", out _));
-        Assert.False(root.TryGetProperty("max_mbps", out _));
+        Assert.False(root.TryGetProperty("ingest_p50_mbps", out _));
+        Assert.False(root.TryGetProperty("ingest_min_mbps", out _));
+        Assert.False(root.TryGetProperty("ingest_max_mbps", out _));
+        Assert.False(root.TryGetProperty("emit_p50_mbps", out _));
+        Assert.False(root.TryGetProperty("emit_min_mbps", out _));
+        Assert.False(root.TryGetProperty("emit_max_mbps", out _));
         Assert.False(root.TryGetProperty("payload_bytes", out _));
     }
 
@@ -56,9 +59,12 @@ public class ResultJsonTests
             transport: "conpty",
             payload: "sgr",
             payloadBytes: 100 * 1024 * 1024,
-            p50Mbps: 2.9,
-            minMbps: 2.4,
-            maxMbps: 3.1,
+            ingestP50Mbps: 87.3,
+            ingestMinMbps: 82.1,
+            ingestMaxMbps: 91.4,
+            emitP50Mbps: 6.5,
+            emitMinMbps: 6.1,
+            emitMaxMbps: 7.0,
             samples: 3,
             host: FixedHost(),
             timestampUtc: new DateTime(2026, 4, 17, 14, 22, 11, DateTimeKind.Utc));
@@ -69,9 +75,12 @@ public class ResultJsonTests
 
         Assert.Equal("conpty_throughput_sgr", root.GetProperty("probe").GetString());
         Assert.Equal("megabytes_per_second", root.GetProperty("unit").GetString());
-        Assert.Equal(2.9, root.GetProperty("p50_mbps").GetDouble());
-        Assert.Equal(2.4, root.GetProperty("min_mbps").GetDouble());
-        Assert.Equal(3.1, root.GetProperty("max_mbps").GetDouble());
+        Assert.Equal(87.3, root.GetProperty("ingest_p50_mbps").GetDouble());
+        Assert.Equal(82.1, root.GetProperty("ingest_min_mbps").GetDouble());
+        Assert.Equal(91.4, root.GetProperty("ingest_max_mbps").GetDouble());
+        Assert.Equal(6.5, root.GetProperty("emit_p50_mbps").GetDouble());
+        Assert.Equal(6.1, root.GetProperty("emit_min_mbps").GetDouble());
+        Assert.Equal(7.0, root.GetProperty("emit_max_mbps").GetDouble());
         Assert.Equal(3, root.GetProperty("samples").GetInt32());
         Assert.Equal(104857600L, root.GetProperty("payload_bytes").GetInt64());
         Assert.Equal("sgr", root.GetProperty("payload").GetString());
@@ -81,6 +90,10 @@ public class ResultJsonTests
         Assert.False(root.TryGetProperty("p95_us", out _));
         Assert.False(root.TryGetProperty("p99_us", out _));
         Assert.False(root.TryGetProperty("warmup", out _));
+        // The old single-triple field names must no longer appear.
+        Assert.False(root.TryGetProperty("p50_mbps", out _));
+        Assert.False(root.TryGetProperty("min_mbps", out _));
+        Assert.False(root.TryGetProperty("max_mbps", out _));
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Bench/ThroughputProbeTests.cs
+++ b/windows/Ghostty.Tests/Bench/ThroughputProbeTests.cs
@@ -1,0 +1,108 @@
+using System.Text;
+using System.Text.Json;
+using Ghostty.Bench.Output;
+using Ghostty.Bench.Probes;
+using Xunit;
+
+namespace Ghostty.Tests.Bench;
+
+public class ThroughputProbeTests
+{
+    // Each iteration must use a distinct nonce. Guards against leftover-
+    // match false positives under ConPTY where a prior iteration's
+    // terminator can linger in conhost's screen buffer.
+    [Fact]
+    public void ThroughputProbe_RegeneratesNoncePerIteration()
+    {
+        var capturedWrites = new List<byte[]>();
+        using var t = new FakeTransport(
+            input =>
+            {
+                capturedWrites.Add(input.ToArray());
+                // Echo back so the probe's reader loop terminates.
+                return input.ToArray();
+            });
+
+        byte[] payload = new byte[64];
+        var probe = new ThroughputProbe("test", "fake", "tiny", payload);
+
+        var host = new HostInfo("Windows", "26200", "Test CPU", "x64", "10.0.0", "inbox");
+        probe.Run(t, host, DateTime.UtcNow);
+
+        // Scan every captured write for terminator occurrences and collect
+        // the nonces. The probe writes payload and terminator as two separate
+        // Input.Write calls; depending on FakeTransport pipe scheduling the
+        // server-side IoLoop may read them as one or two chunks per iteration.
+        // Either way the terminator prefix lands in some captured write, and
+        // three iterations must produce three distinct nonces.
+        var nonces = new HashSet<string>();
+        byte[] prefix = Encoding.ASCII.GetBytes("\r\n~ENDOFBURST_");
+        foreach (byte[] w in capturedWrites)
+        {
+            int idx = w.AsSpan().IndexOf(prefix);
+            if (idx < 0) continue;
+            if (idx + prefix.Length + 16 > w.Length) continue;
+            nonces.Add(Encoding.ASCII.GetString(w, idx + prefix.Length, 16));
+        }
+        Assert.Equal(3, nonces.Count);
+    }
+
+    // The probe must report both ingest and emit numbers. Under echo mode,
+    // ingest and emit differ only by terminator overhead (~31 bytes out of
+    // 65 536), so they are approximately equal.
+    [Fact]
+    public void ThroughputProbe_ReportsBothIngestAndEmitMetrics()
+    {
+        using var t = new FakeTransport();   // echo
+        byte[] payload = new byte[64 * 1024];
+        new Random(1337).NextBytes(payload);
+        var probe = new ThroughputProbe("test", "fake", "medium", payload);
+
+        var host = new HostInfo("Windows", "26200", "Test CPU", "x64", "10.0.0", "inbox");
+        var result = probe.Run(t, host, DateTime.UtcNow);
+
+        // All six rate fields must be non-null and positive.
+        Assert.NotNull(result.IngestP50Mbps);
+        Assert.NotNull(result.IngestMinMbps);
+        Assert.NotNull(result.IngestMaxMbps);
+        Assert.NotNull(result.EmitP50Mbps);
+        Assert.NotNull(result.EmitMinMbps);
+        Assert.NotNull(result.EmitMaxMbps);
+        Assert.True(result.IngestP50Mbps!.Value > 0);
+        Assert.True(result.EmitP50Mbps!.Value > 0);
+
+        // For echo mode, emit ~ ingest * (1 + terminator/payload). With a
+        // 64 KB payload and ~31 B terminator, emit is within ~1 % of ingest.
+        double ratio = result.EmitP50Mbps!.Value / result.IngestP50Mbps!.Value;
+        Assert.InRange(ratio, 0.95, 1.10);
+    }
+
+    // The probe must write payload first, then terminator. Scripted
+    // responder captures all input writes and the assertion validates the
+    // byte order.
+    [Fact]
+    public void ThroughputProbe_WritesPayloadThenTerminator()
+    {
+        var captured = new List<byte>();
+        using var t = new FakeTransport(input =>
+        {
+            captured.AddRange(input.ToArray());
+            return input.ToArray();
+        });
+
+        byte[] payload = Encoding.ASCII.GetBytes("HELLO");
+        var probe = new ThroughputProbe("test", "fake", "tiny", payload);
+        var host = new HostInfo("Windows", "26200", "Test CPU", "x64", "10.0.0", "inbox");
+        probe.Run(t, host, DateTime.UtcNow);
+
+        // Across the full 3-iteration capture, the first 5 bytes must be
+        // the payload "HELLO". The terminator follows starting at offset 5.
+        Assert.True(captured.Count >= 5 + 31, $"captured too few bytes: {captured.Count}");
+        string firstFive = Encoding.ASCII.GetString(captured.GetRange(0, 5).ToArray());
+        Assert.Equal("HELLO", firstFive);
+
+        // Terminator starts with "\r\n~ENDOFBURST_" at offset 5.
+        string prefix = Encoding.ASCII.GetString(captured.GetRange(5, 14).ToArray());
+        Assert.Equal("\r\n~ENDOFBURST_", prefix);
+    }
+}


### PR DESCRIPTION
Fixes the three `conpty-throughput-*` probes to report honest,
well-defined numbers. Replaces the "write N bytes, read N bytes
back, report MB/s" loop with a per-iteration terminator-barrier
protocol: each iteration writes `payload + "\r\n~ENDOFBURST_<nonce>~"`
and reads `Output` until the terminator is detected.

Reports paired **ingest MB/s** and **emit MB/s** per probe:

- **Ingest** = N payload bytes / elapsed. Under DirectPipe this is
  raw pipe throughput. Under ConPTY this is "how fast conhost
  parses the burst," with the terminator as a synchronous
  observation point on `hOutput`.
- **Emit** = bytes read during window / elapsed. Under DirectPipe
  `emit == ingest` (identity echo). Under ConPTY the two diverge
  and the divergence is informative signal about conhost's
  parser-vs-emitter behaviour.

Fresh `Guid.NewGuid()`-derived 16-hex nonce per iteration rules
out false matches from a prior iteration's terminator lingering in
conhost's screen buffer.

`ResultJson.Throughput` gains six paired fields (`ingest_*_mbps`,
`emit_*_mbps`) replacing the old single `p50_mbps / min_mbps /
max_mbps` triple. Breaks backward compat for any throughput
consumer; acceptable because the old numbers were misleading.
`bench_version` stays `"1"` because round-trip consumers see no
change.

### Scale pivot

End-to-end validation against real ConPTY revealed the spec's
aspirational 100 MB target was infeasible. Conhost's ConPTY
emission pipeline is bottlenecked at ~100 KB/s for scrolling ASCII
(measured via the new `conpty-throughput-verify` diagnostic),
because each scrolled row is emitted as a separate VT frame at the
refresh cadence. 100 MB would take ~20 minutes per iteration. 1 MB
keeps each iteration under 10 s end-to-end while still producing a
useful comparison. `Payloads.TargetBytes` is now 1 MB and factory
methods renamed accordingly (`Ascii1Mb`, `Sgr1Mb`, `Stress1Mb`).

### Observed output (AMD Ryzen 7 PRO 5750G, Windows 11 26200)

- `conpty-throughput-ascii`: ingest 0.08 MB/s, emit 0.09 MB/s
- `conpty-throughput-sgr`: ingest 0.66 MB/s, emit 0.33 MB/s
- `conpty-throughput-stress`: ingest 0.84 MB/s, emit 0.26 MB/s
- `direct-pipe-throughput-*`: `ingest == emit`, p50 in hundreds
  of MB/s to low GB/s

The surprise finding from validation: ConPTY ASCII is the slowest
payload because every 'A' advances the cursor and scrolls a row;
SGR and stress are faster because SGR shortens visible-text
density and stress sequences are parser-consumed without screen
rendering. That is the genuinely informative story the probes
expose, not the "parser cost increases" ordering we predicted.

### Tests

- `HarnessTests.RunThroughputIteration_*` (6 new facts): happy
  path, terminator split across reads, EOS, deadline, wrong-nonce
  non-match, scratch-buffer invariant.
- `ThroughputProbeTests` (new file, 3 facts): nonce regeneration
  per iteration, paired ingest+emit reporting, payload+terminator
  write ordering.
- `PayloadsTests.Payloads_DoNotContainTerminatorPrefix` (1 new
  fact): pins the "no payload contains `~ENDOFBURST_`" invariant.
- `ResultJsonTests` (2 updated facts): new schema coverage plus
  round-trip suppression check.

### Manual validation

Run end-to-end from a real PowerShell terminal (not from `dotnet
test` or any Bash-hosted shell — `ConPtyTransport` silently breaks
under MSYS2 pty inheritance):

```
dotnet run --project dist/windows/Bench/Ghostty.Bench --no-build -- conpty-roundtrip-verify
dotnet run --project dist/windows/Bench/Ghostty.Bench --no-build -- conpty-throughput-verify 1024
dotnet run --project dist/windows/Bench/Ghostty.Bench --no-build -- conpty-throughput-ascii
# ... sgr, stress, direct-pipe-{ascii,sgr,stress}
```

### Stack order

IMPORTANT: this PR is the third in the `wintty-263-bypass` stack.

1. #270 - `fix/conpty-transport-audit-263` (ConPTY `UpdateProcThreadAttribute` fix)
2. #272 - `fix/conpty-bench-probe-protocol-263` (round-trip probe redesign)
3. **this PR** - `fix/conpty-throughput-probe-protocol-263` (throughput probe redesign)

Merge in order. Stack Manager auto-retargets children on parent merge.

Refs #263
