### PR TITLE
fix(command-palette): react to theme changes via WindowThemeManager

### DIFF
--- a/windows/Ghostty.Core/Windows/ThemeResolution.cs
+++ b/windows/Ghostty.Core/Windows/ThemeResolution.cs
@@ -1,0 +1,87 @@
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// How the resolver interprets <c>window-theme</c> values that are not
+/// explicitly <c>light</c>, <c>dark</c>, or <c>system</c> (i.e.
+/// <c>auto</c>, <c>ghostty</c>, and unknown values). The terminal
+/// chrome uses Palette so it tracks the active colour palette; the
+/// Settings and command-palette surfaces use System so they feel
+/// OS-native regardless of the terminal's colours.
+/// </summary>
+public enum ThemeFallbackStyle
+{
+    Palette,
+    System,
+}
+
+/// <summary>
+/// Pure resolution of the libghostty <c>window-theme</c> config value
+/// to a dark/light boolean. No WinUI, no Win32, no ambient state —
+/// every input is passed in, so the function is trivially unit-testable
+/// and stays in <c>Ghostty.Core</c>.
+///
+/// Callers (e.g. <c>Ghostty.Services.WindowThemeManager</c>) own the
+/// subscriptions to <c>IConfigService</c> and <c>UISettings</c> and
+/// feed the current values into <see cref="ResolveIsDark"/>. They also
+/// use <see cref="TracksSystem"/> to decide whether a system-theme
+/// flip should trigger a re-resolve.
+/// </summary>
+public static class ThemeResolution
+{
+    /// <summary>
+    /// Resolve a <c>window-theme</c> value to a dark-mode boolean.
+    /// </summary>
+    /// <param name="windowTheme">Config value. Recognised: "light",
+    /// "dark", "system". Anything else (including null/empty) consults
+    /// <paramref name="fallback"/>.</param>
+    /// <param name="backgroundColor">Terminal background colour packed
+    /// as <c>0x00RRGGBB</c>. Only used when <paramref name="fallback"/>
+    /// is <see cref="ThemeFallbackStyle.Palette"/>.</param>
+    /// <param name="fallback">Behaviour for auto/ghostty/unknown values.</param>
+    /// <param name="isSystemDark">Current OS dark-mode state. Used when
+    /// <paramref name="windowTheme"/> is "system" or when
+    /// <paramref name="fallback"/> is
+    /// <see cref="ThemeFallbackStyle.System"/>.</param>
+    public static bool ResolveIsDark(
+        string windowTheme,
+        uint backgroundColor,
+        ThemeFallbackStyle fallback,
+        bool isSystemDark) => windowTheme switch
+    {
+        "light" => false,
+        "dark" => true,
+        "system" => isSystemDark,
+        _ => fallback == ThemeFallbackStyle.System
+            ? isSystemDark
+            : IsBackgroundDark(backgroundColor),
+    };
+
+    /// <summary>
+    /// True when the resolved value depends on the OS theme. Callers
+    /// use this to skip dispatching work on <c>ColorValuesChanged</c>
+    /// when the system theme cannot affect the outcome.
+    /// </summary>
+    public static bool TracksSystem(
+        string windowTheme,
+        ThemeFallbackStyle fallback) => windowTheme switch
+    {
+        "light" or "dark" => false,
+        "system" => true,
+        _ => fallback == ThemeFallbackStyle.System,
+    };
+
+    /// <summary>
+    /// BT.709 relative-luminance test: a colour is "dark" when luminance
+    /// is below 0.5. Matches the macOS port's <c>NSColor.isLightColor</c>
+    /// heuristic upstream, so Windows and macOS agree on auto-theme
+    /// decisions for a given palette.
+    /// </summary>
+    public static bool IsBackgroundDark(uint color)
+    {
+        var r = (color >> 16) & 0xFF;
+        var g = (color >> 8) & 0xFF;
+        var b = color & 0xFF;
+        var luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0;
+        return luminance < 0.5;
+    }
+}

