### PR TITLE
profiles pr 6/6: settings page (read-only inspector + hide toggle)

### DIFF
--- a/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
+++ b/windows/Ghostty.Core/Config/ConfigServiceProfileParser.cs
@@ -38,9 +38,13 @@ public static class ConfigServiceProfileParser
         var profileOrder = ParseCsv(profileOrderRaw);
 
         // Suppress warnings for ids that appear only as a hidden-override
-        // (e.g. "profile.foo.hidden = true" with no name/command). These
-        // are intentional suppression markers, not malformed definitions.
-        var warnings = FilterHiddenOnlyWarnings(parsed.Warnings, parsed.Profiles, hidden);
+        // (e.g. "profile.foo.hidden = true" or "= false" with no
+        // name/command). Both directions are intentional suppression
+        // markers, not malformed definitions; the un-hide path of the
+        // settings-page toggle writes hidden = false, so filtering only
+        // on the true-set would leak false-positive warnings.
+        var hiddenMentions = ProfileSourceParser.ExtractHiddenMentionIds(configText);
+        var warnings = FilterHiddenOnlyWarnings(parsed.Warnings, parsed.Profiles, hiddenMentions);
 
         return new ProfileView(
             ParsedProfiles: parsed.Profiles,
@@ -58,21 +62,21 @@ public static class ConfigServiceProfileParser
     private static IReadOnlyList<string> FilterHiddenOnlyWarnings(
         IReadOnlyList<string> warnings,
         IReadOnlyDictionary<string, ProfileDef> profiles,
-        IReadOnlySet<string> hidden)
+        IReadOnlySet<string> hiddenMentions)
     {
         if (warnings.Count == 0) return warnings;
 
-        // Precompute the "profile '<id>':" prefixes once per hidden id
+        // Precompute the "profile '<id>':" prefixes once per mentioned id
         // rather than per (warning x id) pair; the old string interpolation
         // inside the inner loop allocated a new format string on every
         // iteration. Skip ids that also have a full parsed definition --
         // those warnings are for genuinely broken blocks, not hide-only
         // overrides.
         List<string>? prefixes = null;
-        foreach (var id in hidden)
+        foreach (var id in hiddenMentions)
         {
             if (profiles.ContainsKey(id)) continue;
-            (prefixes ??= new List<string>(hidden.Count)).Add($"profile '{id}':");
+            (prefixes ??= new List<string>(hiddenMentions.Count)).Add($"profile '{id}':");
         }
         if (prefixes is null) return warnings;
 

--- a/windows/Ghostty.Core/Profiles/IProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/IProfileRegistry.cs
@@ -22,6 +22,17 @@ public interface IProfileRegistry : IDisposable
     IReadOnlyList<ResolvedProfile> Profiles { get; }
 
     /// <summary>
+    /// Profiles whose hidden flag is set (either
+    /// <see cref="ProfileDef.Hidden"/> or
+    /// <see cref="IProfileConfigSource.HiddenProfileIds"/>). Same record
+    /// shape as <see cref="Profiles"/>. <see cref="ResolvedProfile.OrderIndex"/>
+    /// restarts at 0 within this list. <see cref="ResolvedProfile.IsDefault"/>
+    /// is always false on entries here -- the resolver never picks a
+    /// hidden profile as default.
+    /// </summary>
+    IReadOnlyList<ResolvedProfile> HiddenProfiles { get; }
+
+    /// <summary>
     /// Id of the entry with <c>IsDefault = true</c> in
     /// <see cref="Profiles"/>, or null when the list is empty.
     /// </summary>

--- a/windows/Ghostty.Core/Profiles/ProfileHiddenKey.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileHiddenKey.cs
@@ -1,0 +1,12 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Builds the config key that toggles a profile's hidden state.
+/// Centralised so the settings page and any future consumer can
+/// share a single format invariant.
+/// </summary>
+public static class ProfileHiddenKey
+{
+    public static string For(string profileId)
+        => $"profile.{profileId}.hidden";
+}

--- a/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
@@ -10,20 +10,23 @@ namespace Ghostty.Core.Profiles;
 /// then unlisted user profiles in the order they were defined, then
 /// unlisted discovered profiles in alphabetical-by-ID order. Hidden
 /// profiles (either via ProfileDef.Hidden or the hidden set parameter)
-/// are omitted entirely.
+/// are returned in <see cref="ResolvedProfileSet.Hidden"/> rather than
+/// the visible list, so the settings-UI inspector can offer an unhide
+/// affordance without re-running the resolver against a different
+/// hidden set.
 /// </summary>
 public static class ProfileOrderResolver
 {
-    public static IReadOnlyList<ResolvedProfile> Resolve(
+    public static ResolvedProfileSet Resolve(
         IReadOnlyList<ProfileDef> user,
         IReadOnlyList<DiscoveredProfile> discovered,
         IReadOnlyList<string>? profileOrder,
         string? defaultProfileId,
-        IReadOnlySet<string> hidden)
+        IReadOnlySet<string> hiddenIds)
     {
         ArgumentNullException.ThrowIfNull(user);
         ArgumentNullException.ThrowIfNull(discovered);
-        ArgumentNullException.ThrowIfNull(hidden);
+        ArgumentNullException.ThrowIfNull(hiddenIds);
 
         var combined = new Dictionary<string, ProfileDef>();
         var userOrder = new List<string>();
@@ -69,45 +72,64 @@ public static class ProfileOrderResolver
         foreach (var id in discoveredById.Keys.OrderBy(k => k, StringComparer.Ordinal))
             if (seen.Add(id)) ordered.Add(id);
 
-        var result = new List<ResolvedProfile>();
-        var index = 0;
-        var defaultResolved = ResolveDefault(defaultProfileId, ordered, combined, hidden);
+        var visible = new List<ResolvedProfile>();
+        var hidden = new List<ResolvedProfile>();
+        var visibleIndex = 0;
+        var hiddenIndex = 0;
+        var defaultResolved = ResolveDefault(defaultProfileId, ordered, combined, hiddenIds);
         foreach (var id in ordered)
         {
             var def = combined[id];
-            if (def.Hidden || hidden.Contains(id)) continue;
-            result.Add(new ResolvedProfile(
-                Id: def.Id,
-                Name: def.Name,
-                Command: def.Command,
-                WorkingDirectory: def.WorkingDirectory,
-                Icon: def.Icon ?? new IconSpec.BundledKey("default"),
-                TabTitle: def.TabTitle ?? def.Name,
-                Visuals: def.Visuals,
-                ProbeId: def.ProbeId,
-                OrderIndex: index++,
-                IsDefault: def.Id == defaultResolved));
+            var isHidden = def.Hidden || hiddenIds.Contains(id);
+            if (isHidden)
+            {
+                hidden.Add(new ResolvedProfile(
+                    Id: def.Id,
+                    Name: def.Name,
+                    Command: def.Command,
+                    WorkingDirectory: def.WorkingDirectory,
+                    Icon: def.Icon ?? new IconSpec.BundledKey("default"),
+                    TabTitle: def.TabTitle ?? def.Name,
+                    Visuals: def.Visuals,
+                    ProbeId: def.ProbeId,
+                    OrderIndex: hiddenIndex++,
+                    IsDefault: false));
+            }
+            else
+            {
+                visible.Add(new ResolvedProfile(
+                    Id: def.Id,
+                    Name: def.Name,
+                    Command: def.Command,
+                    WorkingDirectory: def.WorkingDirectory,
+                    Icon: def.Icon ?? new IconSpec.BundledKey("default"),
+                    TabTitle: def.TabTitle ?? def.Name,
+                    Visuals: def.Visuals,
+                    ProbeId: def.ProbeId,
+                    OrderIndex: visibleIndex++,
+                    IsDefault: def.Id == defaultResolved));
+            }
         }
-        return result;
+        return new ResolvedProfileSet(visible, hidden);
     }
 
     private static string? ResolveDefault(
         string? requested,
         List<string> ordered,
         Dictionary<string, ProfileDef> combined,
-        IReadOnlySet<string> hidden)
+        IReadOnlySet<string> hiddenIds)
     {
         if (requested is not null
             && combined.TryGetValue(requested, out var def)
             && !def.Hidden
-            && !hidden.Contains(requested))
+            && !hiddenIds.Contains(requested))
         {
             return requested;
         }
         foreach (var id in ordered)
         {
             var d = combined[id];
-            if (!d.Hidden && !hidden.Contains(id)) return id;
+            if (!d.Hidden && !hiddenIds.Contains(id)) return id;
         }
         return null;
     }

