### PR TITLE
fix(windows/sponsor): order Error state ahead of download cancel

### DIFF
--- a/windows/Ghostty.Core/Sponsor/Update/VelopackUpdateDriver.cs
+++ b/windows/Ghostty.Core/Sponsor/Update/VelopackUpdateDriver.cs
@@ -254,15 +254,20 @@ internal sealed partial class VelopackUpdateDriver : IUpdateDriver, IDisposable
     {
         _logger.LogWarning("[sponsor/update] TokenInvalidated event fired");
 
-        // Cancel any in-flight download before overwriting state with the
-        // auth-expired Error snapshot.
-        _downloadCts?.Cancel();
-
+        // Write the Error snapshot before cancelling any in-flight download.
+        // DownloadAsync's OperationCanceledException catch reads _current and
+        // only emits FromCancel when the state isn't already Error; publishing
+        // Error first ensures that check wins whether the catch inlines inside
+        // Cancel() or resumes on the threadpool. Cancel() is a release barrier,
+        // so the write is visible to the observer thread. Reversing this order
+        // lets FromCancel race past Error under concurrent load.
         var snap = UpdateStateMapping.FromError(
             new UpdateCheckException(UpdateErrorKind.AuthExpired, "token invalidated"),
             targetVersion: _lastInfo?.Version);
         _current = snap;
         StateChanged?.Invoke(this, snap);
+
+        _downloadCts?.Cancel();
     }
 
     private void Emit(UpdateStateSnapshot snap)


### PR DESCRIPTION
Fixes # 304.

`VelopackUpdateDriver.OnTokenInvalidated` cancelled the download CTS before writing the auth-expired Error snapshot. `DownloadAsync`'s `OperationCanceledException` catch uses a check-then-emit pattern (only emits `FromCancel` when `_current.State != Error`), so under suite load the catch could observe `Downloading` and overwrite the Error snapshot with `UpdateAvailable`. The test then asserted on `Error` and intermittently failed.

Writing Error first, then cancelling, makes `Cancel()`'s release barrier publish the Error state to whichever thread runs the OCE catch (inline or threadpool). The check-then-emit now reliably skips the overwrite.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~VelopackUpdateDriverTests"` five times back-to-back: 18/18 pass each run.
- [x] Full `Ghostty.Tests` assembly once: 633 pass, 1 pre-existing unrelated skip, 0 fail.