### PR TITLE
windows/sponsor: align oauth loopback path and query shape

### DIFF
--- a/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/HttpLoopbackListener.cs
@@ -10,16 +10,32 @@ namespace Ghostty.Core.Sponsor.Auth;
 /// <summary>
 /// One-shot loopback HTTP server for OAuth callback capture. Binds an
 /// ephemeral port on <c>127.0.0.1</c> and responds to the first
-/// <c>/cb</c> request with a confirmation page, then exits. Non-<c>/cb</c>
-/// paths return 404 and listening continues until <c>/cb</c> arrives or
-/// cancellation fires.
+/// <c>/</c> request with a confirmation page, then exits. Non-root
+/// paths return 404 and listening continues until the root request
+/// arrives or cancellation fires.
 /// </summary>
 [SupportedOSPlatform("windows")]
 internal sealed class HttpLoopbackListener : ILoopbackListener
 {
     private HttpListener? _listener;
+    private readonly int _minPort;
+    private readonly int _maxPort;
     private int _port;
     private bool _started;
+
+    // Windows ephemeral range is 49152-65535 since Vista (IPPORT_DYNAMIC).
+    // TcpListener(IPAddress.Loopback, 0) always lands in this range on an
+    // unmodified host. The assertion in Start() catches unexpected
+    // deviations (e.g., registry tweaks to MaxUserPort) so the user sees
+    // a clear local error instead of an opaque remote 400 later in the
+    // OAuth round-trip.
+    public HttpLoopbackListener() : this(49152, 65535) { }
+
+    internal HttpLoopbackListener(int minPort, int maxPort)
+    {
+        _minPort = minPort;
+        _maxPort = maxPort;
+    }
 
     private static readonly byte[] ConfirmPage = Encoding.UTF8.GetBytes(
         "<!doctype html><html><body style='font-family:sans-serif;padding:2em'>"
@@ -42,6 +58,12 @@ internal sealed class HttpLoopbackListener : ILoopbackListener
         tcp.Start();
         _port = ((IPEndPoint)tcp.LocalEndpoint).Port;
         tcp.Stop();
+
+        if (_port < _minPort || _port > _maxPort)
+        {
+            throw new InvalidOperationException(
+                $"loopback port {_port} outside allowed range {_minPort}-{_maxPort}");
+        }
 
         _listener = new HttpListener();
         _listener.Prefixes.Add($"http://127.0.0.1:{_port}/");
@@ -85,7 +107,7 @@ internal sealed class HttpLoopbackListener : ILoopbackListener
             }
 
             var req = ctx.Request;
-            if (req.Url?.AbsolutePath != "/cb")
+            if (req.Url?.AbsolutePath != "/")
             {
                 ctx.Response.StatusCode = 404;
                 ctx.Response.Close();
@@ -94,7 +116,7 @@ internal sealed class HttpLoopbackListener : ILoopbackListener
                 {
                     // Bounds a local process flooding the port with junk
                     // requests. The legitimate OAuth flow makes exactly one
-                    // call to /cb; anything else is either a broken client
+                    // request to /; anything else is either a broken client
                     // or an attack and we shouldn't keep the listener open.
                     return new LoopbackResult(null, null, "too many invalid callbacks");
                 }

--- a/windows/Ghostty.Core/Sponsor/Auth/ILoopbackListener.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/ILoopbackListener.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Ghostty.Core.Sponsor.Auth;
 
 /// <summary>
-/// Abstraction over the ephemeral <c>http://127.0.0.1:N/cb</c>
+/// Abstraction over the ephemeral <c>http://127.0.0.1:N/</c>
 /// listener that receives the OAuth callback. Production impl uses
 /// <see cref="System.Net.HttpListener"/>; tests drive the provider with
 /// pre-baked <see cref="LoopbackResult"/> values.
@@ -25,7 +25,7 @@ internal interface ILoopbackListener : IDisposable
     void Start();
 
     /// <summary>
-    /// Awaits the first incoming request on <c>/cb</c>, parses query
+    /// Awaits the first incoming request on <c>/</c>, parses query
     /// params, and returns a <see cref="LoopbackResult"/>. On cancellation,
     /// throws <see cref="OperationCanceledException"/>. Unknown paths
     /// return a 404 and keep listening.
@@ -34,7 +34,7 @@ internal interface ILoopbackListener : IDisposable
 }
 
 /// <summary>
-/// Parsed query-string payload from the <c>/cb</c> request. Exactly one
+/// Parsed query-string payload from the <c>/</c> request. Exactly one
 /// of <see cref="Token"/> / <see cref="Error"/> is non-null on a
 /// well-formed callback; both null indicates a malformed request and
 /// <c>OAuthTokenProvider</c> treats it as a silent failure.

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -458,11 +458,10 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
             // guard against a rogue local process racing the real callback.
             var nonce = Convert.ToHexString(
                 System.Security.Cryptography.RandomNumberGenerator.GetBytes(16));
-            var callback = $"http://127.0.0.1:{_listener.Port}/cb";
 
             var url = new Uri(
                 $"{_apiBase.GetLeftPart(UriPartial.Authority)}/auth/github/start"
-                + $"?redirect={Uri.EscapeDataString(callback)}"
+                + $"?loopback={_listener.Port}"
                 + $"&nonce={nonce}");
             _browser.Open(url);
 

--- a/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
+++ b/windows/Ghostty.Core/Sponsor/Auth/OAuthTokenProvider.cs
@@ -451,7 +451,7 @@ internal sealed partial class OAuthTokenProvider : ISponsorTokenProvider, IDispo
             }
 
             // The Worker's /auth/github/start endpoint takes a `nonce` query param