--- a/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
@@ -82,36 +82,28 @@ public static class ProfileOrderResolver
             var def = combined[id];
             var isHidden = def.Hidden || hiddenIds.Contains(id);
             if (isHidden)
-            {
-                hidden.Add(new ResolvedProfile(
-                    Id: def.Id,
-                    Name: def.Name,
-                    Command: def.Command,
-                    WorkingDirectory: def.WorkingDirectory,
-                    Icon: def.Icon ?? new IconSpec.BundledKey("default"),
-                    TabTitle: def.TabTitle ?? def.Name,
-                    Visuals: def.Visuals,
-                    ProbeId: def.ProbeId,
-                    OrderIndex: hiddenIndex++,
-                    IsDefault: false));
-            }
+                hidden.Add(MakeProfile(def, hiddenIndex++, isDefault: false));
             else
-            {
-                visible.Add(new ResolvedProfile(
-                    Id: def.Id,
-                    Name: def.Name,
-                    Command: def.Command,
-                    WorkingDirectory: def.WorkingDirectory,
-                    Icon: def.Icon ?? new IconSpec.BundledKey("default"),
-                    TabTitle: def.TabTitle ?? def.Name,
-                    Visuals: def.Visuals,
-                    ProbeId: def.ProbeId,
-                    OrderIndex: visibleIndex++,
-                    IsDefault: def.Id == defaultResolved));
-            }
+                visible.Add(MakeProfile(def, visibleIndex++, isDefault: def.Id == defaultResolved));
         }
         return new ResolvedProfileSet(visible, hidden);
     }
+
+    // Single source of truth for the ProfileDef -> ResolvedProfile
+    // projection so the visible / hidden branches above stay in sync as
+    // the record gains fields.
+    private static ResolvedProfile MakeProfile(ProfileDef def, int orderIndex, bool isDefault)
+        => new(
+            Id: def.Id,
+            Name: def.Name,
+            Command: def.Command,
+            WorkingDirectory: def.WorkingDirectory,
+            Icon: def.Icon ?? new IconSpec.BundledKey("default"),
+            TabTitle: def.TabTitle ?? def.Name,
+            Visuals: def.Visuals,
+            ProbeId: def.ProbeId,
+            OrderIndex: orderIndex,
+            IsDefault: isDefault);
 
     private static string? ResolveDefault(
         string? requested,

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -19,15 +19,18 @@ namespace Ghostty.Core.Profiles;
 /// </summary>
 internal sealed partial class ProfileRegistry : IProfileRegistry
 {
-    // All three fields (Profiles, ById, DefaultProfileId) are published
-    // together via a single volatile reference so readers always see a
-    // consistent set -- no torn snapshot between the list and the dict.
+    // All four fields (Profiles, HiddenProfiles, ById, DefaultProfileId)
+    // are published together via a single volatile reference so readers
+    // always see a consistent set -- no torn snapshot between the visible
+    // list, hidden list, and the lookup dict.
     private sealed record Snapshot(
         IReadOnlyList<ResolvedProfile> Profiles,
+        IReadOnlyList<ResolvedProfile> HiddenProfiles,
         FrozenDictionary<string, ResolvedProfile> ById,
         string? DefaultProfileId);
 
     private static readonly Snapshot EmptySnapshot = new(
+        Array.Empty<ResolvedProfile>(),
         Array.Empty<ResolvedProfile>(),
         FrozenDictionary<string, ResolvedProfile>.Empty,
         DefaultProfileId: null);
@@ -49,6 +52,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
     public event Action<IProfileRegistry>? ProfilesChanged;
 
     public IReadOnlyList<ResolvedProfile> Profiles => _snapshot.Profiles;
+    public IReadOnlyList<ResolvedProfile> HiddenProfiles => _snapshot.HiddenProfiles;
     public string? DefaultProfileId => _snapshot.DefaultProfileId;
     public long Version => Interlocked.Read(ref _version);
 
@@ -105,6 +109,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
         if (Volatile.Read(ref _disposed) != 0) return;
 
         IReadOnlyList<ResolvedProfile> next;
+        IReadOnlyList<ResolvedProfile> nextHidden;
         FrozenDictionary<string, ResolvedProfile> nextById;
         string? nextDefault;
 
@@ -118,6 +123,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
                 hiddenIds: _source.HiddenProfileIds);
 
             next = resolvedSet.Visible;
+            nextHidden = resolvedSet.Hidden;
             var dict = new Dictionary<string, ResolvedProfile>(resolvedSet.Visible.Count, StringComparer.OrdinalIgnoreCase);
             nextDefault = null;
             foreach (var p in resolvedSet.Visible)
@@ -128,7 +134,7 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
             nextById = dict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         }
 
