### PR TITLE
fix(settings): light-mode contrast + gear icon + wintty rename

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -14,4 +14,11 @@ internal static class AppIdentity
     /// caches the process-to-AUMID association on first use.
     /// </summary>
     public const string AumId = "com.deblasis.ghostty";
+
+    /// <summary>
+    /// Brand name shown in user-facing surfaces (window titles, dialog
+    /// captions). Gated behind a single constant so rebrands (Ghostty →
+    /// Wintty → ...) only touch one file instead of scattering literals.
+    /// </summary>
+    public const string ProductName = "Wintty";
 }

--- a/windows/Ghostty/App.xaml
+++ b/windows/Ghostty/App.xaml
@@ -4,12 +4,15 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:tabs="using:Ghostty.Tabs"
-    RequestedTheme="Dark">
-    <!-- RequestedTheme="Dark" is a fallback default. WindowThemeManager
-         overrides this at runtime per the window-theme config value
-         (see issue #195). Removing it entirely would flash white on
-         startup before the manager applies the resolved theme. -->
+    xmlns:tabs="using:Ghostty.Tabs">
+    <!-- Application.RequestedTheme is now set programmatically in
+         App.xaml.cs before InitializeComponent runs (reading the OS
+         light/dark state via OsTheme.IsDark). A hardcoded value here
+         caused a visible flash when opening a window whose theme
+         differed from the hardcoded default (e.g. Settings on a light
+         system after the app-level Dark default painted the first
+         frame). WindowThemeManager still applies the per-window
+         window-theme config on top of this baseline. -->
     <!--
       Application.Resources here SHADOWS the framework's automatic
       load of the WinUI 3 controls theme resources unless we

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -213,12 +213,20 @@ public partial class App : Application
                 ? ApplicationTheme.Dark
                 : ApplicationTheme.Light;
         }
