### PR TITLE
config: suppress unknown-field diagnostic for internal.* keys

### DIFF
--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -137,4 +137,24 @@ public static class WindowsOnlyKeys
         var sep = key.IndexOf('.', Prefix.Length);
         return sep > Prefix.Length && sep < key.Length - 1;
     }
+
+    /// <summary>
+    /// Returns true when <paramref name="key"/> is an internal-namespace
+    /// key of the shape <c>internal.&lt;name&gt;</c>. These are reserved
+    /// for app-private knobs (e.g. update simulator toggles) that are
+    /// read directly from the raw config file and are not meant to be
+    /// surfaced as Windows-only public config; suppressing them here
+    /// keeps libghostty's "unknown field" diagnostic from leaking into
+    /// the settings UI notice list.
+    /// </summary>
+    public static bool IsInternalKey(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        const string Prefix = "internal.";
+        // Need the full prefix plus at least one character of <name>;
+        // bare "internal." or "internal" alone shouldn't match.
+        return key.Length > Prefix.Length
+            && key.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -128,4 +128,19 @@ public class WindowsOnlyKeysTests
     {
         Assert.Equal(expected, Ghostty.Core.Config.WindowsOnlyKeys.IsProfileSubkey(key));
     }
+
+    [Theory]
+    [InlineData("internal.update-simulator", true)]
+    [InlineData("internal.foo", true)]
+    [InlineData("internal.a", true)]                    // minimal valid (single char name)
+    [InlineData("INTERNAL.UPDATE-SIMULATOR", true)]     // case-insensitive prefix
+    [InlineData("internal.", false)]                    // bare prefix, no name
+    [InlineData("internal", false)]                     // exact scalar
+    [InlineData("internalish", false)]                  // prefix-without-dot, different key
+    [InlineData("profile.x.internal", false)]           // different namespace
+    [InlineData("background-style", false)]             // unrelated public key
+    public void IsInternalKey_Expected(string key, bool expected)
+    {
+        Assert.Equal(expected, Ghostty.Core.Config.WindowsOnlyKeys.IsInternalKey(key));
+    }
 }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -290,6 +290,14 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
                     // notice list for a many-profile config).
                     continue;
                 }
+                if (WindowsOnlyKeys.IsInternalKey(key))
+                {
+                    // internal.<name> keys are app-private knobs read
+                    // directly from the raw config file; they aren't
+                    // public Windows-only config, so we don't surface
+                    // them via WindowsOnlyKeysUsed either.
+                    continue;
+                }
                 if (WindowsOnlyKeys.Contains(key))
                 {
                     if (_windowsOnlyKeysSeen.Add(key))


### PR DESCRIPTION
Adds an `IsInternalKey` helper in `WindowsOnlyKeys` that mirrors `IsProfileSubkey`, and wires it into `ConfigService`'s diagnostic loop so app-private knobs (today: `internal.update-simulator`) stop leaking into the settings notice list as "unknown field" warnings.

Surfaced during PR #349 work when the warnings InfoBar showed `internal.update-simulator` even though the key is read directly from the raw config file and isn't meant to be a public Windows-only key.

## Test plan
- [x] `dotnet build windows/Ghostty.sln -c Release` clean (warnings all pre-existing)
- [x] `dotnet test windows/Ghostty.Tests` 790/0/1 (+9 new `IsInternalKey_Expected` theory rows, all green)
- [ ] manual: launch app with `internal.update-simulator = true` in config, confirm it no longer appears in the settings warnings InfoBar