### PR TITLE
feat(host): polish Version dialog (app icon + inline URL hyperlink)

### DIFF
--- a/windows/Ghostty.Core/Version/VersionRenderer.cs
+++ b/windows/Ghostty.Core/Version/VersionRenderer.cs
@@ -39,12 +39,24 @@ public static class VersionRenderer
             Architecture:        RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant());
     }
 
-    /// <summary>Plain rendering. No escape sequences. Used by the dialog
-    /// and by redirected stdout.</summary>
+    /// <summary>Plain rendering with header. No escape sequences. Used by
+    /// redirected stdout and by the clipboard "Copy" payload in the dialog.</summary>
     public static string RenderPlain(VersionInfo info)
     {
         var sb = new StringBuilder();
         AppendHeader(sb, info, ansi: false);
+        AppendBody(sb, info);
+        return sb.ToString();
+    }
+
+    /// <summary>Plain rendering of just the Version + Build Config blocks
+    /// (no header, no commit URL line). The dialog uses this because the
+    /// dialog's title bar already shows "Wintty &lt;version&gt;" and the
+    /// commit URL is rendered as a clickable HyperlinkButton above the text,
+    /// making the header redundant.</summary>
+    public static string RenderPlainBody(VersionInfo info)
+    {
+        var sb = new StringBuilder();
         AppendBody(sb, info);
         return sb.ToString();
     }
@@ -57,6 +69,16 @@ public static class VersionRenderer
         AppendHeader(sb, info, ansi: true);
         AppendBody(sb, info);
         return sb.ToString();
+    }
+
+    /// <summary>Returns the github.com commit URL for the wintty repo, or
+    /// null when no commit is known. The dialog uses this to populate the
+    /// HyperlinkButton; ANSI rendering uses it for the OSC 8 wrap.</summary>
+    public static string? CommitUrl(VersionInfo info)
+    {
+        if (string.IsNullOrEmpty(info.WinttyCommit) || info.WinttyCommit == "unknown")
+            return null;
+        return CommitUrlPrefix + info.WinttyCommit;
     }
 
     private static void AppendHeader(StringBuilder sb, VersionInfo info, bool ansi)

--- a/windows/Ghostty.Tests/Version/VersionRendererTests.cs
+++ b/windows/Ghostty.Tests/Version/VersionRendererTests.cs
@@ -81,4 +81,52 @@ public sealed class VersionRendererTests
         var output = VersionRenderer.RenderAnsi(info);
         Assert.DoesNotContain("\x1b]8", output);
     }
+
+    [Fact]
+    public void RenderPlainBody_OssFixture_StartsAtVersionBlock()
+    {
+        var expected =
+            "Version\n" +
+            "  version:        1.2.0\n" +
+            "  channel:        tip\n" +
+            "  edition:        oss\n" +
+            "\n" +
+            "Build Config\n" +
+            "  Zig version:    0.14.0\n" +
+            "  .NET runtime:   10.0.0\n" +
+            "  app runtime:    WinUI 3\n" +
+            "  renderer:       DX12\n" +
+            "  font engine:    DirectWrite\n" +
+            "  libghostty:     1.2.0+abc1234\n" +
+            "  windows:        11.0.26200\n" +
+            "  arch:           x64\n" +
+            "  build mode:     Release\n";
+
+        var output = VersionRenderer.RenderPlainBody(Sample());
+        Assert.Equal(expected, output);
+        Assert.DoesNotContain("Wintty ", output);
+        Assert.DoesNotContain("github.com", output);
+    }
+
+    [Fact]
+    public void CommitUrl_KnownCommit_ReturnsRepoUrl()
+    {
+        Assert.Equal(
+            "https://github.com/deblasis/wintty/commit/abc1234",
+            VersionRenderer.CommitUrl(Sample()));
+    }
+
+    [Fact]
+    public void CommitUrl_UnknownCommit_ReturnsNull()
+    {
+        var info = Sample() with { WinttyCommit = "unknown" };
+        Assert.Null(VersionRenderer.CommitUrl(info));
+    }
+
+    [Fact]
+    public void CommitUrl_EmptyCommit_ReturnsNull()
+    {
+        var info = Sample() with { WinttyCommit = "" };
+        Assert.Null(VersionRenderer.CommitUrl(info));
+    }
 }

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml
@@ -3,14 +3,32 @@
     x:Class="Ghostty.Dialogs.VersionDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="Wintty version"
     PrimaryButtonText="Copy"
     CloseButtonText="Close"
     DefaultButton="Primary">
