### PR TITLE
termio: utf-8 console handling + force conpty for pwsh (closes # 341)

### DIFF
--- a/dist/windows/ghostty.manifest
+++ b/dist/windows/ghostty.manifest
@@ -4,6 +4,7 @@
     <asmv3:windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
     </asmv3:windowsSettings>
   </asmv3:application>
   <dependency>

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -258,106 +258,7 @@ fn startPosix(self: *Command, arena: Allocator) !void {
     return error.ExecFailedInChild;
 }
 
-/// True once `ensureUtf8Console` successfully attached a hidden UTF-8
-/// console to the current process. Published by `std.once` on the slow
-/// path before its internal release-store, so any reader calling
-/// `utf8_console.call()` before reading this variable sees a consistent
-/// value (call returns only after the init completed on some thread).
-///
-/// When false, either AllocConsole failed (we inherited a console from
-/// a parent terminal) or a downstream step like GetConsoleWindow /
-/// SetConsoleOutputCP failed. Bypass-path callers use this to decide
-/// whether CREATE_NO_WINDOW is still required.
-var utf8_console_owned: bool = false;
-
-var utf8_console = std.once(ensureUtf8ConsoleImpl);
-
-/// Wintty.exe ships as a console-subsystem EXE but `Program.cs`'s
-/// `FreeConsole` gate detaches from the inherited console when we are
-/// its sole owner (Explorer / Start Menu / Default Terminal handoff
-/// launches). In that solo case we then have no console at spawn time,
-/// and children inherit the OEM default code page (e.g. CP850 on
-/// Western European locales). That silently transcodes any non-OEM
-/// Unicode (Nerd Font PUA glyphs, emoji, CJK) to `?` at the shell
-/// before it reaches the VT parser.
-///
-/// This lazily allocates a hidden console with CP = 65001 (UTF-8).
-/// - Raw-pipe (bypass) children normally run with CREATE_NO_WINDOW
-///   and would not see our console at all; once a hidden console
-///   exists we drop that flag so the child inherits our UTF-8 console.
-///   This is the dominant case: `conpty-mode = auto` (the default)
-///   picks bypass for every VT-aware shell (pwsh, wsl, ssh, bash, nu
-///   — everything `windows_shell.classify` tags `.vt_aware`).
-/// - ConPTY children do NOT benefit. `CreatePseudoConsole` spawns a
-///   fresh `conhost.exe --pty` with the system OEM CP regardless of
-///   our parent CP — verified empirically with `conpty-mode = never`,
-///   pwsh child still reports `[Console]::OutputEncoding.CodePage =
-///   850`. Fixing that path requires shell-specific preamble
-///   injection (e.g. `chcp 65001 >nul &&` for cmd, `[Console]::
-///   OutputEncoding = ...` for pwsh), which is out of scope for this
-///   change. Filed as a followup.
-///
-/// When we own the console, spawned children join our console's ctrl
-/// process group. A child that calls `GenerateConsoleCtrlEvent(
-/// CTRL_BREAK_EVENT, 0)` would broadcast to every process in the group
-/// including the WinUI 3 parent, and the default ctrl handler calls
-/// `ExitProcess`. Ignoring this would give us a silent parent teardown
-/// with no unhandled-exception log. We install a suppressing handler
-/// immediately after AllocConsole to neutralize that path.
-///
-/// If AllocConsole fails a console is already attached (e.g. pwsh
-/// launching Ghostty for debugging, or the shared-terminal launch where
-/// `GetConsoleProcessList > 1` in Program.cs). We deliberately do not
-/// touch its CP: flipping a parent-owned console's encoding would
-/// surprise whoever invoked us, and the user can fix their own shell's
-/// CP themselves.
-pub fn ensureUtf8Console() void {
-    utf8_console.call();
-}
-
-fn ensureUtf8ConsoleImpl() void {
-    if (windows.exp.kernel32.AllocConsole() == 0) return;
-
-    // Hide before ShowWindow can race with the compositor. A null HWND
-    // from AllocConsole-success is near-impossible in practice (it only
-    // happens on certain headless Server Core SKUs) but we treat it as
-    // failure anyway: leaving an un-hidden console visible is worse
-    // than having children fall through to the OEM CP.
-    const hwnd = windows.exp.kernel32.GetConsoleWindow() orelse return;
-    _ = windows.exp.user32.ShowWindow(hwnd, windows.exp.SW_HIDE);
-
-    if (windows.exp.kernel32.SetConsoleOutputCP(windows.exp.CP_UTF8) == 0) {
-        log.warn("SetConsoleOutputCP failed err={}", .{windows.kernel32.GetLastError()});
-        return;
-    }
-    if (windows.exp.kernel32.SetConsoleCP(windows.exp.CP_UTF8) == 0) {
-        log.warn("SetConsoleCP failed err={}", .{windows.kernel32.GetLastError()});
-        return;
-    }
-
-    // Suppress default ctrl-handling so a child calling
-    // GenerateConsoleCtrlEvent on our shared console group cannot tear
-    // down the WinUI parent. Returning TRUE from the handler marks the
-    // event handled; the OS does not invoke default ExitProcess. The
-    // handler function pointer is a comptime-known module-level decl,
-    // so the GC-equivalent lifetime concern from other callback APIs
-    // does not apply.
-    _ = windows.exp.kernel32.SetConsoleCtrlHandler(&suppressCtrlHandler, windows.TRUE);
-
-    utf8_console_owned = true;
-}
-
-fn suppressCtrlHandler(ctrl_type: windows.DWORD) callconv(.winapi) windows.BOOL {
-    _ = ctrl_type;
-    return windows.TRUE;
-}
-
 fn startWindows(self: *Command, arena: Allocator) !void {
-    // Before any child spawn, make sure the process owns a UTF-8
-    // console. Idempotent and cheap after the first call. See
-    // `ensureUtf8Console` for the full rationale.
-    ensureUtf8Console();
-
     // CreateProcessW's lpApplicationName requires a fully qualified
     // path. Passing a bare executable name like "cmd.exe" or
     // "pwsh.exe" relies on the current working directory containing
@@ -529,27 +430,18 @@ fn startWindows(self: *Command, arena: Allocator) !void {
     var flags: windows.DWORD = windows.exp.CREATE_UNICODE_ENVIRONMENT;
     flags |= windows.exp.EXTENDED_STARTUPINFO_PRESENT;
 
-    // Suppress console window for raw-pipe sessions. ConPTY attaches the
-    // pseudo-console which automatically suppresses the window; raw pipes need
-    // the flag explicitly.
+    // Suppress console window for raw-pipe sessions. ConPTY attaches a
+    // pseudo-console which automatically suppresses the window; raw pipes
+    // need the flag explicitly.
     //
-    // Exception: when `ensureUtf8Console` above successfully allocated a
-    // hidden UTF-8 console for this process, letting the child inherit
-    // that console is how we force the child's GetConsoleOutputCP() to
-    // report UTF-8 instead of the OEM default (see issue # 299).
-    // CREATE_NO_WINDOW detaches the child from any console, so its
-    // GetConsoleOutputCP() returns 0, and .NET's ConsolePal falls
-    // through to `GetACP()` (system ANSI CP, typically 1252 on WE
-    // locales) -- still not UTF-8. Our parent console is already
-    // hidden, so inheriting it does NOT add a visible window: the
-    // intent of CREATE_NO_WINDOW from PR # 295 is preserved.
-    //
-    // Scope: this affects ALL raw-pipe children, not just shells. A
-    // child that explicitly wants no console (e.g. calls
-    // `FreeConsole()` itself) is unaffected. A child that enumerates
-    // or unhides the console window would find ours, but no caller
-    // today does that; if one appears we'd revisit.
-    if (self.pseudo_console == null and !utf8_console_owned) {
+    // Note: pre-#341 the gate also checked `utf8_console_owned` (an
+    // AllocConsole-based hack) to let raw-pipe children inherit a hidden
+    // UTF-8 parent console. That mechanism turned out not to actually
+    // reach the spawned shell on the user's repro path; the new
+    // utf8-console knob + bypass-path preamble injection (in
+    // `termio/Exec.zig`) is the real fix. The gate is now just the
+    // pseudo-console check.
+    if (self.pseudo_console == null) {
         flags |= windows.exp.CREATE_NO_WINDOW;
     }
 
@@ -746,41 +638,6 @@ fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) 
     }
 
     return buf.toOwnedSliceSentinel(0);
-}
-
-test "ensureUtf8Console: idempotent, sets UTF-8 CP when it owns the console" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    // Back-to-back calls must behave the same; `std.once` guarantees
-    // the init body runs at most once per process lifetime. This is
-    // the main property we can assert portably across test hosts:
-    // both `zig build test` (which launches the test binary in a
-    // detached state where AllocConsole semantics vary) and
-    // production (GUI-subsystem Wintty.exe launched by Explorer)
-    // must tolerate repeat invocation.
-    ensureUtf8Console();
-    ensureUtf8Console();
-
-    // If `ensureUtf8Console` actually allocated the console (the
-    // production case where Wintty.exe has no parent console) we
-    // assert the code page was flipped to UTF-8 and that ownership
-    // latches on a third call. We only assert in this branch
-    // because under `zig build test` the test runner may be in a
-    // state where AllocConsole fails with no observable console
-    // attached; `utf8_console_owned` stays false and we skip the
-    // CP checks to keep the test stable across CI environments.
-    if (utf8_console_owned) {
-        try testing.expectEqual(
-            @as(u32, windows.exp.CP_UTF8),
-            windows.exp.kernel32.GetConsoleOutputCP(),
-        );
-        try testing.expectEqual(
-            @as(u32, windows.exp.CP_UTF8),
-            windows.exp.kernel32.GetConsoleCP(),
-        );
-        ensureUtf8Console();
-        try testing.expect(utf8_console_owned);
-    }
 }
 
 test "createNullDelimitedEnvMap" {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -666,6 +666,9 @@ pub fn init(
             .conpty_mode = if (comptime builtin.os.tag == .windows)
                 config.@"conpty-mode"
             else {},
+            .utf8_console = if (comptime builtin.os.tag == .windows)
+                config.@"utf8-console"
+            else {},
             .rt_pre_exec_info = .init(config),
             .rt_post_fork_info = .init(config),
         });

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2818,9 +2818,9 @@ pub fn keyCallback(
 
         errdefer write_req.deinit();
         self.queueIo(switch (write_req) {
-            .small => |v| .{ .write_small = v },
-            .stable => |v| .{ .write_stable = v },
-            .alloc => |v| .{ .write_alloc = v },
+            .small => |v| .{ .write_small = .{ .data = v.data, .len = v.len } },
+            .stable => |v| .{ .write_stable = .{ .data = v } },
+            .alloc => |v| .{ .write_alloc = .{ .alloc = v.alloc, .data = v.data } },
         }, .unlocked);
     } else {
         // No valid request means that we didn't encode anything.
@@ -3169,9 +3169,9 @@ fn endKeySequence(
     switch (action) {
         .flush => for (self.keyboard.sequence_queued.items) |write_req| {
             self.queueIo(switch (write_req) {
-                .small => |v| .{ .write_small = v },
-                .stable => |v| .{ .write_stable = v },
-                .alloc => |v| .{ .write_alloc = v },
+                .small => |v| .{ .write_small = .{ .data = v.data, .len = v.len } },
+                .stable => |v| .{ .write_stable = .{ .data = v } },
+                .alloc => |v| .{ .write_alloc = .{ .alloc = v.alloc, .data = v.data } },
             }, .unlocked);
         },
 
@@ -3559,7 +3559,7 @@ pub fn scrollCallback(
                     };
                 };
                 for (0..y.magnitude()) |_| {
-                    self.queueIo(.{ .write_stable = seq }, .locked);
+                    self.queueIo(.{ .write_stable = .{ .data = seq } }, .locked);
                 }
             }
 
@@ -4257,13 +4257,13 @@ fn maybePromptClick(self: *Surface) !bool {
             const move = screen.promptClickMove(click_pin);
             for (0..move.left) |_| {
                 self.queueIo(
-                    .{ .write_stable = left_arrow },
+                    .{ .write_stable = .{ .data = left_arrow } },
                     .locked,
                 );
             }
             for (0..move.right) |_| {
                 self.queueIo(
-                    .{ .write_stable = right_arrow },
+                    .{ .write_stable = .{ .data = right_arrow } },
                     .locked,
                 );
             }
@@ -5108,9 +5108,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             };
 
             if (normal) {
-                self.queueIo(.{ .write_stable = ck.normal }, .unlocked);
+                self.queueIo(.{ .write_stable = .{ .data = ck.normal } }, .unlocked);
             } else {
-                self.queueIo(.{ .write_stable = ck.application }, .unlocked);
+                self.queueIo(.{ .write_stable = .{ .data = ck.application } }, .unlocked);
             }
         },
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2859,6 +2859,13 @@ keybind: Keybinds = .{},
 @"conpty-mode": if (builtin.os.tag == .windows) ConptyMode else void =
     if (builtin.os.tag == .windows) .auto else {},
 