-        _snapshot = new Snapshot(next, nextById, nextDefault);
+        _snapshot = new Snapshot(next, nextHidden, nextById, nextDefault);
         var newVersion = Interlocked.Increment(ref _version);
         LogRecomposed(newVersion, next.Count);
 

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -110,17 +110,17 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
 
         lock (_sync)
         {
-            var resolved = ProfileOrderResolver.Resolve(
+            var resolvedSet = ProfileOrderResolver.Resolve(
                 user: [.. _source.ParsedProfiles.Values],
                 discovered: _discovered,
                 profileOrder: _source.ProfileOrder,
                 defaultProfileId: _source.DefaultProfileId,
-                hidden: _source.HiddenProfileIds);
+                hiddenIds: _source.HiddenProfileIds);
 
-            next = resolved;
-            var dict = new Dictionary<string, ResolvedProfile>(resolved.Count, StringComparer.OrdinalIgnoreCase);
+            next = resolvedSet.Visible;
+            var dict = new Dictionary<string, ResolvedProfile>(resolvedSet.Visible.Count, StringComparer.OrdinalIgnoreCase);
             nextDefault = null;
-            foreach (var p in resolved)
+            foreach (var p in resolvedSet.Visible)
             {
                 dict[p.Id] = p;
                 if (p.IsDefault) nextDefault = p.Id;

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -93,6 +93,23 @@ public static partial class ProfileSourceParser
     /// profiles without requiring a full user override.
     /// </summary>
     public static IReadOnlySet<string> ExtractHiddenIds(string configText)
+        => ExtractHiddenIdsCore(configText, requireTrue: true);
+
+    /// <summary>
+    /// Extracts ids for which any <c>profile.&lt;id&gt;.hidden = ...</c>
+    /// line appears, regardless of whether the value parses as true or
+    /// false. Used by the warnings filter so an id whose only
+    /// <c>profile.&lt;id&gt;.*</c> line is a hide-override (true OR
+    /// false) doesn't get a spurious "missing required key 'name'"
+    /// warning. The true-only set isn't sufficient because the settings
+    /// page's un-hide path can leave <c>hidden = false</c> markers in
+    /// the config, and an explicit <c>hidden = false</c> mention is
+    /// still a hide-override marker, not a malformed profile block.
+    /// </summary>
+    public static IReadOnlySet<string> ExtractHiddenMentionIds(string configText)
+        => ExtractHiddenIdsCore(configText, requireTrue: false);
+
+    private static IReadOnlySet<string> ExtractHiddenIdsCore(string configText, bool requireTrue)
     {
         ArgumentNullException.ThrowIfNull(configText);
 
@@ -113,8 +130,11 @@ public static partial class ProfileSourceParser
             if (!string.Equals(subKey, "hidden", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var value = match.Groups[3].Value;
-            if (!bool.TryParse(value, out var flag) || !flag) continue;
+            if (requireTrue)
+            {
+                var value = match.Groups[3].Value;
+                if (!bool.TryParse(value, out var flag) || !flag) continue;
+            }
 
             var id = match.Groups[1].Value.ToLowerInvariant();
             ids.Add(id);

--- a/windows/Ghostty.Core/Profiles/ResolvedProfileSet.cs
+++ b/windows/Ghostty.Core/Profiles/ResolvedProfileSet.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Output of <see cref="ProfileOrderResolver.Resolve"/>: the visible
+/// profiles UI consumers iterate plus the hidden ones the settings
+/// inspector needs in order to offer an unhide affordance.
+/// </summary>
+public sealed record ResolvedProfileSet(
+    IReadOnlyList<ResolvedProfile> Visible,
+    IReadOnlyList<ResolvedProfile> Hidden);

--- a/windows/Ghostty.Tests.Windows/Commands/ProfileChordSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Commands/ProfileChordSmokeTests.cs
@@ -4,18 +4,13 @@ namespace Ghostty.Tests.Windows.Commands;
 
 public class ProfileChordSmokeTests
 {
-    [Fact]
+    // Wire-up plan when WinUITestHost lands:
+    //   1. Build a MainWindow on the WinUITestHost dispatcher.
+    //   2. Inject a FakeProfileRegistry with 3 profiles ("a", "b", "c").
+    //   3. Synthesize a Ctrl+Shift+Number2 KeyboardAccelerator invocation.
+    //   4. Assert OpenProfile was called with id="b", target=NewTab.
+    [Fact(Skip = "TODO: wire WinUITestHost (also blocks PR 4 tasks 17/18)")]
     public void CtrlShift2_With3Profiles_OpensProfileAtIndex1AsNewTab()
     {
-        // Wire-up plan when WinUITestHost lands:
-        //   1. Build a MainWindow on the WinUITestHost dispatcher.
-        //   2. Inject a FakeProfileRegistry with 3 profiles ("a", "b", "c").
-        //   3. Synthesize a Ctrl+Shift+Number2 KeyboardAccelerator invocation.
-        //   4. Assert OpenProfile was called with id="b", target=NewTab.
-        //
-        // Until WinUITestHost exists (also blocking PR 4 tasks 17/18), this
-        // stub fails so the test surface is visible in CI counts and reviewers
-        // can grep for the string.
-        Assert.Fail("TODO: wire WinUITestHost (also blocks PR 4 tasks 17/18)");
     }
 }

--- a/windows/Ghostty.Tests.Windows/Settings/ProfilesPageSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Settings/ProfilesPageSmokeTests.cs
@@ -1,0 +1,27 @@
+using Xunit;
+
+namespace Ghostty.Tests.Windows.Settings;
+
+public class ProfilesPageSmokeTests
+{
+    [Fact]
+    public void ProfilesPage_RendersVisibleAndHiddenProfilesInOneFlatList()
+    {
+        // Wire-up plan when WinUITestHost lands:
+        //   1. Build a SettingsWindow on the WinUITestHost dispatcher.
+        //   2. Inject a FakeProfileRegistry with 2 visible + 1 hidden
+        //      profile and a no-op IConfigFileEditor.
+        //   3. Navigate to the "profiles" tab.
+        //   4. Assert ProfilesGroup.Cards.Count == 3 with toggle states
+        //      off/off/on in registry-order.
+        //   5. Toggle the first row on; assert the editor saw a
+        //      SetValue("profile.<id>.hidden", "true") call.
+        //   6. Toggle the third row off; assert the editor saw a
+        //      RemoveValue("profile.<id>.hidden") call.
+        //
+        // Until WinUITestHost exists (also blocking PR 4 tasks 17/18 and
+        // PR 5 chord smoke), this stub fails so the test surface is
+        // visible in CI counts and reviewers can grep for the string.
+        Assert.Fail("TODO: wire WinUITestHost (also blocks PR 4 tasks 17/18 + PR 5 chord smoke)");
+    }
+}

--- a/windows/Ghostty.Tests.Windows/Settings/ProfilesPageSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Settings/ProfilesPageSmokeTests.cs
@@ -4,24 +4,19 @@ namespace Ghostty.Tests.Windows.Settings;
 
 public class ProfilesPageSmokeTests
 {
-    [Fact]
+    // Wire-up plan when WinUITestHost lands:
+    //   1. Build a SettingsWindow on the WinUITestHost dispatcher.
+    //   2. Inject a FakeProfileRegistry with 2 visible + 1 hidden
+    //      profile and a no-op IConfigFileEditor.
+    //   3. Navigate to the "profiles" tab.
+    //   4. Assert ProfilesGroup.Cards.Count == 3 with toggle states
+    //      off/off/on in registry-order.
+    //   5. Toggle the first row on; assert the editor saw a
+    //      SetValue("profile.<id>.hidden", "true") call.
+    //   6. Toggle the third row off; assert the editor saw a
+    //      RemoveValue("profile.<id>.hidden") call.
+    [Fact(Skip = "TODO: wire WinUITestHost (also blocks PR 4 tasks 17/18 + PR 5 chord smoke)")]
     public void ProfilesPage_RendersVisibleAndHiddenProfilesInOneFlatList()
     {
-        // Wire-up plan when WinUITestHost lands:
-        //   1. Build a SettingsWindow on the WinUITestHost dispatcher.
-        //   2. Inject a FakeProfileRegistry with 2 visible + 1 hidden
-        //      profile and a no-op IConfigFileEditor.
-        //   3. Navigate to the "profiles" tab.
-        //   4. Assert ProfilesGroup.Cards.Count == 3 with toggle states
-        //      off/off/on in registry-order.
-        //   5. Toggle the first row on; assert the editor saw a
-        //      SetValue("profile.<id>.hidden", "true") call.
-        //   6. Toggle the third row off; assert the editor saw a
-        //      RemoveValue("profile.<id>.hidden") call.
-        //
-        // Until WinUITestHost exists (also blocking PR 4 tasks 17/18 and
-        // PR 5 chord smoke), this stub fails so the test surface is
-        // visible in CI counts and reviewers can grep for the string.
-        Assert.Fail("TODO: wire WinUITestHost (also blocks PR 4 tasks 17/18 + PR 5 chord smoke)");
     }
 }

--- a/windows/Ghostty.Tests.Windows/Tabs/NewTabSplitButtonSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tabs/NewTabSplitButtonSmokeTests.cs
@@ -4,25 +4,21 @@ namespace Ghostty.Tests.Windows.Tabs;
 
 public class NewTabSplitButtonSmokeTests
 {
-    [Fact]
+    // Booting a real MainWindow inside a unit test requires the XAML
+    // test host pattern used elsewhere in this project.
+    //
+    // Required helpers (verify exist; create with InternalsVisibleTo
+    // if they do not):
+    //   - WinUITestHost.RunOnUiAsync(() => ...)
+    //   - WinUITestHost.NewMainWindow(stubProfileRegistry)
+    //   - WinUITestHost.FindDescendantOfType<T>(element)
+    //
+    // The body uses these helpers via DispatcherQueueController. If
+    // they do not exist, this test is the right place to introduce
+    // them -- the harness pattern is shared with future PR 4.5 / PR 6
+    // tests.
+    [Fact(Skip = "TODO: wire WinUITestHost. See file header comment.")]
     public void NewTabSplitButton_IsHostedInFooter_AndAddButtonIsHidden()
     {
-        // Booting a real MainWindow inside a unit test requires the
-        // XAML test host pattern used elsewhere in this project. If
-        // the host is not yet established, this test is structured to
-        // fail clearly with TODO guidance rather than silently pass.
-        //
-        // Required helpers (verify exist; create with InternalsVisibleTo
-        // if they do not):
-        //   - WinUITestHost.RunOnUiAsync(() => ...)
-        //   - WinUITestHost.NewMainWindow(stubProfileRegistry)
-        //   - WinUITestHost.FindDescendantOfType<T>(element)
-        //
-        // The body uses these helpers via DispatcherQueueController.
-        // If they do not exist, this test is the right place to
-        // introduce them -- the harness pattern is shared with future
-        // PR 4.5 / PR 6 tests.
-
-        Assert.Fail("TODO: wire WinUITestHost. See file header comment.");
     }
 }

--- a/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigServiceProfileParserTests.cs
@@ -63,6 +63,23 @@ public class ConfigServiceProfileParserTests
     }
 
     [Fact]
+    public void ParseAll_HiddenFalseOnlyOverride_DoesNotProduceWarning()
+    {
+        // The settings-page un-hide path writes hidden = false. An id
+        // with only that line is still a hide-override marker (the user
+        // is explicitly opting back in), not a malformed profile, so
+        // no missing-name warning should surface.
+        const string text = "profile.pwsh-7.hidden = false";
+        var values = new Dictionary<string, string?>();
+
+        var result = ConfigServiceProfileParser.ParseAll(text, key => FileValue(values, key));
+
+        Assert.DoesNotContain("pwsh-7", result.HiddenProfileIds);
+        Assert.Empty(result.ParsedProfiles);
+        Assert.Empty(result.ProfileWarnings);
+    }
+
+    [Fact]
     public void ParseAll_MalformedProfile_ProducesWarning()
     {
         const string text = "profile.broken.name = NoCommand";  // missing command

--- a/windows/Ghostty.Tests/Profiles/FakeProfileRegistry.cs
+++ b/windows/Ghostty.Tests/Profiles/FakeProfileRegistry.cs
@@ -9,8 +9,10 @@ namespace Ghostty.Tests.Profiles;
 internal sealed class FakeProfileRegistry : IProfileRegistry
 {
     private List<ResolvedProfile> _profiles = new();
+    private List<ResolvedProfile> _hidden = new();
 
     public IReadOnlyList<ResolvedProfile> Profiles => _profiles;
+    public IReadOnlyList<ResolvedProfile> HiddenProfiles => _hidden;
     public string? DefaultProfileId { get; set; }
     public long Version { get; private set; }
 
@@ -33,14 +35,19 @@ internal sealed class FakeProfileRegistry : IProfileRegistry
     public void Dispose() { }
 
     /// <summary>
-    /// Test-only helper: replace the profile list, bump
-    /// <see cref="Version"/>, and fire <see cref="ProfilesChanged"/>
-    /// synchronously (mimicking the production UI-dispatch shape from
-    /// the perspective of a single-threaded test).
+    /// Test-only helper: replace the profile list (and optionally the
+    /// hidden list), bump <see cref="Version"/>, and fire
+    /// <see cref="ProfilesChanged"/> synchronously (mimicking the
+    /// production UI-dispatch shape from the perspective of a
+    /// single-threaded test).
     /// </summary>
-    public void SetProfiles(IReadOnlyList<ResolvedProfile> profiles, string? defaultProfileId = null)
+    public void SetProfiles(
+        IReadOnlyList<ResolvedProfile> profiles,
+        IReadOnlyList<ResolvedProfile>? hidden = null,
+        string? defaultProfileId = null)
     {
         _profiles = new List<ResolvedProfile>(profiles);
+        _hidden = hidden is null ? new List<ResolvedProfile>() : new List<ResolvedProfile>(hidden);
         DefaultProfileId = defaultProfileId;
         Version++;
         ProfilesChanged?.Invoke(this);

--- a/windows/Ghostty.Tests/Profiles/ProfileHiddenKeyTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileHiddenKeyTests.cs
@@ -1,0 +1,16 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProfileHiddenKeyTests
+{
+    [Theory]
+    [InlineData("pwsh", "profile.pwsh.hidden")]
+    [InlineData("wsl-debian", "profile.wsl-debian.hidden")]
+    [InlineData("a", "profile.a.hidden")]
+    public void For_ReturnsDottedHiddenKey(string id, string expected)
+    {
+        Assert.Equal(expected, ProfileHiddenKey.For(id));
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileOrderResolverTests.cs
@@ -24,7 +24,7 @@ public sealed class ProfileOrderResolverTests
             discovered: discovered,
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.Equal(new[] { "alpha", "zulu", "bravo", "delta" }, resolved.Select(r => r.Id));
     }
@@ -40,7 +40,7 @@ public sealed class ProfileOrderResolverTests
             discovered: discovered,
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.Single(resolved);
         Assert.Equal("MyPwsh", resolved[0].Name);
@@ -57,7 +57,7 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.Equal(new[] { "a", "c" }, resolved.Select(r => r.Id));
     }
@@ -72,7 +72,7 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string> { "a" }).ToList();
+            hiddenIds: new HashSet<string> { "a" }).Visible.ToList();
 
         Assert.Equal(new[] { "b" }, resolved.Select(r => r.Id));
     }
@@ -89,7 +89,7 @@ public sealed class ProfileOrderResolverTests
             discovered: discovered,
             profileOrder: order,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.Equal(new[] { "delta", "alpha", "zulu", "bravo" }, resolved.Select(r => r.Id));
     }
@@ -105,7 +105,7 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: order,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.Equal(new[] { "a" }, resolved.Select(r => r.Id));
     }
@@ -120,7 +120,7 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: "zulu",
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.False(resolved.Single(r => r.Id == "alpha").IsDefault);
         Assert.True(resolved.Single(r => r.Id == "zulu").IsDefault);
@@ -136,7 +136,7 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: "ghost",
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.True(resolved[0].IsDefault);
         Assert.Equal("alpha", resolved[0].Id);
@@ -152,7 +152,7 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.True(resolved[0].IsDefault);
     }
@@ -167,7 +167,7 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.Equal(0, resolved[0].OrderIndex);
         Assert.Equal(1, resolved[1].OrderIndex);
@@ -182,7 +182,7 @@ public sealed class ProfileOrderResolverTests
             discovered: new[] { Disc("wsl-ubuntu", probe: "wsl") },
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).Single();
+            hiddenIds: new HashSet<string>()).Visible.Single();
 
         Assert.Equal("wsl", resolved.ProbeId);
     }
