### PR TITLE
fix(termio): wrap user -Command and /C scripts with UTF-8 preamble

### DIFF
--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -59,16 +59,31 @@ pub const Preamble = enum {
     /// terminator the shell needs so the caller can just concatenate it
     /// in front of the user's script. See `suffix` for the
     /// non-conflicting argv-append form.
+    ///
+    /// SECURITY: the returned strings are compile-time constants. Do
+    /// not interpolate user input into a new prefix string - that
+    /// would turn this into a shell-injection sink.
+    ///
+    /// The pwsh prefix uses `[System.Text.UTF8Encoding]::new()` whose
+    /// parameterless ctor defaults to `encoderShouldEmitUTF8Identifier
+    /// = false` (no BOM) and `throwOnInvalidBytes = false` (lenient
+    /// decode - U+FFFD substitution on malformed bytes). Both are the
+    /// right choice for a terminal; do not switch to
+    /// `[Encoding]::UTF8` or a stricter ctor without understanding the
+    /// BOM side effects on piped output.
     pub fn prefix(self: Preamble) []const u8 {
         return switch (self) {
             .none => "",
-            // cmd's `&&` runs the user's script only if chcp succeeded;
-            // `>nul` silences the "Active code page: 65001" banner so
-            // the user's first line of output isn't displaced.
+            // cmd's `&&` only runs the user's script when chcp
+            // succeeded. chcp 65001 has no failure modes on supported
+            // Windows SKUs; the `&&` variant matches the shell-wrap
+            // path in Exec.zig so both entrypoints behave identically
+            // if a future SKU ever breaks chcp. `>nul` silences the
+            // "Active code page: 65001" banner.
             .cmd => "chcp 65001 >nul && ",
-            // `;` chains statements in PowerShell; we set output first
-            // so any error in input assignment doesn't leave the pane
-            // half-configured. See `suffix` for why both directions.
+            // `;` chains statements in PowerShell. Output encoding
+            // first, then input so piped stdout and redirected stdin
+            // match. See `suffix` for why we set both.
             .pwsh => "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); [Console]::InputEncoding = [Console]::OutputEncoding; ",
         };
     }

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -52,6 +52,27 @@ pub const Preamble = enum {
         };
     }
 
