### PR TITLE
fix(termio): inject UTF-8 preamble for ConPTY-spawned shells

### DIFF
--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -19,19 +19,99 @@ pub const Awareness = enum {
     console_api,
 };
 
-const known = std.StaticStringMap(Awareness).initComptime(.{
-    .{ "pwsh", .vt_aware },
-    .{ "wsl", .vt_aware },
-    .{ "ssh", .vt_aware },
-    .{ "bash", .vt_aware },
-    .{ "nu", .vt_aware },
-    .{ "zsh", .vt_aware },
-    .{ "fish", .vt_aware },
-    .{ "elvish", .vt_aware },
-    .{ "xonsh", .vt_aware },
-    .{ "cmd", .console_api },
-    .{ "powershell", .console_api },
+/// UTF-8 preamble kind needed to make a shell's *initial* output land
+/// as UTF-8 when it runs under ConPTY. Separate from `Awareness`
+/// because we need to distinguish cmd from powershell (same awareness,
+/// different preamble) and pwsh from the other vt_aware shells
+/// (same awareness, but only powershell-family benefits from the
+/// setup under forced conpty-mode=never - see # 302).
+///
+/// The setup runs once at shell startup inside ConPTY's conhost.exe,
+/// which does not inherit the caller's console codepage.
+pub const Preamble = enum {
+    /// No preamble: either the shell is unknown, or it already handles
+    /// its own encoding (e.g. wsl / bash / nu all decode their own
+    /// output regardless of the Windows console CP).
+    none,
+    /// cmd.exe: run `chcp 65001 >nul` at startup and stay interactive.
+    cmd,
+    /// PowerShell (pwsh.exe or Windows PowerShell 5.1): assign
+    /// `[Console]::OutputEncoding` and `InputEncoding` before the
+    /// prompt appears.
+    pwsh,
+
+    /// Argv elements to append after the user's existing argv so that
+    /// the configured shell runs the UTF-8 setup at startup.
+    /// Returns a slice of string literals owned by `.rodata`; callers
+    /// that need sentinel-terminated copies must dupe.
+    pub fn suffix(self: Preamble) []const []const u8 {
+        return switch (self) {
+            .none => &.{},
+            .cmd => &cmd_suffix,
+            .pwsh => &pwsh_suffix,
+        };
+    }
+
+    const cmd_suffix = [_][]const u8{ "/K", "chcp 65001 >nul" };
+    const pwsh_suffix = [_][]const u8{
+        "-NoExit",
+        "-Command",
+        // Set both output *and* input encodings: the output side fixes
+        // what the pane renders; the input side fixes what redirection
+        // (`>`, `|`) produces when the user pipes pwsh into another
+        // tool.
+        "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); [Console]::InputEncoding = [Console]::OutputEncoding",
+    };
+};
+
+/// Fine-grained shell identity used to select a UTF-8 preamble under
+/// ConPTY. Kept internal; exposed only through `utf8Preamble`.
+const Kind = enum {
+    unknown,
+    cmd,
+    powershell,
+    pwsh,
+    wsl,
+    ssh,
+    bash,
+    nu,
+    zsh,
+    fish,
+    elvish,
+    xonsh,
+};
+
+const kinds = std.StaticStringMap(Kind).initComptime(.{
+    .{ "pwsh", .pwsh },
+    .{ "wsl", .wsl },
+    .{ "ssh", .ssh },
+    .{ "bash", .bash },
+    .{ "nu", .nu },
+    .{ "zsh", .zsh },
+    .{ "fish", .fish },
+    .{ "elvish", .elvish },
+    .{ "xonsh", .xonsh },
+    .{ "cmd", .cmd },
+    .{ "powershell", .powershell },
 });
+
+fn awarenessOf(kind: Kind) Awareness {
+    return switch (kind) {
+        .unknown => .unknown,
+        .cmd, .powershell => .console_api,
+        .pwsh, .wsl, .ssh, .bash, .nu, .zsh, .fish, .elvish, .xonsh => .vt_aware,
+    };
+}
+
+fn preambleOf(kind: Kind) Preamble {
+    return switch (kind) {
+        .cmd => .cmd,
+        .powershell, .pwsh => .pwsh,
+        // All other kinds decode their own output; a Windows CP chcp
+        // would be ignored at best and misleading at worst.
+        .unknown, .wsl, .ssh, .bash, .nu, .zsh, .fish, .elvish, .xonsh => .none,
+    };
+}
 
 /// Classify an executable path or single-token command string. Strips
 /// surrounding quotes, directory prefix, and a trailing `.exe`
@@ -41,6 +121,18 @@ const known = std.StaticStringMap(Awareness).initComptime(.{
 /// This function does not parse argv flags. Callers with a full
 /// command line should split off the first token before calling.
 pub fn classify(exe_path: []const u8) Awareness {
+    return awarenessOf(identify(exe_path));
+}
+
+/// Return the UTF-8 preamble needed to make this shell emit UTF-8 on
+/// startup under ConPTY. Callers should invoke this only when the
+/// transport actually resolves to ConPTY; the raw-pipe bypass path
+/// already inherits our UTF-8 parent console (see PR # 301).
+pub fn utf8Preamble(exe_path: []const u8) Preamble {
+    return preambleOf(identify(exe_path));
+}
+
+fn identify(exe_path: []const u8) Kind {
     const trimmed = std.mem.trim(u8, exe_path, "\"' \t\r\n");
     if (trimmed.len == 0) return .unknown;
 
@@ -69,7 +161,7 @@ pub fn classify(exe_path: []const u8) Awareness {
     }
     const lower = std.ascii.lowerString(buf[0..base.len], base);
 
-    return known.get(lower) orelse .unknown;
+    return kinds.get(lower) orelse .unknown;
 }
 
 test "classify: pwsh variants" {
@@ -137,4 +229,63 @@ test "classify: handles very long path safely" {
     var long_path: [128]u8 = undefined;
     @memset(&long_path, 'a');
     try testing.expectEqual(Awareness.unknown, classify(&long_path));
+}
+
+test "utf8Preamble: cmd.exe returns .cmd" {
+    try testing.expectEqual(Preamble.cmd, utf8Preamble("cmd"));
+    try testing.expectEqual(Preamble.cmd, utf8Preamble("cmd.exe"));
+    try testing.expectEqual(Preamble.cmd, utf8Preamble("CMD.EXE"));
+    try testing.expectEqual(Preamble.cmd, utf8Preamble("C:\\Windows\\System32\\cmd.exe"));
+}
+
+test "utf8Preamble: pwsh.exe returns .pwsh" {
+    try testing.expectEqual(Preamble.pwsh, utf8Preamble("pwsh"));
+    try testing.expectEqual(Preamble.pwsh, utf8Preamble("pwsh.exe"));
+    try testing.expectEqual(Preamble.pwsh, utf8Preamble("PWSH.EXE"));
+    try testing.expectEqual(Preamble.pwsh, utf8Preamble("C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+}
+
+test "utf8Preamble: powershell 5.1 returns .pwsh" {
+    try testing.expectEqual(Preamble.pwsh, utf8Preamble("powershell"));
+    try testing.expectEqual(Preamble.pwsh, utf8Preamble("powershell.exe"));
+    try testing.expectEqual(Preamble.pwsh, utf8Preamble("PowerShell.exe"));
+}
+
+test "utf8Preamble: vt-aware non-powershell shells return .none" {
+    // bash/wsl/ssh/nu don't observe the Windows console CP the same way
+    // powershell does, and auto-mode routes them through the bypass
+    // path anyway. Only powershell-family shells need the preamble
+    // under forced conpty-mode=never.
+    try testing.expectEqual(Preamble.none, utf8Preamble("bash.exe"));
+    try testing.expectEqual(Preamble.none, utf8Preamble("wsl.exe"));
+    try testing.expectEqual(Preamble.none, utf8Preamble("ssh.exe"));
+    try testing.expectEqual(Preamble.none, utf8Preamble("nu"));
+    try testing.expectEqual(Preamble.none, utf8Preamble("zsh"));
+    try testing.expectEqual(Preamble.none, utf8Preamble("fish"));
+}
+
+test "utf8Preamble: unknown returns .none" {
+    try testing.expectEqual(Preamble.none, utf8Preamble("my-custom-repl.exe"));
+    try testing.expectEqual(Preamble.none, utf8Preamble("python.exe"));
+    try testing.expectEqual(Preamble.none, utf8Preamble(""));
+}
+
+test "utf8Preamble: suffix argv matches ConPTY setup contract" {
+    // cmd: /K lets the shell stay interactive after chcp.
+    const cmd_suffix = Preamble.cmd.suffix();
+    try testing.expectEqual(@as(usize, 2), cmd_suffix.len);
+    try testing.expectEqualStrings("/K", cmd_suffix[0]);
+    try testing.expectEqualStrings("chcp 65001 >nul", cmd_suffix[1]);
+
+    // pwsh: -NoExit mirrors the cmd /K behavior; -Command runs the
+    // setup before dropping the user into the prompt.
+    const pwsh_suffix = Preamble.pwsh.suffix();
+    try testing.expectEqual(@as(usize, 3), pwsh_suffix.len);
+    try testing.expectEqualStrings("-NoExit", pwsh_suffix[0]);
+    try testing.expectEqualStrings("-Command", pwsh_suffix[1]);
+    try testing.expect(std.mem.indexOf(u8, pwsh_suffix[2], "[Console]::OutputEncoding") != null);
+    try testing.expect(std.mem.indexOf(u8, pwsh_suffix[2], "[Console]::InputEncoding") != null);
+
+    // none: empty.
+    try testing.expectEqual(@as(usize, 0), Preamble.none.suffix().len);
 }

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -41,10 +41,10 @@ pub const Preamble = enum {
     pwsh,
 
     /// Argv elements to append after the user's existing argv so that
-    /// the configured shell runs the UTF-8 setup at startup.
-    /// Returns a slice of string literals owned by `.rodata`; callers
-    /// that need sentinel-terminated copies must dupe.
-    pub fn suffix(self: Preamble) []const []const u8 {
+    /// the configured shell runs the UTF-8 setup at startup. String
+    /// literals live in `.rodata`, so callers using an arena for argv
+    /// can append the returned slices directly without duping.
+    pub fn suffix(self: Preamble) []const [:0]const u8 {
         return switch (self) {
             .none => &.{},
             .cmd => &cmd_suffix,
@@ -52,8 +52,8 @@ pub const Preamble = enum {
         };
     }
 
-    const cmd_suffix = [_][]const u8{ "/K", "chcp 65001 >nul" };
-    const pwsh_suffix = [_][]const u8{
+    const cmd_suffix = [_][:0]const u8{ "/K", "chcp 65001 >nul" };
+    const pwsh_suffix = [_][:0]const u8{
         "-NoExit",
         "-Command",
         // Set both output *and* input encodings: the output side fixes

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -910,6 +910,7 @@ const Subprocess = struct {
             alloc,
             shell_command,
             internal_os.passwd,
+            cfg.conpty_mode,
         ) catch |err| switch (err) {
             // If we fail to allocate space for the command we want to
             // execute, we'd still like to try to run something so
@@ -1629,6 +1630,10 @@ fn execCommand(
     alloc: Allocator,
     command: configpkg.Command,
     comptime passwdpkg: type,
+    /// Configured transport mode; used only on Windows to decide whether
+    /// to inject the ConPTY UTF-8 preamble (# 302). Ignored on other
+    /// platforms.
+    conpty_mode: configpkg.Config.ConptyMode,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
     // If we're on macOS, we have to use `login(1)` to get all of
     // the proper environment variables set, a login shell, and proper
@@ -1753,7 +1758,17 @@ fn execCommand(
 
     return switch (command) {
         // We need to clone the command since there's no guarantee the config remains valid.
-        .direct => |_| (try command.clone(alloc)).direct,
+        .direct => |_| direct: {
+            const cloned = (try command.clone(alloc)).direct;
+            if (comptime builtin.os.tag == .windows) {
+                break :direct try maybeInjectUtf8Preamble(
+                    alloc,
+                    cloned,
+                    conpty_mode,
+                );
+            }
+            break :direct cloned;
+        },
 
         .shell => |v| shell: {
             if (comptime builtin.os.tag == .windows) {
@@ -1797,7 +1812,12 @@ fn execCommand(
                         break :windows_direct;
                     }
 
-                    break :shell try args.toOwnedSlice(alloc);
+                    const direct_args = try args.toOwnedSlice(alloc);
+                    break :shell try maybeInjectUtf8Preamble(
+                        alloc,
+                        direct_args,
+                        conpty_mode,
+                    );
                 }
 
                 // Command contains cmd.exe metacharacters (or parsing
@@ -1820,9 +1840,25 @@ fn execCommand(
                     "cmd.exe",
                 });
 
+                // cmd.exe is always `console_api` so `auto` + `never`
+                // both pick ConPTY here, and `always` picks the raw-pipe
+                // bypass (which already gets UTF-8 from PR # 301).
+                // Prepend `chcp 65001 >nul && ` to the /C script in the
+                // ConPTY cases so the whole pipeline runs UTF-8.
+                const mode = resolveConptyMode(conpty_mode, cmd);
+                const script: [:0]const u8 = if (mode == .conpty)
+                    try std.fmt.allocPrintSentinel(
+                        alloc,
+                        "chcp 65001 >nul && {s}",
+                        .{v},
+                        0,
+                    )
+                else
+                    try alloc.dupeZ(u8, v);
+
                 try args.append(alloc, cmd);
                 try args.append(alloc, "/C");
-                try args.append(alloc, v);
+                try args.append(alloc, script);
                 break :shell try args.toOwnedSlice(alloc);
             }
 
@@ -1851,6 +1887,96 @@ fn windowsShellNeedsCmdWrapping(s: []const u8) bool {
         '&', '|', '<', '>', '(', ')', '^', '%', '!' => return true,
         else => {},
     };
+    return false;
+}
+
+/// Windows-only. If the configured transport will resolve to ConPTY
+/// for this argv and the shell is known to benefit from a UTF-8
+/// preamble (# 302), return a new argv with the preamble suffix
+/// appended. Returns `args` unchanged otherwise.
+///
+/// Why the injection happens here and not later: we need to emit the
+/// preamble *argv-level*, before the shell has read any input. The
+/// raw-pipe bypass already gets UTF-8 from PR # 301 (parent console
+/// inheritance), but CreatePseudoConsole spawns its own conhost that
+/// starts at the system OEM CP regardless of what the parent has set.
+///
+/// Callers own both the input `args` and the returned slice; when no
+/// injection is needed the returned slice aliases `args` (no copy).
+fn maybeInjectUtf8Preamble(
+    alloc: Allocator,
+    args: []const [:0]const u8,
+    conpty_mode: configpkg.Config.ConptyMode,
+) Allocator.Error![]const [:0]const u8 {
+    if (comptime builtin.os.tag != .windows) return args;
+    if (args.len == 0) return args;
+
+    const mode = resolveConptyMode(conpty_mode, args[0]);
+    if (mode != .conpty) return args;
+
+    const preamble = internal_os.windows_shell.utf8Preamble(args[0]);
+    if (preamble == .none) return args;
+    if (preambleArgsConflict(args, preamble)) return args;
+
+    const suffix = preamble.suffix();
+    const out = try alloc.alloc([:0]const u8, args.len + suffix.len);
+    @memcpy(out[0..args.len], args);
+    for (suffix, 0..) |s, i| {
+        out[args.len + i] = try alloc.dupeZ(u8, s);
+    }
+    return out;
+}
+
+/// Returns true if the existing argv already contains a flag that
+/// would conflict with our preamble suffix. We bail out in that case
+/// rather than silently duplicating `-Command` / `/C` and breaking
+/// whatever the user configured.
+fn preambleArgsConflict(
+    args: []const [:0]const u8,
+    preamble: internal_os.windows_shell.Preamble,
+) bool {
+    if (args.len <= 1) return false;
+    return switch (preamble) {
+        .none => false,
+        .cmd => for (args[1..]) |arg| {
+            // Only `/C` and `/K` consume "the rest of the command line"
+            // and would swallow our preamble. Single-dash `-c` is not
+            // recognized by cmd.exe.
+            if (arg.len != 2 or arg[0] != '/') continue;
+            const c = std.ascii.toLower(arg[1]);
+            if (c == 'c' or c == 'k') break true;
+        } else false,
+        .pwsh => for (args[1..]) |arg| {
+            if (pwshFlagConflicts(arg)) break true;
+        } else false,
+    };
+}
+
+/// Returns true if `arg` is a PowerShell flag whose presence would
+/// conflict with appending `-NoExit -Command <setup>`. We detect the
+/// flags by prefix because PowerShell accepts any unambiguous prefix
+/// of a flag name (e.g. `-Com` for `-Command`).
+fn pwshFlagConflicts(arg: []const u8) bool {
+    if (arg.len < 2 or arg[0] != '-') return false;
+
+    var buf: [32]u8 = undefined;
+    const tail_len = arg.len - 1;
+    // Anything longer than a real PS flag name cannot be a conflict.
+    if (tail_len > buf.len) return false;
+    const lower = std.ascii.lowerString(buf[0..tail_len], arg[1..]);
+
+    // Exact matches for short forms and unambiguous 2-letter abbreviations.
+    if (std.mem.eql(u8, lower, "c")) return true;
+    if (std.mem.eql(u8, lower, "f")) return true;
+    if (std.mem.eql(u8, lower, "ec")) return true;
+    if (std.mem.eql(u8, lower, "enc")) return true;
+
+    // Prefix matches (length >= 3 avoids colliding with -ConfigurationName
+    // which also starts with -C, or -Format* which starts with -F).
+    if (lower.len >= 3 and std.mem.startsWith(u8, "command", lower)) return true;
+    if (lower.len >= 3 and std.mem.startsWith(u8, "file", lower)) return true;
+    if (lower.len >= 4 and std.mem.startsWith(u8, "encodedcommand", lower)) return true;
+
     return false;
 }
 
@@ -1906,7 +2032,7 @@ test "execCommand darwin: shell command" {
                 .name = "testuser",
             };
         }
-    });
+    }, .auto);
 
     try testing.expectEqual(8, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -1936,7 +2062,7 @@ test "execCommand darwin: direct command" {
                 .name = "testuser",
             };
         }
-    });
+    }, .auto);
 
     try testing.expectEqual(5, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -1964,6 +2090,7 @@ test "execCommand: shell command, empty passwd" {
                 return .{};
             }
         },
+        .auto,
     );
 
     try testing.expectEqual(3, result.len);
@@ -1990,6 +2117,7 @@ test "execCommand: shell command, error passwd" {
                 return error.Fail;
             }
         },
+        .auto,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2017,7 +2145,7 @@ test "execCommand: direct command, error passwd" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    });
+    }, .auto);
 
     try testing.expectEqual(2, result.len);
     try testing.expectEqualStrings(result[0], "foo");