+/// Controls whether Ghostty injects a UTF-8 codepage setup into
+/// spawned cmd / PowerShell shells on Windows. See the `Utf8Console`
+/// enum for the full description of `auto`, `always`, and `never`.
+/// Has no effect on non-Windows platforms.
+@"utf8-console": if (builtin.os.tag == .windows) Utf8Console else void =
+    if (builtin.os.tag == .windows) .auto else {},
+
 /// Custom entries into the command palette.
 ///
 /// Each entry requires the title, the corresponding action, and an optional
@@ -8676,6 +8683,33 @@ pub const ShellIntegrationFeatures = packed struct {
 };
 
 pub const ConptyMode = enum { auto, always, never };
+
+/// Controls whether Ghostty injects a UTF-8 codepage setup into spawned
+/// cmd / PowerShell shells on Windows.
+///
+/// * `always`: always inject (`chcp 65001` for cmd; `[Console]::
+///   OutputEncoding = [System.Text.UTF8Encoding]::new()` for pwsh).
+///   This is what most Western Windows users want: it makes Nerd Font
+///   prompts render correctly and stops CSI responses leaking into the
+///   prompt buffer on installs whose OEM codepage is not 65001.
+///
+/// * `never`: never inject. Useful if you run legacy `.bat` scripts
+///   containing literal multi-byte characters in your system OEM
+///   codepage (e.g. Shift-JIS on Japanese Windows) and don't want the
+///   process flipped to UTF-8 underneath them.
+///
+/// * `auto` (default): inject unless the system ANSI codepage is one
+///   of the legacy double-byte CJK codepages (932, 936, 949, 950, 1361).
+///   Equivalent to `always` on Western Windows and `never` on default-
+///   locale Japanese / Simplified Chinese / Korean / Traditional
+///   Chinese installs.
+///
+/// This option has no effect on macOS or Linux.
+pub const Utf8Console = enum {
+    auto,
+    always,
+    never,
+};
 
 pub const SplitPreserveZoom = packed struct {
     navigation: bool = false,

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -51,8 +51,6 @@ pub const exp = struct {
     pub const CREATE_UNICODE_ENVIRONMENT = 0x00000400;
     pub const CREATE_NO_WINDOW = 0x08000000;
     pub const EXTENDED_STARTUPINFO_PRESENT = 0x00080000;
-    pub const SW_HIDE: c_int = 0;
-    pub const CP_UTF8: windows.UINT = 65001;
     pub const LPPROC_THREAD_ATTRIBUTE_LIST = ?*anyopaque;
     pub const FILE_FLAG_FIRST_PIPE_INSTANCE = 0x00080000;
 
@@ -71,28 +69,11 @@ pub const exp = struct {
             lpPipeAttributes: ?*const windows.SECURITY_ATTRIBUTES,
             nSize: windows.DWORD,
         ) callconv(.winapi) windows.BOOL;
-        // Console code page: needed to force spawned shells to inherit
-        // UTF-8 instead of the system OEM CP (see ensureUtf8Console in
-        // Command.zig). std.os.windows does not wrap these.
-        pub extern "kernel32" fn AllocConsole() callconv(.winapi) windows.BOOL;
-        pub extern "kernel32" fn GetConsoleWindow() callconv(.winapi) ?windows.HWND;
-        pub extern "kernel32" fn SetConsoleCP(
-            wCodePageID: windows.UINT,
-        ) callconv(.winapi) windows.BOOL;
-        pub extern "kernel32" fn SetConsoleOutputCP(
-            wCodePageID: windows.UINT,
-        ) callconv(.winapi) windows.BOOL;
-        pub extern "kernel32" fn GetConsoleCP() callconv(.winapi) windows.UINT;
-        pub extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) windows.UINT;
         // System ANSI code page (per-process default ACP, set by the
         // user's locale). Used to detect legacy double-byte CJK locales
         // where forcing UTF-8 on a spawned shell would mojibake legacy
         // .bat scripts. std.os.windows does not wrap this.
         pub extern "kernel32" fn GetACP() callconv(.winapi) windows.UINT;
-        pub extern "kernel32" fn SetConsoleCtrlHandler(
-            HandlerRoutine: ?*const fn (windows.DWORD) callconv(.winapi) windows.BOOL,
-            Add: windows.BOOL,
-        ) callconv(.winapi) windows.BOOL;
         // std.os.windows.kernel32 only exposes CreateEventExW; add the
         // classic CreateEventW for overlapped I/O wait events.
         pub extern "kernel32" fn CreateEventW(
@@ -154,16 +135,6 @@ pub const exp = struct {
         pub extern "kernel32" fn GetComputerNameA(
             lpBuffer: windows.LPSTR,
             nSize: *windows.DWORD,
-        ) callconv(.winapi) windows.BOOL;
-    };
-
-    pub const user32 = struct {
-        // Used by `ensureUtf8Console` in Command.zig to hide the console
-        // window we allocate purely to carry the UTF-8 code page into
-        // spawned children.
-        pub extern "user32" fn ShowWindow(
-            hWnd: windows.HWND,
-            nCmdShow: c_int,
         ) callconv(.winapi) windows.BOOL;
     };
 

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -84,6 +84,11 @@ pub const exp = struct {
         ) callconv(.winapi) windows.BOOL;
         pub extern "kernel32" fn GetConsoleCP() callconv(.winapi) windows.UINT;
         pub extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) windows.UINT;
+        // System ANSI code page (per-process default ACP, set by the
+        // user's locale). Used to detect legacy double-byte CJK locales
+        // where forcing UTF-8 on a spawned shell would mojibake legacy
+        // .bat scripts. std.os.windows does not wrap this.
+        pub extern "kernel32" fn GetACP() callconv(.winapi) windows.UINT;
         pub extern "kernel32" fn SetConsoleCtrlHandler(
             HandlerRoutine: ?*const fn (windows.DWORD) callconv(.winapi) windows.BOOL,
             Add: windows.BOOL,

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -175,6 +175,8 @@ pub fn awarenessOf(kind: Kind) Awareness {
 pub fn requiresConsoleInput(kind: Kind) bool {
     return switch (kind) {
         .pwsh => true,
+        // else explicit so adding a new Kind doesn't silently flip
+        // its console-input requirement.
         else => false,
     };
 }
@@ -201,9 +203,10 @@ pub fn classify(exe_path: []const u8) Awareness {
 }
 
 /// Return the UTF-8 preamble needed to make this shell emit UTF-8 on
-/// startup under ConPTY. Callers should invoke this only when the
-/// transport actually resolves to ConPTY; the raw-pipe bypass path
-/// already inherits our UTF-8 parent console (see PR # 301).
+/// startup. Callers invoke this regardless of transport; the actual
+/// emission gate lives in `Exec.maybeInjectUtf8Preamble` and is
+/// driven by the resolved `utf8-console` policy, not by ConPTY vs
+/// bypass routing. See deblasis/wintty # 341 for the rationale.
 pub fn utf8Preamble(exe_path: []const u8) Preamble {
     return preambleOf(identify(exe_path));
 }

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -10,6 +10,8 @@
 //! the same table; edit both together until the C# side is retired.
 
 const std = @import("std");
+const builtin = @import("builtin");
+const windows = @import("windows.zig");
 const testing = std.testing;
 const log = std.log.scoped(.windows_shell);
 
@@ -214,6 +216,38 @@ fn identify(exe_path: []const u8) Kind {
     return kinds.get(lower) orelse .unknown;
 }
 
+/// Returns true if the system ANSI codepage (`GetACP()`) is one of the
+/// legacy double-byte CJK codepages where forcing UTF-8 on a spawned
+/// shell would mojibake legacy `.bat` scripts whose script text is
+/// stored in that codepage.
+///
+/// We only flag the five double-byte CJK codepages (Shift-JIS, GB2312,
+/// EUC-KR, Big5, Johab). Single-byte legacy codepages (Thai 874, Hebrew
+/// 1255, Vietnamese 1258, etc.) survive a UTF-8 flip of the spawned
+/// shell's encoding and are not classified as CJK here.
+///
+/// Modern CJK developers running native Windows are increasingly UTF-8
+/// (VS Code, WSL, Beta-UTF-8 toggle); they can opt back in via
+/// `utf8-console = always`.
+pub fn isCjkAnsiCodePage() bool {
+    if (comptime builtin.os.tag != .windows) return false;
+    return isCjkAnsiCodePageFor(windows.exp.kernel32.GetACP());
+}
+
+/// Pure-logic variant of `isCjkAnsiCodePage` for testing. Takes an
+/// explicit codepage rather than calling `GetACP()`.
+pub fn isCjkAnsiCodePageFor(acp: std.os.windows.UINT) bool {
+    return switch (acp) {
+        932, // ja_JP: Shift-JIS
+        936, // zh_CN: GB2312
+        949, // ko_KR: EUC-KR
+        950, // zh_TW: Big5
+        1361, // ko_KR: Johab (legacy)
+        => true,
+        else => false,
+    };
+}
+
 test "classify: pwsh variants" {
     try testing.expectEqual(Awareness.vt_aware, classify("pwsh"));
     try testing.expectEqual(Awareness.vt_aware, classify("pwsh.exe"));
@@ -364,4 +398,34 @@ test "utf8Preamble: prefix ends with shell-appropriate separator" {
 
     // none: empty.
     try testing.expectEqualStrings("", Preamble.none.prefix());
+}
+
+test "isCjkAnsiCodePage: links GetACP and agrees with the pure-logic helper" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    // Smoke test: catches a broken `GetACP` extern decl on Windows
+    // and verifies the wrapper agrees with the testable inner helper
+    // for whatever ACP the test host actually has. Per-codepage
+    // assertions live in the OS-agnostic tests below.
+    try testing.expectEqual(
+        isCjkAnsiCodePageFor(windows.exp.kernel32.GetACP()),
+        isCjkAnsiCodePage(),
+    );
+}
+
+test "isCjkAnsiCodePageFor: known CJK codepages return true" {
+    try std.testing.expect(isCjkAnsiCodePageFor(932)); // ja_JP Shift-JIS
+    try std.testing.expect(isCjkAnsiCodePageFor(936)); // zh_CN GB2312
+    try std.testing.expect(isCjkAnsiCodePageFor(949)); // ko_KR EUC-KR
+    try std.testing.expect(isCjkAnsiCodePageFor(950)); // zh_TW Big5
+    try std.testing.expect(isCjkAnsiCodePageFor(1361)); // ko_KR Johab
+}
+
+test "isCjkAnsiCodePageFor: non-CJK codepages return false" {
+    try std.testing.expect(!isCjkAnsiCodePageFor(437)); // OEM US
+    try std.testing.expect(!isCjkAnsiCodePageFor(850)); // OEM WE (Italian)
+    try std.testing.expect(!isCjkAnsiCodePageFor(1252)); // ANSI WE
+    try std.testing.expect(!isCjkAnsiCodePageFor(65001)); // UTF-8
+    try std.testing.expect(!isCjkAnsiCodePageFor(874)); // Thai (single-byte)
+    try std.testing.expect(!isCjkAnsiCodePageFor(1255)); // Hebrew (single-byte)
+    try std.testing.expect(!isCjkAnsiCodePageFor(1258)); // Vietnamese (single-byte)
 }

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -117,8 +117,10 @@ pub const Preamble = enum {
 };
 
 /// Fine-grained shell identity used to select a UTF-8 preamble under
-/// ConPTY. Kept internal; exposed only through `utf8Preamble`.
-const Kind = enum {
+/// ConPTY and to gate per-shell quirks (e.g. PSReadLine under raw-pipe
+/// stdin treats CSI response bytes as user keystrokes, so termio
+/// suppresses VT response writes for `.pwsh` in bypass mode).
+pub const Kind = enum {
     unknown,
     cmd,
     powershell,
@@ -147,11 +149,33 @@ const kinds = std.StaticStringMap(Kind).initComptime(.{
     .{ "powershell", .powershell },
 });
 
-fn awarenessOf(kind: Kind) Awareness {
+pub fn awarenessOf(kind: Kind) Awareness {
     return switch (kind) {
         .unknown => .unknown,
         .cmd, .powershell => .console_api,
         .pwsh, .wsl, .ssh, .bash, .nu, .zsh, .fish, .elvish, .xonsh => .vt_aware,
+    };
+}
+
+/// Returns true if this shell relies on a real console handle for
+/// interactive input (PSReadLine, line-editing) and breaks under raw
+/// pipe stdin on Windows. Used to force ConPTY transport for these
+/// shells regardless of the user's `conpty-mode = auto` preference.
+///
+/// Currently only pwsh.exe (PowerShell 7+) qualifies. PSReadLine
+/// throws InvalidOperationException when stdin is not a console
+/// handle, and pwsh falls back to Console.ReadLine which has no
+/// backspace, no arrow-key history, no tab completion.
+///
+/// powershell.exe (5.1) is .console_api in `awarenessOf` so it
+/// already routes to ConPTY without needing this gate.
+///
+/// See deblasis/pwsh-bypass-research for empirical investigation
+/// of whether this can be worked around without ConPTY.
+pub fn requiresConsoleInput(kind: Kind) bool {
+    return switch (kind) {
+        .pwsh => true,
+        else => false,
     };
 }
 
@@ -184,7 +208,7 @@ pub fn utf8Preamble(exe_path: []const u8) Preamble {
     return preambleOf(identify(exe_path));
 }
 
-fn identify(exe_path: []const u8) Kind {
+pub fn identify(exe_path: []const u8) Kind {
     const trimmed = std.mem.trim(u8, exe_path, "\"' \t\r\n");
     if (trimmed.len == 0) return .unknown;
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2225,6 +2225,28 @@ fn resolveConptyMode(
     return resolved;
 }
 
+/// Binary resolution of `Config.Utf8Console`. `auto` collapses to
+/// `.never` on default-locale CJK Windows (Shift-JIS, GB2312, EUC-KR,
+/// Big5, Johab) and to `.always` everywhere else. The runtime never
+/// sees `.auto`; only its resolved form.
+const ResolvedUtf8Console = enum { always, never };
+
+fn resolveUtf8Console(cfg: configpkg.Config.Utf8Console) ResolvedUtf8Console {
+    const resolved: ResolvedUtf8Console = switch (cfg) {
+        .always => .always,
+        .never => .never,
+        .auto => if (internal_os.windows_shell.isCjkAnsiCodePage())
+            .never
+        else
+            .always,
+    };
+    log_validate.info(
+        "utf8-console resolved: config={s} resolved={s}",
+        .{ @tagName(cfg), @tagName(resolved) },
+    );
+    return resolved;
+}
+
 test "execCommand darwin: shell command" {
     if (comptime !builtin.os.tag.isDarwin()) return error.SkipZigTest;
 
@@ -2582,6 +2604,34 @@ test "resolveConptyMode: auto handles path-prefixed shell" {
 test "resolveConptyMode: auto handles quoted shell" {
     try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "\"pwsh.exe\""));
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "'cmd.exe'"));
+}
+
+test "resolveUtf8Console: always returns always" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    try std.testing.expectEqual(
+        @as(ResolvedUtf8Console, .always),
+        resolveUtf8Console(.always),
+    );
+}
+
+test "resolveUtf8Console: never returns never" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    try std.testing.expectEqual(
+        @as(ResolvedUtf8Console, .never),
+        resolveUtf8Console(.never),
+    );
+}
+
+test "resolveUtf8Console: auto agrees with isCjkAnsiCodePage" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    // Cross-check the resolved value against the linked CJK helper for
+    // whatever ACP the test host actually has. Catches a regression
+    // where the auto branch silently stops calling isCjkAnsiCodePage.
+    const expected: ResolvedUtf8Console = if (internal_os.windows_shell.isCjkAnsiCodePage())
+        .never
+    else
+        .always;
+    try std.testing.expectEqual(expected, resolveUtf8Console(.auto));
 }
 
 // --- # 302 UTF-8 preamble injection tests -----------------------------------

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1647,15 +1647,19 @@ fn execCommand(
     alloc: Allocator,
     command: configpkg.Command,
     comptime passwdpkg: type,
-    /// Configured transport mode; used only on Windows to decide whether
-    /// to inject the ConPTY UTF-8 preamble (# 302). Ignored on other
-    /// platforms.
+    /// Captured for symmetry with `Subprocess.start()` and to keep the
+    /// signature stable across callers. Currently unused: after the
+    /// # 341 fix the UTF-8 preamble decision lives entirely under the
+    /// `utf8_console` policy gate (transport no longer matters because
+    /// .bypass pwsh inherits a non-console handle whose default CP
+    /// also isn't UTF-8). Discard so Zig doesn't flag the param.
     conpty_mode: configpkg.Config.ConptyMode,
     /// Configured UTF-8 console preamble policy; used only on Windows
-    /// to gate ConPTY UTF-8 preamble injection (# 302). Ignored on
-    /// other platforms.
+    /// to gate UTF-8 preamble injection across both ConPTY and bypass
+    /// transports (# 302, # 341). Ignored on other platforms.
     utf8_console: configpkg.Config.Utf8Console,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
+    _ = conpty_mode;
     // If we're on macOS, we have to use `login(1)` to get all of
     // the proper environment variables set, a login shell, and proper
     // hushlogin behavior.
@@ -1785,7 +1789,6 @@ fn execCommand(
                 break :direct try maybeInjectUtf8Preamble(
                     alloc,
                     cloned,
-                    conpty_mode,
                     utf8_console,
                 );
             }
@@ -1838,7 +1841,6 @@ fn execCommand(
                     break :shell try maybeInjectUtf8Preamble(
                         alloc,
                         direct_args,
-                        conpty_mode,
                         utf8_console,
                     );
                 }
@@ -1863,13 +1865,14 @@ fn execCommand(
                     "cmd.exe",
                 });
 
-                // cmd.exe is always `console_api` so `auto` + `never`
-                // both pick ConPTY here, and `always` picks the raw-pipe
-                // bypass (which already gets UTF-8 from PR # 301).
-                // Prepend `chcp 65001 >nul && ` to the /C script in the
-                // ConPTY cases so the whole pipeline runs UTF-8.
-                const mode = resolveConptyMode(conpty_mode, cmd);
-                const script: [:0]const u8 = if (mode == .conpty)
+                // cmd.exe always lands in this `cmd.exe /C <script>`
+                // shape via ConPTY (cmd is `.console_api`, so transport
+                // resolution always picks `.conpty` here). Gate the
+                // chcp prepend on the user's UTF-8 policy directly so
+                // `utf8-console=never` is a real kill switch and `auto`
+                // (resolved to `.always` on non-CJK Windows) still
+                // forces UTF-8 across the whole pipeline.
+                const script: [:0]const u8 = if (resolveUtf8Console(utf8_console) == .always)
                     try std.fmt.allocPrintSentinel(
                         alloc,
                         "chcp 65001 >nul && {s}",
@@ -1913,32 +1916,40 @@ fn windowsShellNeedsCmdWrapping(s: []const u8) bool {
     return false;
 }
 
-/// Windows-only. If the configured transport will resolve to ConPTY
-/// for this argv and the shell is known to benefit from a UTF-8
-/// preamble (# 302), return a new argv with the preamble suffix
-/// appended. Returns `args` unchanged otherwise.
+/// Inject a shell-specific UTF-8 codepage setup into argv when the
+/// resolved utf8-console policy is `always`. Skips when the user
+/// configured `never` or when `auto` resolved to `never` (CJK ACP).
 ///
-/// Why the injection happens here and not later: we need to emit the
-/// preamble *argv-level*, before the shell has read any input. The
-/// raw-pipe bypass already gets UTF-8 from PR # 301 (parent console
-/// inheritance), but CreatePseudoConsole spawns its own conhost that
-/// starts at the system OEM CP regardless of what the parent has set.
+/// Why this fires on BOTH .conpty and .bypass transports for pwsh:
+/// - .conpty: CreatePseudoConsole spawns conhost at the system OEM
+///   CP regardless of parent state, so the child needs an explicit
+///   `[Console]::OutputEncoding = ...` to talk UTF-8.
+/// - .bypass: raw-pipe pwsh (the dominant case under conpty-mode=auto)
+///   inherits stdio pipes, not a console handle. .NET's
+///   ConsoleEncodingHelper falls back to GetACP() on a non-console
+///   handle, which is the system ANSI CP (e.g. 1252 on Italian
+///   Windows) - still not UTF-8. Same fix works.
+///
+/// `Preamble.cmd` only ever fires under .conpty by construction
+/// (cmd is .console_api -> resolveConptyMode picks .conpty). Other
+/// VT-aware shells (bash, wsl, ssh, nu, fish, zsh, elvish, xonsh)
+/// short-circuit on the Preamble.none guard.
 ///
 /// Callers own both the input `args` and the returned slice; when no
 /// injection is needed the returned slice aliases `args` (no copy).
 fn maybeInjectUtf8Preamble(
     alloc: Allocator,
     args: []const [:0]const u8,
-    conpty_mode: configpkg.Config.ConptyMode,
     utf8_console: configpkg.Config.Utf8Console,
 ) Allocator.Error![]const [:0]const u8 {
-    // TODO(#341): gate the preamble decision on this.
-    _ = utf8_console;
     if (comptime builtin.os.tag != .windows) return args;
     if (args.len == 0) return args;
 
-    const mode = resolveConptyMode(conpty_mode, args[0]);
-    if (mode != .conpty) return args;
+    // Honor the user kill switch first. `.auto` resolves against the
+    // system ACP and collapses to `.always` on Western Windows (the
+    // common case) or `.never` on default-locale CJK Windows where
+    // forcing UTF-8 would mojibake legacy double-byte .bat scripts.
+    if (resolveUtf8Console(utf8_console) == .never) return args;
 
     const preamble = internal_os.windows_shell.utf8Preamble(args[0]);
     if (preamble == .none) return args;
@@ -2449,8 +2460,9 @@ test "execCommand windows: shell command, single token spawns directly" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // always mode forces the bypass path so we get the bare argv without
-    // UTF-8 preamble injection - the original behavior the test covers.
+    // always mode forces the bypass path. Pair with utf8-console=never
+    // so the new bypass-path preamble injection (#341) doesn't interfere
+    // with what this test is actually checking: shell-string parsing.
     const result = try execCommand(
         alloc,
         .{ .shell = "pwsh.exe" },
@@ -2460,7 +2472,7 @@ test "execCommand windows: shell command, single token spawns directly" {
             }
         },
         .always,
-        .auto,
+        .never,
     );
 
     // No cmd.exe /C wrapper: args[0] is the configured shell itself.
@@ -2485,7 +2497,7 @@ test "execCommand windows: shell command, args split without cmd wrap" {
             }
         },
         .always,
-        .auto,
+        .never,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2511,7 +2523,7 @@ test "execCommand windows: shell command, quoted path kept as one arg" {
             }
         },
         .always,
-        .auto,
+        .never,
     );
 
     try testing.expectEqual(2, result.len);
@@ -2530,8 +2542,9 @@ test "execCommand windows: shell command with pipe falls back to cmd.exe" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // always mode forces bypass so the cmd-wrap path does not pick up
-    // the ConPTY UTF-8 preamble injection covered in its own test.
+    // utf8-console=never disables the chcp prepend so this test stays
+    // focused on cmd-wrap routing, not preamble injection (covered by
+    // its own test).
     const result = try execCommand(
         alloc,
         .{ .shell = "dir | findstr foo" },
@@ -2541,7 +2554,7 @@ test "execCommand windows: shell command with pipe falls back to cmd.exe" {
             }
         },
         .always,
-        .auto,
+        .never,
     );
 
     // Metachar present: wrap with cmd.exe /C so cmd handles the pipe.
