### PR TITLE
terminal/osc: accept iTerm2 OSC 1337 File= inline images (parser-only)

### DIFF
--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -162,8 +162,8 @@ pub const Command = union(Key) {
 
     /// iTerm2 OSC 1337 File= inline image transmission.
     /// https://iterm2.com/documentation-images.html
-    /// Payload is the raw base64-encoded image bytes (PNG only at this layer;
-    /// the consumer decodes and sniffs the format).
+    /// Payload is the raw base64-encoded image bytes. The parser does not
+    /// decode or sniff the format; the consumer is responsible for both.
     iterm2_image_transmit: [:0]const u8,
 
     pub const SemanticPrompt = parsers.semantic_prompt.Command;

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -160,6 +160,12 @@ pub const Command = union(Key) {
     /// https://uapi-group.org/specifications/specs/osc_context/
     context_signal: parsers.context_signal.Command,
 
+    /// iTerm2 OSC 1337 File= inline image transmission.
+    /// https://iterm2.com/documentation-images.html
+    /// Payload is the raw base64-encoded image bytes (PNG only at this layer;
+    /// the consumer decodes and sniffs the format).
+    iterm2_image_transmit: [:0]const u8,
+
     pub const SemanticPrompt = parsers.semantic_prompt.Command;
 
     pub const KittyClipboardProtocol = parsers.kitty_clipboard_protocol.OSC;
@@ -193,6 +199,7 @@ pub const Command = union(Key) {
             "kitty_text_sizing",
             "kitty_clipboard_protocol",
             "context_signal",
+            "iterm2_image_transmit",
         },
     );
 
@@ -422,6 +429,7 @@ pub const Parser = struct {
             .kitty_text_sizing,
             .kitty_clipboard_protocol,
             .context_signal,
+            .iterm2_image_transmit,
             => {},
         }
 

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -91,21 +91,21 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
 
     switch (key) {
         .File => {
-            // iTerm2 inline image transmission. The value has the form
+            // iTerm2 inline image transmission. Value is
             // `key=value;key=value:BASE64`. The options block ends at the
-            // first ':' (base64 alphabet doesn't include ':'). For MVP we
-            // only honor `inline=1`; all other geometry hints (width,
-            // height, preserveAspectRatio, size, name) are accepted but
-            // unused. Without `inline=1` the image is meant to be stored
-            // as a file in the iTerm2 download folder, which has no
-            // wintty analog so we reject those.
+            // first ':'; the base64 alphabet excludes ':'.
+            //
+            // MVP only honors `inline=1`; geometry hints (width, height,
+            // preserveAspectRatio, size, name) are accepted but unused.
+            // Without `inline=1` the image is a download-to-disk request,
+            // which has no wintty analog so we reject those.
             const value = value_ orelse {
                 parser.command = .invalid;
                 return null;
             };
 
             const colon = std.mem.indexOfScalar(u8, value, ':') orelse {
-                // No payload separator => no image data => invalid.
+                log.debug("OSC 1337 File= rejected: no payload separator", .{});
                 parser.command = .invalid;
                 return null;
             };
@@ -113,15 +113,16 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
             const options = value[0..colon];
             const payload = value[colon + 1 .. value.len :0];
 
-            // Empty payload is invalid; nothing to render.
             if (payload.len == 0) {
+                log.debug("OSC 1337 File= rejected: empty payload", .{});
                 parser.command = .invalid;
                 return null;
             }
 
-            // Walk the options for `inline=1`. We don't validate other
-            // option names here; the spec lets implementations ignore
-            // unknown keys.
+            // Walk options looking for `inline=1`. Key match is
+            // case-insensitive; the value is matched literally because
+            // iTerm2's documented values for `inline` are exactly `1`
+            // and `0`.
             var inline_display = false;
             var it = std.mem.splitScalar(u8, options, ';');
             while (it.next()) |kv| {
@@ -132,12 +133,14 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
                     std.mem.eql(u8, v, "1"))
                 {
                     inline_display = true;
+                    break;
                 }
             }
 
             if (!inline_display) {
                 // iTerm2 treats non-inline File= as a download to disk;
                 // we have no equivalent in wintty.
+                log.debug("OSC 1337 File= rejected: missing inline=1", .{});
                 parser.command = .invalid;
                 return null;
             }
@@ -489,7 +492,7 @@ test "OSC: 1337: test CurrentDir with non-empty value" {
     try testing.expectEqualStrings("abc123", cmd.report_pwd.value);
 }
 
-test "OSC: 1337: File inline image with inline=1 produces iterm2_image_transmit" {
+test "OSC: 1337: test File inline=1 produces iterm2_image_transmit" {
     const testing = std.testing;
 
     var p: Parser = .init(testing.allocator);
@@ -503,7 +506,7 @@ test "OSC: 1337: File inline image with inline=1 produces iterm2_image_transmit"
     try testing.expectEqualStrings("iVBORw0KGgo=", cmd.iterm2_image_transmit);
 }
 
-test "OSC: 1337: File inline image with extra options before inline=1" {
+test "OSC: 1337: test File with extra options before inline=1" {
     const testing = std.testing;
 
     var p: Parser = .init(testing.allocator);
@@ -517,7 +520,7 @@ test "OSC: 1337: File inline image with extra options before inline=1" {
     try testing.expectEqualStrings("YWJjZA==", cmd.iterm2_image_transmit);
 }
 
-test "OSC: 1337: File inline image without inline=1 is rejected (download semantic)" {
+test "OSC: 1337: test File without inline=1 is rejected" {
     const testing = std.testing;
 
     var p: Parser = .init(testing.allocator);
@@ -529,7 +532,7 @@ test "OSC: 1337: File inline image without inline=1 is rejected (download semant
     try testing.expect(p.end('\x1b') == null);
 }
 
-test "OSC: 1337: File inline image with inline=0 is rejected (download semantic)" {
+test "OSC: 1337: test File with inline=0 is rejected" {
     const testing = std.testing;
 
     var p: Parser = .init(testing.allocator);
@@ -541,7 +544,7 @@ test "OSC: 1337: File inline image with inline=0 is rejected (download semantic)
     try testing.expect(p.end('\x1b') == null);
 }
 
-test "OSC: 1337: File with no payload separator is invalid" {
+test "OSC: 1337: test File with no payload separator is invalid" {
     const testing = std.testing;
 
     var p: Parser = .init(testing.allocator);
@@ -553,7 +556,7 @@ test "OSC: 1337: File with no payload separator is invalid" {
     try testing.expect(p.end('\x1b') == null);
 }
 
-test "OSC: 1337: File with empty payload is invalid" {
+test "OSC: 1337: test File with empty payload is invalid" {
     const testing = std.testing;
 
     var p: Parser = .init(testing.allocator);
@@ -565,7 +568,7 @@ test "OSC: 1337: File with empty payload is invalid" {
     try testing.expect(p.end('\x1b') == null);
 }
 
-test "OSC: 1337: File inline=1 is case-insensitive" {
+test "OSC: 1337: test File with case-insensitive Inline=1" {
     const testing = std.testing;
 
     var p: Parser = .init(testing.allocator);

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -90,6 +90,62 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
     };
 
     switch (key) {
+        .File => {
+            // iTerm2 inline image transmission. The value has the form
+            // `key=value;key=value:BASE64`. The options block ends at the
+            // first ':' (base64 alphabet doesn't include ':'). For MVP we
+            // only honor `inline=1`; all other geometry hints (width,
+            // height, preserveAspectRatio, size, name) are accepted but
+            // unused. Without `inline=1` the image is meant to be stored
+            // as a file in the iTerm2 download folder, which has no
+            // wintty analog so we reject those.
+            const value = value_ orelse {
+                parser.command = .invalid;
+                return null;
+            };
+
+            const colon = std.mem.indexOfScalar(u8, value, ':') orelse {
+                // No payload separator => no image data => invalid.
+                parser.command = .invalid;
+                return null;
+            };
+
+            const options = value[0..colon];
+            const payload = value[colon + 1 .. value.len :0];
+
+            // Empty payload is invalid; nothing to render.
+            if (payload.len == 0) {
+                parser.command = .invalid;
+                return null;
+            }
+
+            // Walk the options for `inline=1`. We don't validate other
+            // option names here; the spec lets implementations ignore
+            // unknown keys.
+            var inline_display = false;
+            var it = std.mem.splitScalar(u8, options, ';');
+            while (it.next()) |kv| {
+                const eq = std.mem.indexOfScalar(u8, kv, '=') orelse continue;
+                const k = kv[0..eq];
+                const v = kv[eq + 1 ..];
+                if (std.ascii.eqlIgnoreCase(k, "inline") and
+                    std.mem.eql(u8, v, "1"))
+                {
+                    inline_display = true;
+                }
+            }
+
+            if (!inline_display) {
+                // iTerm2 treats non-inline File= as a download to disk;
+                // we have no equivalent in wintty.
+                parser.command = .invalid;
+                return null;
+            }
+
+            parser.command = .{ .iterm2_image_transmit = payload };
+            return &parser.command;
+        },
+
         .Copy => {
             var value = value_ orelse {
                 parser.command = .invalid;
@@ -165,7 +221,6 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
         .Custom,
         .Disinter,
         .EndCopy,
-        .File,
         .FileEnd,
         .FilePart,
         .HighlightCursorLine,
@@ -432,4 +487,94 @@ test "OSC: 1337: test CurrentDir with non-empty value" {
     const cmd = p.end('\x1b').?.*;
     try testing.expect(cmd == .report_pwd);
     try testing.expectEqualStrings("abc123", cmd.report_pwd.value);
+}
+
+test "OSC: 1337: File inline image with inline=1 produces iterm2_image_transmit" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;File=inline=1:iVBORw0KGgo=";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_image_transmit);
+    try testing.expectEqualStrings("iVBORw0KGgo=", cmd.iterm2_image_transmit);
+}
+
+test "OSC: 1337: File inline image with extra options before inline=1" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;File=name=Zm9v;size=4;inline=1:YWJjZA==";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_image_transmit);
+    try testing.expectEqualStrings("YWJjZA==", cmd.iterm2_image_transmit);
+}
+
+test "OSC: 1337: File inline image without inline=1 is rejected (download semantic)" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;File=name=foo:iVBORw0KGgo=";
+    for (input) |ch| p.next(ch);
+
+    try testing.expect(p.end('\x1b') == null);
+}
+
+test "OSC: 1337: File inline image with inline=0 is rejected (download semantic)" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;File=inline=0:iVBORw0KGgo=";
+    for (input) |ch| p.next(ch);
+
+    try testing.expect(p.end('\x1b') == null);
+}
+
+test "OSC: 1337: File with no payload separator is invalid" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;File=inline=1";
+    for (input) |ch| p.next(ch);
+
+    try testing.expect(p.end('\x1b') == null);
+}
+
+test "OSC: 1337: File with empty payload is invalid" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;File=inline=1:";
+    for (input) |ch| p.next(ch);
+
+    try testing.expect(p.end('\x1b') == null);
+}
+
+test "OSC: 1337: File inline=1 is case-insensitive" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;File=Inline=1:YWJjZA==";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_image_transmit);
+    try testing.expectEqualStrings("YWJjZA==", cmd.iterm2_image_transmit);
 }

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2048,9 +2048,6 @@ pub fn Stream(comptime H: type) type {
                 },
 
                 .iterm2_image_transmit => |payload| {
-                    // Parser accepted an `OSC 1337 File=...:BASE64` with
-                    // inline=1. The renderer wire-up (base64 decode +
-                    // kitty graphics command synthesis) is a follow-up.
                     log.debug(
                         "iterm2 inline image received: {d} base64 bytes",
                         .{payload.len},

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2047,6 +2047,16 @@ pub fn Stream(comptime H: type) type {
                     self.handler.vt(.progress_report, v);
                 },
 
+                .iterm2_image_transmit => |payload| {
+                    // Parser accepted an `OSC 1337 File=...:BASE64` with
+                    // inline=1. The renderer wire-up (base64 decode +
+                    // kitty graphics command synthesis) is a follow-up.
+                    log.debug(
+                        "iterm2 inline image received: {d} base64 bytes",
+                        .{payload.len},
+                    );
+                },
+
                 .conemu_sleep,
                 .conemu_show_message_box,
                 .conemu_change_tab_title,


### PR DESCRIPTION
The OSC 1337 dispatcher already routed `File=`, `FilePart=`, `FileEnd=`, and `MultipartFile=` keys into the "unimplemented" log arm ([osc/parsers/iterm2.zig:166](src/terminal/osc/parsers/iterm2.zig#L166)), so wintty silently dropped iTerm2 inline-image escape sequences and treated the base64 payload as text the cursor can never reach.

This PR adds parser-side handling for the single-shot `File=` case.

## Behavior

- Split the value on the first `:` into options and base64 payload.
- Walk the options for `inline=1` (case-insensitive); reject otherwise.
  iTerm2 treats non-inline `File=` as a download-to-disk, which has no wintty analog.
- Emit a new `iterm2_image_transmit` OSC `Command` carrying the raw base64 string.
- Stream dispatch logs the byte count.

## Deferred to follow-ups

- Base64 decode + kitty graphics command synthesis (the bit that actually renders).
- Multipart: `FilePart`, `FileEnd`, `MultipartFile`.
- Geometry hints: `width`, `height`, `preserveAspectRatio`, `size`.
- JPEG/GIF support (Ghostty's image decoder is PNG-only today).

## Tests

Seven new `OSC: 1337: File ...` cases cover:
- inline=1 happy path
- extra options before inline (`name`, `size`)
- missing inline rejected (download semantic)
- explicit inline=0 rejected
- no payload separator (no `:`)
- empty payload
- case-insensitive `Inline=1`

## Verification

- Windows: `zig build test -Dtest-filter=1337` -> 91/92 pass, 1 skipped
- Mac (macbookale): `zig build test-lib-vt -Dtest-filter=1337` -> 93/95 pass, 2 skipped
- Linux (ubuntinovm): `zig build test-lib-vt -Dtest-filter=1337` -> 93/95 pass, 2 skipped

A smoke probe lives in [wintty-smoke/probe-iterm2-image.ps1](https://github.com/deblasis/wintty/blob/kitten-into-wintty/iterm2-images/.gitignore) (out of tree); it emits a tiny PNG via OSC 1337 and confirms the parser hit via the debug log.

## Test plan

- [x] zig build test passes on Windows
- [x] zig build test-lib-vt passes on Mac
- [x] zig build test-lib-vt passes on Linux
- [ ] Follow-up PR: base64 decode + kitty graphics synthesis
- [ ] Follow-up PR: multipart + geometry hints