### PR TITLE
fix(glslang): write dummy.c in build_msvc.bat

### DIFF
--- a/pkg/glslang/build_msvc.bat
+++ b/pkg/glslang/build_msvc.bat
@@ -81,6 +81,12 @@ set INCLUDE=!MSVC_DIR!\include;%WINSDK_INC%\um;%WINSDK_INC%\ucrt;%WINSDK_INC%\sh
 set OUTDIR=%~dp0msvc_build
 if not exist "%OUTDIR%" mkdir "%OUTDIR%"
 
+REM build.zig anchors the static lib on msvc_build/dummy.c. Write it here so a
+REM fresh clone plus one .bat invocation produces everything build.zig needs;
+REM no separate dummy.c to maintain or forget.
+echo // Dummy compilation unit for the static library. > "%OUTDIR%\dummy.c"
+echo int _glslang_dummy; >> "%OUTDIR%\dummy.c"
+
 set CFLAGS=/nologo /c /std:c++17 /DNDEBUG /DNOMINMAX /D_CRT_SECURE_NO_WARNINGS /EHsc /MT /O2 /W0 /Fo"%OUTDIR%\\"
 
 REM Compile all glslang source files


### PR DESCRIPTION
build.zig anchors the static library on `pkg/glslang/msvc_build/dummy.c` via `addCSourceFiles`. That file is gitignored (whole `msvc_build/` dir is) and not generated by `build_msvc.bat`, so a fresh clone plus one .bat run left dummy.c missing and the follow-up zig build failed with `file_hash FileNotFound`.

Have the .bat write dummy.c alongside the .obj files it already produces. One clone + one .bat run now yields everything build.zig needs.