### PR TITLE
feat(windows): libghostty to C# log callback bridge

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1272,6 +1272,23 @@ GHOSTTY_API void ghostty_set_window_background_blur(ghostty_app_t, void*);
 // Benchmark API, if available.
 GHOSTTY_API bool ghostty_benchmark_cli(const char*, const char*);
 
+// Log bridge. Lets an embedder receive every std.log message libghostty
+// emits. scope_ptr/message_ptr are NOT null-terminated; use the
+// companion length. user_data is echoed verbatim from the registration
+// call. Invoked from whichever thread produces the log, so callbacks
+// must be thread-safe. Level ordinals are pinned:
+//   0 = debug, 1 = info, 2 = warn, 3 = err.
+// Pass NULL cb to clear any previously-installed callback.
+typedef void (*ghostty_log_callback)(
+    uint32_t level,
+    const char *scope_ptr,
+    uintptr_t scope_len,
+    const char *message_ptr,
+    uintptr_t message_len,
+    void *user_data);
+GHOSTTY_API void ghostty_log_set_callback(ghostty_log_callback cb,
+                                          void *user_data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/log_bridge.zig
+++ b/src/log_bridge.zig
@@ -1,0 +1,355 @@
+//! Embedder log bridge for libghostty.
+//!
+//! Exports a C API that lets the embedder (e.g. the Windows C# shell)
+//! register a callback to receive every std.log message produced by
+//! libghostty. The callback is invoked from inside logFn in
+//! main_ghostty.zig, alongside the existing macOS-unified-log and stderr
+//! sinks. On Windows this is the only sink that actually reaches the
+//! user: the WinUI 3 GUI-subsystem exe has no console and macOS unified
+//! log is not available, so Zig logs otherwise vanish.
+//!
+//! Level mapping contract (stable, do not change these integers once
+//! embedders exist):
+//!   0 -> debug
+//!   1 -> info
+//!   2 -> warn
+//!   3 -> err
+//!
+//! Thread safety: logFn may be called from any thread, so the global
+//! callback pointer is loaded with an atomic read. The callback itself
+//! must be reentrant-safe and must not call back into libghostty's
+//! logger in a way that would deadlock.
+//!
+//! Encoding: scope bytes are ASCII (they come from Zig enum tag names).
+//! Message bytes may be arbitrary UTF-8 (paths, shell command values,
+//! etc.). We pass raw bytes in both cases; the embedder decodes.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Stable integer mapping for std.log.Level. std.log.Level's own
+/// ordinals are not part of any public contract and could shift across
+/// Zig versions; by going through this enum the ABI seen by embedders
+/// is pinned regardless of std internals. Keep the values synchronized
+/// with the embedder (see the level mapping contract in the file doc
+/// comment above).
+pub const Level = enum(u32) {
+    debug = 0,
+    info = 1,
+    warn = 2,
+    err = 3,
+};
+
+/// Callback signature the embedder registers. The scope and message
+/// bytes are NOT null-terminated; use the companion length. user_data
+/// is echoed verbatim from the registration call.
+pub const LogCallback = ?*const fn (
+    level: u32,
+    scope_ptr: [*]const u8,
+    scope_len: usize,
+    message_ptr: [*]const u8,
+    message_len: usize,
+    user_data: ?*anyopaque,
+) callconv(.c) void;
+
+/// Maximum rendered message length in bytes. Messages longer than this
+/// are truncated and get a suffix appended (see truncated_suffix).
+/// The bound exists so we can render the formatted message into a
+/// fixed stack buffer per log call and never allocate. 64 KiB is far
+/// larger than any real log line but small enough to fit comfortably on
+/// the stack of any Zig-created thread.
+pub const max_message_bytes: usize = 64 * 1024;
+
+/// Appended to the end of a truncated message so consumers can tell.
+/// Chosen short and ASCII so it always fits in the final bytes of the
+/// buffer without further truncation considerations.
+pub const truncated_suffix: []const u8 = " [truncated]";
+
+// Global callback state. Split across two atomics so the function
+// pointer and user_data stay in sync at the moment of registration:
+// both are stored atomically, and the dispatch path reads the callback
+// pointer first, then user_data. A benign race is possible where a
+// caller tears down the callback between the two loads and we pass
+// stale user_data into a null callback - but we always check the
+// callback pointer for null before invoking, so no harm occurs.
+//
+// We store the function pointer as a usize (its bit pattern) rather
+// than a typed pointer because std.atomic.Value does not support
+// function-pointer generic args. A zero value means "no callback".
+var cb_bits: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+var cb_user_data: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+
+/// Install (or clear) the embedder log callback. Pass null to clear.
+/// Safe to call from any thread.
+pub fn setCallback(cb: LogCallback, user_data: ?*anyopaque) void {
+    const cb_as_int: usize = if (cb) |fn_ptr| @intFromPtr(fn_ptr) else 0;
+    const ud_as_int: usize = if (user_data) |ud| @intFromPtr(ud) else 0;
+    // Release ordering on the store pair so any writes the embedder
+    // did to memory it will hand back via user_data happen-before the
+    // callback sees them.
+    cb_user_data.store(ud_as_int, .release);
+    cb_bits.store(cb_as_int, .release);
+}
+
+/// Dispatch a log event to the embedder callback, if one is set.
+/// Called from logFn. The format+args are rendered into a stack
+/// buffer so the callback receives a fully-formatted message without
+/// any Zig formatter reentering the logger.
+pub fn dispatch(
+    level: std.log.Level,
+    comptime scope: @TypeOf(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    // Fast path: no embedder, nothing to do. One atomic load per log
+    // call is a few nanoseconds, which is negligible compared to the
+    // cost of formatting the message.
+    const cb_int = cb_bits.load(.acquire);
+    if (cb_int == 0) return;
+
+    const cb: *const fn (
+        u32,
+        [*]const u8,
+        usize,
+        [*]const u8,
+        usize,
+        ?*anyopaque,
+    ) callconv(.c) void = @ptrFromInt(cb_int);
+
+    const ud_int = cb_user_data.load(.acquire);
+    const ud: ?*anyopaque = if (ud_int == 0) null else @ptrFromInt(ud_int);
+
+    const level_int: u32 = @intFromEnum(levelToExport(level));
+
+    // Render the message into a stack buffer using a fixed Writer.
+    // std.Io.Writer.fixed keeps the bytes it successfully wrote in
+    // `writer.end` even when a subsequent write fails with
+    // error.WriteFailed (the zig 0.15 fixed writer's overflow error),
+    // so we can salvage a partial render and append a truncation
+    // suffix instead of dropping the whole message.
+    var buf: [max_message_bytes]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    const overflowed: bool = blk: {
+        writer.print(format, args) catch break :blk true;
+        break :blk false;
+    };
+    const rendered: []const u8 = if (overflowed) overflow: {
+        // On overflow writer.end is at or near buf.len. Reserve room
+        // for the suffix by moving the end back by suffix.len (this
+        // may drop a handful of bytes off the tail of the partial
+        // message, which is an acceptable trade for a clear marker).
+        const keep = if (buf.len >= truncated_suffix.len) buf.len - truncated_suffix.len else 0;
+        @memcpy(buf[keep..][0..truncated_suffix.len], truncated_suffix);
+        break :overflow buf[0..buf.len];
+    } else buf[0..writer.end];
+
+    // Scope bytes are the enum tag name. For the default scope we pass
+    // an empty byte slice so the embedder can decide how to render it.
+    const scope_name: []const u8 = if (scope == .default) "" else @tagName(scope);
+
+    // Normalize: avoid passing a null base pointer when len is 0. Some
+    // C# marshalers refuse to decode a (null, 0) pair.
+    const scope_ptr: [*]const u8 = if (scope_name.len == 0) &empty_sentinel else scope_name.ptr;
+    const msg_ptr: [*]const u8 = if (rendered.len == 0) &empty_sentinel else rendered.ptr;
+
+    cb(level_int, scope_ptr, scope_name.len, msg_ptr, rendered.len, ud);
+}
+
+/// One-byte sentinel so we never hand a null base pointer to the
+/// embedder, even for zero-length slices. Using a file-scope const
+/// gives it a stable address.
+const empty_sentinel: [1]u8 = .{0};
+
+fn levelToExport(level: std.log.Level) Level {
+    return switch (level) {
+        .debug => .debug,
+        .info => .info,
+        .warn => .warn,
+        .err => .err,
+    };
+}
+
+// --- C API ------------------------------------------------------------
+// Exported into libghostty from src/main_c.zig.
+
+/// Register or clear the embedder log callback.
+///
+/// Passing null for `cb` clears any previously-installed callback. The
+/// callback is invoked from whichever thread emits a std.log call, so
+/// embedders must handle multi-threaded invocation.
+///
+/// Level integers are stable: see the Level enum in this file.
+///
+/// Scope and message bytes are NOT null-terminated. Use the companion
+/// length argument.
+pub export fn ghostty_log_set_callback(
+    cb: LogCallback,
+    user_data: ?*anyopaque,
+) void {
+    setCallback(cb, user_data);
+}
+
+// --- Tests ------------------------------------------------------------
+
+const testing = std.testing;
+
+const CaptureState = struct {
+    level: u32 = 0,
+    scope: [64]u8 = undefined,
+    scope_len: usize = 0,
+    message: [256]u8 = undefined,
+    message_len: usize = 0,
+    called: usize = 0,
+};
+
+fn captureCallback(
+    level: u32,
+    scope_ptr: [*]const u8,
+    scope_len: usize,
+    message_ptr: [*]const u8,
+    message_len: usize,
+    user_data: ?*anyopaque,
+) callconv(.c) void {
+    const state: *CaptureState = @ptrCast(@alignCast(user_data.?));
+    state.level = level;
+    state.scope_len = @min(scope_len, state.scope.len);
+    @memcpy(state.scope[0..state.scope_len], scope_ptr[0..state.scope_len]);
+    state.message_len = @min(message_len, state.message.len);
+    @memcpy(state.message[0..state.message_len], message_ptr[0..state.message_len]);
+    state.called += 1;
+}
+
+test "dispatch with no callback set is a no-op" {
+    setCallback(null, null);
+    // Must not crash even though no callback is registered.
+    dispatch(.info, .some_scope, "hello {d}", .{42});
+}
+
+test "dispatch routes level, scope, and formatted message" {
+    var state: CaptureState = .{};
+    setCallback(captureCallback, &state);
+    defer setCallback(null, null);
+
+    dispatch(.info, .test_scope, "hello {d}", .{42});
+
+    try testing.expectEqual(@as(usize, 1), state.called);
+    try testing.expectEqual(@as(u32, @intFromEnum(Level.info)), state.level);
+    try testing.expectEqualStrings("test_scope", state.scope[0..state.scope_len]);
+    try testing.expectEqualStrings("hello 42", state.message[0..state.message_len]);
+}
+
+test "dispatch forwards user_data verbatim to the callback" {
+    const Probe = struct {
+        var seen_user_data: ?*anyopaque = null;
+        var expected: u32 = 0xdeadbeef;
+        fn cb(
+            _: u32,
+            _: [*]const u8,
+            _: usize,
+            _: [*]const u8,
+            _: usize,
+            user_data: ?*anyopaque,
+        ) callconv(.c) void {
+            seen_user_data = user_data;
+        }
+    };
+    Probe.seen_user_data = null;
+
+    setCallback(Probe.cb, @ptrCast(&Probe.expected));
+    defer setCallback(null, null);
+
+    dispatch(.info, .s, "x", .{});
+
+    try testing.expect(Probe.seen_user_data != null);
+    try testing.expectEqual(
+        @as(?*anyopaque, @ptrCast(&Probe.expected)),
+        Probe.seen_user_data,
+    );
+}
+
+test "dispatch maps each std.log.Level to the documented integer" {
+    var state: CaptureState = .{};
+    setCallback(captureCallback, &state);
+    defer setCallback(null, null);
+
+    dispatch(.debug, .s, "d", .{});
+    try testing.expectEqual(@as(u32, 0), state.level);
+
+    dispatch(.info, .s, "i", .{});
+    try testing.expectEqual(@as(u32, 1), state.level);
+
+    dispatch(.warn, .s, "w", .{});
+    try testing.expectEqual(@as(u32, 2), state.level);
+
+    dispatch(.err, .s, "e", .{});
+    try testing.expectEqual(@as(u32, 3), state.level);
+}
+
+test "dispatch with default scope passes an empty scope slice" {
+    var state: CaptureState = .{};
+    setCallback(captureCallback, &state);
+    defer setCallback(null, null);
+
+    dispatch(.info, .default, "x", .{});
+    try testing.expectEqual(@as(usize, 0), state.scope_len);
+}
+
+test "dispatch truncates an oversized message with a suffix" {
+    // Capture into a buffer large enough to hold the full
+    // max_message_bytes + suffix so we can inspect the tail directly.
+    const Big = struct {
+        var called: usize = 0;
+        var seen_len: usize = 0;
+        var buf: [max_message_bytes]u8 = undefined;
+    };
+    Big.called = 0;
+    Big.seen_len = 0;
+
+    const Cb = struct {
+        fn cb(
+            _: u32,
+            _: [*]const u8,
+            _: usize,
+            message_ptr: [*]const u8,
+            message_len: usize,
+            _: ?*anyopaque,
+        ) callconv(.c) void {
+            Big.called += 1;
+            Big.seen_len = @min(message_len, Big.buf.len);
+            @memcpy(Big.buf[0..Big.seen_len], message_ptr[0..Big.seen_len]);
+        }
+    };
+
+    setCallback(Cb.cb, null);
+    defer setCallback(null, null);
+
+    // Build a format string that is guaranteed to overflow the stack
+    // buffer: max_message_bytes + 16 copies of 'A'. After truncation
+    // the rendered length must equal buf.len and the tail must be
+    // truncated_suffix.
+    const big = "A" ** (max_message_bytes + 16);
+    dispatch(.info, .s, big, .{});
+
+    try testing.expectEqual(@as(usize, 1), Big.called);
+    try testing.expectEqual(max_message_bytes, Big.seen_len);
+    // Tail is the truncation suffix.
+    const tail_start = max_message_bytes - truncated_suffix.len;
+    try testing.expectEqualStrings(truncated_suffix, Big.buf[tail_start..max_message_bytes]);
+    // Everything before the suffix is still 'A'.
+    for (Big.buf[0..tail_start]) |c| {
+        try testing.expectEqual(@as(u8, 'A'), c);
+    }
+}
+
+test "clearing the callback stops dispatch" {
+    var state: CaptureState = .{};
+    setCallback(captureCallback, &state);
+
+    dispatch(.info, .s, "first", .{});
+    try testing.expectEqual(@as(usize, 1), state.called);
+
+    setCallback(null, null);
+    dispatch(.info, .s, "second", .{});
+    // Still 1 - the clear prevented the second call.
+    try testing.expectEqual(@as(usize, 1), state.called);
+}

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -43,6 +43,11 @@ comptime {
     // Our benchmark API. We probably want to gate this on a build
     // config in the future but for now we always just export it.
     _ = @import("benchmark/main.zig").CApi;
+
+    // Embedder log callback bridge. Referenced here so the
+    // ghostty_log_set_callback export lands in libghostty even when
+    // main_ghostty.zig imports log_bridge only via logFn.
+    _ = @import("log_bridge.zig");
 }
 
 /// ghostty_info_s

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -13,6 +13,7 @@ const apprt = @import("apprt.zig");
 
 const App = @import("App.zig");
 const Ghostty = @import("main_c.zig").Ghostty;
+const log_bridge = @import("log_bridge.zig");
 const state = &@import("global.zig").state;
 
 /// The return type for main() depends on the build artifact. The lib build
@@ -118,6 +119,14 @@ fn logFn(
     comptime format: []const u8,
     args: anytype,
 ) void {
+    // Embedder bridge. When the embedder (e.g. the Windows C# shell)
+    // has registered a callback via ghostty_log_set_callback, render
+    // the formatted message once and hand it over. Runs on every
+    // platform when a callback is set; on Windows this is the only
+    // sink that reaches a reader because the GUI-subsystem exe has no
+    // console and macOS unified log is unavailable.
+    log_bridge.dispatch(level, scope, format, args);
+
     // On Mac, we use unified logging. To view this:
     //
     //   sudo log stream --level debug --predicate 'subsystem=="com.mitchellh.ghostty"'
@@ -190,6 +199,7 @@ test {
     _ = @import("surface_mouse.zig");
 
     // Libraries
+    _ = @import("log_bridge.zig");
     _ = @import("tripwire.zig");
     _ = @import("benchmark/main.zig");
     _ = @import("crash/main.zig");

--- a/windows/Ghostty.Core/Logging/LibghosttyLogBridge.cs
+++ b/windows/Ghostty.Core/Logging/LibghosttyLogBridge.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Logging;
+
+/// <summary>
+/// Forwards libghostty's Zig std.log output into the process-wide
+/// <see cref="ILoggerFactory"/> so Zig messages land in every sink the
+/// C# shell already uses (ETW, rolling file, anything else the bootstrap
+/// registers).
+///
+/// libghostty calls <c>ghostty_log_set_callback(cb, user_data)</c> to
+/// register an embedder callback. Without that bridge the Windows
+/// GUI-subsystem exe gets nothing: stderr is disconnected and macOS
+/// unified logging is not an option. The callback is invoked from
+/// whichever thread emits a log call, so the bridge makes no assumption
+/// about which thread runs <see cref="Log"/>.
+///
+/// Level mapping (contract pinned on the Zig side in log_bridge.zig):
+///   0 -> <see cref="LogLevel.Debug"/>
+///   1 -> <see cref="LogLevel.Information"/>
+///   2 -> <see cref="LogLevel.Warning"/>
+///   3 -> <see cref="LogLevel.Error"/>
+///
+/// Category format: <c>Ghostty.Zig.&lt;scope&gt;</c>. Scope comes
+/// straight from Zig's <c>@tagName(scope)</c>. For the default scope
+/// (empty bytes) we use <c>Ghostty.Zig</c> with no suffix.
+/// </summary>
+internal sealed class LibghosttyLogBridge : IDisposable
+{
+    /// <summary>
+    /// Abstracts the native <c>ghostty_log_set_callback</c> call so the
+    /// bridge can be exercised in tests without loading libghostty.dll.
+    /// The real implementation (in the WinUI 3 shell project) P/Invokes
+    /// through <c>NativeMethods.LogSetCallback</c>.
+    /// </summary>
+    internal interface INativeInstaller
+    {
+        void SetCallback(IntPtr callback, IntPtr userData);
+    }
+
+    /// <summary>
+    /// Matches <c>ghostty_log_set_callback</c>'s callback signature in
+    /// include/ghostty.h (exported by src/log_bridge.zig). Bytes are
+    /// NOT null-terminated; use the companion length. The corresponding
+    /// delegate in the WinUI shell's NativeMethods uses the same shape;
+    /// both must stay in lockstep.
+    /// </summary>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void LogCallbackDelegate(
+        uint level,
+        IntPtr scopePtr,
+        UIntPtr scopeLen,
+        IntPtr messagePtr,
+        UIntPtr messageLen,
+        IntPtr userData);
+
+    // Logger category prefix. Shared as a constant so the smoke parser
+    // on the parent test harness can match emission by prefix.
+    internal const string CategoryPrefix = "Ghostty.Zig";
+    internal const string DefaultCategory = "Ghostty.Zig";
+
+    private readonly ILoggerFactory _factory;
+    private readonly INativeInstaller _installer;
+
+    // Keep the callback delegate alive through a strong field. Zig
+    // holds a raw function pointer via Marshal.GetFunctionPointerForDelegate;
+    // if the delegate were collected the next callback would jump into
+    // freed memory. A plain managed reference plus the bridge's own
+    // lifetime is enough -- the delegate is unreferenced from native
+    // code as soon as Dispose clears the callback.
+    private readonly LogCallbackDelegate _callback;
+    private readonly IntPtr _callbackPtr;
+
+    // One ILogger per unique scope. Zig scope names are small and
+    // bounded (enum tag names from src/log.zig), so the cache size
+    // stays tiny. ConcurrentDictionary because the callback may fire
+    // concurrently from multiple Zig threads. Post-warmup this cache
+    // amortizes the per-call UTF-8 decode and string concat in
+    // ReadCategory; a cold call allocates two strings, a warm call
+    // allocates one (the scope) and reuses the cached logger.
+    private readonly ConcurrentDictionary<string, ILogger> _loggers = new(StringComparer.Ordinal);
+
+    // Static factory delegate for ConcurrentDictionary.GetOrAdd's
+    // (TKey, Func<TKey, TArg, TValue>, TArg) overload. Passing a
+    // static method group + state avoids allocating a fresh closure
+    // delegate on every OnLog call.
+    private static readonly Func<string, ILoggerFactory, ILogger> s_createLogger =
+        static (category, factory) => factory.CreateLogger(category);
+
+    private int _disposed; // 0=live, 1=disposed; swapped via Interlocked.
+
+    internal LibghosttyLogBridge(ILoggerFactory factory, INativeInstaller installer)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(installer);
+        _factory = factory;
+        _installer = installer;
+
+        // Build the delegate once. GetFunctionPointerForDelegate gives
+        // a pointer that Zig stores verbatim; we hand the same pointer
+        // back to clear the callback on Dispose, via null.
+        _callback = OnLog;
+        _callbackPtr = Marshal.GetFunctionPointerForDelegate(_callback);
+    }
+
+    /// <summary>
+    /// Register the callback with libghostty. After this returns, every
+    /// Zig log call produces an <see cref="ILogger"/> emission under
+    /// category <c>Ghostty.Zig.&lt;scope&gt;</c>.
+    /// </summary>
+    internal void Install()
+    {
+        ObjectDisposedException.ThrowIf(_disposed != 0, this);
+        _installer.SetCallback(_callbackPtr, IntPtr.Zero);
+    }
+
+    /// <summary>
+    /// Clear the callback and drop the delegate reference. Safe to call
+    /// multiple times. After disposal any in-flight Zig thread that
+    /// already latched the callback pointer still runs to completion
+    /// (the GCHandle keeps the delegate alive via the field until this
+    /// object itself is collected), but libghostty will not issue any
+    /// new invocations.
+    /// </summary>
+    public void Dispose()
+    {
+        if (System.Threading.Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        // Best-effort: clear the native side first so new calls stop.
+        try { _installer.SetCallback(IntPtr.Zero, IntPtr.Zero); }
+        catch { /* logging must not throw on teardown */ }
+    }
+
+    // Invoked by libghostty from any thread. MUST NOT throw -- an
+    // exception leaking into native code is undefined behavior. Every
+    // step is wrapped in a try/catch that swallows the failure; a
+    // single malformed log line should never crash the process.
+    private void OnLog(
+        uint level,
+        IntPtr scopePtr,
+        UIntPtr scopeLen,
+        IntPtr messagePtr,
+        UIntPtr messageLen,
+        IntPtr userData)
+    {
+        if (_disposed != 0) return;
+
+        try
+        {
+            var logLevel = MapLevel(level);
+            var category = ReadCategory(scopePtr, (int)scopeLen);
+            var message = ReadUtf8(messagePtr, (int)messageLen);
+
+            var logger = _loggers.GetOrAdd(category, s_createLogger, _factory);
+            if (!logger.IsEnabled(logLevel)) return;
+
+            // Pass the already-formatted Zig message as state so MEL
+            // does not try to parse {placeholders} inside it. Format
+            // argument "{Message}" keeps EventSource / file-sink output
+            // identical to what Zig already rendered.
+            logger.Log(
+                logLevel: logLevel,
+                eventId: default,
+                state: message,
+                exception: null,
+                formatter: static (s, _) => s);
+        }
+        catch (Exception ex)
+        {
+            // Never let an exception leak into native code (that would
+            // be UB across the C ABI). Best-effort surface the failure
+            // to a dedicated category so this path is not silent if it
+            // ever fires; the inner try/catch is there because the
+            // failure may itself be a disposed-factory race during
+            // shutdown.
+            try
+            {
+                _factory.CreateLogger(BridgeFailureCategory)
+                    .LogError(ex, "Log bridge callback failed");
+            }
+            catch
+            {
+                // If the diagnostic log also fails, truly swallow.
+            }
+        }
+    }
+
+    // Dedicated category for bridge-internal failures (marshal errors,
+    // factory races). Kept separate from the Ghostty.Zig.* namespace so
+    // users can filter it independently.
+    private const string BridgeFailureCategory = "Ghostty.Zig.Bridge";
+
+    /// <summary>
+    /// Map the Zig-side ordinal to a Microsoft.Extensions.Logging level.
+    /// Unknown integers are surfaced as <see cref="LogLevel.Information"/>
+    /// so a future Zig-side level addition degrades to a safe default
+    /// instead of being dropped.
+    /// </summary>
+    internal static LogLevel MapLevel(uint level) => level switch
+    {
+        0 => LogLevel.Debug,
+        1 => LogLevel.Information,
+        2 => LogLevel.Warning,
+        3 => LogLevel.Error,
+        _ => LogLevel.Information,
+    };
+
+    /// <summary>
+    /// Decode a non-null-terminated UTF-8 byte range into a managed
+    /// string. Returns the empty string for a null pointer or zero
+    /// length. Exposed for tests.
+    /// </summary>
+    internal static string ReadUtf8(IntPtr ptr, int len)
+    {
+        if (ptr == IntPtr.Zero || len <= 0) return string.Empty;
+        // PtrToStringUTF8(IntPtr, int) takes a non-null-terminated
+        // UTF-8 buffer + byte length and returns a managed string,
+        // without requiring an unsafe block. Available on .NET 6+.
+        return Marshal.PtrToStringUTF8(ptr, len);
+    }
+
+    /// <summary>
+    /// Produce the ILogger category name for a given Zig scope. Empty
+    /// scope maps to <see cref="DefaultCategory"/>, anything else maps
+    /// to <c>Ghostty.Zig.&lt;scope&gt;</c>. Exposed for tests.
+    /// </summary>
+    internal static string ReadCategory(IntPtr scopePtr, int scopeLen)
+    {
+        if (scopePtr == IntPtr.Zero || scopeLen <= 0) return DefaultCategory;
+        var scope = ReadUtf8(scopePtr, scopeLen);
+        return string.IsNullOrEmpty(scope) ? DefaultCategory : CategoryPrefix + "." + scope;
+    }
+}

--- a/windows/Ghostty.Tests/Logging/LibghosttyLogBridgeTests.cs
+++ b/windows/Ghostty.Tests/Logging/LibghosttyLogBridgeTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Ghostty.Core.Logging;
+using Ghostty.Core.Logging.Testing;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+/// <summary>
+/// Unit tests for the libghostty log bridge. We drive the bridge with a
+/// fake installer that captures the registered native function pointer,
+/// invoke that pointer directly from managed code (simulating the Zig
+/// call site), and assert the resulting ILogger emission.
+/// </summary>
+public class LibghosttyLogBridgeTests
+{
+    [Fact]
+    public void MapLevel_MatchesZigSideContract()
+    {
+        Assert.Equal(LogLevel.Debug, LibghosttyLogBridge.MapLevel(0));
+        Assert.Equal(LogLevel.Information, LibghosttyLogBridge.MapLevel(1));
+        Assert.Equal(LogLevel.Warning, LibghosttyLogBridge.MapLevel(2));
+        Assert.Equal(LogLevel.Error, LibghosttyLogBridge.MapLevel(3));
+    }
+
+    [Fact]
+    public void MapLevel_UnknownValueFallsBackToInformation()
+    {
+        // Future Zig-side additions must not disappear silently.
+        Assert.Equal(LogLevel.Information, LibghosttyLogBridge.MapLevel(42));
+        Assert.Equal(LogLevel.Information, LibghosttyLogBridge.MapLevel(uint.MaxValue));
+    }
+
+    [Fact]
+    public void ReadUtf8_NullPointerProducesEmptyString()
+    {
+        Assert.Equal(string.Empty, LibghosttyLogBridge.ReadUtf8(IntPtr.Zero, 10));
+    }
+
+    [Fact]
+    public void ReadUtf8_ZeroLengthProducesEmptyString()
+    {
+        // Use any non-null pointer; with len=0 it must not be read.
+        var sentinel = new byte[] { 0xFF };
+        var handle = GCHandle.Alloc(sentinel, GCHandleType.Pinned);
+        try
+        {
+            Assert.Equal(string.Empty,
+                LibghosttyLogBridge.ReadUtf8(handle.AddrOfPinnedObject(), 0));
+        }
+        finally { handle.Free(); }
+    }
+
+    [Fact]
+    public void ReadUtf8_DecodesMultibyteUtf8()
+    {
+        // Include a 3-byte UTF-8 codepoint (U+2192 RIGHTWARDS ARROW,
+        // bytes E2 86 92) so the test covers non-ASCII decoding rather
+        // than just ASCII pass-through. Built from bytes so this source
+        // file stays ASCII-only.
+        var payload = new byte[] {
+            (byte)'h', (byte)'e', (byte)'l', (byte)'l', (byte)'o',
+            (byte)' ', 0xE2, 0x86, 0x92, (byte)' ',
+            (byte)'w', (byte)'o', (byte)'r', (byte)'l', (byte)'d',
+        };
+        var handle = GCHandle.Alloc(payload, GCHandleType.Pinned);
+        try
+        {
+            var s = LibghosttyLogBridge.ReadUtf8(handle.AddrOfPinnedObject(), payload.Length);
+            Assert.Equal(15, payload.Length);
+            // Expected: "hello \u2192 world"
+            Assert.Equal("hello \u2192 world", s);
+        }
+        finally { handle.Free(); }
+    }
+
+    [Fact]
+    public void ReadCategory_EmptyScopeMapsToDefaultCategory()
+    {
+        Assert.Equal(LibghosttyLogBridge.DefaultCategory,
+            LibghosttyLogBridge.ReadCategory(IntPtr.Zero, 0));
+    }
+
+    [Fact]
+    public void ReadCategory_NamedScopeIsPrefixed()
+    {
+        var payload = Encoding.UTF8.GetBytes("termio");
+        var handle = GCHandle.Alloc(payload, GCHandleType.Pinned);
+        try
+        {
+            var category = LibghosttyLogBridge.ReadCategory(
+                handle.AddrOfPinnedObject(), payload.Length);
+            Assert.Equal("Ghostty.Zig.termio", category);
+        }
+        finally { handle.Free(); }
+    }
+
+    [Fact]
+    public void Install_RoutesCallbackIntoLoggerFactory()
+    {
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var installer = new FakeInstaller();
+        using var bridge = new LibghosttyLogBridge(factory, installer);
+        bridge.Install();
+
+        Assert.NotEqual(IntPtr.Zero, installer.LastCallback);
+
+        // Simulate a Zig-side log call.
+        InvokeNativeCallback(
+            installer.LastCallback,
+            level: 1,
+            scope: "termio",
+            message: "conpty-mode=raw verdict={d}");
+
+        var entry = Assert.Single(capture.Entries);
+        Assert.Equal("Ghostty.Zig.termio", entry.Category);
+        Assert.Equal(LogLevel.Information, entry.Level);
+        // The bridge passes the message through verbatim; no format
+        // placeholder substitution happens here (Zig already rendered it).
+        Assert.Equal("conpty-mode=raw verdict={d}", entry.Message);
+    }
+
+    [Fact]
+    public void Dispose_ClearsNativeCallback()
+    {
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var installer = new FakeInstaller();
+        var bridge = new LibghosttyLogBridge(factory, installer);
+        bridge.Install();
+        Assert.NotEqual(IntPtr.Zero, installer.LastCallback);
+
+        bridge.Dispose();
+
+        // Dispose must call SetCallback(null, null) so libghostty stops
+        // emitting into a factory we are about to tear down.
+        Assert.Equal(IntPtr.Zero, installer.LastCallback);
+        Assert.Equal(IntPtr.Zero, installer.LastUserData);
+    }
+
+    [Fact]
+    public void InvokingDisposedBridgeCallback_IsSilentlyIgnored()
+    {
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var installer = new FakeInstaller();
+        var bridge = new LibghosttyLogBridge(factory, installer);
+        bridge.Install();
+        // Capture the native callback pointer BEFORE disposal so we
+        // can simulate a late Zig thread that latched it then slept.
+        var latePtr = installer.LastCallback;
+
+        bridge.Dispose();
+
+        // Invoking the callback post-dispose must not throw and must
+        // not produce an emission: the bridge's internal _disposed
+        // flag short-circuits the OnLog body.
+        InvokeNativeCallback(latePtr, level: 2, scope: "late", message: "after-dispose");
+
+        Assert.Empty(capture.Entries);
+    }
+
+    [Fact]
+    public void UnicodeMessage_PassesThroughIntact()
+    {
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var installer = new FakeInstaller();
+        using var bridge = new LibghosttyLogBridge(factory, installer);
+        bridge.Install();
+
+        // Path with non-ASCII bytes, simulating a Windows shell arg.
+        InvokeNativeCallback(
+            installer.LastCallback,
+            level: 3,
+            scope: "shell",
+            message: "spawn cwd=C:\\Users\\Mocha\\Documents");
+
+        var entry = Assert.Single(capture.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Equal("Ghostty.Zig.shell", entry.Category);
+        Assert.Equal("spawn cwd=C:\\Users\\Mocha\\Documents", entry.Message);
+    }
+
+    [Fact]
+    public void DefaultScope_MapsToBareCategory()
+    {
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var installer = new FakeInstaller();
+        using var bridge = new LibghosttyLogBridge(factory, installer);
+        bridge.Install();
+
+        // Empty scope (Zig passes a zero-length slice for the default
+        // scope) must resolve to "Ghostty.Zig" without a trailing dot.
+        InvokeNativeCallback(
+            installer.LastCallback,
+            level: 1,
+            scope: string.Empty,
+            message: "no-scope");
+
+        var entry = Assert.Single(capture.Entries);
+        Assert.Equal("Ghostty.Zig", entry.Category);
+    }
+
+    [Fact]
+    public void ConcurrentInvocations_AllLandInCapture()
+    {
+        // Exercises the ConcurrentDictionary<string, ILogger> cache and
+        // the _disposed Interlocked guard under contention. The Zig
+        // side calls OnLog from any thread, so this mirrors production.
+        using var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var installer = new FakeInstaller();
+        using var bridge = new LibghosttyLogBridge(factory, installer);
+        bridge.Install();
+
+        const int threads = 8;
+        const int perThread = 128;
+
+        Parallel.For(0, threads, t =>
+        {
+            for (var i = 0; i < perThread; i++)
+            {
+                InvokeNativeCallback(
+                    installer.LastCallback,
+                    level: 1,
+                    scope: "worker" + (t % 4),
+                    message: "msg" + i);
+            }
+        });
+
+        Assert.Equal(threads * perThread, capture.Entries.Count);
+    }
+
+    // --- helpers -----------------------------------------------------
+
+    // Simulate libghostty calling the registered callback. Pins the
+    // UTF-8 bytes for scope and message for the duration of the call,
+    // then invokes the delegate via its captured function pointer.
+    private static void InvokeNativeCallback(
+        IntPtr fnPtr,
+        uint level,
+        string scope,
+        string message)
+    {
+        // Resurrect the managed delegate from the native pointer so we
+        // can invoke through the managed path in tests.
+        var cb = Marshal.GetDelegateForFunctionPointer<LibghosttyLogBridge.LogCallbackDelegate>(fnPtr);
+
+        var scopeBytes = Encoding.UTF8.GetBytes(scope);
+        var messageBytes = Encoding.UTF8.GetBytes(message);
+
+        var scopeHandle = GCHandle.Alloc(scopeBytes, GCHandleType.Pinned);
+        var messageHandle = GCHandle.Alloc(messageBytes, GCHandleType.Pinned);
+        try
+        {
+            cb(
+                level,
+                scopeBytes.Length == 0 ? IntPtr.Zero : scopeHandle.AddrOfPinnedObject(),
+                (UIntPtr)scopeBytes.Length,
+                messageBytes.Length == 0 ? IntPtr.Zero : messageHandle.AddrOfPinnedObject(),
+                (UIntPtr)messageBytes.Length,
+                IntPtr.Zero);
+        }
+        finally
+        {
+            scopeHandle.Free();
+            messageHandle.Free();
+        }
+    }
+
+    private sealed class FakeInstaller : LibghosttyLogBridge.INativeInstaller
+    {
+        public IntPtr LastCallback { get; private set; }
+        public IntPtr LastUserData { get; private set; }
+
+        public void SetCallback(IntPtr callback, IntPtr userData)
+        {
+            LastCallback = callback;
+            LastUserData = userData;
+        }
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -55,6 +55,15 @@ public partial class App : Application
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private Ghostty.Core.Logging.FileLoggerProvider? _fileLogSink;
     private Ghostty.Core.Logging.FilterState? _logFilters;
+    // Bridge for libghostty's Zig std.log output. Installed after the
+    // factory is built so Zig log lines emitted after bootstrap (config
+    // reloads, surface / PTY spawns, render errors, transport verdicts)
+    // land in the same file + ETW sinks as C# logs. The tiny window
+    // before installation - covering state.init() banner lines inside
+    // ConfigService's constructor - is an accepted gap; those banners
+    // are one-shot startup info and the workaround would be to capture
+    // into a pre-factory buffer that is then replayed.
+    private Ghostty.Core.Logging.LibghosttyLogBridge? _zigLogBridge;
 #if SPONSOR_BUILD
     private Ghostty.Sponsor.Update.SponsorOverlayBootstrapper? _sponsorOverlay;
     internal Ghostty.Sponsor.Update.SponsorOverlayBootstrapper? SponsorOverlay => _sponsorOverlay;
@@ -346,6 +355,13 @@ public partial class App : Application
         LoggerFactory = factory;
         _configService.ConfigChanged += OnConfigChanged_ApplyLogFilters;
 
+        // Install the libghostty log bridge now that the factory
+        // exists. After this point every Zig std.log call is delivered
+        // to an ILogger under category "Ghostty.Zig.<scope>".
+        _zigLogBridge = new Ghostty.Core.Logging.LibghosttyLogBridge(
+            factory, new Ghostty.Logging.LibghosttyLogInstaller());
+        _zigLogBridge.Install();
+
         // #259 logging: populate Core-side static logger accessors
         // for types whose call sites are static (e.g., FrecencyStore
         // static methods that can't take a ctor-injected logger).
@@ -534,6 +550,15 @@ public partial class App : Application
                 // ConfigNew + ConfigLoadDefaultFiles.
                 _configService?.Dispose();
 
+                // Dispose the libghostty log bridge before the factory.
+                // Bridge.Dispose clears the native callback and sets an
+                // internal disposed flag, so any Zig thread that already
+                // latched the function pointer still returns to OnLog
+                // but then bails on the flag check. That guarantee lets
+                // the factory tear-down below proceed without racing an
+                // inbound Zig log into a disposed ILoggerFactory.
+                _zigLogBridge?.Dispose();
+
                 // #259 logging: dispose the factory after the config
                 // service so any ConfigChanged callbacks fired during
                 // ConfigService.Dispose don't race a disposed factory.
@@ -565,6 +590,7 @@ public partial class App : Application
                 _configService = null;
                 ConfigService = null;
 
+                _zigLogBridge = null;
                 _fileLogSink = null;
                 _loggerFactory = null;
                 LoggerFactory = null;

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -567,4 +567,17 @@ internal static partial class NativeMethods
     [LibraryImport(Dll, EntryPoint = "ghostty_cli_set_theme_callback")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void CliSetThemeCallback(IntPtr callback);
+
+    // ---- log bridge ----------------------------------------------------
+
+    // Register (or clear, with IntPtr.Zero) an embedder callback that
+    // receives every libghostty std.log message. The delegate type is
+    // LibghosttyLogBridge.LogCallbackDelegate in Ghostty.Core.Logging;
+    // we take IntPtr here so this P/Invoke surface does not pull a
+    // Ghostty.Core type into the marshaling signature. Level maps as:
+    // 0=debug, 1=info, 2=warn, 3=err. Scope and message bytes are NOT
+    // null-terminated; companion lengths are passed to the callback.
+    [LibraryImport(Dll, EntryPoint = "ghostty_log_set_callback")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void LogSetCallback(IntPtr callback, IntPtr userData);
 }

--- a/windows/Ghostty/Logging/LibghosttyLogInstaller.cs
+++ b/windows/Ghostty/Logging/LibghosttyLogInstaller.cs
@@ -1,0 +1,21 @@
+using System;
+using Ghostty.Core.Logging;
+using Ghostty.Interop;
+
+namespace Ghostty.Logging;
+
+/// <summary>
+/// Production installer for the libghostty log bridge. P/Invokes
+/// <c>ghostty_log_set_callback</c> so Zig std.log output flows into the
+/// process-wide <see cref="Microsoft.Extensions.Logging.ILoggerFactory"/>.
+///
+/// Lives in the Ghostty (WinUI) project rather than Ghostty.Core because
+/// Core has no P/Invoke surface of its own and the callback target is
+/// libghostty.dll, which only the shell loads. Tests substitute a fake
+/// installer; see <c>LibghosttyLogBridgeTests</c>.
+/// </summary>
+internal sealed class LibghosttyLogInstaller : LibghosttyLogBridge.INativeInstaller
+{
+    public void SetCallback(IntPtr callback, IntPtr userData)
+        => NativeMethods.LogSetCallback(callback, userData);
+}


### PR DESCRIPTION
libghostty's Zig logs never reached the Windows WinUI 3 shell. The
GUI-subsystem exe has no stderr, macOS unified logging is not
available, and the C# file sink only observes C# ILogger output.
Transport verdicts, OSC 11 diagnostics, and anything else Zig emits
below the apprt boundary went silent on Windows.

This adds a small C export, `ghostty_log_set_callback`, that lets an
embedder register a function pointer called from inside `logFn` on
every `std.log` call. The Zig side renders the formatted message into
a 64 KiB stack buffer and passes raw UTF-8 bytes + length; the callback
is loaded atomically on every call so there is no hot-path lock and a
null callback is a single atomic load. Level ordinals are pinned via a
dedicated enum rather than forwarding `std.log.Level` directly, so the
ABI does not drift with std changes.

On the C# side, `LibghosttyLogBridge` (in `Ghostty.Core.Logging`)
caches one `ILogger` per Zig scope and emits under
`Ghostty.Zig.<scope>`, so Zig logs land in every sink the existing
logger factory already feeds (ETW, rolling file). The bridge installs
right after `LoggingBootstrap.Build` in `App.OnLaunched` and disposes
before the factory teardown to close the late-callback race.

Covered by unit tests on both sides: a Zig test registers a capturing
callback and verifies level/scope/message routing plus truncation, and
13 xUnit cases cover marshaling, level mapping, install/dispose
ordering, post-dispose safety, and multi-threaded invocation.