### PR TITLE
test(windows): conpty-mode end-to-end validation smoke tier

### DIFF
--- a/dev-configs/validate-transport/README.md
+++ b/dev-configs/validate-transport/README.md
@@ -1,0 +1,22 @@
+# validate-transport fixtures
+
+Config fixtures for the ConPTY-mode smoke test. Consumed by
+`just validate-transport-smoke ROW` and the sibling assertion script
+at `scripts/validate-transport-assert.ps1`.
+
+Each fixture pins a `conpty-mode` value and a one-shot `command`
+whose only job is to emit a known OSC 11 query (or to sanity-spawn,
+for cmd) and then exit. `quit-after-last-window-closed = true` plus
+the default `wait-after-command = false` brings the app down
+automatically, and `confirm-close-surface = false` skips the exit
+confirmation prompt.
+
+The pwsh fixtures invoke `emit-osc11.ps1` via `-File`. Keeping the
+emission logic in a standalone script avoids cmd metacharacters in
+the fixture's `command` value (ghostty wraps commands containing
+`&`, `|`, `(`, `)`, `%`, `!` with `cmd /c`, which mangles the
+PowerShell escapes).
+
+Never edit these to chase a test failure. If an expected verdict
+changes, update the assertion table in
+`scripts/validate-transport-assert.ps1` in the same commit.

--- a/dev-configs/validate-transport/README.md
+++ b/dev-configs/validate-transport/README.md
@@ -17,6 +17,12 @@ the fixture's `command` value (ghostty wraps commands containing
 `&`, `|`, `(`, `)`, `%`, `!` with `cmd /c`, which mangles the
 PowerShell escapes).
 
+All `command =` values use the full `.exe` suffix (`pwsh.exe`,
+`cmd.exe`). Ghostty's `internal_os.path.expand` does PATH lookup
+with the literal name and does not try PATHEXT-style suffix hunting;
+a bare `pwsh` would fail to resolve to `pwsh.exe` and CreateProcessW
+would error with ERROR_FILE_NOT_FOUND.
+
 Never edit these to chase a test failure. If an expected verdict
 changes, update the assertion table in
 `scripts/validate-transport-assert.ps1` in the same commit.

--- a/dev-configs/validate-transport/README.md
+++ b/dev-configs/validate-transport/README.md
@@ -11,11 +11,22 @@ the default `wait-after-command = false` brings the app down
 automatically, and `confirm-close-surface = false` skips the exit
 confirmation prompt.
 