@@ -2047,7 +2175,7 @@ test "execCommand: direct command, config freed" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    });
+    }, .auto);
 
     command_arena.deinit();
 
@@ -2064,6 +2192,8 @@ test "execCommand windows: shell command, single token spawns directly" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
+    // always mode forces the bypass path so we get the bare argv without
+    // UTF-8 preamble injection - the original behavior the test covers.
     const result = try execCommand(
         alloc,
         .{ .shell = "pwsh.exe" },
@@ -2072,6 +2202,7 @@ test "execCommand windows: shell command, single token spawns directly" {
                 return .{};
             }
         },
+        .always,
     );
 
     // No cmd.exe /C wrapper: args[0] is the configured shell itself.
@@ -2095,6 +2226,7 @@ test "execCommand windows: shell command, args split without cmd wrap" {
                 return .{};
             }
         },
+        .always,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2119,6 +2251,7 @@ test "execCommand windows: shell command, quoted path kept as one arg" {
                 return .{};
             }
         },
+        .always,
     );
 
     try testing.expectEqual(2, result.len);
@@ -2137,6 +2270,8 @@ test "execCommand windows: shell command with pipe falls back to cmd.exe" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
+    // always mode forces bypass so the cmd-wrap path does not pick up
+    // the ConPTY UTF-8 preamble injection covered in its own test.
     const result = try execCommand(
         alloc,
         .{ .shell = "dir | findstr foo" },
@@ -2145,6 +2280,7 @@ test "execCommand windows: shell command with pipe falls back to cmd.exe" {
                 return .{};
             }
         },