@@ -2568,7 +2581,7 @@ test "execCommand windows: shell command with redirect falls back to cmd.exe" {
             }
         },
         .always,
-        .auto,
+        .never,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2708,20 +2721,6 @@ test "execCommand windows: cmd.exe under auto mode gets cmd preamble" {
     try testing.expectEqualStrings("chcp 65001 >nul", result[2]);
 }
 
-test "execCommand windows: pwsh under auto mode (bypass) has no preamble" {
-    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
-
-    const testing = std.testing;
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe", .auto);
-
-    // auto + pwsh (vt_aware) → bypass → PR # 301's parent console CP
-    // does the work. No preamble.
-    try testing.expectEqual(@as(usize, 1), result.len);
-    try testing.expectEqualStrings("pwsh.exe", result[0]);
-}
-
 test "execCommand windows: pwsh under forced never mode gets pwsh preamble" {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
 
@@ -2783,18 +2782,43 @@ test "execCommand windows: vt-aware non-powershell (bash) under ConPTY has no pr
     try testing.expectEqualStrings("bash.exe", result[0]);
 }
 
-test "execCommand windows: always mode (bypass) never injects preamble" {
+test "execCommand windows: utf8-console=never is a kill switch across transports" {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
 
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
+    const alloc = arena.allocator();
 
-    const cmd_result = try testExecWindowsShell(arena.allocator(), "cmd.exe", .always);
+    // After the # 341 fix the preamble decision is owned by the
+    // utf8-console policy, not the transport. `never` must mean
+    // "no preamble anywhere", regardless of whether the resolved
+    // transport is .conpty (cmd) or .bypass (pwsh under .always).
+    const cmd_result = try execCommand(
+        alloc,
+        .{ .shell = "cmd.exe" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .always,
+        .never,
+    );
     try testing.expectEqual(@as(usize, 1), cmd_result.len);
     try testing.expectEqualStrings("cmd.exe", cmd_result[0]);
 
-    const pwsh_result = try testExecWindowsShell(arena.allocator(), "pwsh.exe", .always);
+    const pwsh_result = try execCommand(
+        alloc,
+        .{ .shell = "pwsh.exe" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .always,
+        .never,
+    );
     try testing.expectEqual(@as(usize, 1), pwsh_result.len);
     try testing.expectEqualStrings("pwsh.exe", pwsh_result[0]);
 }
@@ -2851,12 +2875,13 @@ test "execCommand windows: pwsh with existing -Command wraps user script" {
 
     // -Command consumes "the rest of the command line". We collapse
     // the user's tail tokens back into one script and prepend the
-    // [Console]::*Encoding setup so their script runs UTF-8.
+    // chcp + [Console]::*Encoding setup so their script runs UTF-8.
     try testing.expectEqual(@as(usize, 4), result.len);
     try testing.expectEqualStrings("pwsh.exe", result[0]);
     try testing.expectEqualStrings("-NoProfile", result[1]);
     try testing.expectEqualStrings("-Command", result[2]);
-    try testing.expect(std.mem.startsWith(u8, result[3], "[Console]::OutputEncoding"));
+    try testing.expect(std.mem.startsWith(u8, result[3], "chcp 65001"));
+    try testing.expect(std.mem.indexOf(u8, result[3], "[Console]::OutputEncoding") != null);
     try testing.expect(std.mem.indexOf(u8, result[3], "[Console]::InputEncoding") != null);
     try testing.expect(std.mem.endsWith(u8, result[3], "; Write-Host"));
 }
@@ -3228,4 +3253,89 @@ test "execCommand windows: direct command for pwsh under never gets pwsh preambl
     try testing.expectEqualStrings("-NoLogo", result[1]);
     try testing.expectEqualStrings("-NoExit", result[2]);
     try testing.expectEqualStrings("-Command", result[3]);
+}
+
+test "execCommand windows: pwsh.exe under auto/auto gets pwsh preamble (regression for #341)" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // pwsh.exe under conpty-mode=auto resolves to .bypass transport
+    // (pwsh is .vt_aware). Before this fix, maybeInjectUtf8Preamble
+    // early-returned for any non-.conpty transport, so the preamble
+    // never fired on the user's actual click-from-profile path.
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "pwsh.exe" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .auto, // conpty_mode
+        .auto, // utf8_console - non-CJK ACP resolves to .always
+    );
+
+    // Expect: ["pwsh.exe", "-NoExit", "-Command", "<UTF-8 setup script>"]
+    // The exact suffix string is owned by windows_shell.suffix(.pwsh);
+    // assert structural shape, not the literal script text (which may
+    // evolve).
+    try testing.expect(result.len >= 4);
+    try testing.expectEqualStrings(result[0], "pwsh.exe");
+    try testing.expectEqualStrings(result[1], "-NoExit");
+    try testing.expectEqualStrings(result[2], "-Command");
+    // Script text contains both chcp and OutputEncoding setup.
+    try testing.expect(std.mem.indexOf(u8, result[3], "chcp") != null);
+    try testing.expect(std.mem.indexOf(u8, result[3], "OutputEncoding") != null);
+}
+
+test "execCommand windows: pwsh.exe under utf8-console=never returns args unchanged" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "pwsh.exe" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .auto, // conpty_mode
+        .never, // utf8_console - kill switch
+    );
+
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings(result[0], "pwsh.exe");
+}
+
+test "execCommand windows: bash.exe never gets a preamble (Preamble.none guard)" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "bash.exe" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .auto,
+        .always, // even with always, bash should be untouched
+    );
+
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings(result[0], "bash.exe");
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -989,7 +989,6 @@ const Subprocess = struct {
             alloc,
             shell_command,
             internal_os.passwd,
-            cfg.conpty_mode,
             cfg.utf8_console,
         ) catch |err| switch (err) {
             // If we fail to allocate space for the command we want to
@@ -1722,19 +1721,11 @@ fn execCommand(
     alloc: Allocator,
     command: configpkg.Command,
     comptime passwdpkg: type,
-    /// Captured for symmetry with `Subprocess.start()` and to keep the
-    /// signature stable across callers. Currently unused: after the
-    /// # 341 fix the UTF-8 preamble decision lives entirely under the
-    /// `utf8_console` policy gate (transport no longer matters because
-    /// .bypass pwsh inherits a non-console handle whose default CP
-    /// also isn't UTF-8). Discard so Zig doesn't flag the param.
-    conpty_mode: configpkg.Config.ConptyMode,
     /// Configured UTF-8 console preamble policy; used only on Windows
     /// to gate UTF-8 preamble injection across both ConPTY and bypass
     /// transports (# 302, # 341). Ignored on other platforms.
     utf8_console: configpkg.Config.Utf8Console,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
-    _ = conpty_mode;
     // If we're on macOS, we have to use `login(1)` to get all of
     // the proper environment variables set, a login shell, and proper
     // hushlogin behavior.
@@ -1940,13 +1931,14 @@ fn execCommand(
                     "cmd.exe",
                 });
 
-                // cmd.exe always lands in this `cmd.exe /C <script>`
-                // shape via ConPTY (cmd is `.console_api`, so transport
-                // resolution always picks `.conpty` here). Gate the
-                // chcp prepend on the user's UTF-8 policy directly so
-                // `utf8-console=never` is a real kill switch and `auto`
-                // (resolved to `.always` on non-CJK Windows) still
-                // forces UTF-8 across the whole pipeline.
+                // Gate on the encoding policy directly. The chcp
+                // prepend works under both ConPTY (the dominant case
+                // for cmd) and bypass (under conpty-mode = always);
+                // decoupling from transport means utf8-console = never
+                // is a real kill switch regardless of how the user has
+                // configured conpty-mode, and `auto` (resolved to
+                // `.always` on non-CJK Windows) still forces UTF-8
+                // across the whole pipeline.
                 const script: [:0]const u8 = if (resolveUtf8Console(utf8_console) == .always)
                     try std.fmt.allocPrintSentinel(
                         alloc,
@@ -2381,7 +2373,7 @@ test "execCommand darwin: shell command" {
                 .name = "testuser",
             };
         }
-    }, .auto, .auto);
+    }, .auto);
 
     try testing.expectEqual(8, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -2411,7 +2403,7 @@ test "execCommand darwin: direct command" {
                 .name = "testuser",
             };
         }
