### PR TITLE
nit: toning down comments verbosity and slop

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,12 +1,9 @@
-# Thin release-trigger for the Windows release distribution.
+# On tag push (v*), fires a repository_dispatch at deblasis/wintty-release so
+# the private release repo can build, pack, and upload without R2 or signing
+# credentials living in this public repo.
 #
-# On tag push (v*), fires a repository_dispatch event at deblasis/wintty-release
-# so the private release repo can build, pack, and upload without needing any
-# R2 or signing credentials to live in this public repo.
-#
-# DORMANT UNTIL ENABLED: the job is a no-op while vars.ENABLE_WINTTY_RELEASE_DISPATCH
-# is unset or not 'true'. This prevents noisy failures before the private repo
-# + WINTTY_RELEASE_DISPATCH_PAT secret are provisioned.
+# Dormant until vars.ENABLE_WINTTY_RELEASE_DISPATCH == 'true', so it stays
+# quiet before the private repo + dispatch PAT are provisioned.
 
 name: trigger-release
 

--- a/dist/windows/IconGen/PngWriter.cs
+++ b/dist/windows/IconGen/PngWriter.cs
@@ -30,8 +30,7 @@ internal static class PngWriter
     {
         // Pick the smallest master >= target for cleanest downsample.
         // If none are large enough, fall back to the largest available
-        // and let DrawImage upscale. Written as two statements rather
-        // than a single LINQ chain so the fallback is obvious at a glance.
+        // and let DrawImage upscale.
         var largeEnough = masters.Sizes.Where(s => s >= targetPx).ToList();
         int sourcePx = largeEnough.Count > 0 ? largeEnough.Min() : masters.Sizes.Max();
         using var source = masters.Get(sourcePx);

--- a/dist/windows/IconGen/Program.cs
+++ b/dist/windows/IconGen/Program.cs
@@ -42,8 +42,7 @@ internal static class Program
 
     private static MasterRasters StripeMasters(MasterRasters original)
     {
-        // Clone each source raster, apply the hazard stripe, hand back
-        // a new MasterRasters instance. Caller disposes.
+        // Caller disposes the returned instance.
         var dict = new Dictionary<int, System.Drawing.Bitmap>();
         foreach (var px in original.Sizes)
         {

--- a/pkg/glslang/build.zig
+++ b/pkg/glslang/build.zig
@@ -52,27 +52,19 @@ fn buildGlslang(
     });
     lib.linkLibC();
 
-    // On Windows MSVC, use a pre-built static library compiled with MSVC cl.exe
-    // to avoid C++ ABI issues between Zig's bundled Clang and MSVC's C++ runtime
+    // On Windows MSVC, link pre-built objects compiled by cl.exe to avoid
+    // C++ ABI mismatches between Zig's bundled Clang and MSVC's C++ runtime
     // when the resulting DLL is loaded by .NET.
     if (target.result.abi == .msvc) {
-        // Pre-build glslang to .obj files via MSVC cl.exe. Run as a build step
-        // so `zig build` is one-shot for new contributors and CI; previously
-        // required a manual `cmd /c pkg/glslang/build_msvc.bat` from a VS
-        // Developer Shell before `zig build`, which only failed at the
-        // .obj-consumption step with a confusing "FileNotFound" error and no
-        // hint about the missing pre-step. The bat must run from a VS
-        // Developer Shell (cl.exe + Windows SDK on PATH); this is already a
-        // hard requirement of the .msvc target. The host platform check
-        // narrows this to Windows because cl.exe doesn't exist on
-        // linux/macos hosts cross-compiling to .msvc (rare, but defensive).
+        // Run build_msvc.bat as a build step so `zig build` is one-shot.
+        // The bat requires a VS Developer Shell (cl.exe + Windows SDK on
+        // PATH), which is already implied by the .msvc target. The host
+        // check guards against linux/macos hosts cross-compiling to .msvc.
         //
-        // Caching is best-effort: addSystemCommand has no native way to
-        // express "this step produces these specific .obj files," so the
-        // step is treated as side-effecting and re-runs every time it
-        // appears in the graph. The bat itself uses cl.exe /c which does
-        // not skip up-to-date sources, so cold-build cost is ~10-30s.
-        // Acceptable for v1; can optimize later with a stamp-file scheme.
+        // The step is side-effecting: addSystemCommand can't express
+        // "produces these .obj files" so it re-runs every graph evaluation.
+        // cl.exe /c also doesn't skip up-to-date sources, giving ~10-30s
+        // cold builds.
         if (target.result.os.tag == .windows) {
             const bat_step = b.addSystemCommand(&.{
                 "cmd.exe",
@@ -83,14 +75,13 @@ fn buildGlslang(
             lib.step.dependOn(&bat_step.step);
         }
 
-        // Merge the MSVC-compiled objects directly into this library.
-        // We use a dummy C file so the library has at least one compilation unit.
+        // Dummy C file gives the library at least one compilation unit
+        // before we merge in the MSVC-compiled objects.
         lib.addCSourceFiles(.{
             .root = b.path("msvc_build"),
             .flags = &.{},
             .files = &.{"dummy.c"},
         });
-        // Add each MSVC object file individually
         const msvc_build = b.path("msvc_build");
         lib.addObjectFile(msvc_build.path(b, "CodeGen.obj"));
         lib.addObjectFile(msvc_build.path(b, "Link.obj"));
@@ -148,7 +139,6 @@ fn buildGlslang(
         try apple_sdk.addPaths(b, lib);
     }
 
-    // Non-MSVC: compile C++ sources with Zig's Clang
     if (target.result.abi != .msvc) {
         var flags: std.ArrayList([]const u8) = .empty;
         defer flags.deinit(b.allocator);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -464,28 +464,22 @@ pub const Surface = struct {
     /// that getTitle works without the implementer needing to save it.
     title: ?[:0]const u8 = null,
 
-    /// Windows key event buffering. WM_KEYDOWN and WM_CHAR arrive as
-    /// separate messages on Windows. We buffer the keydown here and
-    /// attach text from the following ghostty_surface_text call before
-    /// dispatching through key encoding. On non-Windows this is void
-    /// and eliminated by comptime.
+    /// Windows buffers WM_KEYDOWN here so a following WM_CHAR can
+    /// attach text before dispatching through key encoding.
     pending_key: if (builtin.os.tag == .windows)
         ?PendingKey
     else
         void = if (builtin.os.tag == .windows) null else {},
 
-    /// Text buffer for Windows key event combining. Lives outside the
-    /// pending_key optional so it doesn't get poisoned when the optional
-    /// is set to null in debug builds. The event.text pointer references
-    /// this buffer during dispatch. Sized to match GTK's im_buf (128)
-    /// so IME compositions aren't silently truncated.
+    /// Text buffer for the pending key. Lives outside the optional so
+    /// it isn't poisoned when the optional is cleared in debug builds.
+    /// Sized to match GTK's im_buf so IME compositions aren't truncated.
     pending_key_text: if (builtin.os.tag == .windows)
         [128]u8
     else
         void = if (builtin.os.tag == .windows) .{0} ** 128 else {},
 
     /// Input redirect for in-process features (e.g., theme picker).
-    /// Windows-only; eliminated by comptime on other platforms.
     input_redirect: if (builtin.os.tag == .windows)
         ?InputRedirect
     else
@@ -505,23 +499,22 @@ pub const Surface = struct {
         event: App.KeyEvent,
     };
 
-    /// Redirect types for in-process features (e.g., inline theme picker).
-    /// Windows-only: intercepted at the apprt boundary before events
-    /// reach core Surface.
+    /// Intercepts events at the apprt boundary before they reach
+    /// core Surface. Used by the inline theme picker.
     const InputRedirect = struct {
         callback: *const fn (ud: ?*anyopaque, event: *const input.KeyEvent) bool,
         userdata: ?*anyopaque,
     };
 
-    /// Scroll redirect for in-process features. yoff is positive for
-    /// scroll-up, negative for scroll-down. Return true if consumed.
+    /// yoff is positive for scroll-up, negative for scroll-down.
+    /// Return true if consumed.
     const ScrollRedirect = struct {
         callback: *const fn (ud: ?*anyopaque, yoff: f64) bool,
         userdata: ?*anyopaque,
     };
 
-    /// Resize redirect for in-process features. Called after the core
-    /// surface recalculates its grid so cols/rows reflect the new size.
+    /// Called after the core surface recalculates its grid, so cols/rows
+    /// reflect the new size.
     const ResizeRedirect = struct {
         callback: *const fn (ud: ?*anyopaque, cols: u16, rows: u16) void,
         userdata: ?*anyopaque,
@@ -1027,8 +1020,6 @@ pub const Surface = struct {
     }
 
     /// Dispatch a key event through the core key handling path.
-    /// Extracted from ghostty_surface_key to share between the
-    /// immediate dispatch and pending key flush paths.
     fn dispatchKey(self: *Surface, event: App.KeyEvent) bool {
         return self.app.keyEvent(
             .{ .surface = self },
@@ -1039,10 +1030,7 @@ pub const Surface = struct {
         };
     }
 
-    /// Flush any pending key event that was buffered by
-    /// ghostty_surface_key on Windows. Called before buffering a
-    /// new key or when a key release arrives. On non-Windows this
-    /// is a no-op eliminated by comptime.
+    /// Flush a buffered Windows key event. No-op on non-Windows.
     fn flushPendingKey(self: *Surface) void {
         if (comptime builtin.os.tag != .windows) return;
         if (self.pending_key) |pending| {
@@ -1427,11 +1415,9 @@ pub const CAPI = struct {
             };
         }
 
-        /// Derive the unshifted codepoint from a Win32 scancode so
-        /// embedders don't need to provide it themselves. Uses
-        /// MapVirtualKeyW to go scancode -> VK -> base character,
-        /// matching what the C example does with MAPVK_VK_TO_CHAR.
-        /// On non-Windows this returns 0 (no-op).
+        /// Derive the unshifted codepoint from a Win32 scancode via
+        /// MapVirtualKeyW (scancode -> VK -> base character). Returns
+        /// 0 on non-Windows.
         fn unshiftedCodepointFromKeycode(keycode: u32) u32 {
             if (comptime builtin.os.tag != .windows) return 0;
 
@@ -1886,17 +1872,11 @@ pub const CAPI = struct {
         surface.core_surface.writeVt(data[0..len]);
     }
 
-    /// Run the inline theme picker on a surface. The picker renders
-    /// into the surface's terminal (alt screen) and intercepts input
-    /// via the surface's input redirect. The theme_callback fires on
-    /// preview (browsing) and confirm (Enter).
-    ///
-    /// This is a non-blocking call: it sets up the picker state and
-    /// input redirect. The picker renders on each key event. The
-    /// embedder should call ghostty_surface_list_themes_deinit when
-    /// the picker signals completion (should_quit).
-    ///
-    /// Returns an opaque pointer to the picker, or null on error.
+    /// Run the inline theme picker on a surface. Non-blocking: sets
+    /// up picker state and input redirect, then returns. The
+    /// theme_callback fires on preview (browsing) and confirm (Enter).
+    /// The embedder must call ghostty_surface_list_themes_deinit once
+    /// the picker signals should_quit. Returns null on error.
     export fn ghostty_surface_list_themes(
         surface: *Surface,
         theme_cb: ?*const fn ([*:0]const u8, bool) callconv(.c) void,
@@ -2008,9 +1988,8 @@ pub const CAPI = struct {
         // Exit alt screen and restore terminal.
         picker.exit();
 
-        // Send a newline to the shell's stdin so it redraws its
-        // prompt. The picker ran in-process while the shell was
-        // waiting for input -- it needs this nudge.
+        // Nudge the shell to redraw its prompt; it was blocked on
+        // stdin while the picker ran in-process.
         surface.core_surface.writePtyInput("\r");
 
         picker.deinit();
@@ -2018,9 +1997,8 @@ pub const CAPI = struct {
 
     /// Return the ID3D12Device* used by this surface's renderer. Shared
     /// texture consumers should call OpenSharedResource1 on this same
-    /// device to avoid cross-device synchronization issues.
-    /// Returns null on non-DX12 builds, or if the renderer device has not
-    /// finished initializing yet.
+    /// device to avoid cross-device synchronization issues. Returns
+    /// null on non-DX12 builds or before the device finishes init.
     export fn ghostty_surface_get_d3d12_device(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
         const api = surface.core_surface.renderer.api;
@@ -2031,10 +2009,9 @@ pub const CAPI = struct {
     }
 
     /// Return the IDXGISwapChain1* used by this surface's renderer.
-    /// The embedder can bind this to a Windows.UI.Composition visual
-    /// via ICompositorInterop.CreateCompositionSurfaceForSwapChain.
-    /// Returns null on non-DX12 builds or if the swap chain has not
-    /// been created yet.
+    /// Bind it to a Windows.UI.Composition visual via
+    /// ICompositorInterop.CreateCompositionSurfaceForSwapChain.
+    /// Returns null on non-DX12 or before the swap chain is created.
     export fn ghostty_surface_get_swap_chain(surface: *Surface) ?*anyopaque {
         if (comptime builtin.os.tag != .windows) return null;
         const api = surface.core_surface.renderer.api;
@@ -2091,11 +2068,10 @@ pub const CAPI = struct {
         // the window size via GetClientRect. Forward the desired dimensions
         // so the resize detection loop in beginFrame picks up the change.
         surface.core_surface.renderer.setTargetSize(w, h);
-        // Wake the renderer thread so it picks up the new desired_size
-        // immediately rather than waiting for its next natural draw-timer
-        // tick (~8 ms). Cheap (single futex op) and safe to call from any
-        // thread. The 120 Hz draw timer is the backstop if the wakeup is
-        // ever coalesced; in either path beginFrame applies the size.
+        // Wake the renderer thread so it applies the new size in
+        // beginFrame without waiting for the ~8ms draw-timer tick.
+        // Single futex op, safe from any thread. The 120Hz draw timer
+        // is the backstop if the wakeup is coalesced.
         surface.core_surface.renderer_thread.wakeup.notify() catch {};
     }
 
@@ -2180,11 +2156,9 @@ pub const CAPI = struct {
     /// This will handle the keymap translation and send the appropriate
     /// key and char events.
     ///
-    /// On Windows, if this is a press/repeat with no text, the event
-    /// is buffered. A following ghostty_surface_text call will attach
-    /// text and dispatch through key encoding. This handles the split
-    /// WM_KEYDOWN / WM_CHAR message pattern so embedders don't need
-    /// to combine them manually.
+    /// On Windows, a press/repeat with no text is buffered until the
+    /// following ghostty_surface_text attaches text, handling the split
+    /// WM_KEYDOWN / WM_CHAR pattern so embedders don't combine manually.
     export fn ghostty_surface_key(
         surface: *Surface,
         event: KeyEvent,
@@ -2192,31 +2166,26 @@ pub const CAPI = struct {
         const key_event = event.keyEvent();
 
         if (comptime builtin.os.tag == .windows) {
-            // If input is redirected (e.g., theme picker active), send
-            // there before keybinding resolution or key buffering.
+            // Theme picker etc. intercepts before keybinding resolution.
             if (surface.input_redirect) |redirect| {
                 const core_event = key_event.core() orelse return false;
                 if (redirect.callback(redirect.userdata, &core_event))
                     return true;
             }
 
-            // Flush any previous pending key that never got text
-            // (e.g. arrow keys, function keys, backspace).
+            // Flush any prior pending key that never got text (arrows,
+            // function keys, backspace).
             surface.flushPendingKey();
 
-            // If this is a press/repeat with no text, buffer it --
-            // a ghostty_surface_text call may follow with the character.
+            // No text yet: buffer until ghostty_surface_text arrives.
             if (key_event.text == null and key_event.action != .release) {
                 surface.pending_key = .{ .event = key_event };
                 return false;
             }
 
-            // Has text already (caller did combining) or is a release --
-            // dispatch immediately.
             return surface.dispatchKey(key_event);
         }
 
-        // Non-Windows: straight passthrough, unchanged.
         return surface.dispatchKey(key_event);
     }
 
@@ -2241,11 +2210,10 @@ pub const CAPI = struct {
         return true;
     }
 
-    /// Send raw text to the terminal. On non-Windows (or when there is
-    /// no pending key event), this is treated like a paste. On Windows,
-    /// if there is a pending key event from ghostty_surface_key, the
-    /// text is attached to that key and dispatched through key encoding
-    /// instead -- this handles the WM_CHAR message that follows WM_KEYDOWN.
+    /// Send raw text to the terminal. Treated as paste, unless on
+    /// Windows there is a pending key event from ghostty_surface_key,
+    /// in which case the text attaches to that key and dispatches
+    /// through key encoding (WM_CHAR after WM_KEYDOWN).
     export fn ghostty_surface_text(
         surface: *Surface,
         ptr: [*]const u8,
@@ -2255,10 +2223,9 @@ pub const CAPI = struct {
             if (surface.pending_key) |*pending| {
                 const text = ptr[0..len];
 
-                // Don't attach C0 control characters as text. WM_CHAR
-                // delivers the raw byte (e.g. 0x03 for Ctrl+C) but the
-                // key encoder expects the printable character. Matches
-                // GTK filtering (surface.zig:1390).
+                // Don't attach C0 control characters. WM_CHAR delivers
+                // the raw byte (e.g. 0x03 for Ctrl+C) but the key
+                // encoder wants the printable character. Mirrors GTK.
                 const is_c0 = text.len == 1 and (text[0] < 0x20 or text[0] == 0x7f);
 
                 var event = pending.event;
@@ -2266,12 +2233,11 @@ pub const CAPI = struct {
                 if (!is_c0) {
                     const copy_len: usize = @min(text.len, surface.pending_key_text.len - 1);
 
-                    // Copy text into the Surface-level buffer (not
-                    // inside the optional) so it survives clearing
-                    // pending_key. Zig poisons optional payloads in
-                    // debug mode when set to null.
+                    // Buffer lives outside the optional so the text
+                    // survives setting pending_key to null (Zig poisons
+                    // optional payloads in debug builds).
                     @memcpy(surface.pending_key_text[0..copy_len], text[0..copy_len]);
-                    surface.pending_key_text[copy_len] = 0; // null-terminate
+                    surface.pending_key_text[copy_len] = 0;
 
                     event.text = surface.pending_key_text[0..copy_len :0];
                 }
@@ -2282,7 +2248,6 @@ pub const CAPI = struct {
             }
         }
 
-        // No pending key (or non-Windows): paste path, unchanged.
         surface.textCallback(ptr[0..len]);
     }
 

--- a/src/cli/inline_theme_picker.zig
+++ b/src/cli/inline_theme_picker.zig
@@ -74,8 +74,8 @@ pub fn discoverThemes(arena: Allocator) ![]ThemeEntry {
     return themes.items;
 }
 
-/// An in-process theme picker that renders via VT escape sequences.
-/// Does not use Vaxis -- writes raw ANSI sequences through the write callback.
+/// In-process theme picker that writes raw ANSI sequences through
+/// the write callback (no Vaxis).
 pub const InlineThemePicker = struct {
     allocator: Allocator,
     /// Arena for per-frame allocations, reset each draw call.
@@ -287,8 +287,8 @@ pub const InlineThemePicker = struct {
                 } else if (key == .key_d) {
                     self.hex = false;
                 } else if (key == .key_f) {
-                    // Could cycle filter, but for inline picker we skip
-                    // color scheme filtering (no config loading overhead).
+                    // Color-scheme filter skipped: would require loading
+                    // every theme config up front.
                 }
                 self.notifyThemeChange();
                 self.draw();
@@ -960,7 +960,7 @@ pub const InlineThemePicker = struct {
 
             self.moveTo(row, x_off + col);
 
-            // Apply special styles for certain words (matching list_themes.zig)
+            // Apply special styles for certain words.
             if (std.mem.eql(u8, "ipsum", word)) {
                 const pc = paletteColor(config, 2);
                 self.setFg(pc[0], pc[1], pc[2]);

--- a/src/font/backend.zig
+++ b/src/font/backend.zig
@@ -51,10 +51,9 @@ pub const Backend = enum {
         }
 
         if (target.os.tag == .windows) {
-            // wintty fork default: prefer DirectWrite for OS-authoritative
-            // font enumeration, locale-aware fallback (CJK / emoji), and
-            // weight/italic scoring. Upstream's freetype_windows directory
-            // scanner remains available as a build option.
+            // DirectWrite gives OS-authoritative font enumeration,
+            // locale-aware fallback (CJK / emoji), and weight/italic
+            // scoring. freetype_windows is still available as an opt-in.
             return .directwrite_freetype;
         }
 

--- a/src/font/directwrite.zig
+++ b/src/font/directwrite.zig
@@ -105,7 +105,7 @@ pub const IDWriteNumberSubstitution = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDWriteNumberSubstitution, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDWriteNumberSubstitution) callconv(.winapi) u32,
         Release: *const fn (*IDWriteNumberSubstitution) callconv(.winapi) u32,
@@ -117,16 +117,15 @@ pub const IDWriteNumberSubstitution = extern struct {
 };
 
 // IDWriteLocalizedStrings
-// Slots: GetCount(3), FindLocaleName(4), [5-6 Reserved], GetStringLength(7), GetString(8)
 pub const IDWriteLocalizedStrings = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteLocalizedStrings) callconv(.winapi) u32,
-        // IDWriteLocalizedStrings (slots 3-8)
+        // IDWriteLocalizedStrings
         GetCount: *const fn (*IDWriteLocalizedStrings) callconv(.winapi) UINT32,
         FindLocaleName: *const fn (
             *IDWriteLocalizedStrings,
@@ -176,16 +175,15 @@ pub const IDWriteLocalizedStrings = extern struct {
 };
 
 // IDWriteFontFace
-// Slots: [3 Reserved], GetFiles(4), GetIndex(5), [6-17 Reserved]
 pub const IDWriteFontFace = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteFontFace) callconv(.winapi) u32,
-        // IDWriteFontFace (slots 3-17)
+        // IDWriteFontFace
         GetType: Reserved,
         GetFiles: *const fn (
             *IDWriteFontFace,
@@ -236,11 +234,11 @@ pub const IDWriteFontFileLoader = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDWriteFontFileLoader, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDWriteFontFileLoader) callconv(.winapi) u32,
         Release: *const fn (*IDWriteFontFileLoader) callconv(.winapi) u32,
-        // IDWriteFontFileLoader (slot 3)
+        // IDWriteFontFileLoader
         CreateStreamFromKey: Reserved,
     };
 
@@ -265,13 +263,13 @@ pub const IDWriteLocalFontFileLoader = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteLocalFontFileLoader) callconv(.winapi) u32,
-        // IDWriteFontFileLoader (slot 3)
+        // IDWriteFontFileLoader
         CreateStreamFromKey: Reserved,
-        // IDWriteLocalFontFileLoader (slots 4-6)
+        // IDWriteLocalFontFileLoader
         GetFilePathLengthFromKey: *const fn (
             *IDWriteLocalFontFileLoader,
             fontFileReferenceKey: *const anyopaque,
@@ -313,16 +311,15 @@ pub const IDWriteLocalFontFileLoader = extern struct {
 };
 
 // IDWriteFontFile
-// Slots: GetReferenceKey(3), GetLoader(4), [5 Reserved]
 pub const IDWriteFontFile = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteFontFile) callconv(.winapi) u32,
-        // IDWriteFontFile (slots 3-5)
+        // IDWriteFontFile
         GetReferenceKey: *const fn (
             *IDWriteFontFile,
             fontFileReferenceKey: *?*const anyopaque,
@@ -358,11 +355,11 @@ pub const IDWriteTextAnalysisSource = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDWriteTextAnalysisSource, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDWriteTextAnalysisSource) callconv(.winapi) u32,
         Release: *const fn (*IDWriteTextAnalysisSource) callconv(.winapi) u32,
-        // IDWriteTextAnalysisSource (slots 3-7)
+        // IDWriteTextAnalysisSource
         GetTextAtPosition: *const fn (
             *IDWriteTextAnalysisSource,
             textPosition: UINT32,
@@ -394,16 +391,15 @@ pub const IDWriteTextAnalysisSource = extern struct {
 };
 
 // IDWriteFontFallback
-// Slot 3: MapCharacters
 pub const IDWriteFontFallback = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteFontFallback) callconv(.winapi) u32,
-        // IDWriteFontFallback (slot 3)
+        // IDWriteFontFallback
         MapCharacters: *const fn (
             *IDWriteFontFallback,
             analysisSource: *IDWriteTextAnalysisSource,
@@ -456,19 +452,15 @@ pub const IDWriteFontFallback = extern struct {
 };
 
 // IDWriteFont (through IDWriteFont2 for IsColorFont)
-// Slots: GetFontFamily(3), GetWeight(4), GetStretch(5), GetStyle(6), IsSymbolFont(7),
-//        GetFaceNames(8), GetInformationalStrings(9), GetSimulations(10),
-//        GetMetrics(11), HasCharacter(12), CreateFontFace(13),
-//        IDWriteFont1 slots 14-17, IsColorFont(18 IDWriteFont2)
 pub const IDWriteFont = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: *const fn (*IDWriteFont) callconv(.winapi) u32,
         Release: *const fn (*IDWriteFont) callconv(.winapi) u32,
-        // IDWriteFont (slots 3-13)
+        // IDWriteFont
         GetFontFamily: Reserved,
         GetWeight: *const fn (*IDWriteFont) callconv(.winapi) DWRITE_FONT_WEIGHT,
         GetStretch: *const fn (*IDWriteFont) callconv(.winapi) DWRITE_FONT_STRETCH,
@@ -485,12 +477,12 @@ pub const IDWriteFont = extern struct {
         GetMetrics: Reserved,
         HasCharacter: *const fn (*IDWriteFont, unicodeValue: UINT32, exists: *BOOL) callconv(.winapi) HRESULT,
         CreateFontFace: *const fn (*IDWriteFont, fontFace: *?*IDWriteFontFace) callconv(.winapi) HRESULT,
-        // IDWriteFont1 (slots 14-17)
+        // IDWriteFont1 reserved padding before IDWriteFont2.IsColorFont
         _slot14: Reserved,
         _slot15: Reserved,
         _slot16: Reserved,
         _slot17: Reserved,
-        // IDWriteFont2 (slot 18)
+        // IDWriteFont2
         IsColorFont: *const fn (*IDWriteFont) callconv(.winapi) BOOL,
     };
 
@@ -545,21 +537,19 @@ pub const IDWriteFont = extern struct {
 };
 
 // IDWriteFontFamily (extends IDWriteFontList)
-// IDWriteFontList slots 3-5: [3 Reserved], GetFontCount(4), GetFont(5)
-// IDWriteFontFamily slots 6-7: GetFamilyNames(6), [7 Reserved]
 pub const IDWriteFontFamily = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteFontFamily) callconv(.winapi) u32,
-        // IDWriteFontList (slots 3-5)
+        // IDWriteFontList
         GetFontCollection: Reserved,
         GetFontCount: *const fn (*IDWriteFontFamily) callconv(.winapi) UINT32,
         GetFont: *const fn (*IDWriteFontFamily, index: UINT32, font: *?*IDWriteFont) callconv(.winapi) HRESULT,
-        // IDWriteFontFamily (slots 6-7)
+        // IDWriteFontFamily
         GetFamilyNames: *const fn (*IDWriteFontFamily, names: *?*IDWriteLocalizedStrings) callconv(.winapi) HRESULT,
         MatchClosestFont: Reserved,
     };
@@ -587,11 +577,11 @@ pub const IDWriteFontCollection = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteFontCollection) callconv(.winapi) u32,
-        // IDWriteFontCollection (slots 3-6)
+        // IDWriteFontCollection
         GetFontFamilyCount: *const fn (*IDWriteFontCollection) callconv(.winapi) UINT32,
         GetFontFamily: *const fn (
             *IDWriteFontCollection,
@@ -630,16 +620,15 @@ pub const IDWriteFontCollection = extern struct {
 };
 
 // IDWriteFontCollection1 (extends IDWriteFontCollection)
-// Adds slots 7-8 (all Reserved for our purposes)
 pub const IDWriteFontCollection1 = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteFontCollection1) callconv(.winapi) u32,
-        // IDWriteFontCollection (slots 3-6)
+        // IDWriteFontCollection
         GetFontFamilyCount: *const fn (*IDWriteFontCollection1) callconv(.winapi) UINT32,
         GetFontFamily: *const fn (
             *IDWriteFontCollection1,
@@ -653,7 +642,7 @@ pub const IDWriteFontCollection1 = extern struct {
             exists: *BOOL,
         ) callconv(.winapi) HRESULT,
         GetFontFromFontFace: Reserved,
-        // IDWriteFontCollection1 (slots 7-8)
+        // IDWriteFontCollection1
         _slot7: Reserved,
         _slot8: Reserved,
     };
@@ -681,11 +670,6 @@ pub const IDWriteFontCollection1 = extern struct {
 };
 
 // IDWriteFactory3
-// IUnknown slots 0-2
-// IDWriteFactory slots 3-23: GetSystemFontCollection(3), ..., CreateNumberSubstitution(22), CreateGlyphRunAnalysis(23)
-// IDWriteFactory1 slots 24-25: all Reserved
-// IDWriteFactory2 slots 26-30: GetSystemFontFallback(26), [27-30 Reserved]
-// IDWriteFactory3 slots 31-39: [31-37 Reserved], GetSystemFontCollection1(38), [39 Reserved]
 pub const IDWriteFactory3 = extern struct {
     vtable: *const VTable,
 
@@ -697,11 +681,11 @@ pub const IDWriteFactory3 = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: *const fn (*IDWriteFactory3) callconv(.winapi) u32,
-        // IDWriteFactory (slots 3-23)
+        // IDWriteFactory
         GetSystemFontCollection: *const fn (
             *IDWriteFactory3,
             fontCollection: *?*IDWriteFontCollection,
@@ -733,10 +717,10 @@ pub const IDWriteFactory3 = extern struct {
             numberSubstitution: *?*IDWriteNumberSubstitution,
         ) callconv(.winapi) HRESULT,
         CreateGlyphRunAnalysis: Reserved,
-        // IDWriteFactory1 (slots 24-25)
+        // IDWriteFactory1
         _slot24: Reserved,
         _slot25: Reserved,
-        // IDWriteFactory2 (slots 26-30)
+        // IDWriteFactory2
         GetSystemFontFallback: *const fn (
             *IDWriteFactory3,
             fontFallback: *?*IDWriteFontFallback,
@@ -745,7 +729,7 @@ pub const IDWriteFactory3 = extern struct {
         _slot28: Reserved,
         _slot29: Reserved,
         _slot30: Reserved,
-        // IDWriteFactory3 (slots 31-39)
+        // IDWriteFactory3
         _slot31: Reserved,
         _slot32: Reserved,
         _slot33: Reserved,

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -254,8 +254,8 @@ pub const DirectWrite = struct {
 
     pub fn init(lib: Library) DirectWrite {
         // DirectWrite manages its own font enumeration via the OS;
-        // FreeType `lib` is unused. Accepting it keeps Discover.init
-        // uniform across backends (per upstream #12386 review).
+        // FreeType `lib` is unused but kept so Discover.init has a
+        // uniform signature across backends.
         _ = lib;
         const createFactory = dwrite.loadDWriteCreateFactory() catch
             @panic("DirectWrite: failed to load DWriteCreateFactory");

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -26,7 +26,7 @@ pub const Awareness = enum {
 /// because we need to distinguish cmd from powershell (same awareness,
 /// different preamble) and pwsh from the other vt_aware shells
 /// (same awareness, but only powershell-family benefits from the
-/// setup under forced conpty-mode=never - see # 302).
+/// setup under forced conpty-mode=never).
 ///
 /// The setup runs once at shell startup inside ConPTY's conhost.exe,
 /// which does not inherit the caller's console codepage.
@@ -169,9 +169,6 @@ pub fn awarenessOf(kind: Kind) Awareness {
 ///
 /// powershell.exe (5.1) is .console_api in `awarenessOf` so it
 /// already routes to ConPTY without needing this gate.
-///
-/// See deblasis/pwsh-bypass-research for empirical investigation
-/// of whether this can be worked around without ConPTY.
 pub fn requiresConsoleInput(kind: Kind) bool {
     return switch (kind) {
         .pwsh => true,
@@ -206,7 +203,7 @@ pub fn classify(exe_path: []const u8) Awareness {
 /// startup. Callers invoke this regardless of transport; the actual
 /// emission gate lives in `Exec.maybeInjectUtf8Preamble` and is
 /// driven by the resolved `utf8-console` policy, not by ConPTY vs
-/// bypass routing. See deblasis/wintty # 341 for the rationale.
+/// bypass routing.
 pub fn utf8Preamble(exe_path: []const u8) Preamble {
     return preambleOf(identify(exe_path));
 }

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -1,13 +1,7 @@
 //! Graphics API wrapper for DirectX 12.
 //!
-//! This module provides the GraphicsAPI contract required by GenericRenderer,
-//! mirroring the structure of Metal.zig and OpenGL.zig.
-//!
-//! Current status: all 5 render pipelines (bg_color, cell_bg, cell_text,
-//! image, bg_image) are wired end-to-end. Shader-visible descriptor heaps
-//! for SRV and sampler binding are created at init. RenderPass.step()
-//! binds PSO, root signature, uniforms, textures, samplers, and instance
-//! buffers, then issues DrawInstanced calls.
+//! Provides the GraphicsAPI contract required by GenericRenderer, mirroring
+//! Metal.zig and OpenGL.zig.
 pub const DirectX12 = @This();
 
 const builtin = @import("builtin");
@@ -70,15 +64,12 @@ pub const ImageTextureFormat = enum {
     bgra,
 };
 
-
 /// Number of CBV/SRV/UAV descriptors in the shader-visible heap.
-/// Covers: font atlas (grayscale + color), grid texture, image textures,
-/// and up to ~50 custom shader textures. Will need tuning if custom
-/// shaders exceed this.
+/// Covers font atlas (grayscale + color), grid texture, image textures,
+/// and ~50 custom shader textures.
 const srv_heap_capacity: u32 = 64;
 
 /// Number of sampler descriptors in the shader-visible heap.
-/// Covers: default point/linear samplers + per-pipeline overrides.
 const sampler_heap_capacity: u32 = 16;
 
 // --- GraphicsAPI contract: mutable state ---
@@ -98,7 +89,6 @@ dev: ?device.Device = null,
 /// Obtained by QueryInterface from the SwapChain1 in dev.
 swap_chain3: ?*dxgi.IDXGISwapChain3 = null,
 
-/// Allocator used to create descriptor heap objects. Stored for deinit.
 allocator: Allocator = undefined,
 
 /// RTV descriptor heap for swap chain back buffers.
@@ -167,28 +157,20 @@ pending_complete: ?struct {
 
 /// Desired surface dimensions, updated by setTargetSize.
 ///
-/// DX12 uses composition swap chains for all surface types (HWND via
-/// DirectComposition, SwapChainPanel via XAML). Composition swap chains
-/// have no HWND to query for size, so the apprt must forward the window
-/// dimensions via setTargetSize.
-///
-/// Width and height are packed into a single u64 (high 32 = width, low 32
-/// = height) so we can store/load both atomically. setTargetSize is invoked
-/// synchronously from ghostty_surface_set_size on the apprt thread (the C#
-/// UI thread for the WinUI 3 shell), while the renderer thread reads it
-/// in beginFrame to drive ResizeBuffers. Two separate atomics would tear
-/// during a drag: a resize that updates only width before the renderer
-/// reads height would briefly show a mismatched back buffer. The renderer
-/// thread tracks what it has actually applied in `applied_width` /
-/// `applied_height` -- if the desired and applied values differ at the
-/// start of beginFrame, it resizes the swap chain there (the only thread
-/// allowed to touch back_buffers/RTVs/fence).
+/// Composition swap chains have no HWND to query for size, so the apprt
+/// must forward window dimensions via setTargetSize. Width and height are
+/// packed into a single u64 (high 32 = width, low 32 = height) so both can
+/// be stored/loaded atomically; two separate atomics would tear during a
+/// drag and briefly show a mismatched back buffer. The renderer thread
+/// tracks what it actually applied in applied_width/applied_height; if
+/// desired and applied differ at the start of beginFrame, it resizes the
+/// swap chain there (the only thread allowed to touch back_buffers, RTVs,
+/// or the fence).
 desired_size: std.atomic.Value(u64) = .init(0),
 applied_width: u32 = 0,
 applied_height: u32 = 0,
 
-/// Pack/unpack helpers for desired_size. Width in the high 32 bits so a
-/// hexdump reads naturally as WWWWWWWW_HHHHHHHH.
+/// Width in the high 32 bits so a hexdump reads as WWWWWWWW_HHHHHHHH.
 inline fn packSize(width: u32, height: u32) u64 {
     return (@as(u64, width) << 32) | @as(u64, height);
 }
@@ -554,9 +536,9 @@ pub fn waitGpu(self: *DirectX12) void {
 
 pub fn drawFrameStart(self: *DirectX12) void {
     _ = self;
-    // RTV heap slots are per-frame and stable. No reset needed -- each
-    // frame's CustomShaderState reuses its own dedicated RTV descriptors
-    // during resize (via the rtv_slot option in Texture.Options).
+    // RTV heap slots are per-frame and stable. No reset needed; each frame's
+    // CustomShaderState reuses its own dedicated RTV descriptors during
+    // resize via the rtv_slot option in Texture.Options.
 }
 
 pub fn drawFrameEnd(self: *DirectX12) void {
@@ -793,7 +775,7 @@ pub inline fn beginFrame(
     target: *Target,
 ) !Frame {
     // self is *const to match the GraphicsAPI contract (Metal and OpenGL
-    // both use *const). Mutable access goes through renderer.api.
+    // both use *const); mutable access goes through renderer.api.
     _ = self;
     const api: *DirectX12 = &renderer.api;
     if (api.device_lost) return error.DeviceLost;
@@ -1108,10 +1090,8 @@ test "device_lost flag is independent of device presence" {
     try std.testing.expect(api.device_lost);
 }
 
-// Pull the directx12 integration test file into the test graph.
-// gpu_test.zig is otherwise orphaned -- it has no consumer outside
-// tests -- so without this @import it would never be compiled or
-// executed by `zig build test`.
+// Pull the directx12 integration test file into the test graph; without
+// this @import gpu_test.zig is orphaned and never compiled by `zig build test`.
 test {
     _ = @import("directx12/gpu_test.zig");
 }

--- a/src/renderer/directx12/d3d12.zig
+++ b/src/renderer/directx12/d3d12.zig
@@ -762,18 +762,11 @@ pub const D3D12_BOX = extern struct {
 
 // --- COM Interfaces ---
 //
-// Inheritance chains (slot counts):
-//   IUnknown: QueryInterface, AddRef, Release (3 slots)
-//   ID3D12Object adds: GetPrivateData, SetPrivateData, SetPrivateDataInterface, SetName (4 slots)
-//   ID3D12DeviceChild adds: GetDevice (1 slot)
-//   ID3D12Pageable adds nothing (0 slots)
-//   ID3D12CommandList adds: GetType (1 slot)
-//
-// Common inherited totals:
-//   Through ID3D12Object:     3 + 4 = 7 slots
-//   Through ID3D12DeviceChild: 7 + 1 = 8 slots
-//   Through ID3D12Pageable:    8 + 0 = 8 slots
-//   Through ID3D12CommandList:  8 + 1 = 9 slots
+// IUnknown: QueryInterface, AddRef, Release
+// ID3D12Object adds: GetPrivateData, SetPrivateData, SetPrivateDataInterface, SetName
+// ID3D12DeviceChild adds: GetDevice
+// ID3D12Pageable adds nothing
+// ID3D12CommandList adds: GetType
 
 // ID3D12Debug
 pub const ID3D12Debug = extern struct {
@@ -786,11 +779,11 @@ pub const ID3D12Debug = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12Debug, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12Debug) callconv(.winapi) u32,
         Release: *const fn (*ID3D12Debug) callconv(.winapi) u32,
-        // ID3D12Debug (slot 3)
+        // ID3D12Debug
         EnableDebugLayer: *const fn (*ID3D12Debug) callconv(.winapi) void,
     };
 
@@ -808,11 +801,11 @@ pub const ID3DBlob = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3DBlob, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3DBlob) callconv(.winapi) u32,
         Release: *const fn (*ID3DBlob) callconv(.winapi) u32,
-        // ID3DBlob (slots 3-4)
+        // ID3DBlob
         GetBufferPointer: *const fn (*ID3DBlob) callconv(.winapi) *anyopaque,
         GetBufferSize: *const fn (*ID3DBlob) callconv(.winapi) usize,
     };
@@ -831,7 +824,7 @@ pub const ID3DBlob = extern struct {
 };
 
 // ID3D12CommandQueue
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12Pageable (0) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12Pageable
 pub const ID3D12CommandQueue = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -842,19 +835,19 @@ pub const ID3D12CommandQueue = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12CommandQueue, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12CommandQueue) callconv(.winapi) u32,
         Release: *const fn (*ID3D12CommandQueue) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
         // ID3D12Pageable adds nothing
-        // ID3D12CommandQueue own methods (slots 8+)
+        // ID3D12CommandQueue own methods
         UpdateTileMappings: Reserved,
         CopyTileMappings: Reserved,
         ExecuteCommandLists: *const fn (*ID3D12CommandQueue, NumCommandLists: u32, ppCommandLists: [*]const *ID3D12GraphicsCommandList) callconv(.winapi) void,
@@ -882,7 +875,7 @@ pub const ID3D12CommandQueue = extern struct {
 };
 
 // ID3D12CommandAllocator
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12Pageable (0) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12Pageable
 pub const ID3D12CommandAllocator = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -893,19 +886,19 @@ pub const ID3D12CommandAllocator = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12CommandAllocator, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12CommandAllocator) callconv(.winapi) u32,
         Release: *const fn (*ID3D12CommandAllocator) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
         // ID3D12Pageable adds nothing
-        // ID3D12CommandAllocator (slot 8)
+        // ID3D12CommandAllocator
         Reset: *const fn (*ID3D12CommandAllocator) callconv(.winapi) HRESULT,
     };
 
@@ -919,7 +912,7 @@ pub const ID3D12CommandAllocator = extern struct {
 };
 
 // ID3D12Fence
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12Pageable (0) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12Pageable
 pub const ID3D12Fence = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -930,19 +923,19 @@ pub const ID3D12Fence = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12Fence, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12Fence) callconv(.winapi) u32,
         Release: *const fn (*ID3D12Fence) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
         // ID3D12Pageable adds nothing
-        // ID3D12Fence (slots 8-10)
+        // ID3D12Fence
         GetCompletedValue: *const fn (*ID3D12Fence) callconv(.winapi) u64,
         SetEventOnCompletion: *const fn (*ID3D12Fence, Value: u64, hEvent: HANDLE) callconv(.winapi) HRESULT,
         Signal: Reserved,
@@ -962,7 +955,7 @@ pub const ID3D12Fence = extern struct {
 };
 
 // ID3D12DescriptorHeap
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12Pageable (0) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12Pageable
 pub const ID3D12DescriptorHeap = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -973,19 +966,19 @@ pub const ID3D12DescriptorHeap = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12DescriptorHeap, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12DescriptorHeap) callconv(.winapi) u32,
         Release: *const fn (*ID3D12DescriptorHeap) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
         // ID3D12Pageable adds nothing
-        // ID3D12DescriptorHeap (slots 8-10)
+        // ID3D12DescriptorHeap
         GetDesc: Reserved,
         // These COM methods return structs via a hidden output pointer
         // (the C ABI convention used in the actual vtable). The C++ wrapper
@@ -1012,7 +1005,7 @@ pub const ID3D12DescriptorHeap = extern struct {
 };
 
 // ID3D12Resource
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12Pageable (0) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12Pageable
 pub const ID3D12Resource = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1023,19 +1016,19 @@ pub const ID3D12Resource = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12Resource, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12Resource) callconv(.winapi) u32,
         Release: *const fn (*ID3D12Resource) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
         // ID3D12Pageable adds nothing
-        // ID3D12Resource (slots 8-14)
+        // ID3D12Resource
         Map: *const fn (*ID3D12Resource, Subresource: u32, pReadRange: ?*const D3D12_RANGE, ppData: *?*anyopaque) callconv(.winapi) HRESULT,
         Unmap: *const fn (*ID3D12Resource, Subresource: u32, pWrittenRange: ?*const D3D12_RANGE) callconv(.winapi) void,
         GetDesc: Reserved,
@@ -1063,7 +1056,7 @@ pub const ID3D12Resource = extern struct {
 };
 
 // ID3D12PipelineState
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12Pageable (0) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12Pageable
 pub const ID3D12PipelineState = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1074,19 +1067,19 @@ pub const ID3D12PipelineState = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12PipelineState, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12PipelineState) callconv(.winapi) u32,
         Release: *const fn (*ID3D12PipelineState) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
         // ID3D12Pageable adds nothing
-        // ID3D12PipelineState (slot 8)
+        // ID3D12PipelineState
         GetCachedBlob: Reserved,
     };
 
@@ -1096,7 +1089,7 @@ pub const ID3D12PipelineState = extern struct {
 };
 
 // ID3D12RootSignature
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild
 // No own methods beyond inherited.
 pub const ID3D12RootSignature = extern struct {
     vtable: *const VTable,
@@ -1108,16 +1101,16 @@ pub const ID3D12RootSignature = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12RootSignature, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12RootSignature) callconv(.winapi) u32,
         Release: *const fn (*ID3D12RootSignature) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
     };
 
@@ -1127,24 +1120,24 @@ pub const ID3D12RootSignature = extern struct {
 };
 
 // ID3D12Heap
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12Pageable (0) = 8 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12Pageable
 pub const ID3D12Heap = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12Heap, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12Heap) callconv(.winapi) u32,
         Release: *const fn (*ID3D12Heap) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
         // ID3D12Pageable adds nothing
-        // ID3D12Heap (slot 8)
+        // ID3D12Heap
         GetDesc: Reserved,
     };
 
@@ -1154,7 +1147,7 @@ pub const ID3D12Heap = extern struct {
 };
 
 // ID3D12GraphicsCommandList
-// Inherits: IUnknown (3) -> ID3D12Object (4) -> ID3D12DeviceChild (1) -> ID3D12CommandList (1) = 9 inherited
+// Inherits: IUnknown -> ID3D12Object -> ID3D12DeviceChild -> ID3D12CommandList
 pub const ID3D12GraphicsCommandList = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1165,126 +1158,75 @@ pub const ID3D12GraphicsCommandList = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12GraphicsCommandList, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12GraphicsCommandList) callconv(.winapi) u32,
         Release: *const fn (*ID3D12GraphicsCommandList) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12DeviceChild (slot 7)
+        // ID3D12DeviceChild
         GetDevice: Reserved,
-        // ID3D12CommandList (slot 8)
+        // ID3D12CommandList
         GetType: Reserved,
-        // ID3D12GraphicsCommandList own methods (slots 9+)
-        // slot 9
+        // ID3D12GraphicsCommandList own methods
         Close: *const fn (*ID3D12GraphicsCommandList) callconv(.winapi) HRESULT,
-        // slot 10
         Reset: *const fn (*ID3D12GraphicsCommandList, pAllocator: *ID3D12CommandAllocator, pInitialState: ?*ID3D12PipelineState) callconv(.winapi) HRESULT,
-        // slot 11
         ClearState: Reserved,
-        // slot 12
         DrawInstanced: *const fn (*ID3D12GraphicsCommandList, VertexCountPerInstance: u32, InstanceCount: u32, StartVertexLocation: u32, StartInstanceLocation: u32) callconv(.winapi) void,
-        // slot 13
         DrawIndexedInstanced: Reserved,
-        // slot 14
         Dispatch: Reserved,
-        // slot 15
         CopyBufferRegion: *const fn (*ID3D12GraphicsCommandList, pDstBuffer: *ID3D12Resource, DstOffset: u64, pSrcBuffer: *ID3D12Resource, SrcOffset: u64, NumBytes: u64) callconv(.winapi) void,
-        // slot 16
         CopyTextureRegion: *const fn (*ID3D12GraphicsCommandList, pDst: *const D3D12_TEXTURE_COPY_LOCATION, DstX: u32, DstY: u32, DstZ: u32, pSrc: *const D3D12_TEXTURE_COPY_LOCATION, pSrcBox: ?*const D3D12_BOX) callconv(.winapi) void,
-        // slot 17
         CopyResource: Reserved,
-        // slot 18
         CopyTiles: Reserved,
-        // slot 19
         ResolveSubresource: Reserved,
-        // slot 20
         IASetPrimitiveTopology: *const fn (*ID3D12GraphicsCommandList, PrimitiveTopology: D3D_PRIMITIVE_TOPOLOGY) callconv(.winapi) void,
-        // slot 21
         RSSetViewports: *const fn (*ID3D12GraphicsCommandList, NumViewports: u32, pViewports: [*]const D3D12_VIEWPORT) callconv(.winapi) void,
-        // slot 22
         RSSetScissorRects: *const fn (*ID3D12GraphicsCommandList, NumRects: u32, pRects: [*]const D3D12_RECT) callconv(.winapi) void,
-        // slot 23
         OMSetBlendFactor: Reserved,
-        // slot 24
         OMSetStencilRef: Reserved,
-        // slot 25
         SetPipelineState: *const fn (*ID3D12GraphicsCommandList, pPipelineState: *ID3D12PipelineState) callconv(.winapi) void,
-        // slot 26
         ResourceBarrier: *const fn (*ID3D12GraphicsCommandList, NumBarriers: u32, pBarriers: [*]const D3D12_RESOURCE_BARRIER) callconv(.winapi) void,
-        // slot 27
         ExecuteBundle: Reserved,
-        // slot 28
         SetDescriptorHeaps: *const fn (*ID3D12GraphicsCommandList, NumDescriptorHeaps: u32, ppDescriptorHeaps: [*]const *ID3D12DescriptorHeap) callconv(.winapi) void,
-        // slot 29
         SetComputeRootSignature: Reserved,
-        // slot 30
         SetGraphicsRootSignature: *const fn (*ID3D12GraphicsCommandList, pRootSignature: ?*ID3D12RootSignature) callconv(.winapi) void,
-        // slot 31
         SetComputeRootDescriptorTable: Reserved,
-        // slot 32
         // BaseDescriptor is D3D12_GPU_DESCRIPTOR_HANDLE (8-byte struct).
         // Use u64 in the vtable for the same ABI reason as the device
         // descriptor handle parameters above.
         SetGraphicsRootDescriptorTable: *const fn (*ID3D12GraphicsCommandList, RootParameterIndex: u32, BaseDescriptor: u64) callconv(.winapi) void,
-        // slot 33
         SetComputeRoot32BitConstant: Reserved,
-        // slot 34
         SetGraphicsRoot32BitConstant: Reserved,
-        // slot 35
         SetComputeRoot32BitConstants: Reserved,
-        // slot 36
         SetGraphicsRoot32BitConstants: Reserved,
-        // slot 37
         SetComputeRootConstantBufferView: Reserved,
-        // slot 38
         SetGraphicsRootConstantBufferView: *const fn (*ID3D12GraphicsCommandList, RootParameterIndex: u32, BufferLocation: u64) callconv(.winapi) void,
-        // slot 39
         SetComputeRootShaderResourceView: Reserved,
-        // slot 40
         SetGraphicsRootShaderResourceView: *const fn (*ID3D12GraphicsCommandList, RootParameterIndex: u32, BufferLocation: u64) callconv(.winapi) void,
-        // slot 41
         SetComputeRootUnorderedAccessView: Reserved,
-        // slot 42
         SetGraphicsRootUnorderedAccessView: Reserved,
-        // slot 43
         IASetIndexBuffer: Reserved,
-        // slot 44
         IASetVertexBuffers: *const fn (*ID3D12GraphicsCommandList, StartSlot: u32, NumViews: u32, pViews: [*]const D3D12_VERTEX_BUFFER_VIEW) callconv(.winapi) void,
-        // slot 45
         SOSetTargets: Reserved,
-        // slot 46
         OMSetRenderTargets: *const fn (*ID3D12GraphicsCommandList, NumRenderTargetDescriptors: u32, pRenderTargetDescriptors: ?[*]const D3D12_CPU_DESCRIPTOR_HANDLE, RTsSingleHandleToDescriptorRange: BOOL, pDepthStencilDescriptor: ?*const D3D12_CPU_DESCRIPTOR_HANDLE) callconv(.winapi) void,
-        // slot 47
         ClearDepthStencilView: Reserved,
-        // slot 48
         // RenderTargetView is D3D12_CPU_DESCRIPTOR_HANDLE (8-byte struct).
         // Use usize in the vtable for the same ABI reason as above.
         ClearRenderTargetView: *const fn (*ID3D12GraphicsCommandList, RenderTargetView: usize, ColorRGBA: *const [4]f32, NumRects: u32, pRects: ?[*]const D3D12_RECT) callconv(.winapi) void,
-        // slot 49
         ClearUnorderedAccessViewUint: Reserved,
-        // slot 50
         ClearUnorderedAccessViewFloat: Reserved,
-        // slot 51
         DiscardResource: Reserved,
-        // slot 52
         BeginQuery: Reserved,
-        // slot 53
         EndQuery: Reserved,
-        // slot 54
         ResolveQueryData: Reserved,
-        // slot 55
         SetPredication: Reserved,
-        // slot 56
         SetMarker: Reserved,
-        // slot 57
         BeginEvent: Reserved,
-        // slot 58
         EndEvent: Reserved,
-        // slot 59
         ExecuteIndirect: Reserved,
     };
 
@@ -1366,7 +1308,7 @@ pub const ID3D12GraphicsCommandList = extern struct {
 };
 
 // ID3D12Device
-// Inherits: IUnknown (3) -> ID3D12Object (4) = 7 inherited slots
+// Inherits: IUnknown -> ID3D12Object
 pub const ID3D12Device = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1377,93 +1319,55 @@ pub const ID3D12Device = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ID3D12Device, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ID3D12Device) callconv(.winapi) u32,
         Release: *const fn (*ID3D12Device) callconv(.winapi) u32,
-        // ID3D12Object (slots 3-6)
+        // ID3D12Object
         GetPrivateData: Reserved,
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         SetName: Reserved,
-        // ID3D12Device own methods (slots 7+)
-        // slot 7
+        // ID3D12Device own methods
         GetNodeCount: Reserved,
-        // slot 8
         CreateCommandQueue: *const fn (*ID3D12Device, *const D3D12_COMMAND_QUEUE_DESC, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 9
         CreateCommandAllocator: *const fn (*ID3D12Device, D3D12_COMMAND_LIST_TYPE, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 10
         CreateGraphicsPipelineState: *const fn (*ID3D12Device, *const D3D12_GRAPHICS_PIPELINE_STATE_DESC, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 11
         CreateComputePipelineState: Reserved,
-        // slot 12
         CreateCommandList: *const fn (*ID3D12Device, NodeMask: u32, Type: D3D12_COMMAND_LIST_TYPE, pCommandAllocator: *ID3D12CommandAllocator, pInitialState: ?*ID3D12PipelineState, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 13
         CheckFeatureSupport: Reserved,
-        // slot 14
         CreateDescriptorHeap: *const fn (*ID3D12Device, *const D3D12_DESCRIPTOR_HEAP_DESC, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 15
         GetDescriptorHandleIncrementSize: *const fn (*ID3D12Device, D3D12_DESCRIPTOR_HEAP_TYPE) callconv(.winapi) u32,
-        // slot 16
         CreateRootSignature: *const fn (*ID3D12Device, NodeMask: u32, pBlobWithRootSignature: *const anyopaque, blobLengthInBytes: usize, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 17
         CreateConstantBufferView: Reserved,
-        // slot 18
         // DestDescriptor is D3D12_CPU_DESCRIPTOR_HANDLE (8-byte struct) passed
         // by value. Use usize in the vtable to avoid Zig callconv(.winapi)
-        // struct-by-value ABI ambiguity -- same class of issue as the
-        // descriptor heap struct-return fix in PR # 142.
+        // struct-by-value ABI ambiguity.
         CreateShaderResourceView: *const fn (*ID3D12Device, pResource: ?*ID3D12Resource, pDesc: ?*const D3D12_SHADER_RESOURCE_VIEW_DESC, DestDescriptor: usize) callconv(.winapi) void,
-        // slot 19
         CreateUnorderedAccessView: Reserved,
-        // slot 20
         CreateRenderTargetView: *const fn (*ID3D12Device, pResource: ?*ID3D12Resource, pDesc: ?*const anyopaque, DestDescriptor: usize) callconv(.winapi) void,
-        // slot 21
         CreateDepthStencilView: Reserved,
-        // slot 22
         CreateSampler: *const fn (*ID3D12Device, pDesc: *const D3D12_SAMPLER_DESC, DestDescriptor: usize) callconv(.winapi) void,
-        // slot 23
         CopyDescriptors: Reserved,
-        // slot 24
         CopyDescriptorsSimple: Reserved,
-        // slot 25
         GetResourceAllocationInfo: Reserved,
-        // slot 26
         GetCustomHeapProperties: Reserved,
-        // slot 27
         CreateCommittedResource: *const fn (*ID3D12Device, *const D3D12_HEAP_PROPERTIES, u32, *const D3D12_RESOURCE_DESC, D3D12_RESOURCE_STATES, ?*const anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 28
         CreateHeap: Reserved,
-        // slot 29
         CreatePlacedResource: Reserved,
-        // slot 30
         CreateReservedResource: Reserved,
-        // slot 31
         CreateSharedHandle: *const fn (*ID3D12Device, *IUnknown, ?*const anyopaque, u32, ?[*:0]const u16, *HANDLE) callconv(.winapi) HRESULT,
-        // slot 32
         OpenSharedHandle: Reserved,
-        // slot 33
         OpenSharedHandleByName: Reserved,
-        // slot 34
         MakeResident: Reserved,
-        // slot 35
         Evict: Reserved,
-        // slot 36
         CreateFence: *const fn (*ID3D12Device, InitialValue: u64, Flags: D3D12_FENCE_FLAGS, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // slot 37
         GetDeviceRemovedReason: *const fn (*ID3D12Device) callconv(.winapi) HRESULT,
-        // slot 38
         GetCopyableFootprints: Reserved,
-        // slot 39
         CreateQueryHeap: Reserved,
-        // slot 40
         SetStablePowerState: Reserved,
-        // slot 41
         CreateCommandSignature: Reserved,
-        // slot 42
         GetResourceTiling: Reserved,
-        // slot 43
         GetAdapterLuid: Reserved,
     };
 
@@ -1584,7 +1488,7 @@ pub const DxcBuffer = extern struct {
 };
 
 // IDxcBlob
-// Inherits: IUnknown(3) > IDxcBlob(2) = 5 total
+// Inherits: IUnknown > IDxcBlob
 pub const IDxcBlob = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1595,11 +1499,11 @@ pub const IDxcBlob = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDxcBlob, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDxcBlob) callconv(.winapi) u32,
         Release: *const fn (*IDxcBlob) callconv(.winapi) u32,
-        // IDxcBlob (slots 3-4)
+        // IDxcBlob
         GetBufferPointer: *const fn (*IDxcBlob) callconv(.winapi) *anyopaque,
         GetBufferSize: *const fn (*IDxcBlob) callconv(.winapi) usize,
     };
@@ -1618,7 +1522,7 @@ pub const IDxcBlob = extern struct {
 };
 
 // IDxcBlobUtf8
-// Inherits: IUnknown(3) > IDxcBlob(2) > IDxcBlobEncoding(1) > IDxcBlobUtf8(2) = 8 total
+// Inherits: IUnknown > IDxcBlob > IDxcBlobEncoding > IDxcBlobUtf8(2)
 pub const IDxcBlobUtf8 = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1629,16 +1533,16 @@ pub const IDxcBlobUtf8 = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDxcBlobUtf8, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDxcBlobUtf8) callconv(.winapi) u32,
         Release: *const fn (*IDxcBlobUtf8) callconv(.winapi) u32,
-        // IDxcBlob (slots 3-4)
+        // IDxcBlob
         GetBufferPointer: *const fn (*IDxcBlobUtf8) callconv(.winapi) *anyopaque,
         GetBufferSize: *const fn (*IDxcBlobUtf8) callconv(.winapi) usize,
-        // IDxcBlobEncoding (slot 5)
+        // IDxcBlobEncoding
         GetEncoding: Reserved,
-        // IDxcBlobUtf8 (slots 6-7)
+        // IDxcBlobUtf8
         GetStringPointer: *const fn (*IDxcBlobUtf8) callconv(.winapi) [*:0]const u8,
         GetStringLength: *const fn (*IDxcBlobUtf8) callconv(.winapi) usize,
     };
@@ -1665,7 +1569,7 @@ pub const IDxcBlobUtf8 = extern struct {
 };
 
 // IDxcResult
-// Inherits: IUnknown(3) > IDxcOperationResult(3) > IDxcResult(5) = 11 total
+// Inherits: IUnknown > IDxcOperationResult > IDxcResult
 pub const IDxcResult = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1676,15 +1580,15 @@ pub const IDxcResult = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDxcResult, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDxcResult) callconv(.winapi) u32,
         Release: *const fn (*IDxcResult) callconv(.winapi) u32,
-        // IDxcOperationResult (slots 3-5)
+        // IDxcOperationResult
         GetStatus: *const fn (*IDxcResult, *HRESULT) callconv(.winapi) HRESULT,
         GetResult: Reserved,
         GetErrorBuffer: Reserved,
-        // IDxcResult (slots 6-10)
+        // IDxcResult
         HasOutput: Reserved,
         GetOutput: *const fn (*IDxcResult, DXC_OUT_KIND, *const GUID, *?*anyopaque, *?*anyopaque) callconv(.winapi) HRESULT,
         GetNumOutputs: Reserved,
@@ -1708,7 +1612,7 @@ pub const IDxcResult = extern struct {
 };
 
 // IDxcUtils
-// Inherits: IUnknown(3) + 13 own methods = 16 total
+// Inherits: IUnknown
 pub const IDxcUtils = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1719,11 +1623,11 @@ pub const IDxcUtils = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDxcUtils, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDxcUtils) callconv(.winapi) u32,
         Release: *const fn (*IDxcUtils) callconv(.winapi) u32,
-        // IDxcUtils (slots 3-15)
+        // IDxcUtils
         CreateBlobFromBlob: Reserved,
         CreateBlobFromPinned: Reserved,
         MoveToBlob: Reserved,
@@ -1749,7 +1653,7 @@ pub const IDxcUtils = extern struct {
 };
 
 // IDxcCompiler3
-// Inherits: IUnknown(3) + 2 own methods = 5 total
+// Inherits: IUnknown
 pub const IDxcCompiler3 = extern struct {
     vtable: *const VTable,
     pub const IID = GUID{
@@ -1760,11 +1664,11 @@ pub const IDxcCompiler3 = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDxcCompiler3, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDxcCompiler3) callconv(.winapi) u32,
         Release: *const fn (*IDxcCompiler3) callconv(.winapi) u32,
-        // IDxcCompiler3 (slots 3-4)
+        // IDxcCompiler3
         Compile: *const fn (
             *IDxcCompiler3,
             *const DxcBuffer,
@@ -1987,7 +1891,7 @@ test "DXC_OUT_KIND has OBJECT and ERRORS variants" {
 }
 
 test "IDxcBlobUtf8 has expected vtable field count" {
-    // IUnknown(3) + IDxcBlob(2) + IDxcBlobEncoding(1) + IDxcBlobUtf8(2) = 8 slots
+    // IUnknown + IDxcBlob + IDxcBlobEncoding + IDxcBlobUtf8(2) = 8 slots
     try std.testing.expectEqual(@sizeOf(*anyopaque), @sizeOf(IDxcBlobUtf8));
     const vtable_size = @sizeOf(IDxcBlobUtf8.VTable);
     const expected_size = 8 * @sizeOf(*anyopaque);
@@ -1995,7 +1899,7 @@ test "IDxcBlobUtf8 has expected vtable field count" {
 }
 
 test "IDxcResult has expected vtable field count" {
-    // IUnknown(3) + IDxcOperationResult(3) + IDxcResult(5) = 11 slots
+    // IUnknown + IDxcOperationResult + IDxcResult = 11 slots
     try std.testing.expectEqual(@sizeOf(*anyopaque), @sizeOf(IDxcResult));
     const vtable_size = @sizeOf(IDxcResult.VTable);
     const expected_size = 11 * @sizeOf(*anyopaque);
@@ -2003,7 +1907,7 @@ test "IDxcResult has expected vtable field count" {
 }
 
 test "IDxcUtils has expected vtable field count" {
-    // IUnknown(3) + 13 methods = 16 slots
+    // IUnknown + 13 methods = 16 slots
     try std.testing.expectEqual(@sizeOf(*anyopaque), @sizeOf(IDxcUtils));
     const vtable_size = @sizeOf(IDxcUtils.VTable);
     const expected_size = 16 * @sizeOf(*anyopaque);
@@ -2011,7 +1915,7 @@ test "IDxcUtils has expected vtable field count" {
 }
 
 test "IDxcCompiler3 has expected vtable field count" {
-    // IUnknown(3) + Compile + Disassemble = 5 slots
+    // IUnknown + Compile + Disassemble = 5 slots
     try std.testing.expectEqual(@sizeOf(*anyopaque), @sizeOf(IDxcCompiler3));
     const vtable_size = @sizeOf(IDxcCompiler3.VTable);
     const expected_size = 5 * @sizeOf(*anyopaque);

--- a/src/renderer/directx12/dcomp.zig
+++ b/src/renderer/directx12/dcomp.zig
@@ -7,8 +7,6 @@ const IUnknown = com.IUnknown;
 const Reserved = com.Reserved;
 const HWND = dxgi.HWND;
 
-// IDCompositionDevice
-// Slots we call: Commit (3), CreateTargetForHwnd (6), CreateVisual (7)
 pub const IDCompositionDevice = extern struct {
     vtable: *const VTable,
 
@@ -20,11 +18,10 @@ pub const IDCompositionDevice = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDCompositionDevice, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDCompositionDevice) callconv(.winapi) u32,
         Release: *const fn (*IDCompositionDevice) callconv(.winapi) u32,
-        // IDCompositionDevice (slots 3-7)
         Commit: *const fn (*IDCompositionDevice) callconv(.winapi) HRESULT,
         WaitForCommitCompletion: Reserved,
         GetFrameStatistics: Reserved,
@@ -49,17 +46,14 @@ pub const IDCompositionDevice = extern struct {
     }
 };
 
-// IDCompositionTarget
-// Slot we call: SetRoot (3)
 pub const IDCompositionTarget = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDCompositionTarget, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDCompositionTarget) callconv(.winapi) u32,
         Release: *const fn (*IDCompositionTarget) callconv(.winapi) u32,
-        // IDCompositionTarget (slot 3)
         SetRoot: *const fn (*IDCompositionTarget, visual: ?*IDCompositionVisual) callconv(.winapi) HRESULT,
     };
 
@@ -72,17 +66,15 @@ pub const IDCompositionTarget = extern struct {
     }
 };
 
-// IDCompositionVisual
-// Slot we call: SetContent (15)
 pub const IDCompositionVisual = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDCompositionVisual, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDCompositionVisual) callconv(.winapi) u32,
         Release: *const fn (*IDCompositionVisual) callconv(.winapi) u32,
-        // IDCompositionVisual (slots 3-14, reserved)
+        // Reserved slots before SetContent.
         SetOffsetX_float: Reserved,
         SetOffsetX_animation: Reserved,
         SetOffsetY_float: Reserved,
@@ -95,9 +87,8 @@ pub const IDCompositionVisual = extern struct {
         SetBorderMode: Reserved,
         SetClip_rect: Reserved,
         SetClip_clip: Reserved,
-        // IDCompositionVisual (slot 15)
         SetContent: *const fn (*IDCompositionVisual, content: ?*IUnknown) callconv(.winapi) HRESULT,
-        // IDCompositionVisual (slots 16-18, reserved)
+        // Reserved slots after SetContent.
         AddVisual: Reserved,
         RemoveVisual: Reserved,
         RemoveAllVisuals: Reserved,

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -364,12 +364,8 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
             );
         },
     }
-    // If anything between here and the final `return` ever gains a
-    // fallible step, this errdefer tears down the shared texture state
-    // instead of leaking the resource and both NT handles. Today it is
-    // defensive -- nothing after this point can fail -- but the cost
-    // is nil and the alternative is a latent leak waiting for the next
-    // edit.
+    // Defensive: if a future fallible step lands between here and the
+    // return, this prevents leaking the resource and both NT handles.
     errdefer if (result_shared_texture) |st| {
         _ = d3d12.CloseHandle(st.fence_handle);
         _ = d3d12.CloseHandle(st.resource_handle);

--- a/src/renderer/directx12/dxgi.zig
+++ b/src/renderer/directx12/dxgi.zig
@@ -85,11 +85,11 @@ pub const IDXGIObject = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGIObject, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGIObject) callconv(.winapi) u32,
         Release: *const fn (*IDXGIObject) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
@@ -102,22 +102,22 @@ pub const IDXGIDeviceSubObject = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: Reserved,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIDeviceSubObject (slot 7)
+        // IDXGIDeviceSubObject
         GetDevice: Reserved,
     };
 };
 
 // IDXGIResource
-// Inherits IDXGIDeviceSubObject. Slot we call: GetSharedHandle (slot 8)
+// Inherits IDXGIDeviceSubObject
 pub const IDXGIResource = extern struct {
     vtable: *const VTable,
 
@@ -129,18 +129,18 @@ pub const IDXGIResource = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGIResource, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGIResource) callconv(.winapi) u32,
         Release: *const fn (*IDXGIResource) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIDeviceSubObject (slot 7)
+        // IDXGIDeviceSubObject
         GetDevice: Reserved,
-        // IDXGIResource (slots 8-11)
+        // IDXGIResource
         GetSharedHandle: *const fn (*IDXGIResource, *?std.os.windows.HANDLE) callconv(.winapi) HRESULT,
         GetUsage: Reserved,
         SetEvictionPriority: Reserved,
@@ -157,23 +157,22 @@ pub const IDXGIResource = extern struct {
 };
 
 // IDXGISwapChain
-// Slots we call: Present (8), GetBuffer (9)
 pub const IDXGISwapChain = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGISwapChain, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGISwapChain) callconv(.winapi) u32,
         Release: *const fn (*IDXGISwapChain) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIDeviceSubObject (slot 7)
+        // IDXGIDeviceSubObject
         GetDevice: Reserved,
-        // IDXGISwapChain (slots 8-17)
+        // IDXGISwapChain
         Present: *const fn (*IDXGISwapChain, SyncInterval: u32, Flags: u32) callconv(.winapi) HRESULT,
         GetBuffer: *const fn (*IDXGISwapChain, Buffer: u32, riid: *const GUID, ppSurface: *?*anyopaque) callconv(.winapi) HRESULT,
         SetFullscreenState: Reserved,
@@ -204,18 +203,18 @@ pub const IDXGISwapChain1 = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGISwapChain1, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGISwapChain1) callconv(.winapi) u32,
         Release: *const fn (*IDXGISwapChain1) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIDeviceSubObject (slot 7)
+        // IDXGIDeviceSubObject
         GetDevice: Reserved,
-        // IDXGISwapChain (slots 8-17)
+        // IDXGISwapChain
         Present: *const fn (*IDXGISwapChain1, u32, u32) callconv(.winapi) HRESULT,
         GetBuffer: *const fn (*IDXGISwapChain1, u32, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         SetFullscreenState: Reserved,
@@ -226,7 +225,7 @@ pub const IDXGISwapChain1 = extern struct {
         GetContainingOutput: Reserved,
         GetFrameStatistics: Reserved,
         GetLastPresentCount: Reserved,
-        // IDXGISwapChain1 (slots 18-28)
+        // IDXGISwapChain1
         GetDesc1: *const fn (*IDXGISwapChain1, *DXGI_SWAP_CHAIN_DESC1) callconv(.winapi) HRESULT,
         GetFullscreenDesc: Reserved,
         GetHwnd: Reserved,
@@ -262,7 +261,6 @@ pub const IDXGISwapChain1 = extern struct {
 };
 
 // IDXGISwapChain2
-// Slot we call: SetMatrixTransform (34)
 pub const IDXGISwapChain2 = extern struct {
     vtable: *const VTable,
 
@@ -274,18 +272,18 @@ pub const IDXGISwapChain2 = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGISwapChain2, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGISwapChain2) callconv(.winapi) u32,
         Release: *const fn (*IDXGISwapChain2) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIDeviceSubObject (slot 7)
+        // IDXGIDeviceSubObject
         GetDevice: Reserved,
-        // IDXGISwapChain (slots 8-17)
+        // IDXGISwapChain
         Present: *const fn (*IDXGISwapChain2, u32, u32) callconv(.winapi) HRESULT,
         GetBuffer: *const fn (*IDXGISwapChain2, u32, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         SetFullscreenState: Reserved,
@@ -296,7 +294,7 @@ pub const IDXGISwapChain2 = extern struct {
         GetContainingOutput: Reserved,
         GetFrameStatistics: Reserved,
         GetLastPresentCount: Reserved,
-        // IDXGISwapChain1 (slots 18-28)
+        // IDXGISwapChain1
         GetDesc1: Reserved,
         GetFullscreenDesc: Reserved,
         GetHwnd: Reserved,
@@ -308,7 +306,7 @@ pub const IDXGISwapChain2 = extern struct {
         GetBackgroundColor: Reserved,
         SetRotation: Reserved,
         GetRotation: Reserved,
-        // IDXGISwapChain2 (slots 29-35)
+        // IDXGISwapChain2
         SetSourceSize: Reserved,
         GetSourceSize: Reserved,
         SetMaximumFrameLatency: Reserved,
@@ -336,7 +334,6 @@ pub const IDXGISwapChain2 = extern struct {
 };
 
 // IDXGISwapChain3
-// Slot we call: GetCurrentBackBufferIndex (36)
 pub const IDXGISwapChain3 = extern struct {
     vtable: *const VTable,
 
@@ -348,18 +345,18 @@ pub const IDXGISwapChain3 = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGISwapChain3, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGISwapChain3) callconv(.winapi) u32,
         Release: *const fn (*IDXGISwapChain3) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIDeviceSubObject (slot 7)
+        // IDXGIDeviceSubObject
         GetDevice: Reserved,
-        // IDXGISwapChain (slots 8-17)
+        // IDXGISwapChain
         Present: *const fn (*IDXGISwapChain3, u32, u32) callconv(.winapi) HRESULT,
         GetBuffer: *const fn (*IDXGISwapChain3, u32, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         SetFullscreenState: Reserved,
@@ -370,7 +367,7 @@ pub const IDXGISwapChain3 = extern struct {
         GetContainingOutput: Reserved,
         GetFrameStatistics: Reserved,
         GetLastPresentCount: Reserved,
-        // IDXGISwapChain1 (slots 18-28)
+        // IDXGISwapChain1
         GetDesc1: Reserved,
         GetFullscreenDesc: Reserved,
         GetHwnd: Reserved,
@@ -382,7 +379,7 @@ pub const IDXGISwapChain3 = extern struct {
         GetBackgroundColor: Reserved,
         SetRotation: Reserved,
         GetRotation: Reserved,
-        // IDXGISwapChain2 (slots 29-35)
+        // IDXGISwapChain2
         SetSourceSize: Reserved,
         GetSourceSize: Reserved,
         SetMaximumFrameLatency: Reserved,
@@ -390,7 +387,7 @@ pub const IDXGISwapChain3 = extern struct {
         GetFrameLatencyWaitableObject: Reserved,
         SetMatrixTransform: Reserved,
         GetMatrixTransform: Reserved,
-        // IDXGISwapChain3 (slot 36)
+        // IDXGISwapChain3
         GetCurrentBackBufferIndex: *const fn (*IDXGISwapChain3) callconv(.winapi) u32,
     };
 
@@ -412,7 +409,6 @@ pub const IDXGISwapChain3 = extern struct {
 };
 
 // IDXGIDevice
-// Slot we call: GetAdapter (slot 7)
 pub const IDXGIDevice = extern struct {
     vtable: *const VTable,
 
@@ -424,16 +420,16 @@ pub const IDXGIDevice = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGIDevice, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGIDevice) callconv(.winapi) u32,
         Release: *const fn (*IDXGIDevice) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIDevice (slots 7-10)
+        // IDXGIDevice
         GetAdapter: *const fn (*IDXGIDevice, ppAdapter: *?*IDXGIAdapter) callconv(.winapi) HRESULT,
         CreateSurface: Reserved,
         QueryResourceResidency: Reserved,
@@ -450,21 +446,20 @@ pub const IDXGIDevice = extern struct {
 };
 
 // IDXGIAdapter
-// Slot we call: GetParent (slot 6, inherited from IDXGIObject)
 pub const IDXGIAdapter = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGIAdapter, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGIAdapter) callconv(.winapi) u32,
         Release: *const fn (*IDXGIAdapter) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: *const fn (*IDXGIAdapter, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
-        // IDXGIAdapter (slots 7-9)
+        // IDXGIAdapter
         EnumOutputs: Reserved,
         GetDesc: Reserved,
         CheckInterfaceSupport: Reserved,
@@ -484,16 +479,16 @@ pub const IDXGIFactory = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: Reserved,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIFactory (slots 7-11)
+        // IDXGIFactory
         EnumAdapters: Reserved,
         MakeWindowAssociation: Reserved,
         GetWindowAssociation: Reserved,
@@ -507,29 +502,28 @@ pub const IDXGIFactory1 = extern struct {
     vtable: *const VTable,
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: Reserved,
         AddRef: Reserved,
         Release: Reserved,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIFactory (slots 7-11)
+        // IDXGIFactory
         EnumAdapters: Reserved,
         MakeWindowAssociation: Reserved,
         GetWindowAssociation: Reserved,
         CreateSwapChain: Reserved,
         CreateSoftwareAdapter: Reserved,
-        // IDXGIFactory1 (slots 12-13)
+        // IDXGIFactory1
         EnumAdapters1: Reserved,
         IsCurrent: Reserved,
     };
 };
 
 // IDXGIFactory2
-// Slot we call: CreateSwapChainForComposition (slot 24)
 pub const IDXGIFactory2 = extern struct {
     vtable: *const VTable,
 
@@ -541,25 +535,25 @@ pub const IDXGIFactory2 = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*IDXGIFactory2, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*IDXGIFactory2) callconv(.winapi) u32,
         Release: *const fn (*IDXGIFactory2) callconv(.winapi) u32,
-        // IDXGIObject (slots 3-6)
+        // IDXGIObject
         SetPrivateData: Reserved,
         SetPrivateDataInterface: Reserved,
         GetPrivateData: Reserved,
         GetParent: Reserved,
-        // IDXGIFactory (slots 7-11)
+        // IDXGIFactory
         EnumAdapters: Reserved,
         MakeWindowAssociation: Reserved,
         GetWindowAssociation: Reserved,
         CreateSwapChain: Reserved,
         CreateSoftwareAdapter: Reserved,
-        // IDXGIFactory1 (slots 12-13)
+        // IDXGIFactory1
         EnumAdapters1: Reserved,
         IsCurrent: Reserved,
-        // IDXGIFactory2 (slots 14-24)
+        // IDXGIFactory2
         IsWindowedStereoEnabled: Reserved,
         CreateSwapChainForHwnd: *const fn (
             self: *IDXGIFactory2,
@@ -615,7 +609,6 @@ pub const IDXGIFactory2 = extern struct {
 };
 
 // ISwapChainPanelNative
-// Slot we call: SetSwapChain (slot 3)
 pub const ISwapChainPanelNative = extern struct {
     vtable: *const VTable,
 
@@ -627,11 +620,11 @@ pub const ISwapChainPanelNative = extern struct {
     };
 
     pub const VTable = extern struct {
-        // IUnknown (slots 0-2)
+        // IUnknown
         QueryInterface: *const fn (*ISwapChainPanelNative, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
         AddRef: *const fn (*ISwapChainPanelNative) callconv(.winapi) u32,
         Release: *const fn (*ISwapChainPanelNative) callconv(.winapi) u32,
-        // ISwapChainPanelNative (slot 3)
+        // ISwapChainPanelNative
         SetSwapChain: *const fn (*ISwapChainPanelNative, ?*IDXGISwapChain) callconv(.winapi) HRESULT,
     };
 

--- a/src/renderer/directx12/gpu_data.zig
+++ b/src/renderer/directx12/gpu_data.zig
@@ -1,14 +1,9 @@
 //! GPU data structs shared between CPU and shader code.
 //!
-//! These structs (Uniforms, CellText, CellBg, Image, BgImage) must match
-//! Metal's layout since GenericRenderer writes to them directly. The HLSL
-//! shaders interpret them differently but the CPU-side layout is shared
-//! across backends.
-//!
-//! The comptime assertions below guard against layout changes in this file
-//! but do not cross-reference the Metal backend's actual struct definitions.
-//! If layout drift between backends is suspected, compare against the Metal
-//! structs manually.
+//! Layout must match Metal's because GenericRenderer writes the same bytes
+//! for both backends. The comptime assertions guard against drift in this
+//! file but do not cross-reference the Metal definitions; verify manually
+//! if drift is suspected.
 const std = @import("std");
 const math = @import("../../math.zig");
 

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -341,7 +341,6 @@ comptime {
     std.debug.assert(bg_image_input_elements[1].AlignedByteOffset == @offsetOf(BgImage, "info"));
 }
 
-/// Shader management for DX12.
 pub const Shaders = struct {
     /// Shared root signature owned by this struct. Pipelines reference it
     /// for draw-time binding but do not own it -- deinit releases it here.

--- a/src/renderer/shaders/hlsl/cell.hlsl
+++ b/src/renderer/shaders/hlsl/cell.hlsl
@@ -1,9 +1,6 @@
 // Cell grid shader for the DX12 renderer.
-//
-// Renders a terminal-like grid of cells using instanced drawing.
-// Each cell instance provides bg/fg colors and a glyph index.
-// The vertex shader generates a quad (2 triangles, 6 vertices) per cell
-// from SV_VertexID + SV_InstanceID, positioned using a constant buffer.
+// Generates a quad per cell from SV_VertexID + SV_InstanceID; positions
+// come from the cbuffer at b0 (matches Pipeline root signature).
 
 cbuffer Constants : register(b0) {
     float2 grid_size;     // (cols, rows)
@@ -59,7 +56,5 @@ VS_OUTPUT VSMain(uint vertex_id : SV_VertexID, uint instance_id : SV_InstanceID,
 }
 
 float4 PSMain(VS_OUTPUT input) : SV_TARGET {
-    // For now, just return the background color.
-    // Glyph atlas sampling will be added in a later task.
     return input.bg_color;
 }

--- a/src/renderer/shaders/hlsl/shaders.hlsl
+++ b/src/renderer/shaders/hlsl/shaders.hlsl
@@ -83,8 +83,6 @@ cbuffer Uniforms : register(b0)
 #define NO_MIN_CONTRAST  1u
 #define IS_CURSOR_GLYPH  2u
 
-// TODO: port from Metal -- fit/position/repeat logic (BgImage.Info bit masks)
-
 // ---------------------------------------------------------------------------
 // Uniform helpers
 // ---------------------------------------------------------------------------
@@ -95,9 +93,9 @@ uint2 unpack_grid_size()
     return uint2(grid_size_packed & 0xFFFFu, (grid_size_packed >> 16u) & 0xFFFFu);
 }
 
-// TODO: re-enable padding_extend once blend state reliably composites
-// transparent pixels.  Until then, CellBgPS always clamps to the nearest
-// edge cell instead of returning transparent for non-extended padding.
+// padding_extend is currently unused: CellBgPS clamps to the nearest edge
+// cell because the blend state does not reliably composite transparent
+// pixels on non-extended padding.
 bool padding_extend_left()  { return (padding_extend_packed & EXTEND_LEFT)  != 0u; }
 bool padding_extend_right() { return (padding_extend_packed & EXTEND_RIGHT) != 0u; }
 bool padding_extend_up()    { return (padding_extend_packed & EXTEND_UP)    != 0u; }
@@ -108,7 +106,6 @@ bool padding_extend_down()  { return (padding_extend_packed & EXTEND_DOWN)  != 0
 //
 // Simplified vs. Metal: no Display P3 conversion, no linearize/unlinearize,
 // no minimum-contrast enforcement.
-// TODO: port full color pipeline from src/renderer/shaders/shaders.metal
 // ---------------------------------------------------------------------------
 
 // Unpack a uint containing RGBA as four u8 bytes (R in the low byte) to
@@ -124,11 +121,10 @@ float4 unpack_u32_rgba(uint packed)
 }
 
 // load_color: converts a packed uint8x4 (RGBA) to premultiplied float4.
-// Premultiplication is required because the blend state uses
-// SrcBlend=ONE (not SRC_ALPHA), so RGB must already be scaled by alpha.
-// Without this, transparent cells (alpha=0) would still add their RGB
-// to the render target, covering content drawn by earlier passes.
-// TODO: port full load_color() from shaders.metal (linearize, Display P3)
+// Premultiplication is required because the blend state uses SrcBlend=ONE
+// (not SRC_ALPHA), so RGB must already be scaled by alpha. Without this,
+// transparent cells (alpha=0) would still add their RGB to the render
+// target and cover content drawn by earlier passes.
 float4 load_color(uint packed)
 {
     float4 c = unpack_u32_rgba(packed);
@@ -139,7 +135,6 @@ float4 load_color(uint packed)
 // Variant for colors that arrived via hardware R8G8B8A8_UNORM conversion
 // (e.g. the CellText color instance attribute). Already in [0, 1].
 // Premultiply to match load_color() -- the blend state uses SrcBlend=ONE.
-// TODO: linearize, Display P3, min-contrast -- port from Metal
 float4 load_color_f4(float4 color)
 {
     color.rgb *= color.a;
@@ -338,7 +333,6 @@ CellTextVSOut CellTextVS(uint vid : SV_VertexID, CellTextVSIn inst)
     o.atlas = inst.atlas;
 
     // Foreground color (R8G8B8A8_UNORM hardware-converted to [0,1] float4).
-    // TODO: linearize, Display P3, min-contrast -- port from Metal
     o.color = load_color_f4(inst.color);
 
     // Per-cell background color composited over the global background
@@ -379,13 +373,11 @@ float4 CellTextPS(CellTextVSOut input) : SV_TARGET
     if (input.atlas == ATLAS_COLOR) {
         // Color glyph: sample from the color atlas.
         // Values arrive already premultiplied; do not premultiply again.
-        // TODO: unlinearize if !use_linear_blending -- port from Metal
         float4 color = ct_atlas_color.Load(int3(tc, 0));
         return color;
     }
 
     // Grayscale glyph: the red channel is an alpha mask applied to fg color.
-    // TODO: linear blending correction, unlinearize -- port from Metal
     float4 color = input.color;
     float a = ct_atlas_grayscale.Load(int3(tc, 0)).r;
     color *= a;
@@ -448,8 +440,6 @@ float4 ImagePS(ImageVSOut input) : SV_TARGET
 {
     int2 tc = int2(input.tex_coord);
     float4 rgba = img_texture.Load(int3(tc, 0));
-
-    // TODO: unlinearize if !use_linear_blending -- port from Metal
     rgba.rgb *= rgba.a;
     return rgba;
 }
@@ -496,22 +486,16 @@ BgImageVSOut BgImageVS(uint vid : SV_VertexID, BgImageVSIn inst)
 
     o.opacity  = inst.opacity;
     o.bg_color = load_color(bg_color_packed);
-
-    // TODO: port from Metal -- fit/position/repeat logic
-
     return o;
 }
 
 float4 BgImagePS(BgImageVSOut input) : SV_TARGET
 {
-    // TODO: port from Metal -- fit/position/repeat logic
-
     // Sample the texture at the normalized screen UV.
     float2 uv = input.position.xy / screen_size;
     float4 rgba = bgi_texture.SampleLevel(bgi_sampler, uv, 0.0);
 
     // Premultiply alpha.
-    // TODO: unlinearize if !use_linear_blending -- port from Metal
     rgba.rgb *= rgba.a;
 
     float bg_alpha = input.bg_color.a;

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1726,7 +1726,7 @@ fn execCommand(
     comptime passwdpkg: type,
     /// Configured UTF-8 console preamble policy; used only on Windows
     /// to gate UTF-8 preamble injection across both ConPTY and bypass
-    /// transports (# 302, # 341). Ignored on other platforms.
+    /// transports. Ignored on other platforms.
     utf8_console: configpkg.Config.Utf8Console,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
     // If we're on macOS, we have to use `login(1)` to get all of
@@ -2815,13 +2815,10 @@ test "resolveUtf8Console: auto agrees with isCjkAnsiCodePage" {
     try std.testing.expectEqual(expected, resolveUtf8Console(.auto));
 }
 
-// --- # 302 UTF-8 preamble injection tests -----------------------------------
-//
-// These check the argv that execCommand hands back when the resolved
-// transport is ConPTY. The preamble's *content* is covered by
-// `utf8Preamble` tests in os/windows_shell.zig; here we only assert
-// the injection decision (when do we inject? on what shells?) and the
-// argv shape (length + flag markers).
+// UTF-8 preamble injection tests: assert the injection decision (when
+// do we inject? on what shells?) and the argv shape (length + flag
+// markers). The preamble's *content* is covered by `utf8Preamble` tests
+// in os/windows_shell.zig.
 
 fn testExecWindowsShell(
     alloc: Allocator,
@@ -2923,9 +2920,9 @@ test "execCommand windows: utf8-console=never is a kill switch across transports
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // After the # 341 fix the preamble decision is owned by the
-    // utf8-console policy, not the transport. `never` must mean
-    // "no preamble anywhere", regardless of how transport resolves.
+    // The preamble decision is owned by the utf8-console policy, not
+    // the transport. `never` must mean "no preamble anywhere",
+    // regardless of how transport resolves.
     const cmd_result = try execCommand(
         alloc,
         .{ .shell = "cmd.exe" },
@@ -3379,11 +3376,10 @@ test "execCommand windows: pwsh.exe under auto/auto gets pwsh preamble (regressi
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    // After the # 341 fix the preamble fires regardless of transport
-    // (see maybeInjectUtf8Preamble), so the user sees `chcp 65001` +
-    // `[Console]::OutputEncoding = UTF8` applied at startup. Before
-    // the fix the preamble was gated on `mode == .conpty`, which
-    // masked this code path because pwsh used to route to .bypass.
+    // The preamble fires regardless of transport (see
+    // maybeInjectUtf8Preamble), so the user sees `chcp 65001` +
+    // `[Console]::OutputEncoding = UTF8` applied at startup even when
+    // pwsh routes to .bypass.
     const result = try execCommand(
         alloc,
         .{ .shell = "pwsh.exe" },

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -149,10 +149,7 @@ test {
 
 test {
     // Ensure we don't grow our IO message size without explicitly wanting to.
-    // The previous size was 40 bytes; adding the WriteKind tag bumped the
-    // largest write variant by one byte. The bump is intentional - see
-    // WriteKind for the reason. Update this constant only when another
-    // intentional growth happens.
+    // The extra byte over the 40-byte WriteReq is the WriteKind tag.
     const testing = std.testing;
     try testing.expectEqual(@as(usize, 41), @sizeOf(Message));
 }

--- a/windows/Ghostty.Bench.EchoChild/Program.cs
+++ b/windows/Ghostty.Bench.EchoChild/Program.cs
@@ -1,17 +1,4 @@
-// Copies every byte arriving on stdin to stdout.
-// When stdin is a ConPTY terminal, switches to raw mode first so bytes
-// arrive immediately without conhost's line-buffering, then writes the
-// "RDY" ready sentinel so the parent (Ghostty.Bench) knows conhost's
-// VT preamble has been routed and raw mode is active before starting
-// to measure. When stdin is a direct pipe (DirectPipeTransport),
-// GetConsoleMode fails cleanly so we skip both steps and behave as a
-// plain byte-for-byte echo.
-//
-// Throughput probes require no active participation here: the terminator
-// travels through this raw-mode CopyTo byte-for-byte, and under ConPTY
-// conhost renders the trailing "~ENDOFBURST_<nonce>~" onto its screen
-// buffer and re-emits it on hOutput as part of the next refresh cycle.
-// No barrier-response logic lives in EchoChild.
+// Bench helper: copies stdin to stdout with explicit per-write flush.
 using System.Runtime.InteropServices;
 
 const uint STD_INPUT_HANDLE = unchecked((uint)-10);
@@ -59,15 +46,9 @@ try
     using var stdin = Console.OpenStandardInput();
     using var stdout = Console.OpenStandardOutput();
 
-    // Manual copy loop with an explicit Flush after each Write, rather than
-    // Stream.CopyTo. Under ConPTY, Console.OpenStandardOutput's stream can
-    // hold the final partial chunk of a large burst (e.g., the ~31-byte
-    // terminator after a 1 MB throughput payload) in an internal buffer
-    // until the next full block or process exit. That delays the parent's
-    // terminator observation past the probe's wall-clock budget. DirectPipe
-    // does not exhibit this because its anonymous pipe backing is unbuffered.
-    // 81920 is Stream.CopyTo's default buffer size; keep parity for round-
-    // trip throughput characteristics.
+    // Explicit Flush per write: ConPTY's stdout buffers partial chunks
+    // (e.g., the trailing terminator after a 1 MB payload) which would
+    // bench-falsely-positive as latency.
     byte[] buf = new byte[81920];
     int n;
     while ((n = stdin.Read(buf, 0, buf.Length)) > 0)

--- a/windows/Ghostty.Core/AssemblyAttributes.cs
+++ b/windows/Ghostty.Core/AssemblyAttributes.cs
@@ -5,12 +5,6 @@
 // later would silently bring back the runtime marshaller.
 [assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
 
-// #259 logging: the main WinUI shell (assembly name "Wintty") and
-// Ghostty.Tests both consume internal logging types defined here
-// (LogEvents constants, LoggingBootstrap, FilterState,
-// CapturingLoggerProvider). Both consumers already reference
-// Ghostty.Core via ProjectReference. The main-app assembly was
-// renamed from Ghostty to Wintty; this grant follows that rename.
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Wintty")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ghostty.Tests.Windows")]

--- a/windows/Ghostty.Core/Clipboard/IClipboardBackend.cs
+++ b/windows/Ghostty.Core/Clipboard/IClipboardBackend.cs
@@ -4,9 +4,8 @@ using System.Threading.Tasks;
 namespace Ghostty.Core.Clipboard;
 
 /// <summary>
-/// Abstracts the Windows clipboard so the service layer is unit-testable
-/// without WinUI. The production implementation lives in the WinUI
-/// project as WinUiClipboardBackend.
+/// Abstracts the Windows clipboard. The production implementation lives
+/// in the WinUI project as WinUiClipboardBackend.
 /// </summary>
 public interface IClipboardBackend
 {

--- a/windows/Ghostty.Core/Config/LegacyUiSettingsMigrator.cs
+++ b/windows/Ghostty.Core/Config/LegacyUiSettingsMigrator.cs
@@ -4,10 +4,7 @@ using System.Collections.Generic;
 namespace Ghostty.Core.Config;
 
 /// <summary>
-/// Pre-migration shape of ui-settings.json for the three fields
-/// being moved into the real config layer. Window placement is
-/// intentionally excluded -- that stays in the shim file (renamed
-/// to window-state.json by the next task).
+/// Shape of legacy ui-settings.json (no window placement).
 /// </summary>
 public sealed record LegacyUiSettingsPayload(
     bool VerticalTabs,

--- a/windows/Ghostty.Core/Config/WindowTransparencyState.cs
+++ b/windows/Ghostty.Core/Config/WindowTransparencyState.cs
@@ -6,11 +6,6 @@ namespace Ghostty.Core.Config;
 /// Pure-logic type that computes what window layers should do based on
 /// the background-opacity config value. No Win32 or WinUI dependencies
 /// so it can be unit-tested directly.
-///
-/// Not yet consumed by MainWindow -- this is scaffolding for issue #196
-/// (actual window transparency via HWND + DirectComposition). The type
-/// and its tests land here so the follow-up PR can wire it in without
-/// a large diff.
 /// </summary>
 public readonly struct WindowTransparencyState : IEquatable<WindowTransparencyState>
 {

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeyParsers.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeyParsers.cs
@@ -14,10 +14,7 @@ public static class WindowsOnlyKeyParsers
 {
     public static bool ParseBool(string? raw, bool defaultValue)
     {
-        // Accept only the canonical true/false spellings that ghostty's
-        // own parser writes and reads; 1/0 are tempting but would mean
-        // our accessors diverge from `ghostty +show-config` output and
-        // from the rest of the config ecosystem.
+        // Only canonical true/false; 1/0 would diverge from Ghostty's parser.
         if (string.IsNullOrWhiteSpace(raw)) return defaultValue;
         var trimmed = raw.Trim();
         if (trimmed.Equals("true", StringComparison.OrdinalIgnoreCase)) return true;

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -12,17 +12,6 @@ namespace Ghostty.Core.Config;
 /// reading the raw config file; this registry lets us suppress the
 /// false-positive diagnostics and surface the keys as informational
 /// instead.
-///
-/// This is also the single place to look when we eventually propose
-/// these keys upstream: each entry carries a short description and
-/// a pointer to where the runtime behavior lives.
-///
-/// When adding a new Windows-only key:
-/// 1. Add an entry here.
-/// 2. Make sure ConfigService reads it via GetFileValue (not through
-///    libghostty, which doesn't know about it).
-/// 3. If it's user-editable from the settings UI, also add it to
-///    SettingsIndex with an appropriate page/section.
 /// </summary>
 public static class WindowsOnlyKeys
 {

--- a/windows/Ghostty.Core/DirectWrite/DWriteFontEnumerator.cs
+++ b/windows/Ghostty.Core/DirectWrite/DWriteFontEnumerator.cs
@@ -1,16 +1,6 @@
-// Pure-logic DWrite font family enumeration shared between the
-// migrated AppearancePage code path (Ghostty WinUI 3 assembly)
-// and the equivalence test (Ghostty.Tests).
-//
-// EnumerateReference is the raw-vtable path, copied verbatim from
-// the pre-migration AppearancePage.EnumerateSystemFonts and kept
-// ONLY as the equivalence baseline. EnumerateMigrated (added in
-// Task 7 Step 3) is the CsWin32-generated path that production
-// AppearancePage will call.
-//
-// Do NOT delete EnumerateReference when the migration lands - it
-// guards against locale-selection or vtable-slot drift in future
-// revisions and is the anchor of DWriteFontFamilyEquivalenceTest.
+// DWrite font family enumeration. EnumerateReference (raw vtable) and
+// EnumerateMigrated (CsWin32) coexist as the equivalence test baseline
+// guarding against locale-selection or vtable-slot drift.
 
 using System;
 using System.Collections.Generic;
@@ -34,10 +24,9 @@ namespace Ghostty.Core.DirectWrite;
 public static class DWriteFontEnumerator
 {
     /// <summary>
-    /// Raw-vtable reference implementation. Kept verbatim from the
-    /// pre-migration AppearancePage code path as the equivalence
-    /// baseline for DWriteFontFamilyEquivalenceTest. Do not refactor
-    /// to use generated CsWin32 types.
+    /// Raw-vtable reference implementation. Equivalence baseline for
+    /// DWriteFontFamilyEquivalenceTest; do not refactor to use
+    /// generated CsWin32 types.
     /// </summary>
     public static unsafe List<string> EnumerateReference()
     {
@@ -94,7 +83,6 @@ public static class DWriteFontEnumerator
 
     private static unsafe string? GetFamilyNameReference(IntPtr familyPtr)
     {
-        // Locale index 0 matches the pre-migration behavior.
         var fvt = (IntPtr*)*(IntPtr*)familyPtr;
         IntPtr namesPtr;
         var getNames = (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)fvt[6];

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -2,12 +2,10 @@ namespace Ghostty.Core.Input;
 
 /// <summary>
 /// The vocabulary of shell-related actions a key binding can invoke.
-/// Covers panes (PR #163), tabs (PR 4), and profiles (PR 5).
-/// Routed through PaneActionRouter.Invoke in the WinUI assembly. Lives
-/// in Ghostty.Core so cross-platform unit tests in Ghostty.Tests can
-/// reference its values directly (KeyBindings and PaneActionRouter both
-/// stay in the Ghostty assembly because they depend on
-/// Windows.System.VirtualKey and on TabManager respectively).
+/// Routed through PaneActionRouter.Invoke in the WinUI assembly
+/// (KeyBindings and PaneActionRouter stay in the Ghostty assembly
+/// because they depend on Windows.System.VirtualKey and on TabManager
+/// respectively).
 ///
 /// Adding a new bindable action is two changes: add a value here,
 /// add a case in PaneActionRouter.Invoke. Bindings in KeyBindings can
@@ -18,7 +16,7 @@ public enum PaneAction
     // Pane operations (#163)
     SplitVertical = 0,
     SplitHorizontal = 1,
-    ClosePane = 2, // legacy: pane-only close, no chord points to it after tabs landed
+    ClosePane = 2,
     FocusLeft = 3,
     FocusRight = 4,
     FocusUp = 5,

--- a/windows/Ghostty.Core/Logging/CoreStaticLoggers.cs
+++ b/windows/Ghostty.Core/Logging/CoreStaticLoggers.cs
@@ -7,12 +7,10 @@ namespace Ghostty.Core.Logging;
 /// <summary>
 /// Static accessor for <see cref="ILogger{T}"/> instances used by
 /// Core types whose call sites are static methods or otherwise
-/// cannot receive a logger through a constructor argument.
-///
-/// Populated once from <c>App.OnLaunched</c> via
-/// <see cref="Initialize(ILoggerFactory)"/>. Before that call, all
-/// accessors return <see cref="NullLogger{T}"/>, so early / test
-/// call sites are safe no-ops.
+/// cannot receive a logger through a constructor argument. Before
+/// <see cref="Initialize(ILoggerFactory)"/> is called, all accessors
+/// return <see cref="NullLogger{T}"/>, so early / test call sites are
+/// safe no-ops.
 ///
 /// Tests should use <see cref="Install"/> instead of Initialize so
 /// the static state is restored to the pre-test NullLogger baseline

--- a/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
@@ -79,12 +79,6 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
     public ILogger CreateLogger(string categoryName)
         => new FileLogger(categoryName, this);
 
-    /// <summary>
-    /// Public writer entry so follow-up work (crash-log path convergence)
-    /// can drive records straight onto the channel without going through
-    /// <see cref="ILogger"/>. Not part of this PR's consumer surface;
-    /// kept public to avoid a breaking change when the follow-up lands.
-    /// </summary>
     public bool TryWrite(LogRecord record)
     {
         if (_writer.TryWrite(record))

--- a/windows/Ghostty.Core/Logging/IClock.cs
+++ b/windows/Ghostty.Core/Logging/IClock.cs
@@ -7,7 +7,7 @@ namespace Ghostty.Core.Logging;
 /// can control time. Production impl is <see cref="SystemClock"/>.
 /// Returns <see cref="DateTimeOffset"/> so callers that persist cache
 /// metadata (e.g. Profiles.DiscoveryCacheFile.CreatedAt) round-trip
-/// losslessly; legacy DateTime-consumers use <c>.UtcDateTime</c>.
+/// losslessly.
 /// </summary>
 internal interface IClock
 {

--- a/windows/Ghostty.Core/Logging/Testing/CapturingLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/Testing/CapturingLoggerProvider.cs
@@ -10,11 +10,6 @@ namespace Ghostty.Core.Logging.Testing;
 /// In-memory <see cref="ILoggerProvider"/> that captures every emitted
 /// entry. Used by contract tests to assert that a specific component
 /// emits a specific <see cref="EventId"/> on a given code path.
-///
-/// This is NOT a test stub - it is a real <see cref="ILoggerProvider"/>
-/// implementation. It lives in <c>Ghostty.Core</c> so both
-/// <c>Ghostty.Tests</c> and any future Core-referencing test project can
-/// use it without duplication.
 /// </summary>
 internal sealed class CapturingLoggerProvider : ILoggerProvider
 {

--- a/windows/Ghostty.Core/Panes/IPaneHost.cs
+++ b/windows/Ghostty.Core/Panes/IPaneHost.cs
@@ -6,10 +6,9 @@ namespace Ghostty.Core.Panes;
 
 /// <summary>
 /// Surface of <see cref="Ghostty.Panes.PaneHost"/> that
-/// <c>Ghostty.Core.Tabs.TabManager</c> consumes. Lives in
-/// <c>Ghostty.Core</c> so the test project can reference it
-/// without dragging in WinAppSDK. The concrete implementation
-/// (<c>Ghostty.Panes.PaneHost</c>) lives in the WinUI project.
+/// <c>Ghostty.Core.Tabs.TabManager</c> consumes. The concrete
+/// implementation (<c>Ghostty.Panes.PaneHost</c>) lives in the WinUI
+/// project.
 ///
 /// Adding members here means adding them to the production
 /// implementation AND any test fakes.
@@ -38,8 +37,7 @@ internal interface IPaneHost
     /// <summary>
     /// Split the active leaf with the given orientation. The new leaf
     /// becomes the active leaf. <paramref name="snapshot"/> is recorded
-    /// on the freshly-created leaf for future hot-apply (PR 6); when
-    /// null, this is the legacy keyboard-Split path with no profile.
+    /// on the freshly-created leaf.
     /// </summary>
     void Split(PaneOrientation orientation, ProfileSnapshot? snapshot);
 

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -22,12 +22,9 @@ internal sealed class LeafPane : PaneNode
     public object? Tag { get; set; }
 
     /// <summary>
-    /// Profile snapshot the leaf was created from. Null for leaves
-    /// created via the legacy no-profile keyboard-Split path
-    /// (<c>Alt+Shift+D</c>) and for the very first leaf in a
-    /// no-profiles-configured cold start. Read by PR 6 for hot-apply
-    /// of visual updates when <c>IProfileRegistry.ProfilesChanged</c>
-    /// fires.
+    /// Profile snapshot the leaf was created from. Null = legacy
+    /// keyboard-Split path (<c>Alt+Shift+D</c>) or the very first leaf
+    /// in a no-profiles-configured cold start.
     /// </summary>
     internal Ghostty.Core.Profiles.ProfileSnapshot? Snapshot { get; set; }
 }

--- a/windows/Ghostty.Core/Panes/PaneTree.cs
+++ b/windows/Ghostty.Core/Panes/PaneTree.cs
@@ -154,9 +154,8 @@ internal static class PaneTree
 
     /// <summary>
     /// Reset every <see cref="SplitPane.Ratio"/> in the tree to 0.5,
-    /// giving all leaves equal space. Mirrors upstream's
-    /// <c>equalize_splits</c> keybind (both Zig and Swift). No-op on
-    /// a single leaf.
+    /// giving all leaves equal space. No-op for parity with Zig/Swift
+    /// on a single leaf.
     /// </summary>
     public static void Equalize(PaneNode root)
     {

--- a/windows/Ghostty.Core/Profiles/DiscoveryService.cs
+++ b/windows/Ghostty.Core/Profiles/DiscoveryService.cs
@@ -34,7 +34,7 @@ internal sealed partial class DiscoveryService
     private readonly string? _cacheFilePath;
     private readonly ILogger<DiscoveryService> _log;
 
-    /// <summary>No-cache constructor used by Task 10 unit tests.</summary>
+    /// <summary>No-cache constructor.</summary>
     public DiscoveryService(
         IEnumerable<IInstalledShellProbe> probes,
         ILogger<DiscoveryService>? log = null)

--- a/windows/Ghostty.Core/Profiles/EffectiveVisualOverrides.cs
+++ b/windows/Ghostty.Core/Profiles/EffectiveVisualOverrides.cs
@@ -1,7 +1,7 @@
 namespace Ghostty.Core.Profiles;
 
 /// <summary>
-/// The five per-profile visual override keys (the "beta" set from the V1 design).
+/// The five per-profile visual override keys.
 /// All fields are optional; null means "inherit from base config".
 /// </summary>
 public sealed record EffectiveVisualOverrides(

--- a/windows/Ghostty.Core/Profiles/IProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/IProfileRegistry.cs
@@ -39,9 +39,8 @@ public interface IProfileRegistry : IDisposable
     string? DefaultProfileId { get; }
 
     /// <summary>
-    /// Monotonic counter bumped by 1 per successful recompose.
-    /// Exposed for <c>ProfileSnapshotStore</c> consumers that need a
-    /// generation id. Starts at 0 pre-ctor, reaches 1 after the ctor's
+    /// Monotonic counter for generation id. Bumped by 1 per successful
+    /// recompose. Starts at 0 pre-ctor, reaches 1 after the ctor's
     /// initial synchronous compose, reaches 2 after the first
     /// background discovery completes.
     /// </summary>

--- a/windows/Ghostty.Core/Profiles/ProfileSnapshotStore.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSnapshotStore.cs
@@ -5,9 +5,8 @@ namespace Ghostty.Core.Profiles;
 
 /// <summary>
 /// Builds and refreshes <see cref="ProfileSnapshot"/> instances for
-/// open tabs. Pure logic: per-tab storage of the snapshot belongs to
-/// <see cref="Ghostty.Core.Tabs.TabModel"/>. This type only knows how
-/// to derive snapshots from resolved profiles.
+/// open tabs. Derives snapshots from resolved profiles; per-tab
+/// storage lives on <see cref="Ghostty.Core.Tabs.TabModel"/>.
 /// </summary>
 public static class ProfileSnapshotStore
 {

--- a/windows/Ghostty.Core/Profiles/Win32IconExtractor.cs
+++ b/windows/Ghostty.Core/Profiles/Win32IconExtractor.cs
@@ -48,9 +48,7 @@ internal static class Win32IconExtractor
     // System.Drawing.Common package. Trimming/AOT analyzers flag the
     // Icon.FromHandle -> Bitmap -> PNG-encode chain because GDI+
     // registration uses reflection; the suppressions below keep the
-    // warnings local to this path. Phase 2 should swap this for a
-    // direct GetIconInfo + WIC encoder path and drop the dependency.
-    // TODO: Phase 2 - migrate to direct WIC encoder to drop System.Drawing.Common.
+    // warnings local to this path.
 #pragma warning disable IL2026, IL3050, CA1416
     // Must be unsafe: HICON.Value is a void* (CsWin32-generated), so the
     // cast to IntPtr for Icon.FromHandle is a pointer-to-nint conversion.

--- a/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
@@ -14,10 +14,6 @@ namespace Ghostty.Core.Profiles;
 /// %LOCALAPPDATA%\Wintty\IconCache\&lt;sha&gt;.png; subsequent resolves
 /// read from disk rather than recomputing. Unknown bundled keys fall
 /// back to the "default" bundled asset.
-///
-/// Task 15 implements Path and BundledKey. AutoForExe (Task 16),
-/// Mdl2Token (Task 16), and AutoForWslDistro (Task 17) are added
-/// incrementally.
 /// </summary>
 internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
 {
@@ -55,23 +51,14 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
     {
         IconSpec.Path p => await fs.ReadAllBytesAsync(p.FilePath, ct).ConfigureAwait(false),
         IconSpec.BundledKey b => ReadBundledOrDefault(b.Key),
-        // Phase 2: DirectWrite rasterization of the Segoe Fluent Icons /
-        // Segoe MDL2 Assets glyph. For V1 scope we return the default
-        // bundled asset so the UI still gets a usable 16x16 PNG.
         IconSpec.Mdl2Token => ReadBundledOrDefault(DefaultBundledKey),
         IconSpec.AutoForExe a => ExtractExeIconAsPng(a.ExePath),
-        // V1: per-distro icon extraction from appx/WSLg is out of scope. Always
-        // fall back to bundled "wsl" - keeps the UI consistent and the cache
-        // bounded. Phase 2 can introduce a WSLg lookup that keys on DistroName.
         IconSpec.AutoForWslDistro => ReadBundledOrDefault("wsl"),
         _ => ReadBundledOrDefault(DefaultBundledKey),
     };
 
-    // Win32 icon extraction lives behind OperatingSystem.IsWindows() so
-    // the non-Windows build graph still compiles WindowsIconResolver.
-    // Any SHGetFileInfoW / GDI failure silently falls back to the default
-    // bundled icon rather than surfacing the exception - icon resolution
-    // is best-effort and must never fail a profile resolve.
+    // Best-effort: any SHGetFileInfoW / GDI failure falls back to the
+    // default bundled icon rather than failing a profile resolve.
     private static byte[] ExtractExeIconAsPng(string exePath)
     {
         // IsWindowsVersionAtLeast (not bare IsWindows) satisfies CA1416's
@@ -114,8 +101,7 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         // like "exe:C:\\Foo.exe" and "exe:c:\\foo.exe" currently hash
         // to different SHAs and produce duplicate cache entries for
         // the same underlying file. Acceptable for Path (user-supplied,
-        // round-trips verbatim); Task 16's AutoForExe should normalize
-        // before hitting this token when it lands.
+        // round-trips verbatim).
         var baseToken = spec switch
         {
             IconSpec.Path p => "path:" + p.FilePath,
@@ -152,9 +138,6 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         catch { /* best-effort */ }
     }
 
-    // The ".png" suffix here is nominal - it's a cache identifier, not a
-    // content-type claim. For IconSpec.Path entries pointing at .ico/.jpg
-    // sources, the cached bytes mirror the source file verbatim.
     private string? CachePathFor(string sha)
     {
         var local = fs.GetKnownFolder(KnownFolderId.LocalAppData);

--- a/windows/Ghostty.Core/Settings/SettingsEntry.cs
+++ b/windows/Ghostty.Core/Settings/SettingsEntry.cs
@@ -1,9 +1,7 @@
 namespace Ghostty.Core.Settings;
 
 /// <summary>
-/// Shape of a settings control. Used by the future search overlay
-/// to render result rows inline. Phase 1 only needs the values to
-/// exist in the index; no rendering logic consumes this yet.
+/// Shape of a settings control.
 /// </summary>
 public enum SettingType
 {

--- a/windows/Ghostty.Core/Shell/AcrylicTintResolver.cs
+++ b/windows/Ghostty.Core/Shell/AcrylicTintResolver.cs
@@ -3,8 +3,8 @@ namespace Ghostty.Core.Shell;
 /// <summary>
 /// Pure resolver for acrylic tint + opacity tuning. When the tint
 /// color override is unset the resolver falls back to the terminal
-/// theme background, so the window inherits the active theme look
-/// instead of washing out to transparent black (issue # 324).
+/// theme background so the window inherits the active theme look
+/// instead of washing out to transparent black.
 ///
 /// Opacity values track <c>background-blur-follows-opacity</c>: when
 /// enabled both tint and luminosity opacity are slaved to the window

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -10,8 +10,7 @@ namespace Ghostty.Core.Tabs;
 /// <summary>
 /// Owns the list of <see cref="TabModel"/>s for one window. All
 /// operations on tabs (create, close, activate, move, navigate) go
-/// through here. Pure C#, no WinUI references — lives in
-/// Ghostty.Core so the test project consumes it directly.
+/// through here.
 ///
 /// PaneHost construction is injected via a factory delegate so the
 /// test project can supply <c>FakePaneHost</c>. The real call site
@@ -66,9 +65,8 @@ internal sealed class TabManager
         : this(paneHostFactory, seed: null) { }
 
     /// <summary>
-    /// Seeded constructor. If <paramref name="seed"/> is non-null the
-    /// manager adopts it as its initial tab and skips the factory call.
-    /// If <paramref name="seed"/> is null the legacy path runs.
+    /// Non-null <paramref name="seed"/> is adopted as the initial tab
+    /// (factory call is skipped); null falls through to the factory.
     ///
     /// Seeded construction does NOT raise <see cref="TabAdded"/> for
     /// the seed: it is the initial tab, and TabAdded is for growth.

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -23,8 +23,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     public IPaneHost PaneHost { get; }
 
     /// <summary>Profile id, set when this tab was created from a
-    /// jump-list profile or context-menu duplicate. Null today
-    /// because the config layer does not exist; reserved for plan 3.</summary>
+    /// jump-list profile or context-menu duplicate.</summary>
     public string? ProfileId { get; set; }
 
     /// <summary>
@@ -34,10 +33,6 @@ internal sealed class TabModel : INotifyPropertyChanged
     /// creation by <see cref="TabManager.NewTab(ProfileSnapshot?)"/>
     /// <b>before</b> <see cref="TabManager.TabAdded"/> fires; downstream
     /// listeners can read it synchronously.
-    ///
-    /// PR 6 will replace the once-only setter with a hot-apply path
-    /// that calls <see cref="ProfileSnapshotStore.Refresh"/> when
-    /// <c>IProfileRegistry.ProfilesChanged</c> fires.
     /// </summary>
     public ProfileSnapshot? ProfileSnapshot { get; private set; }
 

--- a/windows/Ghostty.Core/Tabs/TabProgressState.cs
+++ b/windows/Ghostty.Core/Tabs/TabProgressState.cs
@@ -4,10 +4,6 @@ namespace Ghostty.Core.Tabs;
 /// OSC 9;4 progress state mapped 1:1 onto the discriminated cases
 /// libghostty surfaces report. The percent value is meaningless for
 /// <see cref="Kind.None"/> and <see cref="Kind.Indeterminate"/>.
-///
-/// Pure-logic record (no WinUI types): consumed by the per-tab inline
-/// indicator in <c>TabHost</c> and by the <c>TaskbarProgressCoordinator</c>
-/// introduced in plan 4.
 /// </summary>
 internal readonly record struct TabProgressState(TabProgressState.Kind State, int Percent)
 {

--- a/windows/Ghostty.Tests/Bench/ConPtyTransportTests.cs
+++ b/windows/Ghostty.Tests/Bench/ConPtyTransportTests.cs
@@ -6,26 +6,10 @@ namespace Ghostty.Tests.Bench;
 
 public class ConPtyTransportTests
 {
-    // Regression test for UpdateProcThreadAttribute lpValue marshalling.
-    //
-    // Before the audit fix, cmd.exe and a bare-C kernel32 child both
-    // produced zero output through this transport -- conhost never
-    // routed anything to the read-side pipe because the kernel stored
-    // a pointer to a transient stack slot as the HPCON instead of the
-    // HPCON value itself.
-    //
-    // After the fix, any ConPTY child triggers conhost to emit its VT
-    // preamble (cursor-hide, focus-tracking mode sets, etc.) within a
-    // few hundred milliseconds of spawn. Receiving any output at all is
-    // sufficient to prove the marshalling is correct.
-    //
-    // This test deliberately does NOT assert on stdin-roundtrip content:
-    // conhost sits between us and the child, applies line-buffering and
-    // VT key translation on the input side, and VT screen rendering on
-    // the output side, so byte-for-byte echo is not the right unit of
-    // assertion for a ConPTY transport regression guard.
-    //
-    // Hard-timed to 10s so a reintroduction of the hang fails CI fast.
+    // No byte-for-byte stdin assertion: conhost line-buffers input, VT-
+    // translates keys, and renders output as a screen, so echo symmetry
+    // is not the right contract for a ConPTY regression guard.
+    // 10s timeout: hang reintroduction must fail CI fast.
     [SupportedOSPlatform("windows")]
     [Fact(Timeout = 10_000)]
     public async Task Transport_DeliversConhostOutputWithinSeconds()
@@ -55,18 +39,4 @@ public class ConPtyTransportTests
 
         Assert.True(bytesRead > 0, "ConPtyTransport output pipe EOF'd before conhost sent its VT preamble");
     }
-
-    // Note: WaitReady end-to-end validation is NOT a xunit integration test.
-    // Under `dotnet test`'s testhost-spawned parent, the child's stdio
-    // does not attach to the pseudo-console the same way as under a
-    // `dotnet run` invocation from a native Windows console terminal, so
-    // EchoChild's GetConsoleMode check returns false and the "RDY" sentinel
-    // is never emitted. This is a context-specific property of the Windows
-    // console subsystem, not a bug in WaitReady or EchoChild. End-to-end
-    // coverage for the handshake lives in the manual validation step
-    // documented in the PR: run `dotnet run --project dist/windows/Bench/
-    // Ghostty.Bench -- conpty-roundtrip` from a real PowerShell terminal
-    // (Windows Terminal or pwsh.exe) and confirm valid JSON output. Unit-
-    // level coverage of the WaitReady drain logic lives in HarnessTests
-    // via FakeTransport.
 }

--- a/windows/Ghostty.Tests/Bench/DirectPipeTransportTests.cs
+++ b/windows/Ghostty.Tests/Bench/DirectPipeTransportTests.cs
@@ -7,9 +7,7 @@ namespace Ghostty.Tests.Bench;
 
 public class DirectPipeTransportTests
 {
-    // DirectPipe has no conhost-style preamble to drain, so WaitReady must
-    // return immediately. This test pins the no-op contract so a future
-    // change to DirectPipe cannot silently add latency to every probe.
+    // DirectPipe has no preamble to drain; WaitReady must be a no-op.
     [SupportedOSPlatform("windows")]
     [Fact(Timeout = 10_000)]
     public async Task WaitReady_IsNoop()
@@ -19,20 +17,6 @@ public class DirectPipeTransportTests
 
         using var transport = new DirectPipeTransport(childPath);
 
-        // Pass a non-zero timeout AND assert wall-clock under a tight
-        // ceiling. A zero-timeout passes any implementation that doesn't
-        // poll-then-throw on first tick; a stopwatch ceiling catches
-        // "added a Thread.Sleep" or "drained N bytes" regressions even
-        // when the implementation respects the timeout.
-        //
-        // The stopwatch is started INSIDE the Task.Run lambda so we
-        // measure WaitReady's wall-clock, not the thread-pool scheduling
-        // latency of Task.Run itself (which can spike to 50ms+ when the
-        // pool is saturated by parallel xunit test runs). 20ms is enough
-        // headroom for cold-cache jitter while still being an order of
-        // magnitude under any realistic non-no-op latency.
-        // Wrapped in Task.Run to satisfy xunit 2.9's requirement that
-        // [Fact(Timeout)] tests be async, matching ConPtyTransportTests.
         long elapsedMs = await Task.Run(() =>
         {
             var sw = Stopwatch.StartNew();

--- a/windows/Ghostty.Tests/Bench/FakeTransport.cs
+++ b/windows/Ghostty.Tests/Bench/FakeTransport.cs
@@ -5,27 +5,13 @@ namespace Ghostty.Tests.Bench;
 
 public enum FakeTransportMode
 {
-    // Existing behavior: every byte written to Input is copied back on
-    // Output. Used by HarnessTests that exercise Harness.RunRoundTrip
-    // against a trivial loopback so byte-for-byte symmetry holds.
     Echo,
-
-    // Scripted: each input write from the harness causes the scripted
-    // emitter to enqueue a caller-supplied response sequence. Used by
-    // HarnessTests that need to assert sentinel-scan behavior against
-    // VT-like noise patterns.
     Scripted,
 }
 
-// In-process ITransport used by HarnessTests. Defaults to echo mode for
-// backward compat with the existing tests. Scripted mode lets callers
-// simulate conhost's "VT noise plus sentinel" output shape without
-// spawning a real child.
-//
-// Uses two named pipes with unique GUIDs so we get clean in-process
-// semantics without the handle-ownership complications of anonymous
-// pipes (DisposeLocalCopyOfClientHandle is only safe after a real
-// fork; in-process it closes the only reader/writer and breaks IO).
+// Uses two named pipes with unique GUIDs for clean in-process semantics:
+// anonymous pipes' DisposeLocalCopyOfClientHandle is only safe after a
+// real fork, so in-process it would close the only reader/writer.
 public sealed class FakeTransport : ITransport
 {
     private readonly NamedPipeServerStream _inputServer;
@@ -40,17 +26,8 @@ public sealed class FakeTransport : ITransport
 
     public int DisposeCount => Volatile.Read(ref _disposed);
 
-    // Echo-mode constructor. Preserves the original behavior: every write
-    // to Input is copied verbatim to Output. Existing HarnessTests rely
-    // on this; don't change its semantics.
     public FakeTransport() : this(FakeTransportMode.Echo, scriptedResponder: null) { }
 
-    // Scripted-mode constructor. `scriptedResponder` is called once per
-    // input write chunk read from the pipe. If it returns a byte buffer,
-    // that buffer is written to Output. If it returns null, the Output
-    // stream is closed (emulating child death / EOF). This is the hook
-    // HarnessTests uses to feed SentinelRoundTrip hand-crafted VT noise
-    // plus sentinel bytes.
     public FakeTransport(Func<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>?> scriptedResponder)
         : this(FakeTransportMode.Scripted, scriptedResponder) { }
 
@@ -58,9 +35,6 @@ public sealed class FakeTransport : ITransport
     {
         if (mode == FakeTransportMode.Scripted)
         {
-            // Defense-in-depth: the public scripted ctor already requires a
-            // non-null responder at the call site, but validate again here so
-            // the IoLoop can call the responder without a null-forgiving operator.
             ArgumentNullException.ThrowIfNull(scriptedResponder);
         }
         _mode = mode;

--- a/windows/Ghostty.Tests/Bench/HarnessTests.cs
+++ b/windows/Ghostty.Tests/Bench/HarnessTests.cs
@@ -201,9 +201,7 @@ public class HarnessTests
         });
         byte[] scratch = new byte[64 * 1024];
 
-        // Harness converts the internal OCE from the cancelled ReadAsync
-        // into TimeoutException. Asserting the strict type catches a
-        // regression if the conversion ever silently leaks.
+        // Strict-type assert pins the OCE -> TimeoutException conversion.
         Assert.Throws<TimeoutException>(() =>
             Runner.RunThroughputIteration(
                 t, payload, terminator, TimeSpan.FromMilliseconds(250), scratch));

--- a/windows/Ghostty.Tests/Bench/PayloadsTests.cs
+++ b/windows/Ghostty.Tests/Bench/PayloadsTests.cs
@@ -35,10 +35,8 @@ public class PayloadsTests
     [Fact]
     public void Sgr_ContainsAtLeastFiftyThousandRedSgrSequences()
     {
-        // The SGR chunk is "\x1b[31mhello\x1b[0m " = 15 bytes. 1 MB / 15
-        // = ~69 905 introducers; 50 000 is a comfortable floor that still
-        // detects accidental factory changes (e.g., a payload switch that
-        // dropped the SGR pattern entirely).
+        // SGR chunk is 15 bytes -> 1 MB / 15 ~= 69 905 introducers.
+        // 50 000 floor catches accidental factory changes.
         var p = Payloads.Sgr1Mb().Span;
         int count = 0;
         ReadOnlySpan<byte> needle = [0x1b, (byte)'[', (byte)'3', (byte)'1', (byte)'m'];
@@ -90,11 +88,6 @@ public class PayloadsTests
         Assert.Equal(a.Span.Slice(0, 1024).ToArray(), b.Span.Slice(0, 1024).ToArray());
     }
 
-    // The throughput probe appends a "\r\n~ENDOFBURST_<nonce>~" terminator
-    // after the payload and scans conhost's emitted VT stream for it. If a
-    // payload factory ever emitted the literal "~ENDOFBURST_" substring,
-    // the probe could false-match mid-payload and stop the measurement
-    // early. This test pins the invariant so new payloads must preserve it.
     [Fact]
     public void Payloads_DoNotContainTerminatorPrefix()
     {

--- a/windows/Ghostty.Tests/Bench/ThroughputProbeTests.cs
+++ b/windows/Ghostty.Tests/Bench/ThroughputProbeTests.cs
@@ -8,9 +8,8 @@ namespace Ghostty.Tests.Bench;
 
 public class ThroughputProbeTests
 {
-    // Each iteration must use a distinct nonce. Guards against leftover-
-    // match false positives under ConPTY where a prior iteration's
-    // terminator can linger in conhost's screen buffer.
+    // Distinct nonce per iteration: leftover bytes in conhost's screen
+    // buffer would otherwise match the next iteration's terminator.
     [Fact]
     public void ThroughputProbe_RegeneratesNoncePerIteration()
     {
@@ -29,12 +28,6 @@ public class ThroughputProbeTests
         var host = new HostInfo("Windows", "26200", "Test CPU", "x64", "10.0.0", "inbox");
         probe.Run(t, host, DateTime.UtcNow);
 
-        // Scan every captured write for terminator occurrences and collect
-        // the nonces. The probe writes payload and terminator as two separate
-        // Input.Write calls; depending on FakeTransport pipe scheduling the
-        // server-side IoLoop may read them as one or two chunks per iteration.
-        // Either way the terminator prefix lands in some captured write, and
-        // three iterations must produce three distinct nonces.
         var nonces = new HashSet<string>();
         byte[] prefix = Encoding.ASCII.GetBytes("\r\n~ENDOFBURST_");
         foreach (byte[] w in capturedWrites)
@@ -47,9 +40,6 @@ public class ThroughputProbeTests
         Assert.Equal(3, nonces.Count);
     }
 
-    // The probe must report both ingest and emit numbers. Under echo mode,
-    // ingest and emit differ only by terminator overhead (~31 bytes out of
-    // 65 536), so they are approximately equal.
     [Fact]
     public void ThroughputProbe_ReportsBothIngestAndEmitMetrics()
     {
@@ -77,9 +67,8 @@ public class ThroughputProbeTests
         Assert.InRange(ratio, 0.95, 1.10);
     }
 
-    // The probe must write payload first, then terminator. Scripted
-    // responder captures all input writes and the assertion validates the
-    // byte order.
+    // Payload-then-terminator order: throughput attribution depends on
+    // the terminator landing strictly after the measured payload bytes.
     [Fact]
     public void ThroughputProbe_WritesPayloadThenTerminator()
     {

--- a/windows/Ghostty.Tests/Config/ConfigWriteSchedulerTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigWriteSchedulerTests.cs
@@ -70,8 +70,6 @@ public class ConfigWriteSchedulerTests
         scheduler.Schedule("command-palette-background", "mica");
         scheduler.Schedule("vertical-tabs", "false");
 
-        // Every Schedule call must rearm the debounce timer so a
-        // steady trickle of writes still flushes at the tail end.
         Assert.Equal(3, timer.ScheduleCount);
 
         timer.Fire();
@@ -90,8 +88,7 @@ public class ConfigWriteSchedulerTests
             editor, timer, TimeSpan.FromMilliseconds(100), () => { },
             NullLogger<ConfigWriteScheduler>.Instance);
 
-        // Ghostty's config parser is case-insensitive, so the two
-        // spellings must land on the same pending entry with last-wins.
+        // Case-insensitive: two spellings must collapse to last-wins.
         scheduler.Schedule("vertical-tabs", "true");
         scheduler.Schedule("Vertical-Tabs", "false");
         timer.Fire();
@@ -113,10 +110,7 @@ public class ConfigWriteSchedulerTests
         scheduler.Schedule("vertical-tabs", "true");
         scheduler.Dispose();
 
-        // Disk write happens so persistence is not lost on shutdown,
-        // but onFlushed MUST NOT fire: the app-shutdown handler would
-        // enqueue a reload that runs after the bootstrap host has
-        // already freed the ghostty app (use-after-free).
+        // No flush after shutdown -- would UAF the freed ghostty app.
         Assert.Single(editor.Writes);
         Assert.Equal(0, onFlush);
     }

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -65,13 +65,6 @@ public class WindowsOnlyKeysTests
         Assert.Equal(expected, key);
     }
 
-    // Zig's Diagnostic.format emits "cli:IDX: unknown field" (no key
-    // segment, just a space before the message) when the diagnostic
-    // has a location but no key. TryExtract still matches because the
-    // suffix is present; it returns whatever sits before the suffix,
-    // which for this shape is the line number. That's fine: the line
-    // number isn't in WindowsOnlyKeys.Set, so the caller falls through
-    // to the regular diagnostics list. This test pins that behavior.
     [Fact]
     public void TryExtractUnknownFieldKey_EmptyKeyFormat_YieldsNonMatchingToken()
     {

--- a/windows/Ghostty.Tests/Interop/DWriteFontFamilyEquivalenceTest.cs
+++ b/windows/Ghostty.Tests/Interop/DWriteFontFamilyEquivalenceTest.cs
@@ -1,9 +1,3 @@
-// Equivalence test: reference raw-vtable path (baseline) vs
-// migrated CsWin32 path (production). Fails if the two lists
-// diverge in ANY family name, which catches locale-index drift,
-// vtable-slot mistakes, and PWSTR truncation bugs that a weak
-// "Count > 20" sanity test would silently miss.
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,10 +7,7 @@ using Xunit;
 
 namespace Ghostty.Tests.Interop;
 
-// Ghostty.Tests targets plain net9.0; DWriteFontEnumerator is
-// marked [SupportedOSPlatform("windows10.0.17763")]. This test only
-// runs on Windows hosts in CI/local, so propagate the platform gate
-// here too instead of suppressing CA1416 globally.
+// Propagate the DWriteFontEnumerator platform gate instead of suppressing CA1416.
 [SupportedOSPlatform("windows10.0.17763")]
 public sealed class DWriteFontFamilyEquivalenceTest
 {

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -4,21 +4,10 @@ using Xunit;
 
 namespace Ghostty.Tests.Interop;
 
-// Pins the ordinal values and struct layouts of the ghostty_action_*
-// subset the Windows apprt dispatches on. If any of these drift away
-// from include/ghostty.h, CI fails here instead of users seeing a
-// silently-misrouted action at runtime.
-//
-// When libghostty rebases and these break, re-verify against
-// include/ghostty.h:
-//   grep -n GHOSTTY_ACTION_ include/ghostty.h | \
-//     grep -nE 'SCROLLBAR|SET_TITLE|CLOSE_WINDOW|RING_BELL|PROGRESS_REPORT'
-// then update the constants in Ghostty.Core/Interop/GhosttyActions.cs.
+// Pins ghostty_action_* ordinals and struct layouts (FFI ABI with include/ghostty.h).
 public class GhosttyActionsLayoutTests
 {
-    // Parameters are typed as `int` (not the enum) so the public test
-    // method doesn't leak the now-internal enum type across its public
-    // signature — xUnit requires test classes to be public.
+    // int (not enum) parameter: xUnit needs public test class, internal enum can't leak.
     [Theory]
     [InlineData((int)GhosttyActionTag.Scrollbar, 26)]
     [InlineData((int)GhosttyActionTag.SetTitle, 32)]

--- a/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
+++ b/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
@@ -7,28 +7,8 @@ using Xunit;
 
 namespace Ghostty.Tests.Interop;
 
-// Guardrail for PR 203's DisableRuntimeMarshalling convention. The
-// Ghostty assembly carries [assembly: DisableRuntimeMarshalling], and
-// the two-BOOL-shape convention (byte for libghostty C99 _Bool, int
-// for Win32 BOOL) means no [LibraryImport] or [UnmanagedFunctionPointer]
-// signature in NativeMethods.cs should carry a [MarshalAs(...)] hint.
-//
-// The Ghostty project is a WinAppSDK project; this test project is
-// plain net9.0 and cannot reference it. NativeMethods.cs is embedded
-// as a manifest resource via <EmbeddedResource Link=...> in
-// Ghostty.Tests.csproj so this test can read it without a project
-// reference.
-//
-// Scanner rule: strip trailing `//` line comments before scanning, so
-// that explanatory comments like `// [MarshalAs] was removed here`
-// do NOT false-positive. The scanner does NOT strip `/* ... */` block
-// comments; the project convention in NativeMethods.cs is line
-// comments only, and adding a block-comment stripper would add state
-// to the scanner without a matching benefit.
-//
-// When this test fails: either the convention is being reintroduced
-// (fix the signature), or the convention intentionally moved (update
-// this test).
+// Pins that every P/Invoke surface honors [assembly: DisableRuntimeMarshalling]
+// (no [MarshalAs], two-BOOL-shape: byte for libghostty _Bool, int for Win32 BOOL).
 public class MarshalComplianceTests
 {
     private const string ResourceName = "Ghostty.Tests.Interop.NativeMethods.cs";
@@ -135,23 +115,8 @@ public class MarshalComplianceTests
         Assert.Contains("Flagged", tokenHits[0].Text);
     }
 
-    // Strip trailing `//` line comments from each source line before
-    // searching, so commentary like `// [MarshalAs] was removed here`
-    // does not trigger a false positive. The cheapest correct
-    // implementation: look for the first `//` and take the prefix.
-    // This is NOT a full C# tokenizer: it does not understand string
-    // literals containing `//`, but NativeMethods.cs has no such
-    // lines today and adding one would be obviously wrong anyway.
-    //
-    // PR 202 allowlist: lines that reference a Windows.Win32.* type
-    // are CsWin32-generated boundaries where BOOL is the strongly-
-    // typed Windows.Win32.Foundation.BOOL struct (4 bytes, implicit
-    // bool conversion). The two BOOL conventions coexist by scope:
-    // hand-written [LibraryImport] uses int + != 0 (PR 203), CsWin32
-    // call sites use BOOL via implicit conversion. Today this scanner
-    // only reads NativeMethods.cs (libghostty surface, no CsWin32),
-    // so the rule is a future-proofing measure for if/when the scan
-    // scope ever widens to other interop files.
+    // Allowlist: lines referencing Windows.Win32.* (CsWin32 boundary, marshalling
+    // already enforced upstream).
     private static bool IsCsWin32Boundary(string strippedLine)
         => strippedLine.Contains("Windows.Win32.", StringComparison.Ordinal);
 

--- a/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
+++ b/windows/Ghostty.Tests/Logging/LoggingBootstrapTests.cs
@@ -90,11 +90,6 @@ public class LoggingBootstrapTests
         Assert.Equal("Ghostty.Core", opts.Rules[0].CategoryName);
     }
 
-    // Regression: proves the live-reload filter swap actually takes
-    // effect on subsequent log calls. MEL caches per-(provider, category)
-    // thresholds internally; the filter delegate closed over FilterState
-    // must be consulted on every log call (not just once at builder
-    // time), otherwise ApplyFilters is a no-op in practice.
     [Fact]
     public void ApplyFilters_SwappingInPlace_AppliesToSubsequentLogCalls()
     {
@@ -128,7 +123,6 @@ public class LoggingBootstrapTests
         Assert.Equal("warning-after-swap", entries[0].Message);
     }
 
-    // Regression: per-category filter rules must also live-swap.
     [Fact]
     public void ApplyFilters_AddingPerCategoryOverride_AppliesToSubsequentLogCalls()
     {

--- a/windows/Ghostty.Tests/Profiles/FakeProfileRegistry.cs
+++ b/windows/Ghostty.Tests/Profiles/FakeProfileRegistry.cs
@@ -34,13 +34,6 @@ internal sealed class FakeProfileRegistry : IProfileRegistry
 
     public void Dispose() { }
 
-    /// <summary>
-    /// Test-only helper: replace the profile list (and optionally the
-    /// hidden list), bump <see cref="Version"/>, and fire
-    /// <see cref="ProfilesChanged"/> synchronously (mimicking the
-    /// production UI-dispatch shape from the perspective of a
-    /// single-threaded test).
-    /// </summary>
     public void SetProfiles(
         IReadOnlyList<ResolvedProfile> profiles,
         IReadOnlyList<ResolvedProfile>? hidden = null,
@@ -53,12 +46,7 @@ internal sealed class FakeProfileRegistry : IProfileRegistry
         ProfilesChanged?.Invoke(this);
     }
 
-    /// <summary>
-    /// Convenience: build N profiles named "p1".."pN" with default
-    /// everything else. p1 is marked default and OrderIndex follows
-    /// declaration order. Used by command-palette / keybinding tests
-    /// that only care about the count + ids.
-    /// </summary>
+    /// <summary>Build N profiles "p1".."pN", p1 default, OrderIndex by declaration.</summary>
     public static List<ResolvedProfile> BuildN(int count)
     {
         var list = new List<ResolvedProfile>(count);

--- a/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
@@ -7,14 +7,7 @@ namespace Ghostty.Tests.Settings;
 
 public class SettingsIndexTests
 {
-    // Every config key the settings UI currently edits must have an
-    // index entry. This test is the forcing function: when a new
-    // page handler calls OnValueChanged("some-key", ...), we want
-    // the build to remind the author to register the key here.
-    //
-    // Keys come from hand-inspecting the existing Pages/*.xaml.cs
-    // files as of 2026-04-14. When new config keys are wired up,
-    // add them to this list AND to SettingsIndex.
+    // SettingsIndex must cover every config key the settings UI edits.
     private static readonly string[] ExpectedKeys =
     {
         // General

--- a/windows/Ghostty.Tests/Settings/SettingsSearchTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsSearchTests.cs
@@ -7,14 +7,7 @@ namespace Ghostty.Tests.Settings;
 
 public class SettingsSearchTests
 {
-    // Match tiers, best → worst, per Phase 3 spec
-    // (docs/superpowers/specs/2026-04-14-settings-reorganization-design.md#matching):
-    //   1. ExactLabel        2. LabelPrefix      3. LabelContains
-    //   4. DescriptionContains  5. TagExact      6. TagContains
-    //   7. FuzzyKey
-    //
-    // Tests use tiny per-test corpora so each assertion isolates one
-    // tier boundary without accidental cross-field hits.
+    // Tests cover each match tier in isolation.
 
     private static SettingsEntry Make(
         string key,

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -27,28 +27,7 @@ namespace Ghostty;
 /// </summary>
 public partial class App : Application
 {
-    // -- Option (b) hoist: process-global libghostty ownership. --
-    //
-    // Single ghostty_app_t across all top-level windows. The bootstrap
-    // GhosttyHost owns the runtime callback function pointers libghostty
-    // was given in AppNew, so it must stay alive until the last window
-    // closes. Every MainWindow builds its own per-window GhosttyHost
-    // with its own per-window _surfaces dictionary.
-    //
-    // Dispose order at shutdown (OnAnyWindowClosedInternal handler):
-    //   1. Per-window host for the closing window disposes first, as
-    //      part of MainWindow.OnClosed, and removes itself from
-    //      _hostBySurface via GhosttyHost.Dispose -> UnregisterHostSurfaces.
-    //   2. When WindowsByRoot is empty, bootstrap host disposes: it
-    //      calls AppFree (its HostLifetimeState.OwnsApp is true).
-    //   3. ConfigService disposal is handled by process exit.
-    // Instance fields for the App's own lifecycle (assigned in
-    // OnLaunched, cleared in OnAnyWindowClosedInternal). The matching
-    // static properties below expose the same references to types
-    // (MainWindow, GhosttyHost) that do not hold a reference to the
-    // App instance. WinUI 3's Application is a process singleton so
-    // both always agree; the duplication is the lesser evil compared
-    // to casting Application.Current everywhere.
+    // Process-global libghostty: bootstrap host owns the app handle; per-window hosts own only their surfaces.
     private ConfigService? _configService;
     private ConfigFileEditor? _configEditor;
     private ConfigWriteScheduler? _configWriteScheduler;
@@ -370,11 +349,10 @@ public partial class App : Application
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
         ConfigService = _configService;
 
-        // #259 logging: build the factory from Ghostty config before any
-        // other service constructs an ILogger<T>. Log directory under the
-        // same %LOCALAPPDATA%\Ghostty root that App.LogUnhandled already
-        // uses for crash.log, so a user reporting a bug only has one
-        // folder to attach.
+        // build the factory from Ghostty config before any other service constructs an
+        // ILogger<T>. Log directory under the same %LOCALAPPDATA%\Ghostty root that
+        // App.LogUnhandled already uses for crash.log, so a user reporting a bug only has
+        // one folder to attach.
         var logDir = System.IO.Path.Combine(
             System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
             "Ghostty", "logs");
@@ -395,15 +373,14 @@ public partial class App : Application
             factory, new Ghostty.Logging.LibghosttyLogInstaller());
         _zigLogBridge.Install();
 
-        // #259 logging: populate Core-side static logger accessors
-        // for types whose call sites are static (e.g., FrecencyStore
-        // static methods that can't take a ctor-injected logger).
+        // populate Core-side static logger accessors for types whose call sites are
+        // static (e.g., FrecencyStore static methods that can't take a ctor-injected
+        // logger).
         Ghostty.Core.Logging.CoreStaticLoggers.Initialize(factory);
 
-        // #259 logging: populate Ghostty-project static logger accessors
-        // for types that construct before ctor-injection is possible
-        // (e.g., ConfigService is built above BEFORE the factory exists,
-        // and cannot receive a logger through its ctor) and for call
+        // populate Ghostty-project static logger accessors for types that construct
+        // before ctor-injection is possible (e.g., ConfigService is built above BEFORE
+        // the factory exists, and cannot receive a logger through its ctor) and for call
         // sites inside static scopes.
         Ghostty.Logging.StaticLoggers.Initialize(factory);
 
@@ -656,9 +633,8 @@ public partial class App : Application
                 // inbound Zig log into a disposed ILoggerFactory.
                 _zigLogBridge?.Dispose();
 
-                // #259 logging: dispose the factory after the config
-                // service so any ConfigChanged callbacks fired during
-                // ConfigService.Dispose don't race a disposed factory.
+                // dispose the factory after the config service so any ConfigChanged
+                // callbacks fired during ConfigService.Dispose don't race a disposed factory.
                 // FileLoggerProvider.DisposeAsync flushes its channel
                 // with a 2-second cap; block synchronously so the final
                 // batch of log records lands on disk before process exit.

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -63,11 +63,6 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddBindingCommand(commands, "scroll_to_bottom", "Scroll to Bottom", "Jump to the bottom of scrollback", CommandCategory.Terminal);
         AddBindingCommand(commands, "open_config", "Open Config", "Open the Ghostty configuration file", CommandCategory.Config, "\uE713");
         AddBindingCommand(commands, "reload_config", "Reload Config", "Reload configuration from disk", CommandCategory.Config, "\uE72C");
-        // The following binding actions require apprt-level support that
-        // the Windows port doesn't implement yet. Uncomment as they land:
-        // AddBindingCommand(commands, "toggle_fullscreen", "Toggle Fullscreen", "Enter or exit fullscreen mode", CommandCategory.Terminal, "\uE740");
-        // AddBindingCommand(commands, "equalize_splits", "Equalize Splits", "Make all split panes equal size", CommandCategory.Pane);
-        // AddBindingCommand(commands, "toggle_split_zoom", "Toggle Split Zoom", "Zoom the current split to fill the tab", CommandCategory.Pane);
 
         // Opacity adjustment (Ctrl+Shift+Scroll, or from palette)
         if (_opacityAction is not null)

--- a/windows/Ghostty/Commands/ProfileCommandSource.cs
+++ b/windows/Ghostty/Commands/ProfileCommandSource.cs
@@ -11,7 +11,7 @@ namespace Ghostty.Commands;
 /// IProfileRegistry.Profiles order. The Execute lambda reads
 /// IModifierKeyState at click/Enter time and routes through the
 /// injected openProfile delegate via ClickModifierClassifier, so
-/// Alt/Shift behave the same as the new-tab split button (PR 4).
+/// Alt/Shift behave the same as the new-tab split button.
 ///
 /// Refreshed every time the palette opens (CommandPaletteViewModel.Open
 /// calls Refresh on each source). No event subscription, so no dispose
@@ -65,7 +65,6 @@ internal sealed class ProfileCommandSource : ICommandSource
                 Description = $"Open {profile.Name} as a new tab (Alt: new pane, Shift: new window)",
                 ActionKey = $"open_profile:{profile.Id}",
                 Category = CommandCategory.Tab,
-                // TODO: PR 6 - per-profile icon (use IIconResolver + Profile.Icon).
                 LeadingIcon = "",
                 Shortcut = LookupShortcut(SlotAction(i)),
                 Execute = _ =>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -105,8 +105,7 @@ public sealed partial class TerminalControl : UserControl
     /// Alt+Shift+D split). Set by <see cref="Ghostty.Tabs.PaneHostFactory"/>
     /// before the control loads. Read once in OnLoaded to populate
     /// surfaceConfig.Command and surfaceConfig.WorkingDirectory; ignored
-    /// thereafter. PR 6 will introduce a hot-apply path for live config
-    /// edits.
+    /// thereafter.
     /// </summary>
     internal Ghostty.Core.Profiles.ProfileSnapshot? Snapshot { get; set; }
 
@@ -292,12 +291,8 @@ public sealed partial class TerminalControl : UserControl
 
         var app = Host.App;
 
-        // Surface config. The string fields (working_directory, command,
-        //    initial_input) must be non-null: Zig dereferences them
-        //    unconditionally. We allocate three independent UTF-8 empty
-        //    strings rather than aliasing one buffer - aliasing was a
-        //    footgun if Zig ever wrote through any of them. These live
-        //    until the surface is freed.
+        // surface-config strings are non-null UTF-8 and live until the surface is freed;
+        // allocate independent buffers so writes never alias.
         _workingDirectoryUtf8 = Snapshot is { WorkingDirectory: { Length: > 0 } wd }
             ? AllocUtf8(wd)
             : AllocEmptyUtf8();

--- a/windows/Ghostty/Dialogs/DialogTracker.cs
+++ b/windows/Ghostty/Dialogs/DialogTracker.cs
@@ -9,8 +9,7 @@ namespace Ghostty.Dialogs;
 /// <c>MainWindow.Closed</c> can wait for them to dismiss before
 /// tearing down the libghostty host. Shutting down while a dialog is
 /// still on-screen races the XAML data-binding teardown and throws
-/// <c>COMException</c> out of the runtime — see
-/// files-community/Files #17363 for the well-known reproducer.
+/// <c>COMException</c> out of the runtime.
 ///
 /// Usage:
 ///   using (tracker.Track(dialog))

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -105,16 +105,16 @@ internal sealed class KeyBindings
     }
 
     /// <summary>
-    /// Hardcoded default bindings for PR 2. Mirrors Windows Terminal
-    /// muscle memory: Ctrl+Shift+D / E for splits, Ctrl+Shift+W to
-    /// close, Alt+Arrows for directional focus.
+    /// Hardcoded default bindings; mirrors Windows Terminal muscle
+    /// memory: Ctrl+Shift+D / E for splits, Ctrl+Shift+W to close,
+    /// Alt+Arrows for directional focus.
     /// </summary>
     // OEM virtual-key codes that lack a named VirtualKey member.
     private const VirtualKey VkEquals = (VirtualKey)187;
 
     public static KeyBindings Default { get; } = new(new[]
     {
-        // Panes (#163)
+        // Panes
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.D, PaneAction.SplitVertical),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.E, PaneAction.SplitHorizontal),
         new KeyBinding(VirtualKeyModifiers.Menu, VirtualKey.Left, PaneAction.FocusLeft),
@@ -152,7 +152,7 @@ internal sealed class KeyBindings
         // Command palette
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.P, PaneAction.ToggleCommandPalette),
 
-        // Profiles (PR 5). Slot N = Profiles[N-1] (post hidden filter, ordered by
+        // Profiles. Slot N = Profiles[N-1] (post hidden filter, ordered by
         // profile-order). Out-of-range slots silently no-op in the router.
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Number1, PaneAction.OpenProfile1),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Number2, PaneAction.OpenProfile2),

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -102,7 +102,7 @@ internal sealed class PaneActionRouter
                 ToggleFullscreenRequested?.Invoke(this, EventArgs.Empty);
                 return;
 
-            // PR 5: profile slot chords. Resolve via the live registry; out-of-range
+            // Profile slot chords resolve via the live registry; out-of-range
             // and missing-delegate are silent no-ops.
             case PaneAction.OpenProfile1: OpenProfileSlot(1); return;
             case PaneAction.OpenProfile2: OpenProfileSlot(2); return;

--- a/windows/Ghostty/Interop/ISwapChainPanelNative.cs
+++ b/windows/Ghostty/Interop/ISwapChainPanelNative.cs
@@ -10,20 +10,9 @@
 // SetSwapChain - but we keep the interface here for any case where the
 // shell needs to present its own swap chain (overlays, inspector, etc).
 //
-// Why hand-written instead of CsWin32-generated:
-//
-// CsWin32 0.3.269 emits an ISwapChainPanelNative under
-// Windows.Win32.System.WinRT.Xaml with IID
-// F92F19D2-3ADE-45A6-A20C-F6F1EA90554B from the Microsoft.UI.Xaml
-// metadata, but the WinUI 3 SwapChainPanel responds to QueryInterface
-// for IID 63aad0b8-7c24-40ff-85a8-640d944cc325 (the legacy XAML interop
-// IID). The two are NOT interchangeable; using the generated interface
-// would QI for the wrong IID and either return E_NOINTERFACE or hand
-// back an unrelated vtable.
-//
-// Migrated from [ComImport] to [GeneratedComInterface] in PR 202 so
-// the file is AOT-safe and we can drop
-// EnableGeneratedComInterfaceComImportInterop from the csproj.
+// hand-written: WinUI 3 SwapChainPanel responds to the legacy XAML interop
+// IID 63aad0b8-7c24-40ff-85a8-640d944cc325, which CsWin32-generated bindings
+// don't surface (they emit the Microsoft.UI.Xaml IID instead).
 
 using System;
 using System.Runtime.InteropServices;

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -558,7 +558,7 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void SurfaceListThemesDeinit(GhosttySurface surface, IntPtr handle);
 
-    // ---- CLI actions (PR 218) -------------------------------------------
+    // ---- CLI actions ---------------------------------------------------
 
     [LibraryImport(Dll, EntryPoint = "ghostty_cli_run_action")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ public sealed partial class MainWindow : Window
     // DeleteObject'd when replaced). False when it is a stock object
     // (e.g. NULL_BRUSH from GetStockObject) or the default brush the
     // WNDCLASS was registered with -- stock objects are owned by the
-    // system and MUST NOT be deleted. See # 242.
+    // system and MUST NOT be deleted.
     private bool _classBrushOwned;
 
     // Last color written to RootGrid.Background. ApplyRootGridBackground
@@ -182,8 +182,6 @@ public sealed partial class MainWindow : Window
     // legitimate user repeats (KeyDown -> KeyUp -> KeyDown) come
     // through unmodified. This replaces an earlier 150 ms wall-clock
     // window that ate muscle-memory double-splits.
-    //
-    // Tracked in https://github.com/deblasis/ghostty/issues/165
     private PaneAction? _acceleratorFiredThisKeyDown;
 
     // Win32 interop for the window class background brush. WinUI 3 hosts
@@ -658,9 +656,9 @@ public sealed partial class MainWindow : Window
     /// or the like) and then calling <see cref="Window.Activate"/>.
     ///
     /// Used today by <see cref="DetachTabToNewWindow"/> for cursor-
-    /// anchored placement. PR 201 Snap Layouts will call this same
-    /// factory to install a snap rect before first activation so there
-    /// is no visible placement flicker.
+    /// anchored placement. Snap Layouts will call this same factory to
+    /// install a snap rect before first activation so there is no
+    /// visible placement flicker.
     /// </summary>
     internal static MainWindow CreateForAdoption(
         ConfigService configService,
@@ -698,17 +696,16 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Pre-activation hook for Snap Layouts placement. PR 199's
-    /// detach flow constructs a MainWindow but MUST NOT call
-    /// Activate until any snap target has been applied, otherwise
-    /// the window flashes at the wrong origin. Call this once
-    /// placement is done.
+    /// Pre-activation hook for Snap Layouts placement. The detach flow
+    /// constructs a MainWindow but MUST NOT call Activate until any snap
+    /// target has been applied, otherwise the window flashes at the
+    /// wrong origin. Call this once placement is done.
     /// </summary>
     internal void ActivateAfterPlacement() => Activate();
 
     /// <summary>
-    /// Single funnel for the new-tab split button (PR 4) and the
-    /// command-palette profile rows (PR 5). Resolves
+    /// Single funnel for the new-tab split button and the
+    /// command-palette profile rows. Resolves
     /// <paramref name="profileId"/> against the registry, falling back
     /// to the registry's <c>DefaultProfileId</c> when the requested id
     /// is missing. Logs and returns when both lookups fail (cold-start
@@ -1482,7 +1479,7 @@ public sealed partial class MainWindow : Window
     /// CreateSolidBrush result, we must DeleteObject it; when it was
     /// a stock brush (NULL_BRUSH) or the default WNDCLASS brush, we
     /// must not. <see cref="_classBrushOwned"/> tracks that
-    /// distinction. See # 242.
+    /// distinction.
     /// </summary>
     private void ApplyWindowClassBrush(ClassBrushKind kind)
     {
@@ -1691,10 +1688,9 @@ public sealed partial class MainWindow : Window
 
         var sources = new List<ICommandSource> { builtIn, jump, config };
 
-        // PR 5: profile rows. Null-check App services as a defensive belt
-        // (cold-start where App.ProfileRegistry isn't wired yet would skip
-        // the source entirely; ProfileCommandSource itself returns an empty
-        // list when its registry has no profiles).
+        // Null-check App services as a defensive belt (cold-start where App.ProfileRegistry
+        // isn't wired yet would skip the source entirely; ProfileCommandSource itself
+        // returns an empty list when its registry has no profiles).
         if (App.ProfileRegistry is not null && App.ModifierKeyState is not null)
         {
             sources.Add(new ProfileCommandSource(

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -216,10 +216,6 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // single TransformToVisual + four set-property calls. Covers
         // window resize, splitter drag, and the post-Split layout
         // pass that finally exposes new-leaf bounds.
-        //
-        // TODO: LayoutUpdated fires aggressively (per arrange pass of
-        // any descendant). At <20 leaves this is imperceptible, but
-        // if ETW traces ever flag it, debounce via a DispatcherQueueTimer.
         LayoutUpdated += (_, _) => UpdateHighlightPosition();
 
         // Defer the first LeafFocused so subscribers (MainWindow) can
@@ -246,8 +242,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// <summary>
     /// Split the active leaf with the given orientation. The new leaf
     /// becomes the active leaf. <paramref name="snapshot"/> (when
-    /// non-null) is stored on the new <see cref="LeafPane"/> for
-    /// future hot-apply by PR 6.
+    /// non-null) is stored on the new <see cref="LeafPane"/>.
     /// </summary>
     public void Split(PaneOrientation orientation, ProfileSnapshot? snapshot)
     {
@@ -409,7 +404,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // compositor rendering a ghost DXGI swap chain surface. Without
         // this, the disposed TerminalControl stays in the old Grid's
         // Children and can remain visually rendered even after the Grid
-        // itself is removed from the host. (#185)
+        // itself is removed from the host.
         DetachFromParent(leaf.Terminal());
 
         var newRoot = PaneTree.Close(_root, leaf);
@@ -441,13 +436,12 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // INCREMENTAL rebuild: splice the surviving sibling visual into
         // the collapsed parent Grid's former slot instead of tearing
         // down and rebuilding the whole visual tree. A full Rebuild
-        // works for 2-pane trees (#185 fix) but regresses to ghost
-        // visuals once the tree is 3+ levels deep - the same WinUI 3
-        // "child already has a parent" / stale-DCOMP-visual behavior
-        // that Split mitigates via its non-root incremental path.
-        // Falls back to a full Rebuild for the root-replacement case
-        // where there is no nested visual structure to confuse the
-        // framework. (#282)
+        // works for 2-pane trees but regresses to ghost visuals once
+        // the tree is 3+ levels deep - the same WinUI 3 "child already
+        // has a parent" / stale-DCOMP-visual behavior that Split
+        // mitigates via its non-root incremental path. Falls back to a
+        // full Rebuild for the root-replacement case where there is no
+        // nested visual structure to confuse the framework.
         if (!TryIncrementalCloseRebuild(leafParentGrid)) Rebuild();
         UpdateHighlightPosition();
         DispatcherQueue.TryEnqueue(() => nextActive.Terminal().Focus(FocusState.Programmatic));
@@ -492,7 +486,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         //      grandparent.
         // In both cases we ClearVisualTree the collapsed leafParentGrid
         // so the compositor drops every reference to the now-dead
-        // split Grid and its splitter (same reason as the #185 fix).
+        // split Grid and its splitter, otherwise WinUI 3 leaves ghost
+        // DCOMP visuals on screen.
         if (ReferenceEquals(leafParentGrid, _treeRoot))
         {
             if (Content is not Grid hostGrid) return false;
@@ -774,7 +769,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // Clear old tree children recursively before removal so the
         // compositor drops all references to stale swap chain panels.
         // Without this, removed Grids that still contain child elements
-        // can leave ghost visuals on screen. (#185)
+        // can leave ghost visuals on screen.
         ClearVisualTree(_treeRoot);
 
         hostGrid.Children.Remove(_treeRoot);

--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
@@ -58,7 +58,7 @@ internal sealed partial class RawEditorPage : Page
         // Theme flips while the page is live must force a recompute of
         // the highlight / clear-bg colors cached in EnsureColors, and
         // repaint the document bg so stale dark-mode clears don't remain
-        // visible as dark boxes on a light background (issue #325).
+        // visible as dark boxes on a light background.
         ActualThemeChanged += OnActualThemeChanged;
 
         DiagList.ItemsSource = _diagnostics;
@@ -89,8 +89,8 @@ internal sealed partial class RawEditorPage : Page
     // Wipe any lingering CharacterFormat.BackgroundColor across the whole
     // document. SetText keeps the document's default character format, so
     // any highlight BG left over from a prior Ctrl+F cycle carries into
-    // the freshly-loaded text and paints every character (issue #325:
-    // save-and-reload turns the whole editor black). Also resets
+    // the freshly-loaded text and paints every character (save-and-reload
+    // turns the whole editor black). Also resets
     // Selection.CharacterFormat so subsequent typing doesn't inherit a
     // stale highlight format.
     private void ClearAllBackgrounds()
@@ -277,8 +277,7 @@ internal sealed partial class RawEditorPage : Page
         // Read the Page's ActualTheme rather than the Editor's: during the
         // first Loaded tick the inner RichEditBox may still report
         // ElementTheme.Default before the theme cascades, which previously
-        // made us cache dark-mode brush values inside a light-mode window
-        // (issue #325).
+        // made us cache dark-mode brush values inside a light-mode window.
         var isDark = ActualTheme == ElementTheme.Dark;
         _matchColor = isDark
             ? Color.FromArgb(70, 200, 170, 50)

--- a/windows/Ghostty/Tabs/ColumnDragHandle.cs
+++ b/windows/Ghostty/Tabs/ColumnDragHandle.cs
@@ -14,10 +14,10 @@ namespace Ghostty.Tabs;
 /// width on each pointer move. Used by <see cref="VerticalTabHost"/>
 /// to let the user resize the pinned-expanded strip width live.
 ///
-/// Why not reuse <see cref="Ghostty.Panes.Splitter"/> from #163: that
-/// one is wired to <c>SplitPane.Ratio</c> and assumes a sibling-pair
-/// model. The vertical tab strip has no such pair — it just owns
-/// one column width.
+/// Why not reuse <see cref="Ghostty.Panes.Splitter"/>: that one is
+/// wired to <c>SplitPane.Ratio</c> and assumes a sibling-pair model.
+/// The vertical tab strip has no such pair, it just owns one column
+/// width.
 /// </summary>
 internal sealed partial class ColumnDragHandle : Grid
 {

--- a/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButton.xaml.cs
@@ -143,10 +143,9 @@ internal sealed partial class NewTabSplitButton : UserControl
             item.Click += OnRowClick;
 
             // Icon resolution is fire-and-forget; row keeps placeholder
-            // until the resolve completes. PR 4 does not show a per-row
-            // icon yet because MenuFlyoutItem.Icon expects an IconElement,
-            // not a BitmapImage; full icon support lands when we wrap in
-            // an Image inside a custom MenuFlyoutItem template (PR 6).
+            // until the resolve completes. MenuFlyoutItem.Icon expects an
+            // IconElement, not a BitmapImage; full icon support lands when
+            // we wrap in an Image inside a custom MenuFlyoutItem template.
 
             ProfileMenu.Items.Add(item);
         }

--- a/windows/Ghostty/Tabs/NewTabSplitButtonViewModel.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButtonViewModel.cs
@@ -9,9 +9,8 @@ namespace Ghostty.Tabs;
 /// XAML-side wrapper around <see cref="NewTabFlyoutController"/>.
 /// Owns the per-window controller lifetime and exposes its row list to
 /// <see cref="NewTabSplitButton"/>. Per-row icon resolution is deferred
-/// to PR 6, which will reintroduce IIconResolver wiring inside an
-/// async-safe SetSourceAsync flow (the prior implementation disposed
-/// the source MemoryStream synchronously, racing the async load).
+/// pending an async-safe SetSourceAsync flow (the prior implementation
+/// disposed the source MemoryStream synchronously, racing the async load).
 /// </summary>
 internal sealed class NewTabSplitButtonViewModel : IDisposable
 {

--- a/windows/Ghostty/Tabs/TabCloseConfirmation.cs
+++ b/windows/Ghostty/Tabs/TabCloseConfirmation.cs
@@ -16,7 +16,6 @@ internal static class TabCloseConfirmation
 {
     public static async Task RequestAsync(TabManager manager, TabModel tab, XamlRoot? xamlRoot)
     {
-        // TODO(config): confirm-close-multi-pane (bool, default true)
         const bool confirmCloseMultiPane = true;
 
         var paneCount = tab.PaneHost.PaneCount;

--- a/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
+++ b/windows/Ghostty/Tabs/TabContextMenuBuilder.cs
@@ -71,7 +71,7 @@ internal static class TabContextMenuBuilder
         flyout.Items.Add(rename);
 
         var dup = new MenuFlyoutItem { Text = "Duplicate Tab" };
-        dup.Click += (_, _) => manager.NewTab(); // TODO(config): respect ProfileId once profiles exist
+        dup.Click += (_, _) => manager.NewTab();
         flyout.Items.Add(dup);
 
         flyout.Items.Add(new MenuFlyoutSeparator());

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -65,8 +65,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private void AddItem(TabModel tab)
     {
         // PaneHost parenting and visibility are owned by MainWindow
-        // via a shared container (see #171), so both tab hosts can
-        // coexist without double-parenting the same PaneHost.
+        // via a shared container, so both tab hosts can coexist without
+        // double-parenting the same PaneHost.
         //
         // The TabView item is a header-only placeholder. Content is
         // null on purpose; the actual terminal lives in
@@ -166,8 +166,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private void SelectActive()
     {
         // Active-tab PaneHost visibility is owned by MainWindow's
-        // shared container (see #171). This method only syncs the
-        // TabView strip selection.
+        // shared container. This method only syncs the TabView strip
+        // selection.
         if (!_itemByModel.TryGetValue(_manager.ActiveTab, out var item)) return;
 
         // Re-apply tab color tints so the selected tab gets the


### PR DESCRIPTION
Pure comment cleanup, no code-logic changes.

Strips PR/issue/Phase/Task numbers, "Option (a/b)" / "Plan A/B" narratives, "extracted to Core for tests" boilerplate, "future PR will..." roadmaps, multi-paragraph design-doc essays in source, and test comments that just restate the test name.

Genuine WHYs (framework quirks, ordering invariants, security constraints) are preserved or rewritten to be self-contained.

62 files, +162 / -536. dotnet build clean.