--- a/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
+++ b/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
@@ -1,0 +1,208 @@
+using Ghostty.Core.Windows;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+public sealed class ThemeResolutionTests
+{
+    // Shared black/white backgrounds. The "backgroundColor" argument
+    // only matters when fallback=Palette and the value is not explicit
+    // light/dark/system, so most tests can pick either.
+    private const uint BlackBg = 0x000000;
+    private const uint WhiteBg = 0xFFFFFF;
+
+    // ── ResolveIsDark: explicit values ───────────────────────────────────
+
+    [Theory]
+    [InlineData(ThemeFallbackStyle.Palette, true)]
+    [InlineData(ThemeFallbackStyle.Palette, false)]
+    [InlineData(ThemeFallbackStyle.System, true)]
+    [InlineData(ThemeFallbackStyle.System, false)]
+    public void Light_Always_ReturnsFalse(ThemeFallbackStyle fallback, bool systemDark)
+    {
+        Assert.False(ThemeResolution.ResolveIsDark(
+            "light", BlackBg, fallback, systemDark));
+    }
+
+    [Theory]
+    [InlineData(ThemeFallbackStyle.Palette, true)]
+    [InlineData(ThemeFallbackStyle.Palette, false)]
+    [InlineData(ThemeFallbackStyle.System, true)]
+    [InlineData(ThemeFallbackStyle.System, false)]
+    public void Dark_Always_ReturnsTrue(ThemeFallbackStyle fallback, bool systemDark)
+    {
+        Assert.True(ThemeResolution.ResolveIsDark(
+            "dark", WhiteBg, fallback, systemDark));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void System_FollowsIsSystemDark_RegardlessOfFallback(bool systemDark)
+    {
+        // "system" always consults the OS — fallback is irrelevant here.
+        Assert.Equal(systemDark, ThemeResolution.ResolveIsDark(
+            "system", BlackBg, ThemeFallbackStyle.Palette, systemDark));
+        Assert.Equal(systemDark, ThemeResolution.ResolveIsDark(
+            "system", BlackBg, ThemeFallbackStyle.System, systemDark));
+    }
+
+    // ── ResolveIsDark: fallback-driven (auto/ghostty/unknown) ────────────
+
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("ghostty")]
+    [InlineData("")]
+    [InlineData("unknown-future-value")]
+    public void NonExplicit_WithPaletteFallback_UsesBackgroundLuminance(string windowTheme)
+    {
+        // Dark background → dark theme.
+        Assert.True(ThemeResolution.ResolveIsDark(
+            windowTheme, BlackBg, ThemeFallbackStyle.Palette, isSystemDark: false));
+        // Light background → light theme.
+        Assert.False(ThemeResolution.ResolveIsDark(
+            windowTheme, WhiteBg, ThemeFallbackStyle.Palette, isSystemDark: true));
+    }
+
+    [Theory]
+    [InlineData("auto", true)]
+    [InlineData("auto", false)]
+    [InlineData("ghostty", true)]
+    [InlineData("ghostty", false)]
+    [InlineData("", true)]
+    [InlineData("unknown", false)]
+    public void NonExplicit_WithSystemFallback_FollowsOsTheme(
+        string windowTheme, bool systemDark)
+    {
+        // Background colour must be ignored when fallback=System — use a
+        // contrasting value so a bug would surface.
+        var bg = systemDark ? WhiteBg : BlackBg;
+        Assert.Equal(systemDark, ThemeResolution.ResolveIsDark(
+            windowTheme, bg, ThemeFallbackStyle.System, systemDark));
+    }
+
+    // ── IsBackgroundDark: luminance edges ────────────────────────────────
+
+    [Fact]
+    public void IsBackgroundDark_PureBlack_IsDark() =>
+        Assert.True(ThemeResolution.IsBackgroundDark(0x000000));
+
+    [Fact]
+    public void IsBackgroundDark_PureWhite_IsLight() =>
+        Assert.False(ThemeResolution.IsBackgroundDark(0xFFFFFF));
+
+    [Fact]
+    public void IsBackgroundDark_MidGrey_IsDark()
+    {
+        // 0x808080 → luminance ≈ 0.502? Actually (128*0.2126 + 128*0.7152 +
+        // 128*0.0722) / 255 = 128/255 ≈ 0.502, so "light" at the boundary.
+        Assert.False(ThemeResolution.IsBackgroundDark(0x808080));
+    }
+
+    [Fact]
+    public void IsBackgroundDark_JustBelowMidGrey_IsDark()
+    {
+        // 0x7F7F7F → luminance ≈ 0.498, below 0.5.
+        Assert.True(ThemeResolution.IsBackgroundDark(0x7F7F7F));
+    }
+
+    [Fact]
+    public void IsBackgroundDark_SaturatedGreen_IsLight()
+    {
+        // Pure green: luminance = 0.7152, well above 0.5. Matters for
+        // high-contrast palettes with a bright primary background.
+        Assert.False(ThemeResolution.IsBackgroundDark(0x00FF00));
+    }
+
+    [Fact]
+    public void IsBackgroundDark_SaturatedBlue_IsDark()
+    {
+        // Pure blue: luminance = 0.0722, solidly dark.
+        Assert.True(ThemeResolution.IsBackgroundDark(0x0000FF));
+    }
+
+    [Fact]
+    public void IsBackgroundDark_IgnoresAlphaByte()
+    {
+        // Callers pack 0x00RRGGBB, but a stray alpha byte in the top
+        // octet must not affect the result — R/G/B shifts mask to 0xFF.
+        Assert.True(ThemeResolution.IsBackgroundDark(0xFF000000));
+        Assert.False(ThemeResolution.IsBackgroundDark(0xFFFFFFFF));
+    }
+
+    // ── TracksSystem: dispatch-skip optimisation ─────────────────────────
+
+    [Theory]
+    [InlineData("light", ThemeFallbackStyle.Palette)]
+    [InlineData("light", ThemeFallbackStyle.System)]
+    [InlineData("dark", ThemeFallbackStyle.Palette)]
+    [InlineData("dark", ThemeFallbackStyle.System)]
+    public void TracksSystem_Explicit_IsFalse(
+        string windowTheme, ThemeFallbackStyle fallback)
+    {
+        // Explicit light/dark never consult the OS, so a system-theme
+        // flip cannot change the resolved value.
+        Assert.False(ThemeResolution.TracksSystem(windowTheme, fallback));
+    }
+
+    [Theory]
+    [InlineData(ThemeFallbackStyle.Palette)]
+    [InlineData(ThemeFallbackStyle.System)]
+    public void TracksSystem_System_IsTrue(ThemeFallbackStyle fallback)
+    {
+        Assert.True(ThemeResolution.TracksSystem("system", fallback));
+    }
+
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("ghostty")]
+    [InlineData("")]
+    public void TracksSystem_NonExplicit_PaletteFallback_IsFalse(string windowTheme)
+    {
+        // Palette fallback reads the background colour, not the OS theme
+        // — OS flips are noise; skip the dispatch.
+        Assert.False(ThemeResolution.TracksSystem(
+            windowTheme, ThemeFallbackStyle.Palette));
+    }
+
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("ghostty")]
+    [InlineData("")]
+    public void TracksSystem_NonExplicit_SystemFallback_IsTrue(string windowTheme)
+    {
+        // System fallback means OS flips matter.
+        Assert.True(ThemeResolution.TracksSystem(
+            windowTheme, ThemeFallbackStyle.System));
+    }
+
+    // ── Regression scenarios ─────────────────────────────────────────────
+
+    [Fact]
+    public void Regression_DarkPaletteOnLightOs_SystemFallback_IsLight()
+    {
+        // The bug this PR fixes: command palette was rendering dark
+        // because it tracked the terminal palette luminance directly.
+        // Under the new System fallback, a dark terminal background on
+        // a light OS must resolve to light.
+        Assert.False(ThemeResolution.ResolveIsDark(
+            "ghostty", BlackBg, ThemeFallbackStyle.System, isSystemDark: false));
+    }
+
+    [Fact]
+    public void Regression_LightPaletteOnDarkOs_SystemFallback_IsDark()
+    {
+        Assert.True(ThemeResolution.ResolveIsDark(
+            "ghostty", WhiteBg, ThemeFallbackStyle.System, isSystemDark: true));
+    }
+
+    [Fact]
+    public void Regression_DarkPaletteOnLightOs_PaletteFallback_IsDark()
+    {
+        // The MainWindow chrome keeps palette-tracking behaviour: a
+        // dark terminal background renders a dark frame even when the
+        // OS is light. This test pins that contract.
+        Assert.True(ThemeResolution.ResolveIsDark(
+            "ghostty", BlackBg, ThemeFallbackStyle.Palette, isSystemDark: false));
+    }
+}

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.ComponentModel;
 using Ghostty.Commands;
