### PR TITLE
feat(libghostty): add ghostty_build_info FFI export

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -79,6 +79,15 @@ typedef struct {
   const char *data;
 } ghostty_clipboard_content_s;
 
+typedef struct {
+  const char *version;
+  const char *version_string;
+  const char *commit;
+  const char *channel;
+  const char *zig_version;
+  const char *build_mode;
+} ghostty_build_info_s;
+
 typedef enum {
   GHOSTTY_CLIPBOARD_REQUEST_PASTE,
   GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ,
@@ -1085,6 +1094,7 @@ typedef enum {
 
 GHOSTTY_API int ghostty_init(uintptr_t, char**);
 GHOSTTY_API void ghostty_cli_try_action(void);
+GHOSTTY_API void ghostty_build_info(ghostty_build_info_s *out);
 GHOSTTY_API ghostty_info_s ghostty_info(void);
 GHOSTTY_API const char* ghostty_translate(const char*);
 GHOSTTY_API void ghostty_string_free(ghostty_string_s);

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -146,10 +146,6 @@ pub export fn ghostty_cli_run_action() c_int {
 }
 
 /// ghostty_build_info_s
-///
-/// Build information about the loaded libghostty. All strings have static
-/// lifetime; the caller must not free them. Strings are NUL-terminated UTF-8.
-/// `commit` is the empty string when no build commit is present.
 pub const BuildInfo = extern struct {
     version: [*:0]const u8,
     version_string: [*:0]const u8,
@@ -159,9 +155,10 @@ pub const BuildInfo = extern struct {
     build_mode: [*:0]const u8,
 };
 
-/// Fill `out` with build information about the loaded libghostty. Safe to
-/// call before `ghostty_init`. The strings returned are static and must not
-/// be freed.
+/// Fill `out` with build information about the loaded libghostty. Returned
+/// strings are NUL-terminated UTF-8 with static lifetime; the caller must
+/// not free them. `commit` is empty when no build commit is present. Safe
+/// to call before `ghostty_init`.
 pub export fn ghostty_build_info(out: *BuildInfo) void {
     out.* = .{
         .version = build_config_version_cstr,
@@ -173,23 +170,14 @@ pub export fn ghostty_build_info(out: *BuildInfo) void {
     };
 }
 
-// Comptime-formatted NUL-terminated literals derived from build_config.
-// Kept at file scope so `ghostty_build_info` can return [*:0]const u8 without
-// allocating.
-const build_config_version_cstr: [*:0]const u8 = blk: {
-    const v = build_config.version;
-    break :blk std.fmt.comptimePrint("{d}.{d}.{d}", .{ v.major, v.minor, v.patch });
-};
+const build_config_version_cstr: [*:0]const u8 = std.fmt.comptimePrint(
+    "{d}.{d}.{d}",
+    .{ build_config.version.major, build_config.version.minor, build_config.version.patch },
+);
 
-// `b ++ ""` forces the comptime concatenation that gives us a sentinel-
-// terminated comptime array of known length, which coerces to [*:0]const u8.
-// Requires `version.build` to remain comptime-known; if it ever becomes a
-// runtime value this stops compiling.
 const build_config_commit_cstr: [*:0]const u8 = blk: {
-    if (build_config.version.build) |b| {
-        break :blk b ++ "";
-    }
-    break :blk "";
+    const b = build_config.version.build orelse break :blk "";
+    break :blk std.fmt.comptimePrint("{s}", .{b});
 };
 
 /// Set an optional callback that the +list-themes TUI invokes when the

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -145,6 +145,47 @@ pub export fn ghostty_cli_run_action() c_int {
     });
 }
 
+/// Build information about the loaded libghostty. All strings have static
+/// lifetime — the caller must not free them. Strings are NUL-terminated UTF-8.
+/// `commit` is the empty string when no build commit is present.
+pub const ghostty_build_info_s = extern struct {
+    version: [*:0]const u8,
+    version_string: [*:0]const u8,
+    commit: [*:0]const u8,
+    channel: [*:0]const u8,
+    zig_version: [*:0]const u8,
+    build_mode: [*:0]const u8,
+};
+
+/// Fill `out` with build information about the loaded libghostty. Safe to
+/// call before `ghostty_init`. The strings returned are static and must not
+/// be freed.
+pub export fn ghostty_build_info(out: *ghostty_build_info_s) void {
+    out.* = .{
+        .version = build_config_version_cstr,
+        .version_string = build_config.version_string,
+        .commit = build_config_commit_cstr,
+        .channel = @tagName(build_config.release_channel),
+        .zig_version = builtin.zig_version_string,
+        .build_mode = @tagName(builtin.mode),
+    };
+}
+
+// Comptime-formatted NUL-terminated literals derived from build_config.
+// Kept at file scope so `ghostty_build_info` can return [*:0]const u8 without
+// allocating.
+const build_config_version_cstr: [*:0]const u8 = blk: {
+    const v = build_config.version;
+    break :blk std.fmt.comptimePrint("{d}.{d}.{d}", .{ v.major, v.minor, v.patch });
+};
+
+const build_config_commit_cstr: [*:0]const u8 = blk: {
+    if (build_config.version.build) |b| {
+        break :blk b ++ "";
+    }
+    break :blk "";
+};
+
 /// Set an optional callback that the +list-themes TUI invokes when the
 /// selected theme changes (preview) or is accepted (confirmed). This
 /// lets embedders update their app chrome (title bar, tabs, etc.) to

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -145,10 +145,12 @@ pub export fn ghostty_cli_run_action() c_int {
     });
 }
 
