### PR TITLE
feat(profiles): ProfileRegistry + ConfigService profile parse

### DIFF
--- a/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
+++ b/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Pure helper invoked by <c>ConfigService.ReadFlagsCore</c> after the
+/// raw file cache is populated. Returns the five profile-view values
+/// exposed on <see cref="IConfigService"/> and
+/// <see cref="IProfileConfigSource"/>. Kept separate from
+/// <c>ConfigService</c> so the parse logic is unit-testable on Linux
+/// without the WinUI + libghostty dependency chain.
+/// </summary>
+public static class ConfigServiceProfileParser
+{
+    /// <summary>
+    /// <paramref name="configText"/> is the raw file contents. The
+    /// <paramref name="fileValueReader"/> delegate is a thin adapter
+    /// over <c>ConfigService</c>'s existing <c>GetFileValue</c>
+    /// helper: it returns the last raw value for a key, or
+    /// <see langword="null"/> when the key is absent.
+    /// </summary>
+    public static ProfileView ParseAll(
+        string configText,
+        Func<string, string?> fileValueReader)
+    {
+        ArgumentNullException.ThrowIfNull(configText);
+        ArgumentNullException.ThrowIfNull(fileValueReader);
+
+        var parsed = ProfileSourceParser.Parse(configText);
+        var hidden = ProfileSourceParser.ExtractHiddenIds(configText);
+
+        var defaultId = fileValueReader("default-profile");
+        if (string.IsNullOrEmpty(defaultId)) defaultId = null;
+
+        var profileOrderRaw = fileValueReader("profile-order") ?? string.Empty;
+        var profileOrder = ParseCsv(profileOrderRaw);
+
+        // Suppress warnings for ids that appear only as a hidden-override
+        // (e.g. "profile.foo.hidden = true" with no name/command). These
+        // are intentional suppression markers, not malformed definitions.
+        var warnings = FilterHiddenOnlyWarnings(parsed.Warnings, parsed.Profiles, hidden);
+
+        return new ProfileView(
+            ParsedProfiles: parsed.Profiles,
+            ProfileOrder: profileOrder,
+            DefaultProfileId: defaultId,
+            HiddenProfileIds: hidden,
+            ProfileWarnings: warnings);
+    }
+
+    // Warnings that mention an id which is in the hidden set and absent
+    // from parsed profiles are suppressed -- those entries are pure
+    // hide-overrides, not broken definitions.
+    private static IReadOnlyList<string> FilterHiddenOnlyWarnings(
+        IReadOnlyList<string> warnings,
+        IReadOnlyDictionary<string, ProfileDef> profiles,
+        IReadOnlySet<string> hidden)
+    {
+        if (warnings.Count == 0) return warnings;
+        var result = new List<string>(warnings.Count);
+        foreach (var w in warnings)
+        {
+            var suppressed = false;
+            foreach (var id in hidden)
+            {
+                if (!profiles.ContainsKey(id) && w.Contains(id, StringComparison.OrdinalIgnoreCase))
+                {
+                    suppressed = true;
+                    break;
+                }
+            }
+            if (!suppressed) result.Add(w);
+        }
+        return result;
+    }
+
+    private static IReadOnlyList<string> ParseCsv(string input)
+    {
+        if (input.Length == 0) return Array.Empty<string>();
+        var list = new List<string>();
+        foreach (var segment in input.Split(','))
+        {
+            var trimmed = segment.Trim();
+            if (trimmed.Length > 0) list.Add(trimmed);
+        }
+        return list;
+    }
+}
+
+/// <summary>
+/// Immutable bundle of the five profile-view values. Matches the
+/// member shape of <see cref="IProfileConfigSource"/>.
+/// </summary>
+public sealed record ProfileView(
+    IReadOnlyDictionary<string, ProfileDef> ParsedProfiles,
+    IReadOnlyList<string> ProfileOrder,
+    string? DefaultProfileId,
+    IReadOnlySet<string> HiddenProfileIds,
+    IReadOnlyList<string> ProfileWarnings);

--- a/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
+++ b/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using Ghostty.Core.Profiles;
 
@@ -51,9 +50,11 @@ public static class ConfigServiceProfileParser
             ProfileWarnings: warnings);
     }
 