+    <ContentDialog.Title>
+        <StackPanel Orientation="Horizontal" Spacing="10">
+            <Image x:Name="TitleIcon"
+                   Width="40"
+                   Height="40"
+                   VerticalAlignment="Center"/>
+            <TextBlock x:Name="TitleText"
+                       VerticalAlignment="Center"/>
+        </StackPanel>
+    </ContentDialog.Title>
     <ScrollViewer>
-        <TextBlock x:Name="VersionText"
-                   FontFamily="Cascadia Mono, Consolas"
-                   IsTextSelectionEnabled="True"
-                   TextWrapping="NoWrap"/>
+        <StackPanel Spacing="4">
+            <TextBlock x:Name="CommitLine"
+                       FontFamily="Cascadia Mono, Consolas"
+                       IsTextSelectionEnabled="True">
+                <Hyperlink x:Name="CommitLink">
+                    <Run x:Name="CommitLinkText"/>
+                </Hyperlink>
+            </TextBlock>
+            <TextBlock x:Name="VersionText"
+                       FontFamily="Cascadia Mono, Consolas"
+                       IsTextSelectionEnabled="True"
+                       TextWrapping="NoWrap"/>
+        </StackPanel>
     </ScrollViewer>
 </ContentDialog>

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Ghostty.Branding;
 using Ghostty.Core.Version;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.ApplicationModel.DataTransfer;
 using WinClipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
 
@@ -19,9 +22,29 @@ internal sealed partial class VersionDialog : ContentDialog
         InitializeComponent();
 
         var info = VersionRenderer.Build();
+        // Clipboard payload is the full text (with header + URL line) so the
+        // bug-report use case still has everything when pasted elsewhere.
         _output = VersionRenderer.RenderPlain(info);
-        VersionText.Text = _output;
-        Title = $"Wintty {info.WinttyVersionString}";
+        // The dialog itself shows the body without the header/URL line --
+        // the title bar carries "Wintty <version>" and the URL is rendered
+        // as a clickable HyperlinkButton above the body.
+        VersionText.Text = VersionRenderer.RenderPlainBody(info);
+
+        // Title bar: app icon + "Wintty <version>". Icon URI is the
+        // canonical AppIconSource so packaging changes propagate here.
+        TitleIcon.Source = new BitmapImage(AppIconSource.Current);
+        TitleText.Text = $"Wintty {info.WinttyVersionString}";
+
+        var commitUrl = VersionRenderer.CommitUrl(info);
+        if (commitUrl is null)
+        {
+            CommitLine.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            CommitLink.NavigateUri = new Uri(commitUrl);
+            CommitLinkText.Text = commitUrl;
+        }
 
         // Capture the original button label once so re-entrancy (rapid
         // double-click) can't leave the button stuck on "Copied".


### PR DESCRIPTION
Follow-up to # 365.

## Before
The dialog repeated \`Wintty <version>\` (in the title bar AND the first body line), and the URL was a plain non-clickable string.

## After
- 40x40 app icon next to \`Wintty <version>\` in the title row.
- Body drops the redundant \`Wintty <version>\` line; starts with the URL.
- URL is now an inline \`<Hyperlink>\` inside a \`<TextBlock>\` (clickable, colored, no button chrome / focus outline).
- Clipboard "Copy" still copies the full text (with header + URL line) so bug-report pastes keep every field.

## Renderer changes (Ghostty.Core)
- \`VersionRenderer.RenderPlainBody(VersionInfo)\` -> body only (no header, no URL line). Used by the dialog.
- \`VersionRenderer.CommitUrl(VersionInfo)\` -> github.com commit URL or null when no commit is known. Used by the dialog hyperlink and reused for the existing OSC 8 ANSI wrap.

## Test plan

- [x] \`dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj\` passes 799 + 1 skipped (4 new tests for RenderPlainBody / CommitUrl)
- [x] Manual smoke: palette -> Version -> dialog renders with icon + clickable URL, no border around the link
- [x] \`Wintty.exe +version\` in a terminal still emits the full output with OSC 8 hyperlink (RenderPlain unchanged)
- [x] Copy round-trips the full text (with header) to clipboard