### PR TITLE
renderer/DirectX12: clarify why imageTextureOptions ignores srgb

### DIFF
--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -979,7 +979,13 @@ pub inline fn imageTextureOptions(
     format: ImageTextureFormat,
     srgb: bool,
 ) Texture.Options {
-    _ = srgb; // DX12 sRGB handled by the render target format, not texture views.
+    // The DX12 swap chain back buffer is BGRA8_UNORM, so the pipeline
+    // runs end-to-end in gamma space. Switching this view to
+    // _UNORM_SRGB without also moving the swap chain to a sRGB format
+    // would decode on sample but not re-encode on write, darkening
+    // every image. The Metal renderer pairs an sRGB texture view with
+    // an sRGB drawable; on DX12 we'd need both pieces moved together.
+    _ = srgb;
     return .{
         .device = if (self.dev) |*d| d.device else null,
         .command_list = self.pending_command_list,


### PR DESCRIPTION
The previous comment on `imageTextureOptions` claimed sRGB was handled by the render target format, but the DX12 swap chain is `BGRA8_UNORM`, not `_SRGB` ([directx12/device.zig:111](src/renderer/directx12/device.zig#L111), [directx12/device.zig:532](src/renderer/directx12/device.zig#L532)). The image texture view, the shader, and the swap chain all operate in gamma space.

Switching the image view to `R8G8B8A8_UNORM_SRGB` alone would decode on sample without re-encoding on write, darkening every image.

The Metal renderer pairs an sRGB texture view with an sRGB drawable; honoring the `srgb` argument here would require both pieces of the DX12 pipeline to move together, which is out of scope.

## Verification

- Comment-only; nothing else changed.
- No tests needed.

## Test plan

- [x] N/A (comment-only)