### PR TITLE
feat(power): Windows power saving mode detection and effect flattening

### DIFF
--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -56,6 +56,8 @@ public static class WindowsOnlyKeys
             "Group entries in the command palette by category instead of listing them flat."),
         new("command-palette-background",
             "Backdrop material for the command palette (acrylic / mica / opaque)."),
+        new("power-saver-mode",
+            "How the app reacts to Windows power-saving signals (auto, always, never)."),
     ];
 
     public static readonly FrozenSet<string> Set =

--- a/windows/Ghostty.Core/Power/IPowerStateMonitor.cs
+++ b/windows/Ghostty.Core/Power/IPowerStateMonitor.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Ghostty.Core.Power;
+
+/// <summary>
+/// App-scoped singleton that reports whether low-power mode is currently
+/// active and why. Render-path consumers poll <see cref="IsLowPowerActive"/>
+/// when they paint or resolve an effect; consumers that set state once
+/// (e.g. a title-bar icon) subscribe to <see cref="LowPowerChanged"/>.
+/// </summary>
+public interface IPowerStateMonitor
+{
+    /// <summary>True when low-power mode is currently active.</summary>
+    bool IsLowPowerActive { get; }
+
+    /// <summary>The OS signals that are currently contributing to the active state.
+    /// When <see cref="IsLowPowerActive"/> is false, this is <see cref="PowerSaverTrigger.None"/>.</summary>
+    PowerSaverTrigger ActiveTriggers { get; }
+
+    /// <summary>Raised on the monitor's synchronization context when
+    /// <see cref="IsLowPowerActive"/> flips value. Not raised when only
+    /// <see cref="ActiveTriggers"/> changes without flipping active.</summary>
+    event EventHandler LowPowerChanged;
+
+    /// <summary>Begin observing signals. Idempotent.</summary>
+    void Start();
+
+    /// <summary>Stop observing signals and release subscriptions. Idempotent.</summary>
+    void Stop();
+}

--- a/windows/Ghostty.Core/Power/PowerSaverMode.cs
+++ b/windows/Ghostty.Core/Power/PowerSaverMode.cs
@@ -1,0 +1,17 @@
+namespace Ghostty.Core.Power;
+
+/// <summary>
+/// User-facing power-saver policy mode, read from the
+/// <c>power-saver-mode</c> config key.
+/// </summary>
+public enum PowerSaverMode
+{
+    /// <summary>React to the OS signals (Battery Saver, on-battery, transparency-off, RDP).</summary>
+    Auto,
+
+    /// <summary>Always report low-power active, regardless of OS signals.</summary>
+    Always,
+
+    /// <summary>Never report low-power active, even when OS signals say so.</summary>
+    Never,
+}

--- a/windows/Ghostty.Core/Power/PowerSaverTooltipFormatter.cs
+++ b/windows/Ghostty.Core/Power/PowerSaverTooltipFormatter.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ghostty.Core.Power;
+
+/// <summary>
+/// Renders a <see cref="PowerSaverTrigger"/> flag set as a human-readable
+/// tooltip string for the title-bar indicator.
+/// </summary>
+public static class PowerSaverTooltipFormatter
+{
+    public static string Format(PowerSaverTrigger triggers)
+    {
+        if (triggers == PowerSaverTrigger.None)
+        {
+            return "Power saving mode active.";
+        }
+
+        var parts = new List<string>(4);
+        if (triggers.HasFlag(PowerSaverTrigger.BatterySaverOn))
+            parts.Add("Battery Saver is on");
+        if (triggers.HasFlag(PowerSaverTrigger.OnBattery))
+            parts.Add("running on battery");
+        if (triggers.HasFlag(PowerSaverTrigger.TransparencyEffectsOff))
+            parts.Add("transparency effects are off");
+        if (triggers.HasFlag(PowerSaverTrigger.RemoteSession))
+            parts.Add("Remote Desktop session detected");
+
+        var sb = new StringBuilder("Power saving: ");
+        for (int i = 0; i < parts.Count; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(parts[i]);
+        }
+        sb.Append('.');
+        return sb.ToString();
+    }
+}

--- a/windows/Ghostty.Core/Power/PowerSaverTrigger.cs
+++ b/windows/Ghostty.Core/Power/PowerSaverTrigger.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Ghostty.Core.Power;
+
+/// <summary>
+/// The individual OS signals that can contribute to low-power mode being
+/// active. Exposed as a flag set so consumers (e.g. the title-bar
+/// tooltip) can describe why the mode is on.
+/// </summary>
+[Flags]
+public enum PowerSaverTrigger
+{
+    None                   = 0,
+    BatterySaverOn         = 1 << 0,
+    OnBattery              = 1 << 1,
+    TransparencyEffectsOff = 1 << 2,
+    RemoteSession          = 1 << 3,
+}

--- a/windows/Ghostty.Core/Power/PowerStateResolver.cs
+++ b/windows/Ghostty.Core/Power/PowerStateResolver.cs
@@ -1,0 +1,36 @@
+namespace Ghostty.Core.Power;
+
+/// <summary>
+/// Pure-logic resolver: given the user's configured <see cref="PowerSaverMode"/>
+/// and the current OS signals, decide whether low-power mode is active
+/// and which triggers contributed.
+/// </summary>
+public static class PowerStateResolver
+{
+    public static (bool IsActive, PowerSaverTrigger Triggers) Resolve(
+        PowerSaverMode mode,
+        bool batterySaverOn,
+        bool onBattery,
+        bool transparencyEffectsOff,
+        bool remoteSession)
+    {
+        switch (mode)
+        {
+            case PowerSaverMode.Never:
+                return (false, PowerSaverTrigger.None);
+
+            case PowerSaverMode.Always:
+                // Always mode has no backing OS triggers - the user forced it.
+                return (true, PowerSaverTrigger.None);
+
+            case PowerSaverMode.Auto:
+            default:
+                var triggers = PowerSaverTrigger.None;
+                if (batterySaverOn)         triggers |= PowerSaverTrigger.BatterySaverOn;
+                if (onBattery)              triggers |= PowerSaverTrigger.OnBattery;
+                if (transparencyEffectsOff) triggers |= PowerSaverTrigger.TransparencyEffectsOff;
+                if (remoteSession)          triggers |= PowerSaverTrigger.RemoteSession;
+                return (triggers != PowerSaverTrigger.None, triggers);
+        }
+    }
+}

