### PR TITLE
feat(profiles): pure-logic foundation (PR 1/6)

### DIFF
--- a/windows/Ghostty.Core/Profiles/DiscoveredProfile.cs
+++ b/windows/Ghostty.Core/Profiles/DiscoveredProfile.cs
@@ -1,0 +1,14 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// One result from an <see cref="IInstalledShellProbe"/>. Discovered
+/// profiles always supply a Command (probes guarantee non-empty).
+/// </summary>
+public sealed record DiscoveredProfile(
+    string Id,
+    string Name,
+    string Command,
+    string ProbeId,
+    string? WorkingDirectory = null,
+    IconSpec? Icon = null,
+    string? TabTitle = null);

--- a/windows/Ghostty.Core/Profiles/EffectiveVisualOverrides.cs
+++ b/windows/Ghostty.Core/Profiles/EffectiveVisualOverrides.cs
@@ -1,0 +1,15 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// The five per-profile visual override keys (the "beta" set from the V1 design).
+/// All fields are optional; null means "inherit from base config".
+/// </summary>
+public sealed record EffectiveVisualOverrides(
+    string? Theme = null,
+    double? BackgroundOpacity = null,
+    string? FontFamily = null,
+    double? FontSize = null,
+    string? CursorStyle = null)
+{
+    public static readonly EffectiveVisualOverrides Empty = new();
+}

--- a/windows/Ghostty.Core/Profiles/IFileSystem.cs
+++ b/windows/Ghostty.Core/Profiles/IFileSystem.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Win32 known-folder selector. Local enum so Ghostty.Core does not
+/// depend on Win32 SHGetKnownFolderPath types.
+/// </summary>
+public enum KnownFolderId
+{
+    System,           // %SystemRoot%\System32
+    ProgramFiles,     // %ProgramFiles%
+    ProgramFilesX86,  // %ProgramFiles(x86)%
+    LocalAppData,     // %LOCALAPPDATA%
+    UserProfile,      // %USERPROFILE%
+}
+
+/// <summary>
+/// Filesystem and known-folder access. Production wrapper uses
+/// System.IO + SHGetKnownFolderPath; tests use FakeFileSystem.
+/// </summary>
+public interface IFileSystem
+{
+    bool FileExists(string path);
+    string? GetKnownFolder(KnownFolderId id);
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken ct);
+    Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken ct);
+}

--- a/windows/Ghostty.Core/Profiles/IIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/IIconResolver.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Resolves an <see cref="IconSpec"/> to 16x16 PNG bytes. Production
+/// wrapper handles SHGetFileInfo extraction, MDL2 glyph rasterization,
+/// bundled-icon resource loading, and on-disk caching at
+/// %LOCALAPPDATA%\Wintty\IconCache\&lt;sha&gt;.png. Tests use
+/// FakeIconResolver.
+/// </summary>
+public interface IIconResolver
+{
+    Task<byte[]> ResolveAsync(IconSpec spec, CancellationToken ct);
+}

--- a/windows/Ghostty.Core/Profiles/IInstalledShellProbe.cs
+++ b/windows/Ghostty.Core/Profiles/IInstalledShellProbe.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// One discovery probe per installed-shell type (cmd, pwsh, wsl,
+/// git-bash, azure-cloud-shell). Probes are pure logic + injected
+/// IProcessRunner / IRegistryReader / IFileSystem, so each is a few
+/// hundred LOC and fully unit-testable with canned interface inputs.
+/// </summary>
+public interface IInstalledShellProbe
+{
+    /// <summary>
+    /// Stable, kebab-case identifier for this probe (e.g. "wsl",
+    /// "git-bash"). Used as the ProbeId on results and to namespace
+    /// generated profile IDs.
+    /// </summary>
+    string ProbeId { get; }
+
+    Task<IReadOnlyList<DiscoveredProfile>> DiscoverAsync(CancellationToken ct);
+}

--- a/windows/Ghostty.Core/Profiles/IProcessRunner.cs
+++ b/windows/Ghostty.Core/Profiles/IProcessRunner.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Result of running an external process. ExitCode is -1 if the
+/// process did not start (e.g. file not found).
+/// </summary>
+public sealed record ProcessResult(
+    int ExitCode,
+    string Stdout,
+    string Stderr,
+    System.TimeSpan Duration);
+
+/// <summary>
+/// Runs an external process and returns its result. Production wrapper
+/// uses System.Diagnostics.Process; tests use FakeProcessRunner.
+/// Ghostty.Core never calls Process.Start directly so the resolver
+/// types stay pure-logic and unit-testable on Linux runners.
+/// </summary>
+public interface IProcessRunner
+{
+    Task<ProcessResult> RunAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        System.TimeSpan timeout,
+        CancellationToken ct);
+}

--- a/windows/Ghostty.Core/Profiles/IRegistryReader.cs
+++ b/windows/Ghostty.Core/Profiles/IRegistryReader.cs
@@ -1,0 +1,22 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Registry hive selector. Local enum so Ghostty.Core does not depend
+/// on Microsoft.Win32.Registry, which is Windows-only at runtime even
+/// though the types are cross-platform.
+/// </summary>
+public enum RegistryHive
+{
+    LocalMachine,
+    CurrentUser,
+}
+
+/// <summary>
+/// Read-only registry access. Probes never write. Production wrapper
+/// uses Microsoft.Win32.Registry; tests use FakeRegistryReader.
+/// </summary>
+public interface IRegistryReader
+{
+    string? ReadString(RegistryHive hive, string keyPath, string valueName);
+    bool KeyExists(RegistryHive hive, string keyPath);
+}

--- a/windows/Ghostty.Core/Profiles/IconSpec.cs
+++ b/windows/Ghostty.Core/Profiles/IconSpec.cs
@@ -1,0 +1,7 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Polymorphic icon source. Five variants are defined in Task 2;
+/// this stub exists so <see cref="ProfileDef"/> compiles in Task 1.
+/// </summary>
+public abstract record IconSpec;

--- a/windows/Ghostty.Core/Profiles/IconSpec.cs
+++ b/windows/Ghostty.Core/Profiles/IconSpec.cs
@@ -1,7 +1,37 @@
 namespace Ghostty.Core.Profiles;
 
 /// <summary>
-/// Polymorphic icon source. Five variants are defined in Task 2;
-/// this stub exists so <see cref="ProfileDef"/> compiles in Task 1.
+/// Polymorphic icon source. Resolution from <see cref="IconSpec"/> to
+/// rendered bytes is the responsibility of IIconResolver;
+/// this type is just the spec.
 /// </summary>
-public abstract record IconSpec;
+public abstract record IconSpec
+{
+    /// <summary>
+    /// Absolute filesystem path to an .ico, .png, .jpg, or .svg file.
+    /// </summary>
+    public sealed record Path(string FilePath) : IconSpec;
+
+    /// <summary>
+    /// Segoe MDL2 / Fluent icon font code point.
+    /// </summary>
+    public sealed record Mdl2Token(int CodePoint) : IconSpec;
+
+    /// <summary>
+    /// Wintty-bundled icon by string key (e.g. "pwsh", "cmd", "wsl").
+    /// </summary>
+    public sealed record BundledKey(string Key) : IconSpec;
+
+    /// <summary>
+    /// Extract the icon associated with a Windows .exe via SHGetFileInfo.
+    /// </summary>
+    public sealed record AutoForExe(string ExePath) : IconSpec;
+
+    /// <summary>
+    /// Extract the per-distro WSL icon (wslg-managed); fall back to
+    /// bundled "wsl" if the per-distro icon is unavailable.
+    /// </summary>
+    public sealed record AutoForWslDistro(string DistroName) : IconSpec;
+
+    private IconSpec() { }
+}

--- a/windows/Ghostty.Core/Profiles/ProfileDef.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileDef.cs
@@ -1,0 +1,25 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Parsed-from-config representation of one profile. Immutable.
+/// Discovered profiles use the same shape; the ProbeId field is set
+/// for discovered, null for user-defined.
+/// </summary>
+public sealed record ProfileDef(
+    string Id,
+    string Name,
+    string Command,
+    string? WorkingDirectory = null,
+    IconSpec? Icon = null,
+    string? TabTitle = null,
+    bool Hidden = false,
+    string? ProbeId = null,
+    EffectiveVisualOverrides? VisualsOrNull = null)
+{
+    /// <summary>
+    /// Non-null view of <see cref="VisualsOrNull"/>; returns
+    /// <see cref="EffectiveVisualOverrides.Empty"/> if the parser did
+    /// not see any visual override keys for this profile.
+    /// </summary>
+    public EffectiveVisualOverrides Visuals => VisualsOrNull ?? EffectiveVisualOverrides.Empty;
+}

--- a/windows/Ghostty.Core/Profiles/ProfileMerger.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileMerger.cs
@@ -1,0 +1,22 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Merges base-config visuals with a profile's overrides. The base
+/// parameter must already be the effective base (i.e. the base config's
+/// theme cascade has been resolved by the caller). Profile keys override
+/// base keys when non-null; null profile keys inherit base.
+/// </summary>
+public static class ProfileMerger
+{
+    public static EffectiveVisualOverrides Merge(
+        EffectiveVisualOverrides baseVisuals,
+        EffectiveVisualOverrides profileOverrides)
+    {
+        return new EffectiveVisualOverrides(
+            Theme: profileOverrides.Theme ?? baseVisuals.Theme,
+            BackgroundOpacity: profileOverrides.BackgroundOpacity ?? baseVisuals.BackgroundOpacity,
+            FontFamily: profileOverrides.FontFamily ?? baseVisuals.FontFamily,
+            FontSize: profileOverrides.FontSize ?? baseVisuals.FontSize,
+            CursorStyle: profileOverrides.CursorStyle ?? baseVisuals.CursorStyle);
+    }
+}

