### PR TITLE
tabs: port new-tab split button to vertical strip

### DIFF
--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -368,6 +368,7 @@ public sealed partial class MainWindow : Window
         _horizontalTabHost = new TabHost(_tabManager, _router, _dialogs);
         _horizontalTabHost.AttachOwner(this);
         _verticalTabHost = new VerticalTabHost(_tabManager, _router, _dialogs, _host);
+        _verticalTabHost.AttachOwner(this);
 
         // Place both tab hosts in their RootGrid slots. The
         // horizontal host spans both columns in row 0 so its TabView

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -25,7 +25,11 @@ namespace Ghostty.Shell;
 /// </summary>
 internal sealed class LayoutCoordinator
 {
-    public const double VerticalStripCollapsedWidth = 40;
+    // Wider than the 40px icon cell so the new-tab split button at
+    // the bottom of the vertical strip can render its dropdown
+    // chevron. Must stay in sync with the StripColumn Width in
+    // VerticalTabHost.xaml.
+    public const double VerticalStripCollapsedWidth = 56;
     public const int SwitchDurationMs = 220;
 
     private readonly ColumnDefinition _stripColumn;

--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
@@ -21,14 +21,44 @@ internal sealed partial class NewTabSplitButton : UserControl
     }
 
     /// <summary>
-    /// Owning window. Set by <see cref="TabHost"/> immediately after
-    /// constructing the control so click handlers can call
+    /// Owning window. Set by <see cref="TabHost"/> or
+    /// <see cref="VerticalTabStrip"/> immediately after constructing
+    /// the control so click handlers can call
     /// <see cref="MainWindow.OpenProfile"/>.
     /// </summary>
     internal MainWindow? Owner
     {
         get => _owner;
         set => _owner = value;
+    }
+
+    /// <summary>
+    /// Placement for the profile dropdown flyout. Default
+    /// <see cref="FlyoutPlacementMode.Bottom"/> matches the horizontal
+    /// tab-strip footer; the vertical-strip footer sets it to
+    /// <see cref="FlyoutPlacementMode.Right"/> so the menu opens away
+    /// from the sidebar instead of off the bottom edge of the window.
+    /// </summary>
+    public FlyoutPlacementMode FlyoutPlacement
+    {
+        get => (FlyoutPlacementMode)GetValue(FlyoutPlacementProperty);
+        set => SetValue(FlyoutPlacementProperty, value);
+    }
+
+    public static readonly DependencyProperty FlyoutPlacementProperty =
+        DependencyProperty.Register(
+            nameof(FlyoutPlacement),
+            typeof(FlyoutPlacementMode),
+            typeof(NewTabSplitButton),
+            new PropertyMetadata(FlyoutPlacementMode.Bottom, OnFlyoutPlacementChanged));
+
+    private static void OnFlyoutPlacementChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        // ProfileMenu is created during InitializeComponent; the DP
+        // can be set before parent-XAML attachment in some hosting
+        // paths, so guard the field access defensively.
+        if (d is NewTabSplitButton ctl && ctl.ProfileMenu is not null)
+            ctl.ProfileMenu.Placement = (FlyoutPlacementMode)e.NewValue;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml
@@ -13,7 +13,12 @@
          this UserControl is constrained to the strip column. -->
     <Grid Background="Transparent" ContextRequested="OnStripContextRequested">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="StripColumn" Width="40"/>
+            <!-- Collapsed width is wider than the icon cell (40px) so
+                 the new-tab split button at the bottom of the strip
+                 can render its dropdown chevron. Must match
+                 LayoutCoordinator.VerticalStripCollapsedWidth. The
+                 icon rows above stay 40px wide and left-aligned. -->
+            <ColumnDefinition x:Name="StripColumn" Width="56"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -114,7 +114,10 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
         // via a shared container (see #171). Same for the title-bar
         // TextBlock that used to live in this UserControl.
 
-        _strip.NewTabRequested += (_, _) => _manager.NewTab();
+        // The new-tab button is the composite NewTabSplitButton;
+        // it routes Click / Alt+Click / Shift+Click through
+        // MainWindow.OpenProfile after MainWindow calls AttachOwner.
+        // The chevron is still strip-local (toggles pinned state).
         _strip.ChevronToggled += (_, _) => TogglePinned();
     }
 
@@ -125,6 +128,15 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     /// </summary>
     internal void TogglePinnedFromKeyboard() => TogglePinned();
 
+    /// <summary>
+    /// Forward the owning window into the strip's
+    /// <see cref="NewTabSplitButton"/> so its click handlers can call
+    /// <see cref="MainWindow.OpenProfile"/>. Mirrors
+    /// <see cref="TabHost.AttachOwner"/>; <see cref="MainWindow"/>
+    /// invokes both immediately after constructing the hosts.
+    /// </summary>
+    internal void AttachOwner(MainWindow owner) => _strip.AttachOwner(owner);
+
     private void OnSwitchLayoutClick(object sender, RoutedEventArgs e)
         => _router.RequestToggleTabLayout();
 