-    }, .auto, .auto);
+    }, .auto);
 
     try testing.expectEqual(5, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -2440,7 +2432,6 @@ test "execCommand: shell command, empty passwd" {
             }
         },
         .auto,
-        .auto,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2467,7 +2458,6 @@ test "execCommand: shell command, error passwd" {
                 return error.Fail;
             }
         },
-        .auto,
         .auto,
     );
 
@@ -2496,7 +2486,7 @@ test "execCommand: direct command, error passwd" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    }, .auto, .auto);
+    }, .auto);
 
     try testing.expectEqual(2, result.len);
     try testing.expectEqualStrings(result[0], "foo");
@@ -2526,7 +2516,7 @@ test "execCommand: direct command, config freed" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    }, .auto, .auto);
+    }, .auto);
 
     command_arena.deinit();
 
@@ -2543,9 +2533,9 @@ test "execCommand windows: shell command, single token spawns directly" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // always mode forces the bypass path. Pair with utf8-console=never
-    // so the new bypass-path preamble injection (#341) doesn't interfere
-    // with what this test is actually checking: shell-string parsing.
+    // utf8-console=never disables the bypass-path preamble injection
+    // (# 341) so this test stays focused on what it's actually checking:
+    // shell-string parsing.
     const result = try execCommand(
         alloc,
         .{ .shell = "pwsh.exe" },
@@ -2554,7 +2544,6 @@ test "execCommand windows: shell command, single token spawns directly" {
                 return .{};
             }
         },