@@ -195,9 +195,9 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>());
+            hiddenIds: new HashSet<string>());
 
-        Assert.Empty(resolved);
+        Assert.Empty(resolved.Visible);
     }
 
     [Fact]
@@ -210,14 +210,14 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: null,
             defaultProfileId: "pwsh-7",
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         var after = ProfileOrderResolver.Resolve(
             user: users,
             discovered: new[] { Disc("wsl-ubuntu"), Disc("wsl-debian") },
             profileOrder: null,
             defaultProfileId: "pwsh-7",
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         Assert.Equal("pwsh-7", before[0].Id);
         Assert.Equal("pwsh-7", after[0].Id);
@@ -240,14 +240,14 @@ public sealed class ProfileOrderResolverTests
             discovered: discovered,
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string>()).ToList();
+            hiddenIds: new HashSet<string>()).Visible.ToList();
 
         var hideKali = ProfileOrderResolver.Resolve(
             user: [],
             discovered: discovered,
             profileOrder: null,
             defaultProfileId: null,
-            hidden: new HashSet<string> { "wsl-kali" }).ToList();
+            hiddenIds: new HashSet<string> { "wsl-kali" }).Visible.ToList();
 
         Assert.Equal(new[] { "wsl-debian", "wsl-kali", "wsl-ubuntu" },
                      noHide.Select(r => r.Id));