--- a/windows/Ghostty.Core/Settings/SettingsIndex.cs
+++ b/windows/Ghostty.Core/Settings/SettingsIndex.cs
@@ -120,6 +120,15 @@ public static class SettingsIndex
             new[] { "gradient", "point", "color", "position" },
             SettingType.Custom),
 
+        // ----- Appearance / Power Saving -----
+        new("power-saver-mode", "Power saving",
+            "Dial back expensive effects when Windows is in a power-saving state. " +
+            "Auto: react to Battery Saver, running on battery, Transparency effects off, or Remote Desktop. " +
+            "Always: permanently on. Never: ignore OS signals.",
+            "Appearance", "Power Saving",
+            new[] { "power", "battery", "saver", "energy", "performance", "low", "rdp" },
+            SettingType.Combo),
+
         // ----- Colors / Theme -----
         new("theme", "Color theme",
             "Named theme file loaded from the themes directory. Supports light:X,dark:Y pairs.",

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -19,6 +19,7 @@ public class WindowsOnlyKeysTests
     [InlineData("vertical-tabs")]
     [InlineData("command-palette-group-commands")]
     [InlineData("command-palette-background")]
+    [InlineData("power-saver-mode")]
     public void Contains_KnownKey(string key)
     {
         Assert.True(WindowsOnlyKeys.Contains(key));

--- a/windows/Ghostty.Tests/Power/FakePowerStateMonitor.cs
+++ b/windows/Ghostty.Tests/Power/FakePowerStateMonitor.cs
@@ -1,0 +1,29 @@
+using System;
+using Ghostty.Core.Power;
+
+namespace Ghostty.Tests.Power;
+
+/// <summary>
+/// In-memory test double for <see cref="IPowerStateMonitor"/>. Tests set
+/// <see cref="IsLowPowerActive"/> / <see cref="ActiveTriggers"/> directly
+/// and call <see cref="Flip"/> to raise <see cref="LowPowerChanged"/>.
+/// </summary>
+internal sealed class FakePowerStateMonitor : IPowerStateMonitor
+{
+    public bool IsLowPowerActive { get; set; }
+    public PowerSaverTrigger ActiveTriggers { get; set; }
+    public event EventHandler? LowPowerChanged;
+
+    public int StartCalls { get; private set; }
+    public int StopCalls { get; private set; }
+
+    public void Start() => StartCalls++;
+    public void Stop()  => StopCalls++;
+
+    public void Flip(bool active, PowerSaverTrigger triggers)
+    {
+        IsLowPowerActive = active;
+        ActiveTriggers   = triggers;
+        LowPowerChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/windows/Ghostty.Tests/Power/PowerSaverTooltipFormatterTests.cs
+++ b/windows/Ghostty.Tests/Power/PowerSaverTooltipFormatterTests.cs
@@ -1,0 +1,45 @@
+using Ghostty.Core.Power;
+using Xunit;
+
+namespace Ghostty.Tests.Power;
+
+public class PowerSaverTooltipFormatterTests
+{
+    [Fact]
+    public void Empty_trigger_set_returns_generic_text()
+    {
+        // Covers Always mode, where the user forced low-power without an OS signal.
+        var text = PowerSaverTooltipFormatter.Format(PowerSaverTrigger.None);
+
+        Assert.Equal("Power saving mode active.", text);
+    }
+
+    [Fact]
+    public void Single_trigger_renders_as_full_sentence()
+    {
+        var text = PowerSaverTooltipFormatter.Format(PowerSaverTrigger.BatterySaverOn);
+
+        Assert.Equal("Power saving: Battery Saver is on.", text);
+    }
+
+    [Fact]
+    public void Multiple_triggers_render_as_comma_and_period()
+    {
+        var text = PowerSaverTooltipFormatter.Format(
+            PowerSaverTrigger.BatterySaverOn
+          | PowerSaverTrigger.OnBattery
+          | PowerSaverTrigger.TransparencyEffectsOff);
+
+        Assert.Equal(
+            "Power saving: Battery Saver is on, running on battery, transparency effects are off.",
+            text);
+    }
+
+    [Fact]
+    public void Remote_session_alone_has_its_own_phrasing()
+    {
+        var text = PowerSaverTooltipFormatter.Format(PowerSaverTrigger.RemoteSession);
+
+        Assert.Equal("Power saving: Remote Desktop session detected.", text);
+    }
+}

--- a/windows/Ghostty.Tests/Power/PowerStateResolverTests.cs
+++ b/windows/Ghostty.Tests/Power/PowerStateResolverTests.cs
@@ -1,0 +1,87 @@
+using Ghostty.Core.Power;
+using Xunit;
+
+namespace Ghostty.Tests.Power;
+
+public class PowerStateResolverTests
+{
+    [Fact]
+    public void Never_mode_reports_inactive_regardless_of_signals()
+    {
+        var (active, triggers) = PowerStateResolver.Resolve(
+            mode: PowerSaverMode.Never,
+            batterySaverOn: true,
+            onBattery: true,
+            transparencyEffectsOff: true,
+            remoteSession: true);
+
+        Assert.False(active);
+        Assert.Equal(PowerSaverTrigger.None, triggers);
+    }
+
+    [Fact]
+    public void Always_mode_reports_active_regardless_of_signals()
+    {
+        var (active, triggers) = PowerStateResolver.Resolve(
+            mode: PowerSaverMode.Always,
+            batterySaverOn: false,
+            onBattery: false,
+            transparencyEffectsOff: false,
+            remoteSession: false);
+
+        Assert.True(active);
+        // Always mode has no backing triggers to report.
+        Assert.Equal(PowerSaverTrigger.None, triggers);
+    }
+
+    [Fact]
+    public void Auto_mode_inactive_when_no_signals_fire()
+    {
+        var (active, triggers) = PowerStateResolver.Resolve(
+            mode: PowerSaverMode.Auto,
+            batterySaverOn: false,
+            onBattery: false,
+            transparencyEffectsOff: false,
+            remoteSession: false);
+
+        Assert.False(active);
+        Assert.Equal(PowerSaverTrigger.None, triggers);
+    }
+
+    [Theory]
+    [InlineData(true,  false, false, false, PowerSaverTrigger.BatterySaverOn)]
+    [InlineData(false, true,  false, false, PowerSaverTrigger.OnBattery)]
+    [InlineData(false, false, true,  false, PowerSaverTrigger.TransparencyEffectsOff)]
+    [InlineData(false, false, false, true,  PowerSaverTrigger.RemoteSession)]
+    public void Auto_mode_active_when_any_single_signal_fires(
+        bool bs, bool ob, bool te, bool rdp, PowerSaverTrigger expected)
+    {
+        var (active, triggers) = PowerStateResolver.Resolve(
+            mode: PowerSaverMode.Auto,
+            batterySaverOn: bs,
+            onBattery: ob,
+            transparencyEffectsOff: te,
+            remoteSession: rdp);
+
+        Assert.True(active);
+        Assert.Equal(expected, triggers);
+    }
+
+    [Fact]
+    public void Auto_mode_combines_multiple_active_signals_into_flag_set()
+    {
+        var (active, triggers) = PowerStateResolver.Resolve(
+            mode: PowerSaverMode.Auto,
+            batterySaverOn: true,
+            onBattery: true,
+            transparencyEffectsOff: false,
+            remoteSession: true);
+
+        Assert.True(active);
+        Assert.Equal(
+            PowerSaverTrigger.BatterySaverOn
+          | PowerSaverTrigger.OnBattery
+          | PowerSaverTrigger.RemoteSession,
+            triggers);
+    }
+}

--- a/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
@@ -38,6 +38,7 @@ public class SettingsIndexTests
         "background-gradient-speed",
         "background-gradient-animation",
         "background-gradient-point",
+        "power-saver-mode",
         // Colors
         "theme",
         "foreground",

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -420,8 +420,10 @@ public partial class App : Application
 
         // Re-resolve whenever the user edits power-saver-mode (or any
         // other key -- cheap, and keeps this out of the reload path's
-        // critical section).
-        _configService.ConfigChanged += _ => _powerStateMonitor!.OnConfigReloaded();
+        // critical section). Named handler so we can detach symmetrically
+        // at shutdown (the rest of this codebase detaches every event
+        // subscription explicitly; anonymous lambda breaks that pattern).
+        _configService.ConfigChanged += OnConfigChanged_NotifyPowerMonitor;
 
         _powerStateMonitor.Start();
 
@@ -532,6 +534,11 @@ public partial class App : Application
             _logFilters, cfg.LogLevel, cfg.LogFilter);
     }
 
+    private void OnConfigChanged_NotifyPowerMonitor(Ghostty.Core.Config.IConfigService cfg)
+    {
+        _powerStateMonitor?.OnConfigReloaded();
+    }
+
     /// <summary>
     /// Called when ANY top-level <see cref="MainWindow"/> closes. The
     /// per-window <see cref="GhosttyHost"/> is already disposed by
@@ -571,6 +578,10 @@ public partial class App : Application
 
                 // Dispose between host and config service: the monitor subscribes
                 // to ConfigService.ConfigChanged, so tear it down before ConfigService.
+                if (_configService is not null)
+                {
+                    _configService.ConfigChanged -= OnConfigChanged_NotifyPowerMonitor;
+                }
                 _powerStateMonitor?.Dispose();
 
                 // Dispose ConfigService last: it outlives every host

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -8,7 +8,9 @@ using System.Runtime.InteropServices;
 using Ghostty.Controls;
 using Ghostty.Core.Config;
 using Ghostty.Core.Hosting;
+using Ghostty.Core.Power;
 using Ghostty.Hosting;
+using Ghostty.Power;
 using Ghostty.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
@@ -50,6 +52,7 @@ public partial class App : Application
     private ConfigService? _configService;
     private ConfigFileEditor? _configEditor;
     private ConfigWriteScheduler? _configWriteScheduler;
+    private WindowsPowerStateMonitor? _powerStateMonitor;
     private GhosttyHost? _bootstrapHost;
     private HostLifetimeSupervisor? _lifetimeSupervisor;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
@@ -83,6 +86,12 @@ public partial class App : Application
 
     internal static GhosttyHost? BootstrapHost { get; private set; }
     internal static ConfigService? ConfigService { get; private set; }
+
+    /// <summary>
+    /// Process-wide power-saving-mode monitor. Null before OnLaunched
+    /// runs; null after OnAnyWindowClosedInternal tears services down.
+    /// </summary>
+    internal static IPowerStateMonitor? PowerStateMonitor { get; private set; }
 
     /// <summary>
     /// Process-wide logger factory built at startup from Ghostty config.
@@ -391,6 +400,31 @@ public partial class App : Application
         // sites inside static scopes.
         Ghostty.Logging.StaticLoggers.Initialize(factory);
 
+        // Power-saving monitor. Reads power-saver-mode from config every
+        // time it resolves (Func thunk decouples it from ConfigService
+        // lifetime). Must be constructed on the UI thread so its
+        // UISettings field gets a live DispatcherQueue for change events.
+        _powerStateMonitor = new WindowsPowerStateMonitor(
+            readMode: () =>
+            {
+                var raw = _configService?.GetRawFileValue("power-saver-mode") ?? "auto";
+                return raw.Trim().ToLowerInvariant() switch
+                {
+                    "always" => PowerSaverMode.Always,
+                    "never"  => PowerSaverMode.Never,
+                    _        => PowerSaverMode.Auto,
+                };
+            },
+            logger: factory.CreateLogger<WindowsPowerStateMonitor>());
+        PowerStateMonitor = _powerStateMonitor;
+
+        // Re-resolve whenever the user edits power-saver-mode (or any
+        // other key -- cheap, and keeps this out of the reload path's
+        // critical section).
+        _configService.ConfigChanged += _ => _powerStateMonitor!.OnConfigReloaded();
+
+        _powerStateMonitor.Start();
+
         // One editor + one scheduler per process. Keeping them here
         // (instead of per-settings-window) means rapid edits coalesce
         // across window lifetimes and the file watcher sees a single
@@ -535,6 +569,10 @@ public partial class App : Application
                 // and calls AppFree.
                 _bootstrapHost?.Dispose();
 
+                // Dispose between host and config service: the monitor subscribes
+                // to ConfigService.ConfigChanged, so tear it down before ConfigService.
+                _powerStateMonitor?.Dispose();
+
                 // Dispose ConfigService last: it outlives every host
                 // (by design, so reload round-trips work across
                 // detached windows) but does own a FileSystemWatcher
@@ -583,6 +621,8 @@ public partial class App : Application
                 LifetimeSupervisor = null;
                 _configService = null;
                 ConfigService = null;
+                _powerStateMonitor = null;
+                PowerStateMonitor = null;
 
                 _zigLogBridge = null;
                 _fileLogSink = null;

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -121,5 +121,25 @@
             <cmdpalette:CommandPaletteControl x:Name="CommandPaletteUI"/>
         </Popup>
 
+        <!--
+            Power-saving-mode indicator. Shown in the top-right when
+            IPowerStateMonitor.IsLowPowerActive is true. Positioned
+            outside the tab strips so it stays visible in both
+            horizontal and vertical tab modes. Right margin matches
+            the caption-button inset (146px) so it never collides
+            with the min/max/close buttons.
+        -->
+        <FontIcon x:Name="PowerSaverIcon"
+                  Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                  HorizontalAlignment="Right"
+                  VerticalAlignment="Top"
+                  Margin="0,8,154,0"
+                  Glyph="&#xEC0A;"
+                  FontFamily="{StaticResource SymbolThemeFontFamily}"
+                  FontSize="14"
+                  Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                  Visibility="Collapsed"
+                  ToolTipService.ToolTip="Power saving mode active."/>
+
     </Grid>
 </Window>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1268,11 +1268,22 @@ public sealed partial class MainWindow : Window
     {
         DispatcherQueue.TryEnqueue(() =>
         {
-            ApplyBackdropStyle();
-            UpdateAcrylicTuning();
-            ApplyGradientTint();
-            ApplyRootGridBackground();
-            RefreshPowerSaverIcon();
+            try
+            {
+                ApplyBackdropStyle();
+                UpdateAcrylicTuning();
+                ApplyGradientTint();
+                ApplyRootGridBackground();
+                RefreshPowerSaverIcon();
+            }
+            catch (Exception ex) when (ex is System.Runtime.InteropServices.COMException
+                                    or InvalidOperationException
+                                    or NullReferenceException)
+            {
+                // Window tore down between monitor thread-pool event and UI dispatch.
+                // OnClosedAsync unsubscribes, but there's a narrow window before the
+                // queued lambda runs where XAML objects may already be disposed.
+            }
         });
     }
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -579,6 +579,15 @@ public sealed partial class MainWindow : Window
             ApplyRootGridBackground();
         };
 
+        // Re-evaluate the gradient and other power-gated effects whenever
+        // low-power mode toggles. MainWindow runs on the UI thread so we
+        // marshal back explicitly; the monitor fires on the thread-pool
+        // after its 150ms debounce.
+        if (Ghostty.App.PowerStateMonitor is { } powerMonitor)
+        {
+            powerMonitor.LowPowerChanged += OnLowPowerChanged;
+        }
+
         _tabManager.LastTabClosed += (_, _) => Close();
 
         // Settings page raises this the moment the user flips the
@@ -795,6 +804,10 @@ public sealed partial class MainWindow : Window
         Ghostty.Settings.Pages.GeneralPage.VerticalTabsToggled
             -= OnVerticalTabsToggledFromSettings;
         _configService.ConfigChanged -= OnConfigReloaded;
+        if (Ghostty.App.PowerStateMonitor is { } powerMonitor)
+        {
+            powerMonitor.LowPowerChanged -= OnLowPowerChanged;
+        }
 
         // Persist window placement for next launch. Skip when
         // fullscreen -- restore to the normal size instead.
@@ -1238,6 +1251,14 @@ public sealed partial class MainWindow : Window
         return (tint, t.TintOpacity, t.LuminosityOpacity);
     }
 