+    /// Text to prepend to a user-supplied script when the user already
+    /// consumed the shell's "rest of command line" slot (e.g. `cmd /C
+    /// <script>`, `pwsh -Command <script>`). The returned slice is an
+    /// empty string for `.none`; otherwise it ends in whatever statement
+    /// terminator the shell needs so the caller can just concatenate it
+    /// in front of the user's script. See `suffix` for the
+    /// non-conflicting argv-append form.
+    pub fn prefix(self: Preamble) []const u8 {
+        return switch (self) {
+            .none => "",
+            // cmd's `&&` runs the user's script only if chcp succeeded;
+            // `>nul` silences the "Active code page: 65001" banner so
+            // the user's first line of output isn't displaced.
+            .cmd => "chcp 65001 >nul && ",
+            // `;` chains statements in PowerShell; we set output first
+            // so any error in input assignment doesn't leave the pane
+            // half-configured. See `suffix` for why both directions.
+            .pwsh => "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); [Console]::InputEncoding = [Console]::OutputEncoding; ",
+        };
+    }
+
     const cmd_suffix = [_][:0]const u8{ "/K", "chcp 65001 >nul" };
     const pwsh_suffix = [_][:0]const u8{
         "-NoExit",
@@ -288,4 +309,23 @@ test "utf8Preamble: suffix argv matches ConPTY setup contract" {
 
     // none: empty.
     try testing.expectEqual(@as(usize, 0), Preamble.none.suffix().len);
+}
+
+test "utf8Preamble: prefix ends with shell-appropriate separator" {
+    // cmd: `&&` chains on success, preserving the user's script when
+    // chcp somehow fails; trailing space so concatenation doesn't
+    // mash into the user's script.
+    const cmd_prefix = Preamble.cmd.prefix();
+    try testing.expect(std.mem.startsWith(u8, cmd_prefix, "chcp 65001"));
+    try testing.expect(std.mem.endsWith(u8, cmd_prefix, " && "));
+
+    // pwsh: `;` is a statement separator; trailing space keeps the
+    // wrapped script readable in logs.
+    const pwsh_prefix = Preamble.pwsh.prefix();
+    try testing.expect(std.mem.indexOf(u8, pwsh_prefix, "[Console]::OutputEncoding") != null);
+    try testing.expect(std.mem.indexOf(u8, pwsh_prefix, "[Console]::InputEncoding") != null);
+    try testing.expect(std.mem.endsWith(u8, pwsh_prefix, "; "));
+
+    // none: empty.
+    try testing.expectEqualStrings("", Preamble.none.prefix());
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1916,8 +1916,33 @@ fn maybeInjectUtf8Preamble(
 
     const preamble = internal_os.windows_shell.utf8Preamble(args[0]);
     if (preamble == .none) return args;
-    if (preambleArgsConflict(args, preamble)) return args;
 
+    // If the user passed a flag that already consumes "the rest of the
+    // command line" (cmd `/C`/`/K`, pwsh `-Command`), we can still get
+    // UTF-8 by *wrapping* their script instead of appending to argv.
+    // For `-File` and `-EncodedCommand` that's not feasible (modifying
+    // a script file or re-encoding base64 is too brittle); we bail and
+    // log so users can see why their preamble was skipped.
+    switch (findPreambleConflict(args, preamble)) {
+        .none => return appendSuffix(alloc, args, preamble),
+        .cmd_script => |idx| return wrapScript(alloc, args, idx, preamble.prefix()),
+        .pwsh_command => |idx| return wrapScript(alloc, args, idx, preamble.prefix()),
+        .pwsh_file, .pwsh_encoded_command => |idx| {
+            log.debug(
+                "UTF-8 preamble skipped: arg[{d}]=\"{s}\" consumes the user script opaquely",
+                .{ idx, args[idx] },
+            );
+            return args;
+        },
+    }
+}
+
+/// Append the preamble's argv suffix to `args`. Caller owns the result.
+fn appendSuffix(
+    alloc: Allocator,
+    args: []const [:0]const u8,
+    preamble: internal_os.windows_shell.Preamble,
+) Allocator.Error![]const [:0]const u8 {
     const suffix = preamble.suffix();
     const out = try alloc.alloc([:0]const u8, args.len + suffix.len);
     @memcpy(out[0..args.len], args);
@@ -1928,57 +1953,166 @@ fn maybeInjectUtf8Preamble(
     return out;
 }
 
-/// Returns true if the existing argv already contains a flag that
-/// would conflict with our preamble suffix. We bail out in that case
-/// rather than silently duplicating `-Command` / `/C` and breaking
-/// whatever the user configured.
-fn preambleArgsConflict(
+/// Wrap the user-supplied script that sits at `args[flag_idx+1..]` by
+/// prepending `prefix_text` and collapsing the tail into a single argv
+/// element. Produces `args[0..flag_idx+1] ++ [prefix_text ++ tail]`.
+///
+/// The tail is re-serialized with MS-C-runtime quoting rules (matching
+/// `windowsCreateCommandLine` in Command.zig) so args that originally
+/// contained spaces or quotes round-trip correctly: tokens like
+/// `C:\Program Files` are re-wrapped in quotes when joined back.
+/// Both cmd.exe (`/C`/`/K` re-reads the full command line after the
+/// flag, using MS-C-runtime parsing internally) and pwsh (`-Command`
+/// concatenates the remaining positional args, treating quoted runs as
+/// single tokens) then see the same token structure the user supplied.
+///
+/// When `flag_idx+1 == args.len` (flag is the last arg, so there is
+/// nothing to wrap) we leave argv alone rather than fabricate a bare
+/// preamble that would change how the shell interprets the flag.
+fn wrapScript(
+    alloc: Allocator,
+    args: []const [:0]const u8,
+    flag_idx: usize,
+    prefix_text: []const u8,
+) Allocator.Error![]const [:0]const u8 {
+    const head = args[0 .. flag_idx + 1];
+    const tail = args[flag_idx + 1 ..];
+    if (tail.len == 0) return args;
+
+    var buf: std.Io.Writer.Allocating = .init(alloc);
+    defer buf.deinit();
+    const writer = &buf.writer;
+
+    writer.writeAll(prefix_text) catch return Allocator.Error.OutOfMemory;
+    for (tail, 0..) |arg, i| {
+        if (i > 0) writer.writeByte(' ') catch return Allocator.Error.OutOfMemory;
+        writeQuotedArg(writer, arg) catch return Allocator.Error.OutOfMemory;
+    }
+
+    const wrapped = buf.toOwnedSliceSentinel(0) catch return Allocator.Error.OutOfMemory;
+    const out = try alloc.alloc([:0]const u8, head.len + 1);
+    @memcpy(out[0..head.len], head);
+    out[head.len] = wrapped;
+    return out;
+}
+
+/// Serialize `arg` into `writer` using the MS C runtime quoting rules
+/// (CommandLineToArgvW inverse). Matches `windowsCreateCommandLine` in
+/// Command.zig - we duplicate here rather than cross-module to avoid
+/// leaking an internal helper, and the per-arg surface area is small
+/// enough that drift is easy to audit.
+fn writeQuotedArg(writer: *std.Io.Writer, arg: []const u8) !void {
+    if (std.mem.indexOfAny(u8, arg, " \t\n\"") == null) {
+        try writer.writeAll(arg);
+        return;
+    }
+    try writer.writeByte('"');
+    var backslash_count: usize = 0;
+    for (arg) |byte| switch (byte) {
+        '\\' => backslash_count += 1,
+        '"' => {
+            try writer.splatByteAll('\\', backslash_count * 2 + 1);
+            try writer.writeByte('"');
+            backslash_count = 0;
+        },
+        else => {
+            try writer.splatByteAll('\\', backslash_count);
+            try writer.writeByte(byte);
+            backslash_count = 0;
+        },
+    };
+    try writer.splatByteAll('\\', backslash_count * 2);
+    try writer.writeByte('"');
+}
+
+/// Which preamble-conflicting flag the user supplied, and where it
+/// sits in argv. The payload index points at the flag itself; the
+/// script argument (if any) sits at `idx + 1`.
+const PreambleConflict = union(enum) {
+    none,
+    /// cmd.exe `/C` or `/K`: everything after is a command string we
+    /// can safely prepend `chcp 65001 >nul && ` to.
+    cmd_script: usize,
+    /// pwsh `-Command`: the tail is a script we can prepend the
+    /// `[Console]::*Encoding = ...` setup to.
+    pwsh_command: usize,
+    /// pwsh `-File`: the tail is a path to a script we must not
+    /// modify. Skip and log.
+    pwsh_file: usize,
+    /// pwsh `-EncodedCommand`: the tail is base64-encoded UTF-16LE.
+    /// Rewriting would need a decode/encode round-trip that's out of
+    /// scope here; skip and log.
+    pwsh_encoded_command: usize,
+};
+
+fn findPreambleConflict(
     args: []const [:0]const u8,
     preamble: internal_os.windows_shell.Preamble,
-) bool {
-    if (args.len <= 1) return false;
+) PreambleConflict {
+    if (args.len <= 1) return .none;
     return switch (preamble) {
-        .none => false,
-        .cmd => for (args[1..]) |arg| {
-            // Only `/C` and `/K` consume "the rest of the command line"
-            // and would swallow our preamble. Single-dash `-c` is not
-            // recognized by cmd.exe.
-            if (arg.len != 2 or arg[0] != '/') continue;
-            const c = std.ascii.toLower(arg[1]);
-            if (c == 'c' or c == 'k') break true;
-        } else false,
-        .pwsh => for (args[1..]) |arg| {
-            if (pwshFlagConflicts(arg)) break true;
-        } else false,
+        .none => .none,
+        .cmd => blk: {
+            for (args[1..], 1..) |arg, i| {
+                // Only `/C` and `/K` consume "the rest of the command
+                // line" and would swallow our preamble. Single-dash
+                // `-c` is not recognized by cmd.exe.
+                if (arg.len != 2 or arg[0] != '/') continue;
+                const c = std.ascii.toLower(arg[1]);
+                if (c == 'c' or c == 'k') break :blk .{ .cmd_script = i };
+            }
+            break :blk .none;
+        },
+        .pwsh => blk: {
+            for (args[1..], 1..) |arg, i| switch (pwshConflictKind(arg)) {
+                .none => {},
+                .command => break :blk .{ .pwsh_command = i },
+                .file => break :blk .{ .pwsh_file = i },
+                .encoded_command => break :blk .{ .pwsh_encoded_command = i },
+            };
+            break :blk .none;
+        },
     };
 }
 
-/// Returns true if `arg` is a PowerShell flag whose presence would
-/// conflict with appending `-NoExit -Command <setup>`. We detect the
-/// flags by prefix because PowerShell accepts any unambiguous prefix
-/// of a flag name (e.g. `-Com` for `-Command`).
-fn pwshFlagConflicts(arg: []const u8) bool {
-    if (arg.len < 2 or arg[0] != '-') return false;
+const PwshConflictKind = enum {
+    none,
+    /// `-Command`, `-c`, or any unambiguous prefix like `-Com`.
+    command,
+    /// `-File`, `-f`, or any unambiguous prefix like `-Fi`.
+    file,
+    /// `-EncodedCommand`, `-ec`, `-enc`, or any unambiguous prefix.
+    encoded_command,
+};
+
+/// Classify a single pwsh/powershell argv element as a preamble
+/// conflict. We match by unambiguous prefix because PowerShell accepts
+/// any prefix of a flag name (e.g. `-Com` resolves to `-Command`).
+fn pwshConflictKind(arg: []const u8) PwshConflictKind {
+    if (arg.len < 2 or arg[0] != '-') return .none;
 
     var buf: [32]u8 = undefined;
     const tail_len = arg.len - 1;
     // Anything longer than a real PS flag name cannot be a conflict.
-    if (tail_len > buf.len) return false;
+    if (tail_len > buf.len) return .none;
     const lower = std.ascii.lowerString(buf[0..tail_len], arg[1..]);
 
-    // Exact matches for short forms and unambiguous 2-letter abbreviations.
-    if (std.mem.eql(u8, lower, "c")) return true;
-    if (std.mem.eql(u8, lower, "f")) return true;
-    if (std.mem.eql(u8, lower, "ec")) return true;
-    if (std.mem.eql(u8, lower, "enc")) return true;
+    // Exact matches for short forms and unambiguous 2-letter
+    // abbreviations. These take precedence over prefix matches.
+    if (std.mem.eql(u8, lower, "c")) return .command;
+    if (std.mem.eql(u8, lower, "f")) return .file;
+    if (std.mem.eql(u8, lower, "ec")) return .encoded_command;
+    if (std.mem.eql(u8, lower, "enc")) return .encoded_command;
 
-    // Prefix matches (length >= 3 avoids colliding with -ConfigurationName
-    // which also starts with -C, or -Format* which starts with -F).
-    if (lower.len >= 3 and std.mem.startsWith(u8, "command", lower)) return true;
-    if (lower.len >= 3 and std.mem.startsWith(u8, "file", lower)) return true;
-    if (lower.len >= 4 and std.mem.startsWith(u8, "encodedcommand", lower)) return true;
+    // Prefix matches. We require length >= 3 for command/file to avoid
+    // colliding with `-ConfigurationName` (starts with -C) or
+    // `-Format*` (starts with -F). `encodedcommand` has `ec` covered
+    // above, so the prefix path starts at length 4 (`-enco`).
+    if (lower.len >= 3 and std.mem.startsWith(u8, "command", lower)) return .command;
+    if (lower.len >= 3 and std.mem.startsWith(u8, "file", lower)) return .file;
+    if (lower.len >= 4 and std.mem.startsWith(u8, "encodedcommand", lower)) return .encoded_command;
 
-    return false;
+    return .none;
 }
 
 /// Get information about the process(es) running within the backend. Returns
@@ -2509,7 +2643,7 @@ test "execCommand windows: always mode (bypass) never injects preamble" {
     try testing.expectEqualStrings("pwsh.exe", pwsh_result[0]);
 }
 
-test "execCommand windows: cmd with existing /c arg skips preamble" {
+test "execCommand windows: cmd with existing /c arg wraps user script" {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
 
     const testing = std.testing;
@@ -2517,17 +2651,37 @@ test "execCommand windows: cmd with existing /c arg skips preamble" {
     defer arena.deinit();
     const result = try testExecWindowsShell(arena.allocator(), "cmd.exe /c echo hi", .auto);
 
-    // User's `/c` already consumes "the rest of the command line";
-    // appending `/K chcp ...` after it would either be ignored by cmd
-    // or parsed as part of the user's echo, so we skip.
-    try testing.expectEqual(@as(usize, 4), result.len);
+    // User's `/c` consumes "the rest of the command line", so we wrap
+    // instead of appending: collapse the tail tokens back into one
+    // script and prepend `chcp 65001 >nul && ` (see issue # 299).
+    try testing.expectEqual(@as(usize, 3), result.len);
     try testing.expectEqualStrings("cmd.exe", result[0]);
     try testing.expectEqualStrings("/c", result[1]);
-    try testing.expectEqualStrings("echo", result[2]);
-    try testing.expectEqualStrings("hi", result[3]);
+    try testing.expectEqualStrings("chcp 65001 >nul && echo hi", result[2]);
 }
 
-test "execCommand windows: pwsh with existing -Command skips preamble" {
+test "execCommand windows: cmd with existing /K arg wraps user script" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "cmd.exe /K title UTF8",
+        .never,
+    );
+
+    // /K keeps the shell interactive after running the script; the
+    // wrap still applies because cmd re-reads everything after /K as
+    // one command line.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("cmd.exe", result[0]);
+    try testing.expectEqualStrings("/K", result[1]);
+    try testing.expectEqualStrings("chcp 65001 >nul && title UTF8", result[2]);
+}
+
+test "execCommand windows: pwsh with existing -Command wraps user script" {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
 
     const testing = std.testing;
@@ -2539,13 +2693,144 @@ test "execCommand windows: pwsh with existing -Command skips preamble" {
         .never,
     );
 
-    // Duplicating -Command confuses pwsh's arg parser; let the user's
-    // explicit script run as configured.
+    // -Command consumes "the rest of the command line". We collapse
+    // the user's tail tokens back into one script and prepend the
+    // [Console]::*Encoding setup so their script runs UTF-8.
     try testing.expectEqual(@as(usize, 4), result.len);
     try testing.expectEqualStrings("pwsh.exe", result[0]);
     try testing.expectEqualStrings("-NoProfile", result[1]);
     try testing.expectEqualStrings("-Command", result[2]);
-    try testing.expectEqualStrings("Write-Host", result[3]);
+    try testing.expect(std.mem.startsWith(u8, result[3], "[Console]::OutputEncoding"));
+    try testing.expect(std.mem.indexOf(u8, result[3], "[Console]::InputEncoding") != null);
+    try testing.expect(std.mem.endsWith(u8, result[3], "; Write-Host"));
+}
+
+test "execCommand windows: pwsh with multi-token -Command script is joined" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -Command Write-Host hello world",
+        .never,
+    );
+
+    // pwsh joins remaining positional args after `-Command` into the
+    // script; our wrap must match that behavior by space-joining the
+    // tail before prepending the setup.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-Command", result[1]);
+    try testing.expect(std.mem.endsWith(u8, result[2], "; Write-Host hello world"));
+}
+
+test "execCommand windows: cmd /c with quoted path preserves quoting on wrap" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // The config tokenizer strips the outer quotes, giving us
+    // ["cmd.exe", "/c", "dir", "C:\\Program Files"]. If we space-join
+    // blindly, cmd would see `dir C:\Program Files` and break path
+    // resolution. The wrap must re-quote args containing spaces so
+    // cmd re-tokenizes into `dir "C:\Program Files"` on the inside.
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "cmd.exe /c dir \"C:\\Program Files\"",
+        .auto,
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("cmd.exe", result[0]);
+    try testing.expectEqualStrings("/c", result[1]);
+    try testing.expectEqualStrings(
+        "chcp 65001 >nul && dir \"C:\\Program Files\"",
+        result[2],
+    );
+}
+
+test "execCommand windows: pwsh with -c short form wraps user script" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -c Write-Host",
+        .never,
+    );
+
+    // `-c` is the unambiguous 2-letter short form of -Command; treat
+    // it the same as the long form.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-c", result[1]);
+    try testing.expect(std.mem.endsWith(u8, result[2], "; Write-Host"));
+}
+
+test "execCommand windows: pwsh with -File leaves args untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -File C:\\scripts\\my.ps1",
+        .never,
+    );
+
+    // We can't safely rewrite a user-supplied script file. Leave argv
+    // intact; a log.debug tells operators why the preamble was
+    // skipped. Users who need UTF-8 in -File scripts set
+    // [Console]::OutputEncoding themselves (documented in issue # 299).
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-File", result[1]);
+    try testing.expectEqualStrings("C:\\scripts\\my.ps1", result[2]);
+}
+
+test "execCommand windows: pwsh with -EncodedCommand leaves args untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -EncodedCommand VwByAGkAdABlAC0ASABvAHMAdAAgAGgAaQA=",
+        .never,
+    );
+
+    // -EncodedCommand takes base64-encoded UTF-16LE. Rewriting would
+    // require a decode/re-encode round-trip; we skip to stay
+    // conservative.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-EncodedCommand", result[1]);
+}
+
+test "execCommand windows: pwsh with trailing -Command (no script) leaves args untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -Command",
+        .never,
+    );
+
+    // No tail after `-Command`: fabricating one would change whatever
+    // pwsh does by default with a bare flag. Keep argv intact.
+    try testing.expectEqual(@as(usize, 2), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-Command", result[1]);
 }
 
 test "execCommand windows: pwsh with benign args gets appended preamble" {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1922,11 +1922,24 @@ fn maybeInjectUtf8Preamble(
     // UTF-8 by *wrapping* their script instead of appending to argv.
     // For `-File` and `-EncodedCommand` that's not feasible (modifying
     // a script file or re-encoding base64 is too brittle); we bail and
-    // log so users can see why their preamble was skipped.
+    // log so users can see why their preamble was skipped. For pwsh
+    // scripts whose first non-whitespace token must stay first-
+    // statement (`param(...)`, `#requires`, `{ ... }`) we also bail,
+    // because prepending demotes those constructs silently.
     switch (findPreambleConflict(args, preamble)) {
         .none => return appendSuffix(alloc, args, preamble),
         .cmd_script => |idx| return wrapScript(alloc, args, idx, preamble.prefix()),
-        .pwsh_command => |idx| return wrapScript(alloc, args, idx, preamble.prefix()),
+        .pwsh_command => |idx| {
+            if (pwshTailRequiresFirstStatement(args[idx + 1 ..])) |reason| {
+                log.debug(
+                    "UTF-8 preamble skipped: pwsh -Command script starts with {s} " ++
+                        "which must remain the first statement",
+                    .{reason},
+                );
+                return args;
+            }
+            return wrapScript(alloc, args, idx, preamble.prefix());
+        },
         .pwsh_file, .pwsh_encoded_command => |idx| {
             log.debug(
                 "UTF-8 preamble skipped: arg[{d}]=\"{s}\" consumes the user script opaquely",
@@ -1935,6 +1948,40 @@ fn maybeInjectUtf8Preamble(
             return args;
         },
     }
+}
+
+/// If the first tail arg's leading token is a pwsh construct that must
+/// sit at the top of the script (`param(...)`, `#requires`, or a bare
+/// `{ ... }` scriptblock literal), return a short description for the
+/// skip log. Returns null when prepending our setup is safe.
+///
+/// Rationale:
+/// - `param(...)` must be the first statement in a script; moving it
+///   lower causes `The param statement can only be used as the first
+///   statement in the body of a script`.
+/// - `#requires -Version X` directives only take effect when they sit
+///   on the first non-comment line; otherwise they are parsed as
+///   comments and silently no-op.
+/// - A leading `{ ... }` at the top of a `-Command` script is
+///   interpreted as a scriptblock *literal* expression (its value is
+///   produced and discarded). Our prepend would not change the meaning
+///   here but would suppress whatever the user was hoping to observe;
+///   the safer choice is to leave their argv as-is.
+fn pwshTailRequiresFirstStatement(tail: []const [:0]const u8) ?[]const u8 {
+    if (tail.len == 0) return null;
+    const first = std.mem.trimLeft(u8, tail[0], " \t\r\n");
+    if (first.len == 0) return null;
+    if (first[0] == '{') return "a scriptblock literal";
+    if (asciiStartsWithIgnoreCase(first, "#requires")) return "a #requires directive";
+    if (asciiStartsWithIgnoreCase(first, "param(") or
+        asciiStartsWithIgnoreCase(first, "param ("))
+        return "a param() block";
+    return null;
+}
+
+fn asciiStartsWithIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (haystack.len < needle.len) return false;
+    return std.ascii.eqlIgnoreCase(haystack[0..needle.len], needle);
 }
 
 /// Append the preamble's argv suffix to `args`. Caller owns the result.
@@ -1961,10 +2008,15 @@ fn appendSuffix(
 /// `windowsCreateCommandLine` in Command.zig) so args that originally
 /// contained spaces or quotes round-trip correctly: tokens like
 /// `C:\Program Files` are re-wrapped in quotes when joined back.
-/// Both cmd.exe (`/C`/`/K` re-reads the full command line after the
-/// flag, using MS-C-runtime parsing internally) and pwsh (`-Command`
-/// concatenates the remaining positional args, treating quoted runs as
-/// single tokens) then see the same token structure the user supplied.
+///
+/// The resulting command line survives cmd's two-rule `/C` interaction
+/// documented in `cmd /?`: when our wrapped arg contains any embedded
+/// quotes (because we re-quoted a path with spaces), `lpCommandLine`
+/// has inner `"` characters and cmd falls into rule 1 ("preserve
+/// quoting as seen"). When it contains none, the outermost quoting
+/// `windowsCreateCommandLine` adds is trivially symmetric and rule 2
+/// ("strip outer quotes") is safe to apply. Either way cmd sees the
+/// same tokens the user originally wrote.
 ///
 /// When `flag_idx+1 == args.len` (flag is the last arg, so there is
 /// nothing to wrap) we leave argv alone rather than fabricate a bare
@@ -1979,28 +2031,48 @@ fn wrapScript(
     const tail = args[flag_idx + 1 ..];
     if (tail.len == 0) return args;
 
-    var buf: std.Io.Writer.Allocating = .init(alloc);
-    defer buf.deinit();
-    const writer = &buf.writer;
+    // `std.Io.Writer.Allocating`'s drain can only fail with
+    // `error.WriteFailed`, and the backing is our own allocator, so
+    // the only realistic cause is OOM. Fold the single inner function
+    // into one `catch` to keep the hot path readable.
+    const wrapped = buildWrappedScript(alloc, prefix_text, tail) catch
+        return error.OutOfMemory;
 
-    writer.writeAll(prefix_text) catch return Allocator.Error.OutOfMemory;
-    for (tail, 0..) |arg, i| {
-        if (i > 0) writer.writeByte(' ') catch return Allocator.Error.OutOfMemory;
-        writeQuotedArg(writer, arg) catch return Allocator.Error.OutOfMemory;
-    }
-
-    const wrapped = buf.toOwnedSliceSentinel(0) catch return Allocator.Error.OutOfMemory;
     const out = try alloc.alloc([:0]const u8, head.len + 1);
     @memcpy(out[0..head.len], head);
     out[head.len] = wrapped;
     return out;
 }
 
+fn buildWrappedScript(
+    alloc: Allocator,
+    prefix_text: []const u8,
+    tail: []const [:0]const u8,
+) ![:0]u8 {
+    var buf: std.Io.Writer.Allocating = .init(alloc);
+    errdefer buf.deinit();
+    const writer = &buf.writer;
+
+    try writer.writeAll(prefix_text);
+    for (tail, 0..) |arg, i| {
+        if (i > 0) try writer.writeByte(' ');
+        try writeQuotedArg(writer, arg);
+    }
+    return try buf.toOwnedSliceSentinel(0);
+}
+
 /// Serialize `arg` into `writer` using the MS C runtime quoting rules
 /// (CommandLineToArgvW inverse). Matches `windowsCreateCommandLine` in
-/// Command.zig - we duplicate here rather than cross-module to avoid
-/// leaking an internal helper, and the per-arg surface area is small
-/// enough that drift is easy to audit.
+/// Command.zig byte-for-byte; we duplicate here rather than cross-
+/// module to avoid leaking an internal helper, and the per-arg surface
+/// area is small enough that drift is easy to audit.
+///
+/// Note cmd.exe uses its OWN parser for `/C` tokenization (special
+/// chars `& | < > ^ ( )`, not CRT-style backslash escaping). The round
+/// trip works here because each individual arg survives both parsers
+/// identically: our quoted output has no unescaped cmd metacharacters,
+/// and cmd's rules don't consume backslashes. Do not extend this to
+/// emit cmd-specific escape sequences without adding tests.
 fn writeQuotedArg(writer: *std.Io.Writer, arg: []const u8) !void {
     if (std.mem.indexOfAny(u8, arg, " \t\n\"") == null) {
         try writer.writeAll(arg);
@@ -2831,6 +2903,160 @@ test "execCommand windows: pwsh with trailing -Command (no script) leaves args u
     try testing.expectEqual(@as(usize, 2), result.len);
     try testing.expectEqualStrings("pwsh.exe", result[0]);
     try testing.expectEqualStrings("-Command", result[1]);
+}
+
+test "writeQuotedArg: MS C runtime quoting edge cases" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const Case = struct { in: []const u8, out: []const u8 };
+    const cases: []const Case = &.{
+        // No whitespace or quotes: pass through untouched.
+        .{ .in = "hello", .out = "hello" },
+        // Embedded space: wrap whole arg in quotes.
+        .{ .in = "C:\\Program Files", .out = "\"C:\\Program Files\"" },
+        // Embedded tab/newline: still quotes.
+        .{ .in = "a\tb", .out = "\"a\tb\"" },
+        // Embedded quote: escape as \", no outer backslash needed.
+        .{ .in = "a\"b", .out = "\"a\\\"b\"" },
+        // Trailing backslash in a quoted arg: double the backslash run
+        // so the closing quote isn't escaped.
+        .{ .in = "foo bar\\", .out = "\"foo bar\\\\\"" },
+        // Backslash-quote sequence: 2n+1 backslashes before the quote.
+        .{ .in = "a\\\"b c", .out = "\"a\\\\\\\"b c\"" },
+    };
+
+    for (cases) |c| {
+        var buf: std.Io.Writer.Allocating = .init(alloc);
+        defer buf.deinit();
+        try writeQuotedArg(&buf.writer, c.in);
+        try testing.expectEqualStrings(c.out, buf.writer.buffered());
+    }
+}
+
+test "execCommand windows: cmd with trailing /c (no script) leaves args untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe /c", .never);
+
+    try testing.expectEqual(@as(usize, 2), result.len);
+    try testing.expectEqualStrings("cmd.exe", result[0]);
+    try testing.expectEqualStrings("/c", result[1]);
+}
+
+test "execCommand windows: pwsh -Command with param() is left untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // Prepending `[Console]::...; ` would demote the param() block out
+    // of first-statement position and break pwsh's parse. The skip
+    // branch is preferred: user keeps their script, we log why the
+    // preamble was not injected.
+    //
+    // We build argv directly because the string-shell path triggers
+    // `windowsShellNeedsCmdWrapping` on `(` / `)` and would re-route
+    // through cmd.exe, which is a separate code path with its own
+    // chcp prepend (covered by other tests).
+    const result = try execCommand(
+        arena.allocator(),
+        .{ .direct = &.{
+            "pwsh.exe",
+            "-Command",
+            "param($x) Write-Host $x",
+        } },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .never,
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-Command", result[1]);
+    try testing.expectEqualStrings("param($x) Write-Host $x", result[2]);
+}
+
+test "execCommand windows: pwsh -Command with #requires is left untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // `#requires -Version 7` must be the first non-comment/non-blank
+    // line; prepending `[Console]::...; ` silently demotes it to a
+    // plain comment.
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -Command \"#requires -Version 7\"",
+        .never,
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-Command", result[1]);
+    try testing.expectEqualStrings("#requires -Version 7", result[2]);
+}
+
+test "execCommand windows: pwsh -Command with leading scriptblock is left untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // `-Command "{ Get-Date }"` is unusual but legal; prepending our
+    // setup would turn the scriptblock into a discarded literal value
+    // rather than something that executes.
+    const result = try testExecWindowsShell(
+        arena.allocator(),
+        "pwsh.exe -Command \"{ Get-Date }\"",
+        .never,
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-Command", result[1]);
+    try testing.expectEqualStrings("{ Get-Date }", result[2]);
+}
+
+test "execCommand windows: pwsh -Command with leading whitespace + param is left untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // Detection must trim leading whitespace, otherwise a formatted
+    // `-Command "  param(...)"` silently regresses. Use direct argv
+    // so `(`/`)` don't route through the cmd-wrap path.
+    const result = try execCommand(
+        arena.allocator(),
+        .{ .direct = &.{
+            "pwsh.exe",
+            "-Command",
+            "  param($x) 'ok'",
+        } },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .never,
+    );
+
+    try testing.expectEqual(@as(usize, 3), result.len);
+    try testing.expectEqualStrings("pwsh.exe", result[0]);
+    try testing.expectEqualStrings("-Command", result[1]);
+    try testing.expectEqualStrings("  param($x) 'ok'", result[2]);
 }
 
 test "execCommand windows: pwsh with benign args gets appended preamble" {


### PR DESCRIPTION
## Summary

Closes # 299.

PR # 308 installed a shell-specific UTF-8 preamble for ConPTY-spawned children, but bailed the moment the user's argv already contained a flag that consumes the rest of the command line (cmd `/C`/`/K`, pwsh `-Command`/`-File`/`-EncodedCommand`). Those configurations kept running on the system OEM codepage (CP850 on Western European installs), and Nerd Font PUA glyphs, emoji, and CJK collapsed to `?` at the shell before ever reaching the VT parser.

This PR switches `maybeInjectUtf8Preamble` from skip-on-conflict to wrap-on-conflict:

- cmd `/C <script>` / `/K <script>` becomes `/C "chcp 65001 >/dev/null && <script>"`.
- pwsh `-Command <script>` gets `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new(); [Console]::InputEncoding = [Console]::OutputEncoding; ` prepended inside the user's script.
- `-File` stays skipped, with a `log.debug` explaining why. Rewriting a user's `.ps1` is too invasive.
- `-EncodedCommand` stays skipped, same reason. A base64/UTF-16LE decode-wrap-reencode round-trip is out of scope here. Users who package their shell as `-EncodedCommand` already opted into managing their own encoding.

Tail tokens are re-serialized with the same MS C runtime quoting that `windowsCreateCommandLine` uses, so paths like `C:\Program Files` survive the argv round-trip intact.

## Test plan

- [x] `zig build test` on Windows (full suite, includes 14 new tests in `src/termio/Exec.zig` and `src/os/windows_shell.zig`).
- [ ] Manual: run the issue # 299 verification recipe with `command = pwsh.exe -Command '...diag...'` under `conpty-mode = never`. Expect `[Console]::OutputEncoding.CodePage = 65001` and glyphs rendering post-fix.
- [ ] Manual: run the same recipe with `command = cmd.exe /C '...diag...'` under `conpty-mode = never`. Expect the active codepage to be 65001 when the diag reports.
- [ ] Manual: confirm `-File` and `-EncodedCommand` still run without modification and log the skip reason at debug level.