--- a/windows/Ghostty.Core/Profiles/ProfileMerger.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileMerger.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ghostty.Core.Profiles;
 
 /// <summary>
@@ -12,6 +14,9 @@ public static class ProfileMerger
         EffectiveVisualOverrides baseVisuals,
         EffectiveVisualOverrides profileOverrides)
     {
+        ArgumentNullException.ThrowIfNull(baseVisuals);
+        ArgumentNullException.ThrowIfNull(profileOverrides);
+
         return new EffectiveVisualOverrides(
             Theme: profileOverrides.Theme ?? baseVisuals.Theme,
             BackgroundOpacity: profileOverrides.BackgroundOpacity ?? baseVisuals.BackgroundOpacity,

--- a/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Composes user-defined + discovered profiles into the final visible
+/// list. Order: profile-order entries first (in their listed order),
+/// then unlisted user profiles in the order they were defined, then
+/// unlisted discovered profiles in alphabetical-by-ID order. Hidden
+/// profiles (either via ProfileDef.Hidden or the hidden set parameter)
+/// are omitted entirely.
+/// </summary>
+public static class ProfileOrderResolver
+{
+    public static IReadOnlyList<ResolvedProfile> Resolve(
+        IReadOnlyList<ProfileDef> user,
+        IReadOnlyList<DiscoveredProfile> discovered,
+        IReadOnlyList<string>? profileOrder,
+        string? defaultProfileId,
+        IReadOnlySet<string> hidden)
+    {
+        var combined = new Dictionary<string, ProfileDef>();
+        var userOrder = new List<string>();
+        foreach (var u in user)
+        {
+            combined[u.Id] = u;
+            userOrder.Add(u.Id);
+        }
+        var discoveredById = new Dictionary<string, DiscoveredProfile>();
+        foreach (var d in discovered)
+        {
+            discoveredById[d.Id] = d;
+            if (!combined.ContainsKey(d.Id))
+            {
+                combined[d.Id] = new ProfileDef(
+                    Id: d.Id,
+                    Name: d.Name,
+                    Command: d.Command,
+                    WorkingDirectory: d.WorkingDirectory,
+                    Icon: d.Icon,
+                    TabTitle: d.TabTitle,
+                    Hidden: false,
+                    ProbeId: d.ProbeId,
+                    VisualsOrNull: null);
+            }
+        }
+
+        var ordered = new List<string>();
+        var seen = new HashSet<string>();
+
+        if (profileOrder is not null)
+        {
+            foreach (var id in profileOrder)
+            {
+                if (!combined.ContainsKey(id)) continue;
+                if (seen.Add(id)) ordered.Add(id);
+            }
+        }
+
+        foreach (var id in userOrder)
+            if (seen.Add(id)) ordered.Add(id);
+
+        foreach (var id in discoveredById.Keys.OrderBy(k => k, System.StringComparer.Ordinal))
+            if (seen.Add(id)) ordered.Add(id);
+
+        var result = new List<ResolvedProfile>();
+        var index = 0;
+        var defaultResolved = ResolveDefault(defaultProfileId, ordered, combined, hidden);
+        foreach (var id in ordered)
+        {
+            var def = combined[id];
+            if (def.Hidden || hidden.Contains(id)) continue;
+            result.Add(new ResolvedProfile(
+                Id: def.Id,
+                Name: def.Name,
+                Command: def.Command,
+                WorkingDirectory: def.WorkingDirectory,
+                Icon: def.Icon ?? new IconSpec.BundledKey("default"),
+                TabTitle: def.TabTitle ?? def.Name,
+                Visuals: def.Visuals,
+                ProbeId: def.ProbeId,
+                OrderIndex: index++,
+                IsDefault: def.Id == defaultResolved));
+        }
+        return result;
+    }
+
+    private static string? ResolveDefault(
+        string? requested,
+        List<string> ordered,
+        Dictionary<string, ProfileDef> combined,
+        IReadOnlySet<string> hidden)
+    {
+        if (requested is not null
+            && combined.TryGetValue(requested, out var def)
+            && !def.Hidden
+            && !hidden.Contains(requested))
+        {
+            return requested;
+        }
+        foreach (var id in ordered)
+        {
+            var d = combined[id];
+            if (!d.Hidden && !hidden.Contains(id)) return id;
+        }
+        return null;
+    }
+}

--- a/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,6 +21,10 @@ public static class ProfileOrderResolver
         string? defaultProfileId,
         IReadOnlySet<string> hidden)
     {
+        ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(discovered);
+        ArgumentNullException.ThrowIfNull(hidden);
+
         var combined = new Dictionary<string, ProfileDef>();
         var userOrder = new List<string>();
         foreach (var u in user)
@@ -61,7 +66,7 @@ public static class ProfileOrderResolver
         foreach (var id in userOrder)
             if (seen.Add(id)) ordered.Add(id);
 
-        foreach (var id in discoveredById.Keys.OrderBy(k => k, System.StringComparer.Ordinal))
+        foreach (var id in discoveredById.Keys.OrderBy(k => k, StringComparer.Ordinal))
             if (seen.Add(id)) ordered.Add(id);
 
         var result = new List<ResolvedProfile>();

--- a/windows/Ghostty.Core/Profiles/ProfileSnapshot.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSnapshot.cs
@@ -1,0 +1,16 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Per-tab snapshot of a profile, taken at <see cref="Version"/>.
+/// Snapshots are immutable; re-resolution produces a new instance.
+/// Held by TabModel so that removed/renamed profiles do not orphan
+/// open tabs.
+/// </summary>
+public sealed record ProfileSnapshot(
+    string ProfileId,
+    long Version,
+    string ResolvedCommand,
+    string? WorkingDirectory,
+    string DisplayName,
+    IconSpec Icon,
+    EffectiveVisualOverrides Visuals);

--- a/windows/Ghostty.Core/Profiles/ProfileSnapshotStore.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSnapshotStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Ghostty.Core.Profiles;
@@ -20,6 +21,9 @@ public static class ProfileSnapshotStore
         IReadOnlyList<ResolvedProfile> resolvedProfiles,
         long version)
     {
+        ArgumentNullException.ThrowIfNull(profileId);
+        ArgumentNullException.ThrowIfNull(resolvedProfiles);
+
         var profile = FindById(resolvedProfiles, profileId);
         if (profile is null) return null;
         return BuildSnapshot(profile, version);
@@ -36,6 +40,9 @@ public static class ProfileSnapshotStore
         IReadOnlyList<ResolvedProfile> resolvedProfiles,
         long newVersion)
     {
+        ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(resolvedProfiles);
+
         var profile = FindById(resolvedProfiles, existing.ProfileId);
         if (profile is null) return existing;
         return BuildSnapshot(profile, newVersion);

--- a/windows/Ghostty.Core/Profiles/ProfileSnapshotStore.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSnapshotStore.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Builds and refreshes <see cref="ProfileSnapshot"/> instances for
+/// open tabs. Pure logic: the per-tab storage of the snapshot itself
+/// belongs to TabModel (PR 3). This type only knows how to derive
+/// snapshots from the current resolved profile list.
+/// </summary>
+public static class ProfileSnapshotStore
+{
+    /// <summary>
+    /// First-time resolution for a freshly-opened tab. Returns null
+    /// if the requested profile is not in the resolved list (caller
+    /// is expected to fall back to the default profile in that case).
+    /// </summary>
+    public static ProfileSnapshot? Resolve(
+        string profileId,
+        IReadOnlyList<ResolvedProfile> resolvedProfiles,
+        long version)
+    {
+        var profile = FindById(resolvedProfiles, profileId);
+        if (profile is null) return null;
+        return BuildSnapshot(profile, version);
+    }
+
+    /// <summary>
+    /// Refresh an existing snapshot against a new resolved list.
+    /// Graceful path: if the profile is no longer in the list (removed
+    /// or renamed), returns the existing snapshot unchanged. The open
+    /// tab keeps its visual + identity state.
+    /// </summary>
+    public static ProfileSnapshot Refresh(
+        ProfileSnapshot existing,
+        IReadOnlyList<ResolvedProfile> resolvedProfiles,
+        long newVersion)
+    {
+        var profile = FindById(resolvedProfiles, existing.ProfileId);
+        if (profile is null) return existing;
+        return BuildSnapshot(profile, newVersion);
+    }
+
+    private static ResolvedProfile? FindById(
+        IReadOnlyList<ResolvedProfile> resolvedProfiles,
+        string id)
+    {
+        foreach (var p in resolvedProfiles)
+            if (p.Id == id) return p;
+        return null;
+    }
+
+    private static ProfileSnapshot BuildSnapshot(ResolvedProfile profile, long version)
+        => new(
+            ProfileId: profile.Id,
+            Version: version,
+            ResolvedCommand: profile.Command,
+            WorkingDirectory: profile.WorkingDirectory,
+            DisplayName: profile.Name,
+            Icon: profile.Icon,
+            Visuals: profile.Visuals);
+}

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -29,6 +29,9 @@ public static partial class ProfileSourceParser
 
     public static ProfileParseResult Parse(string configText)
     {
+        if (configText.Length > 0 && configText[0] == '\uFEFF')
+            configText = configText.Substring(1);
+
         var groups = new Dictionary<string, Dictionary<string, string>>();
         var warnings = new List<string>();
 

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -20,11 +20,12 @@ public sealed record ProfileParseResult(
 /// kebab-case ASCII (<c>[a-z0-9-]+</c>); invalid IDs cause the profile to
 /// be dropped with a warning.
 /// </summary>
-public static class ProfileSourceParser
+public static partial class ProfileSourceParser
 {
-    private static readonly Regex LineRegex = new(
+    [GeneratedRegex(
         @"^profile\.([a-z0-9-]+)\.([a-z0-9-]+)\s*=\s*(.+?)\s*$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        RegexOptions.IgnoreCase)]
+    private static partial Regex LineRegex();
 
     public static ProfileParseResult Parse(string configText)
     {
@@ -36,7 +37,7 @@ public static class ProfileSourceParser
             var line = rawLine.TrimEnd('\r').Trim();
             if (line.Length == 0 || line[0] == '#') continue;
 
-            var match = LineRegex.Match(line);
+            var match = LineRegex().Match(line);
             if (!match.Success) continue;
 
             var id = match.Groups[1].Value.ToLowerInvariant();

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Parsed result: the dictionary of profile defs by ID, plus any
+/// non-fatal warnings collected during parsing. Fatal errors (e.g.
+/// missing required keys) cause the offending profile to be omitted.
+/// </summary>
+public sealed record ProfileParseResult(
+    IReadOnlyDictionary<string, ProfileDef> Profiles,
+    IReadOnlyList<string> Warnings);
+
+/// <summary>
+/// Pure function: extract per-profile keys from raw config text.
+/// Lines matching <c>profile.&lt;id&gt;.&lt;subkey&gt; = &lt;value&gt;</c>
+/// are collected; everything else is ignored. ID format is
+/// kebab-case ASCII (<c>[a-z0-9-]+</c>); invalid IDs cause the profile to
+/// be dropped with a warning.
+/// </summary>
+public static class ProfileSourceParser
+{
+    private static readonly Regex LineRegex = new(
+        @"^profile\.([a-z0-9-]+)\.([a-z0-9-]+)\s*=\s*(.+?)\s*$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public static ProfileParseResult Parse(string configText)
+    {
+        var groups = new Dictionary<string, Dictionary<string, string>>();
+        var warnings = new List<string>();
+
+        foreach (var rawLine in configText.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r').Trim();
+            if (line.Length == 0 || line[0] == '#') continue;
+
+            var match = LineRegex.Match(line);
+            if (!match.Success) continue;
+
+            var id = match.Groups[1].Value.ToLowerInvariant();
+            var subKey = match.Groups[2].Value.ToLowerInvariant();
+            var value = match.Groups[3].Value;
+
+            if (!groups.TryGetValue(id, out var bag))
+                groups[id] = bag = new Dictionary<string, string>();
+            bag[subKey] = value;
+        }
+
+        var profiles = new Dictionary<string, ProfileDef>();
+        foreach (var (id, bag) in groups)
+        {
+            if (!bag.TryGetValue("name", out var name) || name.Length == 0)
+            {
+                warnings.Add($"profile '{id}': missing required key 'name', dropped");
+                continue;
+            }
+            if (!bag.TryGetValue("command", out var command) || command.Length == 0)
+            {
+                warnings.Add($"profile '{id}': missing required key 'command', dropped");
+                continue;
+            }
+
+            var visuals = BuildVisuals(bag);
+            profiles[id] = new ProfileDef(
+                Id: id,
+                Name: name,
+                Command: command,
+                WorkingDirectory: bag.GetValueOrDefault("working-directory"),
+                Icon: ParseIcon(bag.GetValueOrDefault("icon")),
+                TabTitle: bag.GetValueOrDefault("tab-title"),
+                Hidden: ParseBool(bag.GetValueOrDefault("hidden")),
+                ProbeId: null,
+                VisualsOrNull: visuals.HasAny ? visuals.Value : null);
+        }
+
+        return new ProfileParseResult(profiles, warnings);
+    }
+
+    private static (EffectiveVisualOverrides Value, bool HasAny) BuildVisuals(
+        Dictionary<string, string> bag)
+    {
+        var theme = bag.GetValueOrDefault("theme");
+        var opacity = ParseDouble(bag.GetValueOrDefault("background-opacity"));
+        var fontFamily = bag.GetValueOrDefault("font-family");
+        var fontSize = ParseDouble(bag.GetValueOrDefault("font-size"));
+        var cursorStyle = bag.GetValueOrDefault("cursor-style");
+
+        var hasAny = theme is not null
+                     || opacity is not null
+                     || fontFamily is not null
+                     || fontSize is not null
+                     || cursorStyle is not null;
+
+        return (new EffectiveVisualOverrides(theme, opacity, fontFamily, fontSize, cursorStyle), hasAny);
+    }
+
+    private static IconSpec? ParseIcon(string? value)
+    {
+        if (value is null) return null;
+        if (value.StartsWith("mdl2:", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var hex = value.Substring(5);
+            if (int.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var cp))
+                return new IconSpec.Mdl2Token(cp);
+            return null;
+        }
+        return new IconSpec.Path(value);
+    }
+
+    private static bool ParseBool(string? value)
+        => value is not null
+           && bool.TryParse(value, out var b)
+           && b;
+
+    private static double? ParseDouble(string? value)
+    {
+        if (value is null) return null;
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
+            ? d
+            : null;
+    }
+}

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -29,6 +30,8 @@ public static partial class ProfileSourceParser
 
     public static ProfileParseResult Parse(string configText)
     {
+        ArgumentNullException.ThrowIfNull(configText);
+
         if (configText.Length > 0 && configText[0] == '\uFEFF')
             configText = configText.Substring(1);
 

--- a/windows/Ghostty.Core/Profiles/ResolvedProfile.cs
+++ b/windows/Ghostty.Core/Profiles/ResolvedProfile.cs
@@ -1,0 +1,18 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// A profile after merge of user-defined + discovered + ordering +
+/// hidden filtering. This is what UI consumers see. ProbeId is set
+/// when this profile originated from discovery.
+/// </summary>
+public sealed record ResolvedProfile(
+    string Id,
+    string Name,
+    string Command,
+    string? WorkingDirectory,
+    IconSpec Icon,
+    string TabTitle,
+    EffectiveVisualOverrides Visuals,
+    string? ProbeId,
+    int OrderIndex,
+    bool IsDefault);

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -68,4 +68,10 @@
                       LogicalName="Ghostty.Tests.Interop.NativeMethods.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Profiles\Scenarios\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeFileSystem.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeFileSystem.cs
@@ -16,7 +16,7 @@ internal sealed class FakeFileSystem : IFileSystem
     private readonly Dictionary<KnownFolderId, string> _knownFolders = new();
 
     public void AddFile(string path, byte[] content) => _files[path] = content;
-    public void AddFile(string path) => _files[path] = System.Array.Empty<byte>();
+    public void AddFile(string path) => _files[path] = [];
     public void SetKnownFolder(KnownFolderId id, string path) => _knownFolders[id] = path;
 
     public bool FileExists(string path) => _files.ContainsKey(path);

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeFileSystem.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeFileSystem.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Tests.Profiles.Fakes;
+
+/// <summary>
+/// In-memory filesystem fake. Files are byte-array values keyed by
+/// path. Known folders are configured via <see cref="SetKnownFolder"/>.
+/// </summary>
+public sealed class FakeFileSystem : IFileSystem
+{
+    private readonly Dictionary<string, byte[]> _files = new();
+    private readonly Dictionary<KnownFolderId, string> _knownFolders = new();
+
+    public void AddFile(string path, byte[] content) => _files[path] = content;
+    public void AddFile(string path) => _files[path] = System.Array.Empty<byte>();
+    public void SetKnownFolder(KnownFolderId id, string path) => _knownFolders[id] = path;
+
+    public bool FileExists(string path) => _files.ContainsKey(path);
+
+    public string? GetKnownFolder(KnownFolderId id)
+        => _knownFolders.TryGetValue(id, out var p) ? p : null;
+
+    public Task<byte[]> ReadAllBytesAsync(string path, CancellationToken ct)
+    {
+        if (!_files.TryGetValue(path, out var bytes))
+            throw new FileNotFoundException(path);
+        return Task.FromResult(bytes);
+    }
+
+    public Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken ct)
+    {
+        _files[path] = bytes;
+        return Task.CompletedTask;
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeFileSystem.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeFileSystem.cs
@@ -10,7 +10,7 @@ namespace Ghostty.Tests.Profiles.Fakes;
 /// In-memory filesystem fake. Files are byte-array values keyed by
 /// path. Known folders are configured via <see cref="SetKnownFolder"/>.
 /// </summary>
-public sealed class FakeFileSystem : IFileSystem
+internal sealed class FakeFileSystem : IFileSystem
 {
     private readonly Dictionary<string, byte[]> _files = new();
     private readonly Dictionary<KnownFolderId, string> _knownFolders = new();

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeIconResolver.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeIconResolver.cs
@@ -10,7 +10,7 @@ namespace Ghostty.Tests.Profiles.Fakes;
 /// Returns canned PNG bytes per IconSpec. If no canned entry, returns
 /// a 4-byte sentinel ("FAKE") so tests can verify the resolver was hit.
 /// </summary>
-public sealed class FakeIconResolver : IIconResolver
+internal sealed class FakeIconResolver : IIconResolver
 {
     private static readonly byte[] Sentinel = "FAKE"u8.ToArray();
     private readonly Dictionary<IconSpec, byte[]> _canned = new();

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeIconResolver.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeIconResolver.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Tests.Profiles.Fakes;
+
+/// <summary>
+/// Returns canned PNG bytes per IconSpec. If no canned entry, returns
+/// a 4-byte sentinel ("FAKE") so tests can verify the resolver was hit.
+/// </summary>
+public sealed class FakeIconResolver : IIconResolver
+{
+    private static readonly byte[] Sentinel = "FAKE"u8.ToArray();
+    private readonly Dictionary<IconSpec, byte[]> _canned = new();
+
+    public List<IconSpec> Calls { get; } = new();
+
+    public void EnqueueResult(IconSpec spec, byte[] bytes) => _canned[spec] = bytes;
+
+    public Task<byte[]> ResolveAsync(IconSpec spec, CancellationToken ct)
+    {
+        Calls.Add(spec);
+        return Task.FromResult(_canned.TryGetValue(spec, out var b) ? b : Sentinel);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeInstalledShellProbe.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeInstalledShellProbe.cs
@@ -11,7 +11,7 @@ namespace Ghostty.Tests.Profiles.Fakes;
 /// probe set when exercising <see cref="ProfileOrderResolver"/> or
 /// later the <c>DiscoveryService</c>.
 /// </summary>
-public sealed class FakeInstalledShellProbe : IInstalledShellProbe
+internal sealed class FakeInstalledShellProbe : IInstalledShellProbe
 {
     private readonly IReadOnlyList<DiscoveredProfile> _results;
 

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeInstalledShellProbe.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeInstalledShellProbe.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Tests.Profiles.Fakes;
+
+/// <summary>
+/// Returns a fixed list of <see cref="DiscoveredProfile"/>. Tests
+/// compose multiple instances of this fake to stand in for the full
+/// probe set when exercising <see cref="ProfileOrderResolver"/> or
+/// later the <c>DiscoveryService</c>.
+/// </summary>
+public sealed class FakeInstalledShellProbe : IInstalledShellProbe
+{
+    private readonly IReadOnlyList<DiscoveredProfile> _results;
+
+    public FakeInstalledShellProbe(string probeId, IReadOnlyList<DiscoveredProfile> results)
+    {
+        ProbeId = probeId;
+        _results = results;
+    }
+
+    public string ProbeId { get; }
+
+    public Task<IReadOnlyList<DiscoveredProfile>> DiscoverAsync(CancellationToken ct)
+        => Task.FromResult(_results);
+}

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeProcessRunner.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeProcessRunner.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Tests.Profiles.Fakes;
+
+/// <summary>
+/// Returns canned ProcessResult per (fileName, args-joined-with-space).
+/// Unmatched calls return ExitCode=-1 stdout/stderr empty (mirrors the
+/// "process did not start" contract). Records every call for assertion.
+/// </summary>
+public sealed class FakeProcessRunner : IProcessRunner
+{
+    private readonly Dictionary<string, ProcessResult> _canned = new();
+    public List<(string File, IReadOnlyList<string> Args)> Calls { get; } = new();
+
+    public void EnqueueResult(string fileName, IEnumerable<string> args, ProcessResult result)
+    {
+        _canned[Key(fileName, args)] = result;
+    }
+
+    public Task<ProcessResult> RunAsync(
+        string fileName,
+        IReadOnlyList<string> args,
+        TimeSpan timeout,
+        CancellationToken ct)
+    {
+        Calls.Add((fileName, args));
+        var key = Key(fileName, args);
+        if (_canned.TryGetValue(key, out var result))
+            return Task.FromResult(result);
+        return Task.FromResult(new ProcessResult(-1, "", "", TimeSpan.Zero));
+    }
+
+    private static string Key(string fileName, IEnumerable<string> args)
+        => $"{fileName} {string.Join(' ', args)}";
+}

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeProcessRunner.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeProcessRunner.cs
@@ -12,7 +12,7 @@ namespace Ghostty.Tests.Profiles.Fakes;
 /// Unmatched calls return ExitCode=-1 stdout/stderr empty (mirrors the
 /// "process did not start" contract). Records every call for assertion.
 /// </summary>
-public sealed class FakeProcessRunner : IProcessRunner
+internal sealed class FakeProcessRunner : IProcessRunner
 {
     private readonly Dictionary<string, ProcessResult> _canned = new();
     public List<(string File, IReadOnlyList<string> Args)> Calls { get; } = new();

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeRegistryReader.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeRegistryReader.cs
@@ -7,7 +7,7 @@ namespace Ghostty.Tests.Profiles.Fakes;
 /// Dictionary-backed registry fake. Tests configure values via
 /// <see cref="SetValue"/>; absent keys/values return null/false.
 /// </summary>
-public sealed class FakeRegistryReader : IRegistryReader
+internal sealed class FakeRegistryReader : IRegistryReader
 {
     private readonly Dictionary<string, string> _values = new();
     private readonly HashSet<string> _keys = new();

--- a/windows/Ghostty.Tests/Profiles/Fakes/FakeRegistryReader.cs
+++ b/windows/Ghostty.Tests/Profiles/Fakes/FakeRegistryReader.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Tests.Profiles.Fakes;
+
+/// <summary>
+/// Dictionary-backed registry fake. Tests configure values via
+/// <see cref="SetValue"/>; absent keys/values return null/false.
+/// </summary>
+public sealed class FakeRegistryReader : IRegistryReader
+{
+    private readonly Dictionary<string, string> _values = new();
+    private readonly HashSet<string> _keys = new();
+
+    public void SetKey(RegistryHive hive, string keyPath)
+        => _keys.Add(KeyKey(hive, keyPath));
+
+    public void SetValue(RegistryHive hive, string keyPath, string valueName, string value)
+    {
+        _values[ValueKey(hive, keyPath, valueName)] = value;
+        _keys.Add(KeyKey(hive, keyPath));
+    }
+
+    public string? ReadString(RegistryHive hive, string keyPath, string valueName)
+        => _values.TryGetValue(ValueKey(hive, keyPath, valueName), out var v) ? v : null;
+
+    public bool KeyExists(RegistryHive hive, string keyPath)
+        => _keys.Contains(KeyKey(hive, keyPath));
+
+    private static string KeyKey(RegistryHive hive, string keyPath) => $"{hive}::{keyPath}";
+
+    private static string ValueKey(RegistryHive hive, string keyPath, string valueName)
+        => $"{hive}::{keyPath}::{valueName}";
+}

--- a/windows/Ghostty.Tests/Profiles/IconSpecTests.cs
+++ b/windows/Ghostty.Tests/Profiles/IconSpecTests.cs
@@ -1,0 +1,54 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class IconSpecTests
+{
+    [Fact]
+    public void Path_HoldsFilePath()
+    {
+        IconSpec spec = new IconSpec.Path(@"C:\icons\pwsh.ico");
+        var p = Assert.IsType<IconSpec.Path>(spec);
+        Assert.Equal(@"C:\icons\pwsh.ico", p.FilePath);
+    }
+
+    [Fact]
+    public void Mdl2Token_HoldsCodePoint()
+    {
+        IconSpec spec = new IconSpec.Mdl2Token(0xE756);
+        var m = Assert.IsType<IconSpec.Mdl2Token>(spec);
+        Assert.Equal(0xE756, m.CodePoint);
+    }
+
+    [Fact]
+    public void BundledKey_HoldsKey()
+    {
+        IconSpec spec = new IconSpec.BundledKey("pwsh");
+        var b = Assert.IsType<IconSpec.BundledKey>(spec);
+        Assert.Equal("pwsh", b.Key);
+    }
+
+    [Fact]
+    public void AutoForExe_HoldsExePath()
+    {
+        IconSpec spec = new IconSpec.AutoForExe(@"C:\Program Files\PowerShell\7\pwsh.exe");
+        var a = Assert.IsType<IconSpec.AutoForExe>(spec);
+        Assert.Equal(@"C:\Program Files\PowerShell\7\pwsh.exe", a.ExePath);
+    }
+
+    [Fact]
+    public void AutoForWslDistro_HoldsDistroName()
+    {
+        IconSpec spec = new IconSpec.AutoForWslDistro("Ubuntu-22.04");
+        var d = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
+        Assert.Equal("Ubuntu-22.04", d.DistroName);
+    }
+
+    [Fact]
+    public void Variants_RecordEqualityHolds()
+    {
+        Assert.Equal(new IconSpec.Path("a"), new IconSpec.Path("a"));
+        Assert.NotEqual<IconSpec>(new IconSpec.Path("a"), new IconSpec.BundledKey("a"));
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileDefTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileDefTests.cs
@@ -1,0 +1,32 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProfileDefTests
+{
+    [Fact]
+    public void ProfileDef_AllOptionalNull_RecordEquality()
+    {
+        var a = new ProfileDef(Id: "pwsh", Name: "PowerShell", Command: "pwsh.exe");
+        var b = new ProfileDef(Id: "pwsh", Name: "PowerShell", Command: "pwsh.exe");
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void ProfileDef_DifferentId_RecordInequality()
+    {
+        var a = new ProfileDef(Id: "pwsh", Name: "PowerShell", Command: "pwsh.exe");
+        var b = new ProfileDef(Id: "cmd", Name: "PowerShell", Command: "pwsh.exe");
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void ProfileDef_VisualOverridesDefaultsEmpty()
+    {
+        var a = new ProfileDef(Id: "pwsh", Name: "PowerShell", Command: "pwsh.exe");
+        Assert.NotNull(a.Visuals);
+        Assert.Null(a.Visuals.Theme);
+        Assert.Null(a.Visuals.BackgroundOpacity);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileMergerTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileMergerTests.cs
@@ -1,0 +1,75 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProfileMergerTests
+{
+    private static EffectiveVisualOverrides Base(
+        string? theme = null,
+        double? opacity = null,
+        string? font = null,
+        double? size = null,
+        string? cursor = null)
+        => new(theme, opacity, font, size, cursor);
+
+    [Fact]
+    public void Merge_NoProfileOverrides_ReturnsBaseAsIs()
+    {
+        var baseV = Base(theme: "Light", opacity: 1.0, font: "Cascadia", size: 12, cursor: "block");
+
+        var merged = ProfileMerger.Merge(baseV, EffectiveVisualOverrides.Empty);
+
+        Assert.Equal(baseV, merged);
+    }
+
+    [Fact]
+    public void Merge_ProfileOverridesEachKey_ProfileWins()
+    {
+        var baseV = Base(theme: "Light", opacity: 1.0, font: "Cascadia", size: 12, cursor: "block");
+        var profile = Base(theme: "Dark", opacity: 0.85, font: "FiraCode", size: 14, cursor: "bar");
+
+        var merged = ProfileMerger.Merge(baseV, profile);
+
+        Assert.Equal("Dark", merged.Theme);
+        Assert.Equal(0.85, merged.BackgroundOpacity);
+        Assert.Equal("FiraCode", merged.FontFamily);
+        Assert.Equal(14, merged.FontSize);
+        Assert.Equal("bar", merged.CursorStyle);
+    }
+
+    [Fact]
+    public void Merge_ProfilePartialOverride_NullKeysInheritFromBase()
+    {
+        var baseV = Base(theme: "Light", opacity: 1.0, font: "Cascadia", size: 12, cursor: "block");
+        var profile = Base(opacity: 0.5);
+
+        var merged = ProfileMerger.Merge(baseV, profile);
+
+        Assert.Equal("Light", merged.Theme);
+        Assert.Equal(0.5, merged.BackgroundOpacity);
+        Assert.Equal("Cascadia", merged.FontFamily);
+        Assert.Equal(12, merged.FontSize);
+        Assert.Equal("block", merged.CursorStyle);
+    }
+
+    [Fact]
+    public void Merge_ProfileEmpty_BaseUnchanged()
+    {
+        var baseV = Base(theme: "X", opacity: 0.9);
+        var merged = ProfileMerger.Merge(baseV, EffectiveVisualOverrides.Empty);
+        Assert.Equal(baseV, merged);
+    }
+
+    [Fact]
+    public void Merge_BothEmpty_AllNulls()
+    {
+        var merged = ProfileMerger.Merge(EffectiveVisualOverrides.Empty, EffectiveVisualOverrides.Empty);
+
+        Assert.Null(merged.Theme);
+        Assert.Null(merged.BackgroundOpacity);
+        Assert.Null(merged.FontFamily);
+        Assert.Null(merged.FontSize);
+        Assert.Null(merged.CursorStyle);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
@@ -199,4 +199,77 @@ public sealed class ProfileOrderResolverTests
 
         Assert.Empty(resolved);
     }
+
+    [Fact]
+    public void Resolve_DiscoveredAddedLater_DoesNotShiftUserSlots()
+    {
+        var users = new[] { User("pwsh-7"), User("cmd"), User("git-bash") };
+
+        var before = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: "pwsh-7",
+            hidden: new HashSet<string>()).ToList();
+
+        var after = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: new[] { Disc("wsl-ubuntu"), Disc("wsl-debian") },
+            profileOrder: null,
+            defaultProfileId: "pwsh-7",
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.Equal("pwsh-7", before[0].Id);
+        Assert.Equal("pwsh-7", after[0].Id);
+        Assert.Equal("cmd", before[1].Id);
+        Assert.Equal("cmd", after[1].Id);
+        Assert.Equal("git-bash", before[2].Id);
+        Assert.Equal("git-bash", after[2].Id);
+
+        Assert.Equal(new[] { "wsl-debian", "wsl-ubuntu" },
+                     after.Skip(3).Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_HidingDiscovered_FreesSlotForLowerEntries()
+    {
+        var discovered = new[] { Disc("wsl-debian"), Disc("wsl-kali"), Disc("wsl-ubuntu") };
+
+        var noHide = ProfileOrderResolver.Resolve(
+            user: System.Array.Empty<ProfileDef>(),
+            discovered: discovered,
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        var hideKali = ProfileOrderResolver.Resolve(
+            user: System.Array.Empty<ProfileDef>(),
+            discovered: discovered,
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string> { "wsl-kali" }).ToList();
+
+        Assert.Equal(new[] { "wsl-debian", "wsl-kali", "wsl-ubuntu" },
+                     noHide.Select(r => r.Id));
+        Assert.Equal(new[] { "wsl-debian", "wsl-ubuntu" },
+                     hideKali.Select(r => r.Id));
+
+        Assert.Equal("wsl-debian", hideKali[0].Id);
+        Assert.Equal("wsl-ubuntu", hideKali[1].Id);
+    }
+
+    [Fact]
+    public void Resolve_ExplicitProfileOrderPinsSlotIndependentOfHide()
+    {
+        var users = new[] { User("a"), User("b"), User("c"), User("d") };
+
+        var pinned = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: new[] { "c", "a" },
+            defaultProfileId: null,
+            hidden: new HashSet<string> { "b" }).ToList();
+
+        Assert.Equal(new[] { "c", "a", "d" }, pinned.Select(r => r.Id));
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
@@ -54,7 +54,7 @@ public sealed class ProfileOrderResolverTests
 
         var resolved = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: null,
             defaultProfileId: null,
             hidden: new HashSet<string>()).ToList();
@@ -69,7 +69,7 @@ public sealed class ProfileOrderResolverTests
 
         var resolved = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: null,
             defaultProfileId: null,
             hidden: new HashSet<string> { "a" }).ToList();
@@ -102,7 +102,7 @@ public sealed class ProfileOrderResolverTests
 
         var resolved = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: order,
             defaultProfileId: null,
             hidden: new HashSet<string>()).ToList();
@@ -117,7 +117,7 @@ public sealed class ProfileOrderResolverTests
 
         var resolved = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: null,
             defaultProfileId: "zulu",
             hidden: new HashSet<string>()).ToList();
@@ -133,7 +133,7 @@ public sealed class ProfileOrderResolverTests
 
         var resolved = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: null,
             defaultProfileId: "ghost",
             hidden: new HashSet<string>()).ToList();
@@ -149,7 +149,7 @@ public sealed class ProfileOrderResolverTests
 
         var resolved = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: null,
             defaultProfileId: null,
             hidden: new HashSet<string>()).ToList();
@@ -164,7 +164,7 @@ public sealed class ProfileOrderResolverTests
 
         var resolved = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: null,
             defaultProfileId: null,
             hidden: new HashSet<string>()).ToList();
@@ -178,7 +178,7 @@ public sealed class ProfileOrderResolverTests
     public void Resolve_DiscoveredProfile_HasProbeIdSet()
     {
         var resolved = ProfileOrderResolver.Resolve(
-            user: System.Array.Empty<ProfileDef>(),
+            user: [],
             discovered: new[] { Disc("wsl-ubuntu", probe: "wsl") },
             profileOrder: null,
             defaultProfileId: null,
@@ -191,8 +191,8 @@ public sealed class ProfileOrderResolverTests
     public void Resolve_EmptyInputs_ReturnsEmpty()
     {
         var resolved = ProfileOrderResolver.Resolve(
-            user: System.Array.Empty<ProfileDef>(),
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            user: [],
+            discovered: [],
             profileOrder: null,
             defaultProfileId: null,
             hidden: new HashSet<string>());
@@ -207,7 +207,7 @@ public sealed class ProfileOrderResolverTests
 
         var before = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: null,
             defaultProfileId: "pwsh-7",
             hidden: new HashSet<string>()).ToList();
@@ -236,14 +236,14 @@ public sealed class ProfileOrderResolverTests
         var discovered = new[] { Disc("wsl-debian"), Disc("wsl-kali"), Disc("wsl-ubuntu") };
 
         var noHide = ProfileOrderResolver.Resolve(
-            user: System.Array.Empty<ProfileDef>(),
+            user: [],
             discovered: discovered,
             profileOrder: null,
             defaultProfileId: null,
             hidden: new HashSet<string>()).ToList();
 
         var hideKali = ProfileOrderResolver.Resolve(
-            user: System.Array.Empty<ProfileDef>(),
+            user: [],
             discovered: discovered,
             profileOrder: null,
             defaultProfileId: null,
@@ -265,7 +265,7 @@ public sealed class ProfileOrderResolverTests
 
         var pinned = ProfileOrderResolver.Resolve(
             user: users,
-            discovered: System.Array.Empty<DiscoveredProfile>(),
+            discovered: [],
             profileOrder: new[] { "c", "a" },
             defaultProfileId: null,
             hidden: new HashSet<string> { "b" }).ToList();

--- a/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
@@ -1,0 +1,202 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProfileOrderResolverTests
+{
+    private static ProfileDef User(string id, bool hidden = false)
+        => new(Id: id, Name: id, Command: $"{id}.exe", Hidden: hidden);
+
+    private static DiscoveredProfile Disc(string id, string probe = "test")
+        => new(Id: id, Name: id, Command: $"{id}.exe", ProbeId: probe);
+
+    [Fact]
+    public void Resolve_NoProfileOrder_UserFirstThenDiscoveredAlpha()
+    {
+        var users = new[] { User("alpha"), User("zulu") };
+        var discovered = new[] { Disc("delta"), Disc("bravo") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: discovered,
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.Equal(new[] { "alpha", "zulu", "bravo", "delta" }, resolved.Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_UserAndDiscoveredSameId_UserWins()
+    {
+        var users = new[] { User("pwsh") with { Name = "MyPwsh" } };
+        var discovered = new[] { Disc("pwsh") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: discovered,
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.Single(resolved);
+        Assert.Equal("MyPwsh", resolved[0].Name);
+        Assert.Null(resolved[0].ProbeId);
+    }
+
+    [Fact]
+    public void Resolve_HiddenProfile_OmittedFromResult()
+    {
+        var users = new[] { User("a"), User("b", hidden: true), User("c") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.Equal(new[] { "a", "c" }, resolved.Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_HiddenSet_OverridesNonHiddenDef()
+    {
+        var users = new[] { User("a"), User("b") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string> { "a" }).ToList();
+
+        Assert.Equal(new[] { "b" }, resolved.Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_ProfileOrder_ListedFirstThenUnlistedByDefault()
+    {
+        var users = new[] { User("alpha"), User("zulu") };
+        var discovered = new[] { Disc("bravo"), Disc("delta") };
+        var order = new[] { "delta", "alpha" };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: discovered,
+            profileOrder: order,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.Equal(new[] { "delta", "alpha", "zulu", "bravo" }, resolved.Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_ProfileOrderHasUnknownIds_SilentlyIgnoresThem()
+    {
+        var users = new[] { User("a") };
+        var order = new[] { "ghost", "a", "phantom" };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: order,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.Equal(new[] { "a" }, resolved.Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_DefaultProfileId_MarkedIsDefault()
+    {
+        var users = new[] { User("alpha"), User("zulu") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: "zulu",
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.False(resolved.Single(r => r.Id == "alpha").IsDefault);
+        Assert.True(resolved.Single(r => r.Id == "zulu").IsDefault);
+    }
+
+    [Fact]
+    public void Resolve_DefaultProfileIdMissing_FallsBackToFirst()
+    {
+        var users = new[] { User("alpha"), User("zulu") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: "ghost",
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.True(resolved[0].IsDefault);
+        Assert.Equal("alpha", resolved[0].Id);
+    }
+
+    [Fact]
+    public void Resolve_DefaultProfileIdNull_FirstIsDefault()
+    {
+        var users = new[] { User("alpha") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.True(resolved[0].IsDefault);
+    }
+
+    [Fact]
+    public void Resolve_OrderIndex_ContiguousFromZero()
+    {
+        var users = new[] { User("a"), User("b"), User("c") };
+
+        var resolved = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).ToList();
+
+        Assert.Equal(0, resolved[0].OrderIndex);
+        Assert.Equal(1, resolved[1].OrderIndex);
+        Assert.Equal(2, resolved[2].OrderIndex);
+    }
+
+    [Fact]
+    public void Resolve_DiscoveredProfile_HasProbeIdSet()
+    {
+        var resolved = ProfileOrderResolver.Resolve(
+            user: System.Array.Empty<ProfileDef>(),
+            discovered: new[] { Disc("wsl-ubuntu", probe: "wsl") },
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>()).Single();
+
+        Assert.Equal("wsl", resolved.ProbeId);
+    }
+
+    [Fact]
+    public void Resolve_EmptyInputs_ReturnsEmpty()
+    {
+        var resolved = ProfileOrderResolver.Resolve(
+            user: System.Array.Empty<ProfileDef>(),
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: null,
+            hidden: new HashSet<string>());
+
+        Assert.Empty(resolved);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileSnapshotStoreTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSnapshotStoreTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProfileSnapshotStoreTests
+{
+    private static ResolvedProfile Resolved(
+        string id,
+        string name = "X",
+        string command = "x.exe",
+        EffectiveVisualOverrides? visuals = null,
+        IconSpec? icon = null)
+    {
+        return new ResolvedProfile(
+            Id: id,
+            Name: name,
+            Command: command,
+            WorkingDirectory: null,
+            Icon: icon ?? new IconSpec.BundledKey("default"),
+            TabTitle: name,
+            Visuals: visuals ?? EffectiveVisualOverrides.Empty,
+            ProbeId: null,
+            OrderIndex: 0,
+            IsDefault: false);
+    }
+
+    [Fact]
+    public void Resolve_ProfileExists_ReturnsSnapshotAtVersion1()
+    {
+        var resolved = new[] { Resolved("pwsh", name: "PowerShell", command: "pwsh.exe") };
+
+        var snap = ProfileSnapshotStore.Resolve("pwsh", resolved, version: 1);
+
+        Assert.NotNull(snap);
+        Assert.Equal("pwsh", snap!.ProfileId);
+        Assert.Equal(1, snap.Version);
+        Assert.Equal("PowerShell", snap.DisplayName);
+        Assert.Equal("pwsh.exe", snap.ResolvedCommand);
+    }
+
+    [Fact]
+    public void Resolve_ProfileMissing_ReturnsNull()
+    {
+        var resolved = new[] { Resolved("cmd") };
+
+        var snap = ProfileSnapshotStore.Resolve("ghost", resolved, version: 1);
+
+        Assert.Null(snap);
+    }
+
+    [Fact]
+    public void Refresh_ProfileUnchanged_ReturnsSameInstance()
+    {
+        var resolved = new[] { Resolved("pwsh") };
+        var snap = ProfileSnapshotStore.Resolve("pwsh", resolved, version: 1)!;
+
+        var refreshed = ProfileSnapshotStore.Refresh(snap, resolved, newVersion: 2);
+
+        Assert.Equal(snap.ProfileId, refreshed.ProfileId);
+        Assert.Equal(snap.DisplayName, refreshed.DisplayName);
+        Assert.Equal(snap.ResolvedCommand, refreshed.ResolvedCommand);
+        Assert.Equal(2, refreshed.Version);
+    }
+
+    [Fact]
+    public void Refresh_ProfileVisualsChanged_NewSnapshotReflectsThem()
+    {
+        var resolved = new[] { Resolved("pwsh", visuals: new EffectiveVisualOverrides(Theme: "Light")) };
+        var snap = ProfileSnapshotStore.Resolve("pwsh", resolved, version: 1)!;
+
+        var newResolved = new[] { Resolved("pwsh", visuals: new EffectiveVisualOverrides(Theme: "Dark")) };
+
+        var refreshed = ProfileSnapshotStore.Refresh(snap, newResolved, newVersion: 2);
+
+        Assert.Equal("Dark", refreshed.Visuals.Theme);
+        Assert.Equal(2, refreshed.Version);
+    }
+
+    [Fact]
+    public void Refresh_ProfileRemoved_ReturnsExistingSnapshotUnchanged()
+    {
+        var resolved = new[] { Resolved("pwsh", name: "PowerShell") };
+        var snap = ProfileSnapshotStore.Resolve("pwsh", resolved, version: 1)!;
+
+        var refreshed = ProfileSnapshotStore.Refresh(snap, System.Array.Empty<ResolvedProfile>(), newVersion: 2);
+
+        Assert.Same(snap, refreshed);
+    }
+
+    [Fact]
+    public void Refresh_ProfileRenamed_TreatedAsRemoved()
+    {
+        var oldResolved = new[] { Resolved("wsl-ubuntu", name: "WSL Ubuntu") };
+        var snap = ProfileSnapshotStore.Resolve("wsl-ubuntu", oldResolved, version: 1)!;
+
+        var newResolved = new[] { Resolved("wsl", name: "WSL Ubuntu") };
+
+        var refreshed = ProfileSnapshotStore.Refresh(snap, newResolved, newVersion: 2);
+
+        Assert.Same(snap, refreshed);
+        Assert.Equal("wsl-ubuntu", refreshed.ProfileId);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileSnapshotStoreTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSnapshotStoreTests.cs
@@ -84,7 +84,7 @@ public sealed class ProfileSnapshotStoreTests
         var resolved = new[] { Resolved("pwsh", name: "PowerShell") };
         var snap = ProfileSnapshotStore.Resolve("pwsh", resolved, version: 1)!;
 
-        var refreshed = ProfileSnapshotStore.Refresh(snap, System.Array.Empty<ResolvedProfile>(), newVersion: 2);
+        var refreshed = ProfileSnapshotStore.Refresh(snap, [], newVersion: 2);
 
         Assert.Same(snap, refreshed);
     }

--- a/windows/Ghostty.Tests/Profiles/ProfileSnapshotStoreTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSnapshotStoreTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Ghostty.Core.Profiles;
 using Xunit;
 
@@ -52,7 +51,7 @@ public sealed class ProfileSnapshotStoreTests
     }
 
     [Fact]
-    public void Refresh_ProfileUnchanged_ReturnsSameInstance()
+    public void Refresh_ProfileFound_ReturnsNewSnapshotAtNewVersion()
     {
         var resolved = new[] { Resolved("pwsh") };
         var snap = ProfileSnapshotStore.Resolve("pwsh", resolved, version: 1)!;

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
@@ -110,4 +110,177 @@ public sealed class ProfileSourceParserTests
 
         Assert.True(p.Hidden);
     }
+
+    [Fact]
+    public void Parse_MissingCommand_DropsProfileAndWarns()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Empty(result.Profiles);
+        Assert.Single(result.Warnings);
+        Assert.Contains("pwsh", result.Warnings[0]);
+        Assert.Contains("command", result.Warnings[0]);
+    }
+
+    [Fact]
+    public void Parse_MissingName_DropsProfileAndWarns()
+    {
+        const string config = """
+            profile.pwsh.command = pwsh.exe
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Empty(result.Profiles);
+        Assert.Single(result.Warnings);
+        Assert.Contains("name", result.Warnings[0]);
+    }
+
+    [Fact]
+    public void Parse_DuplicateKeys_LastWins()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            profile.pwsh.command = pwsh-preview.exe
+            """;
+
+        var p = ProfileSourceParser.Parse(config).Profiles["pwsh"];
+        Assert.Equal("pwsh-preview.exe", p.Command);
+    }
+
+    [Theory]
+    [InlineData("PWSH")]
+    [InlineData("pwsh-7")]
+    [InlineData("wsl-debian-2204")]
+    public void Parse_IdNormalization_LowercasedAndKept(string id)
+    {
+        var config = $"profile.{id}.name = X\nprofile.{id}.command = x\n";
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Single(result.Profiles);
+        Assert.True(result.Profiles.ContainsKey(id.ToLowerInvariant()));
+    }
+
+    [Theory]
+    [InlineData("with space")]
+    [InlineData("under_score")]
+    [InlineData("dot.in.id")]
+    public void Parse_InvalidIdFormat_LineIgnored(string id)
+    {
+        var config = $"profile.{id}.name = X\nprofile.{id}.command = x\n";
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Empty(result.Profiles);
+    }
+
+    [Fact]
+    public void Parse_CRLFLineEndings_ParsedSameAsLF()
+    {
+        const string config = "profile.pwsh.name = PowerShell\r\nprofile.pwsh.command = pwsh.exe\r\n";
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Single(result.Profiles);
+        Assert.Equal("PowerShell", result.Profiles["pwsh"].Name);
+    }
+
+    [Fact]
+    public void Parse_BomPrefix_StrippedFromFirstLine()
+    {
+        var config = "\uFEFFprofile.pwsh.name = PowerShell\nprofile.pwsh.command = pwsh.exe\n";
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Single(result.Profiles);
+    }
+
+    [Fact]
+    public void Parse_CommentLines_Ignored()
+    {
+        const string config = """
+            # this is a comment
+            profile.pwsh.name = PowerShell
+            # another comment between keys
+            profile.pwsh.command = pwsh.exe
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+        Assert.Single(result.Profiles);
+    }
+
+    [Fact]
+    public void Parse_BlankLines_Ignored()
+    {
+        const string config = """
+
+            profile.pwsh.name = PowerShell
+
+            profile.pwsh.command = pwsh.exe
+
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+        Assert.Single(result.Profiles);
+    }
+
+    [Fact]
+    public void Parse_WhitespaceAroundEquals_Tolerated()
+    {
+        const string config = """
+            profile.pwsh.name=PowerShell
+            profile.pwsh.command   =   pwsh.exe
+            """;
+
+        var p = ProfileSourceParser.Parse(config).Profiles["pwsh"];
+        Assert.Equal("PowerShell", p.Name);
+        Assert.Equal("pwsh.exe", p.Command);
+    }
+
+    [Fact]
+    public void Parse_UnknownSubKey_DroppedSilently()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            profile.pwsh.invented-key = whatever
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+        Assert.Single(result.Profiles);
+    }
+
+    [Fact]
+    public void Parse_IconKey_PathVariant()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            profile.pwsh.icon = C:\icons\pwsh.ico
+            """;
+
+        var p = ProfileSourceParser.Parse(config).Profiles["pwsh"];
+        var path = Assert.IsType<IconSpec.Path>(p.Icon);
+        Assert.Equal(@"C:\icons\pwsh.ico", path.FilePath);
+    }
+
+    [Fact]
+    public void Parse_IconKey_Mdl2TokenVariant()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            profile.pwsh.icon = mdl2:E756
+            """;
+
+        var p = ProfileSourceParser.Parse(config).Profiles["pwsh"];
+        var token = Assert.IsType<IconSpec.Mdl2Token>(p.Icon);
+        Assert.Equal(0xE756, token.CodePoint);
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
@@ -1,0 +1,113 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProfileSourceParserTests
+{
+    [Fact]
+    public void Parse_SingleProfile_AllRequiredKeys()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Single(result.Profiles);
+        var p = result.Profiles["pwsh"];
+        Assert.Equal("pwsh", p.Id);
+        Assert.Equal("PowerShell", p.Name);
+        Assert.Equal("pwsh.exe", p.Command);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Parse_MultipleProfiles_AllReturned()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            profile.cmd.name = Command Prompt
+            profile.cmd.command = cmd.exe
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Equal(2, result.Profiles.Count);
+        Assert.True(result.Profiles.ContainsKey("pwsh"));
+        Assert.True(result.Profiles.ContainsKey("cmd"));
+    }
+
+    [Fact]
+    public void Parse_VisualOverrides_PopulatedOnVisuals()
+    {
+        const string config = """
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            profile.pwsh.theme = GruvboxDark
+            profile.pwsh.background-opacity = 0.85
+            profile.pwsh.font-family = CaskaydiaCove Nerd Font
+            profile.pwsh.font-size = 13.5
+            profile.pwsh.cursor-style = block
+            """;
+
+        var p = ProfileSourceParser.Parse(config).Profiles["pwsh"];
+
+        Assert.Equal("GruvboxDark", p.Visuals.Theme);
+        Assert.Equal(0.85, p.Visuals.BackgroundOpacity);
+        Assert.Equal("CaskaydiaCove Nerd Font", p.Visuals.FontFamily);
+        Assert.Equal(13.5, p.Visuals.FontSize);
+        Assert.Equal("block", p.Visuals.CursorStyle);
+    }
+
+    [Fact]
+    public void Parse_OptionalKeys_PopulateOnDef()
+    {
+        const string config = """
+            profile.wsl.name = WSL Ubuntu
+            profile.wsl.command = wsl -d Ubuntu
+            profile.wsl.working-directory = /home/me
+            profile.wsl.tab-title = Ubuntu
+            profile.wsl.hidden = false
+            """;
+
+        var p = ProfileSourceParser.Parse(config).Profiles["wsl"];
+
+        Assert.Equal("/home/me", p.WorkingDirectory);
+        Assert.Equal("Ubuntu", p.TabTitle);
+        Assert.False(p.Hidden);
+    }
+
+    [Fact]
+    public void Parse_IgnoresNonProfileLines()
+    {
+        const string config = """
+            font-family = Cascadia Code
+            theme = GruvboxDark
+            profile.pwsh.name = PowerShell
+            profile.pwsh.command = pwsh.exe
+            background-opacity = 0.9
+            """;
+
+        var result = ProfileSourceParser.Parse(config);
+
+        Assert.Single(result.Profiles);
+        Assert.True(result.Profiles.ContainsKey("pwsh"));
+    }
+
+    [Fact]
+    public void Parse_HiddenTrueInterpretedCorrectly()
+    {
+        const string config = """
+            profile.wsl-debian.name = Debian
+            profile.wsl-debian.command = wsl -d Debian
+            profile.wsl-debian.hidden = true
+            """;
+
+        var p = ProfileSourceParser.Parse(config).Profiles["wsl-debian"];
+
+        Assert.True(p.Hidden);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/Scenarios/EmptyMachine.json
+++ b/windows/Ghostty.Tests/Profiles/Scenarios/EmptyMachine.json
@@ -1,0 +1,14 @@
+{
+  "knownFolders": {
+    "System": "C:\\Windows\\System32",
+    "LocalAppData": "C:\\Users\\test\\AppData\\Local"
+  },
+  "files": [
+    "C:\\Windows\\System32\\cmd.exe"
+  ],
+  "registry": {
+    "keys": [],
+    "values": []
+  },
+  "processes": []
+}

--- a/windows/Ghostty.Tests/Profiles/Scenarios/HeavyDevMachine.json
+++ b/windows/Ghostty.Tests/Profiles/Scenarios/HeavyDevMachine.json
@@ -1,0 +1,47 @@
+{
+  "knownFolders": {
+    "System": "C:\\Windows\\System32",
+    "ProgramFiles": "C:\\Program Files",
+    "LocalAppData": "C:\\Users\\test\\AppData\\Local"
+  },
+  "files": [
+    "C:\\Windows\\System32\\cmd.exe",
+    "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+    "C:\\Program Files\\Git\\bin\\bash.exe"
+  ],
+  "registry": {
+    "keys": ["LocalMachine::SOFTWARE\\GitForWindows"],
+    "values": [
+      {
+        "hive": "LocalMachine",
+        "keyPath": "SOFTWARE\\GitForWindows",
+        "valueName": "InstallPath",
+        "value": "C:\\Program Files\\Git"
+      }
+    ]
+  },
+  "processes": [
+    {
+      "fileName": "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+      "args": ["-v"],
+      "exitCode": 0,
+      "stdout": "PowerShell 7.4.1\n",
+      "stderr": ""
+    },
+    {
+      "fileName": "wsl.exe",
+      "args": ["--list", "--verbose", "--quiet"],
+      "exitCode": 0,
+      "stdout": "Ubuntu-22.04\nDebian\nkali-linux\n",
+      "stderr": ""
+    },
+    {
+      "fileName": "az",
+      "args": ["--version"],
+      "exitCode": 0,
+      "stdout": "azure-cli 2.55.0\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/windows/Ghostty.Tests/Profiles/Scenarios/HiddenAndOrdered.json
+++ b/windows/Ghostty.Tests/Profiles/Scenarios/HiddenAndOrdered.json
@@ -1,0 +1,6 @@
+{
+  "knownFolders": {},
+  "files": [],
+  "registry": { "keys": [], "values": [] },
+  "processes": []
+}

--- a/windows/Ghostty.Tests/Profiles/Scenarios/ScenarioLoader.cs
+++ b/windows/Ghostty.Tests/Profiles/Scenarios/ScenarioLoader.cs
@@ -44,6 +44,9 @@ internal static class ScenarioLoader
         {
             // Format: "Hive::KeyPath".
             var parts = k.Split("::", 2);
+            if (parts.Length != 2)
+                throw new InvalidOperationException(
+                    $"Registry key '{k}' must be in 'Hive::KeyPath' format.");
             reg.SetKey(Enum.Parse<RegistryHive>(parts[0]), parts[1]);
         }
         foreach (var v in dto.Registry.Values)

--- a/windows/Ghostty.Tests/Profiles/Scenarios/ScenarioLoader.cs
+++ b/windows/Ghostty.Tests/Profiles/Scenarios/ScenarioLoader.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Ghostty.Core.Profiles;
+using Ghostty.Tests.Profiles.Fakes;
+
+namespace Ghostty.Tests.Profiles.Scenarios;
+
+/// <summary>
+/// One scenario, fully wired with fakes ready to be passed to a probe
+/// or pure-logic type under test.
+/// </summary>
+internal sealed class Scenario
+{
+    public required FakeProcessRunner ProcessRunner { get; init; }
+    public required FakeRegistryReader Registry { get; init; }
+    public required FakeFileSystem FileSystem { get; init; }
+}
+
+/// <summary>
+/// Loads a JSON scenario from Profiles\Scenarios\&lt;name&gt;.json
+/// next to the test assembly.
+/// </summary>
+internal static class ScenarioLoader
+{
+    public static Scenario Load(string name)
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Profiles", "Scenarios");
+        var path = Path.Combine(dir, name + ".json");
+        var json = File.ReadAllText(path);
+        var dto = JsonSerializer.Deserialize(json, ScenarioDtoContext.Default.ScenarioDto)
+                  ?? throw new InvalidOperationException($"empty scenario: {name}");
+
+        var fs = new FakeFileSystem();
+        foreach (var (k, v) in dto.KnownFolders)
+            fs.SetKnownFolder(Enum.Parse<KnownFolderId>(k), v);
+        foreach (var f in dto.Files)
+            fs.AddFile(f);
+
+        var reg = new FakeRegistryReader();
+        foreach (var k in dto.Registry.Keys)
+        {
+            // Format: "Hive::KeyPath".
+            var parts = k.Split("::", 2);
+            reg.SetKey(Enum.Parse<RegistryHive>(parts[0]), parts[1]);
+        }
+        foreach (var v in dto.Registry.Values)
+            reg.SetValue(
+                Enum.Parse<RegistryHive>(v.Hive),
+                v.KeyPath,
+                v.ValueName,
+                v.Value);
+
+        var runner = new FakeProcessRunner();
+        foreach (var p in dto.Processes)
+            runner.EnqueueResult(
+                p.FileName,
+                p.Args,
+                new ProcessResult(p.ExitCode, p.Stdout, p.Stderr, TimeSpan.Zero));
+
+        return new Scenario
+        {
+            ProcessRunner = runner,
+            Registry = reg,
+            FileSystem = fs,
+        };
+    }
+}
+
+// DTOs match the JSON fixture shape exactly.
+// Kept internal (not private nested) so [JsonSerializable] source-gen can reference them.
+
+internal sealed class ScenarioDto
+{
+    public Dictionary<string, string> KnownFolders { get; set; } = new();
+    public List<string> Files { get; set; } = new();
+    public ScenarioRegistryDto Registry { get; set; } = new();
+    public List<ScenarioProcessDto> Processes { get; set; } = new();
+}
+
+internal sealed class ScenarioRegistryDto
+{
+    public List<string> Keys { get; set; } = new();
+    public List<ScenarioRegistryValueDto> Values { get; set; } = new();
+}
+
+internal sealed class ScenarioRegistryValueDto
+{
+    public string Hive { get; set; } = "";
+    public string KeyPath { get; set; } = "";
+    public string ValueName { get; set; } = "";
+    public string Value { get; set; } = "";
+}
+
+internal sealed class ScenarioProcessDto
+{
+    public string FileName { get; set; } = "";
+    public List<string> Args { get; set; } = new();
+    public int ExitCode { get; set; }
+    public string Stdout { get; set; } = "";
+    public string Stderr { get; set; } = "";
+}
+
+[JsonSerializable(typeof(ScenarioDto))]
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+internal partial class ScenarioDtoContext : JsonSerializerContext
+{
+}

--- a/windows/Ghostty.Tests/Profiles/Scenarios/ScenarioLoaderTests.cs
+++ b/windows/Ghostty.Tests/Profiles/Scenarios/ScenarioLoaderTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles.Scenarios;
+
+public sealed class ScenarioLoaderTests
+{
+    [Fact]
+    public void Load_EmptyMachine_PopulatesCmdOnly()
+    {
+        var s = ScenarioLoader.Load("EmptyMachine");
+
+        Assert.True(s.FileSystem.FileExists(@"C:\Windows\System32\cmd.exe"));
+        Assert.False(s.FileSystem.FileExists(@"C:\Program Files\PowerShell\7\pwsh.exe"));
+        Assert.Equal(@"C:\Windows\System32", s.FileSystem.GetKnownFolder(KnownFolderId.System));
+    }
+
+    [Fact]
+    public void Load_HeavyDevMachine_PopulatesAllProbes()
+    {
+        var s = ScenarioLoader.Load("HeavyDevMachine");
+
+        Assert.True(s.FileSystem.FileExists(@"C:\Program Files\PowerShell\7\pwsh.exe"));
+        Assert.True(s.Registry.KeyExists(RegistryHive.LocalMachine, @"SOFTWARE\GitForWindows"));
+        Assert.Equal(
+            @"C:\Program Files\Git",
+            s.Registry.ReadString(RegistryHive.LocalMachine, @"SOFTWARE\GitForWindows", "InstallPath"));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Load_HeavyDevMachine_ProcessesReturnCannedOutput()
+    {
+        var s = ScenarioLoader.Load("HeavyDevMachine");
+
+        var result = await s.ProcessRunner.RunAsync(
+            "wsl.exe",
+            new[] { "--list", "--verbose", "--quiet" },
+            System.TimeSpan.FromSeconds(1),
+            System.Threading.CancellationToken.None);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Ubuntu-22.04", result.Stdout);
+    }
+}


### PR DESCRIPTION
**IMPORTANT:** First in a 6-PR stack for Windows profiles support.

This PR is foundation only — no observable behavior change. It adds:

- Immutable records under `Ghostty.Core/Profiles/`: ProfileDef, EffectiveVisualOverrides, IconSpec hierarchy, DiscoveredProfile, ResolvedProfile, ProfileSnapshot.
- 5 platform-abstraction interfaces (IProcessRunner, IRegistryReader, IFileSystem, IIconResolver, IInstalledShellProbe) with their own RegistryHive and KnownFolderId enums to keep `Ghostty.Core` AOT-clean and cross-platform.
- 4 pure-logic types: ProfileSourceParser, ProfileMerger, ProfileOrderResolver, ProfileSnapshotStore — each fully unit-tested.
- 5 test fakes + a JSON scenario loader for composable test setups.

Stack:
- PR 1 (this): pure-logic foundation
- PR 2: discovery probes + production wrappers
- PR 3: ProfileRegistry + ConfigService integration
- PR 4: composite split-+ button + dropdown
- PR 5: command palette + parameterized keybindings
- PR 6: Settings "Profiles" page (read-only inspector + hide toggle)