+using Ghostty.Core.Config;
+using Ghostty.Core.Windows;
 using Ghostty.Services;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
@@ -11,7 +13,6 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using Windows.System;
 using Windows.UI;
-using Windows.UI.ViewManagement;
 
 namespace Ghostty.Controls.CommandPalette;
 
@@ -31,71 +32,77 @@ namespace Ghostty.Controls.CommandPalette;
 internal sealed partial class CommandPaletteControl : UserControl
 {
     private CommandPaletteViewModel? _vm;
-    // Cached background mode so ActualThemeChanged can re-resolve the
-    // right theme variant — a code-behind lookup against
+    // Cached background mode so ApplyTheme can re-resolve the right
+    // theme variant on a theme flip — a code-behind lookup against
     // Application.Current.Resources bakes in Application.RequestedTheme
-    // at call time, so the brush wouldn't auto-update when the main
-    // window's theme flipped otherwise.
+    // at call time, so the brush wouldn't auto-update when the window's
+    // theme flipped otherwise.
     private string _backgroundSetting = string.Empty;
 
-    // The palette tracks the OS theme instead of the MainWindow's
-    // palette-derived ElementTheme, matching the Settings window's
-    // "feel OS-native regardless of the terminal's colors" rule. A dark
-    // terminal palette on a light system would otherwise give a dark
-    // command palette over a light taskbar / desktop chrome, which
-    // reads as out of place compared to every other system UI surface.
-    private UISettings? _uiSettings;
-    // Fully-qualified: both Microsoft.UI.Dispatching and Windows.System
-    // export a DispatcherQueue; the WinUI 3 one is what we need.
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher =
-        Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+    // Config+OS-driven theme resolver. The palette uses System fallback
+    // (same as SettingsWindow) so it feels OS-native regardless of the
+    // terminal's palette: a dark palette on a light OS leaves the
+    // palette light, matching every other system UI surface. Created
+    // in Configure() and disposed on Unloaded. Null until Configure
+    // runs, which happens once during MainWindow init.
+    private WindowThemeManager? _themeManager;
 
     public CommandPaletteControl()
     {
         InitializeComponent();
-        // ApplySystemTheme here sets only the UserControl's RequestedTheme;
-        // the Popup parent is fixed up on Loaded once Parent is non-null.
-        RequestedTheme = OsTheme.IsDark() ? ElementTheme.Dark : ElementTheme.Light;
-        ActualThemeChanged += (_, _) =>
-        {
-            if (!string.IsNullOrEmpty(_backgroundSetting))
-                ApplySettings(_backgroundSetting);
-        };
-
-        // UISettings.ColorValuesChanged fires on a background thread, so
-        // the handler marshals back to the UI. Subscribe on Loaded /
-        // unsubscribe on Unloaded so the palette doesn't keep UISettings
-        // alive past its visual-tree lifetime (one palette per main
-        // window, instances can come and go with detach/reattach).
+        // Configure() runs during MainWindow init, before this control
+        // is in the visual tree. Parent-walk to the Popup may not
+        // resolve yet, so re-apply on Loaded to guarantee the Popup's
+        // RequestedTheme ends up in sync.
         Loaded += OnPaletteLoaded;
         Unloaded += OnPaletteUnloaded;
     }
 
-    private void OnPaletteLoaded(object sender, RoutedEventArgs e)
+    private void OnPaletteLoaded(object sender, RoutedEventArgs e) => ApplyTheme();
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Wires theme resolution to the live config + OS theme. Matches
+    /// the SettingsWindow pattern: explicit <c>window-theme</c> wins,
+    /// "system" follows the OS, and any other value (auto/ghostty)
+    /// falls back to the OS too — the palette is a system-native
+    /// surface, not a palette-coloured one.
+    ///
+    /// Idempotent re-wiring is supported: a subsequent call tears
+    /// down the previous subscription before creating a new one. In
+    /// practice MainWindow calls Configure exactly once during init.
+    /// </summary>
+    public void Configure(IConfigService configService)
     {
-        if (_uiSettings is not null) return;
-        _uiSettings = new UISettings();
-        _uiSettings.ColorValuesChanged += OnSystemColorsChanged;
-        // Re-read once on (re)load in case the system theme changed
-        // while the palette was detached from the visual tree.
-        ApplySystemTheme();
+        ArgumentNullException.ThrowIfNull(configService);
+
+        if (_themeManager is not null)
+        {
+            _themeManager.ThemeChanged -= OnThemeChanged;
+            _themeManager.Dispose();
+        }
+
+        _themeManager = new WindowThemeManager(
+            configService, DispatcherQueue, ThemeFallbackStyle.System);
+        _themeManager.ThemeChanged += OnThemeChanged;
+        ApplyTheme();
     }
 
     private void OnPaletteUnloaded(object sender, RoutedEventArgs e)
     {
-        if (_uiSettings is null) return;
-        _uiSettings.ColorValuesChanged -= OnSystemColorsChanged;
-        _uiSettings = null;
+        if (_themeManager is null) return;
+        _themeManager.ThemeChanged -= OnThemeChanged;
+        _themeManager.Dispose();
+        _themeManager = null;
     }
 
-    private void OnSystemColorsChanged(UISettings sender, object args)
-    {
-        _dispatcher?.TryEnqueue(ApplySystemTheme);
-    }
+    private void OnThemeChanged(bool _) => ApplyTheme();
 
-    private void ApplySystemTheme()
+    private void ApplyTheme()
     {
-        var theme = OsTheme.IsDark() ? ElementTheme.Dark : ElementTheme.Light;
+        if (_themeManager is null) return;
+        var theme = _themeManager.ElementTheme;
         RequestedTheme = theme;
         // Popup is a theme-inheritance boundary: its own RequestedTheme
         // stays at Default (= Application.RequestedTheme, which we pin
@@ -107,9 +114,13 @@ internal sealed partial class CommandPaletteControl : UserControl
         // brushes even after our own RequestedTheme flipped. Sync the
         // Popup's theme too.
         if (Parent is Popup popup) popup.RequestedTheme = theme;
+        // Re-resolve the background brush — acrylic + solid-fill brushes
+        // are pulled from Application.Resources.ThemeDictionaries in
+        // code-behind, so they don't auto-update when RequestedTheme
+        // flips the way XAML {ThemeResource} bindings do.
+        if (!string.IsNullOrEmpty(_backgroundSetting))
+            ApplySettings(_backgroundSetting);
     }
-
-    // ── Public API ────────────────────────────────────────────────────────────
 
     /// <summary>
     /// Connects the control to a <see cref="CommandPaletteViewModel"/>.

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -448,6 +448,7 @@ public sealed partial class MainWindow : Window
         InstallPaneAccelerators();
 
         _commandPaletteVm = CreateCommandPaletteViewModel();
+        CommandPaletteUI.Configure(_configService);
         CommandPaletteUI.Bind(_commandPaletteVm);
         CommandPaletteUI.ApplySettings(_configService.CommandPaletteBackground);
 

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -1,5 +1,6 @@
 using System;
 using Ghostty.Core.Config;
+using Ghostty.Core.Windows;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Windows.Win32;
@@ -10,25 +11,15 @@ using WinRT.Interop;
 namespace Ghostty.Services;
 
 /// <summary>
-/// How the manager resolves <c>window-theme</c> values that aren't
-/// explicitly <c>light</c> or <c>dark</c> (i.e. <c>auto</c>,
-/// <c>ghostty</c>). MainWindow uses Palette so terminal chrome tracks
-/// the active palette. SettingsWindow uses System so the config UI
-/// feels OS-native regardless of the terminal's color scheme.
-/// </summary>
-internal enum ThemeFallbackStyle
-{
-    Palette,
-    System,
-}
-
-/// <summary>
 /// Maps the libghostty <c>window-theme</c> config value to WinUI 3
 /// ElementTheme and the DWM immersive dark mode attribute. Handles
 /// "light", "dark", "system" (follows OS), and "auto" (derives from
 /// background color luminance, matching the macOS port).
 ///
 /// Subscribe to <see cref="ThemeChanged"/> for live-reload updates.
+/// Resolution logic lives in
+/// <see cref="Ghostty.Core.Windows.ThemeResolution"/> so it can be
+/// unit-tested without a WinUI runtime.
 /// </summary>
 internal sealed class WindowThemeManager : IDisposable
 {
@@ -91,7 +82,26 @@ internal sealed class WindowThemeManager : IDisposable
             (uint)sizeof(BOOL));
     }
 
