### PR TITLE
fork: restore cross-platform build + Windows test health

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1881,9 +1881,7 @@ pub const CAPI = struct {
         surface: *Surface,
         theme_cb: ?*const fn ([*:0]const u8, bool) callconv(.c) void,
     ) ?*anyopaque {
-        // The picker drives Surface.{input,scroll,resize}_redirect, which
-        // only exist on Windows. Non-Windows targets compile the export so
-        // the libghostty header stays portable, but the body is gated out.
+        // Windows only: drives Surface.{input,scroll,resize}_redirect.
         if (comptime builtin.os.tag != .windows) return null;
 
         const picker_mod = @import("../cli/inline_theme_picker.zig");
@@ -1982,8 +1980,7 @@ pub const CAPI = struct {
         surface: *Surface,
         picker_ptr: ?*anyopaque,
     ) void {
-        // Mirrors the gate in ghostty_surface_list_themes -- the redirect
-        // fields are void on non-Windows targets.
+        // Windows only: drives Surface.{input,scroll,resize}_redirect.
         if (comptime builtin.os.tag != .windows) return;
 
         const picker_mod = @import("../cli/inline_theme_picker.zig");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1881,6 +1881,11 @@ pub const CAPI = struct {
         surface: *Surface,
         theme_cb: ?*const fn ([*:0]const u8, bool) callconv(.c) void,
     ) ?*anyopaque {
+        // The picker drives Surface.{input,scroll,resize}_redirect, which
+        // only exist on Windows. Non-Windows targets compile the export so
+        // the libghostty header stays portable, but the body is gated out.
+        if (comptime builtin.os.tag != .windows) return null;
+
         const picker_mod = @import("../cli/inline_theme_picker.zig");
         const alloc = global.alloc;
 
@@ -1977,6 +1982,10 @@ pub const CAPI = struct {
         surface: *Surface,
         picker_ptr: ?*anyopaque,
     ) void {
+        // Mirrors the gate in ghostty_surface_list_themes -- the redirect
+        // fields are void on non-Windows targets.
+        if (comptime builtin.os.tag != .windows) return;
+
         const picker_mod = @import("../cli/inline_theme_picker.zig");
         const picker: *picker_mod.InlineThemePicker = @ptrCast(@alignCast(picker_ptr orelse return));
 

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -310,9 +310,7 @@ pub fn parseIntoField(
     assert(info == .@"struct");
 
     inline for (info.@"struct".fields) |field| {
-        // Skip platform-gated void fields (e.g. Config.@"conpty-mode" on
-        // non-Windows). These exist in the struct only so configuration
-        // schemas stay stable across platforms; there is no value to set.
+        // Void-typed fields (platform-gated Config keys) have no value to set.
         if (comptime field.type == void) continue;
 
         if (field.name[0] != '_' and mem.eql(u8, field.name, key)) {

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -310,6 +310,11 @@ pub fn parseIntoField(
     assert(info == .@"struct");
 
     inline for (info.@"struct".fields) |field| {
+        // Skip platform-gated void fields (e.g. Config.@"conpty-mode" on
+        // non-Windows). These exist in the struct only so configuration
+        // schemas stay stable across platforms; there is no value to set.
+        if (comptime field.type == void) continue;
+
         if (field.name[0] != '_' and mem.eql(u8, field.name, key)) {
             // For optional fields, we just treat it as the child type.
             // This lets optional fields default to null but get set by

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5030,16 +5030,16 @@ fn cloneValue(
 
     // Back into types of types
     switch (t) {
+        // Trivially copyable: numeric, boolean, enum, union, and the
+        // void slot used for platform-gated Config fields (e.g.
+        // @"conpty-mode" / @"utf8-console" off Windows).
         inline .bool,
         .int,
         .float,
         .@"enum",
         .@"union",
+        .void,
         => return src,
-
-        // Platform-gated void fields (e.g. @"conpty-mode" on non-Windows)
-        // have no value to clone; src is already `{}`.
-        .void => return src,
 
         .optional => |info| return try cloneValue(
             alloc,

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -5037,6 +5037,10 @@ fn cloneValue(
         .@"union",
         => return src,
 
+        // Platform-gated void fields (e.g. @"conpty-mode" on non-Windows)
+        // have no value to clone; src is already `{}`.
+        .void => return src,
+
         .optional => |info| return try cloneValue(
             alloc,
             info.child,

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -507,22 +507,29 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 width: usize,
                 height: usize,
             ) !void {
-                // Reuse existing descriptor slots so each frame keeps its
-                // dedicated RTV and SRV descriptors. This prevents both
-                // RTV overwrites across in-flight frames and SRV heap
-                // exhaustion from leaked descriptors. The slots only
-                // exist on DX12; Metal and OpenGL ignore the args.
-                const has_descriptor_slots =
-                    comptime @hasField(Texture, "rtv");
+                // DX12 reuses the existing RTV/SRV descriptor slots
+                // across resizes so each frame keeps its dedicated heap
+                // entries: prevents RTV overwrites across in-flight
+                // frames and SRV-heap exhaustion from leaked descriptors.
+                // Metal and OpenGL don't model descriptor heaps; their
+                // renderTargetTextureOptions take the slots as `anytype`
+                // and ignore them, so non-DX12 backends pass null and
+                // skip the field reads entirely (comptime-gated, the
+                // `.rtv`/`.srv` paths below never get type-checked on
+                // those backends).
                 const front_rtv_slot, const back_rtv_slot,
                 const front_srv_slot, const back_srv_slot =
-                    if (has_descriptor_slots) reuse: {
-                        const Descriptor = @TypeOf(self.front_texture.rtv);
-                        break :reuse .{
-                            @as(?Descriptor, if (self.front_texture.rtv.cpu.ptr != 0) self.front_texture.rtv else null),
-                            @as(?Descriptor, if (self.back_texture.rtv.cpu.ptr != 0) self.back_texture.rtv else null),
-                            @as(?Descriptor, if (self.front_texture.srv.gpu.ptr != 0) self.front_texture.srv else null),
-                            @as(?Descriptor, if (self.back_texture.srv.gpu.ptr != 0) self.back_texture.srv else null),
+                    if (comptime @hasField(Texture, "rtv")) slots: {
+                        const D = @TypeOf(self.front_texture.rtv);
+                        const fr = self.front_texture.rtv;
+                        const br = self.back_texture.rtv;
+                        const fs = self.front_texture.srv;
+                        const bs = self.back_texture.srv;
+                        break :slots .{
+                            @as(?D, if (fr.cpu.ptr != 0) fr else null),
+                            @as(?D, if (br.cpu.ptr != 0) br else null),
+                            @as(?D, if (fs.gpu.ptr != 0) fs else null),
+                            @as(?D, if (bs.gpu.ptr != 0) bs else null),
                         };
                     } else .{ null, null, null, null };
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -510,16 +510,21 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // Reuse existing descriptor slots so each frame keeps its
                 // dedicated RTV and SRV descriptors. This prevents both
                 // RTV overwrites across in-flight frames and SRV heap
-                // exhaustion from leaked descriptors.
-                const Descriptor = @TypeOf(self.front_texture.rtv);
-                const front_rtv_slot: ?Descriptor =
-                    if (self.front_texture.rtv.cpu.ptr != 0) self.front_texture.rtv else null;
-                const back_rtv_slot: ?Descriptor =
-                    if (self.back_texture.rtv.cpu.ptr != 0) self.back_texture.rtv else null;
-                const front_srv_slot: ?Descriptor =
-                    if (self.front_texture.srv.gpu.ptr != 0) self.front_texture.srv else null;
-                const back_srv_slot: ?Descriptor =
-                    if (self.back_texture.srv.gpu.ptr != 0) self.back_texture.srv else null;
+                // exhaustion from leaked descriptors. The slots only
+                // exist on DX12; Metal and OpenGL ignore the args.
+                const has_descriptor_slots =
+                    comptime @hasField(Texture, "rtv");
+                const front_rtv_slot, const back_rtv_slot,
+                const front_srv_slot, const back_srv_slot =
+                    if (has_descriptor_slots) reuse: {
+                        const Descriptor = @TypeOf(self.front_texture.rtv);
+                        break :reuse .{
+                            @as(?Descriptor, if (self.front_texture.rtv.cpu.ptr != 0) self.front_texture.rtv else null),
+                            @as(?Descriptor, if (self.back_texture.rtv.cpu.ptr != 0) self.back_texture.rtv else null),
+                            @as(?Descriptor, if (self.front_texture.srv.gpu.ptr != 0) self.front_texture.srv else null),
+                            @as(?Descriptor, if (self.back_texture.srv.gpu.ptr != 0) self.back_texture.srv else null),
+                        };
+                    } else .{ null, null, null, null };
 
                 const front_texture = try Texture.init(
                     api.renderTargetTextureOptions(front_rtv_slot, front_srv_slot),
@@ -1636,22 +1641,30 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // resources must be valid -- if any are null (e.g. a texture failed
             // to create during resize), fall back to direct-to-target rendering
             // so the terminal stays visible instead of crashing the GPU driver.
+            // The resource/PSO null checks are DX12-specific (descriptor heaps
+            // can be exhausted, PSOs can be defunct after re-init); Metal and
+            // OpenGL fail at allocation so any state we reach here is valid.
             const use_custom_shader = use_custom_shader: {
                 const state = frame.custom_shader_state orelse break :use_custom_shader false;
-                if (state.front_texture.resource == null or
-                    state.back_texture.resource == null or
-                    state.front_texture.rtv.cpu.ptr == 0 or
-                    state.back_texture.rtv.cpu.ptr == 0 or
-                    state.front_texture.srv.gpu.ptr == 0 or
-                    state.back_texture.srv.gpu.ptr == 0)
-                {
-                    break :use_custom_shader false;
-                }
-                // Verify post-process pipelines have valid PSOs.
-                for (self.shaders.post_pipelines, 0..) |pipeline, i| {
-                    if (pipeline.pso == null or pipeline.root_signature == null) {
-                        log.warn("post-process pipeline {} has null PSO/root_sig, falling back", .{i});
+                if (comptime @hasField(Texture, "resource")) {
+                    if (state.front_texture.resource == null or
+                        state.back_texture.resource == null or
+                        state.front_texture.rtv.cpu.ptr == 0 or
+                        state.back_texture.rtv.cpu.ptr == 0 or
+                        state.front_texture.srv.gpu.ptr == 0 or
+                        state.back_texture.srv.gpu.ptr == 0)
+                    {
                         break :use_custom_shader false;
+                    }
+                }
+                // Verify post-process pipelines have valid PSOs (DX12-only
+                // state -- Metal/OpenGL pipelines have no `pso` field).
+                if (comptime @hasField(GraphicsAPI.Pipeline, "pso")) {
+                    for (self.shaders.post_pipelines, 0..) |pipeline, i| {
+                        if (pipeline.pso == null or pipeline.root_signature == null) {
+                            log.warn("post-process pipeline {} has null PSO/root_sig, falling back", .{i});
+                            break :use_custom_shader false;
+                        }
                     }
                 }
                 break :use_custom_shader true;

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2859,11 +2859,16 @@ test "execCommand windows: cmd.exe under auto mode gets cmd preamble" {
     const testing = std.testing;
     var arena = ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    const result = try testExecWindowsShell(arena.allocator(), "cmd.exe");
+    const alloc = arena.allocator();
+    const result = try testExecWindowsShell(alloc, "cmd.exe");
 
     // auto + cmd (console_api) → ConPTY → cmd preamble appended.
+    // result[0] is %COMSPEC% if set (the documented path to the current
+    // command processor) or the literal "cmd.exe" fallback.
     try testing.expectEqual(@as(usize, 3), result.len);
-    try testing.expectEqualStrings("cmd.exe", result[0]);
+    const expected_cmd = std.process.getEnvVarOwned(alloc, "COMSPEC") catch
+        try alloc.dupe(u8, "cmd.exe");
+    try testing.expectEqualStrings(expected_cmd, result[0]);
     try testing.expectEqualStrings("/K", result[1]);
     try testing.expectEqualStrings("chcp 65001 >nul", result[2]);
 }
@@ -2951,7 +2956,12 @@ test "execCommand windows: utf8-console=never is a kill switch across transports
         .never,
     );
     try testing.expectEqual(@as(usize, 1), cmd_result.len);
-    try testing.expectEqualStrings("cmd.exe", cmd_result[0]);
+    // %COMSPEC% resolution still happens (it's transport-independent
+    // shell-name handling); the .never flag only suppresses preamble
+    // injection. Accept either the env var or the literal fallback.
+    const expected_cmd = std.process.getEnvVarOwned(alloc, "COMSPEC") catch
+        try alloc.dupe(u8, "cmd.exe");
+    try testing.expectEqualStrings(expected_cmd, cmd_result[0]);
 
     const pwsh_result = try execCommand(
         alloc,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -987,9 +987,10 @@ const Subprocess = struct {
             );
         }
 
-        // Build our args list. utf8_console is void on non-Windows;
-        // execCommand only reads it inside Windows-gated blocks, so we
-        // pass `.auto` as a dummy that the function ignores.
+        // Build our args list. cfg.utf8_console is `void` on
+        // non-Windows; pass `.auto` as a no-op concrete value so the
+        // shape of the call site stays cross-platform (execCommand's
+        // body reads utf8_console only inside Windows-gated blocks).
         const args: []const [:0]const u8 = execCommand(
             alloc,
             shell_command,
@@ -1731,7 +1732,11 @@ fn execCommand(
     comptime passwdpkg: type,
     /// Configured UTF-8 console preamble policy; used only on Windows
     /// to gate UTF-8 preamble injection across both ConPTY and bypass
-    /// transports. Ignored on other platforms.
+    /// transports. Ignored on other platforms. We keep the parameter
+    /// concrete (rather than `void` off-Windows) so darwin/posix unit
+    /// tests can keep passing `.auto` literally as a "don't care"
+    /// argument; the function never reads it outside Windows-gated
+    /// blocks.
     utf8_console: configpkg.Config.Utf8Console,
 ) (Allocator.Error || error{SystemError})![]const [:0]const u8 {
     // If we're on macOS, we have to use `login(1)` to get all of
@@ -2568,11 +2573,17 @@ test "execCommand windows: bare cmd.exe resolves via COMSPEC" {
     );
 
     try testing.expectEqual(1, result.len);
+    try testing.expectEqualStrings(try expectedCmdExeArg0(alloc), result[0]);
+}
 
-    // Expect COMSPEC if available, otherwise the documented fallback.
-    const expected = std.process.getEnvVarOwned(alloc, "COMSPEC") catch
-        try alloc.dupe(u8, "C:\\Windows\\System32\\cmd.exe");
-    try testing.expectEqualStrings(expected, result[0]);
+/// Helper for the Windows execCommand tests: what we expect `args[0]`
+/// to be when the configured shell is the bare token "cmd.exe". The
+/// production code at execCommand's shell-handling block resolves it
+/// via %COMSPEC% when set, otherwise leaves the input unchanged -- so
+/// the unset case returns "cmd.exe" literally, not a hard-coded path.
+fn expectedCmdExeArg0(alloc: Allocator) Allocator.Error![]const u8 {
+    return std.process.getEnvVarOwned(alloc, "COMSPEC") catch
+        try alloc.dupe(u8, "cmd.exe");
 }
 
 test "execCommand windows: shell command, single token spawns directly" {
@@ -2863,12 +2874,8 @@ test "execCommand windows: cmd.exe under auto mode gets cmd preamble" {
     const result = try testExecWindowsShell(alloc, "cmd.exe");
 
     // auto + cmd (console_api) → ConPTY → cmd preamble appended.
-    // result[0] is %COMSPEC% if set (the documented path to the current
-    // command processor) or the literal "cmd.exe" fallback.
     try testing.expectEqual(@as(usize, 3), result.len);
-    const expected_cmd = std.process.getEnvVarOwned(alloc, "COMSPEC") catch
-        try alloc.dupe(u8, "cmd.exe");
-    try testing.expectEqualStrings(expected_cmd, result[0]);
+    try testing.expectEqualStrings(try expectedCmdExeArg0(alloc), result[0]);
     try testing.expectEqualStrings("/K", result[1]);
     try testing.expectEqualStrings("chcp 65001 >nul", result[2]);
 }
@@ -2956,12 +2963,9 @@ test "execCommand windows: utf8-console=never is a kill switch across transports
         .never,
     );
     try testing.expectEqual(@as(usize, 1), cmd_result.len);
-    // %COMSPEC% resolution still happens (it's transport-independent
-    // shell-name handling); the .never flag only suppresses preamble
-    // injection. Accept either the env var or the literal fallback.
-    const expected_cmd = std.process.getEnvVarOwned(alloc, "COMSPEC") catch
-        try alloc.dupe(u8, "cmd.exe");
-    try testing.expectEqualStrings(expected_cmd, cmd_result[0]);
+    // %COMSPEC% resolution still happens here (transport-independent
+    // shell-name handling); .never only suppresses preamble injection.
+    try testing.expectEqualStrings(try expectedCmdExeArg0(alloc), cmd_result[0]);
 
     const pwsh_result = try execCommand(
         alloc,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -987,12 +987,17 @@ const Subprocess = struct {
             );
         }
 
-        // Build our args list
+        // Build our args list. utf8_console is void on non-Windows;
+        // execCommand only reads it inside Windows-gated blocks, so we
+        // pass `.auto` as a dummy that the function ignores.
         const args: []const [:0]const u8 = execCommand(
             alloc,
             shell_command,
             internal_os.passwd,
-            cfg.utf8_console,
+            if (comptime builtin.os.tag == .windows)
+                cfg.utf8_console
+            else
+                .auto,
         ) catch |err| switch (err) {
             // If we fail to allocate space for the command we want to
             // execute, we'd still like to try to run something so
@@ -2549,11 +2554,18 @@ test "execCommand windows: bare cmd.exe resolves via COMSPEC" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    const result = try execCommand(alloc, .{ .shell = "cmd.exe" }, struct {
-        fn get(_: Allocator) !PasswdEntry {
-            return .{};
-        }
-    });
+    const result = try execCommand(
+        alloc,
+        .{ .shell = "cmd.exe" },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        // utf8-console=never to disable the chcp preamble; this test
+        // verifies COMSPEC resolution, not preamble injection.
+        .never,
+    );
 
     try testing.expectEqual(1, result.len);
 
@@ -2704,14 +2716,19 @@ test "execCommand windows: direct command is passed through unchanged" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
-    const result = try execCommand(alloc, .{ .direct = &.{
-        "C:\\tools\\foo.exe",
-        "arg with spaces",
-    } }, struct {
-        fn get(_: Allocator) !PasswdEntry {
-            return .{};
-        }
-    });
+    const result = try execCommand(
+        alloc,
+        .{ .direct = &.{
+            "C:\\tools\\foo.exe",
+            "arg with spaces",
+        } },
+        struct {
+            fn get(_: Allocator) !PasswdEntry {
+                return .{};
+            }
+        },
+        .auto,
+    );
 
     try testing.expectEqual(2, result.len);
     try testing.expectEqualStrings("C:\\tools\\foo.exe", result[0]);

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -149,7 +149,11 @@ test {
 
 test {
     // Ensure we don't grow our IO message size without explicitly wanting to.
-    // The extra byte over the 40-byte WriteReq is the WriteKind tag.
+    // Layout on 64-bit:
+    //   - payload max = WriteAllocReq = Allocator(16) + []u8(16) + WriteKind(1)
+    //     padded to 40 bytes
+    //   - union tag = 1 byte, padded to 8 for natural alignment
+    //   => total = 48 bytes
     const testing = std.testing;
-    try testing.expectEqual(@as(usize, 41), @sizeOf(Message));
+    try testing.expectEqual(@as(usize, 48), @sizeOf(Message));
 }


### PR DESCRIPTION
The windows branch's baseline had drifted to where non-Windows targets no longer compiled and two Windows tests asserted values that have since stopped being true. Neither bucket is related to any in-flight feature work; they're just paper cuts that have accumulated. This PR fixes both so we can rely on cross-platform build + clean tests as a stable signal.

## Cross-platform compile fixes

- ``apprt/embedded.zig`` ``ghostty_surface_list_themes`` / ``_deinit`` assign to ``Surface.input_redirect`` / ``scroll_redirect`` / ``resize_redirect``, which are ``void`` on non-Windows. Mirror the early-return pattern that the other Windows-only exports already use.
- ``cli/args.zig`` + ``config/Config.zig`` Config has ``conpty-mode`` and ``utf8-console`` typed ``void`` off Windows so the schema stays platform-stable. ``parseIntoField`` and ``cloneValue`` walk every field at comptime and had no ``void`` arm; added one in each.
- ``renderer/generic.zig`` ``CustomShaderState.resize`` and the ``use_custom_shader`` gate reached into ``Texture.rtv`` / ``resource`` / ``srv`` directly. Those fields only exist on the DX12 texture; Metal and OpenGL don't have them. Gated via ``@hasField`` so non-DX12 backends just pass null descriptor slots (which ``renderTargetTextureOptions`` already accepts as ``anytype``).
- ``termio/Exec.zig`` ``Subprocess.utf8_console`` is ``void`` on non-Windows but ``execCommand``'s parameter is ``Utf8Console`` always. Pass ``.auto`` as a harmless dummy on non-Windows; ``execCommand`` only reads the value inside Windows-gated blocks. Also fixes two Windows tests that still called ``execCommand`` with the pre-``utf8_console`` 3-arg signature.

## Windows test fixes

- ``Exec.zig`` ``cmd.exe under auto mode gets cmd preamble`` and ``utf8-console=never is a kill switch across transports`` both asserted ``result[0] == "cmd.exe"`` literal. When ``%COMSPEC%`` is set (the normal Windows case) ``execCommand`` resolves it to the full path - that's the documented behavior. Switched both to the same env-or-fallback pattern the sibling ``bare cmd.exe resolves via COMSPEC`` test already uses.
- ``message.zig`` ``@sizeOf(Message)`` test still expected 41 bytes from before the ``WriteKind = .input`` field was added to the three Write variants. With the new field plus natural alignment the payload pads to 40 and the union tag pads to 8, so 48 is now correct. Updated and documented the layout.

## Verification

- ``zig build -Dtarget=x86_64-linux-gnu -Dapp-runtime=none`` previously failed with 5 errors (apprt embedded, args, Config, two renderer ones); now succeeds end-to-end producing ``ghostty-internal.so`` (174 MB) and ``ghostty-internal.a`` (251 MB).
- ``zig build test -Dapp-runtime=none`` on Windows previously reported 4 failures (3 termio, 1 unrelated hostname crash); now all listed failures are resolved.

The ``os.hostname.test.isLocal returns false when hostname is not local`` test still crashes (not asserts) on my machine and predates everything here; it appears env-dependent and is out of scope for this PR.