### PR TITLE
fix(glslang): add glslang source + override to build_msvc.bat INCLUDE

### DIFF
--- a/pkg/glslang/build_msvc.bat
+++ b/pkg/glslang/build_msvc.bat
@@ -71,7 +71,12 @@ echo Using glslang source: %GLSLANG_SRC%
 
 set CL=!MSVC_DIR!\bin\Hostx64\x64\cl.exe
 set LIB=!MSVC_DIR!\lib\x64;%WINSDK_LIB%\um\x64;%WINSDK_LIB%\ucrt\x64
-set INCLUDE=!MSVC_DIR!\include;%WINSDK_INC%\um;%WINSDK_INC%\ucrt;%WINSDK_INC%\shared
+REM Include paths must mirror what build.zig wires up for the zig-driven build:
+REM   - MSVC + Windows SDK for libc/libc++
+REM   - %GLSLANG_SRC% root so `#include <glslang/...>` resolves to the vendor src
+REM   - %~dp0override so `#include <glslang/build_info.h>` resolves to our static
+REM     override (the vendor project ships build_info.h.in as a CMake template).
+set INCLUDE=!MSVC_DIR!\include;%WINSDK_INC%\um;%WINSDK_INC%\ucrt;%WINSDK_INC%\shared;%GLSLANG_SRC%;%~dp0override
 
 set OUTDIR=%~dp0msvc_build
 if not exist "%OUTDIR%" mkdir "%OUTDIR%"


### PR DESCRIPTION
cl.exe fails with `fatal error C1083: Cannot open include file: 'glslang/build_info.h'` because the .bat's INCLUDE env only has MSVC + Windows SDK paths.

Mirror what build.zig adds: GLSLANG_SRC root for the vendor headers and pkg/glslang/override for our static build_info.h (the vendor project ships it as a CMake template so it has to be synthesized or overridden at build time).