-        .always,
         .never,
     );
 
@@ -2579,7 +2568,6 @@ test "execCommand windows: shell command, args split without cmd wrap" {
                 return .{};
             }
         },
-        .always,
         .never,
     );
 
@@ -2605,7 +2593,6 @@ test "execCommand windows: shell command, quoted path kept as one arg" {
                 return .{};
             }
         },
-        .always,
         .never,
     );
 
@@ -2636,7 +2623,6 @@ test "execCommand windows: shell command with pipe falls back to cmd.exe" {
                 return .{};
             }
         },
-        .always,
         .never,
     );
 
@@ -2663,7 +2649,6 @@ test "execCommand windows: shell command with redirect falls back to cmd.exe" {
                 return .{};
             }
         },
-        .always,
         .never,
     );
 
@@ -2781,7 +2766,6 @@ test "resolveUtf8Console: auto agrees with isCjkAnsiCodePage" {
 fn testExecWindowsShell(
     alloc: Allocator,
     shell: [:0]const u8,
-    conpty_mode: configpkg.Config.ConptyMode,
 ) ![]const [:0]const u8 {
     return try execCommand(
         alloc,
@@ -2791,7 +2775,6 @@ fn testExecWindowsShell(
                 return .{};
             }
         },
-        conpty_mode,
         .auto,
     );
 }
@@ -2802,7 +2785,7 @@ test "execCommand windows: cmd.exe under auto mode gets cmd preamble" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe", .auto);
+    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe");
 
     // auto + cmd (console_api) → ConPTY → cmd preamble appended.
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -2817,7 +2800,7 @@ test "execCommand windows: pwsh under forced never mode gets pwsh preamble" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe", .never);
+    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe");
 
     // never → ConPTY even for vt_aware shells. pwsh is identified as
     // the powershell family, so we inject the Console encoding setup.
@@ -2834,7 +2817,7 @@ test "execCommand windows: powershell 5.1 under auto mode gets pwsh preamble" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "powershell.exe", .auto);
+    const result = try testExecWindowsShell(arena.allocator(), "powershell.exe");
 
     // Windows PowerShell 5.1 is console_api → auto picks ConPTY → pwsh
     // preamble (same [Console]::*Encoding API as pwsh 7).
@@ -2850,7 +2833,7 @@ test "execCommand windows: unknown shell under ConPTY has no preamble" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "my-custom.exe", .never);
+    const result = try testExecWindowsShell(arena.allocator(), "my-custom.exe");
 
     // Unknown → no preamble even under forced ConPTY; we don't know
     // what syntax to inject.
@@ -2864,7 +2847,7 @@ test "execCommand windows: vt-aware non-powershell (bash) under ConPTY has no pr
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "bash.exe", .never);
+    const result = try testExecWindowsShell(arena.allocator(), "bash.exe");
 
     // bash et al. don't care about the Windows console CP; they decode
     // their own output.
@@ -2882,8 +2865,7 @@ test "execCommand windows: utf8-console=never is a kill switch across transports
 
     // After the # 341 fix the preamble decision is owned by the
     // utf8-console policy, not the transport. `never` must mean
-    // "no preamble anywhere", regardless of whether the resolved
-    // transport is .conpty (cmd) or .bypass (pwsh under .always).
+    // "no preamble anywhere", regardless of how transport resolves.
     const cmd_result = try execCommand(
         alloc,
         .{ .shell = "cmd.exe" },
@@ -2892,7 +2874,6 @@ test "execCommand windows: utf8-console=never is a kill switch across transports
                 return .{};
             }
         },
-        .always,
         .never,
     );
     try testing.expectEqual(@as(usize, 1), cmd_result.len);
@@ -2906,7 +2887,6 @@ test "execCommand windows: utf8-console=never is a kill switch across transports
                 return .{};
             }
         },
-        .always,
         .never,
     );
     try testing.expectEqual(@as(usize, 1), pwsh_result.len);
@@ -2919,7 +2899,7 @@ test "execCommand windows: cmd with existing /c arg wraps user script" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe /c echo hi", .auto);
+    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe /c echo hi");
 
     // User's `/c` consumes "the rest of the command line", so we wrap
     // instead of appending: collapse the tail tokens back into one
@@ -2939,7 +2919,6 @@ test "execCommand windows: cmd with existing /K arg wraps user script" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "cmd.exe /K title UTF8",
-        .never,
     );
 
     // /K keeps the shell interactive after running the script; the
@@ -2960,7 +2939,6 @@ test "execCommand windows: pwsh with existing -Command wraps user script" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -NoProfile -Command Write-Host",
-        .never,
     );
 
     // -Command consumes "the rest of the command line". We collapse
@@ -2985,7 +2963,6 @@ test "execCommand windows: pwsh with multi-token -Command script is joined" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -Command Write-Host hello world",
-        .never,
     );
 
     // pwsh joins remaining positional args after `-Command` into the
@@ -3011,7 +2988,6 @@ test "execCommand windows: cmd /c with quoted path preserves quoting on wrap" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "cmd.exe /c dir \"C:\\Program Files\"",
-        .auto,
     );
 
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -3032,7 +3008,6 @@ test "execCommand windows: pwsh with -c short form wraps user script" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -c Write-Host",
-        .never,
     );
 
     // `-c` is the unambiguous 2-letter short form of -Command; treat
@@ -3052,7 +3027,6 @@ test "execCommand windows: pwsh with -File leaves args untouched" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -File C:\\scripts\\my.ps1",
-        .never,
     );
 
     // We can't safely rewrite a user-supplied script file. Leave argv
@@ -3074,7 +3048,6 @@ test "execCommand windows: pwsh with -EncodedCommand leaves args untouched" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -EncodedCommand VwByAGkAdABlAC0ASABvAHMAdAAgAGgAaQA=",
-        .never,
     );
 
     // -EncodedCommand takes base64-encoded UTF-16LE. Rewriting would
@@ -3094,7 +3067,6 @@ test "execCommand windows: pwsh with trailing -Command (no script) leaves args u
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -Command",
-        .never,
     );
 
     // No tail after `-Command`: fabricating one would change whatever
@@ -3143,7 +3115,7 @@ test "execCommand windows: cmd with trailing /c (no script) leaves args untouche
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe /c", .never);
+    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe /c");
 
     try testing.expectEqual(@as(usize, 2), result.len);
     try testing.expectEqualStrings("cmd.exe", result[0]);
@@ -3177,7 +3149,6 @@ test "execCommand windows: pwsh -Command with param() is left untouched" {
                 return .{};
             }
         },
-        .never,
         .auto,
     );
 
@@ -3199,7 +3170,6 @@ test "execCommand windows: pwsh -Command with #requires is left untouched" {
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -Command \"#requires -Version 7\"",
-        .never,
     );
 
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -3220,7 +3190,6 @@ test "execCommand windows: pwsh -Command with leading scriptblock is left untouc
     const result = try testExecWindowsShell(
         arena.allocator(),
         "pwsh.exe -Command \"{ Get-Date }\"",
-        .never,
     );
 
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -3250,7 +3219,6 @@ test "execCommand windows: pwsh -Command with leading whitespace + param is left
                 return .{};
             }
         },
-        .never,
         .auto,
     );
 
@@ -3266,7 +3234,7 @@ test "execCommand windows: pwsh with benign args gets appended preamble" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe -NoProfile", .never);
+    const result = try testExecWindowsShell(arena.allocator(), "pwsh.exe -NoProfile");
 
     // -NoProfile doesn't conflict with -Command, so we append the
     // preamble after the user's flags.
@@ -3283,7 +3251,7 @@ test "execCommand windows: cmd-wrap path (pipes) gets chcp prepended to /C scrip
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "dir | findstr foo", .auto);
+    const result = try testExecWindowsShell(arena.allocator(), "dir | findstr foo");
 
     // Metachars force a cmd.exe /C wrap (existing behavior). The
     // preamble goes *inside* the /C string so the whole pipeline runs
@@ -3310,7 +3278,6 @@ test "execCommand windows: direct command for cmd.exe gets cmd preamble" {
             }
         },
         .auto,