@@ -132,7 +144,9 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     {
         _pinnedExpanded = !_pinnedExpanded;
         _strip.IsExpanded = _pinnedExpanded;
-        var target = _pinnedExpanded ? ExpandedWidth : 40;
+        var target = _pinnedExpanded
+            ? ExpandedWidth
+            : Ghostty.Shell.LayoutCoordinator.VerticalStripCollapsedWidth;
         // MainWindow listens on this event and tweens both its
         // RootGrid outer strip column AND our internal column in
         // lockstep so the sidebar actually grows on-screen.

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml
@@ -3,6 +3,7 @@
     x:Class="Ghostty.Tabs.VerticalTabStrip"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:tabs="using:Ghostty.Tabs"
     Background="Transparent">
 
     <UserControl.Resources>
@@ -201,15 +202,15 @@
                   ScrollViewer.HorizontalScrollMode="Disabled"
                   ScrollViewer.HorizontalScrollBarVisibility="Hidden"/>
 
-        <Button x:Name="NewTabButton"
-                Grid.Row="2"
-                Width="32" Height="32"
-                Margin="4"
-                Padding="0"
-                Background="Transparent"
-                BorderThickness="0"
-                Click="OnNewTabClick">
-            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE710;"/>
-        </Button>
+        <!-- Composite new-tab control: same UserControl as the
+             horizontal TabHost footer. Routes Click / Alt+Click /
+             Shift+Click through MainWindow.OpenProfile and exposes
+             a profile-selection dropdown. FlyoutPlacement="Right"
+             opens the menu into the pane area instead of off the
+             window's bottom edge. -->
+        <tabs:NewTabSplitButton x:Name="NewTabButton"
+                                Grid.Row="2"
+                                Margin="4"
+                                FlyoutPlacement="Right"/>
     </Grid>
 </UserControl>

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -25,9 +25,6 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// <summary>Raised when the user clicks the chevron toggle.</summary>
     public event EventHandler? ChevronToggled;
 
-    /// <summary>Raised when the user clicks the new-tab "+" button.</summary>
-    public event EventHandler? NewTabRequested;
-
     /// <summary>Raised when a row's close button is clicked. The
     /// consuming <see cref="VerticalTabHost"/> routes this through its
     /// shared <c>RequestCloseTabAsync</c>.</summary>
@@ -150,6 +147,15 @@ internal sealed partial class VerticalTabStrip : UserControl
     private void OnChevronClick(object sender, RoutedEventArgs e) =>
         ChevronToggled?.Invoke(this, EventArgs.Empty);
 
-    private void OnNewTabClick(object sender, RoutedEventArgs e) =>
-        NewTabRequested?.Invoke(this, EventArgs.Empty);
+    /// <summary>
+    /// Wire the owning window into <see cref="NewTabButton"/> so the
+    /// composite control's click handlers can call
+    /// <see cref="MainWindow.OpenProfile"/>. Mirrors
+    /// <see cref="TabHost.AttachOwner"/>; <see cref="VerticalTabHost"/>
+    /// forwards the call after constructing the strip.
+    /// </summary>
+    internal void AttachOwner(MainWindow owner)
+    {
+        NewTabButton.Owner = owner;
+    }
 }


### PR DESCRIPTION
Closes # 344.

Vertical-strip users currently have a plain ` +` button in the strip footer that opens only the default profile. Horizontal mode has the composite ` NewTabSplitButton` (profile-aware, Click/Alt/Shift modifiers, dropdown of all profiles). This ports the same UserControl into the vertical strip footer.

## What changed

- ` NewTabSplitButton` gains a ` FlyoutPlacement` DependencyProperty (default ` Bottom`). Vertical strip sets it to ` Right` so the menu opens into the pane area instead of off the window's bottom edge.
- ` VerticalTabStrip.xaml` swaps the plain ` <Button>` for ` <tabs:NewTabSplitButton>`. The horizontal AttachOwner pattern is mirrored: ` VerticalTabStrip.AttachOwner(MainWindow)` -> ` NewTabButton.Owner = owner`; ` VerticalTabHost.AttachOwner` forwards; ` MainWindow` calls it sibling to the existing horizontal call.
- Drops the now-redundant ` NewTabRequested` event + ` OnNewTabClick` handler on the strip, and the ` _strip.NewTabRequested += _manager.NewTab()` subscription on the host. The default-profile shortcut is preserved through ` OpenProfile(DefaultProfileId)`.
- Bumps collapsed strip width 40 -> 56 so the dropdown chevron is visible in collapsed mode (per design ask). The ` LayoutCoordinator.VerticalStripCollapsedWidth` constant is the single source of truth; XAML references it via comment.

## Test plan

- [x] ` dotnet build windows/Ghostty.sln -c Release` clean (only pre-existing warnings).
- [x] ` dotnet test windows/Ghostty.Tests` 790/0/1 (unchanged from baseline).
- [x] ` dotnet test windows/Ghostty.Tests.Windows` 11/4/0 (unchanged from baseline; 4 manual-smoke specs from PR # 353 still skipped).
- [ ] manual: switch to vertical tabs, confirm split button renders with chevron in collapsed mode and the dropdown opens to the right of the strip.
- [ ] manual: Click / Alt+Click / Shift+Click route through ` OpenProfile` (new tab / new pane / new window) for both default profile and a dropdown selection.
- [ ] manual: drag-reorder, close, expand/collapse, pinned-expanded resize all still work.