@@ -268,8 +268,57 @@ public sealed class ProfileOrderResolverTests
             discovered: [],
             profileOrder: new[] { "c", "a" },
             defaultProfileId: null,
-            hidden: new HashSet<string> { "b" }).ToList();
+            hiddenIds: new HashSet<string> { "b" }).Visible.ToList();
 
         Assert.Equal(new[] { "c", "a", "d" }, pinned.Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_HiddenSet_RetainedInHiddenListInOriginalOrder()
+    {
+        var users = new[] { User("alpha"), User("zulu", hidden: true) };
+        var discovered = new[] { Disc("bravo") };
+
+        var set = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: discovered,
+            profileOrder: null,
+            defaultProfileId: null,
+            hiddenIds: new HashSet<string> { "bravo" });
+
+        Assert.Equal(new[] { "alpha" }, set.Visible.Select(r => r.Id));
+        Assert.Equal(new[] { "zulu", "bravo" }, set.Hidden.Select(r => r.Id));
+    }
+
+    [Fact]
+    public void Resolve_HiddenEntries_OrderIndexRestartsAtZero()
+    {
+        var users = new[] { User("a"), User("b", hidden: true), User("c", hidden: true) };
+
+        var set = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: [],
+            profileOrder: null,
+            defaultProfileId: null,
+            hiddenIds: new HashSet<string>());
+
+        Assert.Equal(new[] { 0 }, set.Visible.Select(r => r.OrderIndex));
+        Assert.Equal(new[] { 0, 1 }, set.Hidden.Select(r => r.OrderIndex));
+    }
+
+    [Fact]
+    public void Resolve_HiddenEntry_NeverMarkedDefault()
+    {
+        var users = new[] { User("a", hidden: true), User("b") };
+
+        var set = ProfileOrderResolver.Resolve(
+            user: users,
+            discovered: [],
+            profileOrder: null,
+            defaultProfileId: "a",
+            hiddenIds: new HashSet<string>());
+
+        Assert.False(set.Hidden.Single(r => r.Id == "a").IsDefault);
+        Assert.True(set.Visible.Single(r => r.Id == "b").IsDefault);
     }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileRegistryTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ghostty.Core.Profiles;
@@ -262,6 +264,57 @@ public class ProfileRegistryTests
         Assert.Equal(versionBefore, registry.Version);        // unchanged
         Assert.Single(registry.Profiles);                      // user still there
         Assert.Equal(0, eventsFiredAfterSubscribe);            // no event after failure