-        .auto,
     );
 
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -3334,7 +3301,6 @@ test "execCommand windows: direct command for pwsh under never gets pwsh preambl
                 return .{};
             }
         },
-        .never,
         .auto,
     );
 
@@ -3353,13 +3319,11 @@ test "execCommand windows: pwsh.exe under auto/auto gets pwsh preamble (regressi
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // pwsh.exe under conpty-mode=auto NOW resolves to .conpty transport
-    // because pwsh requires a console handle for PSReadLine input. The
-    // preamble fires regardless of transport (see maybeInjectUtf8Preamble),
-    // so the user sees `chcp 65001` + `[Console]::OutputEncoding = UTF8`
-    // applied at startup. Before the # 341 fix the preamble was gated on
-    // `mode == .conpty`, which masked this code path because pwsh used to
-    // route to .bypass.
+    // After the # 341 fix the preamble fires regardless of transport
+    // (see maybeInjectUtf8Preamble), so the user sees `chcp 65001` +
+    // `[Console]::OutputEncoding = UTF8` applied at startup. Before
+    // the fix the preamble was gated on `mode == .conpty`, which
+    // masked this code path because pwsh used to route to .bypass.
     const result = try execCommand(
         alloc,
         .{ .shell = "pwsh.exe" },
@@ -3368,7 +3332,6 @@ test "execCommand windows: pwsh.exe under auto/auto gets pwsh preamble (regressi
                 return .{};
             }
         },
-        .auto, // conpty_mode
         .auto, // utf8_console - non-CJK ACP resolves to .always
     );
 
@@ -3401,7 +3364,6 @@ test "execCommand windows: pwsh.exe under utf8-console=never returns args unchan
                 return .{};
             }
         },
-        .auto, // conpty_mode
         .never, // utf8_console - kill switch
     );
 
@@ -3425,7 +3387,6 @@ test "execCommand windows: bash.exe never gets a preamble (Preamble.none guard)"
                 return .{};
             }
         },
-        .auto,
         .always, // even with always, bash should be untouched
     );
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -189,6 +189,12 @@ pub fn threadEnter(
         .read_thread_pipe = pipe[1],
         .read_thread_fd = pty_fds.read,
         .termios_timer = termios_timer,
+        .pty_mode = if (comptime builtin.os.tag == .windows)
+            self.subprocess.resolved_mode orelse .conpty
+        else {},
+        .shell_kind = if (comptime builtin.os.tag == .windows)
+            self.subprocess.resolved_shell_kind
+        else {},
     } };
 
     // On Windows, spawn a dedicated thread that blocks on WaitForSingleObject
@@ -477,12 +483,38 @@ pub fn queueWrite(
     td: *termio.Termio.ThreadData,
     data: []const u8,
     linefeed: bool,
+    kind: termio.Message.WriteKind,
 ) !void {
     _ = self;
     const exec = &td.backend.exec;
 
     // If our process is exited then we don't send any more writes.
     if (exec.exited) return;
+
+    // Windows-only: under raw-pipe (bypass) transport, pwsh disables
+    // PSReadLine because there is no console handle for VT input. It
+    // falls back to Console.ReadLine, which treats CSI bytes on stdin
+    // as literal command text. Suppress writes tagged as parser-driven
+    // responses (cursor position, device attributes, color queries,
+    // etc.) so we don't pollute the prompt buffer.
+    //
+    // Note: under default `conpty-mode = auto`, pwsh now routes to
+    // .conpty (see resolveConptyMode), so this gate is reached only
+    // when the user explicitly sets `conpty-mode = always`. It remains
+    // in place as defense-in-depth and to keep output clean for that
+    // (unusual) configuration.
+    if (comptime builtin.os.tag == .windows) {
+        if (kind == .response and exec.pty_mode == .bypass) {
+            const sk = exec.shell_kind orelse .unknown;
+            if (sk == .pwsh) {
+                log.debug(
+                    "suppressing CSI response under bypass+pwsh ({d} bytes)",
+                    .{data.len},
+                );
+                return;
+            }
+        }
+    }
 
     // We go through and chunk the data if necessary to fit into
     // our cached buffers that we can queue to the stream.
@@ -614,6 +646,23 @@ pub const ThreadData = struct {
     /// to prevent unnecessary locking of expensive mutexes.
     termios_mode: ptypkg.TerminalMode = .{},
 
+    /// Resolved Windows pty transport for the running child. Captured
+    /// from `Subprocess.start` so the write path can gate per-shell
+    /// quirks without re-running shell classification. POSIX has no
+    /// transport selection, so this is always `.conpty` there (the
+    /// enum still has a `.conpty` variant on POSIX for source-shape
+    /// compatibility).
+    pty_mode: if (builtin.os.tag == .windows) ptypkg.Mode else void =
+        if (builtin.os.tag == .windows) .conpty else {},
+
+    /// Resolved Windows shell identity for the running child. Captured
+    /// from `Subprocess.start` so the write path can gate per-shell
+    /// quirks (currently: pwsh + bypass suppresses CSI responses).
+    /// `null` on Windows when classification did not match a known
+    /// shell. Not meaningful on POSIX.
+    shell_kind: if (builtin.os.tag == .windows) ?internal_os.windows_shell.Kind else void =
+        if (builtin.os.tag == .windows) null else {},
+
     pub fn deinit(self: *ThreadData, alloc: Allocator) void {
         posix.close(self.read_thread_pipe);
 
@@ -693,6 +742,21 @@ const Subprocess = struct {
         configpkg.Config.Utf8Console
     else
         void = if (builtin.os.tag == .windows) .auto else {},
+
+    /// Resolved transport mode set by `start` once the shell has been
+    /// classified. `null` until `start` runs. Read by `Exec.threadEnter`
+    /// to populate `Exec.ThreadData.pty_mode`. Windows-only.
+    resolved_mode: if (builtin.os.tag == .windows) ?ptypkg.Mode else void =
+        if (builtin.os.tag == .windows) null else {},
+
+    /// Resolved shell identity set by `start`. `null` until `start`
+    /// runs OR if classification did not match a known shell. Read by
+    /// `Exec.threadEnter` to populate `Exec.ThreadData.shell_kind`.
+    /// Windows-only.
+    resolved_shell_kind: if (builtin.os.tag == .windows)
+        ?internal_os.windows_shell.Kind
+    else
+        void = if (builtin.os.tag == .windows) null else {},
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
@@ -1014,6 +1078,17 @@ const Subprocess = struct {
             resolveConptyMode(self.conpty_mode, self.args[0])
         else
             .conpty;
+
+        // Cache the resolved mode and shell identity so the termio
+        // thread can read them from Exec.ThreadData without re-running
+        // classification (and without holding the renderer lock). The
+        // write path needs both to gate per-shell quirks - currently:
+        // pwsh under bypass cannot consume CSI response bytes on stdin
+        // because PSReadLine is disabled.
+        if (comptime builtin.os.tag == .windows) {
+            self.resolved_mode = mode;
+            self.resolved_shell_kind = internal_os.windows_shell.identify(self.args[0]);
+        }
 
         // Create our pty
         var pty = try Pty.open(.{
@@ -2250,9 +2325,17 @@ fn resolveConptyMode(
     const resolved: ptypkg.Mode = switch (cfg) {
         .never => .conpty,
         .always => .bypass,
-        .auto => switch (internal_os.windows_shell.classify(exe_path)) {
-            .vt_aware => .bypass,
-            .console_api, .unknown => .conpty,
+        .auto => blk: {
+            const kind = internal_os.windows_shell.identify(exe_path);
+            // Force ConPTY for shells whose interactive input layer
+            // (e.g. PSReadLine for pwsh) requires a real console handle.
+            if (internal_os.windows_shell.requiresConsoleInput(kind)) {
+                break :blk .conpty;
+            }
+            break :blk switch (internal_os.windows_shell.awarenessOf(kind)) {
+                .vt_aware => .bypass,
+                .console_api, .unknown => .conpty,
+            };
         },
     };
     log_validate.info(
@@ -2626,9 +2709,16 @@ test "resolveConptyMode: always forces bypass" {
 }
 
 test "resolveConptyMode: auto picks bypass for vt_aware" {
-    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "bash.exe"));
     try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "wsl.exe"));
     try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "bash"));
+}
+
+test "resolveConptyMode: auto picks conpty for pwsh (requires console for PSReadLine)" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "pwsh"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
 }
 
 test "resolveConptyMode: auto picks conpty for console_api" {
@@ -2642,13 +2732,13 @@ test "resolveConptyMode: auto picks conpty for unknown (safe default)" {
 }
 
 test "resolveConptyMode: auto handles path-prefixed shell" {
-    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "C:\\Program Files\\Git\\bin\\bash.exe"));
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "C:\\Windows\\System32\\cmd.exe"));
-    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "C:/Program Files/PowerShell/7/pwsh.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "C:/Program Files/Git/bin/bash.exe"));
 }
 
 test "resolveConptyMode: auto handles quoted shell" {
-    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "\"pwsh.exe\""));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "\"bash.exe\""));
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "'cmd.exe'"));
 }
 
