### PR TITLE
kitty graphics: bundle OpenConsole conpty + fix DX12 image rendering

### DIFF
--- a/src/pty.zig
+++ b/src/pty.zig
@@ -349,15 +349,19 @@ const WindowsPty = struct {
     // to the executable (newer OpenConsole, more permissive about
     // unknown VT pass-through such as kitty graphics APCs) or from the
     // OS kernel32 if no bundled DLL is present. Resolved lazily on the
-    // first ConPTY open and cached for the rest of the process.
+    // first ConPTY open via `std.once` and cached for the rest of the
+    // process. `null` means "not yet resolved"; once `pseudo_console_api`
+    // is set, it always points to a complete, callable trio (bundled or
+    // fallback). The bundled HMODULE is intentionally leaked -- it is a
+    // process-wide singleton and the OS reclaims it at exit.
     const PseudoConsoleApi = struct {
         create: *const @TypeOf(windows.exp.kernel32.CreatePseudoConsole),
         resize: *const @TypeOf(windows.exp.kernel32.ResizePseudoConsole),
         close: *const @TypeOf(windows.exp.kernel32.ClosePseudoConsole),
     };
 
-    var pseudo_console_api_cache: ?PseudoConsoleApi = null;
-    var pseudo_console_api_resolved: bool = false;
+    var pseudo_console_api: ?PseudoConsoleApi = null;
+    var pseudo_console_api_once = std.once(resolvePseudoConsoleApi);
 
     out_pipe: windows.HANDLE,
     in_pipe: windows.HANDLE,
@@ -370,9 +374,12 @@ const WindowsPty = struct {
     mode: Mode,
 
     /// Build a UTF-16 path string for `<exe-dir>\conpty.dll`. Returns
-    /// null on any encoding/length failure; the caller treats null as
-    /// "no bundled DLL found" and falls back to the OS API.
-    fn adjacentConptyPathW(buf_out: []u16) ?[:0]const u16 {
+    /// null if the executable path can't be queried, has no parent
+    /// directory, or the resulting UTF-16 path doesn't fit in
+    /// `buf_out` (which must reserve room for a null terminator).
+    fn adjacentConptyPathW(
+        buf_out: *[std.fs.max_path_bytes]u16,
+    ) ?[:0]const u16 {
         var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
         const exe_path = std.fs.selfExePath(&exe_buf) catch return null;
         const exe_dir = std.fs.path.dirname(exe_path) orelse return null;
@@ -384,7 +391,7 @@ const WindowsPty = struct {
             .{exe_dir},
         ) catch return null;
 
-        // utf8ToUtf16Le returns the count of u16 units written.
+        // Reserve one u16 for the null terminator.
         const utf16_len = std.unicode.utf8ToUtf16Le(
             buf_out[0 .. buf_out.len - 1],
             dll_path,
@@ -393,40 +400,53 @@ const WindowsPty = struct {
         return buf_out[0..utf16_len :0];
     }
 
-    /// Resolve the ConPTY API trio. First call attempts to load
-    /// `conpty.dll` from alongside the executable; subsequent calls
-    /// return the cached resolution. Falls back to the OS kernel32
-    /// exports when nothing is bundled or the DLL is missing one of
-    /// the three exports we depend on.
-    fn pseudoConsoleApi() PseudoConsoleApi {
-        if (!pseudo_console_api_resolved) {
-            pseudo_console_api_resolved = true;
-
-            var path_buf: [std.fs.max_path_bytes]u16 = undefined;
-            if (adjacentConptyPathW(&path_buf)) |path_w| {
-                if (std.os.windows.kernel32.LoadLibraryW(path_w.ptr)) |module| {
-                    const create_ptr = std.os.windows.kernel32.GetProcAddress(module, "CreatePseudoConsole");
-                    const resize_ptr = std.os.windows.kernel32.GetProcAddress(module, "ResizePseudoConsole");
-                    const close_ptr = std.os.windows.kernel32.GetProcAddress(module, "ClosePseudoConsole");
-                    if (create_ptr != null and resize_ptr != null and close_ptr != null) {
-                        pseudo_console_api_cache = .{
-                            .create = @ptrCast(create_ptr.?),
-                            .resize = @ptrCast(resize_ptr.?),
-                            .close = @ptrCast(close_ptr.?),
-                        };
-                        log.info("pty: using bundled conpty.dll", .{});
-                    } else {
-                        log.warn("pty: bundled conpty.dll missing required exports; falling back to OS conhost", .{});
-                    }
-                }
-            }
-        }
-
-        return pseudo_console_api_cache orelse .{
+    /// `std.once`-driven body for resolving the ConPTY trio. Runs at
+    /// most once, regardless of how many threads race to open a PTY.
+    /// On success the bundled DLL is in use; on any failure we leave
+    /// `pseudo_console_api` set to the kernel32 fallback so the
+    /// caller never has to revisit the resolution decision.
+    fn resolvePseudoConsoleApi() void {
+        const fallback: PseudoConsoleApi = .{
             .create = windows.exp.kernel32.CreatePseudoConsole,
             .resize = windows.exp.kernel32.ResizePseudoConsole,
             .close = windows.exp.kernel32.ClosePseudoConsole,
         };
+
+        var path_buf: [std.fs.max_path_bytes]u16 = undefined;
+        const path_w = adjacentConptyPathW(&path_buf) orelse {
+            log.debug("pty: no bundled conpty.dll alongside executable; using OS conhost", .{});
+            pseudo_console_api = fallback;
+            return;
+        };
+
+        const module = std.os.windows.LoadLibraryW(path_w) catch {
+            log.debug("pty: bundled conpty.dll present but LoadLibraryW failed; using OS conhost", .{});
+            pseudo_console_api = fallback;
+            return;
+        };
+
+        const create_ptr = std.os.windows.kernel32.GetProcAddress(module, "CreatePseudoConsole");
+        const resize_ptr = std.os.windows.kernel32.GetProcAddress(module, "ResizePseudoConsole");
+        const close_ptr = std.os.windows.kernel32.GetProcAddress(module, "ClosePseudoConsole");
+        if (create_ptr == null or resize_ptr == null or close_ptr == null) {
+            log.warn("pty: bundled conpty.dll missing required exports; using OS conhost", .{});
+            pseudo_console_api = fallback;
+            return;
+        }
+
+        pseudo_console_api = .{
+            .create = @ptrCast(create_ptr.?),
+            .resize = @ptrCast(resize_ptr.?),
+            .close = @ptrCast(close_ptr.?),
+        };
+        log.info("pty: using bundled conpty.dll", .{});
+    }
+
+    /// Return the resolved ConPTY API trio. First call drives the
+    /// `std.once` resolver; subsequent calls return the cached value.
+    fn pseudoConsoleApi() PseudoConsoleApi {
+        pseudo_console_api_once.call();
+        return pseudo_console_api.?;
     }
 
     pub const OpenError = error{Unexpected};
@@ -690,6 +710,36 @@ test {
         .macos => try testing.expect(std.mem.startsWith(u8, pty.getProcessInfo(.tty_name).?, "/dev/")),
         else => try testing.expect(pty.getProcessInfo(.tty_name) == null),
     }
+}
+
+test "WindowsPty.adjacentConptyPathW: returns path ending in conpty.dll" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var buf: [std.fs.max_path_bytes]u16 = undefined;
+    const path = WindowsPty.adjacentConptyPathW(&buf) orelse {
+        // selfExePath can fail in exotic execution contexts; treat
+        // that as "skip" rather than "fail" since the resolver itself
+        // handles null by falling back to the OS conhost.
+        return error.SkipZigTest;
+    };
+
+    // Convert back to UTF-8 to assert the suffix.
+    var utf8_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const utf8_len = try std.unicode.utf16LeToUtf8(&utf8_buf, path);
+    try std.testing.expect(std.mem.endsWith(u8, utf8_buf[0..utf8_len], "\\conpty.dll"));
+}
+
+test "WindowsPty.adjacentConptyPathW: null-terminated slice" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var buf: [std.fs.max_path_bytes]u16 = undefined;
+    const path = WindowsPty.adjacentConptyPathW(&buf) orelse return error.SkipZigTest;
+
+    // The returned slice is a `[:0]const u16` — the u16 immediately
+    // past the slice end must be zero, because LoadLibraryW reads
+    // until null. Indexing past `path.len` via the parent buffer is
+    // safe since `path` aliases `buf`.
+    try std.testing.expectEqual(@as(u16, 0), buf[path.len]);
 }
 
 test "WindowsPty: conpty mode populates pseudo_console" {

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -345,6 +345,20 @@ const WindowsPty = struct {
     // Process-wide counter for pipe names
     var pipe_name_counter = std.atomic.Value(u32).init(1);
 
+    // ConPTY entry points resolved either from a conpty.dll bundled next
+    // to the executable (newer OpenConsole, more permissive about
+    // unknown VT pass-through such as kitty graphics APCs) or from the
+    // OS kernel32 if no bundled DLL is present. Resolved lazily on the
+    // first ConPTY open and cached for the rest of the process.
+    const PseudoConsoleApi = struct {
+        create: *const @TypeOf(windows.exp.kernel32.CreatePseudoConsole),
+        resize: *const @TypeOf(windows.exp.kernel32.ResizePseudoConsole),
+        close: *const @TypeOf(windows.exp.kernel32.ClosePseudoConsole),
+    };
+
+    var pseudo_console_api_cache: ?PseudoConsoleApi = null;
+    var pseudo_console_api_resolved: bool = false;
+
     out_pipe: windows.HANDLE,
     in_pipe: windows.HANDLE,
     out_pipe_pty: windows.HANDLE,
@@ -354,6 +368,66 @@ const WindowsPty = struct {
     pseudo_console: ?windows.exp.HPCON,
     size: winsize,
     mode: Mode,
+
+    /// Build a UTF-16 path string for `<exe-dir>\conpty.dll`. Returns
+    /// null on any encoding/length failure; the caller treats null as
+    /// "no bundled DLL found" and falls back to the OS API.
+    fn adjacentConptyPathW(buf_out: []u16) ?[:0]const u16 {
+        var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const exe_path = std.fs.selfExePath(&exe_buf) catch return null;
+        const exe_dir = std.fs.path.dirname(exe_path) orelse return null;
+
+        var dll_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const dll_path = std.fmt.bufPrint(
+            &dll_path_buf,
+            "{s}\\conpty.dll",
+            .{exe_dir},
+        ) catch return null;
+
+        // utf8ToUtf16Le returns the count of u16 units written.
+        const utf16_len = std.unicode.utf8ToUtf16Le(
+            buf_out[0 .. buf_out.len - 1],
+            dll_path,
+        ) catch return null;
+        buf_out[utf16_len] = 0;
+        return buf_out[0..utf16_len :0];
+    }
+
+    /// Resolve the ConPTY API trio. First call attempts to load
+    /// `conpty.dll` from alongside the executable; subsequent calls
+    /// return the cached resolution. Falls back to the OS kernel32
+    /// exports when nothing is bundled or the DLL is missing one of
+    /// the three exports we depend on.
+    fn pseudoConsoleApi() PseudoConsoleApi {
+        if (!pseudo_console_api_resolved) {
+            pseudo_console_api_resolved = true;
+
+            var path_buf: [std.fs.max_path_bytes]u16 = undefined;
+            if (adjacentConptyPathW(&path_buf)) |path_w| {
+                if (std.os.windows.kernel32.LoadLibraryW(path_w.ptr)) |module| {
+                    const create_ptr = std.os.windows.kernel32.GetProcAddress(module, "CreatePseudoConsole");
+                    const resize_ptr = std.os.windows.kernel32.GetProcAddress(module, "ResizePseudoConsole");
+                    const close_ptr = std.os.windows.kernel32.GetProcAddress(module, "ClosePseudoConsole");
+                    if (create_ptr != null and resize_ptr != null and close_ptr != null) {
+                        pseudo_console_api_cache = .{
+                            .create = @ptrCast(create_ptr.?),
+                            .resize = @ptrCast(resize_ptr.?),
+                            .close = @ptrCast(close_ptr.?),
+                        };
+                        log.info("pty: using bundled conpty.dll", .{});
+                    } else {
+                        log.warn("pty: bundled conpty.dll missing required exports; falling back to OS conhost", .{});
+                    }
+                }
+            }
+        }
+
+        return pseudo_console_api_cache orelse .{
+            .create = windows.exp.kernel32.CreatePseudoConsole,
+            .resize = windows.exp.kernel32.ResizePseudoConsole,
+            .close = windows.exp.kernel32.ClosePseudoConsole,
+        };
+    }
 
     pub const OpenError = error{Unexpected};
 
@@ -453,7 +527,7 @@ const WindowsPty = struct {
         switch (opts.mode) {
             .conpty => {
                 var hpcon: windows.exp.HPCON = undefined;
-                const result = windows.exp.kernel32.CreatePseudoConsole(
+                const result = pseudoConsoleApi().create(
                     .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
                     pty.in_pipe_pty,
                     pty.out_pipe_pty,
@@ -491,7 +565,7 @@ const WindowsPty = struct {
         _ = windows.CloseHandle(self.out_pipe_pty);
         _ = windows.CloseHandle(self.out_pipe);
         if (self.pseudo_console) |hpcon| {
-            _ = windows.exp.kernel32.ClosePseudoConsole(hpcon);
+            _ = pseudoConsoleApi().close(hpcon);
         }
         self.* = undefined;
     }
@@ -569,7 +643,7 @@ const WindowsPty = struct {
         switch (self.mode) {
             .conpty => {
                 const hpcon = self.pseudo_console orelse return error.ResizeFailed;
-                const result = windows.exp.kernel32.ResizePseudoConsole(
+                const result = pseudoConsoleApi().resize(
                     hpcon,
                     .{ .X = @intCast(size.ws_col), .Y = @intCast(size.ws_row) },
                 );

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -273,14 +273,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 return result;
             }
 
-            pub fn deinit(self: *SwapChain) void {
+            pub fn deinit(self: *SwapChain, alloc: Allocator) void {
                 if (self.defunct) return;
                 self.defunct = true;
 
                 // Wait for all of our inflight draws to complete
                 // so that we can cleanly deinit our GPU state.
                 for (0..buf_count) |_| self.frame_sema.wait();
-                for (&self.frames) |*frame| frame.deinit();
+                for (&self.frames) |*frame| frame.deinit(alloc);
             }
 
             /// Get the next frame state to draw to. This will wait on the
@@ -335,10 +335,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             /// Custom shader state, this is null if we have no custom shaders.
             custom_shader_state: ?CustomShaderState = null,
 
+            /// Per-placement vertex buffers for kitty/overlay image draws.
+            /// The image renderer creates one buffer per placement per
+            /// frame; we own them here so they outlive the GPU command
+            /// list (DX12 IASetVertexBuffers does not retain the
+            /// underlying resource). Recycled when this frame slot is
+            /// reused, after the frame_sema confirms the GPU is done.
+            image_instance_buffers: std.ArrayListUnmanaged(ImageBuffer) = .empty,
+
             const UniformBuffer = Buffer(shaderpkg.Uniforms);
             const CellBgBuffer = Buffer(shaderpkg.CellBg);
             const CellTextBuffer = Buffer(shaderpkg.CellText);
             const BgImageBuffer = Buffer(shaderpkg.BgImage);
+            const ImageBuffer = Buffer(shaderpkg.Image);
 
             pub fn init(api: GraphicsAPI, custom_shaders: bool) !FrameState {
                 // Uniform buffer contains exactly 1 uniform struct. The
@@ -405,7 +414,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 };
             }
 
-            pub fn deinit(self: *FrameState) void {
+            pub fn deinit(self: *FrameState, alloc: Allocator) void {
                 self.target.deinit();
                 self.uniforms.deinit();
                 self.cells.deinit();
@@ -413,7 +422,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.grayscale.deinit();
                 self.color.deinit();
                 self.bg_image_buffer.deinit();
+                for (self.image_instance_buffers.items) |*b| b.deinit();
+                self.image_instance_buffers.deinit(alloc);
                 if (self.custom_shader_state) |*state| state.deinit();
+            }
+
+            /// Drain all in-flight image instance buffers. Caller must
+            /// guarantee the GPU is done reading from them (typically by
+            /// waiting on the frame_sema, which only releases after the
+            /// frame's command list completes).
+            pub fn recycleImageBuffers(self: *FrameState) void {
+                for (self.image_instance_buffers.items) |*b| b.deinit();
+                self.image_instance_buffers.clearRetainingCapacity();
             }
 
             pub fn resize(
@@ -695,7 +715,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 api,
                 has_custom_shaders,
             );
-            errdefer swap_chain.deinit();
+            errdefer swap_chain.deinit(alloc);
 
             // Flush any init-time GPU commands (e.g., DX12 texture barriers).
             // SwapChain.init creates placeholder atlas textures that may need
@@ -840,7 +860,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.terminal_state.deinit(self.alloc);
             if (self.search_selected_match) |*m| m.arena.deinit();
             if (self.search_matches) |*m| m.arena.deinit();
-            self.swap_chain.deinit();
+            self.swap_chain.deinit(self.alloc);
 
             if (DisplayLink != void) {
                 if (self.display_link) |display_link| {
@@ -1026,7 +1046,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             //
             // This will mark them as defunct so that they
             // can't be double-freed or used in draw calls.
-            self.swap_chain.deinit();
+            self.swap_chain.deinit(self.alloc);
             self.shaders.deinit(self.alloc);
         }
 
@@ -1541,6 +1561,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             errdefer self.swap_chain.releaseFrame();
             // log.debug("drawing frame index={}", .{self.swap_chain.frame_index});
 
+            // The frame_sema only releases this slot after the GPU has
+            // finished its previous use, so it's now safe to deinit any
+            // per-placement image vertex buffers we created last time.
+            frame.recycleImageBuffers();
+
             // If we need to reinitialize our shaders, do so.
             // GPU must be idle before destroying PSOs and root signatures
             // that in-flight command lists may still reference.
@@ -1722,10 +1747,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // Then we draw any kitty images that need
                 // to be behind text AND cell backgrounds.
                 self.images.draw(
+                    self.alloc,
                     &self.api,
                     self.shaders.pipelines.image,
                     &pass,
                     .kitty_below_bg,
+                    frame.uniforms.buffer,
+                    &frame.image_instance_buffers,
                 );
 
                 // Then we draw any opaque cell backgrounds.
@@ -1738,10 +1766,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Kitty images between cell backgrounds and text.
                 self.images.draw(
+                    self.alloc,
                     &self.api,
                     self.shaders.pipelines.image,
                     &pass,
                     .kitty_below_text,
+                    frame.uniforms.buffer,
+                    &frame.image_instance_buffers,
                 );
 
                 // Text.
@@ -1765,19 +1796,25 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Kitty images in front of text.
                 self.images.draw(
+                    self.alloc,
                     &self.api,
                     self.shaders.pipelines.image,
                     &pass,
                     .kitty_above_text,
+                    frame.uniforms.buffer,
+                    &frame.image_instance_buffers,
                 );
 
                 // Debug overlay. We do this before any custom shader state
                 // because our debug overlay is aligned with the grid.
                 if (self.overlay != null) self.images.draw(
+                    self.alloc,
                     &self.api,
                     self.shaders.pipelines.image,
                     &pass,
                     .overlay,
+                    frame.uniforms.buffer,
+                    &frame.image_instance_buffers,
                 );
             }
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -262,25 +262,29 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             /// the renderer is deinited after that.
             defunct: bool = false,
 
-            pub fn init(api: GraphicsAPI, custom_shaders: bool) !SwapChain {
+            pub fn init(
+                alloc: Allocator,
+                api: GraphicsAPI,
+                custom_shaders: bool,
+            ) !SwapChain {
                 var result: SwapChain = .{ .frames = undefined };
 
                 // Initialize all of our frame state.
                 for (&result.frames) |*frame| {
-                    frame.* = try FrameState.init(api, custom_shaders);
+                    frame.* = try FrameState.init(alloc, api, custom_shaders);
                 }
 
                 return result;
             }
 
-            pub fn deinit(self: *SwapChain, alloc: Allocator) void {
+            pub fn deinit(self: *SwapChain) void {
                 if (self.defunct) return;
                 self.defunct = true;
 
                 // Wait for all of our inflight draws to complete
                 // so that we can cleanly deinit our GPU state.
                 for (0..buf_count) |_| self.frame_sema.wait();
-                for (&self.frames) |*frame| frame.deinit(alloc);
+                for (&self.frames) |*frame| frame.deinit();
             }
 
             /// Get the next frame state to draw to. This will wait on the
@@ -311,6 +315,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ///
         /// This is used to implement double/triple buffering.
         const FrameState = struct {
+            /// Allocator the frame state owns; used to manage the
+            /// growable `image_instance_buffers` list. Stored here so
+            /// deinit / recycle don't need to thread it through callers.
+            alloc: Allocator,
+
             uniforms: UniformBuffer,
             cells: CellTextBuffer,
             cells_bg: CellBgBuffer,
@@ -335,12 +344,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             /// Custom shader state, this is null if we have no custom shaders.
             custom_shader_state: ?CustomShaderState = null,
 
-            /// Per-placement vertex buffers for kitty/overlay image draws.
-            /// The image renderer creates one buffer per placement per
-            /// frame; we own them here so they outlive the GPU command
-            /// list (DX12 IASetVertexBuffers does not retain the
-            /// underlying resource). Recycled when this frame slot is
-            /// reused, after the frame_sema confirms the GPU is done.
+            /// Per-placement vertex buffers for kitty / overlay image
+            /// draws. Each placement gets a fresh buffer per frame; we
+            /// never reuse a buffer instance from a prior frame, only
+            /// its slot in this list. Buffers outlive the GPU command
+            /// list because DX12 IASetVertexBuffers does not retain the
+            /// underlying resource. Recycled when this frame slot is
+            /// reused, after frame_sema confirms the GPU is done.
             image_instance_buffers: std.ArrayListUnmanaged(ImageBuffer) = .empty,
 
             const UniformBuffer = Buffer(shaderpkg.Uniforms);
@@ -349,7 +359,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const BgImageBuffer = Buffer(shaderpkg.BgImage);
             const ImageBuffer = Buffer(shaderpkg.Image);
 
-            pub fn init(api: GraphicsAPI, custom_shaders: bool) !FrameState {
+            pub fn init(
+                alloc: Allocator,
+                api: GraphicsAPI,
+                custom_shaders: bool,
+            ) !FrameState {
                 // Uniform buffer contains exactly 1 uniform struct. The
                 // uniform data will be undefined so this must be set before
                 // a frame is drawn.
@@ -403,6 +417,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 const target = try api.initTarget(1, 1);
 
                 return .{
+                    .alloc = alloc,
                     .uniforms = uniforms,
                     .cells = cells,
                     .cells_bg = cells_bg,
@@ -414,7 +429,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 };
             }
 
-            pub fn deinit(self: *FrameState, alloc: Allocator) void {
+            pub fn deinit(self: *FrameState) void {
                 self.target.deinit();
                 self.uniforms.deinit();
                 self.cells.deinit();
@@ -423,14 +438,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.color.deinit();
                 self.bg_image_buffer.deinit();
                 for (self.image_instance_buffers.items) |*b| b.deinit();
-                self.image_instance_buffers.deinit(alloc);
+                self.image_instance_buffers.deinit(self.alloc);
                 if (self.custom_shader_state) |*state| state.deinit();
             }
 
-            /// Drain all in-flight image instance buffers. Caller must
-            /// guarantee the GPU is done reading from them (typically by
-            /// waiting on the frame_sema, which only releases after the
-            /// frame's command list completes).
+            /// Drain all per-placement image vertex buffers from the
+            /// previous use of this frame slot. Safe to call only after
+            /// frame_sema has released this slot -- that signals the GPU
+            /// has finished reading them.
             pub fn recycleImageBuffers(self: *FrameState) void {
                 for (self.image_instance_buffers.items) |*b| b.deinit();
                 self.image_instance_buffers.clearRetainingCapacity();
@@ -712,10 +727,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Prepare our swap chain
             var swap_chain = try SwapChain.init(
+                alloc,
                 api,
                 has_custom_shaders,
             );
-            errdefer swap_chain.deinit(alloc);
+            errdefer swap_chain.deinit();
 
             // Flush any init-time GPU commands (e.g., DX12 texture barriers).
             // SwapChain.init creates placeholder atlas textures that may need
@@ -860,7 +876,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.terminal_state.deinit(self.alloc);
             if (self.search_selected_match) |*m| m.arena.deinit();
             if (self.search_matches) |*m| m.arena.deinit();
-            self.swap_chain.deinit(self.alloc);
+            self.swap_chain.deinit();
 
             if (DisplayLink != void) {
                 if (self.display_link) |display_link| {
@@ -1021,6 +1037,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // We reinitialize our shaders and our swap chain.
             try self.initShaders();
             self.swap_chain = try SwapChain.init(
+                self.alloc,
                 self.api,
                 self.has_custom_shaders,
             );
@@ -1046,7 +1063,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             //
             // This will mark them as defunct so that they
             // can't be double-freed or used in draw calls.
-            self.swap_chain.deinit(self.alloc);
+            self.swap_chain.deinit();
             self.shaders.deinit(self.alloc);
         }
 
@@ -1561,9 +1578,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             errdefer self.swap_chain.releaseFrame();
             // log.debug("drawing frame index={}", .{self.swap_chain.frame_index});
 
-            // The frame_sema only releases this slot after the GPU has
-            // finished its previous use, so it's now safe to deinit any
-            // per-placement image vertex buffers we created last time.
+            // `nextFrame` has waited on frame_sema, so the GPU is no
+            // longer reading last frame's image vertex buffers. Recycle
+            // them now, before any new draw calls in this frame can
+            // append fresh ones.
             frame.recycleImageBuffers();
 
             // If we need to reinitialize our shaders, do so.
@@ -1645,13 +1663,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             var frame_ctx = try self.api.beginFrame(self, &frame.target);
             defer frame_ctx.complete(sync);
 
-            // Upload kitty graphics images to the GPU as necessary. Placed
-            // after beginFrame so the DX12 command list is available for
-            // staging-buffer CopyTextureRegion.
+            // Upload kitty graphics images to the GPU as necessary.
             _ = self.images.upload(self.alloc, &self.api);
 
-            // Upload the background image to the GPU as necessary. Same
-            // command-list dependency as the kitty image upload above.
+            // Upload the background image to the GPU as necessary.
             try self.uploadBackgroundImage();
 
             // If our font atlas changed, sync the texture data.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1596,12 +1596,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 frame.target_config_modified = self.target_config_modified;
             }
 
-            // Upload images to the GPU as necessary.
-            _ = self.images.upload(self.alloc, &self.api);
-
-            // Upload the background image to the GPU as necessary.
-            try self.uploadBackgroundImage();
-
             // Update per-frame custom shader uniforms.
             try self.updateCustomShaderUniformsForFrame();
 
@@ -1618,12 +1612,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             }
 
             // Get a frame context from the graphics API.
-            // This must happen before atlas sync because DX12 texture uploads
-            // (CopyTextureRegion) require the frame's command list, which is
-            // only available after beginFrame. Metal and OpenGL use immediate
-            // CPU-to-GPU copies so this ordering is transparent to them.
+            // This must happen before any texture upload because DX12
+            // CopyTextureRegion requires the frame's command list, which is
+            // only available between beginFrame and drawFrameEnd. Metal and
+            // OpenGL use immediate CPU-to-GPU copies so this ordering is
+            // transparent to them.
             var frame_ctx = try self.api.beginFrame(self, &frame.target);
             defer frame_ctx.complete(sync);
+
+            // Upload kitty graphics images to the GPU as necessary. Placed
+            // after beginFrame so the DX12 command list is available for
+            // staging-buffer CopyTextureRegion.
+            _ = self.images.upload(self.alloc, &self.api);
+
+            // Upload the background image to the GPU as necessary. Same
+            // command-list dependency as the kitty image upload above.
+            try self.uploadBackgroundImage();
 
             // If our font atlas changed, sync the texture data.
             // Placed after beginFrame so the DX12 command list is available.

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -102,12 +102,12 @@ pub const State = struct {
     /// Any placements that have non-uploaded images are ignored. Any
     /// graphics API errors during drawing are also ignored.
     ///
-    /// `frame_buffers` is owned by the caller (the frame state) and
-    /// retains each per-placement vertex buffer until the GPU finishes
-    /// reading them. DX12's IASetVertexBuffers does not retain the
-    /// underlying ID3D12Resource, so releasing it early (e.g. via
-    /// `defer buf.deinit()`) before the command list executes results
-    /// in the GPU reading zeros.
+    /// `frame_buffers` is owned by the caller; each appended buffer
+    /// must outlive the GPU's read of it. On DX12, IASetVertexBuffers
+    /// records only the GPU virtual address, so freeing the underlying
+    /// ID3D12Resource before the command list executes makes the GPU
+    /// read zeros. The frame state retains buffers until its semaphore
+    /// confirms the previous frame is done.
     pub fn draw(
         self: *State,
         alloc: Allocator,
@@ -143,6 +143,15 @@ pub const State = struct {
                 },
             };
 
+            // Reserve the slot first so we can build the buffer directly
+            // into the caller-owned retention list; avoids the
+            // append-then-handle-OOM dance that would otherwise need to
+            // call deinit on a buffer the GPU may already be reading.
+            frame_buffers.ensureUnusedCapacity(alloc, 1) catch |err| {
+                log.warn("error reserving image vertex buffer slot err={}", .{err});
+                continue;
+            };
+
             // Create our vertex buffer, which is always exactly one item.
             // future(mitchellh): we can group rendering multiple instances of a single image
             const buf = GraphicsAPI.Buffer(GraphicsAPI.shaders.Image).initFill(
@@ -174,18 +183,12 @@ pub const State = struct {
                 log.warn("error creating image vertex buffer err={}", .{err});
                 continue;
             };
-            frame_buffers.append(alloc, buf) catch |err| {
-                log.warn("error retaining image vertex buffer err={}", .{err});
-                var dropped = buf;
-                dropped.deinit();
-                continue;
-            };
-            const buf_ref = &frame_buffers.items[frame_buffers.items.len - 1];
+            frame_buffers.appendAssumeCapacity(buf);
 
             pass.step(.{
                 .pipeline = pipeline,
                 .uniforms = uniforms,
-                .buffers = &.{buf_ref.buffer},
+                .buffers = &.{frame_buffers.items[frame_buffers.items.len - 1].buffer},
                 .textures = &.{texture},
                 .draw = .{
                     .type = .triangle_strip,

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -101,12 +101,22 @@ pub const State = struct {
     ///
     /// Any placements that have non-uploaded images are ignored. Any
     /// graphics API errors during drawing are also ignored.
+    ///
+    /// `frame_buffers` is owned by the caller (the frame state) and
+    /// retains each per-placement vertex buffer until the GPU finishes
+    /// reading them. DX12's IASetVertexBuffers does not retain the
+    /// underlying ID3D12Resource, so releasing it early (e.g. via
+    /// `defer buf.deinit()`) before the command list executes results
+    /// in the GPU reading zeros.
     pub fn draw(
         self: *State,
+        alloc: Allocator,
         api: *GraphicsAPI,
         pipeline: GraphicsAPI.Pipeline,
         pass: *GraphicsAPI.RenderPass,
         placement_type: DrawPlacements,
+        uniforms: anytype,
+        frame_buffers: *std.ArrayListUnmanaged(GraphicsAPI.Buffer(GraphicsAPI.shaders.Image)),
     ) void {
         const placements: []const Placement = switch (placement_type) {
             .kitty_below_bg => self.kitty_placements.items[0..self.kitty_bg_end],
@@ -135,7 +145,7 @@ pub const State = struct {
 
             // Create our vertex buffer, which is always exactly one item.
             // future(mitchellh): we can group rendering multiple instances of a single image
-            var buf = GraphicsAPI.Buffer(GraphicsAPI.shaders.Image).initFill(
+            const buf = GraphicsAPI.Buffer(GraphicsAPI.shaders.Image).initFill(
                 api.imageBufferOptions(),
                 &.{.{
                     .grid_pos = .{
@@ -164,11 +174,18 @@ pub const State = struct {
                 log.warn("error creating image vertex buffer err={}", .{err});
                 continue;
             };
-            defer buf.deinit();
+            frame_buffers.append(alloc, buf) catch |err| {
+                log.warn("error retaining image vertex buffer err={}", .{err});
+                var dropped = buf;
+                dropped.deinit();
+                continue;
+            };
+            const buf_ref = &frame_buffers.items[frame_buffers.items.len - 1];
 
             pass.step(.{
                 .pipeline = pipeline,
-                .buffers = &.{buf.buffer},
+                .uniforms = uniforms,
+                .buffers = &.{buf_ref.buffer},
                 .textures = &.{texture},
                 .draw = .{
                     .type = .triangle_strip,

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -96,17 +96,24 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
     <!--
-      Bundle the OpenConsole-derived ConPTY DLL (Microsoft-signed) next to
-      the executable. Loaded at runtime by the Zig pty layer in preference
-      to the OS-shipped conhost so we get newer VT pass-through behavior
-      (the in-box conhost strips unknown APC/DCS sequences such as the
-      Kitty graphics protocol).
+      Bundle the OpenConsole-derived ConPTY DLL alongside Wintty.exe.
+      Loaded at runtime by the Zig pty layer in preference to the
+      OS-shipped conhost so we get newer VT pass-through behavior
+      (the in-box conhost strips unknown APC/DCS sequences such as
+      the Kitty graphics protocol). Package contents are Microsoft-
+      signed; signature is verified at install time by the MSIX
+      runtime.
 
-      ExcludeAssets="all" stops the package's auto-applied build targets
-      from leaking into a managed project — they expect a C++ link step.
-      GeneratePathProperty exposes $(PkgMicrosoft_Windows_Console_ConPTY)
-      pointing at the package content root so we can pick out the per-RID
-      runtime files with explicit None items below.
+      Pinned to 1.25.260427001-preview because that's the first
+      release whose conpty.dll forwards Kitty graphics APCs without
+      mangling; bumping requires re-validating the protocol-smoke
+      matrix in wintty-smoke.
+
+      ExcludeAssets="all" stops the package's auto-applied build
+      targets from injecting a C++-style link step into this managed
+      project. GeneratePathProperty exposes
+      $(PkgMicrosoft_Windows_Console_ConPTY) for the per-RID copies
+      below.
     -->
     <PackageReference Include="Microsoft.Windows.Console.ConPTY"
                       Version="1.25.260427001-preview"
@@ -122,9 +129,13 @@
     of CreatePseudoConsole; bundling it ensures the same version pair as
     the DLL.
 
-    Ghostty's <Platforms> list is x86;x64;ARM64. NuGet uses lowercase
-    "win-x64" / "win-arm64" / "win-x86" RIDs and the OpenConsole package
-    uses "x64" / "arm64" / "x86" subdirs in build/native/runtimes.
+    The block below repeats the same shape per RID. We tried collapsing
+    via _ConPtyRuntime item metadata + a single None pattern, but
+    MSBuild rejects metadata refs in Condition on cross-item None
+    (MSB4190 for Identity, MSB4191 for custom metadata): batching
+    only works inside a Target, not inline. The explicit listing
+    is the form MSBuild accepts; the project Platforms list is
+    x86;x64;ARM64, so three pairs is the closed set.
   -->
   <ItemGroup>
     <None Include="$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-x64\native\conpty.dll"

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -95,6 +95,74 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
+    <!--
+      Bundle the OpenConsole-derived ConPTY DLL (Microsoft-signed) next to
+      the executable. Loaded at runtime by the Zig pty layer in preference
+      to the OS-shipped conhost so we get newer VT pass-through behavior
+      (the in-box conhost strips unknown APC/DCS sequences such as the
+      Kitty graphics protocol).
+
+      ExcludeAssets="all" stops the package's auto-applied build targets
+      from leaking into a managed project — they expect a C++ link step.
+      GeneratePathProperty exposes $(PkgMicrosoft_Windows_Console_ConPTY)
+      pointing at the package content root so we can pick out the per-RID
+      runtime files with explicit None items below.
+    -->
+    <PackageReference Include="Microsoft.Windows.Console.ConPTY"
+                      Version="1.25.260427001-preview"
+                      GeneratePathProperty="true"
+                      ExcludeAssets="all" />
+  </ItemGroup>
+
+  <!--
+    Deploy the runtime conpty.dll matching the build platform alongside
+    Wintty.exe so LoadLibraryW("conpty.dll") from the pty layer resolves
+    against the bundled DLL rather than the older OS copy. OpenConsole.exe
+    is the conhost replacement that the bundled DLL launches as the child
+    of CreatePseudoConsole; bundling it ensures the same version pair as
+    the DLL.
+
+    Ghostty's <Platforms> list is x86;x64;ARM64. NuGet uses lowercase
+    "win-x64" / "win-arm64" / "win-x86" RIDs and the OpenConsole package
+    uses "x64" / "arm64" / "x86" subdirs in build/native/runtimes.
+  -->
+  <ItemGroup>
+    <None Include="$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-x64\native\conpty.dll"
+          Condition="'$(Platform)' == 'x64' and Exists('$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-x64\native\conpty.dll')">
+      <Link>conpty.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\x64\OpenConsole.exe"
+          Condition="'$(Platform)' == 'x64' and Exists('$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\x64\OpenConsole.exe')">
+      <Link>OpenConsole.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-arm64\native\conpty.dll"
+          Condition="'$(Platform)' == 'ARM64' and Exists('$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-arm64\native\conpty.dll')">
+      <Link>conpty.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\arm64\OpenConsole.exe"
+          Condition="'$(Platform)' == 'ARM64' and Exists('$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\arm64\OpenConsole.exe')">
+      <Link>OpenConsole.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-x86\native\conpty.dll"
+          Condition="'$(Platform)' == 'x86' and Exists('$(PkgMicrosoft_Windows_Console_ConPTY)\runtimes\win-x86\native\conpty.dll')">
+      <Link>conpty.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\x86\OpenConsole.exe"
+          Condition="'$(Platform)' == 'x86' and Exists('$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\x86\OpenConsole.exe')">
+      <Link>OpenConsole.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
First slice of the kitty/iTerm2 image protocols stack: get a single PNG to render correctly inline through wintty, end-to-end. Three independent fixes that together unblock visible image rendering on Windows.

## What changes

**1. Bundle OpenConsole conpty.dll alongside Wintty.exe** (`windows/Ghostty/Ghostty.csproj`, `src/pty.zig`)

The in-box conhost strips unknown APC/DCS sequences before they reach the renderer, so kitty graphics escapes never make it past the pty layer. The Microsoft-signed `Microsoft.Windows.Console.ConPTY` package ships a newer conpty.dll that passes them through. The csproj copies the per-RID conpty.dll and OpenConsole.exe next to Wintty.exe; the pty layer's new `pseudoConsoleApi()` resolver loads the adjacent DLL on first use and caches its CreatePseudoConsole / ResizePseudoConsole / ClosePseudoConsole exports. Falls back to kernel32 transparently when the bundled DLL is missing.

**2. Upload images after beginFrame** (`src/renderer/generic.zig`)

DX12 texture uploads go through CopyTextureRegion which needs the frame's open command list. `images.upload` and `uploadBackgroundImage` were called before `beginFrame`, so on DX12 those uploads had nowhere to attach and silently failed. Metal/OpenGL didn't notice because they use immediate CPU-to-GPU copies. Moved both uploads to immediately after `beginFrame`.

**3. Keep image vertex buffers alive across the frame fence** (`src/renderer/generic.zig`, `src/renderer/image.zig`)

The image renderer was creating one per-placement vertex buffer per draw and releasing it via `defer buf.deinit()`. On DX12 that's a use-after-free: `IASetVertexBuffers` records only the GPU virtual address, the underlying `ID3D12Resource` is destroyed before the command list executes, and the GPU reads zeros. Every placement collapsed to a degenerate quad at the origin and rendered invisibly. Metal hides it because `MTLRenderCommandEncoder` retains buffer references at encode time.

The fix moves ownership of those buffers into `FrameState.image_instance_buffers`. The image renderer appends each per-placement buffer into the caller-owned ArrayList; the FrameState drains the list when the `frame_sema` confirms the slot's previous GPU work has finished. Required threading an `Allocator` through `SwapChain.deinit` / `FrameState.deinit` to own the list itself.

## How to verify

1. Build the DLL + WinUI shell (`just build-dll`, `just build-win`).
2. Launch Wintty.exe.
3. From a separate pwsh prompt, run the smoke probe:
   ```
   C:\Users\Alessandro\CODE\wintty-smoke\probe-kitty-image.ps1
   ```
   The wintty-logo PNG should render inline at the cursor.
4. Run the probe 30+ times in a loop to confirm no resource leak:
   ```
   1..30 | ForEach-Object { .\probe-kitty-image.ps1 }
   ```
   COM handle count should stay flat (verified at ~1470 handles before and after 90 probes). Working-set growth is bounded by the image-map decoded-pixel cache (~180 KB per uploaded image), not by leaked DX12 resources.

## Followups (not in this PR)

- Sixel and iTerm2 inline-image protocols on top of the same renderer plumbing.
- Kitty keyboard protocol pass-through end-to-end (key probe currently works but full matrix not validated).
- Validate sRGB color path on DX12 (`imageTextureOptions` ignores the srgb flag); current visual looks correct so no fix landed here.