-        catch
+        catch (Exception ex) when (ex is COMException or InvalidOperationException or UnauthorizedAccessException)
         {
             // UISettings can throw in certain packaged / sandboxed
             // startup edges. Fall back to the pre-existing default so
             // the app still launches; users on a system whose theme
             // doesn't match will see the old one-frame flash.
+            //
+            // Unhandled-exception handlers aren't wired up yet (done
+            // below), so Debug.WriteLine is the most signal we can
+            // surface to a devenv-attached run without taking the app
+            // down. A packaged Release launch will lose this — that's
+            // acceptable for a one-frame cosmetic flash.
+            System.Diagnostics.Debug.WriteLine(
+                $"[Ghostty] OsTheme.IsDark() threw during App ctor; falling back to Dark. {ex.GetType().Name}: {ex.Message}");
             RequestedTheme = ApplicationTheme.Dark;
         }
 

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -199,6 +199,29 @@ public partial class App : Application
 
     public App()
     {
+        // Match the OS theme before any XAML parses so the first paint
+        // of every window is already in the right mode. Without this,
+        // App.xaml's static RequestedTheme (previously "Dark") drew the
+        // first frame of Settings / Raw Editor in dark mode even when
+        // the user is on a light system, producing a visible flash when
+        // WindowThemeManager later switched to Light. Application.
+        // RequestedTheme is only settable before the first window is
+        // created; setting it here is the one safe window.
+        try
+        {
+            RequestedTheme = Ghostty.Services.OsTheme.IsDark()
+                ? ApplicationTheme.Dark
+                : ApplicationTheme.Light;
+        }
+        catch
+        {
+            // UISettings can throw in certain packaged / sandboxed
+            // startup edges. Fall back to the pre-existing default so
+            // the app still launches; users on a system whose theme
+            // doesn't match will see the old one-frame flash.
+            RequestedTheme = ApplicationTheme.Dark;
+        }
+
         InitializeComponent();
 
         // Surface unhandled exceptions to stderr AND to a file under

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -186,36 +186,11 @@ internal sealed partial class CommandPaletteControl : UserControl
     // wrong-tone acrylic in the command palette.
     private Brush ResolveAppBrushForElementTheme(string key)
     {
-        var themeKey = ActualTheme == ElementTheme.Light ? "Light" : "Default";
-        if (TryFindInThemeDictionaries(Application.Current.Resources, key, themeKey, out var brush))
+        if (ThemedResources.TryFindBrush(Application.Current.Resources, key, ActualTheme, out var brush))
             return brush;
         // Fallback preserves pre-fix behavior if the theme dictionary
         // can't be walked (custom app resources, HighContrast, etc.).
         return (Brush)Application.Current.Resources[key];
-    }
-
-    private static bool TryFindInThemeDictionaries(
-        ResourceDictionary rd, string key, string themeKey, out Brush brush)
-    {
-        if (rd.ThemeDictionaries.TryGetValue(themeKey, out var dictObj) &&
-            dictObj is ResourceDictionary themeDict)
-        {
-            if (themeDict.TryGetValue(key, out var v) && v is Brush b)
-            {
-                brush = b;
-                return true;
-            }
-            foreach (var m in themeDict.MergedDictionaries)
-            {
-                if (TryFindInThemeDictionaries(m, key, themeKey, out brush)) return true;
-            }
-        }
-        foreach (var m in rd.MergedDictionaries)
-        {
-            if (TryFindInThemeDictionaries(m, key, themeKey, out brush)) return true;
-        }
-        brush = default!;
-        return false;
     }
 
     // ── ViewModel → UI ────────────────────────────────────────────────────────

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -1,14 +1,17 @@
 using System;
 using System.ComponentModel;
 using Ghostty.Commands;
+using Ghostty.Services;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using Windows.System;
 using Windows.UI;
+using Windows.UI.ViewManagement;
 
 namespace Ghostty.Controls.CommandPalette;
 
@@ -28,11 +31,82 @@ namespace Ghostty.Controls.CommandPalette;
 internal sealed partial class CommandPaletteControl : UserControl
 {
     private CommandPaletteViewModel? _vm;
+    // Cached background mode so ActualThemeChanged can re-resolve the
+    // right theme variant — a code-behind lookup against
+    // Application.Current.Resources bakes in Application.RequestedTheme
+    // at call time, so the brush wouldn't auto-update when the main
+    // window's theme flipped otherwise.
+    private string _backgroundSetting = string.Empty;
 
-    // Suppress "Event never fired" — fired by WinUI runtime via ContainerContentChanging.
+    // The palette tracks the OS theme instead of the MainWindow's
+    // palette-derived ElementTheme, matching the Settings window's
+    // "feel OS-native regardless of the terminal's colors" rule. A dark
+    // terminal palette on a light system would otherwise give a dark
+    // command palette over a light taskbar / desktop chrome, which
+    // reads as out of place compared to every other system UI surface.
+    private UISettings? _uiSettings;
+    // Fully-qualified: both Microsoft.UI.Dispatching and Windows.System
+    // export a DispatcherQueue; the WinUI 3 one is what we need.
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher =
+        Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+
     public CommandPaletteControl()
     {
         InitializeComponent();
+        // ApplySystemTheme here sets only the UserControl's RequestedTheme;
+        // the Popup parent is fixed up on Loaded once Parent is non-null.
+        RequestedTheme = OsTheme.IsDark() ? ElementTheme.Dark : ElementTheme.Light;
+        ActualThemeChanged += (_, _) =>
+        {
+            if (!string.IsNullOrEmpty(_backgroundSetting))
+                ApplySettings(_backgroundSetting);
+        };
+
+        // UISettings.ColorValuesChanged fires on a background thread, so
+        // the handler marshals back to the UI. Subscribe on Loaded /
+        // unsubscribe on Unloaded so the palette doesn't keep UISettings
+        // alive past its visual-tree lifetime (one palette per main
+        // window, instances can come and go with detach/reattach).
+        Loaded += OnPaletteLoaded;
+        Unloaded += OnPaletteUnloaded;
+    }
+
+    private void OnPaletteLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_uiSettings is not null) return;
+        _uiSettings = new UISettings();
+        _uiSettings.ColorValuesChanged += OnSystemColorsChanged;
+        // Re-read once on (re)load in case the system theme changed
+        // while the palette was detached from the visual tree.
+        ApplySystemTheme();
+    }
+
+    private void OnPaletteUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_uiSettings is null) return;
+        _uiSettings.ColorValuesChanged -= OnSystemColorsChanged;
+        _uiSettings = null;
+    }
+
+    private void OnSystemColorsChanged(UISettings sender, object args)
+    {
+        _dispatcher?.TryEnqueue(ApplySystemTheme);
+    }
+
+    private void ApplySystemTheme()
+    {
+        var theme = OsTheme.IsDark() ? ElementTheme.Dark : ElementTheme.Light;
+        RequestedTheme = theme;
+        // Popup is a theme-inheritance boundary: its own RequestedTheme
+        // stays at Default (= Application.RequestedTheme, which we pin
+        // at launch based on the initial system theme) regardless of
+        // what we set on the child UserControl. That leaves XAML
+        // {ThemeResource} bindings in templated ListView rows resolved
+        // against the stale Application theme, which is why flipping
+        // Windows light/dark left the palette text stuck on the wrong
+        // brushes even after our own RequestedTheme flipped. Sync the
+        // Popup's theme too.
+        if (Parent is Popup popup) popup.RequestedTheme = theme;
     }
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -91,12 +165,57 @@ internal sealed partial class CommandPaletteControl : UserControl
     /// </summary>
     public void ApplySettings(string backgroundSetting)
     {
-        OuterBorder.Background = backgroundSetting switch
+        _backgroundSetting = backgroundSetting ?? string.Empty;
+        var key = backgroundSetting switch
         {
-            "mica" => (Brush)Application.Current.Resources["SolidBackgroundFillColorBaseBrush"],
-            "opaque" => (Brush)Application.Current.Resources["SolidBackgroundFillColorBaseBrush"],
-            _ => (Brush)Application.Current.Resources["AcrylicInAppFillColorDefaultBrush"],
+            "mica" => "SolidBackgroundFillColorBaseBrush",
+            "opaque" => "SolidBackgroundFillColorBaseBrush",
+            _ => "AcrylicInAppFillColorDefaultBrush",
         };
+        OuterBorder.Background = ResolveAppBrushForElementTheme(key);
+    }
+
+    // Resolve a system brush by walking
+    // Application.Resources.ThemeDictionaries with THIS control's
+    // ActualTheme rather than the Application's RequestedTheme.
+    // Application.Current.Resources[key] returns whichever theme entry
+    // the Application is pinned to, which is wrong whenever the control
+    // lives under a window whose ElementTheme differs from the app's —
+    // e.g. a dark-palette main window while the OS (and Application) are
+    // in Light mode. That mismatch was visible as invisible text on a
+    // wrong-tone acrylic in the command palette.
+    private Brush ResolveAppBrushForElementTheme(string key)
+    {
+        var themeKey = ActualTheme == ElementTheme.Light ? "Light" : "Default";
+        if (TryFindInThemeDictionaries(Application.Current.Resources, key, themeKey, out var brush))
+            return brush;
+        // Fallback preserves pre-fix behavior if the theme dictionary
+        // can't be walked (custom app resources, HighContrast, etc.).
+        return (Brush)Application.Current.Resources[key];
+    }
+
+    private static bool TryFindInThemeDictionaries(
+        ResourceDictionary rd, string key, string themeKey, out Brush brush)
+    {
+        if (rd.ThemeDictionaries.TryGetValue(themeKey, out var dictObj) &&
+            dictObj is ResourceDictionary themeDict)
+        {
+            if (themeDict.TryGetValue(key, out var v) && v is Brush b)
+            {
+                brush = b;
+                return true;
+            }
+            foreach (var m in themeDict.MergedDictionaries)
+            {
+                if (TryFindInThemeDictionaries(m, key, themeKey, out brush)) return true;
+            }
+        }
+        foreach (var m in rd.MergedDictionaries)
+        {
+            if (TryFindInThemeDictionaries(m, key, themeKey, out brush)) return true;
+        }
+        brush = default!;
+        return false;
     }
 
     // ── ViewModel → UI ────────────────────────────────────────────────────────