@@ -3263,10 +3353,13 @@ test "execCommand windows: pwsh.exe under auto/auto gets pwsh preamble (regressi
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // pwsh.exe under conpty-mode=auto resolves to .bypass transport
-    // (pwsh is .vt_aware). Before this fix, maybeInjectUtf8Preamble
-    // early-returned for any non-.conpty transport, so the preamble
-    // never fired on the user's actual click-from-profile path.
+    // pwsh.exe under conpty-mode=auto NOW resolves to .conpty transport
+    // because pwsh requires a console handle for PSReadLine input. The
+    // preamble fires regardless of transport (see maybeInjectUtf8Preamble),
+    // so the user sees `chcp 65001` + `[Console]::OutputEncoding = UTF8`
+    // applied at startup. Before the # 341 fix the preamble was gated on
+    // `mode == .conpty`, which masked this code path because pwsh used to
+    // route to .bypass.
     const result = try execCommand(
         alloc,
         .{ .shell = "pwsh.exe" },

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -652,6 +652,14 @@ pub const Config = struct {
     else
         void = if (builtin.os.tag == .windows) .auto else {},
 
+    /// Windows UTF-8 console preamble policy. Resolved at spawn time
+    /// against the system ANSI codepage (see `resolveUtf8Console`).
+    /// Ignored on POSIX.
+    utf8_console: if (builtin.os.tag == .windows)
+        configpkg.Config.Utf8Console
+    else
+        void = if (builtin.os.tag == .windows) .auto else {},
+
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
 };
@@ -676,6 +684,13 @@ const Subprocess = struct {
     /// the shell classifier at spawn time. Ignored on POSIX.
     conpty_mode: if (builtin.os.tag == .windows)
         configpkg.Config.ConptyMode
+    else
+        void = if (builtin.os.tag == .windows) .auto else {},
+
+    /// Captured from Config.utf8_console at init time; resolved against
+    /// the system ACP per-spawn inside maybeInjectUtf8Preamble.
+    utf8_console: if (builtin.os.tag == .windows)
+        configpkg.Config.Utf8Console
     else
         void = if (builtin.os.tag == .windows) .auto else {},
 
@@ -911,6 +926,7 @@ const Subprocess = struct {
             shell_command,
             internal_os.passwd,
             cfg.conpty_mode,
+            cfg.utf8_console,
         ) catch |err| switch (err) {
             // If we fail to allocate space for the command we want to
             // execute, we'd still like to try to run something so
@@ -955,6 +971,7 @@ const Subprocess = struct {
             .args = args,
 
             .conpty_mode = cfg.conpty_mode,
+            .utf8_console = cfg.utf8_console,
 
             .rt_pre_exec_info = cfg.rt_pre_exec_info,
             .rt_post_fork_info = cfg.rt_post_fork_info,
@@ -1634,6 +1651,10 @@ fn execCommand(
     /// to inject the ConPTY UTF-8 preamble (# 302). Ignored on other
     /// platforms.
     conpty_mode: configpkg.Config.ConptyMode,
+    /// Configured UTF-8 console preamble policy; used only on Windows
+    /// to gate ConPTY UTF-8 preamble injection (# 302). Ignored on
+    /// other platforms.
+    utf8_console: configpkg.Config.Utf8Console,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
     // If we're on macOS, we have to use `login(1)` to get all of
     // the proper environment variables set, a login shell, and proper
@@ -1765,6 +1786,7 @@ fn execCommand(
                     alloc,
                     cloned,
                     conpty_mode,
+                    utf8_console,
                 );
             }
             break :direct cloned;
@@ -1817,6 +1839,7 @@ fn execCommand(
                         alloc,
                         direct_args,
                         conpty_mode,
+                        utf8_console,
                     );
                 }
 
@@ -1907,7 +1930,10 @@ fn maybeInjectUtf8Preamble(
     alloc: Allocator,
     args: []const [:0]const u8,
     conpty_mode: configpkg.Config.ConptyMode,
+    utf8_console: configpkg.Config.Utf8Console,
 ) Allocator.Error![]const [:0]const u8 {
+    // TODO(#341): gate the preamble decision on this.
+    _ = utf8_console;
     if (comptime builtin.os.tag != .windows) return args;
     if (args.len == 0) return args;
 
@@ -2261,7 +2287,7 @@ test "execCommand darwin: shell command" {
                 .name = "testuser",
             };
         }
-    }, .auto);
+    }, .auto, .auto);
 
     try testing.expectEqual(8, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -2291,7 +2317,7 @@ test "execCommand darwin: direct command" {
                 .name = "testuser",
             };
         }
-    }, .auto);
+    }, .auto, .auto);
 
     try testing.expectEqual(5, result.len);
     try testing.expectEqualStrings(result[0], "/usr/bin/login");
@@ -2320,6 +2346,7 @@ test "execCommand: shell command, empty passwd" {
             }
         },
         .auto,
+        .auto,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2346,6 +2373,7 @@ test "execCommand: shell command, error passwd" {
                 return error.Fail;
             }
         },
+        .auto,
         .auto,
     );
 
@@ -2374,7 +2402,7 @@ test "execCommand: direct command, error passwd" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    }, .auto);
+    }, .auto, .auto);
 
     try testing.expectEqual(2, result.len);
     try testing.expectEqualStrings(result[0], "foo");
@@ -2404,7 +2432,7 @@ test "execCommand: direct command, config freed" {
             // login command and falls back to POSIX behavior.
             return error.Fail;
         }
-    }, .auto);
+    }, .auto, .auto);
 
     command_arena.deinit();
 
@@ -2432,6 +2460,7 @@ test "execCommand windows: shell command, single token spawns directly" {
             }
         },
         .always,
+        .auto,
     );
 
     // No cmd.exe /C wrapper: args[0] is the configured shell itself.
@@ -2456,6 +2485,7 @@ test "execCommand windows: shell command, args split without cmd wrap" {
             }
         },
         .always,
+        .auto,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2481,6 +2511,7 @@ test "execCommand windows: shell command, quoted path kept as one arg" {
             }
         },
         .always,
+        .auto,
     );
 
     try testing.expectEqual(2, result.len);
@@ -2510,6 +2541,7 @@ test "execCommand windows: shell command with pipe falls back to cmd.exe" {
             }
         },
         .always,
+        .auto,
     );
 
     // Metachar present: wrap with cmd.exe /C so cmd handles the pipe.
@@ -2536,6 +2568,7 @@ test "execCommand windows: shell command with redirect falls back to cmd.exe" {
             }
         },
         .always,
+        .auto,
     );
 
     try testing.expectEqual(3, result.len);
@@ -2656,6 +2689,7 @@ fn testExecWindowsShell(
             }
         },
         conpty_mode,
+        .auto,
     );
 }
 
@@ -3029,6 +3063,7 @@ test "execCommand windows: pwsh -Command with param() is left untouched" {
             }
         },
         .never,
+        .auto,
     );
 
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -3101,6 +3136,7 @@ test "execCommand windows: pwsh -Command with leading whitespace + param is left
             }
         },
         .never,
+        .auto,
     );
 
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -3159,6 +3195,7 @@ test "execCommand windows: direct command for cmd.exe gets cmd preamble" {
             }
         },
         .auto,
+        .auto,
     );
 
     try testing.expectEqual(@as(usize, 3), result.len);
@@ -3183,6 +3220,7 @@ test "execCommand windows: direct command for pwsh under never gets pwsh preambl
             }
         },
         .never,
+        .auto,
     );
 
     try testing.expectEqual(@as(usize, 5), result.len);

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -358,7 +358,7 @@ pub fn threadEnter(
 
     // If we have inputs, then queue them all up.
     for (inputs orelse &.{}) |input| switch (input) {
-        .string => |v| self.queueWrite(data, v, false) catch |err| {
+        .string => |v| self.queueWrite(data, v, false, .input) catch |err| {
             log.warn("failed to queue input string err={}", .{err});
             return error.InputFailed;
         },
@@ -372,6 +372,7 @@ pub fn threadEnter(
                 return error.InputFailed;
             },
             false,
+            .input,
         ) catch |err| {
             log.warn("failed to queue input file err={}", .{err});
             return error.InputFailed;
@@ -408,13 +409,20 @@ pub fn queueMessage(
 /// mailbox messages instead.
 ///
 /// If you're not using termio.Thread, this is not threadsafe.
+///
+/// `kind` classifies the write so the backend can suppress it under
+/// shells that can't consume CSI bytes on stdin (see
+/// `termio.Message.WriteKind`). Pass `.input` for user-driven writes
+/// (keystrokes, paste, focus events, scripted inputs) and `.response`
+/// for parser-driven replies to child queries.
 pub inline fn queueWrite(
     self: *Termio,
     td: *ThreadData,
     data: []const u8,
     linefeed: bool,
+    kind: termio.Message.WriteKind,
 ) !void {
-    try self.backend.queueWrite(self.alloc, td, data, linefeed);
+    try self.backend.queueWrite(self.alloc, td, data, linefeed, kind);
 }
 
 /// Update the configuration.
@@ -528,7 +536,7 @@ fn sizeReportLocked(self: *Termio, td: *ThreadData, style: termio.Message.SizeRe
         report_size,
     );
 
-    try self.queueWrite(td, writer.buffered(), false);
+    try self.queueWrite(td, writer.buffered(), false, .response);
 }
 
 /// Reset the synchronized output mode. This is usually called by timer
@@ -592,7 +600,8 @@ pub fn clearScreen(self: *Termio, td: *ThreadData, history: bool) !void {
     }
 
     // If we reached here it means we're at a prompt, so we send a form-feed.
-    try self.queueWrite(td, &[_]u8{0x0C}, false);
+    // This is user-driven (the user invoked clear-screen) so it's `.input`.
+    try self.queueWrite(td, &[_]u8{0x0C}, false, .input);
 }
 
 /// Scroll the viewport
@@ -630,7 +639,9 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
             log.err("error encoding focus event err={}", .{err});
             return;
         };
-        try self.queueWrite(td, writer.buffered(), false);
+        // Focus events are triggered by user/window-manager focus changes,
+        // not by a child VT query, so they're classified as `.input`.
+        try self.queueWrite(td, writer.buffered(), false, .input);
     }
 
     // We always notify our backend of focus changes.
@@ -716,7 +727,7 @@ pub fn colorSchemeReportLocked(self: *Termio, td: *ThreadData, force: bool) !voi
         .light => "\x1B[?997;2n",
         .dark => "\x1B[?997;1n",
     };
-    try self.queueWrite(td, output, false);
+    try self.queueWrite(td, output, false, .response);
 }
 
 /// ThreadData is the data created and stored in the termio thread

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -337,11 +337,13 @@ fn drainMailbox(
                 data,
                 v.data[0..v.len],
                 self.flags.linefeed_mode,
+                v.kind,
             ),
             .write_stable => |v| try io.queueWrite(
                 data,
-                v,
+                v.data,
                 self.flags.linefeed_mode,
+                v.kind,
             ),
             .write_alloc => |v| {
                 defer v.alloc.free(v.data);
@@ -349,6 +351,7 @@ fn drainMailbox(
                     data,
                     v.data,
                     self.flags.linefeed_mode,
+                    v.kind,
                 );
             },
         }