+    private void OnLowPowerChanged(object? sender, EventArgs args)
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            ApplyGradientTint();
+        });
+    }
+
     /// <summary>
     /// Create, update, or remove the gradient tint visual based on
     /// the current config. Called on startup and config reload.
@@ -1253,7 +1274,12 @@ public sealed partial class MainWindow : Window
     {
         var points = _configService.GradientPoints;
 
-        if (points.Count == 0)
+        // Low-power mode flattens the backdrop: no animated gradient,
+        // no composition work beyond the system backdrop. Treat as if
+        // no points were configured so the existing teardown runs.
+        var lowPowerActive = Ghostty.App.PowerStateMonitor?.IsLowPowerActive ?? false;
+
+        if (points.Count == 0 || lowPowerActive)
         {
             _gradientVisual?.Dispose();
             _gradientVisual = null;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -385,6 +385,7 @@ public sealed partial class MainWindow : Window
         // paint RootGrid.Background from the resolved state.
         ApplyShellTheme();
         ApplyRootGridBackground();
+        RefreshPowerSaverIcon();
 
         // Parent every existing and future PaneHost into the shared
         // container declared in MainWindow.xaml. This is the single
@@ -1271,7 +1272,22 @@ public sealed partial class MainWindow : Window
             UpdateAcrylicTuning();
             ApplyGradientTint();
             ApplyRootGridBackground();
+            RefreshPowerSaverIcon();
         });
