### PR TITLE
tabs: stack new-tab chevron below primary in vertical mode

### DIFF
--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -25,11 +25,12 @@ namespace Ghostty.Shell;
 /// </summary>
 internal sealed class LayoutCoordinator
 {
-    // Wider than the 40px icon cell so the new-tab split button at
-    // the bottom of the vertical strip can render its dropdown
-    // chevron. Must stay in sync with the StripColumn Width in
-    // VerticalTabHost.xaml.
-    public const double VerticalStripCollapsedWidth = 56;
+    // Width of the icon cell (chevron, tab rows, new-tab control).
+    // The new-tab split button stacks its dropdown chevron
+    // vertically in this mode (Orientation=Vertical on
+    // NewTabSplitButton), so the column can stay narrow. Must stay
+    // in sync with the StripColumn Width in VerticalTabHost.xaml.
+    public const double VerticalStripCollapsedWidth = 40;
     public const int SwitchDurationMs = 220;
 
     private readonly ColumnDefinition _stripColumn;

--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml
@@ -6,15 +6,34 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     HorizontalAlignment="Left"
     VerticalAlignment="Center">
-    <controls:SplitButton x:Name="ButtonRoot"
-                          Click="OnPrimaryClick"
-                          ToolTipService.ToolTip="New tab (Alt: pane, Shift: window)"
-                          AutomationProperties.Name="New tab">
-        <controls:FontIcon Glyph="&#xE710;"
-                           FontFamily="Segoe Fluent Icons"
-                           FontSize="14"/>
-        <controls:SplitButton.Flyout>
-            <controls:MenuFlyout x:Name="ProfileMenu" Placement="Bottom"/>
-        </controls:SplitButton.Flyout>
-    </controls:SplitButton>
+    <!--
+        Two stacked Buttons sharing a MenuFlyout: a primary "+" button
+        that routes through MainWindow.OpenProfile (with Click / Alt /
+        Shift modifiers via ClickModifierClassifier) and a smaller
+        chevron button that opens the profile dropdown. The
+        Orientation property switches between horizontal (TabHost
+        footer) and vertical (VerticalTabStrip footer) layouts; the
+        chevron stays a separate hit target either way so the
+        keyboard / accessibility surface is the same in both modes.
+    -->
+    <StackPanel x:Name="LayoutRoot" Orientation="Horizontal">
+        <Button x:Name="PrimaryButton"
+                Click="OnPrimaryClick"
+                ToolTipService.ToolTip="New tab (Alt: pane, Shift: window)"
+                AutomationProperties.Name="New tab">
+            <controls:FontIcon Glyph="&#xE710;"
+                               FontFamily="Segoe Fluent Icons"
+                               FontSize="14"/>
+        </Button>
+        <Button x:Name="ChevronButton"
+                ToolTipService.ToolTip="New tab from profile..."
+                AutomationProperties.Name="Open profile menu">
+            <controls:FontIcon Glyph="&#xE70D;"
+                               FontFamily="Segoe Fluent Icons"
+                               FontSize="10"/>
+            <Button.Flyout>
+                <controls:MenuFlyout x:Name="ProfileMenu" Placement="Bottom"/>
+            </Button.Flyout>
+        </Button>
+    </StackPanel>
 </UserControl>

--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
@@ -11,7 +11,6 @@ namespace Ghostty.Tabs;
 internal sealed partial class NewTabSplitButton : UserControl
 {
     private NewTabSplitButtonViewModel? _vm;
-    private MainWindow? _owner;
 
     public NewTabSplitButton()
     {
@@ -26,11 +25,7 @@ internal sealed partial class NewTabSplitButton : UserControl
     /// the control so click handlers can call
     /// <see cref="MainWindow.OpenProfile"/>.
     /// </summary>
-    internal MainWindow? Owner
-    {
-        get => _owner;
-        set => _owner = value;
-    }
+    internal MainWindow? Owner { get; set; }
 
     /// <summary>
     /// Placement for the profile dropdown flyout. Default
@@ -59,6 +54,33 @@ internal sealed partial class NewTabSplitButton : UserControl
         // paths, so guard the field access defensively.
         if (d is NewTabSplitButton ctl && ctl.ProfileMenu is not null)
             ctl.ProfileMenu.Placement = (FlyoutPlacementMode)e.NewValue;
+    }
+
+    /// <summary>
+    /// Stack direction for the primary "+" button and its chevron
+    /// dropdown. Horizontal (default) places the chevron to the right
+    /// of the primary action, matching the WinUI SplitButton it
+    /// replaces. Vertical stacks the chevron below the primary so the
+    /// control fits in a narrow vertical-strip footer without forcing
+    /// the strip column to widen.
+    /// </summary>
+    public Orientation Orientation
+    {
+        get => (Orientation)GetValue(OrientationProperty);
+        set => SetValue(OrientationProperty, value);
+    }
+
+    public static readonly DependencyProperty OrientationProperty =
+        DependencyProperty.Register(
+            nameof(Orientation),
+            typeof(Orientation),
+            typeof(NewTabSplitButton),
+            new PropertyMetadata(Orientation.Horizontal, OnOrientationChanged));
+
+    private static void OnOrientationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is NewTabSplitButton ctl && ctl.LayoutRoot is not null)
+            ctl.LayoutRoot.Orientation = (Orientation)e.NewValue;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -119,27 +141,27 @@ internal sealed partial class NewTabSplitButton : UserControl
         }
     }
 