-    // Warnings that mention an id which is in the hidden set and absent
-    // from parsed profiles are suppressed -- those entries are pure
-    // hide-overrides, not broken definitions.
+    // Warnings for an id which is in the hidden set and absent from parsed
+    // profiles are suppressed -- those entries are pure hide-overrides,
+    // not broken definitions. Anchor on the exact "profile '<id>':" prefix
+    // emitted by ProfileSourceParser so a hidden id that happens to be a
+    // substring of another id's warning does not accidentally suppress it.
     private static IReadOnlyList<string> FilterHiddenOnlyWarnings(
         IReadOnlyList<string> warnings,
         IReadOnlyDictionary<string, ProfileDef> profiles,
@@ -66,7 +67,8 @@ public static class ConfigServiceProfileParser
             var suppressed = false;
             foreach (var id in hidden)
             {
-                if (!profiles.ContainsKey(id) && w.Contains(id, StringComparison.OrdinalIgnoreCase))
+                if (profiles.ContainsKey(id)) continue;
+                if (w.StartsWith($"profile '{id}':", StringComparison.OrdinalIgnoreCase))
                 {
                     suppressed = true;
                     break;

--- a/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
+++ b/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
@@ -61,14 +61,28 @@ public static class ConfigServiceProfileParser
         IReadOnlySet<string> hidden)
     {
         if (warnings.Count == 0) return warnings;
+
+        // Precompute the "profile '<id>':" prefixes once per hidden id
+        // rather than per (warning x id) pair; the old string interpolation
+        // inside the inner loop allocated a new format string on every
+        // iteration. Skip ids that also have a full parsed definition --
+        // those warnings are for genuinely broken blocks, not hide-only
+        // overrides.
+        List<string>? prefixes = null;
+        foreach (var id in hidden)
+        {
+            if (profiles.ContainsKey(id)) continue;
+            (prefixes ??= new List<string>(hidden.Count)).Add($"profile '{id}':");
+        }
+        if (prefixes is null) return warnings;
+
         var result = new List<string>(warnings.Count);
         foreach (var w in warnings)
         {
             var suppressed = false;
-            foreach (var id in hidden)
+            foreach (var prefix in prefixes)
             {
-                if (profiles.ContainsKey(id)) continue;
-                if (w.StartsWith($"profile '{id}':", StringComparison.OrdinalIgnoreCase))
+                if (w.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 {
                     suppressed = true;
                     break;
@@ -82,13 +96,11 @@ public static class ConfigServiceProfileParser
     private static IReadOnlyList<string> ParseCsv(string input)
     {
         if (input.Length == 0) return Array.Empty<string>();
-        var list = new List<string>();
-        foreach (var segment in input.Split(','))
-        {
-            var trimmed = segment.Trim();
-            if (trimmed.Length > 0) list.Add(trimmed);
-        }
-        return list;
+        // TrimEntries + RemoveEmptyEntries collapses the pre-existing
+        // trim-then-skip-empties loop into the BCL split options.
+        return input.Split(
+            ',',
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
     }
 }
 

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -110,4 +110,33 @@ public interface IConfigService : IDisposable
     /// as an informational notice (not an error).
     /// </summary>
     IReadOnlyList<string> WindowsOnlyKeysUsed { get; }
+
+    /// <summary>
+    /// Parsed user-defined profiles from <c>profile.&lt;id&gt;.*</c>
+    /// lines. Keys are lowercase-ASCII ids. Replaced on every reload.
+    /// See <c>Ghostty.Core.Profiles.IProfileConfigSource</c> for the
+    /// narrow interface that <c>ProfileRegistry</c> depends on.
+    /// </summary>
+    IReadOnlyDictionary<string, Ghostty.Core.Profiles.ProfileDef> ParsedProfiles { get; }
+
+    /// <summary>
+    /// Ids from <c>profile-order</c>, empty when unset.
+    /// </summary>
+    IReadOnlyList<string> ProfileOrder { get; }
+
+    /// <summary>
+    /// Value of <c>default-profile</c>, or null when unset.
+    /// </summary>
+    string? DefaultProfileId { get; }
+
+    /// <summary>
+    /// Ids for which <c>profile.&lt;id&gt;.hidden = true</c> appears.
+    /// </summary>
+    IReadOnlySet<string> HiddenProfileIds { get; }
+
+    /// <summary>
+    /// Non-fatal warnings emitted by the profile parser during the
+    /// last reload.
+    /// </summary>
+    IReadOnlyList<string> ProfileWarnings { get; }
 }

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -58,6 +58,10 @@ public static class WindowsOnlyKeys
             "Backdrop material for the command palette (acrylic / mica / opaque)."),
         new("power-saver-mode",
             "How the app reacts to Windows power-saving signals (auto, always, never)."),
+        new("default-profile",
+            "Id of the profile opened for a new tab or window when none is specified."),
+        new("profile-order",
+            "Comma-separated list of profile ids defining the order shown in the tab picker and command palette."),
     ];
 
     public static readonly FrozenSet<string> Set =
@@ -106,5 +110,31 @@ public static class WindowsOnlyKeys
         var lastColon = prefix.LastIndexOf(':');
         key = lastColon >= 0 ? prefix[(lastColon + 1)..] : prefix;
         return key.Length > 0;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="key"/> is a dotted
+    /// per-profile key of the shape <c>profile.&lt;id&gt;.&lt;subkey&gt;</c>.
+    /// Used by <c>ConfigService</c>'s diagnostic filter to absorb
+    /// libghostty's "unknown field" output for user-defined profile
+    /// blocks without polluting <c>WindowsOnlyKeysUsed</c> with one
+    /// entry per subkey per profile.
+    /// </summary>
+    public static bool IsProfileSubkey(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        const string Prefix = "profile.";
+        if (!key.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // Must have at least one character of <id>, then '.', then at
+        // least one character of <subkey>. IndexOf('.', Prefix.Length)
+        // skips the initial "profile." dot and looks for the id-subkey
+        // separator; the result must be strictly greater than
+        // Prefix.Length (non-empty id) and strictly less than the
+        // string end (non-empty subkey).
+        var sep = key.IndexOf('.', Prefix.Length);
+        return sep > Prefix.Length && sep < key.Length - 1;
     }
 }

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -27,8 +27,11 @@ internal static class LogEvents
     // 1200-1299: Profiles / discovery
     internal static class Profiles
     {
-        public const int ProbeFailed      = 1200;
-        public const int CacheReadFailed  = 1201;
-        public const int CacheWriteFailed = 1202;
+        public const int ProbeFailed             = 1200;
+        public const int CacheReadFailed         = 1201;
+        public const int CacheWriteFailed        = 1202;
+        public const int RegistryRecomposed      = 1203;
+        public const int DiscoveryRefreshFailed  = 1204;
+        public const int ProfileParseWarning     = 1205;
     }
 }

--- a/windows/Ghostty.Core/Profiles/DiscoveryService.cs
+++ b/windows/Ghostty.Core/Profiles/DiscoveryService.cs
@@ -60,11 +60,18 @@ internal sealed partial class DiscoveryService
         _cacheFilePath = cacheFilePath;
     }
 
-    public async Task<IReadOnlyList<DiscoveredProfile>> DiscoverAsync(CancellationToken ct)
+    public Task<IReadOnlyList<DiscoveredProfile>> DiscoverAsync(CancellationToken ct)
+        => DiscoverAsync(bypassCache: false, ct);
+
+    public async Task<IReadOnlyList<DiscoveredProfile>> DiscoverAsync(
+        bool bypassCache, CancellationToken ct)
     {
-        var cached = await TryLoadFreshCacheAsync(ct).ConfigureAwait(false);
-        if (cached is not null)
-            return cached;
+        if (!bypassCache)
+        {
+            var cached = await TryLoadFreshCacheAsync(ct).ConfigureAwait(false);
+            if (cached is not null)
+                return cached;
+        }
 
         var merged = await RunProbesAsync(ct).ConfigureAwait(false);
         await TryWriteCacheAsync(merged, ct).ConfigureAwait(false);

--- a/windows/Ghostty.Core/Profiles/IProfileConfigSource.cs
+++ b/windows/Ghostty.Core/Profiles/IProfileConfigSource.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Narrow, read-only view of the parsed profile section of the user's
+/// config file. <c>ConfigService</c> implements this alongside
+/// <c>IConfigService</c>; <c>ProfileRegistry</c> depends only on this
+/// interface so it can be unit-tested cross-platform against a fake.
+/// All properties return the last successfully-parsed view and are
+/// replaced atomically after a config reload; the
+/// <see cref="ProfileConfigChanged"/> event fires on the UI dispatcher
+/// once the new values are visible.
+/// </summary>
+public interface IProfileConfigSource
+{
+    /// <summary>
+    /// Parsed user-defined profiles from <c>profile.&lt;id&gt;.*</c>
+    /// blocks. Keys are lowercase-ASCII ids. Replaced on every reload.
+    /// </summary>
+    IReadOnlyDictionary<string, ProfileDef> ParsedProfiles { get; }
+
+    /// <summary>
+    /// Ids from <c>profile-order = a,b,c</c>. Empty when the key is
+    /// absent. Order is preserved; ids absent from both
+    /// <see cref="ParsedProfiles"/> and the registry's discovered list
+    /// are filtered silently by <c>ProfileOrderResolver</c>.
+    /// </summary>
+    IReadOnlyList<string> ProfileOrder { get; }
+
+    /// <summary>
+    /// Value of <c>default-profile</c>, or <see langword="null"/> when
+    /// the key is absent. The registry falls back to the first visible
+    /// profile when this id is unknown.
+    /// </summary>
+    string? DefaultProfileId { get; }
+
+    /// <summary>
+    /// Ids for which <c>profile.&lt;id&gt;.hidden = true</c> is set.
+    /// Primarily used to hide discovered profiles; for user-defined
+    /// profiles the <c>Hidden</c> flag on <see cref="ProfileDef"/>
+    /// already captures this but inclusion here is idempotent.
+    /// </summary>
+    IReadOnlySet<string> HiddenProfileIds { get; }
+
+    /// <summary>
+    /// Non-fatal warnings from <see cref="ProfileSourceParser.Parse"/>
+    /// (missing required keys, malformed visuals, etc.). Surfaced in
+    /// the settings UI in PR 6.
+    /// </summary>
+    IReadOnlyList<string> ProfileWarnings { get; }
+
+    /// <summary>
+    /// Raised on the UI dispatcher after <c>ConfigService</c> finishes
+    /// a successful reload. Fires once per reload regardless of whether
+    /// the profile-view values actually changed -- consumers must treat
+    /// recomposition as idempotent.
+    /// </summary>
+    event Action? ProfileConfigChanged;
+}

--- a/windows/Ghostty.Core/Profiles/IProfileConfigSource.cs
+++ b/windows/Ghostty.Core/Profiles/IProfileConfigSource.cs
@@ -47,7 +47,7 @@ public interface IProfileConfigSource
     /// <summary>
     /// Non-fatal warnings from <see cref="ProfileSourceParser.Parse"/>
     /// (missing required keys, malformed visuals, etc.). Surfaced in
-    /// the settings UI in PR 6.
+    /// the settings UI.
     /// </summary>
     IReadOnlyList<string> ProfileWarnings { get; }
 

--- a/windows/Ghostty.Core/Profiles/IProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/IProfileRegistry.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Ordered, UI-dispatched view of user-defined + discovered profiles.
+/// Recomposed on config reload and on discovery refresh. Consumers
+/// subscribe to <see cref="ProfilesChanged"/> and re-read
+/// <see cref="Profiles"/> / <see cref="DefaultProfileId"/> when it
+/// fires. Safe to read from any thread -- <see cref="Profiles"/> is a
+/// volatile immutable snapshot.
+/// </summary>
+public interface IProfileRegistry : IDisposable
+{
+    /// <summary>
+    /// Ordered composition of user + discovered profiles, with
+    /// user-defined entries winning on id conflicts. Never null.
+    /// </summary>
+    IReadOnlyList<ResolvedProfile> Profiles { get; }
+
+    /// <summary>
+    /// Id of the entry with <c>IsDefault = true</c> in
+    /// <see cref="Profiles"/>, or null when the list is empty.
+    /// </summary>
+    string? DefaultProfileId { get; }
+
+    /// <summary>
+    /// Monotonic counter bumped by 1 per successful recompose.
+    /// Exposed for <c>ProfileSnapshotStore</c> consumers that need a
+    /// generation id. Starts at 0 pre-ctor, reaches 1 after the ctor's
+    /// initial synchronous compose, reaches 2 after the first
+    /// background discovery completes.
+    /// </summary>
+    long Version { get; }
+
+    /// <summary>
+    /// Fired on the UI dispatcher after every successful recompose
+    /// including the two ctor-triggered emissions.
+    /// </summary>
+    event Action<IProfileRegistry>? ProfilesChanged;
+
+    /// <summary>
+    /// O(1) lookup by id against the current snapshot. Returns null
+    /// when the id is unknown.
+    /// </summary>
+    ResolvedProfile? Resolve(string profileId);
+
+    /// <summary>
+    /// Forces a probe run bypassing the 24h cache, then recomposes.
+    /// Exposed for the settings-UI "Refresh discovery" affordance.
+    /// </summary>
+    Task RefreshDiscoveryAsync(CancellationToken ct);
+}

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Composition service: merges <see cref="IProfileConfigSource"/>
+/// user-defined profiles with a discovery probe run into the ordered
+/// snapshot consumed by the settings-UI and command-palette consumers.
+/// Dispatches <see cref="IProfileRegistry.ProfilesChanged"/> on the UI
+/// thread via an injected <c>Action&lt;Action&gt;</c> (wraps
+/// <c>DispatcherQueue.TryEnqueue</c> in the production wiring).
+/// </summary>
+internal sealed partial class ProfileRegistry : IProfileRegistry
+{
+    private readonly IProfileConfigSource _source;
+    private readonly Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> _discover;
+    private readonly Action<Action> _dispatcher;
+    private readonly ILogger<ProfileRegistry> _log;
+    private readonly Lock _sync = new();
+
+    private volatile IReadOnlyList<ResolvedProfile> _profiles = Array.Empty<ResolvedProfile>();
+    private volatile FrozenDictionary<string, ResolvedProfile> _byId =
+        FrozenDictionary<string, ResolvedProfile>.Empty;
+    private long _version;
+
+    private IReadOnlyList<DiscoveredProfile> _discovered = Array.Empty<DiscoveredProfile>();
+
+    public event Action<IProfileRegistry>? ProfilesChanged;
+
+    public IReadOnlyList<ResolvedProfile> Profiles => _profiles;
+    public string? DefaultProfileId { get; private set; }
+    public long Version => Interlocked.Read(ref _version);
+
+    public ProfileRegistry(
+        IProfileConfigSource source,
+        Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> discover,
+        Action<Action> dispatcher,
+        ILogger<ProfileRegistry>? log = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(discover);
+        ArgumentNullException.ThrowIfNull(dispatcher);
+
+        _source = source;
+        _discover = discover;
+        _dispatcher = dispatcher;
+        _log = log ?? NullLogger<ProfileRegistry>.Instance;
+
+        RecomposeAndFire();
+    }
+
+    private void RecomposeAndFire()
+    {
+        IReadOnlyList<ResolvedProfile> next;
+        FrozenDictionary<string, ResolvedProfile> nextById;
+        string? nextDefault;
+
+        lock (_sync)
+        {
+            var resolved = ProfileOrderResolver.Resolve(
+                user: [.. _source.ParsedProfiles.Values],
+                discovered: _discovered,
+                profileOrder: _source.ProfileOrder,
+                defaultProfileId: _source.DefaultProfileId,
+                hidden: _source.HiddenProfileIds);
+
+            next = resolved;
+            var dict = new Dictionary<string, ResolvedProfile>(resolved.Count, StringComparer.OrdinalIgnoreCase);
+            nextDefault = null;
+            foreach (var p in resolved)
+            {
+                dict[p.Id] = p;
+                if (p.IsDefault) nextDefault = p.Id;
+            }
+            nextById = dict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        }
+
+        _profiles = next;
+        _byId = nextById;
+        DefaultProfileId = nextDefault;
+        var newVersion = Interlocked.Increment(ref _version);
+        LogRecomposed(newVersion, next.Count);
+
+        _dispatcher(() => ProfilesChanged?.Invoke(this));
+    }
+
+    public ResolvedProfile? Resolve(string profileId)
+    {
+        ArgumentNullException.ThrowIfNull(profileId);
+        return _byId.TryGetValue(profileId, out var p) ? p : null;
+    }
+
+    public Task RefreshDiscoveryAsync(CancellationToken ct)
+        => throw new NotImplementedException();
+
+    public void Dispose()
+    {
+        // Resources added in later tasks (CancellationTokenSource for
+        // background discovery, config-changed subscription). Nothing
+        // to release for the ctor-only compose path.
+    }
+
+    [LoggerMessage(EventId = LogEvents.Profiles.RegistryRecomposed,
+                   Level = LogLevel.Debug,
+                   Message = "registry recomposed: version={Version} count={Count}")]
+    private partial void LogRecomposed(long version, int count);
+}

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -157,9 +157,9 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
 
     public void Dispose()
     {
-        // Resources added in later tasks (CancellationTokenSource for
-        // background discovery, config-changed subscription). Nothing
-        // to release for the ctor-only compose path.
+        _source.ProfileConfigChanged -= OnSourceChanged;
+        _discoveryCts.Cancel();
+        _discoveryCts.Dispose();
     }
 
     [LoggerMessage(EventId = LogEvents.Profiles.RegistryRecomposed,

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -133,8 +133,27 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
         return _snapshot.ById.TryGetValue(profileId, out var p) ? p : null;
     }
 
-    public Task RefreshDiscoveryAsync(CancellationToken ct)
-        => throw new NotImplementedException();
+    public async Task RefreshDiscoveryAsync(CancellationToken ct)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _discoveryCts.Token);
+        try
+        {
+            var discovered = await _discover(true, linked.Token).ConfigureAwait(false);
+            lock (_sync)
+            {
+                _discovered = discovered;
+            }
+            RecomposeAndFire();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogDiscoveryRefreshFailed(ex);
+        }
+    }
 
     public void Dispose()
     {

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -97,6 +97,13 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
 
     private void RecomposeAndFire()
     {
+        // Disposed-guard: a probe that ignores its cancellation token
+        // can still return normally after Dispose cancels _discoveryCts.
+        // If that happens, the continuation reaches here -- skip the
+        // snapshot publish and event dispatch so subscribers don't
+        // see updates against a torn-down registry.
+        if (Volatile.Read(ref _disposed) != 0) return;
+
         IReadOnlyList<ResolvedProfile> next;
         FrozenDictionary<string, ResolvedProfile> nextById;
         string? nextDefault;
@@ -158,7 +165,12 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
         }
         catch (Exception ex)
         {
+            // User-initiated refresh: log and rethrow so the caller
+            // (settings-UI button, command palette) can show a failure
+            // toast. The bootstrap path in RunInitialDiscoveryAsync
+            // swallows by design because no caller is waiting on it.
             LogDiscoveryRefreshFailed(ex);
+            throw;
         }
     }
 

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -39,6 +39,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
     private readonly Lock _sync = new();
 
     private readonly CancellationTokenSource _discoveryCts = new();
+    private int _disposed;
 
     private volatile Snapshot _snapshot = EmptySnapshot;
     private long _version;
@@ -135,6 +136,12 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
 
     public async Task RefreshDiscoveryAsync(CancellationToken ct)
     {
+        // Dispose guard: CreateLinkedTokenSource below would throw
+        // ObjectDisposedException on _discoveryCts after Dispose, so
+        // surface the disposal explicitly instead of as a noisy fault.
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(ProfileRegistry));
+
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _discoveryCts.Token);
         try
         {
@@ -157,6 +164,10 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
 
     public void Dispose()
     {
+        // Idempotent: second call is a no-op. App.xaml.cs's shutdown
+        // path can run twice on error recovery, and CTS.Cancel throws
+        // ObjectDisposedException after the first Dispose.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
         _source.ProfileConfigChanged -= OnSourceChanged;
         _discoveryCts.Cancel();
         _discoveryCts.Dispose();

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -38,6 +38,8 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
     private readonly ILogger<ProfileRegistry> _log;
     private readonly Lock _sync = new();
 
+    private readonly CancellationTokenSource _discoveryCts = new();
+
     private volatile Snapshot _snapshot = EmptySnapshot;
     private long _version;
 
@@ -65,6 +67,28 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
         _log = log ?? NullLogger<ProfileRegistry>.Instance;
 
         RecomposeAndFire();
+        _ = RunInitialDiscoveryAsync();
+    }
+
+    private async Task RunInitialDiscoveryAsync()
+    {
+        try
+        {
+            var discovered = await _discover(false, _discoveryCts.Token).ConfigureAwait(false);
+            lock (_sync)
+            {
+                _discovered = discovered;
+            }
+            RecomposeAndFire();
+        }
+        catch (OperationCanceledException)
+        {
+            // Disposal-initiated cancellation is expected; do not log.
+        }
+        catch (Exception ex)
+        {
+            LogDiscoveryRefreshFailed(ex);
+        }
     }
 
     private void RecomposeAndFire()
@@ -120,4 +144,9 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
                    Level = LogLevel.Debug,
                    Message = "registry recomposed: version={Version} count={Count}")]
     private partial void LogRecomposed(long version, int count);