+    }
+
+    private void RefreshPowerSaverIcon()
+    {
+        var monitor = Ghostty.App.PowerStateMonitor;
+        var active = monitor?.IsLowPowerActive ?? false;
+        PowerSaverIcon.Visibility = active
+            ? Microsoft.UI.Xaml.Visibility.Visible
+            : Microsoft.UI.Xaml.Visibility.Collapsed;
+
+        var triggers = monitor?.ActiveTriggers ?? Ghostty.Core.Power.PowerSaverTrigger.None;
+        Microsoft.UI.Xaml.Controls.ToolTipService.SetToolTip(
+            PowerSaverIcon,
+            Ghostty.Core.Power.PowerSaverTooltipFormatter.Format(triggers));
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1160,15 +1160,22 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void ApplyBackdropStyle()
     {
-        var opacity = _configService.BackgroundOpacity;
+        var lowPowerActive = Ghostty.App.PowerStateMonitor?.IsLowPowerActive ?? false;
+
+        var configOpacity = _configService.BackgroundOpacity;
+        var opacity = lowPowerActive ? 1.0 : configOpacity;
         var configStyle = _configService.BackgroundStyle;
 
         // If the user's configured style is acrylic-based, keep the
         // acrylic backdrop alive even at opacity=1.0 so Ctrl+Shift+Scroll
         // doesn't flash between Mica and acrylic at the boundary.
-        var style = (opacity >= 1.0 && configStyle != BackdropStyles.Frosted)
+        // Low-power mode overrides this: flatten unconditionally to Solid
+        // (Mica) to drop the composition cost of acrylic/crystal.
+        var style = lowPowerActive
             ? BackdropStyles.Solid
-            : configStyle;
+            : ((opacity >= 1.0 && configStyle != BackdropStyles.Frosted)
+                ? BackdropStyles.Solid
+                : configStyle);
 
         // Skip if the effective style hasn't changed.
         if (style == _currentBackdropStyle && SystemBackdrop is not null)
@@ -1230,6 +1237,11 @@ public sealed partial class MainWindow : Window
     private (Windows.UI.Color tintColor, float tintOpacity, float luminosityOpacity)
         ResolveAcrylicTuning()
     {
+        // Low-power flattens opacity to 1.0 so the tuning resolver picks
+        // the opaque fallback consistent with ApplyBackdropStyle.
+        var lowPowerActive = Ghostty.App.PowerStateMonitor?.IsLowPowerActive ?? false;
+        var effectiveOpacity = lowPowerActive ? 1.0 : _configService.BackgroundOpacity;
+
         uint? overrideArgb = _configService.BackgroundTintColor is { } c
             ? ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B
             : null;
@@ -1240,7 +1252,7 @@ public sealed partial class MainWindow : Window
             tintOpacityOverride: _configService.BackgroundTintOpacity,
             luminosityOpacityOverride: _configService.BackgroundLuminosityOpacity,
             blurFollowsOpacity: _configService.BackgroundBlurFollowsOpacity,
-            backgroundOpacity: _configService.BackgroundOpacity);
+            backgroundOpacity: effectiveOpacity);
 
         var tint = Windows.UI.Color.FromArgb(
             (byte)(t.TintArgb >> 24),
@@ -1255,7 +1267,10 @@ public sealed partial class MainWindow : Window
     {
         DispatcherQueue.TryEnqueue(() =>
         {
+            ApplyBackdropStyle();
+            UpdateAcrylicTuning();
             ApplyGradientTint();
+            ApplyRootGridBackground();
         });
     }
 

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -28,6 +28,10 @@ WINDOW_STYLE
 WINDOWPLACEMENT
 WM_SYSCOMMAND
 
+// user32 (power monitor)
+GetSystemMetrics
+SYSTEM_METRICS_INDEX
+
 // gdi32 - CreateSolidBrush and SetClassLongPtr are not in CsWin32
 // 0.3.269 metadata for this platform target; hand-written in MainWindow.
 

--- a/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
+++ b/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
@@ -143,7 +143,7 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
 
     private void OnUiSettingsChanged(
         UISettings sender,
-        UISettingsAdvancedEffectsEnabledChangedEventArgs args)
+        object args)
     {
         _transparencyEffectsOff = !sender.AdvancedEffectsEnabled;
         ScheduleResolve();

--- a/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
+++ b/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
@@ -28,6 +28,10 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
     private readonly Func<PowerSaverMode> _readMode;
     private readonly ILogger<WindowsPowerStateMonitor> _logger;
     private readonly Lock _gate = new();
+
+    // UISettings raises change events on the DispatcherQueue of the
+    // thread that constructed it. DI resolves this singleton on the UI
+    // thread, which has one.
     private readonly UISettings _uiSettings = new();
 
     private Timer? _debounceTimer;
@@ -61,17 +65,20 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
         {
             if (_started || _disposed) return;
             _started = true;
-        }
 
-        // Seed state outside the lock: these accessors hit WinRT and
-        // can block briefly on the first call. No other thread can
-        // observe the fields yet because no event handler is wired up.
-        _batterySaverOn = PowerManager.EnergySaverStatus == EnergySaverStatus.On;
-        _onBattery =
-            PowerManager.PowerSupplyStatus == PowerSupplyStatus.NotPresent &&
-            PowerManager.BatteryStatus != BatteryStatus.NotPresent;
-        _transparencyEffectsOff = !_uiSettings.AdvancedEffectsEnabled;
-        _remoteSession = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_REMOTESESSION) != 0;
+            // Seed initial state under the lock so the first
+            // ResolveAndMaybeEmit sees a consistent snapshot even if a
+            // subscribed event fires immediately after we register
+            // below. Taking the lock also gives the seed writes a
+            // release fence paired with the reader's acquire; on ARM64
+            // this is required, on x64 it's free.
+            _batterySaverOn = PowerManager.EnergySaverStatus == EnergySaverStatus.On;
+            _onBattery =
+                PowerManager.PowerSupplyStatus == PowerSupplyStatus.NotPresent &&
+                PowerManager.BatteryStatus != BatteryStatus.NotPresent;
+            _transparencyEffectsOff = !_uiSettings.AdvancedEffectsEnabled;
+            _remoteSession = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_REMOTESESSION) != 0;
+        }
 
         PowerManager.EnergySaverStatusChanged += OnPowerSignalChanged;
         PowerManager.BatteryStatusChanged += OnPowerSignalChanged;