--- a/windows/Ghostty/Services/ThemedResources.cs
+++ b/windows/Ghostty/Services/ThemedResources.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Services;
+
+/// <summary>
+/// Helpers for resolving XAML resources against a specific element's
+/// ActualTheme rather than Application.RequestedTheme.
+///
+/// Application.Current.Resources[key] and FrameworkElement.Resources[key]
+/// both resolve ThemeDictionaries using Application.RequestedTheme. When
+/// Application.RequestedTheme is pinned at launch (as it is here — see
+/// App.xaml.cs), any control whose ActualTheme differs from the app
+/// theme reads the wrong dictionary entry. The methods here walk the
+/// theme dictionaries explicitly with the caller-supplied theme key so
+/// lookups stay correct in mixed-theme scenes (issue # 325).
+/// </summary>
+internal static class ThemedResources
+{
+    /// <summary>
+    /// Returns "Light" or "Default" (the WinUI key for dark/unthemed) for
+    /// the given element theme. Callers use this to index into
+    /// ResourceDictionary.ThemeDictionaries.
+    /// </summary>
+    public static string ThemeDictionaryKey(ElementTheme theme) =>
+        theme == ElementTheme.Light ? "Light" : "Default";
+
+    /// <summary>
+    /// Look up a brush under <paramref name="key"/> in the supplied
+    /// ResourceDictionary's theme dictionary matching
+    /// <paramref name="theme"/>, walking merged dictionaries recursively.
+    /// Returns false if the key is absent from every theme dict in the
+    /// graph; callers can then fall back to the default app-theme lookup.
+    /// </summary>
+    public static bool TryFindBrush(
+        ResourceDictionary resources,
+        string key,
+        ElementTheme theme,
+        [NotNullWhen(true)] out Brush? brush)
+    {
+        var themeKey = ThemeDictionaryKey(theme);
+        return TryFindBrushCore(resources, key, themeKey, out brush);
+    }
+
+    private static bool TryFindBrushCore(
+        ResourceDictionary rd, string key, string themeKey,
+        [NotNullWhen(true)] out Brush? brush)
+    {
+        if (rd.ThemeDictionaries.TryGetValue(themeKey, out var dictObj) &&
+            dictObj is ResourceDictionary themeDict)
+        {
+            if (themeDict.TryGetValue(key, out var v) && v is Brush b)
+            {
+                brush = b;
+                return true;
+            }
+            foreach (var m in themeDict.MergedDictionaries)
+            {
+                if (TryFindBrushCore(m, key, themeKey, out brush)) return true;
+            }
+        }
+        foreach (var m in rd.MergedDictionaries)
+        {
+            if (TryFindBrushCore(m, key, themeKey, out brush)) return true;
+        }
+        brush = null;
+        return false;
+    }
+}

--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
@@ -38,6 +38,14 @@ internal sealed partial class RawEditorPage : Page
     // Reusable colors invalidated on theme change.
     private Color _matchColor;
     private Color _currentColor;
+    // "Clear" color for wiping a highlight off a range. In WinUI 3's
+    // RichEditBox, ITextCharacterFormat.BackgroundColor appears to ignore
+    // the alpha channel, so Color.FromArgb(0,0,0,0) — which reads as
+    // "transparent" to a human — actually renders as opaque black and
+    // paints a black rectangle over the character. Pick a color that
+    // matches the editor's theme background so cleared ranges visually
+    // disappear regardless of whether alpha is respected.
+    private Color _clearBgColor;
     private bool _colorsReady;
 
     public RawEditorPage(IConfigService configService, IConfigFileEditor editor)
@@ -45,6 +53,12 @@ internal sealed partial class RawEditorPage : Page
         _configService = configService;
         _editor = editor;
         InitializeComponent();
+
+        // Theme flips while the page is live must force a recompute of
+        // the highlight / clear-bg colors cached in EnsureColors, and
+        // repaint the document bg so stale dark-mode clears don't remain
+        // visible as dark boxes on a light background (issue #325).
+        ActualThemeChanged += OnActualThemeChanged;
 
         DiagList.ItemsSource = _diagnostics;
         DiagList.ContainerContentChanging += OnContainerContentChanging;