+        .always,
     );
 
     // Metachar present: wrap with cmd.exe /C so cmd handles the pipe.
@@ -2170,6 +2306,7 @@ test "execCommand windows: shell command with redirect falls back to cmd.exe" {
                 return .{};
             }
         },
+        .always,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2238,4 +2375,257 @@ test "resolveConptyMode: auto handles path-prefixed shell" {
 test "resolveConptyMode: auto handles quoted shell" {
     try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "\"pwsh.exe\""));
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "'cmd.exe'"));
+}
+
+// --- # 302 UTF-8 preamble injection tests -----------------------------------
+//
+// These check the argv that execCommand hands back when the resolved
+// transport is ConPTY. The preamble's *content* is covered by
+// `utf8Preamble` tests in os/windows_shell.zig; here we only assert
+// the injection decision (when do we inject? on what shells?) and the
+// argv shape (length + flag markers).
+
+fn testExecWindowsShell(
+    alloc: Allocator,
+    shell: [:0]const u8,
+    conpty_mode: configpkg.Config.ConptyMode,
+) ![]const [:0]const u8 {
+    return try execCommand(
+        alloc,
+        .{ .shell = shell },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        conpty_mode,
+    );
+}
+
+test "execCommand windows: cmd.exe under auto mode gets cmd preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe", .auto);
+
+    // auto + cmd (console_api) → ConPTY → cmd preamble appended.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("cmd.exe", result[0]);
+    try testing.expectEqualStrings("/K", result[1]);
+    try testing.expectEqualStrings("chcp 65001 >nul", result[2]);
+}
+
+test "execCommand windows: pwsh under auto mode (bypass) has no preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe", .auto);
+
+    // auto + pwsh (vt_aware) → bypass → PR # 301's parent console CP
+    // does the work. No preamble.
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+}
+
+test "execCommand windows: pwsh under forced never mode gets pwsh preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe", .never);
+
+    // never → ConPTY even for vt_aware shells. pwsh is identified as
+    // the powershell family, so we inject the Console encoding setup.
+    try testing.expectEqual(@as(usize, 4), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-NoExit", result[1]);
+    try testing.expectEqualStrings("-Command", result[2]);
+    try testing.expect(std.mem.indexOf(u8, result[3], "[Console]::OutputEncoding") != null);
+}
+
+test "execCommand windows: powershell 5.1 under auto mode gets pwsh preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "powershell.exe", .auto);
+
+    // Windows PowerShell 5.1 is console_api → auto picks ConPTY → pwsh
+    // preamble (same [Console]::*Encoding API as pwsh 7).
+    try testing.expectEqual(@as(usize, 4), result.len);
+    try testing.expectEqualStrings("powershell.exe", result[0]);
+    try testing.expectEqualStrings("-NoExit", result[1]);
+    try testing.expectEqualStrings("-Command", result[2]);
+}
+
+test "execCommand windows: unknown shell under ConPTY has no preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "my-custom.exe", .never);
+
+    // Unknown → no preamble even under forced ConPTY; we don't know
+    // what syntax to inject.
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings("my-custom.exe", result[0]);
+}
+
+test "execCommand windows: vt-aware non-powershell (bash) under ConPTY has no preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "bash.exe", .never);
+
+    // bash et al. don't care about the Windows console CP; they decode
+    // their own output.
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings("bash.exe", result[0]);
+}
+
+test "execCommand windows: always mode (bypass) never injects preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const cmd_result = try testExecWindowsShell(arena.allocator(), "cmd.exe", .always);
+    try testing.expectEqual(@as(usize, 1), cmd_result.len);
+    try testing.expectEqualStrings("cmd.exe", cmd_result[0]);
+
+    const pwsh_result = try testExecWindowsShell(arena.allocator(), "pwsh.exe", .always);
+    try testing.expectEqual(@as(usize, 1), pwsh_result.len);
+    try testing.expectEqualStrings("pwsh.exe", pwsh_result[0]);
+}
+
+test "execCommand windows: cmd with existing /c arg skips preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe /c echo hi", .auto);
+
+    // User's `/c` already consumes "the rest of the command line";
+    // appending `/K chcp ...` after it would either be ignored by cmd
+    // or parsed as part of the user's echo, so we skip.
+    try testing.expectEqual(@as(usize, 4), result.len);
+    try testing.expectEqualStrings("cmd.exe", result[0]);
+    try testing.expectEqualStrings("/c", result[1]);
+    try testing.expectEqualStrings("echo", result[2]);
+    try testing.expectEqualStrings("hi", result[3]);
+}
+
+test "execCommand windows: pwsh with existing -Command skips preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -NoProfile -Command Write-Host",
+        .never,
+    );
+
+    // Duplicating -Command confuses pwsh's arg parser; let the user's
+    // explicit script run as configured.
+    try testing.expectEqual(@as(usize, 4), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-NoProfile", result[1]);
+    try testing.expectEqualStrings("-Command", result[2]);
+    try testing.expectEqualStrings("Write-Host", result[3]);
+}
+
+test "execCommand windows: pwsh with benign args gets appended preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe -NoProfile", .never);
+
+    // -NoProfile doesn't conflict with -Command, so we append the
+    // preamble after the user's flags.
+    try testing.expectEqual(@as(usize, 5), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-NoProfile", result[1]);
+    try testing.expectEqualStrings("-NoExit", result[2]);
+    try testing.expectEqualStrings("-Command", result[3]);
+}
+
+test "execCommand windows: cmd-wrap path (pipes) gets chcp prepended to /C script" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "dir | findstr foo", .auto);
+
+    // Metachars force a cmd.exe /C wrap (existing behavior). The
+    // preamble goes *inside* the /C string so the whole pipeline runs
+    // in the same UTF-8 codepage.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expect(std.mem.endsWith(u8, result[0], "cmd.exe"));
+    try testing.expectEqualStrings("/C", result[1]);
+    try testing.expectEqualStrings("chcp 65001 >nul && dir | findstr foo", result[2]);
+}
+
+test "execCommand windows: direct command for cmd.exe gets cmd preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = try execCommand(
+        arena.allocator(),
+        .{ .direct = &.{"cmd.exe"} },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .auto,
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("cmd.exe", result[0]);
+    try testing.expectEqualStrings("/K", result[1]);
+    try testing.expectEqualStrings("chcp 65001 >nul", result[2]);
+}
+
+test "execCommand windows: direct command for pwsh under never gets pwsh preamble" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = try execCommand(
+        arena.allocator(),
+        .{ .direct = &.{ "pwsh.exe", "-NoLogo" } },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .never,
+    );
+
+    try testing.expectEqual(@as(usize, 5), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-NoLogo", result[1]);
+    try testing.expectEqualStrings("-NoExit", result[2]);
+    try testing.expectEqualStrings("-Command", result[3]);
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1921,9 +1921,10 @@ fn maybeInjectUtf8Preamble(
     const suffix = preamble.suffix();
     const out = try alloc.alloc([:0]const u8, args.len + suffix.len);
     @memcpy(out[0..args.len], args);
-    for (suffix, 0..) |s, i| {
-        out[args.len + i] = try alloc.dupeZ(u8, s);
-    }
+    // The suffix elements are `.rodata` string literals; they outlive
+    // any arena and spawning reads them during CreateProcess. No dupe
+    // needed, matching how `"/C"` is appended inline elsewhere here.
+    @memcpy(out[args.len..], suffix);
     return out;
 }
 


### PR DESCRIPTION
Followup to #301. Closes #302.

## Problem

PR #301 fixed the raw-pipe bypass path by having the parent process own a hidden UTF-8 console. The ConPTY path still shows CP 850 (or the local OEM default): `CreatePseudoConsole` spawns its own `conhost.exe --pty` that does NOT inherit the caller's console CP, so under `conpty-mode = never` (any shell), or `conpty-mode = auto` with cmd.exe / Windows PowerShell 5.1, children still render Nerd Font PUA glyphs and CJK as `?`.

## Fix

Inject a shell-specific UTF-8 preamble at the argv level in `execCommand`, gated on the resolved transport being ConPTY:

- **cmd.exe**: append `/K "chcp 65001 >nul"` in the direct-spawn path, or prepend `chcp 65001 >/dev/null && ` to the `/C` script in the cmd-wrap path (pipes/redirects).
- **pwsh / powershell.exe**: append `-NoExit -Command "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); [Console]::InputEncoding = [Console]::OutputEncoding"`. Same snippet works on .NET Framework (PS 5.1) and .NET 8+ (pwsh 7+).
- **Other shells** (bash / wsl / nu / ssh / zsh / fish / elvish / xonsh / unknown): no-op. Non-PowerShell VT-aware shells decode their own output and don't observe the Windows console CP; for genuinely unknown executables we don't know the syntax.

Skip injection when the user's configured command already has a conflicting flag (`/c`, `/k` for cmd; `-c`, `-Command`, `-File`, `-EncodedCommand` and their unambiguous prefixes for powershell) so we don't silently clobber user-specified scripts.

## What this does NOT change

- Bypass path (default for pwsh/wsl/bash/nu under `conpty-mode = auto` and everything under `conpty-mode = always`): still untouched. PR # 301's parent console CP already gives UTF-8 there.
- Shell classification for transport selection: `classify()` still returns the same `Awareness`. A new private `Kind` enum inside `windows_shell.zig` distinguishes cmd / pwsh / powershell / bash / etc. for preamble routing.

## Test plan

- [x] `zig build test --summary all` on Windows: 2815/2869 passed, 54 skipped, 0 failed.
- [x] `zig build test-lib-vt --summary all` on macOS: 4160/4178 passed, 18 skipped, 0 failed (cross-platform compile check; new tests are Windows-gated with `error.SkipZigTest`).
- [x] Regression tests: `utf8Preamble` per shell kind, suffix argv shape, and execCommand's decision matrix across `auto` / `never` / `always` x cmd / pwsh / powershell / bash / unknown, plus conflicting-flag skip, plus cmd-wrap pipeline path.
- [ ] Manual end-to-end probe (reuse #299 recipe, `conpty-mode = never`, pwsh child reading `[Console]::OutputEncoding.CodePage`). Expect 65001.

IMPORTANT: target `windows` branch.