@@ -108,7 +115,10 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
     /// </summary>
     public void OnSessionChanged()
     {
-        _remoteSession = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_REMOTESESSION) != 0;
+        lock (_gate)
+        {
+            _remoteSession = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_REMOTESESSION) != 0;
+        }
         ScheduleResolve();
     }
 
@@ -134,10 +144,13 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
     // this shape, so one method handles all of them.
     private void OnPowerSignalChanged(object? sender, object e)
     {
-        _batterySaverOn = PowerManager.EnergySaverStatus == EnergySaverStatus.On;
-        _onBattery =
-            PowerManager.PowerSupplyStatus == PowerSupplyStatus.NotPresent &&
-            PowerManager.BatteryStatus != BatteryStatus.NotPresent;
+        lock (_gate)
+        {
+            _batterySaverOn = PowerManager.EnergySaverStatus == EnergySaverStatus.On;
+            _onBattery =
+                PowerManager.PowerSupplyStatus == PowerSupplyStatus.NotPresent &&
+                PowerManager.BatteryStatus != BatteryStatus.NotPresent;
+        }
         ScheduleResolve();
     }
 
@@ -145,7 +158,10 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
         UISettings sender,
         object args)
     {
-        _transparencyEffectsOff = !sender.AdvancedEffectsEnabled;
+        lock (_gate)
+        {
+            _transparencyEffectsOff = !sender.AdvancedEffectsEnabled;
+        }
         ScheduleResolve();
     }
 
