### PR TITLE
fix(glslang): use absolute path to sort.exe in build_msvc.bat

### DIFF
--- a/pkg/glslang/build_msvc.bat
+++ b/pkg/glslang/build_msvc.bat
@@ -9,7 +9,10 @@ if not defined MSVC_DIR (
         for /f "usebackq delims=" %%d in (`"!VSWHERE!" -latest -property installationPath`) do set "VS_PATH=%%d"
     )
     if defined VS_PATH (
-        for /f "usebackq delims=" %%t in (`dir /b /ad "!VS_PATH!\VC\Tools\MSVC" 2^>nul ^| sort /r`) do (
+        REM Use absolute path to sort.exe: GNU coreutils sort from git-bash/MSYS2/WSL
+        REM on PATH ahead of System32 silently shadows Windows sort and treats /r as
+        REM a filename, which empties this loop and breaks SDK auto-detection.
+        for /f "usebackq delims=" %%t in (`dir /b /ad "!VS_PATH!\VC\Tools\MSVC" 2^>nul ^| %SystemRoot%\System32\sort.exe /r`) do (
             set "MSVC_DIR=!VS_PATH!\VC\Tools\MSVC\%%t"
             goto :found_msvc
         )
@@ -36,7 +39,8 @@ REM Discover Windows SDK version (use latest)
 set WINSDK_VER=
 set WINSDK_ROOT=%ProgramFiles(x86)%\Windows Kits\10
 if exist "%WINSDK_ROOT%\Include" (
-    for /f "delims=" %%v in ('dir /b /ad "%WINSDK_ROOT%\Include" 2^>nul ^| sort /r') do (
+    REM Absolute path to sort.exe; see comment above on shadowed PATH lookups.
+    for /f "delims=" %%v in ('dir /b /ad "%WINSDK_ROOT%\Include" 2^>nul ^| %SystemRoot%\System32\sort.exe /r') do (
         if exist "%WINSDK_ROOT%\Include\%%v\um" (
             set WINSDK_VER=%%v
             goto :found_sdk


### PR DESCRIPTION
`build_msvc.bat` uses bare `sort /r` on lines 12 and 39 to discover the latest installed MSVC tools dir and Windows SDK version. On developer machines with git-bash, MSYS2, or WSL ahead of `%SystemRoot%\System32` on PATH, GNU coreutils `sort` shadows Windows `sort.exe` and interprets the `/r` reverse flag as a filename argument. It exits with `sort: cannot read: /r: No such file or directory`, the surrounding `for /f` loop receives no input, `MSVC_DIR` and `WINSDK_VER` never get set, and the script either errors with "Could not find Windows SDK" or silently produces no `.obj` files. Downstream `zig build -Dapp-runtime=none` then fails with `error: failed to open object .../msvc_build/CodeGen.obj: FileNotFound`.

Use the absolute path `%SystemRoot%\System32\sort.exe` so the PATH lookup can't be shadowed. Confirmed in repro: with this fix, `build_msvc.bat` runs to completion and produces all expected `.obj` files; without it, fails immediately on any shell whose PATH carries a Unix-style toolchain.