@@ -68,6 +82,33 @@ internal sealed partial class RawEditorPage : Page
     private void SetEditorText(string text)
     {
         Editor.Document.SetText(TextSetOptions.None, text);
+        ClearAllBackgrounds();
+    }
+
+    // Wipe any lingering CharacterFormat.BackgroundColor across the whole
+    // document. SetText keeps the document's default character format, so
+    // any highlight BG left over from a prior Ctrl+F cycle carries into
+    // the freshly-loaded text and paints every character (issue #325:
+    // save-and-reload turns the whole editor black). Also resets
+    // Selection.CharacterFormat so subsequent typing doesn't inherit a
+    // stale highlight format.
+    private void ClearAllBackgrounds()
+    {
+        EnsureColors();
+        // int.MaxValue is the documented "to end of document" sentinel for
+        // RichEditTextDocument.GetRange; RichEditBox uses CRLF internally,
+        // so the C# input string length would under-count.
+        var range = Editor.Document.GetRange(0, int.MaxValue);
+        range.CharacterFormat.BackgroundColor = _clearBgColor;
+        Editor.Document.Selection.CharacterFormat.BackgroundColor = _clearBgColor;
+        _prevRanges.Clear();
+        _prevCurrentRange = default;
+    }
+
+    private void OnActualThemeChanged(FrameworkElement sender, object args)
+    {
+        _colorsReady = false;
+        ClearAllBackgrounds();
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -232,27 +273,39 @@ internal sealed partial class RawEditorPage : Page
     private void EnsureColors()
     {
         if (_colorsReady) return;
-        var isDark = Editor.ActualTheme == ElementTheme.Dark;
+        // Read the Page's ActualTheme rather than the Editor's: during the
+        // first Loaded tick the inner RichEditBox may still report
+        // ElementTheme.Default before the theme cascades, which previously
+        // made us cache dark-mode brush values inside a light-mode window
+        // (issue #325).
+        var isDark = ActualTheme == ElementTheme.Dark;
         _matchColor = isDark
             ? Color.FromArgb(70, 200, 170, 50)
             : Color.FromArgb(90, 255, 230, 100);
         _currentColor = isDark
             ? Color.FromArgb(180, 255, 200, 60)
             : Color.FromArgb(220, 255, 190, 50);
+        // Opaque editor-background color so a "cleared" highlight renders
+        // indistinguishable from un-highlighted text. Values approximate the
+        // RichEditBox defaults in dark (#202020) and light (#FFFFFF) modes.
+        _clearBgColor = isDark
+            ? Color.FromArgb(255, 32, 32, 32)
+            : Color.FromArgb(255, 255, 255, 255);
         _colorsReady = true;
     }
 
     private void ClearPreviousHighlights()
     {
+        EnsureColors();
         foreach (var (s, e) in _prevRanges)
         {
             var r = Editor.Document.GetRange(s, e);
-            r.CharacterFormat.BackgroundColor = Color.FromArgb(0, 0, 0, 0);
+            r.CharacterFormat.BackgroundColor = _clearBgColor;
         }
         if (_prevCurrentRange != default)
         {
             var cr = Editor.Document.GetRange(_prevCurrentRange.start, _prevCurrentRange.end);
-            cr.CharacterFormat.BackgroundColor = Color.FromArgb(0, 0, 0, 0);
+            cr.CharacterFormat.BackgroundColor = _clearBgColor;
         }
         _prevRanges.Clear();
         _prevCurrentRange = default;

--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Windows.System;
 using Windows.UI;
 
@@ -286,12 +287,44 @@ internal sealed partial class RawEditorPage : Page
             ? Color.FromArgb(180, 255, 200, 60)
             : Color.FromArgb(220, 255, 190, 50);
         // Opaque editor-background color so a "cleared" highlight renders
-        // indistinguishable from un-highlighted text. Values approximate the
-        // RichEditBox defaults in dark (#202020) and light (#FFFFFF) modes.
-        _clearBgColor = isDark
-            ? Color.FromArgb(255, 32, 32, 32)
-            : Color.FromArgb(255, 255, 255, 255);
+        // indistinguishable from un-highlighted text. Read it from the
+        // active theme dictionary via TextControlBackground (the brush
+        // RichEditBox fills its surface with) so the clear colour tracks
+        // the editor regardless of future Fluent/brand tweaks. Fall back
+        // to ApplicationPageBackgroundThemeBrush, then to the pre-fix
+        // hand-picked values as a last resort.
+        _clearBgColor = TryReadSolidThemeColor("TextControlBackground", isDark, out var c)
+            || TryReadSolidThemeColor("ApplicationPageBackgroundThemeBrush", isDark, out c)
+            ? c
+            : (isDark ? Color.FromArgb(255, 32, 32, 32) : Color.FromArgb(255, 255, 255, 255));
         _colorsReady = true;
+    }
+
+    // Look up a resource by key from Application.Current.Resources'
+    // theme dictionaries, picking the Light/Default variant from this
+    // Page's theme rather than Application.RequestedTheme. Handles
+    // either a SolidColorBrush or a raw Color value under that key —
+    // TextControlBackground is a Color on WinAppSDK, not a Brush, so
+    // callers can't assume either shape.
+    private static bool TryReadSolidThemeColor(string key, bool isDark, out Color color)
+    {
+        var themeKey = isDark ? "Default" : "Light";
+        if (Application.Current.Resources.ThemeDictionaries.TryGetValue(themeKey, out var dictObj)
+            && dictObj is Microsoft.UI.Xaml.ResourceDictionary themeDict
+            && themeDict.TryGetValue(key, out var v))
+        {
+            switch (v)
+            {
+                case SolidColorBrush b:
+                    color = b.Color;
+                    return true;
+                case Color raw:
+                    color = raw;
+                    return true;
+            }
+        }
+        color = default;
+        return false;
     }
 
     private void ClearPreviousHighlights()

--- a/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml
@@ -47,14 +47,13 @@
                     <SolidColorBrush x:Key="SearchCardBgBrush" Color="#B3FFFFFF" />
                     <SolidColorBrush x:Key="SearchCardStrokeBrush" Color="#0F000000" />
                 </ResourceDictionary>
-                <ResourceDictionary x:Key="HighContrast">
-                    <SolidColorBrush x:Key="SearchHighlightBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-                    <SolidColorBrush x:Key="SearchDescBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
-                    <SolidColorBrush x:Key="SearchSectionBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
-                    <SolidColorBrush x:Key="SearchBreadcrumbBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
-                    <SolidColorBrush x:Key="SearchCardBgBrush" Color="{ThemeResource SystemColorWindowColor}" />
-                    <SolidColorBrush x:Key="SearchCardStrokeBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
-                </ResourceDictionary>
+                <!--
+                  HighContrast deliberately omitted: ActualTheme only
+                  exposes Light/Dark/Default, so GetThemedBrush would
+                  never route here without an AccessibilitySettings
+                  bridge. If HC parity matters later, add that plumbing
+                  then reintroduce the dict.
+                -->
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Page.Resources>

--- a/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml
@@ -11,6 +11,53 @@
       a XAML DataTemplateSelector would be heavier than the one-off
       layout needs.
     -->
+    <Page.Resources>
+        <!--
+          Theme-aware brushes for imperatively constructed rows. Looking
+          up TextFillColor*Brush via Application.Current.Resources resolves
+          against Application.RequestedTheme (Dark), not the Page's
+          ActualTheme — which made description/breadcrumb/section-header
+          text nearly invisible in light mode. Defining the brushes here
+          means `this.Resources[key]` honors the Page's ActualTheme chain.
+        -->
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <!--
+                  Color values mirror WinUI 3 system ThemeResources
+                  (TextFillColorSecondary/Tertiary, AccentTextFillColorPrimary,
+                  CardBackgroundFillColorDefault, CardStrokeColorDefault)
+                  as of WindowsAppSDK 1.8. Duplicating the constants lets
+                  the lookup run in code-behind without walking up to
+                  Application.Current.Resources, which is pinned to
+                  RequestedTheme="Dark".
+                -->
+                <ResourceDictionary x:Key="Default">
+                    <SolidColorBrush x:Key="SearchHighlightBrush" Color="#60CDFF" />
+                    <SolidColorBrush x:Key="SearchDescBrush" Color="#C5FFFFFF" />
+                    <SolidColorBrush x:Key="SearchSectionBrush" Color="#C5FFFFFF" />
+                    <SolidColorBrush x:Key="SearchBreadcrumbBrush" Color="#87FFFFFF" />
+                    <SolidColorBrush x:Key="SearchCardBgBrush" Color="#0DFFFFFF" />
+                    <SolidColorBrush x:Key="SearchCardStrokeBrush" Color="#17FFFFFF" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="SearchHighlightBrush" Color="#005FB8" />
+                    <SolidColorBrush x:Key="SearchDescBrush" Color="#9E000000" />
+                    <SolidColorBrush x:Key="SearchSectionBrush" Color="#9E000000" />
+                    <SolidColorBrush x:Key="SearchBreadcrumbBrush" Color="#72000000" />
+                    <SolidColorBrush x:Key="SearchCardBgBrush" Color="#B3FFFFFF" />
+                    <SolidColorBrush x:Key="SearchCardStrokeBrush" Color="#0F000000" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush x:Key="SearchHighlightBrush" Color="{ThemeResource SystemColorHighlightColor}" />
+                    <SolidColorBrush x:Key="SearchDescBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+                    <SolidColorBrush x:Key="SearchSectionBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+                    <SolidColorBrush x:Key="SearchBreadcrumbBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
+                    <SolidColorBrush x:Key="SearchCardBgBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                    <SolidColorBrush x:Key="SearchCardStrokeBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
     <ScrollViewer Padding="24">
         <StackPanel MaxWidth="800">
             <TextBlock

--- a/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml.cs
@@ -13,12 +13,20 @@ namespace Ghostty.Settings.Pages;
 internal sealed partial class SearchResultsPage : Page
 {
     private string _query = string.Empty;
+    private IReadOnlyList<SearchHit>? _pendingHits;
     private Action<string>? _onChosen;
     private Action? _onClear;
 
     public SearchResultsPage()
     {
         InitializeComponent();
+        // Theme-aware brushes live in Page.Resources. Before the page is
+        // attached to the visual tree, ActualTheme isn't resolved, so
+        // `this.Resources[key]` would pick the Default dictionary. Defer
+        // the first render to Loaded; subsequent Show() calls run
+        // synchronously because the page is cached and stays loaded.
+        Loaded += OnPageLoaded;
+        ActualThemeChanged += OnActualThemeChanged;
     }
 
     public void Show(
@@ -28,24 +36,57 @@ internal sealed partial class SearchResultsPage : Page
         Action onClear)
     {
         _query = query;
+        _pendingHits = hits;
         _onChosen = onChosen;
         _onClear = onClear;
 
+        if (IsLoaded) Render();
+    }
+
+    private void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_pendingHits != null) Render();
+    }
+
+    // Rebuild if the user toggles the window theme while results are
+    // visible — cached SolidColorBrush instances don't auto-update when
+    // the ThemeDictionaries active entry flips.
+    private void OnActualThemeChanged(FrameworkElement sender, object args)
+    {
+        if (IsLoaded && _pendingHits != null) Render();
+    }
+
+    private void Render()
+    {
+        var hits = _pendingHits ?? Array.Empty<SearchHit>();
+
         TitleText.Text = hits.Count == 0
             ? "Search"
-            : $"{hits.Count} result{(hits.Count == 1 ? "" : "s")} for \"{query}\"";
+            : $"{hits.Count} result{(hits.Count == 1 ? "" : "s")} for \"{_query}\"";
 
         ResultsPanel.Children.Clear();
 
         if (hits.Count == 0)
         {
-            EmptyText.Text = $"No settings match \"{query}\".";
+            EmptyText.Text = $"No settings match \"{_query}\".";
             EmptyPanel.Visibility = Visibility.Visible;
             return;
         }
 
         EmptyPanel.Visibility = Visibility.Collapsed;
         BuildGroupedResults(hits);
+    }
+
+    // Resolve a brush from Page.Resources.ThemeDictionaries by the Page's
+    // ActualTheme. Direct `this.Resources[key]` calls bottom out in
+    // Application.Current.Resources when the key is inside a theme
+    // dictionary, which re-introduces the original bug (app theme wins).
+    // Reading the theme-keyed sub-dict ourselves is deterministic.
+    private Brush GetThemedBrush(string key)
+    {
+        var themeKey = ActualTheme == ElementTheme.Light ? "Light" : "Default";
+        var dict = (ResourceDictionary)Resources.ThemeDictionaries[themeKey];
+        return (Brush)dict[key];
     }
 
     private void BuildGroupedResults(IReadOnlyList<SearchHit> hits)
