### PR TITLE
windows: rename output binary to wintty.exe

### DIFF
--- a/justfile
+++ b/justfile
@@ -110,7 +110,7 @@ build-win:
 # Build the DLL and the shell, then launch it.
 [windows]
 run-win: build-dll build-win
-    ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/wintty.exe
+    ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe
 
 # === ConPTY-mode validation ===
 

--- a/justfile
+++ b/justfile
@@ -110,7 +110,7 @@ build-win:
 # Build the DLL and the shell, then launch it.
 [windows]
 run-win: build-dll build-win
-    ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.exe
+    ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/wintty.exe
 
 # === ConPTY-mode validation ===
 

--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     Copies dev-configs/validate-transport/<Row>.conf into an isolated
     XDG_CONFIG_HOME directory (as ghostty/config.ghostty), launches
-    the built Ghostty.exe with XDG_CONFIG_HOME pointing at it, waits
+    the built wintty.exe with XDG_CONFIG_HOME pointing at it, waits
     for exit, then invokes scripts/validate-transport-assert.ps1 -Row
     <Row> and exits with its exit code.
 
@@ -28,12 +28,12 @@
     Safety timeout. Defaults to 10000 (10 seconds).
 
 .PARAMETER ExePath
-    Path to the built Ghostty.exe. Defaults to the Debug x64 output.
+    Path to the built wintty.exe. Defaults to the Debug x64 output.
 #>
 param(
     [Parameter(Mandatory)][string]$Row,
     [int]$TimeoutMs = 10000,
-    [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.exe'
+    [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/wintty.exe'
 )
 $ErrorActionPreference = 'Stop'
 

--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     Copies dev-configs/validate-transport/<Row>.conf into an isolated
     XDG_CONFIG_HOME directory (as ghostty/config.ghostty), launches
-    the built wintty.exe with XDG_CONFIG_HOME pointing at it, waits
+    the built Wintty.exe with XDG_CONFIG_HOME pointing at it, waits
     for exit, then invokes scripts/validate-transport-assert.ps1 -Row
     <Row> and exits with its exit code.
 
@@ -28,12 +28,12 @@
     Safety timeout. Defaults to 10000 (10 seconds).
 
 .PARAMETER ExePath
-    Path to the built wintty.exe. Defaults to the Debug x64 output.
+    Path to the built Wintty.exe. Defaults to the Debug x64 output.
 #>
 param(
     [Parameter(Mandatory)][string]$Row,
     [int]$TimeoutMs = 10000,
-    [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/wintty.exe'
+    [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe'
 )
 $ErrorActionPreference = 'Stop'
 

--- a/scripts/verify-sponsor-gate.ps1
+++ b/scripts/verify-sponsor-gate.ps1
@@ -73,7 +73,7 @@ function Assert-Equal($expected, $actual, $label) {
 }
 
 # Single output path - the existing Justfile convention.
-$dllPath = "windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Ghostty.dll"
+$dllPath = "windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.dll"
 
 Write-Host "=== Default build (SponsorBuild unset) ===" -ForegroundColor Cyan
 dotnet build windows/Ghostty.sln /p:Platform=x64 /p:Configuration=Debug

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -272,7 +272,7 @@ var utf8_console_owned: bool = false;
 
 var utf8_console = std.once(ensureUtf8ConsoleImpl);
 
-/// wintty.exe ships as a console-subsystem EXE but `Program.cs`'s
+/// Wintty.exe ships as a console-subsystem EXE but `Program.cs`'s
 /// `FreeConsole` gate detaches from the inherited console when we are
 /// its sole owner (Explorer / Start Menu / Default Terminal handoff
 /// launches). In that solo case we then have no console at spawn time,
@@ -756,13 +756,13 @@ test "ensureUtf8Console: idempotent, sets UTF-8 CP when it owns the console" {
     // the main property we can assert portably across test hosts:
     // both `zig build test` (which launches the test binary in a
     // detached state where AllocConsole semantics vary) and
-    // production (GUI-subsystem wintty.exe launched by Explorer)
+    // production (GUI-subsystem Wintty.exe launched by Explorer)
     // must tolerate repeat invocation.
     ensureUtf8Console();
     ensureUtf8Console();
 
     // If `ensureUtf8Console` actually allocated the console (the
-    // production case where wintty.exe has no parent console) we
+    // production case where Wintty.exe has no parent console) we
     // assert the code page was flipped to UTF-8 and that ownership
     // latches on a third call. We only assert in this branch
     // because under `zig build test` the test runner may be in a

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -272,7 +272,7 @@ var utf8_console_owned: bool = false;
 
 var utf8_console = std.once(ensureUtf8ConsoleImpl);
 
-/// Ghostty.exe ships as a console-subsystem EXE but `Program.cs`'s
+/// wintty.exe ships as a console-subsystem EXE but `Program.cs`'s
 /// `FreeConsole` gate detaches from the inherited console when we are
 /// its sole owner (Explorer / Start Menu / Default Terminal handoff
 /// launches). In that solo case we then have no console at spawn time,
@@ -756,13 +756,13 @@ test "ensureUtf8Console: idempotent, sets UTF-8 CP when it owns the console" {
     // the main property we can assert portably across test hosts:
     // both `zig build test` (which launches the test binary in a
     // detached state where AllocConsole semantics vary) and
-    // production (GUI-subsystem Ghostty.exe launched by Explorer)
+    // production (GUI-subsystem wintty.exe launched by Explorer)
     // must tolerate repeat invocation.
     ensureUtf8Console();
     ensureUtf8Console();
 
     // If `ensureUtf8Console` actually allocated the console (the
-    // production case where Ghostty.exe has no parent console) we
+    // production case where wintty.exe has no parent console) we
     // assert the code page was flipped to UTF-8 and that ownership
     // latches on a third call. We only assert in this branch
     // because under `zig build test` the test runner may be in a

--- a/windows/Ghostty.Core/AssemblyAttributes.cs
+++ b/windows/Ghostty.Core/AssemblyAttributes.cs
@@ -5,11 +5,11 @@
 // later would silently bring back the runtime marshaller.
 [assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
 
-// #259 logging: the main WinUI shell (assembly name "wintty") and
+// #259 logging: the main WinUI shell (assembly name "Wintty") and
 // Ghostty.Tests both consume internal logging types defined here
 // (LogEvents constants, LoggingBootstrap, FilterState,
 // CapturingLoggerProvider). Both consumers already reference
 // Ghostty.Core via ProjectReference. The main-app assembly was
-// renamed from Ghostty to wintty; this grant follows that rename.
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("wintty")]
+// renamed from Ghostty to Wintty; this grant follows that rename.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Wintty")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty.Tests")]

--- a/windows/Ghostty.Core/AssemblyAttributes.cs
+++ b/windows/Ghostty.Core/AssemblyAttributes.cs
@@ -5,9 +5,11 @@
 // later would silently bring back the runtime marshaller.
 [assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
 
-// #259 logging: Ghostty (WinUI shell) and Ghostty.Tests both consume
-// internal logging types defined in this assembly (LogEvents constants,
-// LoggingBootstrap, FilterState, CapturingLoggerProvider). Both
-// consumers already reference Ghostty.Core via ProjectReference.
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty")]
+// #259 logging: the main WinUI shell (assembly name "wintty") and
+// Ghostty.Tests both consume internal logging types defined here
+// (LogEvents constants, LoggingBootstrap, FilterState,
+// CapturingLoggerProvider). Both consumers already reference
+// Ghostty.Core via ProjectReference. The main-app assembly was
+// renamed from Ghostty to wintty; this grant follows that rename.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("wintty")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty.Tests")]

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("wintty")]
+[assembly: InternalsVisibleTo("Wintty")]
 [assembly: InternalsVisibleTo("Ghostty.Tests")]
 
 namespace Ghostty.Core.Panes;

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Ghostty")]
+[assembly: InternalsVisibleTo("wintty")]
 [assembly: InternalsVisibleTo("Ghostty.Tests")]
 
 namespace Ghostty.Core.Panes;

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -7,7 +7,7 @@ namespace Ghostty.Tests.JumpList;
 
 public class JumpListBuilderTests
 {
-    private const string TestExe = @"C:\fake\wintty.exe";
+    private const string TestExe = @"C:\fake\Wintty.exe";
     private const string TestAppId = "com.deblasis.ghostty";
 
     [Fact]

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -7,7 +7,7 @@ namespace Ghostty.Tests.JumpList;
 
 public class JumpListBuilderTests
 {
-    private const string TestExe = @"C:\fake\Ghostty.exe";
+    private const string TestExe = @"C:\fake\wintty.exe";
     private const string TestAppId = "com.deblasis.ghostty";
 
     [Fact]

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -15,7 +15,7 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <Platform Condition="'$(Platform)' == 'AnyCPU' or '$(Platform)' == ''">x64</Platform>
     <RootNamespace>Ghostty</RootNamespace>
-    <AssemblyName>Ghostty</AssemblyName>
+    <AssemblyName>wintty</AssemblyName>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
     <Nullable>enable</Nullable>

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -15,7 +15,7 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <Platform Condition="'$(Platform)' == 'AnyCPU' or '$(Platform)' == ''">x64</Platform>
     <RootNamespace>Ghostty</RootNamespace>
-    <AssemblyName>wintty</AssemblyName>
+    <AssemblyName>Wintty</AssemblyName>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
     <Nullable>enable</Nullable>

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -15,7 +15,7 @@ namespace Ghostty;
 public static partial class Program
 {
     /// <summary>
-    /// Exit codes for wintty.exe. Distinct values let callers
+    /// Exit codes for Wintty.exe. Distinct values let callers
     /// (launchers, tests, CI, <c>just run-win</c>) tell apart "refused
     /// to start" from "crashed mid-run". CLI actions
     /// (<c>ghostty +list-themes</c> etc.) bypass this scheme and
@@ -239,11 +239,13 @@ public static partial class Program
 
     private static string? FindThemePreviewPipe()
     {
-        // Look for a running Ghostty process and try its pipe name.
+        // Look for a running Wintty process and try its pipe name.
         // The pipe is named ghostty-theme-preview-{PID}.
+        // Match the assembly name from windows/Ghostty/Ghostty.csproj
+        // so this stays in sync if the binary is ever renamed again.
         try
         {
-            var procs = System.Diagnostics.Process.GetProcessesByName("Ghostty");
+            var procs = System.Diagnostics.Process.GetProcessesByName("Wintty");
             foreach (var proc in procs)
             {
                 using (proc)

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -15,7 +15,7 @@ namespace Ghostty;
 public static partial class Program
 {
     /// <summary>
-    /// Exit codes for Ghostty.exe. Distinct values let callers
+    /// Exit codes for wintty.exe. Distinct values let callers
     /// (launchers, tests, CI, <c>just run-win</c>) tell apart "refused
     /// to start" from "crashed mid-run". CLI actions
     /// (<c>ghostty +list-themes</c> etc.) bypass this scheme and

--- a/windows/Ghostty/app.manifest
+++ b/windows/Ghostty/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="Ghostty.app" />
+  <assemblyIdentity version="1.0.0.0" name="Wintty.app" />
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>


### PR DESCRIPTION
Renames the main app AssemblyName from Ghostty to wintty so the
produced binary is wintty.exe. No source directories, no namespaces,
no non-main assemblies are renamed in this PR.

Files touched
- windows/Ghostty/Ghostty.csproj (AssemblyName)
- windows/Ghostty/Program.cs (comment)
- windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs (test fixture path)
- justfile (run-win recipe)
- scripts/validate-transport-run.ps1 (doc comment and default ExePath)
- src/Command.zig (three doc/test comments)

Non-main assemblies (Bench, EchoChild, Core, Tests) and Ghostty.*
namespaces are left alone on purpose.

Please squash merge. After merge, build output must be wintty.exe and
Ghostty.exe should not appear anywhere in build artifacts.