### PR TITLE
input/kitty: add Apps key and media keys to functional table

### DIFF
--- a/src/input/key_encode.zig
+++ b/src/input/key_encode.zig
@@ -990,8 +990,9 @@ const KittySequence = struct {
     text: []const u8 = "",
 
     /// Values for the event code (see "event-type" in above comment).
-    /// Note that Kitty omits the ":1" for the press event but other
-    /// terminals include it. We'll include it.
+    /// Press is the default and is omitted from the encoded sequence;
+    /// repeat (2) and release (3) are emitted as ":N" after the modifier
+    /// field. See encodeFull below.
     const Event = enum(u2) {
         none = 0,
         press = 1,
@@ -1880,6 +1881,33 @@ test "kitty: keypad number" {
     });
     const actual = writer.buffered();
     try testing.expectEqualStrings("[57400;;49u", actual[1..]);
+}
+
+test "kitty: context menu (Apps key)" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try kitty(&writer, .{ .key = .context_menu, .mods = .{}, .utf8 = "" }, .{
+        .kitty_flags = .{ .disambiguate = true },
+    });
+    try testing.expectEqualStrings("\x1b[57363u", writer.buffered());
+}
+
+test "kitty: media play pause" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try kitty(&writer, .{ .key = .media_play_pause, .mods = .{}, .utf8 = "" }, .{
+        .kitty_flags = .{ .disambiguate = true },
+    });
+    try testing.expectEqualStrings("\x1b[57430u", writer.buffered());
+}
+
+test "kitty: audio volume up" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try kitty(&writer, .{ .key = .audio_volume_up, .mods = .{}, .utf8 = "" }, .{
+        .kitty_flags = .{ .disambiguate = true },
+    });
+    try testing.expectEqualStrings("\x1b[57439u", writer.buffered());
 }
 
 test "kitty: backspace with utf8 (dead key state)" {

--- a/src/input/kitty.zig
+++ b/src/input/kitty.zig
@@ -61,6 +61,7 @@ const raw_entries: []const RawEntry = &.{
     .{ .num_lock, 57360, 'u', true },
     .{ .print_screen, 57361, 'u', false },
     .{ .pause, 57362, 'u', false },
+    .{ .context_menu, 57363, 'u', false },
 
     .{ .f1, 1, 'P', false },
     .{ .f2, 1, 'Q', false },
@@ -117,6 +118,14 @@ const raw_entries: []const RawEntry = &.{
     .{ .numpad_insert, 57425, 'u', false },
     .{ .numpad_delete, 57426, 'u', false },
     .{ .numpad_begin, 57427, 'u', false },
+
+    .{ .media_play_pause, 57430, 'u', false },
+    .{ .media_stop, 57432, 'u', false },
+    .{ .media_track_next, 57435, 'u', false },
+    .{ .media_track_previous, 57436, 'u', false },
+    .{ .audio_volume_down, 57438, 'u', false },
+    .{ .audio_volume_up, 57439, 'u', false },
+    .{ .audio_volume_mute, 57440, 'u', false },
 
     .{ .shift_left, 57441, 'u', true },
     .{ .shift_right, 57447, 'u', true },


### PR DESCRIPTION
The Key enum already defined `context_menu` and the media/audio_volume variants, but `src/input/kitty.zig` had no entries for them, so Kitty keyboard mode silently dropped these keys. Multimedia keyboards and the Apps key (VK_APPS on Windows) now report their Kitty functional codes when the protocol is active.

## Entries added

| Key enum               | Kitty code        |
|------------------------|-------------------|
| `context_menu`         | 57363 (MENU)      |
| `media_play_pause`     | 57430             |
| `media_stop`           | 57432             |
| `media_track_next`     | 57435             |
| `media_track_previous` | 57436             |
| `audio_volume_down`    | 57438             |
| `audio_volume_up`      | 57439             |
| `audio_volume_mute`    | 57440             |

Also fixes a stale doc-comment on `KittySequence.Event` that claimed the encoder emits `:1` for press events; the encoder actually omits press as the spec default. Code path unchanged.

## Tests

Three new `kitty:` cases in `src/input/key_encode.zig` cover the wire codes for `context_menu`, `media_play_pause`, and `audio_volume_up`.

## Verification

- Windows: `zig build test -Dtest-filter=kitty` -> 247/249 pass, 2 skipped
- Mac: `zig build test-lib-vt -Dtest-filter=kitty` -> 452/454 pass, 2 skipped
- Linux: `zig build test-lib-vt -Dtest-filter=kitty` -> 431/437 pass, 6 skipped (table change applied on top of older base; doc-comment + new tests not applied there, but all pre-existing kitty tests stay green with the new table entries)

## Test plan

- [x] zig build test passes locally on Windows
- [x] zig build test-lib-vt passes on Mac
- [x] zig build test-lib-vt passes on Linux (table addition validated)