+
+    [LoggerMessage(EventId = LogEvents.Profiles.DiscoveryRefreshFailed,
+                   Level = LogLevel.Warning,
+                   Message = "discovery refresh failed")]
+    private partial void LogDiscoveryRefreshFailed(Exception ex);
 }

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -67,6 +67,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
         _log = log ?? NullLogger<ProfileRegistry>.Instance;
 
         RecomposeAndFire();
+        _source.ProfileConfigChanged += OnSourceChanged;
         _ = RunInitialDiscoveryAsync();
     }
 
@@ -90,6 +91,8 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
             LogDiscoveryRefreshFailed(ex);
         }
     }
+
+    private void OnSourceChanged() => RecomposeAndFire();
 
     private void RecomposeAndFire()
     {

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -19,23 +19,34 @@ namespace Ghostty.Core.Profiles;
 /// </summary>
 internal sealed partial class ProfileRegistry : IProfileRegistry
 {
+    // All three fields (Profiles, ById, DefaultProfileId) are published
+    // together via a single volatile reference so readers always see a
+    // consistent set -- no torn snapshot between the list and the dict.
+    private sealed record Snapshot(
+        IReadOnlyList<ResolvedProfile> Profiles,
+        FrozenDictionary<string, ResolvedProfile> ById,
+        string? DefaultProfileId);
+
+    private static readonly Snapshot EmptySnapshot = new(
+        Array.Empty<ResolvedProfile>(),
+        FrozenDictionary<string, ResolvedProfile>.Empty,
+        DefaultProfileId: null);
+
     private readonly IProfileConfigSource _source;
     private readonly Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> _discover;
     private readonly Action<Action> _dispatcher;
     private readonly ILogger<ProfileRegistry> _log;
     private readonly Lock _sync = new();
 
-    private volatile IReadOnlyList<ResolvedProfile> _profiles = Array.Empty<ResolvedProfile>();
-    private volatile FrozenDictionary<string, ResolvedProfile> _byId =
-        FrozenDictionary<string, ResolvedProfile>.Empty;
+    private volatile Snapshot _snapshot = EmptySnapshot;
     private long _version;
 
     private IReadOnlyList<DiscoveredProfile> _discovered = Array.Empty<DiscoveredProfile>();
 
     public event Action<IProfileRegistry>? ProfilesChanged;
 
-    public IReadOnlyList<ResolvedProfile> Profiles => _profiles;
-    public string? DefaultProfileId { get; private set; }
+    public IReadOnlyList<ResolvedProfile> Profiles => _snapshot.Profiles;
+    public string? DefaultProfileId => _snapshot.DefaultProfileId;
     public long Version => Interlocked.Read(ref _version);
 
     public ProfileRegistry(
@@ -82,9 +93,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
             nextById = dict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         }
 
-        _profiles = next;
-        _byId = nextById;
-        DefaultProfileId = nextDefault;
+        _snapshot = new Snapshot(next, nextById, nextDefault);
         var newVersion = Interlocked.Increment(ref _version);
         LogRecomposed(newVersion, next.Count);
 
@@ -94,7 +103,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
     public ResolvedProfile? Resolve(string profileId)
     {
         ArgumentNullException.ThrowIfNull(profileId);
-        return _byId.TryGetValue(profileId, out var p) ? p : null;
+        return _snapshot.ById.TryGetValue(profileId, out var p) ? p : null;
     }
 
     public Task RefreshDiscoveryAsync(CancellationToken ct)

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -28,44 +28,6 @@ public static partial class ProfileSourceParser
         RegexOptions.IgnoreCase)]
     private static partial Regex LineRegex();
 