-    private void OnConfigChanged(IConfigService _)
+    // ConfigService.ConfigChanged can be raised synchronously from a
+    // non-UI thread (ThemePreviewService.ApplyThemeColors invokes it
+    // inline; the reload path already marshals, but we can't rely on
+    // every callsite doing so). Route through the dispatcher so
+    // ThemeChanged subscribers — which touch XAML properties — always
+    // run on the UI thread.
+    private void OnConfigChanged(IConfigService _) =>
+        _dispatcher.TryEnqueue(ResolveAndNotifyIfChanged);
+
+    private void OnSystemThemeChanged(
+        Windows.UI.ViewManagement.UISettings sender, object args)
+    {
+        // ColorValuesChanged fires on a background thread. System theme
+        // flips only matter when the resolved mode consults the OS;
+        // skip the dispatch otherwise.
+        if (!ThemeResolution.TracksSystem(_configService.WindowTheme, _fallback)) return;
+        _dispatcher.TryEnqueue(ResolveAndNotifyIfChanged);
+    }
+
+    private void ResolveAndNotifyIfChanged()
     {
         var previous = IsDarkMode;
         Resolve();
@@ -99,74 +109,12 @@ internal sealed class WindowThemeManager : IDisposable
             ThemeChanged?.Invoke(IsDarkMode);
     }
 
