### PR TITLE
tabs: unified chrome + orientation-aware chevron on new-tab button

### DIFF
--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml
@@ -4,36 +4,66 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    HorizontalAlignment="Left"
+    HorizontalAlignment="Stretch"
     VerticalAlignment="Center">
     <!--
-        Two stacked Buttons sharing a MenuFlyout: a primary "+" button
-        that routes through MainWindow.OpenProfile (with Click / Alt /
-        Shift modifiers via ClickModifierClassifier) and a smaller
-        chevron button that opens the profile dropdown. The
-        Orientation property switches between horizontal (TabHost
-        footer) and vertical (VerticalTabStrip footer) layouts; the
-        chevron stays a separate hit target either way so the
-        keyboard / accessibility surface is the same in both modes.
+        Unified chrome that wraps a primary "+" Button + a smaller
+        chevron Button + a 1px separator into a single visual unit.
+        Theme key overrides at UserControl scope (NOT per-button:
+        per-button Resources crashed the WinUI runtime in
+        ApplyBackdropStyle during MainWindow ctor) make the inner
+        Buttons transparent by default while preserving the standard
+        PointerOver / Pressed background brushes so each half still
+        highlights individually on hover.
     -->
-    <StackPanel x:Name="LayoutRoot" Orientation="Horizontal">
-        <Button x:Name="PrimaryButton"
-                Click="OnPrimaryClick"
-                ToolTipService.ToolTip="New tab (Alt: pane, Shift: window)"
-                AutomationProperties.Name="New tab">
-            <controls:FontIcon Glyph="&#xE710;"
-                               FontFamily="Segoe Fluent Icons"
-                               FontSize="14"/>
-        </Button>
-        <Button x:Name="ChevronButton"
-                ToolTipService.ToolTip="New tab from profile..."
-                AutomationProperties.Name="Open profile menu">
-            <controls:FontIcon Glyph="&#xE70D;"
-                               FontFamily="Segoe Fluent Icons"
-                               FontSize="10"/>
-            <Button.Flyout>
-                <controls:MenuFlyout x:Name="ProfileMenu" Placement="Bottom"/>
-            </Button.Flyout>
-        </Button>
-    </StackPanel>
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="ButtonBackground" Color="Transparent"/>
+        <SolidColorBrush x:Key="ButtonBorderBrush" Color="Transparent"/>
+        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="Transparent"/>
+        <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent"/>
+        <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Transparent"/>
+    </UserControl.Resources>
+    <Border x:Name="OuterChrome"
+            CornerRadius="4"
+            Background="{ThemeResource SubtleFillColorTransparentBrush}"
+            BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+            BorderThickness="1">
+        <StackPanel x:Name="LayoutRoot" Orientation="Horizontal">
+            <Button x:Name="PrimaryButton"
+                    Click="OnPrimaryClick"
+                    Padding="8,4"
+                    MinWidth="0"
+                    MinHeight="0"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Center"
+                    ToolTipService.ToolTip="New tab (Alt: pane, Shift: window)"
+                    AutomationProperties.Name="New tab">
+                <controls:FontIcon Glyph="&#xE710;"
+                                   FontFamily="Segoe Fluent Icons"
+                                   FontSize="14"/>
+            </Button>
+            <!-- Separator. Width=1 in horizontal mode (vertical line);
+                 OnOrientationChanged flips this to Width=NaN + Height=1
+                 (horizontal line) when the layout is stacked. -->
+            <Border x:Name="SeparatorBorder"
+                    Width="1"
+                    Background="{ThemeResource ControlStrokeColorDefaultBrush}"/>
+            <Button x:Name="ChevronButton"
+                    Padding="6,2"
+                    MinWidth="0"
+                    MinHeight="0"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Center"
+                    ToolTipService.ToolTip="New tab from profile..."
+                    AutomationProperties.Name="Open profile menu">
+                <controls:FontIcon x:Name="ChevronGlyph"
+                                   Glyph="&#xE70D;"
+                                   FontFamily="Segoe Fluent Icons"
+                                   FontSize="10"/>
+                <Button.Flyout>
+                    <controls:MenuFlyout x:Name="ProfileMenu" Placement="Bottom"/>
+                </Button.Flyout>
+            </Button>
+        </StackPanel>
+    </Border>
 </UserControl>

--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
@@ -110,8 +110,8 @@ internal sealed partial class NewTabSplitButton : UserControl
         if (ctl.ChevronGlyph is not null)
         {
             ctl.ChevronGlyph.Glyph = orient == Orientation.Vertical
-                ? ""
-                : "";
+                ? "\uE76C"
+                : "\uE70D";
         }
     }
 

--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
@@ -79,8 +79,40 @@ internal sealed partial class NewTabSplitButton : UserControl
 
     private static void OnOrientationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is NewTabSplitButton ctl && ctl.LayoutRoot is not null)
-            ctl.LayoutRoot.Orientation = (Orientation)e.NewValue;
+        if (d is not NewTabSplitButton ctl) return;
+        var orient = (Orientation)e.NewValue;
+
+        if (ctl.LayoutRoot is not null)
+            ctl.LayoutRoot.Orientation = orient;
+
+        // Separator is a 1px line perpendicular to the StackPanel
+        // direction: vertical line in a horizontal stack, horizontal
+        // line in a vertical stack. Setting one dimension to NaN lets
+        // the StackPanel stretch the other to fill its cross-axis.
+        if (ctl.SeparatorBorder is not null)
+        {
+            if (orient == Orientation.Horizontal)
+            {
+                ctl.SeparatorBorder.Width = 1;
+                ctl.SeparatorBorder.Height = double.NaN;
+            }
+            else
+            {
+                ctl.SeparatorBorder.Width = double.NaN;
+                ctl.SeparatorBorder.Height = 1;
+            }
+        }
+
+        // Chevron glyph points toward where the menu opens: down
+        // (E70D ChevronDown) in horizontal mode where the flyout
+        // opens below, right (E76C ChevronRight) in vertical mode
+        // where it opens beside the strip.
+        if (ctl.ChevronGlyph is not null)
+        {
+            ctl.ChevronGlyph.Glyph = orient == Orientation.Vertical
+                ? ""
+                : "";
+        }
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Visual polish on top of # 355. Paired plain Buttons left two adjacent default rectangles with no cohesion; this wraps them in a rounded outer Border with a 1px separator and transparent inner Buttons. Each half still highlights individually on hover via the standard Button visual states.

The chevron glyph derives from the existing ` Orientation` DP: E70D (ChevronDown) in horizontal mode where the flyout opens below, E76C (ChevronRight) in vertical mode where it opens beside the strip. Same ` OnOrientationChanged` callback that already flipped the ` StackPanel` and separator now also writes the ` FontIcon.Glyph`.

The theme key overrides (` ButtonBackground` / ` ButtonBorderBrush*`) live at ` UserControl.Resources` scope. Per-button ` <Button.Resources>` blocks were tried first but crashed at startup with an access violation in ` Window.SystemBackdrop` during ` MainWindow.ApplyBackdropStyle`; moving the same overrides up to ` UserControl.Resources` works. The XAML carries a comment so the next person doesn't repeat the experiment.

## Test plan
- [x] manual: vertical strip stays 40px wide; primary ` +` stacked over right-pointing chevron; click / alt-click / shift-click route through ` OpenProfile`; flyout opens to the right
- [x] manual: horizontal footer renders primary + down-pointing chevron side by side, no regression vs # 355
- [x] ` dotnet build windows/Ghostty.sln` clean (only pre-existing warnings)