### PR TITLE
feat(windows): conpty-mode config + ConPTY bypass for VT-aware shells (# 112)

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -388,8 +388,8 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         @memcpy(handles, unique[0..unique_len]);
 
         // lpValue for PROC_THREAD_ATTRIBUTE_HANDLE_LIST is the handles
-        // array pointer passed BY VALUE (not by ref) - the same lesson
-        // PR # 270 enforced for PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE.
+        // array pointer passed BY VALUE (not by ref), matching how
+        // PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE above passes `pseudo_console`.
         if (windows.exp.kernel32.UpdateProcThreadAttribute(
             attribute_list_buf.ptr,
             0,

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -979,7 +979,7 @@ test "Command: posix fork handles execveZ failure" {
 // If cmd.start fails with error.ExecFailedInChild it's the _child_ process that is running. If it does not
 // terminate in response to that error both the parent and child will continue as if they _are_ the test suite
 // process.
-fn testingStart(self: *Command) !void {
+pub fn testingStart(self: *Command) !void {
     self.start(testing.allocator) catch |err| {
         if (err == error.ExecFailedInChild) {
             // I am a child process, I must not get confused and continue running the rest of the test suite.

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -332,12 +332,80 @@ fn startWindows(self: *Command, arena: Allocator) !void {
         const stdin = if (self.stdin) |f| f.handle else null_fd.?;
         const stdout = if (self.stdout) |f| f.handle else null_fd.?;
         const stderr = if (self.stderr) |f| f.handle else null_fd.?;
-        break :b .{ null, stdin, stdout, stderr };
+
+        // All three handles must be HANDLE_FLAG_INHERIT for
+        // PROC_THREAD_ATTRIBUTE_HANDLE_LIST. The PTY path flips _pty
+        // ends inheritable in pty.zig; null_fd and caller-provided
+        // files may or may not be. Flip them unconditionally here -
+        // it's idempotent, and handles our code owns are closed after
+        // spawn anyway.
+        try windows.SetHandleInformation(stdin, windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT);
+        try windows.SetHandleInformation(stdout, windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT);
+        try windows.SetHandleInformation(stderr, windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT);
+
+        // Bypass path: restrict inheritance to just these three handles
+        // via PROC_THREAD_ATTRIBUTE_HANDLE_LIST. Without this,
+        // bInheritHandles = TRUE leaks every inheritable parent handle
+        // to the child - a real security bug.
+        var attribute_list_size: usize = undefined;
+        _ = windows.exp.kernel32.InitializeProcThreadAttributeList(
+            null,
+            1,
+            0,
+            &attribute_list_size,
+        );
+
+        const attribute_list_buf = try arena.alloc(u8, attribute_list_size);
+        if (windows.exp.kernel32.InitializeProcThreadAttributeList(
+            attribute_list_buf.ptr,
+            1,
+            0,
+            &attribute_list_size,
+        ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+
+        // Allocate the handle list from the arena so its lifetime
+        // outlives the attribute list until after CreateProcessW.
+        // PROC_THREAD_ATTRIBUTE_HANDLE_LIST rejects duplicate handles,
+        // which is easy to hit: tests use null_fd for both stdin and
+        // stderr, and PTY bypass uses out_pipe_pty for both stdout and
+        // stderr. Build a list of unique handles only.
+        var unique: [3]windows.HANDLE = .{ stdin, stdout, stderr };
+        var unique_len: usize = 1;
+        for (unique[1..]) |h| {
+            var seen = false;
+            for (unique[0..unique_len]) |u| {
+                if (u == h) {
+                    seen = true;
+                    break;
+                }
+            }
+            if (!seen) {
+                unique[unique_len] = h;
+                unique_len += 1;
+            }
+        }
+        const handles = try arena.alloc(windows.HANDLE, unique_len);
+        @memcpy(handles, unique[0..unique_len]);
+
+        // lpValue for PROC_THREAD_ATTRIBUTE_HANDLE_LIST is the handles
+        // array pointer passed BY VALUE (not by ref) - the same lesson
+        // PR # 270 enforced for PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE.
+        if (windows.exp.kernel32.UpdateProcThreadAttribute(
+            attribute_list_buf.ptr,
+            0,
+            windows.exp.PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+            @ptrCast(handles.ptr),
+            @sizeOf(windows.HANDLE) * handles.len,
+            null,
+            null,
+        ) == 0) return windows.unexpectedError(windows.kernel32.GetLastError());
+
+        break :b .{ attribute_list_buf.ptr, stdin, stdout, stderr };
     };
 
     var startup_info_ex = windows.exp.STARTUPINFOEX{
         .StartupInfo = .{
-            .cb = if (attribute_list != null) @sizeOf(windows.exp.STARTUPINFOEX) else @sizeOf(windows.STARTUPINFOW),
+            .cb = @sizeOf(windows.exp.STARTUPINFOEX),
             .hStdError = stderr,
             .hStdOutput = stdout,
             .hStdInput = stdin,
@@ -360,7 +428,7 @@ fn startWindows(self: *Command, arena: Allocator) !void {
     };
 
     var flags: windows.DWORD = windows.exp.CREATE_UNICODE_ENVIRONMENT;
-    if (attribute_list != null) flags |= windows.exp.EXTENDED_STARTUPINFO_PRESENT;
+    flags |= windows.exp.EXTENDED_STARTUPINFO_PRESENT;
 
     var process_information: windows.PROCESS_INFORMATION = undefined;
     if (windows.exp.kernel32.CreateProcessW(

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -663,6 +663,9 @@ pub fn init(
             .working_directory = if (config.@"working-directory") |wd| wd.value() else null,
             .resources_dir = global_state.resources_dir.host(),
             .term = config.term,
+            .conpty_mode = if (comptime builtin.os.tag == .windows)
+                config.@"conpty-mode"
+            else {},
             .rt_pre_exec_info = .init(config),
             .rt_post_fork_info = .init(config),
         });

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2844,6 +2844,23 @@ keybind: Keybinds = .{},
 /// `xterm-256color` with environment variables if terminfo installation fails.
 @"shell-integration-features": ShellIntegrationFeatures = .{},
 
+/// Controls how Windows terminal sessions communicate with the child
+/// shell. `auto` picks the bypass path (raw stdin/stdout/stderr
+/// pipes, no CreatePseudoConsole) for VT-aware shells like pwsh,
+/// wsl, ssh, bash, and nu, and keeps ConPTY for cmd.exe and
+/// PowerShell 5.1. `always` forces the bypass path; `never` forces
+/// ConPTY. Has no effect on non-Windows platforms.
+///
+/// Bypass enables Kitty graphics and avoids conhost's VT mangling,
+/// at the cost of losing ConPTY's compatibility shims for Win32
+/// Console API programs. Resize signalling under bypass is
+/// best-effort via CSI 8;rows;cols t; use `conpty-mode = never` if
+/// precise resize behavior matters.
+///
+/// Available since: <next version>
+@"conpty-mode": if (builtin.os.tag == .windows) ConptyMode else void =
+    if (builtin.os.tag == .windows) .auto else {},
+
 /// Custom entries into the command palette.
 ///
 /// Each entry requires the title, the corresponding action, and an optional
@@ -8659,6 +8676,8 @@ pub const ShellIntegrationFeatures = packed struct {
     @"ssh-terminfo": bool = false,
     path: bool = true,
 };
+
+pub const ConptyMode = enum { auto, always, never };
 
 pub const SplitPreserveZoom = packed struct {
     navigation: bool = false,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2856,8 +2856,6 @@ keybind: Keybinds = .{},
 /// Console API programs. Resize signalling under bypass is
 /// best-effort via CSI 8;rows;cols t; use `conpty-mode = never` if
 /// precise resize behavior matters.
-///
-/// Available since: <next version>
 @"conpty-mode": if (builtin.os.tag == .windows) ConptyMode else void =
     if (builtin.os.tag == .windows) .auto else {},
 

--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -28,6 +28,7 @@ pub const path = @import("path.zig");
 pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");
+pub const windows_shell = @import("windows_shell.zig");
 pub const macos = @import("macos.zig");
 pub const shell = @import("shell.zig");
 pub const uri = @import("uri.zig");
@@ -71,6 +72,7 @@ test {
     _ = path;
     _ = uri;
     _ = shell;
+    _ = windows_shell;
 
     if (comptime builtin.os.tag == .linux) {
         _ = kernel_info;

--- a/src/os/passwd.zig
+++ b/src/os/passwd.zig
@@ -66,7 +66,7 @@ pub fn get(alloc: Allocator) !Entry {
         // some operating systems (NixOS tested) don't set the PATH for various
         // utilities properly until we get a login shell.
         const Pty = @import("../pty.zig").Pty;
-        var pty = try Pty.open(.{});
+        var pty = try Pty.open(.{ .size = .{} });
         defer pty.deinit();
         var cmd: internal_os.FlatpakHostCommand = .{
             .argv = &[_][]const u8{

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -31,6 +31,16 @@ pub const WAIT_FAILED = windows.WAIT_FAILED;
 pub const FALSE = windows.FALSE;
 pub const TRUE = windows.TRUE;
 
+/// GetHandleInformation is not wrapped in Zig std yet (std only wraps
+/// SetHandleInformation). Expose a small wrapper here so callers can
+/// verify handle inheritance flags without reaching into kernel32
+/// directly.
+pub fn GetHandleInformation(handle: windows.HANDLE, flags: *windows.DWORD) !void {
+    if (exp.kernel32.GetHandleInformation(handle, flags) == 0) {
+        return windows.unexpectedError(windows.kernel32.GetLastError());
+    }
+}
+
 pub const exp = struct {
     pub const HPCON = windows.LPVOID;
 
@@ -53,6 +63,10 @@ pub const exp = struct {
             hWritePipe: *windows.HANDLE,
             lpPipeAttributes: ?*const windows.SECURITY_ATTRIBUTES,
             nSize: windows.DWORD,
+        ) callconv(.winapi) windows.BOOL;
+        pub extern "kernel32" fn GetHandleInformation(
+            hObject: windows.HANDLE,
+            lpdwFlags: *windows.DWORD,
         ) callconv(.winapi) windows.BOOL;
         pub extern "kernel32" fn CreatePseudoConsole(
             size: windows.COORD,

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -19,6 +19,7 @@ pub const HANDLE_FLAG_INHERIT = windows.HANDLE_FLAG_INHERIT;
 pub const INFINITE = windows.INFINITE;
 pub const INVALID_HANDLE_VALUE = windows.INVALID_HANDLE_VALUE;
 pub const OPEN_EXISTING = windows.OPEN_EXISTING;
+pub const OVERLAPPED = windows.OVERLAPPED;
 pub const PIPE_ACCESS_OUTBOUND = windows.PIPE_ACCESS_OUTBOUND;
 pub const PIPE_TYPE_BYTE = windows.PIPE_TYPE_BYTE;
 pub const PROCESS_INFORMATION = windows.PROCESS_INFORMATION;
@@ -28,6 +29,7 @@ pub const STARTUPINFOW = windows.STARTUPINFOW;
 pub const STARTF_USESTDHANDLES = windows.STARTF_USESTDHANDLES;
 pub const SYNCHRONIZE = windows.SYNCHRONIZE;
 pub const WAIT_FAILED = windows.WAIT_FAILED;
+pub const WAIT_OBJECT_0 = windows.WAIT_OBJECT_0;
 pub const FALSE = windows.FALSE;
 pub const TRUE = windows.TRUE;
 
@@ -64,6 +66,14 @@ pub const exp = struct {
             lpPipeAttributes: ?*const windows.SECURITY_ATTRIBUTES,
             nSize: windows.DWORD,
         ) callconv(.winapi) windows.BOOL;
+        // std.os.windows.kernel32 only exposes CreateEventExW; add the
+        // classic CreateEventW for overlapped I/O wait events.
+        pub extern "kernel32" fn CreateEventW(
+            lpEventAttributes: ?*windows.SECURITY_ATTRIBUTES,
+            bManualReset: windows.BOOL,
+            bInitialState: windows.BOOL,
+            lpName: ?windows.LPCWSTR,
+        ) callconv(.winapi) ?windows.HANDLE;
         pub extern "kernel32" fn GetHandleInformation(
             hObject: windows.HANDLE,
             lpdwFlags: *windows.DWORD,

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -136,6 +136,7 @@ pub const exp = struct {
     pub const PROC_THREAD_ATTRIBUTE_ADDITIVE = 0x00040000;
 
     pub const ProcThreadAttributeNumber = enum(windows.DWORD) {
+        ProcThreadAttributeHandleList = 2,
         ProcThreadAttributePseudoConsole = 22,
         _,
     };
@@ -154,4 +155,5 @@ pub const exp = struct {
     }
 
     pub const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = ProcThreadAttributeValue(.ProcThreadAttributePseudoConsole, false, true, false);
+    pub const PROC_THREAD_ATTRIBUTE_HANDLE_LIST = ProcThreadAttributeValue(.ProcThreadAttributeHandleList, false, true, false);
 };

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -1,0 +1,136 @@
+//! VT-awareness classification for Windows shell executables.
+//!
+//! This is orthogonal to src/termio/shell_integration.zig's `Shell`
+//! enum: `Shell` identifies bash/zsh/etc for RC-file injection;
+//! `Awareness` says whether the shell speaks VT natively or uses the
+//! Win32 Console API. A shell can be recognized here without being
+//! recognized there (e.g. `wsl.exe`) and vice versa.
+//!
+//! Ported 1:1 from the merged C# ShellDetector in
+//! windows/Ghostty.Core/Shell/ShellDetector.cs (PR # 266). Keep the
+//! two tables in sync until the C# side is retired.
+
+const std = @import("std");
+const testing = std.testing;
+
+pub const Awareness = enum {
+    unknown,
+    vt_aware,
+    console_api,
+};
+
+const known = std.StaticStringMap(Awareness).initComptime(.{
+    .{ "pwsh", .vt_aware },
+    .{ "wsl", .vt_aware },
+    .{ "ssh", .vt_aware },
+    .{ "bash", .vt_aware },
+    .{ "nu", .vt_aware },
+    .{ "zsh", .vt_aware },
+    .{ "fish", .vt_aware },
+    .{ "elvish", .vt_aware },
+    .{ "xonsh", .vt_aware },
+    .{ "cmd", .console_api },
+    .{ "powershell", .console_api },
+});
+
+/// Classify an executable path or single-token command string. Strips
+/// surrounding quotes, directory prefix, and a trailing `.exe`
+/// suffix, then matches case-insensitively against the known table.
+/// Returns `.unknown` for anything unrecognized.
+///
+/// This function does not parse argv flags. Callers with a full
+/// command line should split off the first token before calling.
+pub fn classify(exe_path: []const u8) Awareness {
+    const trimmed = std.mem.trim(u8, exe_path, "\"' \t\r\n");
+    if (trimmed.len == 0) return .unknown;
+
+    // Last path separator (forward or back slash).
+    const base_start = blk: {
+        var i: usize = trimmed.len;
+        while (i > 0) : (i -= 1) {
+            const c = trimmed[i - 1];
+            if (c == '\\' or c == '/') break :blk i;
+        }
+        break :blk 0;
+    };
+    var base = trimmed[base_start..];
+
+    // Strip trailing .exe case-insensitively.
+    if (base.len >= 4 and std.ascii.eqlIgnoreCase(base[base.len - 4 ..], ".exe")) {
+        base = base[0 .. base.len - 4];
+    }
+
+    // StaticStringMap is case-sensitive; lowercase into a stack buffer.
+    var buf: [64]u8 = undefined;
+    if (base.len > buf.len) return .unknown;
+    const lower = std.ascii.lowerString(buf[0..base.len], base);
+
+    return known.get(lower) orelse .unknown;
+}
+
+test "classify: pwsh variants" {
+    try testing.expectEqual(Awareness.vt_aware, classify("pwsh"));
+    try testing.expectEqual(Awareness.vt_aware, classify("pwsh.exe"));
+    try testing.expectEqual(Awareness.vt_aware, classify("PWSH.EXE"));
+    try testing.expectEqual(Awareness.vt_aware, classify("C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+}
+
+test "classify: wsl, ssh, bash" {
+    try testing.expectEqual(Awareness.vt_aware, classify("wsl.exe"));
+    try testing.expectEqual(Awareness.vt_aware, classify("ssh.exe"));
+    try testing.expectEqual(Awareness.vt_aware, classify("bash.exe"));
+    try testing.expectEqual(Awareness.vt_aware, classify("C:\\Windows\\System32\\wsl.exe"));
+}
+
+test "classify: nu, zsh, fish" {
+    try testing.expectEqual(Awareness.vt_aware, classify("nu.exe"));
+    try testing.expectEqual(Awareness.vt_aware, classify("zsh"));
+    try testing.expectEqual(Awareness.vt_aware, classify("fish"));
+}
+
+test "classify: elvish, xonsh" {
+    try testing.expectEqual(Awareness.vt_aware, classify("elvish.exe"));
+    try testing.expectEqual(Awareness.vt_aware, classify("xonsh"));
+}
+
+test "classify: cmd.exe is console_api" {
+    try testing.expectEqual(Awareness.console_api, classify("cmd"));
+    try testing.expectEqual(Awareness.console_api, classify("cmd.exe"));
+    try testing.expectEqual(Awareness.console_api, classify("CMD.EXE"));
+    try testing.expectEqual(Awareness.console_api, classify("C:\\Windows\\System32\\cmd.exe"));
+}
+
+test "classify: powershell 5.1 is console_api" {
+    try testing.expectEqual(Awareness.console_api, classify("powershell"));
+    try testing.expectEqual(Awareness.console_api, classify("powershell.exe"));
+    try testing.expectEqual(Awareness.console_api, classify("PowerShell.exe"));
+}
+
+test "classify: unknown returns unknown" {
+    try testing.expectEqual(Awareness.unknown, classify("my-custom-repl.exe"));
+    try testing.expectEqual(Awareness.unknown, classify("python.exe"));
+    try testing.expectEqual(Awareness.unknown, classify("notepad.exe"));
+}
+
+test "classify: strips surrounding quotes" {
+    try testing.expectEqual(Awareness.vt_aware, classify("\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\""));
+    try testing.expectEqual(Awareness.console_api, classify("'cmd.exe'"));
+}
+
+test "classify: handles forward slashes" {
+    try testing.expectEqual(Awareness.vt_aware, classify("C:/Program Files/PowerShell/7/pwsh.exe"));
+}
+
+test "classify: empty and whitespace" {
+    try testing.expectEqual(Awareness.unknown, classify(""));
+    try testing.expectEqual(Awareness.unknown, classify("   "));
+    try testing.expectEqual(Awareness.unknown, classify("\t\n"));
+}
+
+test "classify: handles very long path safely" {
+    // Longer than the 64-byte lowercase buffer. Must return .unknown
+    // instead of crashing or false-matching.
+    var long_path: [128]u8 = undefined;
+    @memset(&long_path, 'a');
+    try testing.expectEqual(Awareness.unknown, classify(&long_path));
+}

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -6,12 +6,12 @@
 //! Win32 Console API. A shell can be recognized here without being
 //! recognized there (e.g. `wsl.exe`) and vice versa.
 //!
-//! Ported 1:1 from the merged C# ShellDetector in
-//! windows/Ghostty.Core/Shell/ShellDetector.cs (PR # 266). Keep the
-//! two tables in sync until the C# side is retired.
+//! The C# port at windows/Ghostty.Core/Shell/ShellDetector.cs keeps
+//! the same table; edit both together until the C# side is retired.
 
 const std = @import("std");
 const testing = std.testing;
+const log = std.log.scoped(.windows_shell);
 
 pub const Awareness = enum {
     unknown,
@@ -62,7 +62,11 @@ pub fn classify(exe_path: []const u8) Awareness {
 
     // StaticStringMap is case-sensitive; lowercase into a stack buffer.
     var buf: [64]u8 = undefined;
-    if (base.len > buf.len) return .unknown;
+    if (base.len > buf.len) {
+        // Any realistic shell basename fits; log for diagnosability.
+        log.debug("shell basename too long ({d}B) - treating as unknown", .{base.len});
+        return .unknown;
+    }
     const lower = std.ascii.lowerString(buf[0..base.len], base);
 
     return known.get(lower) orelse .unknown;

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -498,19 +498,22 @@ const WindowsPty = struct {
 
     /// Bypass-mode resize signal: write `CSI 8 ; rows ; cols t` (XTWINOPS)
     /// to the parent-side input pipe so that a VT-aware child parses it
-    /// as a size change. Full resize parity (SIGWINCH via WSL interop,
-    /// per-shell signalling) is a follow-up (# 263 section 5).
+    /// as a size change.
     ///
-    /// Best-effort: if the child isn't reading we don't want to stall
-    /// the UI thread, so the overlapped WriteFile is bounded by a 100 ms
-    /// wait; on timeout we cancel the I/O and log a warning.
-    fn writeResizeSequence(self: *Pty, size: winsize) SetSizeError!void {
+    /// Best-effort by design: if the child isn't reading we don't want
+    /// to stall the UI thread, so the overlapped WriteFile is bounded
+    /// by a 100 ms wait and any failure is logged, not returned. Full
+    /// resize parity (SIGWINCH via WSL interop, per-shell signalling)
+    /// is a deferred follow-up.
+    fn writeResizeSequence(self: *Pty, size: winsize) void {
         var buf: [32]u8 = undefined;
+        // 32 bytes fits any "\x1b[8;rows;cols t" for u16 dimensions,
+        // so bufPrint cannot actually fail. Treat as unreachable.
         const seq = std.fmt.bufPrint(
             &buf,
             "\x1b[8;{d};{d}t",
             .{ size.ws_row, size.ws_col },
-        ) catch return error.ResizeFailed;
+        ) catch unreachable;
 
         var overlapped = std.mem.zeroes(windows.OVERLAPPED);
         overlapped.hEvent = windows.exp.kernel32.CreateEventW(
@@ -519,7 +522,10 @@ const WindowsPty = struct {
             windows.FALSE,
             null,
         );
-        if (overlapped.hEvent == null) return error.ResizeFailed;
+        if (overlapped.hEvent == null) {
+            log.warn("bypass resize signal: CreateEventW failed", .{});
+            return;
+        }
         defer _ = windows.CloseHandle(overlapped.hEvent.?);
 
         var written: windows.DWORD = 0;
@@ -569,10 +575,9 @@ const WindowsPty = struct {
                 );
                 if (result != windows.S_OK) return error.ResizeFailed;
             },
-            .bypass => self.writeResizeSequence(size) catch |err| {
-                log.warn("bypass resize write error: {}", .{err});
-                // Fall through: update self.size regardless.
-            },
+            // Best-effort: any transport failure is logged inside
+            // writeResizeSequence; we still record `self.size` below.
+            .bypass => self.writeResizeSequence(size),
         }
         self.size = size;
     }

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -496,6 +496,59 @@ const WindowsPty = struct {
         self.* = undefined;
     }
 
+    /// Bypass-mode resize signal: write `CSI 8 ; rows ; cols t` (XTWINOPS)
+    /// to the parent-side input pipe so that a VT-aware child parses it
+    /// as a size change. Full resize parity (SIGWINCH via WSL interop,
+    /// per-shell signalling) is a follow-up (# 263 section 5).
+    ///
+    /// Best-effort: if the child isn't reading we don't want to stall
+    /// the UI thread, so the overlapped WriteFile is bounded by a 100 ms
+    /// wait; on timeout we cancel the I/O and log a warning.
+    fn writeResizeSequence(self: *Pty, size: winsize) SetSizeError!void {
+        var buf: [32]u8 = undefined;
+        const seq = std.fmt.bufPrint(
+            &buf,
+            "\x1b[8;{d};{d}t",
+            .{ size.ws_row, size.ws_col },
+        ) catch return error.ResizeFailed;
+
+        var overlapped = std.mem.zeroes(windows.OVERLAPPED);
+        overlapped.hEvent = windows.exp.kernel32.CreateEventW(
+            null,
+            windows.TRUE,
+            windows.FALSE,
+            null,
+        );
+        if (overlapped.hEvent == null) return error.ResizeFailed;
+        defer _ = windows.CloseHandle(overlapped.hEvent.?);
+
+        var written: windows.DWORD = 0;
+        const write_ok = windows.kernel32.WriteFile(
+            self.in_pipe,
+            seq.ptr,
+            @intCast(seq.len),
+            &written,
+            &overlapped,
+        );
+        if (write_ok == 0) {
+            const err = windows.kernel32.GetLastError();
+            if (err == .IO_PENDING) {
+                // Wait up to 100 ms. Best-effort: if the child isn't
+                // reading we don't want to block the UI thread.
+                const wait = windows.kernel32.WaitForSingleObject(
+                    overlapped.hEvent.?,
+                    100,
+                );
+                if (wait != windows.WAIT_OBJECT_0) {
+                    _ = windows.kernel32.CancelIoEx(self.in_pipe, &overlapped);
+                    log.warn("bypass resize signal timed out", .{});
+                }
+            } else {
+                log.warn("bypass resize signal write failed: {}", .{err});
+            }
+        }
+    }
+
     pub const GetSizeError = error{};
 
     /// Return the size of the pty.
@@ -516,7 +569,10 @@ const WindowsPty = struct {
                 );
                 if (result != windows.S_OK) return error.ResizeFailed;
             },
-            .bypass => return error.ResizeFailed, // real impl lands in Task 6
+            .bypass => self.writeResizeSequence(size) catch |err| {
+                log.warn("bypass resize write error: {}", .{err});
+                // Fall through: update self.size regardless.
+            },
         }
         self.size = size;
     }
@@ -588,4 +644,34 @@ test "WindowsPty: bypass mode skips pseudo_console and flips _pty handles inheri
     try std.testing.expect((flags & windows.HANDLE_FLAG_INHERIT) != 0);
     try windows.GetHandleInformation(pty.out_pipe_pty, &flags);
     try std.testing.expect((flags & windows.HANDLE_FLAG_INHERIT) != 0);
+}
+
+test "WindowsPty: bypass setSize writes CSI 8;r;c;t to in_pipe" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var pty = try Pty.open(.{
+        .size = .{ .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0 },
+        .mode = .bypass,
+    });
+    defer pty.deinit();
+
+    try pty.setSize(.{ .ws_row = 40, .ws_col = 120, .ws_xpixel = 0, .ws_ypixel = 0 });
+
+    // Read from the child-side pipe end. The resize escape was
+    // written to in_pipe (parent) and must be readable from
+    // in_pipe_pty (child).
+    var buf: [32]u8 = undefined;
+    var read: windows.DWORD = 0;
+    const ok = windows.kernel32.ReadFile(
+        pty.in_pipe_pty,
+        &buf,
+        @intCast(buf.len),
+        &read,
+        null,
+    );
+    try std.testing.expect(ok != 0);
+    try std.testing.expectEqualStrings("\x1b[8;40;120t", buf[0..read]);
+
+    // Size accounting still correct.
+    try std.testing.expectEqual(@as(u16, 40), pty.size.ws_row);
+    try std.testing.expectEqual(@as(u16, 120), pty.size.ws_col);
 }

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -675,3 +675,57 @@ test "WindowsPty: bypass setSize writes CSI 8;r;c;t to in_pipe" {
     try std.testing.expectEqual(@as(u16, 40), pty.size.ws_row);
     try std.testing.expectEqual(@as(u16, 120), pty.size.ws_col);
 }
+
+test "WindowsPty: bypass end-to-end with cmd.exe /c echo" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    const Command = @import("Command.zig");
+    const testing = std.testing;
+
+    var pty = try Pty.open(.{
+        .size = .{ .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0 },
+        .mode = .bypass,
+    });
+    defer pty.deinit();
+
+    var cmd: Command = .{
+        .path = "C:\\Windows\\System32\\cmd.exe",
+        .args = &.{ "cmd.exe", "/c", "echo hi" },
+        .stdin = .{ .handle = pty.in_pipe_pty },
+        .stdout = .{ .handle = pty.out_pipe_pty },
+        .stderr = .{ .handle = pty.out_pipe_pty },
+        .pseudo_console = null,
+        .os_pre_exec = null,
+        .rt_pre_exec = null,
+        .rt_post_fork = null,
+        .rt_pre_exec_info = undefined,
+        .rt_post_fork_info = undefined,
+    };
+    try cmd.testingStart();
+    defer _ = cmd.wait(true) catch {};
+
+    // Close our parent copies of _pty ends so EOF reaches us when
+    // the child exits. Matches the termio/Exec.zig post-spawn
+    // cleanup for bypass mode.
+    _ = windows.CloseHandle(pty.in_pipe_pty);
+    _ = windows.CloseHandle(pty.out_pipe_pty);
+    pty.in_pipe_pty = windows.INVALID_HANDLE_VALUE;
+    pty.out_pipe_pty = windows.INVALID_HANDLE_VALUE;
+
+    // Drain stdout until EOF or buffer full.
+    var buf: [256]u8 = undefined;
+    var total: usize = 0;
+    while (total < buf.len) {
+        var read: windows.DWORD = 0;
+        const ok = windows.kernel32.ReadFile(
+            pty.out_pipe,
+            buf[total..].ptr,
+            @intCast(buf.len - total),
+            &read,
+            null,
+        );
+        if (ok == 0 or read == 0) break;
+        total += read;
+    }
+
+    try testing.expect(std.mem.indexOf(u8, buf[0..total], "hi") != null);
+}

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -22,18 +22,29 @@ pub const Pty = switch (builtin.os.tag) {
     else => PosixPty,
 };
 
-/// The modes of a pty. Not all of these modes are supported on
-/// all platforms but all platforms share the same mode struct.
+/// The terminal modes of a pty. Not all of these modes are supported
+/// on all platforms but all platforms share the same mode struct.
 ///
-/// The default values of fields in this struct are set to the
-/// most typical values for a pty. This makes it easier for cross-platform
+/// The default values of fields in this struct are set to the most
+/// typical values for a pty. This makes it easier for cross-platform
 /// code which doesn't support all of the modes to work correctly.
-pub const Mode = packed struct {
+pub const TerminalMode = packed struct {
     /// ICANON on POSIX
     canonical: bool = true,
 
     /// ECHO on POSIX
     echo: bool = true,
+};
+
+/// Transport mode. Only meaningful on Windows - POSIX always uses
+/// the kernel PTY. See `Options.mode`.
+pub const Mode = enum { conpty, bypass };
+
+/// Arguments to `Pty.open`.
+pub const Options = struct {
+    size: winsize,
+    /// Windows-only. Ignored on POSIX.
+    mode: Mode = .conpty,
 };
 
 pub const ProcessInfo = enum {
@@ -66,8 +77,10 @@ const NullPty = struct {
 
     pub const OpenError = error{};
 
-    pub fn open(size: winsize) OpenError!Pty {
+    pub fn open(opts: Options) OpenError!Pty {
+        const size = opts.size;
         _ = size;
+        _ = opts.mode;
         return .{ .master = 0, .slave = 0 };
     }
 
@@ -77,7 +90,7 @@ const NullPty = struct {
 
     pub const GetModeError = error{GetModeFailed};
 
-    pub fn getMode(self: Pty) GetModeError!Mode {
+    pub fn getMode(self: Pty) GetModeError!TerminalMode {
         _ = self;
         return .{};
     }
@@ -131,7 +144,9 @@ const PosixPty = struct {
     pub const OpenError = error{OpenptyFailed};
 
     /// Open a new PTY with the given initial size.
-    pub fn open(size: winsize) OpenError!Pty {
+    pub fn open(opts: Options) OpenError!Pty {
+        const size = opts.size;
+        _ = opts.mode;
         // Need to copy so that it becomes non-const.
         var sizeCopy = size;
 
@@ -192,7 +207,7 @@ const PosixPty = struct {
 
     pub const GetModeError = error{GetModeFailed};
 
-    pub fn getMode(self: Pty) GetModeError!Mode {
+    pub fn getMode(self: Pty) GetModeError!TerminalMode {
         var attrs: c.termios = undefined;
         if (c.tcgetattr(self.master, &attrs) != 0)
             return error.GetModeFailed;
@@ -340,7 +355,9 @@ const WindowsPty = struct {
     pub const OpenError = error{Unexpected};
 
     /// Open a new PTY with the given initial size.
-    pub fn open(size: winsize) OpenError!Pty {
+    pub fn open(opts: Options) OpenError!Pty {
+        const size = opts.size;
+        _ = opts.mode; // transport branch lands in a later commit
         var pty: Pty = undefined;
 
         var pipe_path_buf: [128]u8 = undefined;
@@ -486,7 +503,7 @@ test {
         .ws_ypixel = 1,
     };
 
-    var pty = try Pty.open(ws);
+    var pty = try Pty.open(.{ .size = ws });
     defer pty.deinit();
 
     // Initialize size should match what we gave it

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -463,7 +463,23 @@ const WindowsPty = struct {
                 if (result != windows.S_OK) return error.Unexpected;
                 pty.pseudo_console = hpcon;
             },
-            .bypass => return error.Unexpected, // real impl lands in Task 5
+            .bypass => {
+                // Bypass: no pseudoconsole. The child inherits in_pipe_pty as
+                // stdin and out_pipe_pty as stdout/stderr via
+                // STARTF_USESTDHANDLES. To make that inheritance work, the
+                // _pty ends must be HANDLE_FLAG_INHERIT. Parent ends stay
+                // non-inheritable so they don't leak.
+                try windows.SetHandleInformation(
+                    pty.in_pipe_pty,
+                    windows.HANDLE_FLAG_INHERIT,
+                    windows.HANDLE_FLAG_INHERIT,
+                );
+                try windows.SetHandleInformation(
+                    pty.out_pipe_pty,
+                    windows.HANDLE_FLAG_INHERIT,
+                    windows.HANDLE_FLAG_INHERIT,
+                );
+            },
         }
 
         return pty;
@@ -550,4 +566,26 @@ test "WindowsPty: conpty mode populates pseudo_console" {
     defer pty.deinit();
     try std.testing.expect(pty.pseudo_console != null);
     try std.testing.expectEqual(Mode.conpty, pty.mode);
+}
+
+test "WindowsPty: bypass mode skips pseudo_console and flips _pty handles inheritable" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var pty = try Pty.open(.{
+        .size = .{ .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0 },
+        .mode = .bypass,
+    });
+    defer pty.deinit();
+    try std.testing.expect(pty.pseudo_console == null);
+    try std.testing.expectEqual(Mode.bypass, pty.mode);
+    try std.testing.expect(pty.in_pipe != windows.INVALID_HANDLE_VALUE);
+    try std.testing.expect(pty.out_pipe != windows.INVALID_HANDLE_VALUE);
+
+    // _pty ends must be inheritable so CreateProcessW with
+    // bInheritHandles = TRUE + HANDLE_LIST attribute passes them to
+    // the child's stdio.
+    var flags: windows.DWORD = 0;
+    try windows.GetHandleInformation(pty.in_pipe_pty, &flags);
+    try std.testing.expect((flags & windows.HANDLE_FLAG_INHERIT) != 0);
+    try windows.GetHandleInformation(pty.out_pipe_pty, &flags);
+    try std.testing.expect((flags & windows.HANDLE_FLAG_INHERIT) != 0);
 }

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -349,15 +349,17 @@ const WindowsPty = struct {
     in_pipe: windows.HANDLE,
     out_pipe_pty: windows.HANDLE,
     in_pipe_pty: windows.HANDLE,
-    pseudo_console: windows.exp.HPCON,
+    /// null when mode == .bypass. In ConPTY mode this holds the HPCON
+    /// that owns the pipe pair internally.
+    pseudo_console: ?windows.exp.HPCON,
     size: winsize,
+    mode: Mode,
 
     pub const OpenError = error{Unexpected};
 
     /// Open a new PTY with the given initial size.
     pub fn open(opts: Options) OpenError!Pty {
         const size = opts.size;
-        _ = opts.mode; // transport branch lands in a later commit
         var pty: Pty = undefined;
 
         var pipe_path_buf: [128]u8 = undefined;
@@ -444,16 +446,26 @@ const WindowsPty = struct {
         try windows.SetHandleInformation(pty.out_pipe, windows.HANDLE_FLAG_INHERIT, 0);
         try windows.SetHandleInformation(pty.out_pipe_pty, windows.HANDLE_FLAG_INHERIT, 0);
 
-        const result = windows.exp.kernel32.CreatePseudoConsole(
-            .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
-            pty.in_pipe_pty,
-            pty.out_pipe_pty,
-            0,
-            &pty.pseudo_console,
-        );
-        if (result != windows.S_OK) return error.Unexpected;
-
         pty.size = size;
+        pty.mode = opts.mode;
+        pty.pseudo_console = null;
+
+        switch (opts.mode) {
+            .conpty => {
+                var hpcon: windows.exp.HPCON = undefined;
+                const result = windows.exp.kernel32.CreatePseudoConsole(
+                    .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
+                    pty.in_pipe_pty,
+                    pty.out_pipe_pty,
+                    0,
+                    &hpcon,
+                );
+                if (result != windows.S_OK) return error.Unexpected;
+                pty.pseudo_console = hpcon;
+            },
+            .bypass => return error.Unexpected, // real impl lands in Task 5
+        }
+
         return pty;
     }
 
@@ -462,7 +474,9 @@ const WindowsPty = struct {
         _ = windows.CloseHandle(self.in_pipe);
         _ = windows.CloseHandle(self.out_pipe_pty);
         _ = windows.CloseHandle(self.out_pipe);
-        _ = windows.exp.kernel32.ClosePseudoConsole(self.pseudo_console);
+        if (self.pseudo_console) |hpcon| {
+            _ = windows.exp.kernel32.ClosePseudoConsole(hpcon);
+        }
         self.* = undefined;
     }
 
@@ -477,12 +491,17 @@ const WindowsPty = struct {
 
     /// Set the size of the pty.
     pub fn setSize(self: *Pty, size: winsize) SetSizeError!void {
-        const result = windows.exp.kernel32.ResizePseudoConsole(
-            self.pseudo_console,
-            .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
-        );
-
-        if (result != windows.S_OK) return error.ResizeFailed;
+        switch (self.mode) {
+            .conpty => {
+                const hpcon = self.pseudo_console orelse return error.ResizeFailed;
+                const result = windows.exp.kernel32.ResizePseudoConsole(
+                    hpcon,
+                    .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
+                );
+                if (result != windows.S_OK) return error.ResizeFailed;
+            },
+            .bypass => return error.ResizeFailed, // real impl lands in Task 6
+        }
         self.size = size;
     }
 
@@ -520,4 +539,15 @@ test {
         .macos => try testing.expect(std.mem.startsWith(u8, pty.getProcessInfo(.tty_name).?, "/dev/")),
         else => try testing.expect(pty.getProcessInfo(.tty_name) == null),
     }
+}
+
+test "WindowsPty: conpty mode populates pseudo_console" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    var pty = try Pty.open(.{
+        .size = .{ .ws_row = 24, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0 },
+        .mode = .conpty,
+    });
+    defer pty.deinit();
+    try std.testing.expect(pty.pseudo_console != null);
+    try std.testing.expectEqual(Mode.conpty, pty.mode);
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -899,10 +899,12 @@ const Subprocess = struct {
 
         // Create our pty
         var pty = try Pty.open(.{
-            .ws_row = @intCast(self.grid_size.rows),
-            .ws_col = @intCast(self.grid_size.columns),
-            .ws_xpixel = @intCast(self.screen_size.width),
-            .ws_ypixel = @intCast(self.screen_size.height),
+            .size = .{
+                .ws_row = @intCast(self.grid_size.rows),
+                .ws_col = @intCast(self.grid_size.columns),
+                .ws_xpixel = @intCast(self.screen_size.width),
+                .ws_ypixel = @intCast(self.screen_size.height),
+            },
         });
         self.pty = pty;
         errdefer if (!in_child) {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -571,6 +571,13 @@ pub const Config = struct {
     resources_dir: ?[]const u8,
     term: []const u8,
 
+    /// Windows ConPTY transport mode. Resolved at spawn time against the
+    /// shell classifier (see `resolveConptyMode`). Ignored on POSIX.
+    conpty_mode: if (builtin.os.tag == .windows)
+        configpkg.Config.ConptyMode
+    else
+        void = if (builtin.os.tag == .windows) .auto else {},
+
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
 };
@@ -590,6 +597,13 @@ const Subprocess = struct {
     screen_size: renderer.ScreenSize,
     pty: ?Pty = null,
     process: ?Process = null,
+
+    /// Captured from Config.conpty_mode at init time; resolved against
+    /// the shell classifier at spawn time. Ignored on POSIX.
+    conpty_mode: if (builtin.os.tag == .windows)
+        configpkg.Config.ConptyMode
+    else
+        void = if (builtin.os.tag == .windows) .auto else {},
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
@@ -865,6 +879,8 @@ const Subprocess = struct {
             .cwd = cwd,
             .args = args,
 
+            .conpty_mode = cfg.conpty_mode,
+
             .rt_pre_exec_info = cfg.rt_pre_exec_info,
             .rt_post_fork_info = cfg.rt_post_fork_info,
 
@@ -897,6 +913,13 @@ const Subprocess = struct {
         // process).
         var in_child: bool = false;
 
+        // Resolve the transport mode from config + shell classification.
+        // Windows-only; POSIX ignores opts.mode.
+        const mode: ptypkg.Mode = if (comptime builtin.os.tag == .windows)
+            resolveConptyMode(self.conpty_mode, self.args[0])
+        else
+            .conpty;
+
         // Create our pty
         var pty = try Pty.open(.{
             .size = .{
@@ -905,6 +928,7 @@ const Subprocess = struct {
                 .ws_xpixel = @intCast(self.screen_size.width),
                 .ws_ypixel = @intCast(self.screen_size.height),
             },
+            .mode = mode,
         });
         self.pty = pty;
         errdefer if (!in_child) {
@@ -924,6 +948,24 @@ const Subprocess = struct {
                 // side. This prevents the slave fd from being leaked to
                 // future children.
                 _ = posix.close(pty.slave);
+            } else {
+                // In bypass mode the child holds its own inherited dup of
+                // `in_pipe_pty` / `out_pipe_pty`. Close our parent copies
+                // so EOF propagates on `out_pipe` when the child exits.
+                // In ConPTY mode the pseudoconsole owns those handles
+                // internally and we keep them alive until `Pty.deinit`.
+                if (mode == .bypass) {
+                    _ = windows.CloseHandle(pty.in_pipe_pty);
+                    _ = windows.CloseHandle(pty.out_pipe_pty);
+                    pty.in_pipe_pty = windows.INVALID_HANDLE_VALUE;
+                    pty.out_pipe_pty = windows.INVALID_HANDLE_VALUE;
+                    // Keep `self.pty` in sync; `Pty.deinit` tolerates
+                    // `INVALID_HANDLE_VALUE` via `CloseHandle` returning 0.
+                    if (self.pty) |*sp| {
+                        sp.in_pipe_pty = windows.INVALID_HANDLE_VALUE;
+                        sp.out_pipe_pty = windows.INVALID_HANDLE_VALUE;
+                    }
+                }
             }
 
             // Successful start we can clear out some memory.
@@ -1007,16 +1049,42 @@ const Subprocess = struct {
             };
         }
 
-        // Build our subcommand
+        // Build our subcommand. On Windows, stdio and `pseudo_console` are
+        // wired differently per transport mode: ConPTY owns stdio via the
+        // pseudoconsole handle; bypass mode feeds the child our raw pipe
+        // ends and leaves `pseudo_console` null.
         var cmd: Command = .{
             .path = self.args[0],
             .args = self.args,
             .env = if (self.env) |*env| env else null,
             .cwd = cwd,
-            .stdin = if (builtin.os.tag == .windows) null else .{ .handle = pty.slave },
-            .stdout = if (builtin.os.tag == .windows) null else .{ .handle = pty.slave },
-            .stderr = if (builtin.os.tag == .windows) null else .{ .handle = pty.slave },
-            .pseudo_console = if (builtin.os.tag == .windows) pty.pseudo_console else {},
+            .stdin = if (comptime builtin.os.tag == .windows)
+                switch (mode) {
+                    .bypass => std.fs.File{ .handle = pty.in_pipe_pty },
+                    .conpty => null,
+                }
+            else
+                .{ .handle = pty.slave },
+            .stdout = if (comptime builtin.os.tag == .windows)
+                switch (mode) {
+                    .bypass => std.fs.File{ .handle = pty.out_pipe_pty },
+                    .conpty => null,
+                }
+            else
+                .{ .handle = pty.slave },
+            .stderr = if (comptime builtin.os.tag == .windows)
+                switch (mode) {
+                    .bypass => std.fs.File{ .handle = pty.out_pipe_pty },
+                    .conpty => null,
+                }
+            else
+                .{ .handle = pty.slave },
+            .pseudo_console = if (comptime builtin.os.tag == .windows)
+                switch (mode) {
+                    .conpty => pty.pseudo_console,
+                    .bypass => null,
+                }
+            else {},
             .os_pre_exec = switch (comptime builtin.os.tag) {
                 .windows => null,
                 else => f: {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1658,6 +1658,29 @@ pub fn getProcessInfo(self: *Exec, comptime info: ProcessInfo) ?ProcessInfo.Type
     return self.subprocess.getProcessInfo(info);
 }
 
+/// Resolve the requested transport mode at spawn time. Windows-only
+/// in effect; POSIX callers should pass `.conpty` and the value is
+/// ignored by PosixPty.
+///
+/// - `.never` always picks ConPTY (classic behavior).
+/// - `.always` always picks the raw-pipe bypass.
+/// - `.auto` defers to the shell classifier: VT-aware shells use the
+///   bypass, console-API shells and anything unrecognized fall back
+///   to ConPTY so unknown programs keep the safe default.
+fn resolveConptyMode(
+    cfg: configpkg.Config.ConptyMode,
+    exe_path: []const u8,
+) ptypkg.Mode {
+    return switch (cfg) {
+        .never => .conpty,
+        .always => .bypass,
+        .auto => switch (internal_os.windows_shell.classify(exe_path)) {
+            .vt_aware => .bypass,
+            .console_api, .unknown => .conpty,
+        },
+    };
+}
+
 test "execCommand darwin: shell command" {
     if (comptime !builtin.os.tag.isDarwin()) return error.SkipZigTest;
 
@@ -1965,4 +1988,32 @@ test "windowsShellNeedsCmdWrapping" {
     try testing.expect(windowsShellNeedsCmdWrapping("echo %USERNAME%"));
     try testing.expect(windowsShellNeedsCmdWrapping("echo !var!"));
     try testing.expect(windowsShellNeedsCmdWrapping("a^b"));
+}
+
+test "resolveConptyMode: never forces conpty" {
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.never, "pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.never, "cmd.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.never, "unknown.exe"));
+}
+
+test "resolveConptyMode: always forces bypass" {
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.always, "pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.always, "cmd.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.always, "unknown.exe"));
+}
+
+test "resolveConptyMode: auto picks bypass for vt_aware" {
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "wsl.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "bash"));
+}
+
+test "resolveConptyMode: auto picks conpty for console_api" {
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "cmd.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "powershell.exe"));
+}
+
+test "resolveConptyMode: auto picks conpty for unknown (safe default)" {
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "my-custom.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, ""));
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -349,7 +349,7 @@ fn termiosTimer(
 
     // This is kind of hacky but we rebuild a Pty struct to get the
     // termios data.
-    const mode: ptypkg.Mode = (Pty{
+    const mode: ptypkg.TerminalMode = (Pty{
         .master = exec.read_thread_fd,
         .slave = undefined,
     }).getMode() catch |err| err: {
@@ -538,7 +538,7 @@ pub const ThreadData = struct {
 
     /// The last known termios mode. Used for change detection
     /// to prevent unnecessary locking of expensive mutexes.
-    termios_mode: ptypkg.Mode = .{},
+    termios_mode: ptypkg.TerminalMode = .{},
 
     pub fn deinit(self: *ThreadData, alloc: Allocator) void {
         posix.close(self.read_thread_pipe);


### PR DESCRIPTION
First child of umbrella #263 section 1 to ship behavior, not just infrastructure.

Adds a Windows-only `conpty-mode = auto|always|never` config key (default `auto`).
When the spawned shell is VT-aware (pwsh, wsl, ssh, bash, nu, zsh, fish, elvish,
xonsh) the session uses raw stdin/stdout/stderr pipes via STARTF_USESTDHANDLES
instead of CreatePseudoConsole. cmd.exe and PowerShell 5.1 keep the ConPTY path.

The VT-awareness classifier is a Zig port of the merged C# ShellDetector
(PR #266). The C# copy stays during the transition; removing it is a later PR.

## Security fix along the way

The pre-existing no-pseudo-console branch in Command.zig relied on
`bInheritHandles = TRUE` with no attribute-list restriction, which leaks every
inheritable parent handle to the child. The bypass path now adds a
`PROC_THREAD_ATTRIBUTE_HANDLE_LIST` whitelisting just the three stdio handles.

## Resize signalling

Bypass resize is best-effort via `CSI 8;r;c;t` written to the child's stdin.
Shells that parse XTWINOPS pick it up; others ignore. Full resize parity
(SIGWINCH via WSL, per-shell signalling) is a follow-up per umbrella #263 sec 5.

## Explicit deferrals

- Subprocess inheritance (pwsh-spawns-cmd leaks raw pipes into a Console API child)
- WSL SIGWINCH interop
- Signal delivery parity (0x03 / 0x04 / 0x1A)
- Retiring the C# ShellDetector
- Transport contract tests (depend on #79)
- Perf gating in CI

## Tests

- 12 classifier unit tests (pure logic, runs on every platform)
- 5 mode-resolver unit tests
- 4 WindowsPty tests (conpty mode populates HPCON, bypass clears it + flips
  inherit flags, bypass setSize writes CSI 8, end-to-end cmd.exe echo through
  the full bypass path)
- All existing Command.zig + os/hostname tests still green
- `zig build test -Dapp-runtime=none` green on rebased branch
- `dotnet build windows/Ghostty.sln` green
- Manual: `Ghostty.exe` launches with clean stderr

## Baseline

An earlier draft of this PR reported an apprt startup crash
(`error.Unexpected: GetLastError(2)`) and blamed it on this branch. That
was misattribution. The crash reproduced identically on `windows` and was
a pre-existing bug from PR #285 where bare shell names like `cmd.exe`
were handed to `CreateProcessW`'s `lpApplicationName` (which requires a
fully qualified path). PR #287 fixed it in `Command.zig` + `os/path.zig`.
This branch is now rebased on top of that fix and launches clean.

## Stack reference

- Umbrella: #263
- Detector landed: #266
- Bench harness: #267 (and follow-ups #270, #272, #273)
- `command` config bug surfaced + fixed: #281 / #285
- Path-resolution fix unblocking this PR: #287