### PR TITLE
feat(settings): add clear button to acrylic tint color picker

### DIFF
--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -115,8 +115,17 @@
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Acrylic tint color"
                                    ctrl:SettingsCard.ConfigKey="background-tint-color">
-                    <ctrl:ColorPickerControl x:Name="TintColorPicker"
-                                             ColorChanged="TintColor_ColorChanged" />
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <ctrl:ColorPickerControl x:Name="TintColorPicker"
+                                                 ColorChanged="TintColor_ColorChanged" />
+                        <Button x:Name="TintColorResetButton"
+                                Click="TintColor_Reset"
+                                ToolTipService.ToolTip="Use the default tint color"
+                                Padding="6,4"
+                                Visibility="Collapsed">
+                            <FontIcon Glyph="&#xE894;" FontSize="12" />
+                        </Button>
+                    </StackPanel>
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Acrylic tint opacity"
                                    ctrl:SettingsCard.ConfigKey="background-tint-opacity">

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -50,10 +50,19 @@ internal sealed partial class AppearancePage : Page
         {
             SelectComboByTag(BackgroundStyleCombo, cs.BackgroundStyle);
             BlurFollowsOpacityToggle.IsOn = cs.BackgroundBlurFollowsOpacity;
-            if (cs.BackgroundTintColor.HasValue)
+            if (cs.IsConfiguredInFile("background-tint-color"))
             {
-                var c = cs.BackgroundTintColor.Value;
-                TintColorPicker.Color = new Rgb(c.R, c.G, c.B).ToHex();
+                if (cs.BackgroundTintColor.HasValue)
+                {
+                    var c = cs.BackgroundTintColor.Value;
+                    TintColorPicker.Color = new Rgb(c.R, c.G, c.B).ToHex();
+                }
+                TintColorResetButton.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                TintColorPicker.Color = "";
+                TintColorResetButton.Visibility = Visibility.Collapsed;
             }
             TintOpacitySlider.Value = cs.BackgroundTintOpacity ?? 0.3;
             LuminosityOpacitySlider.Value = cs.BackgroundLuminosityOpacity ?? 0.3;
@@ -229,7 +238,24 @@ internal sealed partial class AppearancePage : Page
     }
 
     private void TintColor_ColorChanged(object? sender, string hex)
-        => OnValueChanged("background-tint-color", hex);
+    {
+        OnValueChanged("background-tint-color", hex);
+        TintColorResetButton.Visibility = Visibility.Visible;
+    }
+
+    private void TintColor_Reset(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+        _configService.SuppressWatcher(true);
+        try { _editor.RemoveValue("background-tint-color"); }
+        finally { _configService.SuppressWatcher(false); }
+        _configService.Reload();
+
+        _loading = true;
+        try { TintColorPicker.Color = ""; }
+        finally { _loading = false; }
+        TintColorResetButton.Visibility = Visibility.Collapsed;
+    }
 
     private void TintOpacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {


### PR DESCRIPTION
## Summary

- Adds a reset (X) button to the acrylic tint color picker on the Appearance page, matching the pattern already used by the four color override pickers on the Colors page.
- Seeds the reset button visibility based on `IsConfiguredInFile` so inherited/default tint colors show as "unset" rather than appearing as user overrides.
- The clear button removes the config key, reloads, and collapses the picker state.

## Test plan

- [ ] Open Settings > Appearance > set a tint color via the picker, verify X button appears
- [ ] Click X, verify picker clears and config entry is removed
- [ ] Reload page, verify no reset button shown when tint is not in config file
- [ ] Verify existing tint color from config file still shows with reset button on page load