### PR TITLE
fix(windows): set CREATE_NO_WINDOW on bypass CreateProcessW

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -430,6 +430,15 @@ fn startWindows(self: *Command, arena: Allocator) !void {
     var flags: windows.DWORD = windows.exp.CREATE_UNICODE_ENVIRONMENT;
     flags |= windows.exp.EXTENDED_STARTUPINFO_PRESENT;
 
+    // When spawning a console-subsystem process (shell) from a GUI-subsystem
+    // parent (Ghostty.exe via WinUI 3), Windows allocates a visible console
+    // window for the child. ConPTY hides this automatically via pseudo-console
+    // attachment; the bypass path must set CREATE_NO_WINDOW explicitly.
+    // ConPTY overrides this flag anyway, so setting it unconditionally is safe.
+    if (self.pseudo_console == null) {
+        flags |= windows.CREATE_NO_WINDOW;
+    }
+
     var process_information: windows.PROCESS_INFORMATION = undefined;
     if (windows.exp.kernel32.CreateProcessW(
         application_w.ptr,

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -430,13 +430,11 @@ fn startWindows(self: *Command, arena: Allocator) !void {
     var flags: windows.DWORD = windows.exp.CREATE_UNICODE_ENVIRONMENT;
     flags |= windows.exp.EXTENDED_STARTUPINFO_PRESENT;
 
-    // When spawning a console-subsystem process (shell) from a GUI-subsystem
-    // parent (Ghostty.exe via WinUI 3), Windows allocates a visible console
-    // window for the child. ConPTY hides this automatically via pseudo-console
-    // attachment; the bypass path must set CREATE_NO_WINDOW explicitly.
-    // ConPTY overrides this flag anyway, so setting it unconditionally is safe.
+    // Suppress console window for raw-pipe sessions. ConPTY attaches the
+    // pseudo-console which automatically suppresses the window; raw pipes need
+    // the flag explicitly.
     if (self.pseudo_console == null) {
-        flags |= windows.CREATE_NO_WINDOW;
+        flags |= windows.exp.CREATE_NO_WINDOW;
     }
 
     var process_information: windows.PROCESS_INFORMATION = undefined;


### PR DESCRIPTION
When spawning a console-subsystem shell from Ghostty (a GUI-subsystem parent),
Windows allocates a visible console window. ConPTY hides this automatically via
the pseudo-console attachment; the raw-pipe bypass path must set CREATE_NO_WINDOW
explicitly to prevent the extra window.

Stdio still flows via STARTF_USESTDHANDLES, so this is cosmetic, but the extra
window is user-visible and wrong.

Closes #291