### PR TITLE
fix(termio): resolve bare shell names before CreateProcessW

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -27,6 +27,7 @@ const mem = std.mem;
 const linux = std.os.linux;
 const posix = std.posix;
 const debug = std.debug;
+const log = std.log.scoped(.command);
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const File = std.fs.File;
@@ -258,7 +259,25 @@ fn startPosix(self: *Command, arena: Allocator) !void {
 }
 
 fn startWindows(self: *Command, arena: Allocator) !void {
-    const application_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, self.path);
+    // CreateProcessW's lpApplicationName requires a fully qualified
+    // path. Passing a bare executable name like "cmd.exe" or
+    // "pwsh.exe" relies on the current working directory containing
+    // the module, which it usually doesn't, so the spawn fails with
+    // ERROR_FILE_NOT_FOUND even when the executable is on PATH.
+    //
+    // `internal_os.path.expand` does the PATH search for bare names
+    // and returns already-qualified paths (including drive-relative
+    // ones) unchanged. Fall back to the raw value if resolution
+    // fails so any spawn error surfaces from CreateProcessW with the
+    // original command rather than being masked here.
+    const resolved_path: []const u8 = blk: {
+        const r = internal_os.path.expand(arena, self.path) catch |err| {
+            log.warn("failed to resolve path on PATH cmd={s} err={}", .{ self.path, err });
+            break :blk self.path;
+        };
+        break :blk r orelse self.path;
+    };
+    const application_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, resolved_path);
     const cwd_w = if (self.cwd) |cwd| try std.unicode.utf8ToUtf16LeAllocZ(arena, cwd) else null;
     const command_line_w = if (self.args.len > 0) b: {
         const command_line = try windowsCreateCommandLine(arena, self.args);

--- a/src/os/path.zig
+++ b/src/os/path.zig
@@ -7,9 +7,16 @@ const testing = std.testing;
 /// always allocate if there is a non-null result. The caller must free the
 /// resulting value.
 pub fn expand(alloc: Allocator, cmd: []const u8) !?[]u8 {
-    // If the command already contains a slash, then we return it as-is
-    // because it is assumed to be absolute or relative.
-    if (std.mem.indexOfScalar(u8, cmd, '/') != null) {
+    // If the command already contains a path separator, return as-is.
+    // POSIX: '/'. Windows additionally accepts '\\' and drive-letter
+    // prefixes like 'X:'. Without the Windows extensions a path such
+    // as `C:\Windows\System32\cmd.exe` would miss the fast path and
+    // get joined onto every PATH dir, always producing null.
+    const already_path = std.mem.indexOfScalar(u8, cmd, '/') != null or
+        (builtin.os.tag == .windows and
+            (std.mem.indexOfScalar(u8, cmd, '\\') != null or
+                (cmd.len >= 2 and std.ascii.isAlphabetic(cmd[0]) and cmd[1] == ':')));
+    if (already_path) {
         return try alloc.dupe(u8, cmd);
     }
 
@@ -86,4 +93,32 @@ test "expand: slash" {
     const path = (try expand(testing.allocator, "foo/env")).?;
     defer testing.allocator.free(path);
     try testing.expect(path.len == 7);
+}
+
+test "expand: windows backslash passes through" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    const input = "C:\\Windows\\System32\\cmd.exe";
+    const path = (try expand(testing.allocator, input)).?;
+    defer testing.allocator.free(path);
+    try testing.expectEqualStrings(input, path);
+}
+
+test "expand: windows drive-letter only passes through" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    // No separator, but the drive prefix means this is already a
+    // path (drive-relative) and expand() must not treat it as a
+    // bare name to search PATH for.
+    const input = "C:cmd.exe";
+    const path = (try expand(testing.allocator, input)).?;
+    defer testing.allocator.free(path);
+    try testing.expectEqualStrings(input, path);
+}
+
+test "expand: windows bare cmd.exe resolves on PATH" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    const path = (try expand(testing.allocator, "cmd.exe")).?;
+    defer testing.allocator.free(path);
+    // System32\cmd.exe lives on the default Windows PATH.
+    try testing.expect(std.ascii.endsWithIgnoreCase(path, "cmd.exe"));
+    try testing.expect(path.len > "cmd.exe".len);
 }


### PR DESCRIPTION
## Context

PR 285 switched Windows shell spawning from \`cmd.exe /C <cmd>\` wrapping
to a direct spawn of the first token. That's the right shape for
\`command = pwsh.exe\` (issue 281), but it silently broke the default
shell too.

## Bug

With no user \`command\`, Config falls back to \`.shell = \"cmd.exe\"\`.
\`execCommand\` then produces \`args = [\"cmd.exe\"]\` and \`Command.start\`
passes that bare name as \`lpApplicationName\` to \`CreateProcessW\`,
which requires a fully qualified path and returns
\`ERROR_FILE_NOT_FOUND\` when it gets one that isn't.

The failure surfaces on the termio thread a moment after surface init
as:

\`\`\`
error.Unexpected: GetLastError(2): The system cannot find the file specified.
\`\`\`

The C# host doesn't die (the error is on a background thread), so a
GUI window still appears - hence the bug hid in plain sight on
\`windows\`. Any user \`command = pwsh.exe\` without an absolute path
hits it too.

## Fix

Run \`Command.path\` through \`internal_os.path.expand\` inside
\`Command.startWindows\` so a PATH search happens in Zig before the
\`CreateProcessW\` call. Already-qualified paths pass through
unchanged.

\`path.expand\` only recognised \`/\` as a separator - any Windows
path like \`C:\\Windows\\System32\\cmd.exe\` missed the fast path
and got joined onto every PATH dir, always producing \`null\`. Teach
it about \`\\\` and the \`X:\` drive-letter prefix too, with tests.

## Test plan

- [x] Existing Zig tests pass.
- [x] New tests cover Windows backslash, drive-letter-only, and bare
      \`cmd.exe\` PATH resolution.
- [x] Manual: Ghostty.exe launches with a clean stderr and the
      terminal child spawns (verified by bypassing the GUI and
      checking the termio flow completes without the Unexpected error).