-The pwsh fixtures invoke `emit-osc11.ps1` via `-File`. Keeping the
-emission logic in a standalone script avoids cmd metacharacters in
-the fixture's `command` value (ghostty wraps commands containing
-`&`, `|`, `(`, `)`, `%`, `!` with `cmd /c`, which mangles the
-PowerShell escapes).
+The pwsh fixtures emit OSC 11 via `pwsh.exe -EncodedCommand <base64>`.
+The base64 payload is UTF-16LE of:
+
+```
+[Console]::Out.Write([char]0x1B + ']11;?' + [char]0x1B + '\')
+```
+
+which writes `ESC ]11;? ESC \` (OSC 11 query with ST terminator) to
+stdout and exits. Inlining via `-EncodedCommand` avoids three things
+that broke earlier iterations: cwd-relative script paths (Ghostty's
+working-directory resolution is surprising under launch-by-test),
+PowerShell execution policy blocking `.ps1` loads, and cmd-metachar
+wrapping in ghostty's spawn path (ghostty wraps commands containing
+`&`, `|`, `(`, `)`, `%`, `!` with `cmd /c`, which mangles quoted
+arguments). The base64 alphabet (`A-Za-z0-9+/=`) contains none of
+those.
 
 All `command =` values use the full `.exe` suffix (`pwsh.exe`,
 `cmd.exe`). Ghostty's `internal_os.path.expand` does PATH lookup

--- a/dev-configs/validate-transport/cmd-auto.conf
+++ b/dev-configs/validate-transport/cmd-auto.conf
@@ -1,0 +1,11 @@
+# Smoke fixture: cmd + conpty-mode=auto. Expected transport=conpty.
+# cmd.exe does not emit OSC 11 natively, so OSC 11 is N/A for this
+# row - the assertion script skips the OSC 11 check.
+conpty-mode = auto
+command = cmd /c exit
+
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = debug
+log-filter = validate

--- a/dev-configs/validate-transport/cmd-auto.conf
+++ b/dev-configs/validate-transport/cmd-auto.conf
@@ -2,7 +2,7 @@
 # cmd.exe does not emit OSC 11 natively, so OSC 11 is N/A for this
 # row - the assertion script skips the OSC 11 check.
 conpty-mode = auto
-command = cmd /c exit
+command = cmd.exe /c exit
 
 quit-after-last-window-closed = true
 confirm-close-surface = false

--- a/dev-configs/validate-transport/cmd-auto.conf
+++ b/dev-configs/validate-transport/cmd-auto.conf
@@ -7,5 +7,10 @@ command = cmd.exe /c exit
 quit-after-last-window-closed = true
 confirm-close-surface = false
 
-log-level = debug
-log-filter = validate
+# Keep the global floor at warn so only errors/warnings from other
+# scopes land in the log; raise just the validate_transport scope to
+# info so the runner's assertion can see verdict + OSC 11 lines.
+# log-filter requires CATEGORY=LEVEL pairs (MEL semantics, longest
+# prefix wins); a bare "validate" would be silently skipped.
+log-level = warn
+log-filter = Ghostty.Zig.validate_transport=info

--- a/dev-configs/validate-transport/emit-osc11.ps1
+++ b/dev-configs/validate-transport/emit-osc11.ps1
@@ -1,3 +1,0 @@
-# Emit a raw OSC 11 query to stdout, then exit. Consumed by the
-# pwsh-* smoke fixtures in this directory.
-[Console]::Out.Write([char]0x1B + ']11;?' + [char]0x1B + '\')

--- a/dev-configs/validate-transport/emit-osc11.ps1
+++ b/dev-configs/validate-transport/emit-osc11.ps1
@@ -1,0 +1,3 @@
+# Emit a raw OSC 11 query to stdout, then exit. Consumed by the
+# pwsh-* smoke fixtures in this directory.
+[Console]::Out.Write([char]0x1B + ']11;?' + [char]0x1B + '\')

--- a/dev-configs/validate-transport/pwsh-always.conf
+++ b/dev-configs/validate-transport/pwsh-always.conf
@@ -10,5 +10,10 @@ command = pwsh.exe -NoProfile -NoLogo -EncodedCommand WwBDAG8AbgBzAG8AbABlAF0AOg
 quit-after-last-window-closed = true
 confirm-close-surface = false
 
-log-level = debug
-log-filter = validate
+# Keep the global floor at warn so only errors/warnings from other
+# scopes land in the log; raise just the validate_transport scope to
+# info so the runner's assertion can see verdict + OSC 11 lines.
+# log-filter requires CATEGORY=LEVEL pairs (MEL semantics, longest
+# prefix wins); a bare "validate" would be silently skipped.
+log-level = warn
+log-filter = Ghostty.Zig.validate_transport=info

--- a/dev-configs/validate-transport/pwsh-always.conf
+++ b/dev-configs/validate-transport/pwsh-always.conf
@@ -1,0 +1,14 @@
+# Smoke fixture: pwsh + conpty-mode=always. Expected transport=bypass,
+# OSC 11 observed.
+conpty-mode = always
+command = pwsh -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+
+# App shutdown on shell exit: wait-after-command defaults to false
+# (surface closes on command exit); quit-after-last-window-closed
+# makes the process exit when the only surface closes;
+# confirm-close-surface suppresses any exit confirmation prompt.
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = debug
+log-filter = validate

--- a/dev-configs/validate-transport/pwsh-always.conf
+++ b/dev-configs/validate-transport/pwsh-always.conf
@@ -1,7 +1,7 @@
 # Smoke fixture: pwsh + conpty-mode=always. Expected transport=bypass,
 # OSC 11 observed.
 conpty-mode = always
-command = pwsh.exe -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+command = pwsh.exe -NoProfile -NoLogo -EncodedCommand WwBDAG8AbgBzAG8AbABlAF0AOgA6AE8AdQB0AC4AVwByAGkAdABlACgAWwBjAGgAYQByAF0AMAB4ADEAQgAgACsAIAAnAF0AMQAxADsAPwAnACAAKwAgAFsAYwBoAGEAcgBdADAAeAAxAEIAIAArACAAJwBcACcAKQA=
 
 # App shutdown on shell exit: wait-after-command defaults to false
 # (surface closes on command exit); quit-after-last-window-closed

--- a/dev-configs/validate-transport/pwsh-always.conf
+++ b/dev-configs/validate-transport/pwsh-always.conf
@@ -1,7 +1,7 @@
 # Smoke fixture: pwsh + conpty-mode=always. Expected transport=bypass,
 # OSC 11 observed.
 conpty-mode = always
-command = pwsh -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+command = pwsh.exe -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
 
 # App shutdown on shell exit: wait-after-command defaults to false
 # (surface closes on command exit); quit-after-last-window-closed

--- a/dev-configs/validate-transport/pwsh-auto.conf
+++ b/dev-configs/validate-transport/pwsh-auto.conf
@@ -1,7 +1,7 @@
 # Smoke fixture: pwsh + conpty-mode=auto. Expected transport=bypass,
 # OSC 11 observed.
 conpty-mode = auto
-command = pwsh.exe -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+command = pwsh.exe -NoProfile -NoLogo -EncodedCommand WwBDAG8AbgBzAG8AbABlAF0AOgA6AE8AdQB0AC4AVwByAGkAdABlACgAWwBjAGgAYQByAF0AMAB4ADEAQgAgACsAIAAnAF0AMQAxADsAPwAnACAAKwAgAFsAYwBoAGEAcgBdADAAeAAxAEIAIAArACAAJwBcACcAKQA=
 
 # App shutdown on shell exit: wait-after-command defaults to false
 # (surface closes on command exit); quit-after-last-window-closed

--- a/dev-configs/validate-transport/pwsh-auto.conf
+++ b/dev-configs/validate-transport/pwsh-auto.conf
@@ -10,5 +10,10 @@ command = pwsh.exe -NoProfile -NoLogo -EncodedCommand WwBDAG8AbgBzAG8AbABlAF0AOg
 quit-after-last-window-closed = true
 confirm-close-surface = false
 
-log-level = debug
-log-filter = validate
+# Keep the global floor at warn so only errors/warnings from other
+# scopes land in the log; raise just the validate_transport scope to
+# info so the runner's assertion can see verdict + OSC 11 lines.
+# log-filter requires CATEGORY=LEVEL pairs (MEL semantics, longest
+# prefix wins); a bare "validate" would be silently skipped.
+log-level = warn
+log-filter = Ghostty.Zig.validate_transport=info

--- a/dev-configs/validate-transport/pwsh-auto.conf
+++ b/dev-configs/validate-transport/pwsh-auto.conf
@@ -1,0 +1,14 @@
+# Smoke fixture: pwsh + conpty-mode=auto. Expected transport=bypass,
+# OSC 11 observed.
+conpty-mode = auto
+command = pwsh -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+
+# App shutdown on shell exit: wait-after-command defaults to false
+# (surface closes on command exit); quit-after-last-window-closed
+# makes the process exit when the only surface closes;
+# confirm-close-surface suppresses any exit confirmation prompt.
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = debug
+log-filter = validate

--- a/dev-configs/validate-transport/pwsh-auto.conf
+++ b/dev-configs/validate-transport/pwsh-auto.conf
@@ -1,7 +1,7 @@
 # Smoke fixture: pwsh + conpty-mode=auto. Expected transport=bypass,
 # OSC 11 observed.
 conpty-mode = auto
-command = pwsh -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+command = pwsh.exe -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
 
 # App shutdown on shell exit: wait-after-command defaults to false
 # (surface closes on command exit); quit-after-last-window-closed

--- a/dev-configs/validate-transport/pwsh-never.conf
+++ b/dev-configs/validate-transport/pwsh-never.conf
@@ -1,7 +1,7 @@
 # Smoke fixture: pwsh + conpty-mode=never. Expected transport=conpty,
 # OSC 11 absent (conhost swallows).
 conpty-mode = never
-command = pwsh -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+command = pwsh.exe -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
 
 # App shutdown on shell exit: wait-after-command defaults to false
 # (surface closes on command exit); quit-after-last-window-closed

--- a/dev-configs/validate-transport/pwsh-never.conf
+++ b/dev-configs/validate-transport/pwsh-never.conf
@@ -10,5 +10,10 @@ command = pwsh.exe -NoProfile -NoLogo -EncodedCommand WwBDAG8AbgBzAG8AbABlAF0AOg
 quit-after-last-window-closed = true
 confirm-close-surface = false
 
-log-level = debug
-log-filter = validate
+# Keep the global floor at warn so only errors/warnings from other
+# scopes land in the log; raise just the validate_transport scope to
+# info so the runner's assertion can see verdict + OSC 11 lines.
+# log-filter requires CATEGORY=LEVEL pairs (MEL semantics, longest
+# prefix wins); a bare "validate" would be silently skipped.
+log-level = warn
+log-filter = Ghostty.Zig.validate_transport=info

--- a/dev-configs/validate-transport/pwsh-never.conf
+++ b/dev-configs/validate-transport/pwsh-never.conf
@@ -1,0 +1,14 @@
+# Smoke fixture: pwsh + conpty-mode=never. Expected transport=conpty,
+# OSC 11 absent (conhost swallows).
+conpty-mode = never
+command = pwsh -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+
+# App shutdown on shell exit: wait-after-command defaults to false
+# (surface closes on command exit); quit-after-last-window-closed
+# makes the process exit when the only surface closes;
+# confirm-close-surface suppresses any exit confirmation prompt.
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = debug
+log-filter = validate

--- a/dev-configs/validate-transport/pwsh-never.conf
+++ b/dev-configs/validate-transport/pwsh-never.conf
@@ -1,7 +1,7 @@
 # Smoke fixture: pwsh + conpty-mode=never. Expected transport=conpty,
 # OSC 11 absent (conhost swallows).
 conpty-mode = never
-command = pwsh.exe -NoProfile -NoLogo -File dev-configs/validate-transport/emit-osc11.ps1
+command = pwsh.exe -NoProfile -NoLogo -EncodedCommand WwBDAG8AbgBzAG8AbABlAF0AOgA6AE8AdQB0AC4AVwByAGkAdABlACgAWwBjAGgAYQByAF0AMAB4ADEAQgAgACsAIAAnAF0AMQAxADsAPwAnACAAKwAgAFsAYwBoAGEAcgBdADAAeAAxAEIAIAArACAAJwBcACcAKQA=
 
 # App shutdown on shell exit: wait-after-command defaults to false
 # (surface closes on command exit); quit-after-last-window-closed

--- a/justfile
+++ b/justfile
@@ -112,6 +112,18 @@ build-win:
 run-win: build-dll build-win
     ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.exe
 
+# === ConPTY-mode validation ===
+
+# Run one smoke row. ROW = pwsh-auto | pwsh-always | pwsh-never | cmd-auto.
+[windows]
+validate-transport-smoke ROW: build-dll build-win
+    pwsh -NoProfile -File scripts/validate-transport-run.ps1 -Row {{ROW}}
+
+# Run all four smoke rows; summarize, non-zero exit if any fail.
+[windows]
+validate-transport-smoke-all: build-dll build-win
+    pwsh -NoProfile -File scripts/validate-transport-run-all.ps1
+
 # === Upstream Sync ===
 
 # Pinned to bash via shebang so the POSIX `[` branch test below works

--- a/scripts/validate-transport-assert.ps1
+++ b/scripts/validate-transport-assert.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+    Assert conpty-mode smoke verdict from ghostty log.
+
+.DESCRIPTION
+    Reads the most recent ghostty log under -LogDir, extracts the
+    validate_transport verdict line and OSC 11 receipt line, and
+    asserts the pairing matches the expected outcome for -Row.
+
+    Exit 0 on match, 1 on mismatch, 2 on missing instrumentation or
+    unknown row (distinguishes test-infra broken from test-failed).
+
+.PARAMETER Row
+    One of: pwsh-auto, pwsh-always, pwsh-never, cmd-auto.
+
+.PARAMETER LogDir
+    Directory containing ghostty log files. Defaults to
+    %LOCALAPPDATA%\Ghostty\logs.
+#>
+param(
+    [Parameter(Mandatory)][string]$Row,
+    [string]$LogDir = "$env:LOCALAPPDATA\Ghostty\logs"
+)
+$ErrorActionPreference = 'Stop'
+
+$Expected = @{
+    'pwsh-auto'   = @{ Transport = 'bypass'; Osc11 = 'observed' }
+    'pwsh-always' = @{ Transport = 'bypass'; Osc11 = 'observed' }
+    'pwsh-never'  = @{ Transport = 'conpty'; Osc11 = 'absent'   }
+    'cmd-auto'    = @{ Transport = 'conpty'; Osc11 = 'na'       }
+}
+
+if (-not $Expected.ContainsKey($Row)) {
+    Write-Host "ERROR: unknown row '$Row'. Valid rows: $($Expected.Keys -join ', ')"
+    exit 2
+}
+
+if (-not (Test-Path $LogDir)) {
+    Write-Host "ERROR: log directory not found: $LogDir"
+    exit 2
+}
+
+$log = Get-ChildItem $LogDir -Filter '*.log' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+if (-not $log) {
+    Write-Host "ERROR: no log files under $LogDir"
+    exit 2
+}
+
+$lines = Get-Content -LiteralPath $log.FullName
+
+# Verdict: "transport resolved: shell=\"...\" config_mode=<mode> resolved=<transport>"
+$verdictMatch = $lines |
+    Select-String -Pattern 'transport resolved:.*resolved=(\w+)' |
+    Select-Object -Last 1
+if (-not $verdictMatch) {
+    Write-Host "ERROR: no verdict line in $($log.Name) (validate_transport instrumentation missing or filter excludes it)"
+    exit 2
+}
+$observedTransport = $verdictMatch.Matches[0].Groups[1].Value
+
+# OSC 11 receipt: "osc11 from pty: kind=query"
+$osc11Match = $lines | Select-String -Pattern 'osc11 from pty' | Select-Object -Last 1
+$observedOsc11 = if ($osc11Match) { 'observed' } else { 'absent' }
+
+$exp = $Expected[$Row]
+$transportOk = ($observedTransport -eq $exp.Transport)
+$osc11Ok = if ($exp.Osc11 -eq 'na') { $true } else { $observedOsc11 -eq $exp.Osc11 }
+
+if ($transportOk -and $osc11Ok) {
+    Write-Host "OK: $Row transport=$observedTransport osc11=$observedOsc11 (log=$($log.Name))"
+    exit 0
+}
+
+Write-Host "FAIL: $Row"
+Write-Host "  expected: transport=$($exp.Transport) osc11=$($exp.Osc11)"
+Write-Host "  observed: transport=$observedTransport osc11=$observedOsc11"
+Write-Host "  log:      $($log.FullName)"
+exit 1

--- a/scripts/validate-transport-assert.ps1
+++ b/scripts/validate-transport-assert.ps1
@@ -19,7 +19,8 @@
 #>
 param(
     [Parameter(Mandatory)][string]$Row,
-    [string]$LogDir = "$env:LOCALAPPDATA\Ghostty\logs"
+    [string]$LogDir = "$env:LOCALAPPDATA\Ghostty\logs",
+    [string]$Since
 )
 $ErrorActionPreference = 'Stop'
 
@@ -49,6 +50,14 @@ if (-not $log) {
 }
 
 $lines = Get-Content -LiteralPath $log.FullName
+
+# Filter to entries emitted on or after -Since so earlier runs in the
+# same log file cannot contaminate the result. Log lines begin with
+# "YYYY-MM-DDTHH:MM:SS.fffZ |"; compare lexicographically against the
+# caller-provided ISO-8601 UTC timestamp.
+if ($PSBoundParameters.ContainsKey('Since') -and $Since) {
+    $lines = $lines | Where-Object { $_.Length -ge 24 -and $_.Substring(0, 24) -ge $Since }
+}
 
 # Verdict: "transport resolved: shell=\"...\" config_mode=<mode> resolved=<transport>"
 $verdictMatch = $lines |

--- a/scripts/validate-transport-run-all.ps1
+++ b/scripts/validate-transport-run-all.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Run all four conpty-mode smoke rows and aggregate results.
+
+.DESCRIPTION
+    Invokes scripts/validate-transport-run.ps1 for each of the four
+    rows, captures the exit code per row, prints a summary table,
+    and exits non-zero if any row failed or timed out.
+#>
+param(
+    [int]$TimeoutMs = 15000
+)
+$ErrorActionPreference = 'Stop'
+
+$rows = @('pwsh-auto', 'pwsh-always', 'pwsh-never', 'cmd-auto')
+$results = [ordered]@{}
+
+foreach ($r in $rows) {
+    Write-Host "===== $r ====="
+    pwsh -NoProfile -File scripts/validate-transport-run.ps1 -Row $r -TimeoutMs $TimeoutMs
+    $results[$r] = switch ($LASTEXITCODE) {
+        0 { 'pass' }
+        1 { 'fail' }
+        default { "infra ($LASTEXITCODE)" }
+    }
+}
+
+Write-Host ''
+Write-Host '=== Summary ==='
+foreach ($r in $rows) {
+    Write-Host ("{0,-14} {1}" -f $r, $results[$r])
+}
+
+$anyFailed = ($results.Values | Where-Object { $_ -ne 'pass' }).Count -gt 0
+if ($anyFailed) { exit 1 }
+exit 0

--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -61,13 +61,18 @@ try {
     $proc = Start-Process -FilePath $ExePath -PassThru
     $exited = $proc.WaitForExit($TimeoutMs)
     if (-not $exited) {
-        Write-Host "WARN: app did not exit within ${TimeoutMs}ms, killing"
+        # The conpty path currently leaves the window open after the
+        # shell exits (separate Ghostty bug). The logs still contain
+        # the verdict + OSC 11 receipt we need, so kill the app and
+        # defer to the assertion for pass/fail.
+        Write-Host "WARN: app did not exit within ${TimeoutMs}ms, killing and running assertion anyway"
         try { Stop-Process -Id $proc.Id -Force } catch {}
-        Write-Host "FAIL: $Row (timeout)"
-        exit 2
+        # Give the file sink a moment to flush its buffered writes.
+        Start-Sleep -Milliseconds 500
+    } else {
+        Write-Host "app exited with code $($proc.ExitCode); running assertion"
     }
 
-    Write-Host "app exited with code $($proc.ExitCode); running assertion"
     pwsh -NoProfile -File scripts/validate-transport-assert.ps1 -Row $Row
     exit $LASTEXITCODE
 }

--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -57,7 +57,11 @@ $originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Write-Host "launching: $ExePath (XDG_CONFIG_HOME=$tempXdg)"
+    # Capture UTC start time at millisecond precision so the assertion
+    # can filter log entries to just this run's window. Log lines are
+    # "YYYY-MM-DDTHH:MM:SS.fffZ | ..." so a lexical >= comparison works.
+    $runStart = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+    Write-Host "launching: $ExePath (XDG_CONFIG_HOME=$tempXdg) since=$runStart"
     $proc = Start-Process -FilePath $ExePath -PassThru
     $exited = $proc.WaitForExit($TimeoutMs)
     if (-not $exited) {
@@ -73,7 +77,7 @@ try {
         Write-Host "app exited with code $($proc.ExitCode); running assertion"
     }
 
-    pwsh -NoProfile -File scripts/validate-transport-assert.ps1 -Row $Row
+    pwsh -NoProfile -File scripts/validate-transport-assert.ps1 -Row $Row -Since $runStart
     exit $LASTEXITCODE
 }
 finally {

--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -1,0 +1,56 @@
+<#
+.SYNOPSIS
+    Run one conpty-mode smoke row end-to-end.
+
+.DESCRIPTION
+    Copies dev-configs/validate-transport/<Row>.conf to a temp file,
+    launches the built Ghostty.exe with --config-file pointing at it,
+    waits up to -TimeoutMs for exit, then invokes
+    scripts/validate-transport-assert.ps1 -Row <Row> and exits with
+    its exit code.
+
+    Assumes the app is already built. Call from `just
+    validate-transport-smoke <Row>` which chains the build.
+
+.PARAMETER Row
+    One of: pwsh-auto, pwsh-always, pwsh-never, cmd-auto.
+
+.PARAMETER TimeoutMs
+    Safety timeout. Defaults to 15000 (15 seconds).
+
+.PARAMETER ExePath
+    Path to the built Ghostty.exe. Defaults to the Debug x64 output.
+#>
+param(
+    [Parameter(Mandatory)][string]$Row,
+    [int]$TimeoutMs = 15000,
+    [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.exe'
+)
+$ErrorActionPreference = 'Stop'
+
+$fixturePath = "dev-configs/validate-transport/$Row.conf"
+if (-not (Test-Path $fixturePath)) {
+    Write-Host "ERROR: fixture not found: $fixturePath"
+    exit 2
+}
+if (-not (Test-Path $ExePath)) {
+    Write-Host "ERROR: exe not found: $ExePath (run ``just build-dll build-win`` first)"
+    exit 2
+}
+
+$tmpConfig = Join-Path $env:TEMP "ghostty-validate-$Row.conf"
+Copy-Item -LiteralPath $fixturePath -Destination $tmpConfig -Force
+
+Write-Host "launching: $ExePath --config-file=$tmpConfig"
+$proc = Start-Process -FilePath $ExePath -ArgumentList "--config-file=$tmpConfig" -PassThru
+$exited = $proc.WaitForExit($TimeoutMs)
+if (-not $exited) {
+    Write-Host "WARN: app did not exit within ${TimeoutMs}ms, killing"
+    try { Stop-Process -Id $proc.Id -Force } catch {}
+    Write-Host "FAIL: $Row (timeout)"
+    exit 2
+}
+
+Write-Host "app exited with code $($proc.ExitCode); running assertion"
+pwsh -NoProfile -File scripts/validate-transport-assert.ps1 -Row $Row
+exit $LASTEXITCODE

--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -3,11 +3,16 @@
     Run one conpty-mode smoke row end-to-end.
 
 .DESCRIPTION
-    Copies dev-configs/validate-transport/<Row>.conf to a temp file,
-    launches the built Ghostty.exe with --config-file pointing at it,
-    waits up to -TimeoutMs for exit, then invokes
+    Copies dev-configs/validate-transport/<Row>.conf into an isolated
+    XDG_CONFIG_HOME directory (as ghostty/config.ghostty), launches
+    the built Ghostty.exe with XDG_CONFIG_HOME pointing at it, waits
+    up to -TimeoutMs for exit, then invokes
     scripts/validate-transport-assert.ps1 -Row <Row> and exits with
     its exit code.
+
+    The WinUI shell does not honor a --config-file CLI flag - it calls
+    ghostty_config_load_default_files which reads from the XDG path.
+    So we isolate via environment instead of argv.
 
     Assumes the app is already built. Call from `just
     validate-transport-smoke <Row>` which chains the build.
@@ -38,19 +43,41 @@ if (-not (Test-Path $ExePath)) {
     exit 2
 }
 
-$tmpConfig = Join-Path $env:TEMP "ghostty-validate-$Row.conf"
-Copy-Item -LiteralPath $fixturePath -Destination $tmpConfig -Force
+# Isolated XDG_CONFIG_HOME: Ghostty looks up its default config at
+# $XDG_CONFIG_HOME/ghostty/config.ghostty. Stage our fixture there
+# and point the env var at the temp dir.
+$tempXdg = Join-Path $env:TEMP "ghostty-validate-xdg-$Row-$((New-Guid).Guid)"
+$ghosttyDir = Join-Path $tempXdg 'ghostty'
+New-Item -ItemType Directory -Path $ghosttyDir -Force | Out-Null
+$configPath = Join-Path $ghosttyDir 'config.ghostty'
+Copy-Item -LiteralPath $fixturePath -Destination $configPath -Force
 
-Write-Host "launching: $ExePath --config-file=$tmpConfig"
-$proc = Start-Process -FilePath $ExePath -ArgumentList "--config-file=$tmpConfig" -PassThru
-$exited = $proc.WaitForExit($TimeoutMs)
-if (-not $exited) {
-    Write-Host "WARN: app did not exit within ${TimeoutMs}ms, killing"
-    try { Stop-Process -Id $proc.Id -Force } catch {}
-    Write-Host "FAIL: $Row (timeout)"
-    exit 2
+$originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
+$originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
+
+try {
+    $env:XDG_CONFIG_HOME = $tempXdg
+    Write-Host "launching: $ExePath (XDG_CONFIG_HOME=$tempXdg)"
+    $proc = Start-Process -FilePath $ExePath -PassThru
+    $exited = $proc.WaitForExit($TimeoutMs)
+    if (-not $exited) {
+        Write-Host "WARN: app did not exit within ${TimeoutMs}ms, killing"
+        try { Stop-Process -Id $proc.Id -Force } catch {}
+        Write-Host "FAIL: $Row (timeout)"
+        exit 2
+    }
+
+    Write-Host "app exited with code $($proc.ExitCode); running assertion"
+    pwsh -NoProfile -File scripts/validate-transport-assert.ps1 -Row $Row
+    exit $LASTEXITCODE
 }
-
-Write-Host "app exited with code $($proc.ExitCode); running assertion"
-pwsh -NoProfile -File scripts/validate-transport-assert.ps1 -Row $Row
-exit $LASTEXITCODE
+finally {
+    if ($originalXdgSet) {
+        $env:XDG_CONFIG_HOME = $originalXdg
+    } else {
+        Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue
+    }
+    if (Test-Path $tempXdg) {
+        Remove-Item -LiteralPath $tempXdg -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2091,3 +2091,14 @@ test "resolveConptyMode: auto picks conpty for unknown (safe default)" {
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "my-custom.exe"));
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, ""));
 }
+
+test "resolveConptyMode: auto handles path-prefixed shell" {
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "C:\\Windows\\System32\\cmd.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "C:/Program Files/PowerShell/7/pwsh.exe"));
+}
+
+test "resolveConptyMode: auto handles quoted shell" {
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "\"pwsh.exe\""));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "'cmd.exe'"));
+}

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -915,6 +915,9 @@ const Subprocess = struct {
 
         // Resolve the transport mode from config + shell classification.
         // Windows-only; POSIX ignores opts.mode.
+        // args[0] is the shell executable path (bare basename or full path),
+        // never a joined command line. resolveConptyMode relies on this -
+        // windows_shell.classify does not split tokens on spaces.
         const mode: ptypkg.Mode = if (comptime builtin.os.tag == .windows)
             resolveConptyMode(self.conpty_mode, self.args[0])
         else
@@ -1735,6 +1738,9 @@ pub fn getProcessInfo(self: *Exec, comptime info: ProcessInfo) ?ProcessInfo.Type
 /// - `.auto` defers to the shell classifier: VT-aware shells use the
 ///   bypass, console-API shells and anything unrecognized fall back
 ///   to ConPTY so unknown programs keep the safe default.
+///
+/// `exe_path` must be a single executable path (basename or full path),
+/// not a joined argv string. Callers holding argv should pass argv[0].
 fn resolveConptyMode(
     cfg: configpkg.Config.ConptyMode,
     exe_path: []const u8,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -30,6 +30,7 @@ const windows = internal_os.windows;
 const ProcessInfo = @import("../pty.zig").ProcessInfo;
 
 const log = std.log.scoped(.io_exec);
+const log_validate = std.log.scoped(.validate_transport);
 
 /// The termios poll rate in milliseconds.
 const TERMIOS_POLL_MS = 200;
@@ -1745,7 +1746,7 @@ fn resolveConptyMode(
     cfg: configpkg.Config.ConptyMode,
     exe_path: []const u8,
 ) ptypkg.Mode {
-    return switch (cfg) {
+    const resolved: ptypkg.Mode = switch (cfg) {
         .never => .conpty,
         .always => .bypass,
         .auto => switch (internal_os.windows_shell.classify(exe_path)) {
@@ -1753,6 +1754,11 @@ fn resolveConptyMode(
             .console_api, .unknown => .conpty,
         },
     };
+    log_validate.info(
+        "transport resolved: shell=\"{s}\" config_mode={s} resolved={s}",
+        .{ exe_path, @tagName(cfg), @tagName(resolved) },
+    );
+    return resolved;
 }
 
 test "execCommand darwin: shell command" {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -14,6 +14,7 @@ const terminfo = @import("../terminfo/main.zig");
 const posix = std.posix;
 
 const log = std.log.scoped(.io_handler);
+const log_validate = std.log.scoped(.validate_transport);
 
 /// This is used as the handler for the terminal.Stream type. This is
 /// stateful and is expected to live for the entire lifetime of the terminal.
@@ -1338,6 +1339,12 @@ pub const StreamHandler = struct {
                 ),
 
                 .query => |kind| report: {
+                    // Fire validation log before the early-return so we capture
+                    // OSC 11 arrival regardless of osc-color-report-format.
+                    if (kind == .dynamic and kind.dynamic == .background) {
+                        log_validate.info("osc11 from pty: kind=query", .{});
+                    }
+
                     if (self.osc_color_report_format == .none) break :report;
 
                     const color = switch (kind) {


### PR DESCRIPTION
Follow-up to #112 (conpty-mode config + ConPTY bypass). Adds an
operator-driven smoke tier that exercises the full libghostty path
and asserts the transport verdict plus OSC 11 receipt for each row
of a pwsh x {auto, always, never} + cmd x auto matrix. Runs via
`just validate-transport-smoke ROW` or `-smoke-all`; fixtures live
under `dev-configs/validate-transport/`, assertion under
`scripts/validate-transport-assert.ps1`.

Also adds two diagnostic Zig log lines (transport verdict, OSC 11
arrival) under a new `validate_transport` scope, plus documentation
and tests for the input shape `resolveConptyMode` expects.

pwsh-never (conpty-mode = never) confirms conhost still swallows
OSC 11 on Windows 11 23H2 - the premise the bypass work is built
on. bypass rows confirm OSC 11 passes through to the VT parser.