### PR TITLE
tabs: theme resources + VSM for new-tab split button orientation

### DIFF
--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml
@@ -28,6 +28,33 @@
             Background="{ThemeResource SubtleFillColorTransparentBrush}"
             BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
             BorderThickness="1">
+        <!--
+            Orientation states. The Orientation DP's PropertyChangedCallback
+            calls VisualStateManager.GoToState; the initial XAML-declared
+            values on LayoutRoot/SeparatorBorder/ChevronGlyph match
+            HorizontalState so an uninitialized control still renders
+            correctly before the callback fires.
+        -->
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="OrientationStates">
+                <VisualState x:Name="HorizontalState">
+                    <VisualState.Setters>
+                        <Setter Target="LayoutRoot.Orientation" Value="Horizontal"/>
+                        <Setter Target="SeparatorBorder.Width" Value="1"/>
+                        <Setter Target="SeparatorBorder.Height" Value="NaN"/>
+                        <Setter Target="ChevronGlyph.Glyph" Value="&#xE70D;"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="VerticalState">
+                    <VisualState.Setters>
+                        <Setter Target="LayoutRoot.Orientation" Value="Vertical"/>
+                        <Setter Target="SeparatorBorder.Width" Value="NaN"/>
+                        <Setter Target="SeparatorBorder.Height" Value="1"/>
+                        <Setter Target="ChevronGlyph.Glyph" Value="&#xE76C;"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
         <StackPanel x:Name="LayoutRoot" Orientation="Horizontal">
             <Button x:Name="PrimaryButton"
                     Click="OnPrimaryClick"
@@ -39,11 +66,11 @@
                     ToolTipService.ToolTip="New tab (Alt: pane, Shift: window)"
                     AutomationProperties.Name="New tab">
                 <controls:FontIcon Glyph="&#xE710;"
-                                   FontFamily="Segoe Fluent Icons"
-                                   FontSize="14"/>
+                                   FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                   FontSize="{StaticResource BodyTextBlockFontSize}"/>
             </Button>
             <!-- Separator. Width=1 in horizontal mode (vertical line);
-                 OnOrientationChanged flips this to Width=NaN + Height=1
+                 VerticalState flips this to Width=NaN + Height=1
                  (horizontal line) when the layout is stacked. -->
             <Border x:Name="SeparatorBorder"
                     Width="1"
@@ -56,9 +83,13 @@
                     HorizontalContentAlignment="Center"
                     ToolTipService.ToolTip="New tab from profile..."
                     AutomationProperties.Name="Open profile menu">
+                <!-- 10px chevron is intentionally smaller than the
+                     14px primary glyph: there is no theme ramp entry
+                     for 10 (Caption=12, Body=14), so the literal stays
+                     to preserve the visual hierarchy. -->
                 <controls:FontIcon x:Name="ChevronGlyph"
                                    Glyph="&#xE70D;"
-                                   FontFamily="Segoe Fluent Icons"
+                                   FontFamily="{StaticResource SymbolThemeFontFamily}"
                                    FontSize="10"/>
                 <Button.Flyout>
                     <controls:MenuFlyout x:Name="ProfileMenu" Placement="Bottom"/>

--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
@@ -82,37 +82,16 @@ internal sealed partial class NewTabSplitButton : UserControl
         if (d is not NewTabSplitButton ctl) return;
         var orient = (Orientation)e.NewValue;
 
-        if (ctl.LayoutRoot is not null)
-            ctl.LayoutRoot.Orientation = orient;
-
-        // Separator is a 1px line perpendicular to the StackPanel
-        // direction: vertical line in a horizontal stack, horizontal
-        // line in a vertical stack. Setting one dimension to NaN lets
-        // the StackPanel stretch the other to fill its cross-axis.
-        if (ctl.SeparatorBorder is not null)
-        {
-            if (orient == Orientation.Horizontal)
-            {
-                ctl.SeparatorBorder.Width = 1;
-                ctl.SeparatorBorder.Height = double.NaN;
-            }
-            else
-            {
-                ctl.SeparatorBorder.Width = double.NaN;
-                ctl.SeparatorBorder.Height = 1;
-            }
-        }
-
+        // VSM owns the property mutations (LayoutRoot.Orientation,
+        // SeparatorBorder.Width/Height, ChevronGlyph.Glyph). See
+        // OrientationStates in NewTabSplitButton.xaml. useTransitions
+        // is false because this is a layout/visual swap, not animated.
         // Chevron glyph points toward where the menu opens: down
-        // (E70D ChevronDown) in horizontal mode where the flyout
-        // opens below, right (E76C ChevronRight) in vertical mode
-        // where it opens beside the strip.
-        if (ctl.ChevronGlyph is not null)
-        {
-            ctl.ChevronGlyph.Glyph = orient == Orientation.Vertical
-                ? "\uE76C"
-                : "\uE70D";
-        }
+        // (E70D ChevronDown) in horizontal mode where the flyout opens
+        // below, right (E76C ChevronRight) in vertical mode where it
+        // opens beside the strip.
+        var stateName = orient == Orientation.Vertical ? "VerticalState" : "HorizontalState";
+        VisualStateManager.GoToState(ctl, stateName, false);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Folds the two reviewer items deferred from # 356.

- ` FontFamily="Segoe Fluent Icons"` -> ` {StaticResource SymbolThemeFontFamily}` on both ` FontIcon` elements (matches the existing ` VerticalTabStrip.xaml` pattern). Primary ` FontSize="14"` -> ` {StaticResource BodyTextBlockFontSize}`. The 10px chevron stays a literal: there is no theme ramp entry that matches (Caption=12, Body=14), and a comment explains the intentional break in the hierarchy.
- ` OnOrientationChanged` stops mutating four properties imperatively. A new ` <VisualStateManager.VisualStateGroups>` on the outer Border declares ` OrientationStates` with ` HorizontalState` + ` VerticalState` Setters; the callback collapses to one ` VisualStateManager.GoToState`. Initial XAML values on ` LayoutRoot`, ` SeparatorBorder`, and ` ChevronGlyph` match ` HorizontalState` so the control renders correctly before the callback first fires.

Behavior unchanged.

## Test plan
- [x] ` dotnet build windows/Ghostty.sln -c Release` clean (only pre-existing warnings)
- [x] ` dotnet test windows/Ghostty.Tests` 790/0/1 (unchanged)
- [x] ` dotnet test windows/Ghostty.Tests.Windows` 11/4/0 (unchanged)
- [ ] manual: vertical strip renders chevron pointing right at FontSize 10; horizontal renders chevron pointing down at FontSize 10; switching modes flips both glyph and separator orientation cleanly