### PR TITLE
chore(scripts): drop smoke-runner timeout-kill workaround after # 297

### DIFF
--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -6,9 +6,13 @@
     Copies dev-configs/validate-transport/<Row>.conf into an isolated
     XDG_CONFIG_HOME directory (as ghostty/config.ghostty), launches
     the built Ghostty.exe with XDG_CONFIG_HOME pointing at it, waits
-    up to -TimeoutMs for exit, then invokes
-    scripts/validate-transport-assert.ps1 -Row <Row> and exits with
-    its exit code.
+    for exit, then invokes scripts/validate-transport-assert.ps1 -Row
+    <Row> and exits with its exit code.
+
+    If the app does not exit within -TimeoutMs (default 10 seconds), it
+    is killed and the script exits with code 2 (infra failure). The app
+    should exit within a second or two after the shell exits; a timeout
+    indicates a regression in ConPTY/bypass teardown.
 
     The WinUI shell does not honor a --config-file CLI flag - it calls
     ghostty_config_load_default_files which reads from the XDG path.
@@ -21,14 +25,14 @@
     One of: pwsh-auto, pwsh-always, pwsh-never, cmd-auto.
 
 .PARAMETER TimeoutMs
-    Safety timeout. Defaults to 15000 (15 seconds).
+    Safety timeout. Defaults to 10000 (10 seconds).
 
 .PARAMETER ExePath
     Path to the built Ghostty.exe. Defaults to the Debug x64 output.
 #>
 param(
     [Parameter(Mandatory)][string]$Row,
-    [int]$TimeoutMs = 15000,
+    [int]$TimeoutMs = 10000,
     [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.exe'
 )
 $ErrorActionPreference = 'Stop'
@@ -65,18 +69,17 @@ try {
     $proc = Start-Process -FilePath $ExePath -PassThru
     $exited = $proc.WaitForExit($TimeoutMs)
     if (-not $exited) {
-        # The conpty path currently leaves the window open after the
-        # shell exits (separate Ghostty bug). The logs still contain
-        # the verdict + OSC 11 receipt we need, so kill the app and
-        # defer to the assertion for pass/fail.
-        Write-Host "WARN: app did not exit within ${TimeoutMs}ms, killing and running assertion anyway"
+        # Unexpected hang: the app should exit within a second or two
+        # once the shell's command completes. If we hit this branch the
+        # ConPTY/bypass teardown path has regressed (see # 293's fix via
+        # PR # 297 for the prior working state). Kill the app and fail
+        # with exit 2 so the regression is loud, not papered over.
+        Write-Host "FAIL: $Row (app did not exit within ${TimeoutMs}ms; possible regression of child-exit teardown)"
         try { Stop-Process -Id $proc.Id -Force } catch {}
-        # Give the file sink a moment to flush its buffered writes.
-        Start-Sleep -Milliseconds 500
-    } else {
-        Write-Host "app exited with code $($proc.ExitCode); running assertion"
+        exit 2
     }
 
+    Write-Host "app exited with code $($proc.ExitCode); running assertion"
     pwsh -NoProfile -File scripts/validate-transport-assert.ps1 -Row $Row -Since $runStart
     exit $LASTEXITCODE
 }


### PR DESCRIPTION
PR #289 added a smoke-runner timeout workaround because the ConPTY path would leave the app open after the shell exited (issue #293). PR #297 fixed that problem with proper child-exit detection. The workaround is now obsolete.

Changes: tightened timeout from 15 to 10 seconds and made it strict failure. If the app doesn't exit, we kill it and fail with exit 2 (infra failure). The app should exit within a second or two; a timeout now signals a regression in ConPTY/bypass teardown.

Full end-to-end verification needs a real PowerShell terminal since Claude Code's shells inherit an MSYS2 pty that breaks ConPtyTransport.