@@ -171,6 +187,8 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
 
         lock (_gate)
         {
+            if (!_started) return; // Queued timer callback after Stop(); drop it.
+
             previousActive = IsLowPowerActive;
             (nextActive, nextTriggers) = PowerStateResolver.Resolve(
                 mode:                   _readMode(),

--- a/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
+++ b/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
@@ -64,6 +64,8 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
         Func<PowerSaverMode> readMode,
         ILogger<WindowsPowerStateMonitor> logger)
     {
+        ArgumentNullException.ThrowIfNull(readMode);
+        ArgumentNullException.ThrowIfNull(logger);
         _readMode = readMode;
         _logger = logger;
     }

--- a/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
+++ b/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
@@ -25,6 +25,14 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
     // long enough to coalesce them without being user-perceptible.
     private const int DebounceMs = 150;
 
+    // RDP session transitions don't raise a WinRT event, and wiring a
+    // WM_WTSSESSION_CHANGE hook into MainWindow would couple this
+    // service to the UI layer. Polling SM_REMOTESESSION every 5 s is
+    // the spec-approved fallback: session changes are rare and a
+    // 5 s latency is imperceptible in the transparency/gradient
+    // gating path.
+    private const int RdpPollMs = 5000;
+
     private readonly Func<PowerSaverMode> _readMode;
     private readonly ILogger<WindowsPowerStateMonitor> _logger;
     private readonly Lock _gate = new();
@@ -35,6 +43,7 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
     private readonly UISettings _uiSettings = new();
 
     private Timer? _debounceTimer;
+    private System.Threading.Timer? _rdpPollTimer;
     private bool _started;
     private bool _disposed;
 
@@ -85,6 +94,17 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
         PowerManager.PowerSupplyStatusChanged += OnPowerSignalChanged;
         _uiSettings.AdvancedEffectsEnabledChanged += OnUiSettingsChanged;
 
+        // RDP change notifications would normally come from a
+        // WM_WTSSESSION_CHANGE hook on the main window. We avoid that
+        // coupling by polling instead; session transitions are rare and
+        // the 5-second latency is acceptable for the transparency /
+        // gradient gating path.
+        _rdpPollTimer = new Timer(
+            _ => OnSessionChanged(),
+            state: null,
+            dueTime: RdpPollMs,
+            period:  RdpPollMs);
+
         // Publish the seeded state. Consumers subscribed before Start()
         // will get a LowPowerChanged if the initial resolution is
         // active (previous IsLowPowerActive is false by default).
@@ -105,6 +125,8 @@ internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
 
             _debounceTimer?.Dispose();
             _debounceTimer = null;
+            _rdpPollTimer?.Dispose();
+            _rdpPollTimer = null;
         }
     }
 