-    private void OnSystemThemeChanged(
-        Windows.UI.ViewManagement.UISettings sender, object args)
-    {
-        // ColorValuesChanged fires on a background thread.
-        _dispatcher.TryEnqueue(() =>
-        {
-            // System theme flips only matter when the resolved mode
-            // consults the OS. Explicit light/dark never do; "system"
-            // always does; auto/ghostty do only when fallback=System.
-            if (!TracksSystem(_configService.WindowTheme)) return;
-
-            var previous = IsDarkMode;
-            Resolve();
-            if (IsDarkMode != previous)
-                ThemeChanged?.Invoke(IsDarkMode);
-        });
-    }
-
-    private bool TracksSystem(string windowTheme) => windowTheme switch
-    {
-        "light" or "dark" => false,
-        "system" => true,
-        _ => _fallback == ThemeFallbackStyle.System,
-    };
-
     private void Resolve()
     {
-        IsDarkMode = _configService.WindowTheme switch
-        {
-            "light" => false,
-            "dark" => true,
-            "system" => IsSystemDark(),
-            // auto/ghostty (and any unknown value): consult the fallback.
-            // Palette matches the terminal's chrome to the active palette;
-            // System makes the window feel OS-native regardless.
-            _ => _fallback == ThemeFallbackStyle.System
-                ? IsSystemDark()
-                : IsBackgroundDark(),
-        };
+        IsDarkMode = ThemeResolution.ResolveIsDark(
+            _configService.WindowTheme,
+            _configService.BackgroundColor,
+            _fallback,
+            OsTheme.IsDark());
     }