@@ -72,6 +113,12 @@ internal sealed partial class SearchResultsPage : Page
             sectionBucket.Hits.Add(hit);
         }
 
+        var descBrush = GetThemedBrush("SearchDescBrush");
+        var sectionBrush = GetThemedBrush("SearchSectionBrush");
+        var breadcrumbBrush = GetThemedBrush("SearchBreadcrumbBrush");
+        var cardBgBrush = GetThemedBrush("SearchCardBgBrush");
+        var cardStrokeBrush = GetThemedBrush("SearchCardStrokeBrush");
+
         foreach (var (page, sections) in byPage)
         {
             ResultsPanel.Children.Add(new TextBlock
@@ -87,18 +134,18 @@ internal sealed partial class SearchResultsPage : Page
                 {
                     Text = section,
                     Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                    Foreground = sectionBrush,
                     Margin = new Thickness(0, 4, 0, 4),
                 });
                 foreach (var hit in sectionHits)
                 {
-                    ResultsPanel.Children.Add(BuildRow(hit));
+                    ResultsPanel.Children.Add(BuildRow(hit, descBrush, breadcrumbBrush, cardBgBrush, cardStrokeBrush));
                 }
             }
         }
     }
 
-    private UIElement BuildRow(SearchHit hit)
+    private UIElement BuildRow(SearchHit hit, Brush descBrush, Brush breadcrumbBrush, Brush cardBgBrush, Brush cardStrokeBrush)
     {
         // Rows are buttons so keyboard focus + Enter work out of the
         // box. The row itself is a Border inside the Button content;
@@ -112,7 +159,7 @@ internal sealed partial class SearchResultsPage : Page
         var description = new TextBlock
         {
             Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            Foreground = descBrush,
             TextWrapping = TextWrapping.Wrap,
             Margin = new Thickness(0, 2, 0, 0),
         };
@@ -122,7 +169,7 @@ internal sealed partial class SearchResultsPage : Page
         {
             Text = $"{hit.Entry.Page} > {hit.Entry.Section}",
             Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-            Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
+            Foreground = breadcrumbBrush,
             Margin = new Thickness(0, 4, 0, 0),
         };
 
@@ -136,8 +183,8 @@ internal sealed partial class SearchResultsPage : Page
             Padding = new Thickness(16, 10, 16, 10),
             MinHeight = 68,
             CornerRadius = new CornerRadius(4),
-            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"],
-            BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+            Background = cardBgBrush,
+            BorderBrush = cardStrokeBrush,
             BorderThickness = new Thickness(1),
             Margin = new Thickness(0, 0, 0, 6),
             Child = panel,
@@ -160,7 +207,7 @@ internal sealed partial class SearchResultsPage : Page
     // Split `text` around each case-insensitive occurrence of `query`
     // and render matches bolded with accent foreground. Inline spans
     // avoid re-measuring a child TextBlock for every match.
-    private static void AppendHighlighted(InlineCollection inlines, string text, string query)
+    private void AppendHighlighted(InlineCollection inlines, string text, string query)
     {
         inlines.Clear();
         if (string.IsNullOrEmpty(query) || string.IsNullOrEmpty(text))
@@ -169,7 +216,7 @@ internal sealed partial class SearchResultsPage : Page
             return;
         }
 
-        var accent = (Brush)Application.Current.Resources["AccentTextFillColorPrimaryBrush"];
+        var accent = GetThemedBrush("SearchHighlightBrush");
         int cursor = 0;
         while (cursor < text.Length)
         {

--- a/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/SearchResultsPage.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ghostty.Core.Settings;
+using Ghostty.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
@@ -81,12 +82,13 @@ internal sealed partial class SearchResultsPage : Page
     // ActualTheme. Direct `this.Resources[key]` calls bottom out in
     // Application.Current.Resources when the key is inside a theme
     // dictionary, which re-introduces the original bug (app theme wins).
-    // Reading the theme-keyed sub-dict ourselves is deterministic.
+    // Delegates to ThemedResources so the walk stays consistent with the
+    // command-palette lookup path.
     private Brush GetThemedBrush(string key)
     {
-        var themeKey = ActualTheme == ElementTheme.Light ? "Light" : "Default";
-        var dict = (ResourceDictionary)Resources.ThemeDictionaries[themeKey];
-        return (Brush)dict[key];
+        if (ThemedResources.TryFindBrush(Resources, key, ActualTheme, out var brush))
+            return brush;
+        return (Brush)Resources[key];
     }
 
     private void BuildGroupedResults(IReadOnlyList<SearchHit> hits)

--- a/windows/Ghostty/Settings/SettingsWindow.xaml
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml
@@ -2,86 +2,129 @@
 <Window
     x:Class="Ghostty.Settings.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="Ghostty Settings">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <NavigationView
-        x:Name="NavView"
-        IsBackButtonVisible="Collapsed"
-        IsSettingsVisible="False"
-        PaneDisplayMode="Left"
-        SelectionChanged="NavView_SelectionChanged">
+    <!--
+      Title + AppTitleBarText are set in code-behind from
+      AppIdentity.ProductName so a future rebrand touches one constant
+      instead of XAML strings. Window.Title is still set so the taskbar,
+      alt-tab switcher, and Win+Tab overlay show the branded name.
+    -->
+    <Grid x:Name="RootGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-        <NavigationView.AutoSuggestBox>
-            <!--
-              Standard WinUI 3 pattern: NavigationView renders an
-              AutoSuggestBox at the top of the pane. Used here as a
-              plain search field (QueryIcon, no suggestions). Ctrl+F
-              focuses it; Esc clears it and restores the previous page.
-            -->
-            <AutoSuggestBox
-                x:Name="SearchBox"
-                PlaceholderText="Search settings"
-                QueryIcon="Find"
-                TextChanged="SearchBox_TextChanged"
-                KeyDown="SearchBox_KeyDown" />
-        </NavigationView.AutoSuggestBox>
-
-        <NavigationView.MenuItems>
-            <NavigationViewItem x:Name="NavGeneral" Content="General" Tag="general">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Setting" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem x:Name="NavAppearance" Content="Appearance" Tag="appearance">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Font" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem x:Name="NavColors" Content="Colors" Tag="colors">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Highlight" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem x:Name="NavTerminal" Content="Terminal" Tag="terminal">
-                <NavigationViewItem.Icon>
-                    <FontIcon Glyph="&#xE756;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem x:Name="NavKeybindings" Content="Keybindings" Tag="keybindings">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Keyboard" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem x:Name="NavAdvanced" Content="Advanced" Tag="advanced">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Repair" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-
-            <NavigationViewItemSeparator />
-
-            <NavigationViewItem x:Name="NavRaw" Content="Raw Editor" Tag="raw">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Edit" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-        </NavigationView.MenuItems>
-
-        <NavigationView.PaneFooter>
-            <!--
-              Only visible while searching. Spec: "Total result count at
-              the bottom of the sidebar." Hidden when no query; pane
-              footer layout collapses cleanly with zero-opacity text.
-            -->
+        <!--
+          Custom title bar paired with ExtendsContentIntoTitleBar=true in
+          code-behind. The FontIcon glyph (E713 = Settings gear) gives
+          this window a visual identity distinct from MainWindow, so users
+          can tell the two apart in the taskbar/alt-tab and on screen.
+          SetTitleBar(AppTitleBar) marks the row as drag region; the
+          caption buttons (min/max/close) are laid out by the system on
+          the right and automatically excluded from hit-testing.
+        -->
+        <Grid
+            x:Name="AppTitleBar"
+            Grid.Row="0"
+            Background="Transparent">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <FontIcon
+                Grid.Column="0"
+                Glyph="&#xE713;"
+                FontSize="16"
+                Margin="14,0,10,0"
+                VerticalAlignment="Center" />
             <TextBlock
-                x:Name="ResultCountText"
-                Margin="12,4,12,12"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                Visibility="Collapsed" />
-        </NavigationView.PaneFooter>
+                x:Name="AppTitleBarText"
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                Style="{ThemeResource CaptionTextBlockStyle}" />
+        </Grid>
 
-        <Frame x:Name="ContentFrame" />
-    </NavigationView>
+        <NavigationView
+            x:Name="NavView"
+            Grid.Row="1"
+            IsBackButtonVisible="Collapsed"
+            IsSettingsVisible="False"
+            PaneDisplayMode="Left"
+            SelectionChanged="NavView_SelectionChanged">
+
+            <NavigationView.AutoSuggestBox>
+                <!--
+                  Standard WinUI 3 pattern: NavigationView renders an
+                  AutoSuggestBox at the top of the pane. Used here as a
+                  plain search field (QueryIcon, no suggestions). Ctrl+F
+                  focuses it; Esc clears it and restores the previous page.
+                -->
+                <AutoSuggestBox
+                    x:Name="SearchBox"
+                    PlaceholderText="Search settings"
+                    QueryIcon="Find"
+                    TextChanged="SearchBox_TextChanged"
+                    KeyDown="SearchBox_KeyDown" />
+            </NavigationView.AutoSuggestBox>
+
+            <NavigationView.MenuItems>
+                <NavigationViewItem x:Name="NavGeneral" Content="General" Tag="general">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Setting" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavAppearance" Content="Appearance" Tag="appearance">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Font" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavColors" Content="Colors" Tag="colors">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Highlight" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavTerminal" Content="Terminal" Tag="terminal">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE756;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavKeybindings" Content="Keybindings" Tag="keybindings">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Keyboard" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavAdvanced" Content="Advanced" Tag="advanced">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Repair" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+
+                <NavigationViewItemSeparator />
+
+                <NavigationViewItem x:Name="NavRaw" Content="Raw Editor" Tag="raw">
+                    <NavigationViewItem.Icon>
+                        <SymbolIcon Symbol="Edit" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <NavigationView.PaneFooter>
+                <!--
+                  Only visible while searching. Spec: "Total result count at
+                  the bottom of the sidebar." Hidden when no query; pane
+                  footer layout collapses cleanly with zero-opacity text.
+                -->
+                <TextBlock
+                    x:Name="ResultCountText"
+                    Margin="12,4,12,12"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Visibility="Collapsed" />
+            </NavigationView.PaneFooter>
+
+            <Frame x:Name="ContentFrame" />
+        </NavigationView>
+    </Grid>
 </Window>

--- a/windows/Ghostty/Settings/SettingsWindow.xaml
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml
@@ -5,46 +5,32 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--
-      Title + AppTitleBarText are set in code-behind from
+      Title + AppTitleBar.Title are set in code-behind from
       AppIdentity.ProductName so a future rebrand touches one constant
       instead of XAML strings. Window.Title is still set so the taskbar,
       alt-tab switcher, and Win+Tab overlay show the branded name.
+
+      The WinAppSDK 1.8 Microsoft.UI.Xaml.Controls.TitleBar primitive
+      replaces the earlier hand-rolled drag-region Grid: it inherits
+      RequestedTheme from its parent, owns the IconSource / Title /
+      Subtitle slots, and participates in the standard drag-region +
+      caption-button layout that SetTitleBar plumbs in code-behind.
     -->
     <Grid x:Name="RootGrid">
         <Grid.RowDefinitions>
-            <RowDefinition Height="40" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <!--
-          Custom title bar paired with ExtendsContentIntoTitleBar=true in
-          code-behind. The FontIcon glyph (E713 = Settings gear) gives
-          this window a visual identity distinct from MainWindow, so users
-          can tell the two apart in the taskbar/alt-tab and on screen.
-          SetTitleBar(AppTitleBar) marks the row as drag region; the
-          caption buttons (min/max/close) are laid out by the system on
-          the right and automatically excluded from hit-testing.
-        -->
-        <Grid
+        <TitleBar
             x:Name="AppTitleBar"
-            Grid.Row="0"
-            Background="Transparent">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <FontIcon
-                Grid.Column="0"
-                Glyph="&#xE713;"
-                FontSize="16"
-                Margin="14,0,10,0"
-                VerticalAlignment="Center" />
-            <TextBlock
-                x:Name="AppTitleBarText"
-                Grid.Column="1"
-                VerticalAlignment="Center"
-                Style="{ThemeResource CaptionTextBlockStyle}" />
-        </Grid>
+            Grid.Row="0">
+            <TitleBar.IconSource>
+                <!-- E713 = Settings gear, distinguishing this window from
+                     MainWindow in the taskbar / alt-tab overlay. -->
+                <FontIconSource Glyph="&#xE713;" />
+            </TitleBar.IconSource>
+        </TitleBar>
 
         <NavigationView
             x:Name="NavView"

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -58,12 +58,12 @@ internal sealed partial class SettingsWindow : Window
         InitializeComponent();
 
         // Branded window title and custom title bar. Title is used by the
-        // taskbar / alt-tab; AppTitleBarText renders the same text inside
+        // taskbar / alt-tab; AppTitleBar.Title renders the same text inside
         // the window next to the gear FontIcon. Both read from
         // AppIdentity.ProductName so a rebrand touches one constant.
         var titleText = $"{AppIdentity.ProductName} Settings";
         Title = titleText;
-        AppTitleBarText.Text = titleText;
+        AppTitleBar.Title = titleText;
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
 
@@ -155,27 +155,35 @@ internal sealed partial class SettingsWindow : Window
     // light Mica backdrop when the window is focused. AppWindow.TitleBar
     // exposes per-state color slots; pick ones that follow the window
     // theme rather than the Application's (pinned-Dark) theme.
+    //
+    // Inactive foreground is theme-neutral mid-grey (#999) — reads on
+    // both Mica tints. Hover/pressed use the foreground tone layered
+    // at CaptionButtonHoverAlpha / CaptionButtonPressedAlpha so the
+    // feedback tint comes from the current theme rather than a hard
+    // colour.
+    private const byte CaptionButtonHoverAlpha = 0x33;
+    private const byte CaptionButtonPressedAlpha = 0x66;
+    private static readonly Windows.UI.Color CaptionButtonInactiveFg =
+        Windows.UI.Color.FromArgb(0xFF, 0x99, 0x99, 0x99);
+
     private void ApplyCaptionButtonColors()
     {
         var hwnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
         var titleBar = AppWindow.GetFromWindowId(windowId).TitleBar;
         var dark = _themeManager.ElementTheme == ElementTheme.Dark;
+        var fg = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
 
         titleBar.ButtonBackgroundColor = Microsoft.UI.Colors.Transparent;
         titleBar.ButtonInactiveBackgroundColor = Microsoft.UI.Colors.Transparent;
-        titleBar.ButtonForegroundColor = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
-        titleBar.ButtonInactiveForegroundColor = dark
-            ? Windows.UI.Color.FromArgb(0xFF, 0x99, 0x99, 0x99)
-            : Windows.UI.Color.FromArgb(0xFF, 0x99, 0x99, 0x99);
-        titleBar.ButtonHoverBackgroundColor = dark
-            ? Windows.UI.Color.FromArgb(0x33, 0xFF, 0xFF, 0xFF)
-            : Windows.UI.Color.FromArgb(0x33, 0x00, 0x00, 0x00);
-        titleBar.ButtonHoverForegroundColor = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
-        titleBar.ButtonPressedBackgroundColor = dark
-            ? Windows.UI.Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)
-            : Windows.UI.Color.FromArgb(0x66, 0x00, 0x00, 0x00);
-        titleBar.ButtonPressedForegroundColor = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
+        titleBar.ButtonForegroundColor = fg;
+        titleBar.ButtonInactiveForegroundColor = CaptionButtonInactiveFg;
+        titleBar.ButtonHoverBackgroundColor =
+            Windows.UI.Color.FromArgb(CaptionButtonHoverAlpha, fg.R, fg.G, fg.B);
+        titleBar.ButtonHoverForegroundColor = fg;
+        titleBar.ButtonPressedBackgroundColor =
+            Windows.UI.Color.FromArgb(CaptionButtonPressedAlpha, fg.R, fg.G, fg.B);
+        titleBar.ButtonPressedForegroundColor = fg;
     }
 
     private void NavView_SelectionChanged(

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Ghostty.Core;
 using Ghostty.Core.Config;
 using Ghostty.Core.Settings;
 using Ghostty.Services;
@@ -55,6 +56,16 @@ internal sealed partial class SettingsWindow : Window
         _keybindings = keybindings;
         _theme = theme;
         InitializeComponent();
+
+        // Branded window title and custom title bar. Title is used by the
+        // taskbar / alt-tab; AppTitleBarText renders the same text inside
+        // the window next to the gear FontIcon. Both read from
+        // AppIdentity.ProductName so a rebrand touches one constant.
+        var titleText = $"{AppIdentity.ProductName} Settings";
+        Title = titleText;
+        AppTitleBarText.Text = titleText;
+        ExtendsContentIntoTitleBar = true;
+        SetTitleBar(AppTitleBar);
 
         // Mica backdrop so the window isn't a black flash while XAML
         // measures its first layout pass.
@@ -129,8 +140,42 @@ internal sealed partial class SettingsWindow : Window
 
     private void ApplyTheme()
     {
-        NavView.RequestedTheme = _themeManager.ElementTheme;
+        // RequestedTheme on the root Grid cascades to the custom title
+        // bar AND the NavView subtree, so the gear FontIcon + title text
+        // track the window theme. Without this the Grid falls back to
+        // Application.RequestedTheme (Dark), leaving white title-bar
+        // text on a light Mica backdrop.
+        RootGrid.RequestedTheme = _themeManager.ElementTheme;
         _themeManager.ApplyToWindow(this);
+        ApplyCaptionButtonColors();
+    }
+
+    // With ExtendsContentIntoTitleBar=true, the system-rendered caption
+    // buttons (min/max/close) default to white glyphs — invisible on a
+    // light Mica backdrop when the window is focused. AppWindow.TitleBar
+    // exposes per-state color slots; pick ones that follow the window
+    // theme rather than the Application's (pinned-Dark) theme.
+    private void ApplyCaptionButtonColors()
+    {
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
+        var titleBar = AppWindow.GetFromWindowId(windowId).TitleBar;
+        var dark = _themeManager.ElementTheme == ElementTheme.Dark;
+
+        titleBar.ButtonBackgroundColor = Microsoft.UI.Colors.Transparent;
+        titleBar.ButtonInactiveBackgroundColor = Microsoft.UI.Colors.Transparent;
+        titleBar.ButtonForegroundColor = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
+        titleBar.ButtonInactiveForegroundColor = dark
+            ? Windows.UI.Color.FromArgb(0xFF, 0x99, 0x99, 0x99)
+            : Windows.UI.Color.FromArgb(0xFF, 0x99, 0x99, 0x99);
+        titleBar.ButtonHoverBackgroundColor = dark
+            ? Windows.UI.Color.FromArgb(0x33, 0xFF, 0xFF, 0xFF)
+            : Windows.UI.Color.FromArgb(0x33, 0x00, 0x00, 0x00);
+        titleBar.ButtonHoverForegroundColor = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
+        titleBar.ButtonPressedBackgroundColor = dark
+            ? Windows.UI.Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)
+            : Windows.UI.Color.FromArgb(0x66, 0x00, 0x00, 0x00);
+        titleBar.ButtonPressedForegroundColor = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
     }
 
     private void NavView_SelectionChanged(


### PR DESCRIPTION
## Summary

Two commits:

1. **feat(settings): add gear icon and rename title to Wintty** - new `AppIdentity.ProductName` constant drives the settings window title and custom title bar. Custom title bar uses `ExtendsContentIntoTitleBar` with a Segoe Fluent gear glyph. Caption buttons (min/max/close) now track the window theme.

2. **fix(ui): theme-aware brushes across settings, palette, raw editor** - the recurring root cause was code-behind `Application.Current.Resources["*Brush"]` lookups, which resolve against `Application.RequestedTheme` rather than the target element's theme. Routed those through element-theme-aware paths. Also:
   - App.xaml no longer pins `RequestedTheme="Dark"`. App.xaml.cs now reads `OsTheme.IsDark()` before `InitializeComponent`, eliminating the dark flash when the settings window opens on a light system.
   - Raw editor (issue # 325): `Color.FromArgb(0, 0, 0, 0)` used as a "transparent" sentinel for `CharacterFormat.BackgroundColor` was rendering as opaque black because WinUI 3 ignores alpha on that property. Replaced with a theme-matched opaque color plus a `ClearAllBackgrounds` helper on `SetText` and on theme flips.
   - Command palette now tracks the OS theme like the settings window instead of inheriting the terminal palette theme. Also syncs the parent `Popup`'s `RequestedTheme` because Popup is a theme-inheritance boundary and ThemeResource bindings inside templated ListView rows resolved against the stale Application theme otherwise.

Related: issue # 327 tracks the contrast test harness that would catch these regressions going forward.

## Test plan

- [x] Open settings on a light system: no dark flash on first paint.
- [x] Search "theme" in settings: descriptions and breadcrumbs readable in both themes.
- [x] Navigate to Raw Editor: no black boxes on text.
- [x] Ctrl+F search in Raw Editor, clear, Save and Reload: text stays readable throughout.
- [x] Flip Windows light/dark with settings open: transitions cleanly.
- [x] Open command palette: matches system theme, not terminal palette theme.
- [x] Flip Windows light/dark with command palette open: transitions cleanly.
- [x] min/max/close buttons visible in both light and dark mode, focused and unfocused.