### PR TITLE
tests: reframe WinUI smoke stubs as manual-smoke specs

### DIFF
--- a/windows/Ghostty.Tests.Windows/Commands/ProfileChordSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Commands/ProfileChordSmokeTests.cs
@@ -4,12 +4,19 @@ namespace Ghostty.Tests.Windows.Commands;
 
 public class ProfileChordSmokeTests
 {
-    // Wire-up plan when WinUITestHost lands:
-    //   1. Build a MainWindow on the WinUITestHost dispatcher.
-    //   2. Inject a FakeProfileRegistry with 3 profiles ("a", "b", "c").
-    //   3. Synthesize a Ctrl+Shift+Number2 KeyboardAccelerator invocation.
-    //   4. Assert OpenProfile was called with id="b", target=NewTab.
-    [Fact(Skip = "TODO: wire WinUITestHost (also blocks PR 4 tasks 17/18)")]
+    // Manual smoke spec for the Ctrl+Shift+N profile chord.
+    //
+    // Slot-to-id resolution is already covered exhaustively by
+    // ProfileSlotResolverTests in Ghostty.Tests. The piece this
+    // test would exercise -- the WinUI keyboard accelerator into
+    // PaneAction routing -- requires a real MainWindow on a
+    // dispatcher, which is the same architectural blocker that
+    // keeps NewTabSplitButtonSmokeTests un-automated.
+    //
+    // To validate by hand: with 3 profiles ("a","b","c") in the
+    // config, press Ctrl+Shift+2 and confirm a new tab opens for
+    // profile "b".
+    [Fact(Skip = "Manual smoke; XAML+dispatcher hosting not in scope for this test project.")]
     public void CtrlShift2_With3Profiles_OpensProfileAtIndex1AsNewTab()
     {
     }

--- a/windows/Ghostty.Tests.Windows/Settings/ProfilesPageSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Settings/ProfilesPageSmokeTests.cs
@@ -4,18 +4,28 @@ namespace Ghostty.Tests.Windows.Settings;
 
 public class ProfilesPageSmokeTests
 {
-    // Wire-up plan when WinUITestHost lands:
-    //   1. Build a SettingsWindow on the WinUITestHost dispatcher.
-    //   2. Inject a FakeProfileRegistry with 2 visible + 1 hidden
-    //      profile and a no-op IConfigFileEditor.
-    //   3. Navigate to the "profiles" tab.
-    //   4. Assert ProfilesGroup.Cards.Count == 3 with toggle states
-    //      off/off/on in registry-order.
-    //   5. Toggle the first row on; assert the editor saw a
-    //      SetValue("profile.<id>.hidden", "true") call.
-    //   6. Toggle the third row off; assert the editor saw a
-    //      RemoveValue("profile.<id>.hidden") call.
-    [Fact(Skip = "TODO: wire WinUITestHost (also blocks PR 4 tasks 17/18 + PR 5 chord smoke)")]
+    // Manual smoke spec for the Profiles settings page.
+    //
+    // Visible/hidden ordering and per-row hide-marker parsing are
+    // already covered by ProfileOrderResolverTests,
+    // ProfileRegistryTests, ProfileHiddenKeyTests, and
+    // ProfileSourceParserHiddenIdsTests in Ghostty.Tests. What this
+    // test would add is the SettingsCard rendering and the
+    // ToggleSwitch into IConfigFileEditor write path inside a real
+    // SettingsWindow on a dispatcher, and hosting WinUI 3 here is
+    // the same architectural blocker that keeps the other smoke
+    // tests un-automated.
+    //
+    // To validate by hand:
+    //   1. Open Settings -> Profiles with 2 visible + 1 hidden
+    //      profile.
+    //   2. Confirm 3 rows render in registry order with toggle
+    //      states off/off/on.
+    //   3. Toggle the first row on; confirm the config file gains
+    //      'profile.<id>.hidden = true'.
+    //   4. Toggle the third row off; confirm the line is removed
+    //      via RemoveValue (not rewritten as 'hidden = false').
+    [Fact(Skip = "Manual smoke; XAML+dispatcher hosting not in scope for this test project.")]
     public void ProfilesPage_RendersVisibleAndHiddenProfilesInOneFlatList()
     {
     }

--- a/windows/Ghostty.Tests.Windows/Tabs/NewTabSplitButtonSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tabs/NewTabSplitButtonSmokeTests.cs
@@ -4,20 +4,20 @@ namespace Ghostty.Tests.Windows.Tabs;
 
 public class NewTabSplitButtonSmokeTests
 {
-    // Booting a real MainWindow inside a unit test requires the XAML
-    // test host pattern used elsewhere in this project.
+    // Manual smoke spec for the new-tab split button placement.
     //
-    // Required helpers (verify exist; create with InternalsVisibleTo
-    // if they do not):
-    //   - WinUITestHost.RunOnUiAsync(() => ...)
-    //   - WinUITestHost.NewMainWindow(stubProfileRegistry)
-    //   - WinUITestHost.FindDescendantOfType<T>(element)
+    // Not automated: hosting a real MainWindow inside this test
+    // project would require Microsoft.WindowsAppSDK + a XAML
+    // dispatcher host + a ProjectReference to Ghostty.csproj, and
+    // MainWindow's ctor calls into libghostty via GhosttyHost.
+    // Ghostty.Tests.Windows intentionally references only
+    // Ghostty.Core, so neither dependency is acceptable here.
     //
-    // The body uses these helpers via DispatcherQueueController. If
-    // they do not exist, this test is the right place to introduce
-    // them -- the harness pattern is shared with future PR 4.5 / PR 6
-    // tests.
-    [Fact(Skip = "TODO: wire WinUITestHost. See file header comment.")]
+    // To validate by hand:
+    //   1. Run the app.
+    //   2. Confirm the new-tab control is hosted in the tab footer
+    //      and the legacy add-button is hidden.
+    [Fact(Skip = "Manual smoke; XAML+dispatcher hosting not in scope for this test project.")]
     public void NewTabSplitButton_IsHostedInFooter_AndAddButtonIsHidden()
     {
     }

--- a/windows/Ghostty.Tests.Windows/Tabs/TitleBarPassthroughTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tabs/TitleBarPassthroughTests.cs
@@ -4,19 +4,23 @@ namespace Ghostty.Tests.Windows.Tabs;
 
 public class TitleBarPassthroughTests
 {
-    [Fact]
+    // Manual smoke spec for split-button title-bar passthrough.
+    //
+    // Same architectural blocker as NewTabSplitButtonSmokeTests:
+    // verifying the SplitButton bounds sit outside the title-bar
+    // drag region requires a live MainWindow on a dispatcher,
+    // which is outside the contract of Ghostty.Tests.Windows
+    // (Core-only references; no WinUI host).
+    //
+    // To validate by hand:
+    //   1. Run the app.
+    //   2. Drag the window from the area just left of the new-tab
+    //      split button. The drag should succeed (the spacer cell
+    //      is the title-bar element).
+    //   3. Click the same split button. It should activate the
+    //      new-tab dropdown without dragging the window.
+    [Fact(Skip = "Manual smoke; XAML+dispatcher hosting not in scope for this test project.")]
     public void SplitButton_BoundsAreNotInsideTitleBarElement()
     {
-        // Same WinUITestHost helper as NewTabSplitButtonSmokeTests.
-        // Assertions:
-        //   1. Find the SplitButton ('ButtonRoot') inside MainWindow.
-        //   2. Find the element passed to AppWindow.SetTitleBar
-        //      (TabHost.CustomDragRegion = the cell-1 spacer).
-        //   3. Compute SplitButton.TransformToVisual(spacer)
-        //      .TransformBounds(Rect.Empty).
-        //   4. Assert the SplitButton bounds are NOT contained within
-        //      the spacer's bounds (i.e. they live in cell 0, not cell 1).
-
-        Assert.Fail("TODO: wire WinUITestHost (shared with NewTabSplitButtonSmokeTests).");
     }
 }


### PR DESCRIPTION
The 4 WinUI smoke tests in `Ghostty.Tests.Windows` had Skip messages reading `"TODO: wire WinUITestHost..."` which is misleading: hosting a real `MainWindow` here would require `Microsoft.WindowsAppSDK` + a XAML dispatcher host + a ProjectReference to `Ghostty.csproj`, and `MainWindow`'s ctor calls into libghostty via `GhosttyHost`. `Ghostty.Tests.Windows` references only `Ghostty.Core` by design, so neither dependency is acceptable.

Reframes each test as a manual-smoke spec: the header documents what to check by hand, the Skip message says why it cannot be automated under the current infra contract. Slot-resolution and hidden-marker logic are already covered by pure-logic tests in `Ghostty.Tests` (`ProfileSlotResolverTests`, `ProfileOrderResolverTests`, `ProfileHiddenKeyTests`), so the gap closed by these tests would be integration-level only.

Also flips `TitleBarPassthroughTests` from `[Fact]` + `Assert.Fail("TODO...")` to `[Fact(Skip=...)]`, matching the other three and dropping a spurious red CI signal.

If a real WinUI smoke harness becomes worth building later (e.g. by extracting MainWindow construction onto interfaces in the PR # 65 `IDispatcher` style), the manual-smoke specs in these files double as a checklist of what each test should assert.

## Test plan
- [x] \`dotnet test windows/Ghostty.Tests.Windows\` 11 pass / 4 skip / 0 fail (was 11 / 3 / 1).
- [x] Skip messages render in xUnit console output.