-
-    /// <summary>
-    /// Check whether the OS is currently in dark mode. Uses the
-    /// shared <see cref="OsTheme"/> helper; we keep the
-    /// <see cref="_uiSettings"/> instance for the ColorValuesChanged
-    /// subscription but route the actual dark-mode read through the
-    /// shared heuristic so it can't diverge from ConfigService.
-    /// </summary>
-    private static bool IsSystemDark() => OsTheme.IsDark();
-
-    /// <summary>
-    /// Derive theme from the terminal background color luminance,
-    /// matching the macOS port's "auto" behavior. A background with
-    /// relative luminance below 0.5 is considered dark.
-    /// </summary>
-    private bool IsBackgroundDark()
-    {
-        // BackgroundColor is packed 0x00RRGGBB.
-        var color = _configService.BackgroundColor;
-        var r = (color >> 16) & 0xFF;
-        var g = (color >> 8) & 0xFF;
-        var b = color & 0xFF;
-
-        // Same luminance test the macOS port uses via NSColor.isLightColor:
-        // relative luminance (BT.709 coefficients). A color is "light" if
-        // luminance >= 0.5, matching the NSColor extension upstream.
-        var luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0;
-        return luminance < 0.5;
-    }
-
 }

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Ghostty.Core;
 using Ghostty.Core.Config;
 using Ghostty.Core.Settings;
