### PR TITLE
termio: document canonical CSI 6 n reply shape

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -892,9 +892,9 @@ pub const StreamHandler = struct {
                 // This emits exactly `ESC [ <row> ; <col> R`, the shortest
                 // legal CSI 6 n reply. If a reader ever sees a longer
                 // payload before the `R`, the extra bytes are not from
-                // here: look at transport interleaving (raw-pipe vs
-                // ConPTY) or an out-of-band reply (e.g. mode 2048 size
-                // report, which ends in `t` but may precede this one).
+                // here -- see #367 for the investigation. Note that the
+                // mode 2048 in-band size report (`size_report.zig`) ends
+                // in `t`, not `R`, and may precede this one.
                 var msg: termio.Message = .{ .write_small = .{ .kind = .response } };
                 const resp = try std.fmt.bufPrint(&msg.write_small.data, "\x1B[{};{}R", .{
                     pos.y + 1,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -888,6 +888,13 @@ pub const StreamHandler = struct {
                 // Response always is at least 4 chars, so this leaves the
                 // remainder for the row/column as base-10 numbers. This
                 // will support a very large terminal.
+                //
+                // This emits exactly `ESC [ <row> ; <col> R`, the shortest
+                // legal CSI 6 n reply. If a reader ever sees a longer
+                // payload before the `R`, the extra bytes are not from
+                // here: look at transport interleaving (raw-pipe vs
+                // ConPTY) or an out-of-band reply (e.g. mode 2048 size
+                // report, which ends in `t` but may precede this one).
                 var msg: termio.Message = .{ .write_small = .{ .kind = .response } };
                 const resp = try std.fmt.bufPrint(&msg.write_small.data, "\x1B[{};{}R", .{
                     pos.y + 1,


### PR DESCRIPTION
Investigation for # 367. No behavioral change.

## What I checked

The two emit sites for CSI 6 n cursor-position responses both write
the canonical \`\x1B[<row>;<col>R\` form:

- \`src/terminal/stream_terminal.zig:318\` -- libghostty terminal layer.
  Already covered by tests at \`stream_terminal.zig:1797\`, \`1827\`
  asserting \`\x1B[1;1R\`, \`\x1B[5;10R\`, \`\x1B[3;5R\`.
- \`src/termio/stream_handler.zig:892\` -- the apprt termio layer that
  wintty actually executes through. Same \`\"\x1B[{};{}R\"\` format.
  No unit test today.

The reply travels: \`stream_handler.deviceStatusReport\` -> \`messageWriter\`
-> mailbox -> \`Termio.queueWrite\` (\`Termio.zig:418\`) -> backend
\`Exec.queueWrite\` (\`Exec.zig:483\`). \`Exec.queueWrite\` does CRLF
translation only when \`linefeed_mode\` is set, and the response has no
CR, so the bytes reach the PTY unmodified.

The C# wrapper under \`windows/\` does not parse, intercept, or rewrite
PTY response bytes -- a grep across \`windows/Ghostty\`,
\`windows/Ghostty.Core\` for cursor / DSR / 6n returned nothing
relevant. PTY ownership is entirely on the libghostty side.

## Conclusion

The 18-byte observation in deblasis/wintty-bench # 25 cannot be
explained by the libghostty emit path -- the format string is
literally 4 bytes plus base-10 row and column. The next investigation
step needs the actual hex dump of the bytes the reader sees, which
the original report did not capture. With that hex in hand the source
becomes obvious (transport interleaving vs. an out-of-band reply
preceding the cursor reply vs. shell echo of the query bytes).

## What this PR ships

A short inline note above the canonical \`bufPrint\` call so that the
next person to come back here does not re-walk the same trail. No
test added (the layer above is already covered, and adding a test
without a confirmed defect would be noise).

## Suggested follow-up

Re-run the bench probe with the hex capture the original issue
suggested (\`printf '%s' \"\$_resp\" | xxd -p\` after the \`read -d R\`)
and post the bytes on # 367. With the hex, the fix (or non-fix) is a
half-hour read.