-    /// <summary>
-    /// Extracts ids for which <c>profile.&lt;id&gt;.hidden = true</c>
-    /// appears. Matches the same id format as <see cref="Parse"/>
-    /// (lowercase ASCII). Ignores <c>hidden = false</c> and any other
-    /// subkey. Used by <c>ProfileRegistry</c> to suppress discovered
-    /// profiles without requiring a full user override.
-    /// </summary>
-    public static IReadOnlySet<string> ExtractHiddenIds(string configText)
-    {
-        ArgumentNullException.ThrowIfNull(configText);
-
-        if (configText.Length > 0 && configText[0] == '\uFEFF')
-            configText = configText.Substring(1);
-
-        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var rawLine in configText.Split('\n'))
-        {
-            var line = rawLine.TrimEnd('\r').Trim();
-            if (line.Length == 0 || line[0] == '#') continue;
-
-            var match = LineRegex().Match(line);
-            if (!match.Success) continue;
-
-            var subKey = match.Groups[2].Value;
-            if (!string.Equals(subKey, "hidden", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            var value = match.Groups[3].Value;
-            if (!bool.TryParse(value, out var flag) || !flag) continue;
-
-            var id = match.Groups[1].Value.ToLowerInvariant();
-            ids.Add(id);
-        }
-
-        return ids;
-    }
-
     public static ProfileParseResult Parse(string configText)
     {
         ArgumentNullException.ThrowIfNull(configText);
@@ -121,6 +83,44 @@ public static partial class ProfileSourceParser
         }
 
         return new ProfileParseResult(profiles, warnings);
+    }
+
+    /// <summary>
+    /// Extracts ids for which <c>profile.&lt;id&gt;.hidden = true</c>
+    /// appears. Matches the same id format as <see cref="Parse"/>
+    /// (lowercase ASCII). Ignores <c>hidden = false</c> and any other
+    /// subkey. Used by <c>ProfileRegistry</c> to suppress discovered
+    /// profiles without requiring a full user override.
+    /// </summary>
+    public static IReadOnlySet<string> ExtractHiddenIds(string configText)
+    {
+        ArgumentNullException.ThrowIfNull(configText);
+
+        if (configText.Length > 0 && configText[0] == '\uFEFF')
+            configText = configText.Substring(1);
+
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rawLine in configText.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r').Trim();
+            if (line.Length == 0 || line[0] == '#') continue;
+
+            var match = LineRegex().Match(line);
+            if (!match.Success) continue;
+
+            var subKey = match.Groups[2].Value;
+            if (!string.Equals(subKey, "hidden", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = match.Groups[3].Value;
+            if (!bool.TryParse(value, out var flag) || !flag) continue;
+
+            var id = match.Groups[1].Value.ToLowerInvariant();
+            ids.Add(id);
+        }
+
+        return ids;
     }
 
     private static (EffectiveVisualOverrides Value, bool HasAny) BuildVisuals(

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -28,6 +28,44 @@ public static partial class ProfileSourceParser
         RegexOptions.IgnoreCase)]
     private static partial Regex LineRegex();
 
+    /// <summary>
+    /// Extracts ids for which <c>profile.&lt;id&gt;.hidden = true</c>
+    /// appears. Matches the same id format as <see cref="Parse"/>
+    /// (lowercase ASCII). Ignores <c>hidden = false</c> and any other
+    /// subkey. Used by <c>ProfileRegistry</c> to suppress discovered
+    /// profiles without requiring a full user override.
+    /// </summary>
+    public static IReadOnlySet<string> ExtractHiddenIds(string configText)
+    {
+        ArgumentNullException.ThrowIfNull(configText);
+
+        if (configText.Length > 0 && configText[0] == '\uFEFF')
+            configText = configText.Substring(1);
+
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rawLine in configText.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r').Trim();
+            if (line.Length == 0 || line[0] == '#') continue;
+
+            var match = LineRegex().Match(line);
+            if (!match.Success) continue;
+
+            var subKey = match.Groups[2].Value;
+            if (!string.Equals(subKey, "hidden", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = match.Groups[3].Value;
+            if (!bool.TryParse(value, out var flag) || !flag) continue;
+
+            var id = match.Groups[1].Value.ToLowerInvariant();
+            ids.Add(id);
+        }
+
+        return ids;
+    }
+
     public static ProfileParseResult Parse(string configText)
     {
         ArgumentNullException.ThrowIfNull(configText);

--- a/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
@@ -113,4 +113,20 @@ public class ConfigServiceProfileParserTests
 
         Assert.Null(result.DefaultProfileId);
     }
+
+    [Fact]
+    public void ParseAll_HiddenIdIsSubstringOfMalformedId_DoesNotSuppressWarning()
+    {
+        const string text = """
+            profile.bro.hidden = true
+            profile.broken.name = NoCommand
+            """;
+        var values = new Dictionary<string, string?>();
+
+        var result = ConfigServiceProfileParser.ParseAll(text, key => FileValue(values, key));
+
+        Assert.Contains("bro", result.HiddenProfileIds);
+        Assert.Single(result.ProfileWarnings);
+        Assert.Contains("broken", result.ProfileWarnings[0]);
+    }
 }

--- a/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using Ghostty.Core.Config;
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public class ConfigServiceProfileParserTests
+{
+    private static string? FileValue(IReadOnlyDictionary<string, string?> bag, string key)
+        => bag.TryGetValue(key, out var v) ? v : null;
+
+    [Fact]
+    public void ParseAll_EmptyInputs_ReturnsEmptyView()
+    {
+        var values = new Dictionary<string, string?>();
+        var result = ConfigServiceProfileParser.ParseAll(
+            string.Empty, key => FileValue(values, key));
+
+        Assert.Empty(result.ParsedProfiles);
+        Assert.Empty(result.ProfileOrder);
+        Assert.Null(result.DefaultProfileId);
+        Assert.Empty(result.HiddenProfileIds);
+        Assert.Empty(result.ProfileWarnings);
+    }
+
+    [Fact]
+    public void ParseAll_TwoProfiles_ParsedAndOrderedAndDefault()
+    {
+        const string text = """
+            profile.a.name = A
+            profile.a.command = cmd.exe
+            profile.b.name = B
+            profile.b.command = pwsh.exe
+            """;
+        var values = new Dictionary<string, string?>
+        {
+            ["default-profile"] = "a",
+            ["profile-order"] = "b, a",
+        };
+
+        var result = ConfigServiceProfileParser.ParseAll(text, key => FileValue(values, key));
+
+        Assert.Equal(2, result.ParsedProfiles.Count);
+        Assert.Contains("a", result.ParsedProfiles.Keys);
+        Assert.Contains("b", result.ParsedProfiles.Keys);
+        Assert.Equal("a", result.DefaultProfileId);
+        Assert.Equal(new[] { "b", "a" }, result.ProfileOrder);
+        Assert.Empty(result.HiddenProfileIds);
+    }
+
+    [Fact]
+    public void ParseAll_HiddenOnlyOverride_PopulatesHiddenSet()
+    {
+        const string text = "profile.azure.hidden = true";
+        var values = new Dictionary<string, string?>();
+
+        var result = ConfigServiceProfileParser.ParseAll(text, key => FileValue(values, key));
+
+        Assert.Contains("azure", result.HiddenProfileIds);
+        Assert.Empty(result.ParsedProfiles);  // hidden-only is not a full def
+        Assert.Empty(result.ProfileWarnings);
+    }
+
+    [Fact]
+    public void ParseAll_MalformedProfile_ProducesWarning()
+    {
+        const string text = "profile.broken.name = NoCommand";  // missing command
+        var values = new Dictionary<string, string?>();
+
+        var result = ConfigServiceProfileParser.ParseAll(text, key => FileValue(values, key));
+
+        Assert.Empty(result.ParsedProfiles);
+        Assert.Single(result.ProfileWarnings);
+        Assert.Contains("broken", result.ProfileWarnings[0]);
+    }
+
+    [Fact]
+    public void ParseAll_ProfileOrderWithExtraWhitespace_IsTrimmed()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["profile-order"] = "  a ,b  ,   c",
+        };
+
+        var result = ConfigServiceProfileParser.ParseAll(string.Empty, key => FileValue(values, key));
+
+        Assert.Equal(new[] { "a", "b", "c" }, result.ProfileOrder);
+    }
+
+    [Fact]
+    public void ParseAll_EmptyProfileOrderString_YieldsEmptyList()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["profile-order"] = "",
+        };
+
+        var result = ConfigServiceProfileParser.ParseAll(string.Empty, key => FileValue(values, key));
+
+        Assert.Empty(result.ProfileOrder);
+    }
+
+    [Fact]
+    public void ParseAll_DefaultProfileEmptyString_IsNull()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["default-profile"] = "",
+        };
+
+        var result = ConfigServiceProfileParser.ParseAll(string.Empty, key => FileValue(values, key));
+
+        Assert.Null(result.DefaultProfileId);
+    }
+}

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -20,6 +20,8 @@ public class WindowsOnlyKeysTests
     [InlineData("command-palette-group-commands")]
     [InlineData("command-palette-background")]
     [InlineData("power-saver-mode")]