--- a/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
+++ b/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Threading;
+using Ghostty.Core.Power;
+using Microsoft.Extensions.Logging;
+using Windows.System.Power;
+using Windows.UI.ViewManagement;
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Ghostty.Power;
+
+/// <summary>
+/// Production <see cref="IPowerStateMonitor"/>. Observes WinRT
+/// <see cref="PowerManager"/> and <see cref="UISettings"/> events plus
+/// <c>GetSystemMetrics(SM_REMOTESESSION)</c> for RDP, feeds the signals
+/// through <see cref="PowerStateResolver"/>, debounces bursts, and
+/// raises <see cref="LowPowerChanged"/> only when the resolved bool
+/// flips.
+/// </summary>
+internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
+{
+    // Debounce window for coalescing bursts. A mode flip, a battery
+    // unplug, and a transparency toggle triggered by the OS power
+    // profile can all land within a few ms of each other; 150 ms is
+    // long enough to coalesce them without being user-perceptible.
+    private const int DebounceMs = 150;
+
+    private readonly Func<PowerSaverMode> _readMode;
+    private readonly ILogger<WindowsPowerStateMonitor> _logger;
+    private readonly Lock _gate = new();
+    private readonly UISettings _uiSettings = new();
+
+    private Timer? _debounceTimer;
+    private bool _started;
+    private bool _disposed;
+
+    // Last-known OS signals. Mutated under _gate on the event-source
+    // threads (PowerManager events fire on a thread-pool thread); read
+    // under _gate by the debounce callback.
+    private bool _batterySaverOn;
+    private bool _onBattery;
+    private bool _transparencyEffectsOff;
+    private bool _remoteSession;
+
+    public bool IsLowPowerActive { get; private set; }
+    public PowerSaverTrigger ActiveTriggers { get; private set; }
+
+    public event EventHandler? LowPowerChanged;
+
+    public WindowsPowerStateMonitor(
+        Func<PowerSaverMode> readMode,
+        ILogger<WindowsPowerStateMonitor> logger)
+    {
+        _readMode = readMode;
+        _logger = logger;
+    }
+
+    public void Start()
+    {
+        lock (_gate)
+        {
+            if (_started || _disposed) return;
+            _started = true;
+        }
+
+        // Seed state outside the lock: these accessors hit WinRT and
+        // can block briefly on the first call. No other thread can
+        // observe the fields yet because no event handler is wired up.
+        _batterySaverOn = PowerManager.EnergySaverStatus == EnergySaverStatus.On;
+        _onBattery =
+            PowerManager.PowerSupplyStatus == PowerSupplyStatus.NotPresent &&
+            PowerManager.BatteryStatus != BatteryStatus.NotPresent;
+        _transparencyEffectsOff = !_uiSettings.AdvancedEffectsEnabled;
+        _remoteSession = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_REMOTESESSION) != 0;
+
+        PowerManager.EnergySaverStatusChanged += OnPowerSignalChanged;
+        PowerManager.BatteryStatusChanged += OnPowerSignalChanged;
+        PowerManager.PowerSupplyStatusChanged += OnPowerSignalChanged;
+        _uiSettings.AdvancedEffectsEnabledChanged += OnUiSettingsChanged;
+
+        // Publish the seeded state. Consumers subscribed before Start()
+        // will get a LowPowerChanged if the initial resolution is
+        // active (previous IsLowPowerActive is false by default).
+        ResolveAndMaybeEmit();
+    }
+
+    public void Stop()
+    {
+        lock (_gate)
+        {
+            if (!_started) return;
+            _started = false;
+
+            PowerManager.EnergySaverStatusChanged -= OnPowerSignalChanged;
+            PowerManager.BatteryStatusChanged -= OnPowerSignalChanged;
+            PowerManager.PowerSupplyStatusChanged -= OnPowerSignalChanged;
+            _uiSettings.AdvancedEffectsEnabledChanged -= OnUiSettingsChanged;
+
+            _debounceTimer?.Dispose();
+            _debounceTimer = null;
+        }
+    }
+
+    /// <summary>
+    /// Called by the Win32 message pump when it sees
+    /// <c>WM_WTSSESSION_CHANGE</c>. Re-reads the RDP signal and
+    /// schedules a resolve.
+    /// </summary>
+    public void OnSessionChanged()
+    {
+        _remoteSession = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_REMOTESESSION) != 0;
+        ScheduleResolve();
+    }
+
+    /// <summary>
+    /// Called after <see cref="Ghostty.Services.IConfigService"/>
+    /// raises ConfigChanged. The mode thunk will now return a
+    /// potentially different value; re-resolve so the active flag
+    /// reflects the new policy.
+    /// </summary>
+    public void OnConfigReloaded() => ScheduleResolve();
+
+    public void Dispose()
+    {
+        Stop();
+        lock (_gate)
+        {
+            _disposed = true;
+        }
+    }
+
+    // WinRT PowerManager static events project as EventHandler<object>
+    // with a nullable sender. The three signals we subscribe to share
+    // this shape, so one method handles all of them.
+    private void OnPowerSignalChanged(object? sender, object e)
+    {
+        _batterySaverOn = PowerManager.EnergySaverStatus == EnergySaverStatus.On;
+        _onBattery =
+            PowerManager.PowerSupplyStatus == PowerSupplyStatus.NotPresent &&
+            PowerManager.BatteryStatus != BatteryStatus.NotPresent;
+        ScheduleResolve();
+    }
+
+    private void OnUiSettingsChanged(
+        UISettings sender,
+        UISettingsAdvancedEffectsEnabledChangedEventArgs args)
+    {
+        _transparencyEffectsOff = !sender.AdvancedEffectsEnabled;
+        ScheduleResolve();
+    }
+
+    private void ScheduleResolve()
+    {
+        lock (_gate)
+        {
+            if (!_started) return;
+            // Lazy-allocate the timer so test harnesses that create a
+            // monitor but never Start it don't pay the System.Threading
+            // allocation. Period is infinite - we only want one shot
+            // per burst.
+            _debounceTimer ??= new Timer(_ => ResolveAndMaybeEmit(), null, Timeout.Infinite, Timeout.Infinite);
+            _debounceTimer.Change(DebounceMs, Timeout.Infinite);
+        }
+    }
+
+    private void ResolveAndMaybeEmit()
+    {
+        bool previousActive;
+        bool nextActive;
+        PowerSaverTrigger nextTriggers;
+
+        lock (_gate)
+        {
+            previousActive = IsLowPowerActive;
+            (nextActive, nextTriggers) = PowerStateResolver.Resolve(
+                mode:                   _readMode(),
+                batterySaverOn:         _batterySaverOn,
+                onBattery:              _onBattery,
+                transparencyEffectsOff: _transparencyEffectsOff,
+                remoteSession:          _remoteSession);
+
+            IsLowPowerActive = nextActive;
+            ActiveTriggers   = nextTriggers;
+        }
+
+        // Raise the event outside the lock. Subscribers run arbitrary
+        // code (title-bar glyph update, renderer re-eval) and must not
+        // observe us holding _gate, or a re-entrant Stop/Dispose call
+        // from a handler would deadlock.
+        if (nextActive != previousActive)
+        {
+            _logger.LogInformation(
+                "Power-saver mode {State} (triggers={Triggers})",
+                nextActive ? "active" : "inactive",
+                nextTriggers);
+            LowPowerChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -217,6 +217,20 @@
                                                ctrl:SettingsCard.ConfigKey="background-gradient-point" />
                 </StackPanel>
             </ctrl:SettingsGroup>
+
+            <ctrl:SettingsGroup Header="Power Saving"
+                                Description="Reduce GPU and compositor work when Windows is in a power-saving state.">
+                <ctrl:SettingsCard Header="Power saving mode"
+                                   Description="Auto reacts to Battery Saver, running on battery, Transparency effects off, or Remote Desktop. Always forces the mode on. Never ignores all OS signals."
+                                   ctrl:SettingsCard.ConfigKey="power-saver-mode">
+                    <ComboBox x:Name="PowerSaverModeCombo" MinWidth="180"
+                              SelectionChanged="PowerSaverMode_SelectionChanged">
+                        <ComboBoxItem Content="Auto" Tag="auto" />
+                        <ComboBoxItem Content="Always" Tag="always" />
+                        <ComboBoxItem Content="Never" Tag="never" />
+                    </ComboBox>
+                </ctrl:SettingsCard>
+            </ctrl:SettingsGroup>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -49,6 +49,12 @@ internal sealed partial class AppearancePage : Page
         if (configService is ConfigService cs)
         {
             SelectComboByTag(BackgroundStyleCombo, cs.BackgroundStyle);
+
+            // Seed power saver mode from config, defaulting to "auto".
+            var powerMode = cs.GetRawFileValue("power-saver-mode");
+            if (string.IsNullOrWhiteSpace(powerMode)) powerMode = "auto";
+            SelectComboByTag(PowerSaverModeCombo, powerMode.Trim().ToLowerInvariant());
+
             BlurFollowsOpacityToggle.IsOn = cs.BackgroundBlurFollowsOpacity;
             if (cs.IsConfiguredInFile("background-tint-color"))
             {
@@ -229,6 +235,12 @@ internal sealed partial class AppearancePage : Page
     {
         if (sender is ComboBox combo && combo.SelectedItem is ComboBoxItem item)
             OnValueChanged("background-style", item.Tag?.ToString() ?? "frosted");
+    }
+
+    private void PowerSaverMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (sender is ComboBox combo && combo.SelectedItem is ComboBoxItem item)
+            OnValueChanged("power-saver-mode", item.Tag?.ToString() ?? "auto");
     }
 
     private void BlurFollowsOpacity_Toggled(object sender, RoutedEventArgs e)

--- a/windows/Ghostty/Shell/AcrylicBackdrop.cs
+++ b/windows/Ghostty/Shell/AcrylicBackdrop.cs
@@ -55,7 +55,11 @@ internal sealed partial class AcrylicBackdrop : SystemBackdrop
             TintColor = _tintColor,
             TintOpacity = _tintOpacity,
             LuminosityOpacity = _luminosityOpacity,
-            FallbackColor = Windows.UI.Color.FromArgb(0, 0, 0, 0),
+            // Shown when Windows disables acrylic internally (low-end GPU,
+            // system-level Battery Saver, transparency effects off). A
+            // transparent fallback produces a see-through hole; using the
+            // configured tint keeps the terminal visually coherent.
+            FallbackColor = Windows.UI.Color.FromArgb(0xFF, _tintColor.R, _tintColor.G, _tintColor.B),
         };
 
         // Keep the backdrop active even when the window loses focus.


### PR DESCRIPTION
Closes # 276.

## Summary

Detect Windows power-saving conditions (Battery Saver, on-battery, transparency effects off, Remote Desktop) and dial back GPU/compositor-expensive effects until the condition clears. Config knob \`power-saver-mode = auto | always | never\` (default \`auto\`) exposed in Settings -> Appearance. Leaf glyph appears in the title bar while active, tooltip lists which triggers fired.

## What flattens when active

- Gradient tint visual -> disposed
- \`background-opacity\` -> forced to 1.0
- Backdrop -> Mica (Solid), regardless of configured style
- Acrylic tuning -> recomputed with opacity 1.0

\`AcrylicBackdrop.FallbackColor\` also switches from transparent to the configured tint — separate latent bug where a system-level acrylic fallback produced see-through holes.

## Architecture

- Pure-logic \`PowerStateResolver\` and \`PowerSaverTooltipFormatter\` in \`Ghostty.Core.Power\`, truth-table tested.
- \`IPowerStateMonitor\` interface + \`FakePowerStateMonitor\` test double.
- Production \`WindowsPowerStateMonitor\` in \`Ghostty.Power\`: WinRT \`PowerManager\` + \`UISettings.AdvancedEffectsEnabledChanged\` + 5-second \`GetSystemMetrics(SM_REMOTESESSION)\` poll for RDP. 150 ms debounce. Raises \`LowPowerChanged\` only on the active-bit edge.
- Wired into App.xaml.cs as a static singleton alongside the existing service pattern.

## Scope deferred

- Custom-shader pass gating: the DX12 shader pipeline is a separate WIP branch. Infrastructure here is ready to hook in once that lands.
- FPS cap reconfigure: no FPS cap knob on the renderer yet.
- \`WM_WTSSESSION_CHANGE\` hook replaced by a 5-second RDP poll (spec-approved fallback). Switching to the hook is a one-file change if we want lower RDP latency later.

## Test plan

- \`dotnet test\` on \`Ghostty.Tests\` -> 672 pass, 1 pre-existing skip. 12 new tests for the resolver and formatter.
- Manual: toggle Battery Saver while the app is running -> effects flatten, title-bar glyph appears with accurate trigger tooltip; toggle off -> full effects return.
- \`power-saver-mode = always\` -> icon shows, effects flatten regardless of OS state. \`never\` -> icon stays hidden, OS signals ignored.