-    private void OnPrimaryClick(SplitButton sender, SplitButtonClickEventArgs args)
+    private void OnPrimaryClick(object sender, RoutedEventArgs e)
     {
         var registry = App.ProfileRegistry;
         var defaultId = registry?.DefaultProfileId;
-        if (defaultId is null || _owner is null) return;
+        if (defaultId is null || Owner is null) return;
 
         var modifiers = App.ModifierKeyState;
         if (modifiers is null) return;
 
-        _owner.OpenProfile(defaultId, ClickModifierClassifier.Classify(modifiers));
+        Owner.OpenProfile(defaultId, ClickModifierClassifier.Classify(modifiers));
     }
 
     private void OnRowClick(object sender, RoutedEventArgs e)
     {
         if (sender is not MenuFlyoutItem item) return;
         if (item.Tag is not string profileId) return;
-        if (_owner is null) return;
+        if (Owner is null) return;
 
         var modifiers = App.ModifierKeyState;
         if (modifiers is null) return;
 
-        _owner.OpenProfile(profileId, ClickModifierClassifier.Classify(modifiers));
+        Owner.OpenProfile(profileId, ClickModifierClassifier.Classify(modifiers));
     }
 }

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml
@@ -13,12 +13,12 @@
          this UserControl is constrained to the strip column. -->
     <Grid Background="Transparent" ContextRequested="OnStripContextRequested">
         <Grid.ColumnDefinitions>
-            <!-- Collapsed width is wider than the icon cell (40px) so
-                 the new-tab split button at the bottom of the strip
-                 can render its dropdown chevron. Must match
-                 LayoutCoordinator.VerticalStripCollapsedWidth. The
-                 icon rows above stay 40px wide and left-aligned. -->
-            <ColumnDefinition x:Name="StripColumn" Width="56"/>
+            <!-- Collapsed width matches the icon cell (40px). The
+                 new-tab split button at the bottom uses
+                 Orientation="Vertical" to stack its chevron below
+                 the primary button, so it fits in this width.
+                 Must match LayoutCoordinator.VerticalStripCollapsedWidth. -->
+            <ColumnDefinition x:Name="StripColumn" Width="40"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml
@@ -205,12 +205,15 @@
         <!-- Composite new-tab control: same UserControl as the
              horizontal TabHost footer. Routes Click / Alt+Click /
              Shift+Click through MainWindow.OpenProfile and exposes
-             a profile-selection dropdown. FlyoutPlacement="Right"
-             opens the menu into the pane area instead of off the
-             window's bottom edge. -->
+             a profile-selection dropdown. Orientation="Vertical"
+             stacks the chevron below the primary button so the
+             control fits in the 40px strip column without forcing
+             it to widen. FlyoutPlacement="Right" opens the menu
+             into the pane area instead of off the bottom edge. -->
         <tabs:NewTabSplitButton x:Name="NewTabButton"
                                 Grid.Row="2"
                                 Margin="4"
+                                Orientation="Vertical"
                                 FlyoutPlacement="Right"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Follow-up to # 354. PR # 354 made the dropdown chevron visible in collapsed mode by widening the vertical strip 40 -> 56. This swaps the underlying ` SplitButton` for a paired Button + chevron pair so the chevron can stack below the primary button in vertical mode, restoring the 40px strip width.

## What changed

- ` NewTabSplitButton` UserControl now uses a ` StackPanel` + two ` Button`s + a shared ` MenuFlyout` (instead of a single ` SplitButton`). The primary Button's Click handler is unchanged (routes through ` MainWindow.OpenProfile` with ` ClickModifierClassifier`); the chevron Button uses ` Button.Flyout` to auto-open the menu.
- New ` Orientation` DP on ` NewTabSplitButton` (default ` Horizontal`). Vertical strip sets ` Orientation=\"Vertical\"`.
- ` LayoutCoordinator.VerticalStripCollapsedWidth` reverted 56 -> 40 (single source of truth; ` VerticalTabHost.xaml` ` StripColumn` follows).
- ` Owner` collapsed from explicit field-backed property to auto-property (over-engineered before).

## Behavioral note

Horizontal-mode users also move from a real ` SplitButton` to two paired Buttons. The visual delta should be subtle (default Button styling is similar to ` SplitButton`'s primary + chevron), but it's not a no-op.

## Test plan

- [x] ` dotnet build windows/Ghostty.sln -c Release` clean (only pre-existing warnings).
- [x] ` dotnet test windows/Ghostty.Tests` 790/0/1 (unchanged from baseline).
- [x] ` dotnet test windows/Ghostty.Tests.Windows` 11/4/0 (unchanged from baseline).
- [ ] manual: vertical mode renders strip at 40px wide, primary ` +` button on top, chevron just below; clicking the chevron opens the profile menu to the right of the strip.
- [ ] manual: Click / Alt+Click / Shift+Click on the primary button still produce new tab / new pane / new window.
- [ ] manual: horizontal mode renders primary + chevron side by side, no visible regression vs # 354.