+    [InlineData("default-profile")]
+    [InlineData("profile-order")]
     public void Contains_KnownKey(string key)
     {
         Assert.True(WindowsOnlyKeys.Contains(key));

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -95,4 +95,35 @@ public class WindowsOnlyKeysTests
         Assert.False(WindowsOnlyKeys.TryExtractUnknownFieldKey(null!, out var key));
         Assert.Equal(string.Empty, key);
     }
+
+    [Fact]
+    public void All_Contains_DefaultProfile()
+    {
+        Assert.Contains(Ghostty.Core.Config.WindowsOnlyKeys.All,
+                        e => e.Key == "default-profile");
+    }
+
+    [Fact]
+    public void All_Contains_ProfileOrder()
+    {
+        Assert.Contains(Ghostty.Core.Config.WindowsOnlyKeys.All,
+                        e => e.Key == "profile-order");
+    }
+
+    [Theory]
+    [InlineData("profile.foo.name", true)]
+    [InlineData("profile.foo.command", true)]
+    [InlineData("profile.foo.hidden", true)]
+    [InlineData("profile.a.b", true)]                   // minimal valid
+    [InlineData("PROFILE.FOO.NAME", true)]              // case-insensitive prefix
+    [InlineData("profile.foo", false)]                  // missing subkey
+    [InlineData("profile.", false)]                     // missing id + subkey
+    [InlineData("profile", false)]                      // exact scalar
+    [InlineData("profile..bar", false)]                 // empty id
+    [InlineData("profileorder", false)]                 // no dot
+    [InlineData("default-profile", false)]              // exact scalar, not subkey
+    public void IsProfileSubkey_Expected(string key, bool expected)
+    {
+        Assert.Equal(expected, Ghostty.Core.Config.WindowsOnlyKeys.IsProfileSubkey(key));
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/DiscoveryServiceTests.cs
+++ b/windows/Ghostty.Tests/Profiles/DiscoveryServiceTests.cs
@@ -162,6 +162,12 @@ public sealed class DiscoveryServiceTests
         // Second call with bypassCache: true must run probes again.
         var _ = await warmSvc.DiscoverAsync(bypassCache: true, CancellationToken.None);
         Assert.Equal(2, probe.CallCount);
+
+        // Also assert cache was refreshed: file now has freshly-dated cache.
+        var rewritten = DiscoveryCache.Deserialize(await fs.ReadAllBytesAsync(cachePath, CancellationToken.None));
+        Assert.Equal(clock.UtcNow, rewritten!.CreatedAt);
+        Assert.Single(rewritten.Profiles);
+        Assert.Equal("a", rewritten.Profiles[0].Id);
     }
 
     internal sealed class FakeClock : IClock

--- a/windows/Ghostty.Tests/Profiles/DiscoveryServiceTests.cs
+++ b/windows/Ghostty.Tests/Profiles/DiscoveryServiceTests.cs
@@ -140,6 +140,30 @@ public sealed class DiscoveryServiceTests
         Assert.Equal("1.2.4", rewritten!.WinttyVersion);
     }
 
+    [Fact]
+    public async Task DiscoverAsync_BypassCache_AlwaysRunsProbes()
+    {
+        var fs = new Ghostty.Tests.Profiles.Fakes.FakeFileSystem();
+        var clock = new FakeClock { UtcNow = DateTimeOffset.Parse("2026-01-01T00:00:00Z") };
+        var cachePath = @"C:\wintty\cache\v1.json";
+
+        // Warm cache with a single entry so the regular code path
+        // would short-circuit.
+        var probe = new Ghostty.Tests.Profiles.Fakes.FakeInstalledShellProbe(
+            "probe-a",
+            new[] { new DiscoveredProfile(
+                Id: "a", Name: "A", Command: "a.exe", ProbeId: "probe-a",
+                WorkingDirectory: null, Icon: null, TabTitle: null) });
+        var warmSvc = new DiscoveryService(new[] { probe }, fs, clock, "1.0.0", cachePath);
+        var cacheWarm = await warmSvc.DiscoverAsync(CancellationToken.None);
+        Assert.Single(cacheWarm);
+        Assert.Equal(1, probe.CallCount);
+
+        // Second call with bypassCache: true must run probes again.
+        var _ = await warmSvc.DiscoverAsync(bypassCache: true, CancellationToken.None);
+        Assert.Equal(2, probe.CallCount);
+    }
+
     internal sealed class FakeClock : IClock
     {
         public DateTimeOffset UtcNow { get; set; }

--- a/windows/Ghostty.Tests/Profiles/FakeProfileConfigSource.cs
+++ b/windows/Ghostty.Tests/Profiles/FakeProfileConfigSource.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Tests.Profiles;
+
+/// <summary>
+/// In-memory <see cref="IProfileConfigSource"/> for registry tests.
+/// Each setter replaces the backing field and does NOT raise
+/// <see cref="ProfileConfigChanged"/>; call <see cref="Raise"/>
+/// explicitly when the test wants to simulate a config reload.
+/// </summary>
+internal sealed class FakeProfileConfigSource : IProfileConfigSource
+{
+    public IReadOnlyDictionary<string, ProfileDef> ParsedProfiles { get; set; } =
+        new Dictionary<string, ProfileDef>();
+    public IReadOnlyList<string> ProfileOrder { get; set; } = [];
+    public string? DefaultProfileId { get; set; }
+    public IReadOnlySet<string> HiddenProfileIds { get; set; } = FrozenSet<string>.Empty;
+    public IReadOnlyList<string> ProfileWarnings { get; set; } = [];
+
+    public event Action? ProfileConfigChanged;
+
+    public void Raise() => ProfileConfigChanged?.Invoke();
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -101,4 +101,42 @@ public class ProfileRegistryTests
         Assert.Single(events);
         Assert.Equal(2, events[0]);
     }
+
+    [Fact]
+    public async Task ProfileConfigChanged_RecomposesWithCachedDiscovered()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["a"] = UserDef("a"),
+            },
+        };
+
+        var discoveredOnce = new List<DiscoveredProfile>
+        {
+            new(Id: "wsl", Name: "Ubuntu", Command: "wsl.exe",
+                ProbeId: "wsl", WorkingDirectory: null, Icon: null, TabTitle: null),
+        };
+        var firstCallDone = new TaskCompletionSource();
+        Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> discovery =
+            (_, _) => { firstCallDone.TrySetResult(); return Task.FromResult<IReadOnlyList<DiscoveredProfile>>(discoveredOnce); };
+
+        using var registry = new ProfileRegistry(
+            src, discovery, SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+        await firstCallDone.Task;
+        for (int i = 0; i < 20 && registry.Version < 2; i++) await Task.Delay(5);
+
+        // Replace user profiles + raise the event; registry should
+        // recompose with the same discovered list (Version bumps to 3).
+        src.ParsedProfiles = new Dictionary<string, ProfileDef>
+        {
+            ["a"] = UserDef("a"),
+            ["b"] = UserDef("b"),
+        };
+        src.Raise();
+
+        Assert.Equal(3L, registry.Version);
+        Assert.Equal(3, registry.Profiles.Count);  // user a, b + wsl
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -139,4 +139,71 @@ public class ProfileRegistryTests
         Assert.Equal(3L, registry.Version);
         Assert.Equal(3, registry.Profiles.Count);  // user a, b + wsl
     }