+using Ghostty.Core.Windows;
 using Ghostty.Services;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;


### PR DESCRIPTION
## Summary

The command palette was rendering with dark chrome on a light OS whenever the terminal palette background was dark. Root cause: the palette was theming itself off the terminal's background-colour luminance directly, so a live OS-theme flip or a config reload left it visually out of sync with Settings.

This PR switches the palette onto the same `WindowThemeManager` subscription model Settings uses, and extracts the pure resolution logic into `Ghostty.Core` so it can be unit-tested without a WinUI runtime.

## Changes

- **`Ghostty.Core/Windows/ThemeResolution.cs`** (new) — pure `ResolveIsDark` / `TracksSystem` / `IsBackgroundDark` + `ThemeFallbackStyle` enum. No WinUI, no Win32, no ambient state.
- **`Ghostty/Services/WindowThemeManager.cs`** — delegates to the pure resolver. Both `OnConfigChanged` and `OnSystemThemeChanged` now marshal through the dispatcher via a shared `ResolveAndNotifyIfChanged` helper, so `ThemeChanged` subscribers always run on the UI thread even when `ThemePreviewService` raises `ConfigChanged` synchronously off-thread.
- **`Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs`** — subscribes to `WindowThemeManager.ThemeChanged` with `ThemeFallbackStyle.System` so the palette follows the OS theme. Null-check at the `Configure` boundary, dropped the duplicate `ActualThemeChanged` ctor handler (`ApplyTheme` tail-calls `ApplySettings`), tightened the `Configure` doc.
- **`Ghostty.Tests/Windows/ThemeResolutionTests.cs`** (new) — 42 cases covering explicit values, system/palette fallback, BT.709 luminance edges, `TracksSystem` dispatch-skip, plus regression tests pinning both contracts (command palette = System fallback, MainWindow chrome = Palette fallback).

## Test plan

- [x] `dotnet build Ghostty.sln -c Debug -p:Platform=x64` - clean
- [x] `dotnet test Ghostty.Tests --filter ThemeResolutionTests` - 42/42 pass
- [ ] Manual: flip OS light/dark while palette is open; palette chrome tracks OS
- [ ] Manual: change `window-theme` in config; live reload without palette close/reopen
- [ ] Manual: MainWindow chrome still follows palette luminance (unchanged behaviour)