+/// ghostty_build_info_s
+///
 /// Build information about the loaded libghostty. All strings have static
-/// lifetime — the caller must not free them. Strings are NUL-terminated UTF-8.
+/// lifetime; the caller must not free them. Strings are NUL-terminated UTF-8.
 /// `commit` is the empty string when no build commit is present.
-pub const ghostty_build_info_s = extern struct {
+pub const BuildInfo = extern struct {
     version: [*:0]const u8,
     version_string: [*:0]const u8,
     commit: [*:0]const u8,
@@ -160,7 +162,7 @@ pub const ghostty_build_info_s = extern struct {
 /// Fill `out` with build information about the loaded libghostty. Safe to
 /// call before `ghostty_init`. The strings returned are static and must not
 /// be freed.
-pub export fn ghostty_build_info(out: *ghostty_build_info_s) void {
+pub export fn ghostty_build_info(out: *BuildInfo) void {
     out.* = .{
         .version = build_config_version_cstr,
         .version_string = build_config.version_string,
@@ -179,6 +181,10 @@ const build_config_version_cstr: [*:0]const u8 = blk: {
     break :blk std.fmt.comptimePrint("{d}.{d}.{d}", .{ v.major, v.minor, v.patch });
 };
 
+// `b ++ ""` forces the comptime concatenation that gives us a sentinel-
+// terminated comptime array of known length, which coerces to [*:0]const u8.
+// Requires `version.build` to remain comptime-known; if it ever becomes a
+// runtime value this stops compiling.
 const build_config_commit_cstr: [*:0]const u8 = blk: {
     if (build_config.version.build) |b| {
         break :blk b ++ "";


### PR DESCRIPTION
> [!IMPORTANT]
> Stack order:
> - **PR A (this)** -> ghostty_build_info FFI export
> - PR B -> Ghostty.Core: VersionInfo, VersionRenderer, BuildInfo.g.cs generator
> - PR C -> Wintty.exe: \`+version\` action and Version palette dialog

## Summary

Adds a new libghostty FFI \`ghostty_build_info\` that returns build metadata (version, commit, channel, Zig version, build mode) as a struct of NUL-terminated UTF-8 strings with static lifetime. Safe to call before \`ghostty_init\`.

The Wintty C# host will P/Invoke this for the \`+version\` CLI action and the "Version" command-palette dialog (PRs B and C). Mac/linux upstream's \`+version\` flow is unchanged - the Zig CLI action in \`src/cli/version.zig\` still owns that path.

## Why an FFI rather than rendering on the Zig side

Wintty wants a single C# renderer driving both the CLI output and the in-app dialog. Zig owns the source-of-truth fields (libghostty version, channel, Zig compile-time toolchain); C# owns the Wintty-side fields (Wintty version, .NET runtime, edition, MSBuild config). This export hands C# the Zig-side half.

## ABI

\`extern struct\` of six \`[*:0]const u8\` pointers, no padding, NativeAOT-friendly on the C# side. Strings come from comptime constants (\`comptimePrint\`, \`@tagName\`, \`builtin.zig_version_string\`) and never need freeing. ABI was reviewed against the C# struct shape, calling convention, and string lifetimes before commit.

## Test plan

- [x] \`zig build -Dapp-runtime=none\` succeeds
- [x] \`nm zig-out/lib/ghostty.lib | grep ghostty_build_info\` shows the export
- [ ] PR B's C# bridge round-trips the fields (covered when PR B lands)