### PR TITLE
fix(settings): suppress stray Ctrl+F tooltip in settings window

### DIFF
--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml
@@ -1,7 +1,8 @@
 <Page
     x:Class="Ghostty.Settings.Pages.RawEditorPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    KeyboardAcceleratorPlacementMode="Hidden">
 
     <Page.KeyboardAccelerators>
         <KeyboardAccelerator Key="F" Modifiers="Control" Invoked="CtrlF_Invoked" />

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -120,10 +120,11 @@ internal sealed partial class SettingsWindow : Window
         ctrlF.Invoked += (_, args) => { args.Handled = true; SearchBox.Focus(FocusState.Keyboard); };
         NavView.KeyboardAccelerators.Add(ctrlF);
 
-        // Suppress the auto-generated "Ctrl+F" tooltip that WinUI attaches
-        // to every NavigationView menu item when an accelerator lives on
-        // NavView. The shortcut is advertised by the SearchBox placeholder,
-        // not by hovering unrelated nav items. Matches MainWindow's policy.
+        // NavView hosts this accelerator, so WinUI auto-shows its shortcut
+        // tooltip wherever hover lands inside NavView's template -- which
+        // is every nav item. The shortcut is already advertised by the
+        // SearchBox placeholder, so hide the auto-tooltip. Matches the
+        // policy on MainWindow's RootGrid accelerators.
         NavView.KeyboardAcceleratorPlacementMode = KeyboardAcceleratorPlacementMode.Hidden;
 
         Closed += OnClosed;

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -120,6 +120,12 @@ internal sealed partial class SettingsWindow : Window
         ctrlF.Invoked += (_, args) => { args.Handled = true; SearchBox.Focus(FocusState.Keyboard); };
         NavView.KeyboardAccelerators.Add(ctrlF);
 
+        // Suppress the auto-generated "Ctrl+F" tooltip that WinUI attaches
+        // to every NavigationView menu item when an accelerator lives on
+        // NavView. The shortcut is advertised by the SearchBox placeholder,
+        // not by hovering unrelated nav items. Matches MainWindow's policy.
+        NavView.KeyboardAcceleratorPlacementMode = KeyboardAcceleratorPlacementMode.Hidden;
+
         Closed += OnClosed;
         NavView.SelectedItem = NavView.MenuItems[0];
     }


### PR DESCRIPTION
Closes #326

## What

Hovering any item in the settings sidebar (including the gear icon) showed a "Ctrl+F" tooltip. The Raw Editor page had the same shape for Ctrl+F / F3 / Shift+F3.

## Why

`SettingsWindow` registers a `Ctrl+F` `KeyboardAccelerator` on `NavView` so the shortcut fires even when focus is inside a page loaded into `ContentFrame`. WinUI's default `KeyboardAcceleratorPlacementMode` is `Auto`, which auto-generates a shortcut tooltip on the owning control - so every NavigationView menu item advertised the shortcut on hover.

`RawEditorPage` has the same problem with three page-level accelerators.

## Fix

Set `KeyboardAcceleratorPlacementMode = Hidden` in both places. Same policy MainWindow already uses on `RootGrid` (see MainWindow.xaml.cs:964).

Two files:
- `SettingsWindow.xaml.cs` - code-behind, right after the accelerator is registered
- `RawEditorPage.xaml` - attribute on the Page root

## Test plan

- [x] Build succeeds
- [ ] Open Settings, hover each sidebar item + gear -> no tooltip
- [ ] Ctrl+F still focuses the search box
- [ ] Open Raw Editor -> no tooltip anywhere on hover
- [ ] Ctrl+F / F3 / Shift+F3 still toggle and navigate the find bar