### PR TITLE
build(glslang): run build_msvc.bat from zig for native-msvc target

### DIFF
--- a/pkg/glslang/build.zig
+++ b/pkg/glslang/build.zig
@@ -56,6 +56,33 @@ fn buildGlslang(
     // to avoid C++ ABI issues between Zig's bundled Clang and MSVC's C++ runtime
     // when the resulting DLL is loaded by .NET.
     if (target.result.abi == .msvc) {
+        // Pre-build glslang to .obj files via MSVC cl.exe. Run as a build step
+        // so `zig build` is one-shot for new contributors and CI; previously
+        // required a manual `cmd /c pkg/glslang/build_msvc.bat` from a VS
+        // Developer Shell before `zig build`, which only failed at the
+        // .obj-consumption step with a confusing "FileNotFound" error and no
+        // hint about the missing pre-step. The bat must run from a VS
+        // Developer Shell (cl.exe + Windows SDK on PATH); this is already a
+        // hard requirement of the .msvc target. The host platform check
+        // narrows this to Windows because cl.exe doesn't exist on
+        // linux/macos hosts cross-compiling to .msvc (rare, but defensive).
+        //
+        // Caching is best-effort: addSystemCommand has no native way to
+        // express "this step produces these specific .obj files," so the
+        // step is treated as side-effecting and re-runs every time it
+        // appears in the graph. The bat itself uses cl.exe /c which does
+        // not skip up-to-date sources, so cold-build cost is ~10-30s.
+        // Acceptable for v1; can optimize later with a stamp-file scheme.
+        if (target.result.os.tag == .windows) {
+            const bat_step = b.addSystemCommand(&.{
+                "cmd.exe",
+                "/c",
+                b.pathFromRoot("build_msvc.bat"),
+            });
+            bat_step.setName("build_msvc.bat (glslang)");
+            lib.step.dependOn(&bat_step.step);
+        }
+
         // Merge the MSVC-compiled objects directly into this library.
         // We use a dummy C file so the library has at least one compilation unit.
         lib.addCSourceFiles(.{


### PR DESCRIPTION
`pkg/glslang/build.zig` adds ~38 pre-built `.obj` files via `lib.addObjectFile(...)`, but nothing in zig produces them. Today the developer must manually invoke `pkg/glslang/build_msvc.bat` from a VS Developer Shell before running `zig build` for the native-msvc target. Skipping the pre-step fails downstream with `error: failed to open object .../msvc_build/CodeGen.obj: FileNotFound`, with no hint that a separate script was needed. New contributors and CI alike trip on this.

Wrap the bat in a `b.addSystemCommand` build step gated on `target.result.os.tag == .windows and target.result.abi == .msvc`, and make the library's compile step depend on it. `zig build` is now one-shot. The bat itself is unchanged and still callable directly for anyone who wants to run it standalone.

Caching is best-effort: zig has no native expression for "this step produces these specific files," so the bat may re-run more often than strictly necessary. Cold cost is ~10-30s and the result is byte-identical when sources don't change; optimizing this is a follow-up.

Complementary fix: # 338 makes the bat itself robust to GNU `sort` shadowing on Unix-style PATHs. Either PR is independently useful; together they make `zig build` for native-msvc work cleanly on every dev machine.