### PR TITLE
fix(scripts): refresh verify-sponsor-gate for net10 and portable metadata read

### DIFF
--- a/scripts/verify-sponsor-gate.ps1
+++ b/scripts/verify-sponsor-gate.ps1
@@ -23,15 +23,45 @@ function Get-IsSponsorBuild([string]$assemblyPath) {
     if (-not (Test-Path $assemblyPath)) {
         throw "Assembly not found: $assemblyPath"
     }
-    # Load into a throwaway context. Reflection sees internal members fine.
-    $bytes = [System.IO.File]::ReadAllBytes((Resolve-Path $assemblyPath))
-    $asm = [System.Reflection.Assembly]::Load($bytes)
-    $type = $asm.GetType("Ghostty.BuildFlags", $true)
-    $field = $type.GetField("IsSponsorBuild",
-        [System.Reflection.BindingFlags]::Public -bor
-        [System.Reflection.BindingFlags]::NonPublic -bor
-        [System.Reflection.BindingFlags]::Static)
-    return [bool]$field.GetValue($null)
+    # Read the constant from PE metadata instead of Assembly.Load. The app
+    # targets net10.0-windows10.0.19041.0 and references WindowsAppSDK, so a
+    # runtime load would force the pwsh 7 host (which ships on .NET 8 or 9)
+    # to resolve references it has no TPA entries for. MetadataReader walks
+    # the immutable metadata tables without ever binding the assembly, so it
+    # works regardless of host runtime version.
+    Add-Type -AssemblyName "System.Reflection.Metadata" | Out-Null
+    $resolved = (Resolve-Path -LiteralPath $assemblyPath).Path
+    $stream = [System.IO.File]::OpenRead($resolved)
+    try {
+        $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+        try {
+            # GetMetadataReader is an extension method on PEReader; call it
+            # via the static form because PowerShell does not resolve C#
+            # extension methods as instance methods.
+            $reader = [System.Reflection.Metadata.PEReaderExtensions]::GetMetadataReader($peReader)
+            foreach ($fieldHandle in $reader.FieldDefinitions) {
+                $field = $reader.GetFieldDefinition($fieldHandle)
+                $name = $reader.GetString($field.Name)
+                if ($name -ne "IsSponsorBuild") { continue }
+                $declaring = $reader.GetTypeDefinition($field.GetDeclaringType())
+                $ns = $reader.GetString($declaring.Namespace)
+                $type = $reader.GetString($declaring.Name)
+                if ($ns -ne "Ghostty" -or $type -ne "BuildFlags") { continue }
+                $constantHandle = $field.GetDefaultValue()
+                if ($constantHandle.IsNil) {
+                    throw "Ghostty.BuildFlags.IsSponsorBuild has no constant value (not a compile-time literal)"
+                }
+                $constant = $reader.GetConstant($constantHandle)
+                $blob = $reader.GetBlobReader($constant.Value)
+                return [bool]$blob.ReadBoolean()
+            }
+            throw "Field Ghostty.BuildFlags.IsSponsorBuild not found in $resolved"
+        } finally {
+            $peReader.Dispose()
+        }
+    } finally {
+        $stream.Dispose()
+    }
 }
 
 function Assert-Equal($expected, $actual, $label) {
@@ -43,10 +73,10 @@ function Assert-Equal($expected, $actual, $label) {
 }
 
 # Single output path - the existing Justfile convention.
-$dllPath = "windows/Ghostty/bin/x64/Debug/net9.0-windows10.0.19041.0/Ghostty.dll"
+$dllPath = "windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.dll"
 
 Write-Host "=== Default build (SponsorBuild unset) ===" -ForegroundColor Cyan
-dotnet build windows/Ghostty/Ghostty.sln /p:Platform=x64 /p:Configuration=Debug
+dotnet build windows/Ghostty.sln /p:Platform=x64 /p:Configuration=Debug
 if ($LASTEXITCODE -ne 0) { throw "default build failed" }
 $defaultVal = Get-IsSponsorBuild $dllPath
 Assert-Equal $false $defaultVal "default build BuildFlags.IsSponsorBuild"
@@ -54,7 +84,7 @@ Assert-Equal $false $defaultVal "default build BuildFlags.IsSponsorBuild"
 Write-Host ""
 Write-Host "=== Sponsor build (SponsorBuild=true) ===" -ForegroundColor Cyan
 # Same Configuration=Debug, only SponsorBuild differs. Overwrites the default output.
-dotnet build windows/Ghostty/Ghostty.sln /p:Platform=x64 /p:Configuration=Debug /p:SponsorBuild=true
+dotnet build windows/Ghostty.sln /p:Platform=x64 /p:Configuration=Debug /p:SponsorBuild=true
 if ($LASTEXITCODE -ne 0) { throw "sponsor build failed" }
 $sponsorVal = Get-IsSponsorBuild $dllPath
 Assert-Equal $true $sponsorVal "sponsor build BuildFlags.IsSponsorBuild"


### PR DESCRIPTION
Fixes # 305.

Three drift fixes in `scripts/verify-sponsor-gate.ps1`:

- Solution path moved to `windows/Ghostty.sln` (the justfile already uses this).
- Target framework bumped to `net10.0-windows10.0.19041.0` per PRs # 257, # 260, # 261.
- Replaced `Assembly.Load` reflection with `System.Reflection.Metadata.MetadataReader`. The app targets net10 and references WindowsAppSDK; pwsh 7.4 ships on .NET 8 and pwsh 7.5 on .NET 9, so a runtime load throws `FileNotFoundException: System.Runtime 10.0.0.0`. Metadata reading walks the PE tables without binding the TPA graph, so it works regardless of host runtime. The script pulls the `IsSponsorBuild` constant blob from `FieldDefinition.GetDefaultValue()` and calls `ReadBoolean()`.

## Test plan

- [x] `pwsh -NoProfile -File .\scripts\verify-sponsor-gate.ps1` on pwsh 7.5 (.NET 9 host): default build reports `IsSponsorBuild : False`, `SponsorBuild=true` build reports `True`, exit 0.
- [x] Parse check via `[System.Management.Automation.Language.Parser]::ParseFile` returns no errors.