### PR TITLE
windows(csproj): replace AppIcon scale wildcard with explicit list

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -188,8 +188,21 @@
           WorkingDirectory="$(MSBuildThisFileDirectory)" />
   </Target>
 
+  <!--
+    Explicit scale list, not a wildcard. Wildcards in <Content Include>
+    expand at MSBuild evaluation time; GenerateBrandingAssets above runs
+    in BeforeBuild (after evaluation), so on a clean build the wildcard
+    matches zero files, no Content items are added, and bin\Assets\ stays
+    empty. ms-appx:///Assets/AppIcon.png then 404s and the WinUI 3
+    AppIconBadge renders the broken-image placeholder instead of the
+    Ghostty ghost. Explicit names get added to @(Content) at evaluation
+    regardless of whether the files exist yet; the Copy task at build
+    time succeeds because GenerateBrandingAssets has produced them by
+    then. Keep this list in sync with PngWriter.ScaleTargets in
+    dist/windows/IconGen/PngWriter.cs.
+  -->
   <ItemGroup>
-    <Content Include="$(GeneratedBrandingDir)AppIcon.scale-*.png">
+    <Content Include="$(GeneratedBrandingDir)AppIcon.scale-100.png;$(GeneratedBrandingDir)AppIcon.scale-150.png;$(GeneratedBrandingDir)AppIcon.scale-200.png;$(GeneratedBrandingDir)AppIcon.scale-400.png">
       <Link>Assets\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>


### PR DESCRIPTION
## Summary

The \`<Content Include=\"\$(GeneratedBrandingDir)AppIcon.scale-*.png\">\`
uses a wildcard, which expands at MSBuild evaluation time. The
\`GenerateBrandingAssets\` target above runs in \`BeforeBuild\`, after
evaluation, so on a clean build the wildcard matches zero files, no
Content items are added, and \`bin\Assets\\` never appears. The
\`AppIconBadge\` then resolves \`ms-appx:///Assets/AppIcon.png\` to
nothing and renders the broken-image placeholder where the Ghostty
ghost should be.

This is the second instance of the same evaluation-time-vs-target-
execution-time anti-pattern in this csproj. The first was the
\`<None Include=\"...ghostty.dll\" Condition=\"Exists(...)\">\` trap,
fixed in # 360.

Replacing the wildcard with explicit scale names (100 / 150 / 200 / 400
to match \`PngWriter.ScaleTargets\` in
\`dist/windows/IconGen/PngWriter.cs\`) lets MSBuild add the items at
evaluation regardless of whether the files exist yet; the Copy task at
build time succeeds because \`GenerateBrandingAssets\` has produced them
by then.

## Test plan

- [x] Clean materialised \`_build/sponsor\` tree (\`just rematerialize sponsor\` then \`just build-tier sponsor\`):
  - **pre-fix:** \`bin\Release\...\Assets\\` does not exist after build, \`Wintty.exe\` launches with broken-image placeholder where the app-menu icon should be.
  - **post-fix:** \`bin\Release\...\Assets\AppIcon.scale-{100,150,200,400}.png\` produced (5502 / 11400 / 19157 / 63813 bytes), \`Wintty.exe\` launches with the Ghostty ghost icon resolving via \`ms-appx:///Assets/AppIcon.png\`.
- [x] No CI impact: \`test-windows\` is gated on \`github.repository == 'ghostty-org/ghostty'\` so it skips on this fork.
- [ ] Reviewer: visual confirmation of the rendered icon in a fresh sponsor build.