+
+    [Fact]
+    public void Resolve_ReturnsProfile_WhenIdKnown()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["target"] = UserDef("target", "Target"),
+            },
+        };
+
+        using var registry = new ProfileRegistry(
+            src, EmptyDiscovery(), SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        var result = registry.Resolve("target");
+        Assert.NotNull(result);
+        Assert.Equal("target", result!.Id);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsNull_WhenIdUnknown()
+    {
+        var src = new FakeProfileConfigSource();
+        using var registry = new ProfileRegistry(
+            src, EmptyDiscovery(), SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        Assert.Null(registry.Resolve("nope"));
+    }
+
+    [Fact]
+    public void Version_IsMonotonic_AcrossRecompose()
+    {
+        var src = new FakeProfileConfigSource();
+        using var registry = new ProfileRegistry(
+            src, EmptyDiscovery(), SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        var v1 = registry.Version;
+        src.Raise();
+        var v2 = registry.Version;
+        src.Raise();
+        var v3 = registry.Version;
+
+        Assert.True(v2 > v1);
+        Assert.True(v3 > v2);
+        Assert.Equal(v1 + 1, v2);
+        Assert.Equal(v2 + 1, v3);
+    }
+
+    [Fact]
+    public void DefaultProfileId_TracksIsDefaultEntry()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["a"] = UserDef("a"),
+                ["b"] = UserDef("b"),
+            },
+            DefaultProfileId = "b",
+        };
+
+        using var registry = new ProfileRegistry(
+            src, EmptyDiscovery(), SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        Assert.Equal("b", registry.DefaultProfileId);
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -233,4 +233,34 @@ public class ProfileRegistryTests
         Assert.Equal(1, callsWithBypass);     // explicit refresh
         Assert.Equal(1, eventsBefore);        // one recompose event after refresh
     }
+
+    [Fact]
+    public async Task DiscoveryThrows_KeepsPriorState_DoesNotFireEvent()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["user"] = UserDef("user"),
+            },
+        };
+        var throwOnBootstrap = new TaskCompletionSource<IReadOnlyList<DiscoveredProfile>>();
+        Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> discovery =
+            (_, _) => throwOnBootstrap.Task;
+
+        using var registry = new ProfileRegistry(
+            src, discovery, SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        var versionBefore = registry.Version;
+        var eventsFiredAfterSubscribe = 0;
+        registry.ProfilesChanged += _ => eventsFiredAfterSubscribe++;
+
+        throwOnBootstrap.SetException(new InvalidOperationException("boom"));
+        // Give the continuation time to run.
+        for (int i = 0; i < 20; i++) await Task.Delay(5);
+
+        Assert.Equal(versionBefore, registry.Version);        // unchanged
+        Assert.Single(registry.Profiles);                      // user still there
+        Assert.Equal(0, eventsFiredAfterSubscribe);            // no event after failure
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -263,4 +263,32 @@ public class ProfileRegistryTests
         Assert.Single(registry.Profiles);                      // user still there
         Assert.Equal(0, eventsFiredAfterSubscribe);            // no event after failure
     }
+
+    [Fact]
+    public async Task Dispose_CancelsPendingDiscovery_AndUnsubscribesSource()
+    {
+        var src = new FakeProfileConfigSource();
+        var tcs = new TaskCompletionSource<IReadOnlyList<DiscoveredProfile>>();
+        Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> discovery =
+            (_, ct) =>
+            {
+                ct.Register(() => tcs.TrySetCanceled(ct));
+                return tcs.Task;
+            };
+
+        var registry = new ProfileRegistry(
+            src, discovery, SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        var eventsAfterDispose = 0;
+        registry.ProfilesChanged += _ => eventsAfterDispose++;
+
+        registry.Dispose();
+
+        // Post-dispose: raising ProfileConfigChanged must not fire events.
+        src.Raise();
+
+        // Pending discovery is cancelled.
+        await Assert.ThrowsAsync<TaskCanceledException>(() => tcs.Task);
+        Assert.Equal(0, eventsAfterDispose);
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -59,4 +59,46 @@ public class ProfileRegistryTests
         Assert.Equal(2, registry.Profiles.Count);
         Assert.Equal("a", registry.DefaultProfileId);
     }
+
+    [Fact]
+    public async Task DiscoveryCompletes_FiresSecondEvent_WithDiscovered()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["user-a"] = UserDef("user-a", "User A"),
+            },
+            DefaultProfileId = "user-a",
+        };
+
+        var tcs = new TaskCompletionSource<IReadOnlyList<DiscoveredProfile>>();
+        Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> deferred =
+            (_, _) => tcs.Task;
+
+        var events = new List<int>();
+        using var registry = new ProfileRegistry(
+            src, deferred, SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+        registry.ProfilesChanged += r => events.Add(r.Profiles.Count);
+
+        // Version is 1, Profiles has only the user entry.
+        Assert.Equal(1L, registry.Version);
+        Assert.Single(registry.Profiles);
+
+        // Complete discovery with one discovered profile.
+        tcs.SetResult(new List<DiscoveredProfile>
+        {
+            new(Id: "wsl-ubuntu", Name: "Ubuntu", Command: "wsl.exe",
+                ProbeId: "wsl", WorkingDirectory: null, Icon: null, TabTitle: null),
+        });
+
+        // Give the continuation a chance to run.
+        await Task.Yield();
+        for (int i = 0; i < 20 && registry.Version < 2; i++) await Task.Delay(5);
+
+        Assert.Equal(2L, registry.Version);
+        Assert.Equal(2, registry.Profiles.Count);
+        Assert.Single(events);
+        Assert.Equal(2, events[0]);
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public class ProfileRegistryTests
+{
+    // Test shim: the registry takes a dispatch delegate (Action<Action>)
+    // so tests can run everything synchronously on the calling thread.
+    private static readonly Action<Action> SynchronousDispatcher = a => a();
+
+    // Discovery delegate returning an empty list synchronously. Later
+    // tests use a TaskCompletionSource to control completion timing.
+    private static Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> EmptyDiscovery()
+        => (_, _) => Task.FromResult<IReadOnlyList<DiscoveredProfile>>(Array.Empty<DiscoveredProfile>());
+
+    private static ProfileDef UserDef(string id, string name = "", string command = "cmd.exe")
+        => new(
+            Id: id,
+            Name: name.Length > 0 ? name : id,
+            Command: command,
+            WorkingDirectory: null,
+            Icon: null,
+            TabTitle: null,
+            Hidden: false,
+            ProbeId: null,
+            VisualsOrNull: null);
+
+    [Fact]
+    public void Ctor_FiresInitialEvent_UserOnlyCompose()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["a"] = UserDef("a", "A"),
+                ["b"] = UserDef("b", "B"),
+            },
+            DefaultProfileId = "a",
+        };
+
+        using var registry = new ProfileRegistry(
+            src,
+            EmptyDiscovery(),
+            SynchronousDispatcher,
+            NullLogger<ProfileRegistry>.Instance);
+
+        // Post-ctor, the registry has already done an initial synchronous
+        // compose (discovery is still running). We verify via direct state
+        // reads; the Ctor fires events synchronously before returning so
+        // subscribers that only need "subsequent changes" add their handler
+        // after construction.
+        Assert.True(registry.Version >= 1);
+        Assert.Equal(2, registry.Profiles.Count);
+        Assert.Equal("a", registry.DefaultProfileId);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -206,4 +206,31 @@ public class ProfileRegistryTests
 
         Assert.Equal("b", registry.DefaultProfileId);
     }
