### PR TITLE
fix(termio): spawn configured shell directly on Windows

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1572,10 +1572,10 @@ fn execCommand(
                     var args: std.ArrayList([:0]const u8) = .empty;
                     errdefer args.deinit(alloc);
 
-                    var iter = std.process.ArgIteratorGeneral(.{}).init(
+                    var iter = try std.process.ArgIteratorGeneral(.{}).init(
                         alloc,
                         v,
-                    ) catch break :windows_direct;
+                    );
                     defer iter.deinit();
 
                     while (iter.next()) |arg| {
@@ -1583,9 +1583,10 @@ fn execCommand(
                         try args.append(alloc, copy);
                     }
 
-                    // Parser produced nothing usable — fall through to
-                    // cmd.exe wrapping so the error surfaces from
-                    // cmd.exe rather than from an empty argv here.
+                    // Parser produced nothing usable (empty or
+                    // whitespace-only command): fall through to cmd.exe
+                    // wrapping so the error surfaces from cmd.exe rather
+                    // than from an empty argv here.
                     if (args.items.len == 0) {
                         args.deinit(alloc);
                         break :windows_direct;
@@ -1638,7 +1639,7 @@ fn execCommand(
 /// actually need cmd.exe to interpret (pipes, redirects, chaining,
 /// grouping, escape, env expansion, delayed expansion). If it returns
 /// false we can safely tokenize `s` ourselves and spawn the first
-/// token directly. Quotes are intentionally not in the list — they're
+/// token directly. Quotes are intentionally not in the list: they're
 /// handled by the argv tokenizer.
 fn windowsShellNeedsCmdWrapping(s: []const u8) bool {
     for (s) |c| switch (c) {
@@ -1838,7 +1839,7 @@ test "execCommand windows: shell command, single token spawns directly" {
     );
 
     // No cmd.exe /C wrapper: args[0] is the configured shell itself.
-    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqual(1, result.len);
     try testing.expectEqualStrings("pwsh.exe", result[0]);
 }
 
@@ -1860,7 +1861,7 @@ test "execCommand windows: shell command, args split without cmd wrap" {
         },
     );
 
-    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqual(3, result.len);
     try testing.expectEqualStrings("pwsh.exe", result[0]);
     try testing.expectEqualStrings("-NoLogo", result[1]);
     try testing.expectEqualStrings("-NoProfile", result[2]);
@@ -1884,7 +1885,7 @@ test "execCommand windows: shell command, quoted path kept as one arg" {
         },
     );
 
-    try testing.expectEqual(@as(usize, 2), result.len);
+    try testing.expectEqual(2, result.len);
     try testing.expectEqualStrings(
         "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
         result[0],
@@ -1910,8 +1911,8 @@ test "execCommand windows: shell command with pipe falls back to cmd.exe" {
         },
     );
 
-    // Metachar present — wrap with cmd.exe /C so cmd handles the pipe.
-    try testing.expectEqual(@as(usize, 3), result.len);
+    // Metachar present: wrap with cmd.exe /C so cmd handles the pipe.
+    try testing.expectEqual(3, result.len);
     try testing.expect(std.mem.endsWith(u8, result[0], "cmd.exe"));
     try testing.expectEqualStrings("/C", result[1]);
     try testing.expectEqualStrings("dir | findstr foo", result[2]);
@@ -1935,7 +1936,7 @@ test "execCommand windows: shell command with redirect falls back to cmd.exe" {
         },
     );
 
-    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqual(3, result.len);
     try testing.expect(std.mem.endsWith(u8, result[0], "cmd.exe"));
     try testing.expectEqualStrings("/C", result[1]);
     try testing.expectEqualStrings("echo hi > out.txt", result[2]);

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1551,12 +1551,53 @@ fn execCommand(
         .direct => |_| (try command.clone(alloc)).direct,
 
         .shell => |v| shell: {
-            var args: std.ArrayList([:0]const u8) = try .initCapacity(alloc, 4);
-            defer args.deinit(alloc);
-
             if (comptime builtin.os.tag == .windows) {
-                // We run our shell wrapped in `cmd.exe` so that we don't have
-                // to parse the command line ourselves if it has arguments.
+                // On Windows we only fall back to `cmd.exe /C <cmd>` when
+                // the command actually needs cmd.exe features (pipes,
+                // redirects, chaining, env expansion). Otherwise we parse
+                // the string into argv and spawn directly.
+                //
+                // Why: `cmd.exe /C <cmd>` does NOT exec-replace itself
+                // with <cmd>, unlike `/bin/sh -c <cmd>` on POSIX where
+                // sh often optimizes into an exec of the final command.
+                // Wrapping therefore makes cmd.exe the spawned process
+                // and the parent of the user's shell. That means
+                // `command = pwsh.exe` ends up with args[0] = cmd.exe,
+                // ConPTY attaches to cmd.exe, and any process
+                // classification that looks at args[0] (e.g. the
+                // ConPTY-bypass detector for # 112) sees the wrapper
+                // instead of the configured shell. Spawning directly
+                // fixes all three.
+                if (!windowsShellNeedsCmdWrapping(v)) windows_direct: {
+                    var args: std.ArrayList([:0]const u8) = .empty;
+                    errdefer args.deinit(alloc);
+
+                    var iter = std.process.ArgIteratorGeneral(.{}).init(
+                        alloc,
+                        v,
+                    ) catch break :windows_direct;
+                    defer iter.deinit();
+
+                    while (iter.next()) |arg| {
+                        const copy = try alloc.dupeZ(u8, arg);
+                        try args.append(alloc, copy);
+                    }
+
+                    // Parser produced nothing usable — fall through to
+                    // cmd.exe wrapping so the error surfaces from
+                    // cmd.exe rather than from an empty argv here.
+                    if (args.items.len == 0) {
+                        args.deinit(alloc);
+                        break :windows_direct;
+                    }
+
+                    break :shell try args.toOwnedSlice(alloc);
+                }
+
+                // Command contains cmd.exe metacharacters (or parsing
+                // produced no tokens). Let cmd.exe handle it.
+                var args: std.ArrayList([:0]const u8) = try .initCapacity(alloc, 4);
+                defer args.deinit(alloc);
 
                 // Note we don't free any of the memory below since it is
                 // allocated in the arena.
@@ -1575,21 +1616,36 @@ fn execCommand(
 
                 try args.append(alloc, cmd);
                 try args.append(alloc, "/C");
-            } else {
-                // We run our shell wrapped in `/bin/sh` so that we don't have
-                // to parse the command line ourselves if it has arguments.
-                // Additionally, some environments (NixOS, I found) use /bin/sh
-                // to setup some environment variables that are important to
-                // have set.
-                try args.append(alloc, "/bin/sh");
-                if (internal_os.isFlatpak()) try args.append(alloc, "-l");
-                try args.append(alloc, "-c");
+                try args.append(alloc, v);
+                break :shell try args.toOwnedSlice(alloc);
             }
 
+            // POSIX: wrap with `/bin/sh -c` so the shell handles argument
+            // splitting, quoting, and expansion. On POSIX the extra sh
+            // is usually optimized away via tail exec.
+            var args: std.ArrayList([:0]const u8) = try .initCapacity(alloc, 4);
+            defer args.deinit(alloc);
+            try args.append(alloc, "/bin/sh");
+            if (internal_os.isFlatpak()) try args.append(alloc, "-l");
+            try args.append(alloc, "-c");
             try args.append(alloc, v);
             break :shell try args.toOwnedSlice(alloc);
         },
     };
+}
+
+/// Returns true if `s` contains any cmd.exe metacharacter that would
+/// actually need cmd.exe to interpret (pipes, redirects, chaining,
+/// grouping, escape, env expansion, delayed expansion). If it returns
+/// false we can safely tokenize `s` ourselves and spawn the first
+/// token directly. Quotes are intentionally not in the list — they're
+/// handled by the argv tokenizer.
+fn windowsShellNeedsCmdWrapping(s: []const u8) bool {
+    for (s) |c| switch (c) {
+        '&', '|', '<', '>', '(', ')', '^', '%', '!' => return true,
+        else => {},
+    };
+    return false;
 }
 
 /// Get information about the process(es) running within the backend. Returns
@@ -1761,4 +1817,149 @@ test "execCommand: direct command, config freed" {
     try testing.expectEqual(2, result.len);
     try testing.expectEqualStrings(result[0], "foo");
     try testing.expectEqualStrings(result[1], "bar baz");
+}
+
+test "execCommand windows: shell command, single token spawns directly" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "pwsh.exe" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+    );
+
+    // No cmd.exe /C wrapper: args[0] is the configured shell itself.
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+}
+
+test "execCommand windows: shell command, args split without cmd wrap" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "pwsh.exe -NoLogo -NoProfile" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-NoLogo", result[1]);
+    try testing.expectEqualStrings("-NoProfile", result[2]);
+}
+
+test "execCommand windows: shell command, quoted path kept as one arg" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\" -NoLogo" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+    );
+
+    try testing.expectEqual(@as(usize, 2), result.len);
+    try testing.expectEqualStrings(
+        "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+        result[0],
+    );
+    try testing.expectEqualStrings("-NoLogo", result[1]);
+}
+
+test "execCommand windows: shell command with pipe falls back to cmd.exe" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "dir | findstr foo" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+    );
+
+    // Metachar present — wrap with cmd.exe /C so cmd handles the pipe.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expect(std.mem.endsWith(u8, result[0], "cmd.exe"));
+    try testing.expectEqualStrings("/C", result[1]);
+    try testing.expectEqualStrings("dir | findstr foo", result[2]);
+}
+
+test "execCommand windows: shell command with redirect falls back to cmd.exe" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "echo hi > out.txt" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expect(std.mem.endsWith(u8, result[0], "cmd.exe"));
+    try testing.expectEqualStrings("/C", result[1]);
+    try testing.expectEqualStrings("echo hi > out.txt", result[2]);
+}
+
+test "windowsShellNeedsCmdWrapping" {
+    const testing = std.testing;
+
+    // Simple commands don't need cmd.exe.
+    try testing.expect(!windowsShellNeedsCmdWrapping("pwsh.exe"));
+    try testing.expect(!windowsShellNeedsCmdWrapping("pwsh.exe -NoLogo"));
+    try testing.expect(!windowsShellNeedsCmdWrapping("cmd.exe"));
+    try testing.expect(!windowsShellNeedsCmdWrapping(
+        "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\"",
+    ));
+    try testing.expect(!windowsShellNeedsCmdWrapping(""));
+
+    // Metachars trigger the wrapper.
+    try testing.expect(windowsShellNeedsCmdWrapping("a | b"));
+    try testing.expect(windowsShellNeedsCmdWrapping("a && b"));
+    try testing.expect(windowsShellNeedsCmdWrapping("a > b"));
+    try testing.expect(windowsShellNeedsCmdWrapping("a < b"));
+    try testing.expect(windowsShellNeedsCmdWrapping("(a) & (b)"));
+    try testing.expect(windowsShellNeedsCmdWrapping("echo %USERNAME%"));
+    try testing.expect(windowsShellNeedsCmdWrapping("echo !var!"));
+    try testing.expect(windowsShellNeedsCmdWrapping("a^b"));
 }


