### PR TITLE
fix(glslang): quote %CL% in build_msvc.bat

### DIFF
--- a/pkg/glslang/build_msvc.bat
+++ b/pkg/glslang/build_msvc.bat
@@ -128,7 +128,11 @@ for %%f in (
 )
 
 echo Compiling with MSVC...
-%CL% %CFLAGS% %FILES%
+REM Quote %CL%: the expanded path contains "Program Files" (with a space) on
+REM stock Windows, so an unquoted invocation has cmd parse 'C:\Program' as the
+REM command and the rest as args. Breaks on windows-latest runners and any
+REM default VS install.
+"%CL%" %CFLAGS% %FILES%
 
 if errorlevel 1 (
     echo ERROR: Compilation failed


### PR DESCRIPTION
Expanded path contains `Program Files` (with a space) on stock Windows, so `%CL% %CFLAGS% %FILES%` has cmd parse `C:\Program` as the command and the rest as args, failing with:

```
'C:\Program' is not recognized as an internal or external command
```

Fixes the build on windows-latest CI and any default VS install. Likely passed locally only because of a non-default install path.