### PR TITLE
fix(os/path): honor PATHEXT when resolving bare command names on Windows

### DIFF
--- a/src/os/path.zig
+++ b/src/os/path.zig
@@ -6,6 +6,10 @@ const testing = std.testing;
 /// Search for "cmd" in the PATH and return the absolute path. This will
 /// always allocate if there is a non-null result. The caller must free the
 /// resulting value.
+///
+/// On Windows, honors PATHEXT when searching for bare command names.
+/// If cmd is already a path or has an extension, tries it literally first
+/// before attempting PATHEXT extensions.
 pub fn expand(alloc: Allocator, cmd: []const u8) !?[]u8 {
     // If the command already contains a path separator, return as-is.
     // POSIX: '/'. Windows additionally accepts '\\' and drive-letter
@@ -30,43 +34,103 @@ pub fn expand(alloc: Allocator, cmd: []const u8) !?[]u8 {
     };
     defer if (builtin.os.tag == .windows) alloc.free(PATH);
 
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    var it = std.mem.tokenizeScalar(u8, PATH, std.fs.path.delimiter);
-    var seen_eacces = false;
-    while (it.next()) |search_path| {
-        // We need enough space in our path buffer to store this
-        const path_len = search_path.len + cmd.len + 1;
-        if (path_buf.len < path_len) return error.PathTooLong;
+    // Parse PATHEXT on Windows
+    var pathext_list: ?[][]const u8 = null;
+    var pathext_buf: ?[]u8 = null;
+    const has_extension = std.mem.indexOfScalar(u8, cmd, '.') != null;
+    defer {
+        if (pathext_buf) |pb| alloc.free(pb);
+        if (pathext_list) |pl| alloc.free(pl);
+    }
 
-        // Copy in the full path
-        @memcpy(path_buf[0..search_path.len], search_path);
-        path_buf[search_path.len] = std.fs.path.sep;
-        @memcpy(path_buf[search_path.len + 1 ..][0..cmd.len], cmd);
-        path_buf[path_len] = 0;
-        const full_path = path_buf[0..path_len :0];
-
-        // Stat it
-        const f = std.fs.cwd().openFile(
-            full_path,
-            .{},
-        ) catch |err| switch (err) {
-            error.FileNotFound => continue,
-            error.AccessDenied => {
-                // Accumulate this and return it later so we can try other
-                // paths that we have access to.
-                seen_eacces = true;
-                continue;
-            },
-            else => return err,
+    if (builtin.os.tag == .windows and !has_extension) {
+        const pathext_str = blk: {
+            if (std.process.getenvW(std.unicode.utf8ToUtf16LeStringLiteral("PATHEXT"))) |we| {
+                const utf8_pathext = try std.unicode.utf16LeToUtf8Alloc(alloc, we);
+                break :blk utf8_pathext;
+            } else {
+                // Fallback to default Windows extensions
+                break :blk try alloc.dupe(u8, ".COM;.EXE;.BAT;.CMD");
+            }
         };
-        defer f.close();
-        const stat = try f.stat();
-        if (stat.kind != .directory and isExecutable(stat.mode)) {
-            return try alloc.dupe(u8, full_path);
+        pathext_buf = pathext_str;
+
+        // Count semicolons to determine how many extensions
+        var ext_count: usize = 1;
+        for (pathext_str) |ch| {
+            if (ch == ';') ext_count += 1;
+        }
+
+        // Allocate and populate extension list
+        pathext_list = try alloc.alloc([]const u8, ext_count);
+        var idx: usize = 0;
+        var it = std.mem.tokenizeScalar(u8, pathext_str, ';');
+        while (it.next()) |ext| {
+            pathext_list.?[idx] = ext;
+            idx += 1;
         }
     }
 
-    if (seen_eacces) return error.AccessDenied;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var it = std.mem.tokenizeScalar(u8, PATH, std.fs.path.delimiter);
+    while (it.next()) |search_path| {
+        // First, try the command as-is (literal match, or if it has an extension)
+        if (try tryPath(alloc, search_path, cmd, &path_buf)) |result| {
+            return result;
+        }
+
+        // On Windows, if no extension, try with PATHEXT extensions
+        if (builtin.os.tag == .windows and !has_extension and pathext_list != null) {
+            for (pathext_list.?) |ext| {
+                // Build cmd + extension
+                const combined_len = cmd.len + ext.len;
+                if (combined_len > std.fs.max_path_bytes) return error.PathTooLong;
+                var cmd_with_ext: [std.fs.max_path_bytes]u8 = undefined;
+                @memcpy(cmd_with_ext[0..cmd.len], cmd);
+                @memcpy(cmd_with_ext[cmd.len..][0..ext.len], ext);
+                const cmd_ext_str = cmd_with_ext[0..combined_len];
+
+                if (try tryPath(alloc, search_path, cmd_ext_str, &path_buf)) |result| {
+                    return result;
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+/// Helper function to try opening a file at search_path/cmd.
+/// Returns the allocated full path on success, null on FileNotFound,
+/// or error on other failures.
+fn tryPath(alloc: Allocator, search_path: []const u8, cmd: []const u8, path_buf: *[std.fs.max_path_bytes]u8) !?[]u8 {
+    const path_len = search_path.len + cmd.len + 1;
+    if (path_buf.len < path_len) return error.PathTooLong;
+
+    // Copy in the full path
+    @memcpy(path_buf[0..search_path.len], search_path);
+    path_buf[search_path.len] = std.fs.path.sep;
+    @memcpy(path_buf[search_path.len + 1 ..][0..cmd.len], cmd);
+    path_buf[path_len] = 0;
+    const full_path = path_buf[0..path_len :0];
+
+    // Try to open the file
+    const f = std.fs.cwd().openFile(
+        full_path,
+        .{},
+    ) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        error.AccessDenied => {
+            // TODO: accumulate and return later so we can try other paths
+            return null;
+        },
+        else => return err,
+    };
+    defer f.close();
+    const stat = try f.stat();
+    if (stat.kind != .directory and isExecutable(stat.mode)) {
+        return try alloc.dupe(u8, full_path);
+    }
 
     return null;
 }
@@ -121,4 +185,33 @@ test "expand: windows bare cmd.exe resolves on PATH" {
     // System32\cmd.exe lives on the default Windows PATH.
     try testing.expect(std.ascii.endsWithIgnoreCase(path, "cmd.exe"));
     try testing.expect(path.len > "cmd.exe".len);
+}
+
+test "expand: windows bare pwsh resolves via PATHEXT" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    // This test requires pwsh.exe to be on the system PATH.
+    // If not found, it returns null rather than erroring.
+    const path = try expand(testing.allocator, "pwsh");
+    if (path) |p| {
+        defer testing.allocator.free(p);
+        try testing.expect(std.ascii.endsWithIgnoreCase(p, "pwsh.exe") or std.ascii.endsWithIgnoreCase(p, "pwsh.com") or std.ascii.endsWithIgnoreCase(p, "pwsh.bat") or std.ascii.endsWithIgnoreCase(p, "pwsh.cmd"));
+        try testing.expect(p.len > "pwsh".len);
+    }
+}
+
+test "expand: windows name with extension does not PATHEXT hunt" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    // If we provide a name with an extension (even unknown), it should
+    // try that literally, not attempt PATHEXT extensions.
+    const path = try expand(testing.allocator, "cmd.xyz");
+    try testing.expect(path == null);
+}
+
+test "expand: windows extension present bypasses PATHEXT" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    // cmd.exe should resolve literally via the literal-first attempt,
+    // not via PATHEXT hunting.
+    const path = (try expand(testing.allocator, "cmd.exe")).?;
+    defer testing.allocator.free(path);
+    try testing.expect(std.ascii.endsWithIgnoreCase(path, "cmd.exe"));
 }

--- a/src/os/path.zig
+++ b/src/os/path.zig
@@ -73,9 +73,10 @@ pub fn expand(alloc: Allocator, cmd: []const u8) !?[]u8 {
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var it = std.mem.tokenizeScalar(u8, PATH, std.fs.path.delimiter);
+    var seen_eacces = false;
     while (it.next()) |search_path| {
         // First, try the command as-is (literal match, or if it has an extension)
-        if (try tryPath(alloc, search_path, cmd, &path_buf)) |result| {
+        if (try tryPathImpl(alloc, search_path, cmd, &path_buf, &seen_eacces)) |result| {
             return result;
         }
 
@@ -90,20 +91,22 @@ pub fn expand(alloc: Allocator, cmd: []const u8) !?[]u8 {
                 @memcpy(cmd_with_ext[cmd.len..][0..ext.len], ext);
                 const cmd_ext_str = cmd_with_ext[0..combined_len];
 
-                if (try tryPath(alloc, search_path, cmd_ext_str, &path_buf)) |result| {
+                if (try tryPathImpl(alloc, search_path, cmd_ext_str, &path_buf, &seen_eacces)) |result| {
                     return result;
                 }
             }
         }
     }
 
+    if (seen_eacces) return error.AccessDenied;
+
     return null;
 }
 
 /// Helper function to try opening a file at search_path/cmd.
 /// Returns the allocated full path on success, null on FileNotFound,
-/// or error on other failures.
-fn tryPath(alloc: Allocator, search_path: []const u8, cmd: []const u8, path_buf: *[std.fs.max_path_bytes]u8) !?[]u8 {
+/// tracks AccessDenied in seen_eacces pointer, or error on other failures.
+fn tryPathImpl(alloc: Allocator, search_path: []const u8, cmd: []const u8, path_buf: *[std.fs.max_path_bytes]u8, seen_eacces: *bool) !?[]u8 {
     const path_len = search_path.len + cmd.len + 1;
     if (path_buf.len < path_len) return error.PathTooLong;
 
@@ -121,7 +124,9 @@ fn tryPath(alloc: Allocator, search_path: []const u8, cmd: []const u8, path_buf:
     ) catch |err| switch (err) {
         error.FileNotFound => return null,
         error.AccessDenied => {
-            // TODO: accumulate and return later so we can try other paths
+            // Accumulate this and return it later so we can try other
+            // paths that we have access to.
+            seen_eacces.* = true;
             return null;
         },
         else => return err,


### PR DESCRIPTION
On Windows, the path resolver now honors the PATHEXT environment variable when searching for bare command names. This fixes cases like 'pwsh' failing to resolve to 'pwsh.exe'.

The implementation reads PATHEXT at function entry (fallback to .COM;.EXE;.BAT;.CMD if unset), parses it into a list of extensions, and for bare names tries the literal name first then appends each PATHEXT extension in order. Names with extensions try literally only, preserving current behavior. Edge cases like unknown extensions and very long concatenations are covered.

Closes #294