### PR DESCRIPTION
Closes the bug half of #281. The feature half (per-tab/per-pane shell picker, `shell-profiles` config, palette variants) will land separately.

## Problem

Setting `command = pwsh.exe` didn't actually spawn pwsh.exe. On Windows, `src/termio/Exec.zig:execCommand` always wrapped `.shell` commands with `cmd.exe /C <cmd>`, so:

- `args[0]` = `cmd.exe`, pwsh.exe as a grandchild
- ConPTY attached to cmd.exe, not pwsh
- The args[0]-based classifier from #112's bypass detector saw `cmd.exe` and picked ConPTY instead of raw pipes

Unlike `/bin/sh -c` on POSIX (which commonly tail-execs into the child), `cmd.exe /C` stays as the parent.

## Fix

On Windows, if the `.shell` string contains no cmd.exe metacharacters (`& | < > ( ) ^ % !`), tokenize it with `ArgIteratorGeneral` and spawn the first token directly. Commands with pipes, redirects, chaining, grouping, escape, or env expansion still route through `cmd.exe /C` so cmd.exe handles them.

POSIX path is untouched.

## Tests

Six new cases in `src/termio/Exec.zig`:
- single token (`pwsh.exe`) -> direct spawn
- multi-arg (`pwsh.exe -NoLogo -NoProfile`) -> direct spawn
- quoted path with spaces -> direct spawn
- pipe (`dir | findstr foo`) -> `cmd.exe /C` wrapper
- redirect (`echo hi > out.txt`) -> `cmd.exe /C` wrapper
- `windowsShellNeedsCmdWrapping` helper unit test

Full suite results:
- Windows: 71 passed, 6 skipped
- Linux: 68 passed, 7 skipped
- Mac: 72 passed, 5 skipped

## Unblocks

- End-to-end validation of the #112 ConPTY bypass path with pwsh
- Users actually getting the shell they configured