+
+    [Fact]
+    public async Task RefreshDiscoveryAsync_BypassesCache_AndFiresEvent()
+    {
+        var src = new FakeProfileConfigSource();
+        var callsWithBypass = 0;
+        var callsWithoutBypass = 0;
+        Func<bool, CancellationToken, Task<IReadOnlyList<DiscoveredProfile>>> discovery =
+            (bypass, _) =>
+            {
+                if (bypass) callsWithBypass++; else callsWithoutBypass++;
+                return Task.FromResult<IReadOnlyList<DiscoveredProfile>>(Array.Empty<DiscoveredProfile>());
+            };
+
+        using var registry = new ProfileRegistry(
+            src, discovery, SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+        for (int i = 0; i < 20 && registry.Version < 2; i++) await Task.Delay(5);
+
+        var eventsBefore = 0;
+        registry.ProfilesChanged += _ => eventsBefore++;
+
+        await registry.RefreshDiscoveryAsync(CancellationToken.None);
+
+        Assert.Equal(1, callsWithoutBypass);  // initial bootstrap
+        Assert.Equal(1, callsWithBypass);     // explicit refresh
+        Assert.Equal(1, eventsBefore);        // one recompose event after refresh
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
@@ -1,0 +1,96 @@
+using System.Linq;
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public class ProfileSourceParserHiddenIdsTests
+{
+    [Fact]
+    public void ExtractHiddenIds_EmptyText_ReturnsEmpty()
+    {
+        var result = ProfileSourceParser.ExtractHiddenIds(string.Empty);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_HiddenTrue_ReturnsId()
+    {
+        const string text = "profile.azure.hidden = true";
+        var result = ProfileSourceParser.ExtractHiddenIds(text);
+        Assert.Single(result);
+        Assert.Contains("azure", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_HiddenFalse_IsIgnored()
+    {
+        const string text = "profile.azure.hidden = false";
+        var result = ProfileSourceParser.ExtractHiddenIds(text);
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("profile.FOO.hidden = TRUE", "foo")]
+    [InlineData("profile.Bar.HIDDEN = True", "bar")]
+    public void ExtractHiddenIds_CaseInsensitive(string line, string expectedId)
+    {
+        var result = ProfileSourceParser.ExtractHiddenIds(line);
+        Assert.Contains(expectedId, result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_StripsBom()
+    {
+        const string text = "\uFEFFprofile.azure.hidden = true";
+        var result = ProfileSourceParser.ExtractHiddenIds(text);
+        Assert.Contains("azure", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_MixedWithOtherKeys_OnlyHiddenExtracted()
+    {
+        const string text = """
+            profile.full.name = Full
+            profile.full.command = cmd.exe
+            profile.full.hidden = true
+            profile.azure.hidden = true
+            profile.visible.name = Visible
+            profile.visible.command = pwsh.exe
+            """;
+        var result = ProfileSourceParser.ExtractHiddenIds(text);
+        Assert.Equal(2, result.Count);
+        Assert.Contains("full", result);
+        Assert.Contains("azure", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_IgnoresCommentsAndBlanks()
+    {
+        const string text = """
+
+            # profile.ignored.hidden = true
+            profile.real.hidden = true
+            """;
+        var result = ProfileSourceParser.ExtractHiddenIds(text);
+        Assert.Single(result);
+        Assert.Contains("real", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_InvalidIdCharacters_AreIgnored()
+    {
+        // Same regex as Parse -- id must be [a-z0-9-]+
+        const string text = "profile.BAD_ID.hidden = true";
+        var result = ProfileSourceParser.ExtractHiddenIds(text);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ExtractHiddenIds_NonHiddenSubkey_Ignored()
+    {
+        const string text = "profile.azure.name = Azure";
+        var result = ProfileSourceParser.ExtractHiddenIds(text);
+        Assert.Empty(result);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
@@ -1,10 +1,9 @@
-using System.Linq;
 using Ghostty.Core.Profiles;
 using Xunit;
 
 namespace Ghostty.Tests.Profiles;
 
-public class ProfileSourceParserHiddenIdsTests
+public sealed class ProfileSourceParserHiddenIdsTests
 {
     [Fact]
     public void ExtractHiddenIds_EmptyText_ReturnsEmpty()

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -53,6 +53,8 @@ public partial class App : Application
     private ConfigFileEditor? _configEditor;
     private ConfigWriteScheduler? _configWriteScheduler;
     private WindowsPowerStateMonitor? _powerStateMonitor;
+    private Ghostty.Core.Profiles.DiscoveryService? _discoveryService;
+    private Ghostty.Core.Profiles.ProfileRegistry? _profileRegistry;
     private GhosttyHost? _bootstrapHost;
     private HostLifetimeSupervisor? _lifetimeSupervisor;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
@@ -86,6 +88,7 @@ public partial class App : Application
 
     internal static GhosttyHost? BootstrapHost { get; private set; }
     internal static ConfigService? ConfigService { get; private set; }
+    internal static Ghostty.Core.Profiles.IProfileRegistry? ProfileRegistry { get; private set; }
 
     /// <summary>
     /// Process-wide power-saving-mode monitor. Null before OnLaunched
@@ -467,6 +470,40 @@ public partial class App : Application
             logger: factory.CreateLogger<ConfigWriteScheduler>());
         ConfigWriteScheduler = _configWriteScheduler;
 
+        // Profiles discovery + composition. No UI consumer lands yet,
+        // but the registry bootstraps here so future settings-UI and
+        // command-palette consumers can plug in without touching this
+        // file again.
+        var discoveryCachePath = System.IO.Path.Combine(
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
+            "Wintty", "DiscoveryCache", "v1.json");
+        var winttyVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "dev";
+
+        var processRunner = new Ghostty.Core.Profiles.WindowsProcessRunner();
+        var registryReader = new Ghostty.Core.Profiles.WindowsRegistryReader();
+        var fileSystem = new Ghostty.Core.Profiles.WindowsFileSystem();
+
+        var probes = new Ghostty.Core.Profiles.IInstalledShellProbe[]
+        {
+            new Ghostty.Core.Profiles.Probes.CmdProbe(fileSystem),
+            new Ghostty.Core.Profiles.Probes.PowerShellProbe(fileSystem, processRunner),
+            new Ghostty.Core.Profiles.Probes.WslProbe(processRunner),
+            new Ghostty.Core.Profiles.Probes.GitBashProbe(registryReader, fileSystem),
+            new Ghostty.Core.Profiles.Probes.AzureCloudShellProbe(processRunner),
+        };
+
+        _discoveryService = new Ghostty.Core.Profiles.DiscoveryService(
+            probes, fileSystem, Ghostty.Core.Logging.SystemClock.Instance,
+            winttyVersion, discoveryCachePath,
+            factory.CreateLogger<Ghostty.Core.Profiles.DiscoveryService>());
+
+        _profileRegistry = new Ghostty.Core.Profiles.ProfileRegistry(
+            source: _configService,
+            discover: (bypass, ct) => _discoveryService.DiscoverAsync(bypass, ct),
+            dispatcher: action => uiDispatcher.TryEnqueue(() => action()),
+            log: factory.CreateLogger<Ghostty.Core.Profiles.ProfileRegistry>());
+        ProfileRegistry = _profileRegistry;
+
         // One-shot migration of the legacy ui-settings.json into the
         // real config + a placement-only window-state.json. Runs
         // before the first window opens so MainWindow's initial reads
@@ -564,6 +601,16 @@ public partial class App : Application
         {
             try
             {
+                // Dispose the registry first: its Dispose cancels any
+                // pending discovery and unsubscribes from
+                // _configService's ProfileConfigChanged event. The
+                // DiscoveryService holds no unmanaged resources, so
+                // we just drop the ref and let GC claim it.
+                _profileRegistry?.Dispose();
+                _profileRegistry = null;
+                ProfileRegistry = null;
+                _discoveryService = null;
+
                 // Flush any pending debounced writes before the editor
                 // is gone. Dispose waits for an in-flight timer
                 // callback so disk writes happen-before the host tears

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -607,9 +607,6 @@ public partial class App : Application
                 // DiscoveryService holds no unmanaged resources, so
                 // we just drop the ref and let GC claim it.
                 _profileRegistry?.Dispose();
-                _profileRegistry = null;
-                ProfileRegistry = null;
-                _discoveryService = null;
 
                 // Flush any pending debounced writes before the editor
                 // is gone. Dispose waits for an in-flight timer
@@ -669,6 +666,9 @@ public partial class App : Application
             }
             finally
             {
+                _profileRegistry = null;
+                ProfileRegistry = null;
+                _discoveryService = null;
                 _configWriteScheduler = null;
                 ConfigWriteScheduler = null;
                 _configEditor = null;

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -24,7 +24,7 @@ internal readonly record struct GradientPoint(
 /// Fires <see cref="ConfigChanged"/> on the UI thread after every
 /// successful reload so consumers can re-read values they depend on.
 /// </summary>
-internal sealed class ConfigService : IConfigService
+internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IProfileConfigSource
 {
     private GhosttyConfig _config;
     private GhosttyApp _app;
@@ -100,6 +100,14 @@ internal sealed class ConfigService : IConfigService
 
     public IReadOnlyList<string> WindowsOnlyKeysUsed => _windowsOnlyKeysUsed;
 
+    public IReadOnlyDictionary<string, Ghostty.Core.Profiles.ProfileDef> ParsedProfiles => _parsedProfiles;
+    public IReadOnlyList<string> ProfileOrder => _profileOrder;
+    public string? DefaultProfileId => _defaultProfileId;
+    public IReadOnlySet<string> HiddenProfileIds => _hiddenProfileIds;
+    public IReadOnlyList<string> ProfileWarnings => _profileWarnings;
+
+    public event Action? ProfileConfigChanged;
+
     /// <summary>
     /// Filtered diagnostic messages from the last load/reload.
     /// "Unknown field" errors for <see cref="WindowsOnlyKeys"/> are
@@ -123,6 +131,13 @@ internal sealed class ConfigService : IConfigService
     /// </summary>
     private readonly HashSet<string> _windowsOnlyKeysSeen =
         new(StringComparer.OrdinalIgnoreCase);
+
+    private IReadOnlyDictionary<string, Ghostty.Core.Profiles.ProfileDef> _parsedProfiles =
+        new Dictionary<string, Ghostty.Core.Profiles.ProfileDef>();
+    private IReadOnlyList<string> _profileOrder = Array.Empty<string>();
+    private string? _defaultProfileId;
+    private IReadOnlySet<string> _hiddenProfileIds = System.Collections.Frozen.FrozenSet<string>.Empty;
+    private IReadOnlyList<string> _profileWarnings = Array.Empty<string>();
 
     /// <summary>
     /// Snapshot of the config file's key/value lines, populated at the
@@ -220,7 +235,11 @@ internal sealed class ConfigService : IConfigService
 
         _suppressWatcher = wasSuppressed;
 
-        _dispatcher.TryEnqueue(() => ConfigChanged?.Invoke(this));
+        _dispatcher.TryEnqueue(() =>
+        {
+            ConfigChanged?.Invoke(this);
+            ProfileConfigChanged?.Invoke();
+        });
         return true;
     }
 
@@ -433,6 +452,28 @@ internal sealed class ConfigService : IConfigService
         }
 
         AnsiPalette = GetAllPaletteColors();
+
+        // Profile-view second pass. Reuses the raw file read done at
+        // the top of ReadFlags via _configFileCache; the parser only
+        // needs the raw text for profile.<id>.* regex matching and for
+        // the hidden-ids extraction. The scalar keys (default-profile
+        // and profile-order) are read through GetFileValue which hits
+        // the same cache.
+        var rawConfigText = File.Exists(ConfigFilePath)
+            ? File.ReadAllText(ConfigFilePath)
+            : string.Empty;
+        var view = Ghostty.Core.Config.ConfigServiceProfileParser.ParseAll(
+            rawConfigText,
+            key =>
+            {
+                var v = GetFileValue(key, string.Empty);
+                return v.Length == 0 ? null : v;
+            });
+        _parsedProfiles = view.ParsedProfiles;
+        _profileOrder = view.ProfileOrder;
+        _defaultProfileId = view.DefaultProfileId;
+        _hiddenProfileIds = view.HiddenProfileIds;
+        _profileWarnings = view.ProfileWarnings;
     }
 
     /// <summary>

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -272,12 +272,23 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
             // Filter "unknown field" diagnostics for keys we know are
             // Windows-only; surface them via WindowsOnlyKeysUsed instead.
-            if (WindowsOnlyKeys.TryExtractUnknownFieldKey(message, out var key)
-                && WindowsOnlyKeys.Contains(key))
+            if (WindowsOnlyKeys.TryExtractUnknownFieldKey(message, out var key))
             {
-                if (_windowsOnlyKeysSeen.Add(key))
-                    _windowsOnlyKeysUsed.Add(key);
-                continue;
+                if (WindowsOnlyKeys.IsProfileSubkey(key))
+                {
+                    // profile.<id>.<subkey> keys are handled by
+                    // ProfileRegistry; suppress the diagnostic entirely
+                    // without surfacing a per-subkey entry in
+                    // WindowsOnlyKeysUsed (would flood the settings UI
+                    // notice list for a many-profile config).
+                    continue;
+                }
+                if (WindowsOnlyKeys.Contains(key))
+                {
+                    if (_windowsOnlyKeysSeen.Add(key))
+                        _windowsOnlyKeysUsed.Add(key);
+                    continue;
+                }
             }
 
             _diagnosticMessages.Add(message);

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -100,11 +100,16 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
     public IReadOnlyList<string> WindowsOnlyKeysUsed => _windowsOnlyKeysUsed;
 
-    public IReadOnlyDictionary<string, Ghostty.Core.Profiles.ProfileDef> ParsedProfiles => _parsedProfiles;
-    public IReadOnlyList<string> ProfileOrder => _profileOrder;
-    public string? DefaultProfileId => _defaultProfileId;
-    public IReadOnlySet<string> HiddenProfileIds => _hiddenProfileIds;
-    public IReadOnlyList<string> ProfileWarnings => _profileWarnings;
+    // Profile view is published atomically via a single volatile
+    // ProfileView reference so non-UI consumers see a consistent
+    // five-field set without tearing. IProfileConfigSource is public,
+    // so while today's only consumer (ProfileRegistry) reads via the
+    // UI-dispatched event, future worker-thread consumers are safe.
+    public IReadOnlyDictionary<string, Ghostty.Core.Profiles.ProfileDef> ParsedProfiles => _profileView.ParsedProfiles;
+    public IReadOnlyList<string> ProfileOrder => _profileView.ProfileOrder;
+    public string? DefaultProfileId => _profileView.DefaultProfileId;
+    public IReadOnlySet<string> HiddenProfileIds => _profileView.HiddenProfileIds;
+    public IReadOnlyList<string> ProfileWarnings => _profileView.ProfileWarnings;
 
     public event Action? ProfileConfigChanged;
 
@@ -132,12 +137,14 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     private readonly HashSet<string> _windowsOnlyKeysSeen =
         new(StringComparer.OrdinalIgnoreCase);
 
-    private IReadOnlyDictionary<string, Ghostty.Core.Profiles.ProfileDef> _parsedProfiles =
-        new Dictionary<string, Ghostty.Core.Profiles.ProfileDef>();
-    private IReadOnlyList<string> _profileOrder = Array.Empty<string>();
-    private string? _defaultProfileId;
-    private IReadOnlySet<string> _hiddenProfileIds = System.Collections.Frozen.FrozenSet<string>.Empty;
-    private IReadOnlyList<string> _profileWarnings = Array.Empty<string>();
+    private static readonly Ghostty.Core.Config.ProfileView EmptyProfileView = new(
+        ParsedProfiles: new Dictionary<string, Ghostty.Core.Profiles.ProfileDef>(),
+        ProfileOrder: Array.Empty<string>(),
+        DefaultProfileId: null,
+        HiddenProfileIds: System.Collections.Frozen.FrozenSet<string>.Empty,
+        ProfileWarnings: Array.Empty<string>());
+
+    private volatile Ghostty.Core.Config.ProfileView _profileView = EmptyProfileView;
 
     /// <summary>
     /// Snapshot of the config file's key/value lines, populated at the
@@ -464,12 +471,16 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
         AnsiPalette = GetAllPaletteColors();
 
-        // Profile-view second pass. Reuses the raw file read done at
-        // the top of ReadFlags via _configFileCache; the parser only
-        // needs the raw text for profile.<id>.* regex matching and for
-        // the hidden-ids extraction. The scalar keys (default-profile
+        // Profile-view second pass. The scalar keys (default-profile
         // and profile-order) are read through GetFileValue which hits
-        // the same cache.
+        // the parsed line cache populated at the top of ReadFlags.
+        // The profile.<id>.* regex and hidden-id extraction need the
+        // raw file text though, and _configFileCache stores parsed
+        // pairs rather than the original bytes, so this second read is
+        // deliberate -- the reload is already cold-path and the config
+        // is small. Readers of the five profile-view properties see a
+        // consistent snapshot via the single volatile _profileView
+        // assignment below.
         var rawConfigText = File.Exists(ConfigFilePath)
             ? File.ReadAllText(ConfigFilePath)
             : string.Empty;
@@ -480,11 +491,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
                 var v = GetFileValue(key, string.Empty);
                 return v.Length == 0 ? null : v;
             });
-        _parsedProfiles = view.ParsedProfiles;
-        _profileOrder = view.ProfileOrder;
-        _defaultProfileId = view.DefaultProfileId;
-        _hiddenProfileIds = view.HiddenProfileIds;
-        _profileWarnings = view.ProfileWarnings;
+        _profileView = view;
 
         foreach (var warning in view.ProfileWarnings)
             StaticLoggers.ConfigService.LogProfileParseWarning(warning);

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -485,6 +485,9 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         _defaultProfileId = view.DefaultProfileId;
         _hiddenProfileIds = view.HiddenProfileIds;
         _profileWarnings = view.ProfileWarnings;
+
+        foreach (var warning in view.ProfileWarnings)
+            StaticLoggers.ConfigService.LogProfileParseWarning(warning);
     }
 
     /// <summary>
@@ -923,4 +926,16 @@ internal static partial class ConfigServiceLogExtensions
                    Message = "[ConfigService] Reload failed to create new config")]
     internal static partial void LogReloadFailed(
         this ILogger<ConfigService> logger, System.Exception ex);
+
+    // Surfaces each warning string returned by
+    // ConfigServiceProfileParser.ParseAll so admin-visible parse
+    // issues (malformed profile blocks, unknown ids, etc.) land in
+    // the log stream rather than only in the _profileWarnings
+    // field. Warning level because the reload still succeeds --
+    // the offending block is just skipped.
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Profiles.ProfileParseWarning,
+                   Level = LogLevel.Warning,
+                   Message = "[ConfigService] profile parse: {Warning}")]
+    internal static partial void LogProfileParseWarning(
+        this ILogger<ConfigService> logger, string warning);
 }


### PR DESCRIPTION
**IMPORTANT:** PR 3 of 6 in the Windows profiles V1 stack. Parents: wintty#328 (PR 1, pure-logic foundation) and wintty#333 (PR 2, discovery probes). Merge in order; do not squash-merge out of sequence.

## Summary

Wires the profiles pipeline end to end for the Windows app:

- `ConfigService` gets a second-pass parser that reads `profile.<id>.<subkey>`, `default-profile`, `profile-order`, and the hidden-profile filter from the config file on every reload. Results are published atomically via a single volatile `ProfileView` record so readers never see a torn snapshot across the five profile properties. Warnings surface through `LoggerMessage`.
- `ProfileRegistry` composes user-defined entries with the discovery probe results into an ordered, id-keyed snapshot. Recomposition runs on ctor (synchronous user-only pass), on `ProfileConfigChanged`, and on discovery completion / refresh. The snapshot is a single volatile record (list + `FrozenDictionary` + default id) to keep `Resolve`, `Profiles`, and `DefaultProfileId` mutually consistent.
- `App.xaml.cs` instantiates `DiscoveryService` + `ProfileRegistry` during bootstrap and null-guards both in the shutdown finally. `ProfileRegistry.Dispose` is idempotent (exchange-guarded flag) so the double-dispose path on shutdown error recovery does not throw.
- `RefreshDiscoveryAsync` surfaces `ObjectDisposedException` explicitly rather than faulting inside `CreateLinkedTokenSource` after disposal.

## Test plan

- [x] `Ghostty.Tests` green (includes new FakeProfileConfigSource + registry behavior pins).
- [x] Full solution build (`Ghostty.sln`) clean.
- [x] Manual smoke: `just run-win` boots through ConfigService -> DiscoveryService -> ProfileRegistry, writes `%LOCALAPPDATA%\Wintty\DiscoveryCache\v1.json` with 6 resolved profiles (cmd, pwsh-7, pwsh-windows, 2x wsl, git-bash), shuts down cleanly with no crash log.
- [x] Rebased on current `windows` (clean 26/26), TabHost diff empty vs base.