-            // and echoes it verbatim in the final /cb 302. This is an ADDITIONAL
+            // and echoes it verbatim in the final loopback 302. This is an ADDITIONAL
             // CSRF defense on top of the OAuth `state` param (which the Worker
             // owns end-to-end and HS256-signs with its own secret). The client
             // never touches OAuth `state`; our `nonce` is the client-local replay

--- a/windows/Ghostty.Tests/Sponsor/Auth/HttpLoopbackListenerTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/HttpLoopbackListenerTests.cs
@@ -21,7 +21,7 @@ public class HttpLoopbackListenerTests
         _ = Task.Run(async () =>
         {
             await Task.Delay(50);
-            await http.GetAsync($"http://127.0.0.1:{listener.Port}/cb?token=abc&nonce=xyz");
+            await http.GetAsync($"http://127.0.0.1:{listener.Port}/?token=abc&nonce=xyz");
         });
 
         var result = await listener.AwaitCallbackAsync(CancellationToken.None);
@@ -41,7 +41,7 @@ public class HttpLoopbackListenerTests
         _ = Task.Run(async () =>
         {
             await Task.Delay(50);
-            await http.GetAsync($"http://127.0.0.1:{listener.Port}/cb?error=access_denied");
+            await http.GetAsync($"http://127.0.0.1:{listener.Port}/?error=access_denied");
         });
 
         var result = await listener.AwaitCallbackAsync(CancellationToken.None);
@@ -64,7 +64,7 @@ public class HttpLoopbackListenerTests
             Assert.Equal(System.Net.HttpStatusCode.NotFound, wrong.StatusCode);
 
             await Task.Delay(50);
-            await http.GetAsync($"http://127.0.0.1:{listener.Port}/cb?token=t&nonce=n");
+            await http.GetAsync($"http://127.0.0.1:{listener.Port}/?token=t&nonce=n");
         });
 
         var result = await listener.AwaitCallbackAsync(CancellationToken.None);
@@ -90,5 +90,16 @@ public class HttpLoopbackListenerTests
         using var listener = new HttpLoopbackListener();
 
         Assert.Throws<InvalidOperationException>(() => _ = listener.Port);
+    }
+
+    [Fact]
+    public void Start_ThrowsWhenPortOutsideEphemeralRange()
+    {
+        // Force a range that no real ephemeral port can satisfy so the
+        // assertion inside Start() has to fire.
+        using var listener = new HttpLoopbackListener(minPort: 1, maxPort: 1);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => listener.Start());
+        Assert.Contains("outside allowed range", ex.Message);
     }
 }

--- a/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
+++ b/windows/Ghostty.Tests/Sponsor/Auth/OAuthTokenProviderTests.cs
@@ -246,6 +246,27 @@ public partial class OAuthTokenProviderTests
     }
 
     [Fact]
+    public async Task SignInAsync_StartUrlUsesLoopbackAndNonceQueryShape()
+    {
+        var (provider, _, browser, listener, _, time) = Build();
+        var jwt = MakeJwt(time, secondsFromNow: 3600);
+        listener.Behavior = _ =>
+        {
+            var opened = browser.Opened[^1];
+            var nonce = GetQueryParam(opened, "nonce")!;
+            return Task.FromResult(new LoopbackResult(jwt, nonce, null));
+        };
+
+        await provider.SignInAsync(CancellationToken.None);
+
+        var opened = browser.Opened[0];
+        // Contract with the Worker: ?loopback=<port>&nonce=<hex>.
+        Assert.Equal("54321", GetQueryParam(opened, "loopback"));
+        Assert.Matches(@"^[0-9A-Fa-f]{32}$", GetQueryParam(opened, "nonce"));
+        Assert.Null(GetQueryParam(opened, "redirect"));
+    }
+
+    [Fact]
     public async Task SignInAsync_NonceMismatch_ReturnsFalse()
     {
         var (provider, _, _, listener, _, time) = Build();

--- a/windows/Ghostty/Sponsor/DEV_NOTES.md
+++ b/windows/Ghostty/Sponsor/DEV_NOTES.md
@@ -13,7 +13,7 @@ self-sponsor test account.
 4. Command palette -> "Sign in to wintty".
 5. Default browser opens to `https://api.wintty.io/auth/github/start?...`.
 6. Authorize on GitHub.
-7. Redirected to `http://127.0.0.1:<port>/cb`, page says "You can close this window".
+7. Redirected to `http://127.0.0.1:<port>/`, page says "You can close this window".
 8. App pill transitions from NoToken-silent to Idle.
 9. Verify `auth.bin` exists under `%LocalAppData%\Ghostty\`, non-empty, is binary (not JSON - DPAPI envelope).
 10. Trigger update check via palette -> manifest call succeeds with bearer.


### PR DESCRIPTION
Follow-up to #290. Aligns the D.2.5 OAuth client with the API it
actually speaks to. Blocked on the companion server change reaching
production.

## Summary

- HttpLoopbackListener listens on root and rejects the legacy /cb path.
- Listener gains an ephemeral-range guard (49152-65535) as
  defense-in-depth against registry-tweaked hosts.
- OAuthTokenProvider sends ?loopback=<port>&nonce=<hex> on
  /auth/github/start instead of the old redirect+nonce pair.
- Unit tests pin the new listener path, the port-range guard, and
  the start URL query shape.
- DEV_NOTES.md step 7 shows the root callback path.

## Test plan

- [x] dotnet test ~Sponsor passes locally (132/133; 1 pre-existing flake tracked separately)
- [ ] End-to-end sign-in smoke against production api.wintty.io with
      a real sponsor account after merge