+    }
+
+    [Fact]
+    public void HiddenProfiles_ExposesEntriesFilteredFromVisibleList()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["a"] = UserDef("a", "A"),
+                ["b"] = new ProfileDef(
+                    Id: "b",
+                    Name: "B",
+                    Command: "b.exe",
+                    WorkingDirectory: null,
+                    Icon: null,
+                    TabTitle: null,
+                    Hidden: true,
+                    ProbeId: null,
+                    VisualsOrNull: null),
+            },
+        };
+
+        using var registry = new ProfileRegistry(
+            src, EmptyDiscovery(), SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        Assert.Equal(new[] { "a" }, registry.Profiles.Select(p => p.Id));
+        Assert.Equal(new[] { "b" }, registry.HiddenProfiles.Select(p => p.Id));
+    }
+
+    [Fact]
+    public void HiddenProfiles_RecomposedAfterConfigChange()
+    {
+        var src = new FakeProfileConfigSource
+        {
+            ParsedProfiles = new Dictionary<string, ProfileDef>
+            {
+                ["a"] = UserDef("a", "A"),
+            },
+        };
+
+        using var registry = new ProfileRegistry(
+            src, EmptyDiscovery(), SynchronousDispatcher, NullLogger<ProfileRegistry>.Instance);
+
+        Assert.Empty(registry.HiddenProfiles);
+
+        src.HiddenProfileIds = new HashSet<string> { "a" }.ToFrozenSet();
+        src.Raise();
+
+        Assert.Empty(registry.Profiles);
+        Assert.Equal(new[] { "a" }, registry.HiddenProfiles.Select(p => p.Id));
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserHiddenIdsTests.cs
@@ -92,4 +92,46 @@ public sealed class ProfileSourceParserHiddenIdsTests
         var result = ProfileSourceParser.ExtractHiddenIds(text);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public void ExtractHiddenMentionIds_HiddenFalse_Included()
+    {
+        const string text = "profile.azure.hidden = false";
+        var result = ProfileSourceParser.ExtractHiddenMentionIds(text);
+        Assert.Single(result);
+        Assert.Contains("azure", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenMentionIds_BothTrueAndFalse_BothIncluded()
+    {
+        const string text = """
+            profile.foo.hidden = true
+            profile.bar.hidden = false
+            """;
+        var result = ProfileSourceParser.ExtractHiddenMentionIds(text);
+        Assert.Equal(2, result.Count);
+        Assert.Contains("foo", result);
+        Assert.Contains("bar", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenMentionIds_NonBoolValue_StillIncluded()
+    {
+        // Even nonsense values count as mentions -- the warnings filter
+        // wants to know "did the user mention this id via a hidden line",
+        // not "did the value parse cleanly". Resolver-side filtering
+        // (ExtractHiddenIds) keeps the strict semantics.
+        const string text = "profile.weird.hidden = oops";
+        var result = ProfileSourceParser.ExtractHiddenMentionIds(text);
+        Assert.Contains("weird", result);
+    }
+
+    [Fact]
+    public void ExtractHiddenMentionIds_NonHiddenSubkey_Ignored()
+    {
+        const string text = "profile.azure.name = Azure";
+        var result = ProfileSourceParser.ExtractHiddenMentionIds(text);
+        Assert.Empty(result);
+    }
 }

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml
@@ -8,6 +8,13 @@
         <StackPanel MaxWidth="800">
             <TextBlock Text="Profiles" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,20" />
 
+            <InfoBar x:Name="WarningsBar"
+                     IsOpen="False"
+                     IsClosable="False"
+                     Severity="Warning"
+                     Title="Profile config warnings"
+                     Margin="0,0,0,12" />
+
             <ctrl:SettingsGroup Header="Default profile"
                                 Description="Used when no profile is specified at launch.">
                 <ctrl:SettingsCard x:Name="DefaultProfileCard" Header="Default profile id" />

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml
@@ -1,0 +1,21 @@
+<Page
+    x:Class="Ghostty.Settings.Pages.ProfilesPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Ghostty.Controls.Settings">
+
+    <ScrollViewer Padding="24">
+        <StackPanel MaxWidth="800">
+            <TextBlock Text="Profiles" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,20" />
+
+            <ctrl:SettingsGroup Header="Default profile"
+                                Description="Used when no profile is specified at launch.">
+                <ctrl:SettingsCard x:Name="DefaultProfileCard" Header="Default profile id" />
+            </ctrl:SettingsGroup>
+
+            <ctrl:SettingsGroup x:Name="ProfilesGroup"
+                                Header="Profiles"
+                                Description="Read-only view of profiles parsed from your config and discovered on this system." />
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml
@@ -15,7 +15,7 @@
 
             <ctrl:SettingsGroup x:Name="ProfilesGroup"
                                 Header="Profiles"
-                                Description="Read-only view of profiles parsed from your config and discovered on this system." />
+                                Description="Hidden profiles stay listed here but don't appear in the new-tab menu, command palette, or Ctrl+Shift+1..9 chords." />
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
@@ -53,6 +53,19 @@ internal sealed partial class ProfilesPage : Page
 
     private void Rebind()
     {
+        var warnings = _configService.ProfileWarnings;
+        Debug.WriteLine($"ProfilesPage.Rebind: ProfileWarnings.Count = {warnings.Count}");
+        if (warnings.Count == 0)
+        {
+            WarningsBar.IsOpen = false;
+            WarningsBar.Message = string.Empty;
+        }
+        else
+        {
+            WarningsBar.Message = string.Join("\n", warnings);
+            WarningsBar.IsOpen = true;
+        }
+
         DefaultProfileCard.Description =
             _registry.DefaultProfileId ?? "(no default profile set)";
 
@@ -112,17 +125,28 @@ internal sealed partial class ProfilesPage : Page
             // explicitly so the in-memory ProfileView updates and the
             // page rebinds deterministically rather than depending on
             // when the watcher's debounce timer happens to land.
+            //
+            // Hide via SetValue("true"); un-hide via RemoveValue rather
+            // than SetValue("false") so the config stays minimal --
+            // hidden defaults to false, so a stray "false" line is just
+            // noise that also confuses the warnings filter for
+            // hidden-only blocks.
+            var key = ProfileHiddenKey.For(id);
             _configService.SuppressWatcher(true);
-            try { _editor.SetValue(ProfileHiddenKey.For(id), toggle.IsOn ? "true" : "false"); }
+            try
+            {
+                if (toggle.IsOn) _editor.SetValue(key, "true");
+                else _editor.RemoveValue(key);
+            }
             finally { _configService.SuppressWatcher(false); }
             _configService.Reload();
         }
         catch (Exception ex)
         {
-            // SetValue / Reload failure leaves the toggle visually
-            // flipped; the next ProfilesChanged event from a successful
-            // reload would either confirm or revert it. Logged for
-            // diagnostic only -- no user-facing surface in V1.
+            // SetValue / RemoveValue / Reload failure leaves the toggle
+            // visually flipped; the next ProfilesChanged event from a
+            // successful reload would either confirm or revert it.
+            // Logged for diagnostic only -- no user-facing surface in V1.
             Debug.WriteLine($"failed to toggle profile {id} hidden: {ex}");
         }
     }

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Diagnostics;
 using Ghostty.Controls.Settings;
+using Ghostty.Core.Config;
 using Ghostty.Core.Profiles;
 using Microsoft.UI.Xaml.Controls;
 
@@ -7,18 +9,28 @@ namespace Ghostty.Settings.Pages;
 
 /// <summary>
 /// Read-only listing of the visible profiles plus the resolved
-/// default-profile id. Re-binds whenever the registry recomposes (config
-/// reload or background discovery refresh). Hide-toggle, hidden expander,
-/// and parser-warning surface land in subsequent commits.
+/// default-profile id, with a per-row toggle that flips the profile's
+/// hidden state. Re-binds whenever the registry recomposes (config
+/// reload or background discovery refresh). Hidden expander and
+/// parser-warning surface land in subsequent commits.
 /// </summary>
 internal sealed partial class ProfilesPage : Page
 {
     private readonly IProfileRegistry _registry;
+    private readonly IConfigService _configService;
+    private readonly IConfigFileEditor _editor;
 
-    public ProfilesPage(IProfileRegistry registry)
+    public ProfilesPage(
+        IProfileRegistry registry,
+        IConfigService configService,
+        IConfigFileEditor editor)
     {
         ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(configService);
+        ArgumentNullException.ThrowIfNull(editor);
         _registry = registry;
+        _configService = configService;
+        _editor = editor;
         InitializeComponent();
 
         // Subscribe at Loaded / unsubscribe at Unloaded so a cached
@@ -52,11 +64,57 @@ internal sealed partial class ProfilesPage : Page
         ProfilesGroup.Cards.Clear();
         foreach (var profile in _registry.Profiles)
         {
-            ProfilesGroup.Cards.Add(new SettingsCard
-            {
-                Header = profile.Name,
-                Description = profile.Command,
-            });
+            ProfilesGroup.Cards.Add(BuildRow(profile, isHidden: false));
+        }
+    }
+
+    // Builds one SettingsCard with a ToggleSwitch on the right. The
+    // toggle's current state mirrors the row's section: off in the
+    // visible list, on in the hidden list (when that section lands in
+    // a follow-up commit). Tag carries the profile id so the handler
+    // does not need a per-row closure capture.
+    private SettingsCard BuildRow(ResolvedProfile profile, bool isHidden)
+    {
+        var toggle = new ToggleSwitch
+        {
+            IsOn = isHidden,
+            OffContent = "Visible",
+            OnContent = "Hidden",
+            Tag = profile.Id,
+        };
+        toggle.Toggled += OnHiddenToggled;
+        return new SettingsCard
+        {
+            Header = profile.Name,
+            Description = profile.Command,
+            Control = toggle,
+        };
+    }
+
+    private void OnHiddenToggled(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        if (sender is not ToggleSwitch toggle) return;
+        if (toggle.Tag is not string id) return;
+        try
+        {
+            // Mirror the AppearancePage / RawEditorPage pattern: suppress
+            // the FileSystemWatcher around our own write so its 300ms
+            // debounce doesn't double-fire Reload, then call Reload
+            // explicitly so the in-memory ProfileView updates and the
+            // page rebinds deterministically rather than depending on
+            // when the watcher's debounce timer happens to land.
+            _configService.SuppressWatcher(true);
+            try { _editor.SetValue(ProfileHiddenKey.For(id), toggle.IsOn ? "true" : "false"); }
+            finally { _configService.SuppressWatcher(false); }
+            _configService.Reload();
+        }
+        catch (Exception ex)
+        {
+            // SetValue / Reload failure leaves the toggle visually
+            // flipped; the next ProfilesChanged event from a successful
+            // reload would either confirm or revert it. Logged for
+            // diagnostic only -- no user-facing surface in V1.
+            Debug.WriteLine($"failed to toggle profile {id} hidden: {ex}");
         }
     }
 }

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
@@ -1,0 +1,62 @@
+using System;
+using Ghostty.Controls.Settings;
+using Ghostty.Core.Profiles;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings.Pages;
+
+/// <summary>
+/// Read-only listing of the visible profiles plus the resolved
+/// default-profile id. Re-binds whenever the registry recomposes (config
+/// reload or background discovery refresh). Hide-toggle, hidden expander,
+/// and parser-warning surface land in subsequent commits.
+/// </summary>
+internal sealed partial class ProfilesPage : Page
+{
+    private readonly IProfileRegistry _registry;
+
+    public ProfilesPage(IProfileRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        _registry = registry;
+        InitializeComponent();
+
+        // Subscribe at Loaded / unsubscribe at Unloaded so a cached
+        // Page that gets navigated away from doesn't keep holding the
+        // registry's event source alive past its useful lifetime.
+        Loaded += (_, _) =>
+        {
+            Rebind();
+            _registry.ProfilesChanged += OnProfilesChanged;
+        };
+        Unloaded += (_, _) => _registry.ProfilesChanged -= OnProfilesChanged;
+    }
+
+    // ProfilesChanged is raised on the UI dispatcher per
+    // IProfileRegistry's contract, but TryEnqueue keeps Rebind safe if
+    // a future implementation ever fires synchronously from a
+    // background thread.
+    private void OnProfilesChanged(IProfileRegistry _) =>
+        DispatcherQueue.TryEnqueue(Rebind);
+
+    private void Rebind()
+    {
+        DefaultProfileCard.Description =
+            _registry.DefaultProfileId ?? "(no default profile set)";
+
+        // Populate SettingsGroup.Cards directly rather than nesting an
+        // ItemsControl: SettingsGroup wraps Cards in a Spacing-aware
+        // StackPanel, so per-row separation Just Works. This also
+        // sidesteps the DataTemplate x:Bind-vs-ContainerContentChanging
+        // wrinkle the rest of this codebase has worked around.
+        ProfilesGroup.Cards.Clear();
+        foreach (var profile in _registry.Profiles)
+        {
+            ProfilesGroup.Cards.Add(new SettingsCard
+            {
+                Header = profile.Name,
+                Description = profile.Command,
+            });
+        }
+    }
+}

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
@@ -62,9 +62,18 @@ internal sealed partial class ProfilesPage : Page
         // sidesteps the DataTemplate x:Bind-vs-ContainerContentChanging
         // wrinkle the rest of this codebase has worked around.
         ProfilesGroup.Cards.Clear();
+        // Visible first, then hidden -- both sets share one flat list so
+        // the user can flip a profile's hidden state without losing it
+        // off-screen. Hidden profiles still get filtered out of the
+        // new-tab menu / palette / chords because those consumers read
+        // _registry.Profiles, which excludes the hidden half.
         foreach (var profile in _registry.Profiles)
         {
             ProfilesGroup.Cards.Add(BuildRow(profile, isHidden: false));
+        }
+        foreach (var profile in _registry.HiddenProfiles)
+        {
+            ProfilesGroup.Cards.Add(BuildRow(profile, isHidden: true));
         }
     }
 

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
 using Ghostty.Controls.Settings;
 using Ghostty.Core.Config;
 using Ghostty.Core.Profiles;
@@ -19,6 +20,19 @@ internal sealed partial class ProfilesPage : Page
     private readonly IProfileRegistry _registry;
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
+
+    // Per-id row cache so a Rebind triggered by a background event
+    // (e.g. discovery completion) updates existing SettingsCard instances
+    // in place rather than tearing down the whole list. Preserves the
+    // ToggleSwitch identity of any row the user happens to be touching.
+    private readonly Dictionary<string, SettingsCard> _cardsByProfileId =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    // Set while Rebind is mutating ToggleSwitch state programmatically
+    // so OnHiddenToggled doesn't see the synthetic Toggled event and
+    // try to write back to config. Mirrors AppearancePage's _loading
+    // pattern for the same reason.
+    private bool _loading;
 
     public ProfilesPage(
         IProfileRegistry registry,
@@ -53,48 +67,77 @@ internal sealed partial class ProfilesPage : Page
 
     private void Rebind()
     {
-        var warnings = _configService.ProfileWarnings;
-        Debug.WriteLine($"ProfilesPage.Rebind: ProfileWarnings.Count = {warnings.Count}");
-        if (warnings.Count == 0)
+        _loading = true;
+        try
         {
-            WarningsBar.IsOpen = false;
-            WarningsBar.Message = string.Empty;
-        }
-        else
-        {
-            WarningsBar.Message = string.Join("\n", warnings);
-            WarningsBar.IsOpen = true;
-        }
+            var warnings = _configService.ProfileWarnings;
+            if (warnings.Count == 0)
+            {
+                WarningsBar.IsOpen = false;
+                WarningsBar.Message = string.Empty;
+            }
+            else
+            {
+                WarningsBar.Message = string.Join("\n", warnings);
+                WarningsBar.IsOpen = true;
+            }
 
-        DefaultProfileCard.Description =
-            _registry.DefaultProfileId ?? "(no default profile set)";
+            DefaultProfileCard.Description =
+                _registry.DefaultProfileId ?? "(no default profile set)";
 
-        // Populate SettingsGroup.Cards directly rather than nesting an
-        // ItemsControl: SettingsGroup wraps Cards in a Spacing-aware
-        // StackPanel, so per-row separation Just Works. This also
-        // sidesteps the DataTemplate x:Bind-vs-ContainerContentChanging
-        // wrinkle the rest of this codebase has worked around.
-        ProfilesGroup.Cards.Clear();
-        // Visible first, then hidden -- both sets share one flat list so
-        // the user can flip a profile's hidden state without losing it
-        // off-screen. Hidden profiles still get filtered out of the
-        // new-tab menu / palette / chords because those consumers read
-        // _registry.Profiles, which excludes the hidden half.
-        foreach (var profile in _registry.Profiles)
-        {
-            ProfilesGroup.Cards.Add(BuildRow(profile, isHidden: false));
+            // Build the desired ordered list (visible first, then hidden)
+            // and upsert into ProfilesGroup.Cards in place. Visible and
+            // hidden share one flat list so the user can flip a profile's
+            // hidden state without losing it off-screen; hidden profiles
+            // still get filtered out of the new-tab menu / palette /
+            // chords because those consumers read _registry.Profiles.
+            var desired = new List<(ResolvedProfile Profile, bool IsHidden)>(
+                _registry.Profiles.Count + _registry.HiddenProfiles.Count);
+            foreach (var p in _registry.Profiles) desired.Add((p, false));
+            foreach (var p in _registry.HiddenProfiles) desired.Add((p, true));
+
+            // Drop cards whose id is no longer in the registry.
+            var desiredIds = new HashSet<string>(desired.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (var (p, _) in desired) desiredIds.Add(p.Id);
+            var stale = _cardsByProfileId.Keys.Where(k => !desiredIds.Contains(k)).ToList();
+            foreach (var id in stale)
+            {
+                var card = _cardsByProfileId[id];
+                if (card.Control is ToggleSwitch t) t.Toggled -= OnHiddenToggled;
+                ProfilesGroup.Cards.Remove(card);
+                _cardsByProfileId.Remove(id);
+            }
+
+            // Place each desired card at the correct index, creating new
+            // cards as needed and reordering existing ones via Move so
+            // the visual tree of an unaffected row survives the rebind.
+            for (int i = 0; i < desired.Count; i++)
+            {
+                var (profile, isHidden) = desired[i];
+                if (_cardsByProfileId.TryGetValue(profile.Id, out var card))
+                {
+                    card.Header = profile.Name;
+                    card.Description = profile.Command;
+                    if (card.Control is ToggleSwitch toggle && toggle.IsOn != isHidden)
+                        toggle.IsOn = isHidden;
+
+                    var currentIdx = ProfilesGroup.Cards.IndexOf(card);
+                    if (currentIdx != i) ProfilesGroup.Cards.Move(currentIdx, i);
+                }
+                else
+                {
+                    card = BuildRow(profile, isHidden);
+                    _cardsByProfileId[profile.Id] = card;
+                    ProfilesGroup.Cards.Insert(i, card);
+                }
+            }
         }
-        foreach (var profile in _registry.HiddenProfiles)
-        {
-            ProfilesGroup.Cards.Add(BuildRow(profile, isHidden: true));
-        }
+        finally { _loading = false; }
     }
 
-    // Builds one SettingsCard with a ToggleSwitch on the right. The
-    // toggle's current state mirrors the row's section: off in the
-    // visible list, on in the hidden list (when that section lands in
-    // a follow-up commit). Tag carries the profile id so the handler
-    // does not need a per-row closure capture.
+    // Builds one SettingsCard with a ToggleSwitch on the right. Tag
+    // carries the profile id so the handler does not need a per-row
+    // closure capture.
     private SettingsCard BuildRow(ResolvedProfile profile, bool isHidden)
     {
         var toggle = new ToggleSwitch
@@ -115,39 +158,29 @@ internal sealed partial class ProfilesPage : Page
 
     private void OnHiddenToggled(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
+        if (_loading) return;
         if (sender is not ToggleSwitch toggle) return;
         if (toggle.Tag is not string id) return;
+
+        // Mirror the AppearancePage / RawEditorPage pattern: suppress the
+        // FileSystemWatcher around our own write so its 300ms debounce
+        // doesn't double-fire Reload, then call Reload explicitly so the
+        // in-memory ProfileView updates and the page rebinds
+        // deterministically rather than depending on when the watcher's
+        // debounce timer happens to land.
+        //
+        // Hide via SetValue("true"); un-hide via RemoveValue rather than
+        // SetValue("false") so the config stays minimal -- hidden
+        // defaults to false, so a stray "false" line is just noise that
+        // also confuses the warnings filter for hidden-only blocks.
+        var key = ProfileHiddenKey.For(id);
+        _configService.SuppressWatcher(true);
         try
         {
-            // Mirror the AppearancePage / RawEditorPage pattern: suppress
-            // the FileSystemWatcher around our own write so its 300ms
-            // debounce doesn't double-fire Reload, then call Reload
-            // explicitly so the in-memory ProfileView updates and the
-            // page rebinds deterministically rather than depending on
-            // when the watcher's debounce timer happens to land.
-            //
-            // Hide via SetValue("true"); un-hide via RemoveValue rather
-            // than SetValue("false") so the config stays minimal --
-            // hidden defaults to false, so a stray "false" line is just
-            // noise that also confuses the warnings filter for
-            // hidden-only blocks.
-            var key = ProfileHiddenKey.For(id);
-            _configService.SuppressWatcher(true);
-            try
-            {
-                if (toggle.IsOn) _editor.SetValue(key, "true");
-                else _editor.RemoveValue(key);
-            }
-            finally { _configService.SuppressWatcher(false); }
-            _configService.Reload();
+            if (toggle.IsOn) _editor.SetValue(key, "true");
+            else _editor.RemoveValue(key);
         }
-        catch (Exception ex)
-        {
-            // SetValue / RemoveValue / Reload failure leaves the toggle
-            // visually flipped; the next ProfilesChanged event from a
-            // successful reload would either confirm or revert it.
-            // Logged for diagnostic only -- no user-facing surface in V1.
-            Debug.WriteLine($"failed to toggle profile {id} hidden: {ex}");
-        }
+        finally { _configService.SuppressWatcher(false); }
+        _configService.Reload();
     }
 }

--- a/windows/Ghostty/Settings/SettingsWindow.xaml
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml
@@ -66,6 +66,15 @@
                         <SymbolIcon Symbol="Font" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem x:Name="NavProfiles" Content="Profiles" Tag="profiles">
+                    <NavigationViewItem.Icon>
+                        <!-- E748 Segoe Fluent "PreviewLink": ProfileCommandSource
+                             ships LeadingIcon="" today, so there's no existing
+                             glyph to reuse for visual continuity. PreviewLink
+                             reads as a list-of-launchables which fits the page. -->
+                        <FontIcon Glyph="&#xE748;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem x:Name="NavColors" Content="Colors" Tag="colors">
                     <NavigationViewItem.Icon>
                         <SymbolIcon Symbol="Highlight" />

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -105,6 +105,9 @@ internal sealed partial class SettingsWindow : Window
         {
             new PageMapping("general", "General", NavGeneral),
             new PageMapping("appearance", "Appearance", NavAppearance),
+            // Profiles page renders the registry directly and doesn't host
+            // SettingsIndex entries yet; null IndexName keeps it out of search.
+            new PageMapping("profiles", null, NavProfiles),
             new PageMapping("colors", "Colors", NavColors),
             new PageMapping("terminal", "Terminal", NavTerminal),
             new PageMapping("keybindings", "Keybindings", NavKeybindings),
@@ -221,6 +224,9 @@ internal sealed partial class SettingsWindow : Window
             {
                 "general" => new Pages.GeneralPage(_configService, _editor),
                 "appearance" => new Pages.AppearancePage(_configService, _editor),
+                "profiles" => new Pages.ProfilesPage(
+                    App.ProfileRegistry
+                        ?? throw new InvalidOperationException("ProfileRegistry not initialized")),
                 "colors" => new Pages.ColorsPage(_configService, _editor, _theme),
                 "terminal" => new Pages.TerminalPage(_configService, _editor),
                 "keybindings" => new Pages.KeybindingsPage(_keybindings),

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -226,7 +226,9 @@ internal sealed partial class SettingsWindow : Window
                 "appearance" => new Pages.AppearancePage(_configService, _editor),
                 "profiles" => new Pages.ProfilesPage(
                     App.ProfileRegistry
-                        ?? throw new InvalidOperationException("ProfileRegistry not initialized")),
+                        ?? throw new InvalidOperationException("ProfileRegistry not initialized"),
+                    _configService,
+                    _editor),
                 "colors" => new Pages.ColorsPage(_configService, _editor, _theme),
                 "terminal" => new Pages.TerminalPage(_configService, _editor),
                 "keybindings" => new Pages.KeybindingsPage(_keybindings),


### PR DESCRIPTION
Last slice of the V1 Wintty profiles stack (after # 328, # 333, # 337, # 345, # 346). Adds a "Profiles" page to the settings window with a flat list of every profile (visible + hidden), a per-row Visible/Hidden toggle that round-trips through the config, and a Warning InfoBar surfacing parser issues.

## What changed

- `ProfileOrderResolver` returns a `ResolvedProfileSet(Visible, Hidden)`. Hidden entries are preserved in a parallel list with their own OrderIndex sequence and `IsDefault` forced false.
- `IProfileRegistry.HiddenProfiles` exposes the hidden half so the inspector can render an unhide affordance. The visible list (`Profiles`) is unchanged, so consumer surfaces (new-tab split button, command palette, Ctrl+Shift+1..9 chords) keep filtering correctly.
- `ProfileHiddenKey.For(id)` centralises the `profile.<id>.hidden` key format.
- New `ProfilesPage` (XAML + code-behind) with title, default-profile readout, all profiles in one flat list, and a Warnings InfoBar. Toggle handler suppresses the file watcher and calls `Reload()` explicitly so the page rebinds deterministically (matches `AppearancePage` / `RawEditorPage`). Unhide path uses `RemoveValue` so the config stays minimal.
- `ProfileSourceParser.ExtractHiddenMentionIds` paired with the existing `ExtractHiddenIds` so the warnings filter suppresses missing-name warnings for any id whose only `profile.<id>.*` line is a hide-override (true OR false).

## UX decision (mid-stream)

The plan called for a separate "Hidden" expander; we changed to a single flat list with per-row toggles after smoke testing. Matches Windows Terminal's inspector model and avoids stranding hidden profiles off-screen.

## Manual matrix (smoked end-to-end)

- Open Settings -> Profiles: title + default-profile card + flat list render correctly.
- Toggle a profile to Hidden: row stays in list with toggle on, drops from new-tab menu + palette + chords.
- Toggle back to Visible: row returns to consumer surfaces, config line removed entirely.
- Malformed \`profile.X.font-size = 14\` (no name): warning InfoBar appears with the parser warning verbatim.
- Stray \`profile.X.hidden = false\` (un-hide artifact): no spurious warning (covered by the filter fix).
- Default-profile card reflects current \`default-profile\` config value.

## Tests

- Cross-platform: 781 passed, 0 failed, 1 skipped (pre-existing).
- Windows: 11 passed, 4 deferred-fail stubs (PR 4 tasks 17/18 + PR 5 chord smoke + this PR's ProfilesPage smoke; all blocked on the same WinUITestHost).
- AOT publish: zero new IL2/IL3 warnings.

## Out of scope (follow-ups)

- "Refresh discovery" button on \`IProfileRegistry.RefreshDiscoveryAsync\`.
- Per-row "Open in raw editor" deep-link.
- Phase 2 full CRUD editor (deferred until usage data).
- Stand-alone task spawned: whitelist \`internal.*\` config keys from "unknown field" diagnostics.