--- a/src/termio/backend.zig
+++ b/src/termio/backend.zig
@@ -79,9 +79,10 @@ pub const Backend = union(Kind) {
         td: *termio.Termio.ThreadData,
         data: []const u8,
         linefeed: bool,
+        kind: termio.Message.WriteKind,
     ) !void {
         switch (self.*) {
-            .exec => |*exec| try exec.queueWrite(alloc, td, data, linefeed),
+            .exec => |*exec| try exec.queueWrite(alloc, td, data, linefeed, kind),
         }
     }
 

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -16,6 +16,48 @@ pub const Message = union(enum) {
     /// in the future.
     pub const WriteReq = MessageData(u8, 38);
 
+    /// Classification of a pty write so the termio thread can decide
+    /// whether to deliver it to the child. Used by Windows to suppress
+    /// VT response bytes when the child is pwsh under raw-pipe (bypass)
+    /// stdin: in that configuration PSReadLine is disabled and
+    /// Console.ReadLine treats the response bytes as command text,
+    /// polluting the prompt buffer.
+    ///
+    /// The default is `.input` so writes that aren't explicitly tagged
+    /// (keystrokes, paste, mouse events, focus events, anything user-
+    /// driven) pass through unchanged.
+    pub const WriteKind = enum {
+        /// User-driven write: keystrokes, paste, mouse events, focus
+        /// events, anything that should always reach the child.
+        input,
+        /// Reply to a parser-driven query from the child (cursor
+        /// position, device attributes, color queries, etc.). May be
+        /// suppressed on Windows when the child cannot consume CSI
+        /// bytes on stdin.
+        response,
+    };
+
+    /// Wrappers around the three `WriteReq` variants that carry an
+    /// extra `kind` tag (see `WriteKind`). Field names match
+    /// `WriteReq.Small`/`WriteReq.Alloc` so call sites that don't care
+    /// about `kind` keep working unchanged via the default.
+    pub const WriteSmallReq = struct {
+        data: WriteReq.Small.Array = undefined,
+        len: WriteReq.Small.Len = 0,
+        kind: WriteKind = .input,
+    };
+
+    pub const WriteStableReq = struct {
+        data: []const u8,
+        kind: WriteKind = .input,
+    };
+
+    pub const WriteAllocReq = struct {
+        alloc: Allocator,
+        data: []u8,
+        kind: WriteKind = .input,
+    };
+
     /// Request a color scheme report is sent to the pty.
     color_scheme_report: struct {
         /// Force write the current color scheme
@@ -74,22 +116,26 @@ pub const Message = union(enum) {
     focused: bool,
 
     /// Write where the data fits in the union.
-    write_small: WriteReq.Small,
+    write_small: WriteSmallReq,
 
     /// Write where the data pointer is stable.
-    write_stable: WriteReq.Stable,
+    write_stable: WriteStableReq,
 
     /// Write where the data is allocated and must be freed.
-    write_alloc: WriteReq.Alloc,
+    write_alloc: WriteAllocReq,
 
     /// Return a write request for the given data. This will use
     /// write_small if it fits or write_alloc otherwise. This should NOT
     /// be used for stable pointers which can be manually set to write_stable.
+    ///
+    /// The resulting message is tagged as `.input`. Callers that want to
+    /// tag the write as a parser-driven response should set
+    /// `.kind = .response` on the resulting variant before sending.
     pub fn writeReq(alloc: Allocator, data: anytype) !Message {
         return switch (try WriteReq.init(alloc, data)) {
             .stable => unreachable,
-            .small => |v| Message{ .write_small = v },
-            .alloc => |v| Message{ .write_alloc = v },
+            .small => |v| Message{ .write_small = .{ .data = v.data, .len = v.len } },
+            .alloc => |v| Message{ .write_alloc = .{ .alloc = v.alloc, .data = v.data } },
         };
     }
 
@@ -103,6 +149,10 @@ test {
 
 test {
     // Ensure we don't grow our IO message size without explicitly wanting to.
+    // The previous size was 40 bytes; adding the WriteKind tag bumped the
+    // largest write variant by one byte. The bump is intentional - see
+    // WriteKind for the reason. Update this constant only when another
+    // intentional growth happens.
     const testing = std.testing;
-    try testing.expectEqual(@as(usize, 40), @sizeOf(Message));
+    try testing.expectEqual(@as(usize, 41), @sizeOf(Message));
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -150,7 +150,7 @@ pub const StreamHandler = struct {
             .write_small => |*v| v.kind = .response,
             .write_stable => |*v| v.kind = .response,
             .write_alloc => |*v| v.kind = .response,
-            else => {},
+            else => unreachable, // Message.writeReq only returns write variants
         }
     }
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -141,6 +141,19 @@ pub const StreamHandler = struct {
         self.termio_messaged = true;
     }
 
+    /// Mutate a `Message` produced by `Message.writeReq` so its write
+    /// variant is tagged as a parser-driven response. This lets the
+    /// termio thread suppress the write under shells that can't consume
+    /// CSI bytes on stdin (see `WriteKind`).
+    inline fn tagResponse(msg: *termio.Message) void {
+        switch (msg.*) {
+            .write_small => |*v| v.kind = .response,
+            .write_stable => |*v| v.kind = .response,
+            .write_alloc => |*v| v.kind = .response,
+            else => {},
+        }
+    }
+
     /// Send a renderer message and unlock the renderer state mutex
     /// if necessary to ensure we don't deadlock.
     ///
@@ -448,10 +461,12 @@ pub const StreamHandler = struct {
                         .command => |command| {
                             assert(command.len > 0);
                             assert(command[command.len - 1] == '\n');
-                            self.messageWriter(try termio.Message.writeReq(
+                            var msg = try termio.Message.writeReq(
                                 self.alloc,
                                 command,
-                            ));
+                            );
+                            tagResponse(&msg);
+                            self.messageWriter(msg);
                         },
 
                         .windows => {
@@ -465,7 +480,10 @@ pub const StreamHandler = struct {
                 const map = comptime terminfo.ghostty.xtgettcapMap();
                 while (gettcap.next()) |key| {
                     const response = map.get(key) orelse continue;
-                    self.messageWriter(.{ .write_stable = response });
+                    self.messageWriter(.{ .write_stable = .{
+                        .data = response,
+                        .kind = .response,
+                    } });
                 }
             },
 
@@ -536,7 +554,8 @@ pub const StreamHandler = struct {
 
                 // Write the response prefix into the buffer
                 _ = try std.fmt.bufPrint(response[0..prefix_len], prefix_fmt, .{@intFromBool(valid)});
-                const msg = try termio.Message.writeReq(self.alloc, response[0..stream.pos]);
+                var msg = try termio.Message.writeReq(self.alloc, response[0..stream.pos]);
+                tagResponse(&msg);
                 self.messageWriter(msg);
             },
         }
@@ -556,7 +575,9 @@ pub const StreamHandler = struct {
                     const final = writer.buffered();
                     if (final.len > 2) {
                         log.debug("kitty graphics response: {x}", .{final});
-                        self.messageWriter(try termio.Message.writeReq(self.alloc, final));
+                        var msg = try termio.Message.writeReq(self.alloc, final);
+                        tagResponse(&msg);
+                        self.messageWriter(msg);
                     }
                 }
             },
@@ -628,6 +649,7 @@ pub const StreamHandler = struct {
         self.messageWriter(.{ .write_small = .{
             .data = data,
             .len = @intCast(writer.buffered().len),
+            .kind = .response,
         } });
     }
 
@@ -821,14 +843,20 @@ pub const StreamHandler = struct {
                 // 62 = Level 2 conformance
                 // 22 = Color text
                 // 52 = Clipboard access
-                .write_stable = if (self.clipboard_write != .deny)
-                    "\x1B[?62;22;52c"
-                else
-                    "\x1B[?62;22c",
+                .write_stable = .{
+                    .data = if (self.clipboard_write != .deny)
+                        "\x1B[?62;22;52c"
+                    else
+                        "\x1B[?62;22c",
+                    .kind = .response,
+                },
             }),
 
             .secondary => self.messageWriter(.{
-                .write_stable = "\x1B[>1;10;0c",
+                .write_stable = .{
+                    .data = "\x1B[>1;10;0c",
+                    .kind = .response,
+                },
             }),
 
             else => log.warn("unimplemented device attributes req: {}", .{req}),
@@ -840,7 +868,10 @@ pub const StreamHandler = struct {
         req: terminal.device_status.Request,
     ) !void {
         switch (req) {
-            .operating_status => self.messageWriter(.{ .write_stable = "\x1B[0n" }),
+            .operating_status => self.messageWriter(.{ .write_stable = .{
+                .data = "\x1B[0n",
+                .kind = .response,
+            } }),
 
             .cursor_position => {
                 const pos: struct {
@@ -857,7 +888,7 @@ pub const StreamHandler = struct {
                 // Response always is at least 4 chars, so this leaves the
                 // remainder for the row/column as base-10 numbers. This
                 // will support a very large terminal.
-                var msg: termio.Message = .{ .write_small = .{} };
+                var msg: termio.Message = .{ .write_small = .{ .kind = .response } };
                 const resp = try std.fmt.bufPrint(&msg.write_small.data, "\x1B[{};{}R", .{
                     pos.y + 1,
                     pos.x + 1,
@@ -934,7 +965,9 @@ pub const StreamHandler = struct {
 
     pub fn enquiry(self: *StreamHandler) !void {
         log.debug("sending enquiry response={s}", .{self.enquiry_response});
-        self.messageWriter(try termio.Message.writeReq(self.alloc, self.enquiry_response));
+        var msg = try termio.Message.writeReq(self.alloc, self.enquiry_response);
+        tagResponse(&msg);
+        self.messageWriter(msg);
     }
 
     fn configureCharset(
@@ -969,6 +1002,7 @@ pub const StreamHandler = struct {
             .write_small = .{
                 .data = data,
                 .len = @intCast(resp.len),
+                .kind = .response,
             },
         });
     }
@@ -986,7 +1020,8 @@ pub const StreamHandler = struct {
                 build_config.version_string,
             },
         );
-        const msg = try termio.Message.writeReq(self.alloc, resp);
+        var msg = try termio.Message.writeReq(self.alloc, resp);
+        tagResponse(&msg);
         self.messageWriter(msg);
     }
 
@@ -1431,7 +1466,8 @@ pub const StreamHandler = struct {
         if (response.items.len > 0) {
             // If any of the operations were reports, finalize the report
             // string and send it to the terminal.
-            const msg = try termio.Message.writeReq(self.alloc, response.items);
+            var msg = try termio.Message.writeReq(self.alloc, response.items);
+            tagResponse(&msg);
             self.messageWriter(msg);
         }
     }
@@ -1547,6 +1583,7 @@ pub const StreamHandler = struct {
                 .write_alloc = .{
                     .alloc = self.alloc,
                     .data = try stream.toOwnedSlice(),
+                    .kind = .response,
                 },
             });
         }


### PR DESCRIPTION
## Summary

Closes #341. Fixes pwsh under default config on non-UTF-8 OEM Windows (e.g. Italian CP-850): encoding lands at 65001, Nerd Font glyphs render, full PSReadLine line-editing works.

7 commits, see individual messages for details. The big two:

* `termio: inject utf-8 preamble on bypass transport (#341)` drops the `mode != .conpty` early-return so PR # 308's preamble fires on `.bypass` for pwsh under the user's actual repro path.
* `termio: force conpty for pwsh + suppress csi response under bypass+pwsh` matches WezTerm / Alacritty / libghostty-vt-dotnet: pwsh's PSReadLine needs a console handle for VT input. Other VT-aware shells (bash, wsl, ssh, nu, fish, zsh, elvish, xonsh) keep using bypass.

## Test plan

- [x] `zig build test` green (2850/2905, 1 pre-existing tripwire warning unrelated)
- [x] Manual on Italian CP-850 Windows: `chcp` reports 65001, `[Console]::OutputEncoding` reports CodePage 65001, Oh-My-Posh Nerd Font glyphs render, backspace + Enter + history + tab all work
- [x] `[Console]::IsInputRedirected` reports `False`
- [x] `utf8-console = never` kill switch flips to broken baseline (verified)
- [x] cmd profile + POSIX tests still pass

## Followups

* Drop `_ = conpty_mode;` discard from `execCommand` (filed as task chip).
* wintty-bench C3 validation against user hardware (deferred to separate wintty-bench PR).
* Empirical falsification of "bypass-pwsh can't be made fully functional" via deblasis/pwsh-bypass-research (pi-autoresearch in progress). If it falsifies, the CSI suppression infrastructure landed here is ready to use.