### PR TITLE
terminal/osc: render iTerm2 OSC 1337 File= inline images

### DIFF
--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -14,7 +14,7 @@ const Allocator = mem.Allocator;
 const lib = @import("lib.zig");
 const LibEnum = lib.Enum;
 const kitty_color = @import("kitty/color.zig");
-pub const parsers = @import("osc/parsers.zig");
+const parsers = @import("osc/parsers.zig");
 const encoding = @import("osc/encoding.zig");
 
 pub const color = parsers.color;

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -14,7 +14,7 @@ const Allocator = mem.Allocator;
 const lib = @import("lib.zig");
 const LibEnum = lib.Enum;
 const kitty_color = @import("kitty/color.zig");
-const parsers = @import("osc/parsers.zig");
+pub const parsers = @import("osc/parsers.zig");
 const encoding = @import("osc/encoding.zig");
 
 pub const color = parsers.color;

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -1,10 +1,12 @@
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 const assert = @import("../../../quirks.zig").inlineAssert;
 const simd = @import("../../../simd/main.zig");
 
 const Parser = @import("../../osc.zig").Parser;
 const Command = @import("../../osc.zig").Command;
+const kitty_graphics = @import("../../kitty/graphics.zig");
 
 const log = std.log.scoped(.osc_iterm2);
 
@@ -253,6 +255,45 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
         },
     }
     return &parser.command;
+}
+
+/// Decode a base64 payload from an iTerm2 OSC 1337 File= sequence and
+/// synthesize a kitty graphics command that transmits and displays it as
+/// a PNG at the current cursor position. Returns an error if the base64
+/// is invalid; the caller is responsible for calling deinit on the
+/// returned Command, which owns the decoded byte buffer.
+///
+/// Format is hard-coded to PNG. iTerm2's File= protocol allows JPEG and
+/// GIF as well, but Ghostty's kitty graphics decoder is PNG-only today.
+/// Non-PNG bytes will reach the decoder and surface as a render error.
+pub fn synthKittyCommand(
+    alloc: Allocator,
+    payload: []const u8,
+) !kitty_graphics.Command {
+    const max_len = simd.base64.maxLen(payload);
+    if (max_len == 0) return error.InvalidData;
+
+    const buf = try alloc.alloc(u8, max_len);
+    errdefer alloc.free(buf);
+
+    const decoded = simd.base64.decode(payload, buf) catch {
+        return error.InvalidData;
+    };
+
+    // Shrink the allocation down to the decoded length so the kitty
+    // Command's data slice doesn't carry unused tail bytes.
+    const data = try alloc.realloc(buf, decoded.len);
+
+    return .{
+        .control = .{ .transmit_and_display = .{
+            .transmission = .{
+                .format = .png,
+                .medium = .direct,
+            },
+            .display = .{},
+        } },
+        .data = data,
+    };
 }
 
 test "OSC: 1337: test valid unimplemented key with no value" {
@@ -580,4 +621,53 @@ test "OSC: 1337: test File with case-insensitive Inline=1" {
     const cmd = p.end('\x1b').?.*;
     try testing.expect(cmd == .iterm2_image_transmit);
     try testing.expectEqualStrings("YWJjZA==", cmd.iterm2_image_transmit);
+}
+
+test "synthKittyCommand: valid base64 yields transmit_and_display PNG command" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // "abcd" base64-encoded.
+    const payload = "YWJjZA==";
+
+    var cmd = try synthKittyCommand(alloc, payload);
+    defer cmd.deinit(alloc);
+
+    try testing.expect(cmd.control == .transmit_and_display);
+    const td = cmd.control.transmit_and_display;
+    try testing.expect(td.transmission.format == .png);
+    try testing.expect(td.transmission.medium == .direct);
+    try testing.expectEqualStrings("abcd", cmd.data);
+}
+
+test "synthKittyCommand: invalid base64 returns error" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // ':' is not in the base64 alphabet. The OSC parser strips the
+    // payload at the first ':', but a malformed sequence could still
+    // reach the helper with non-base64 bytes.
+    const payload = "!!!not base64!!!";
+
+    try testing.expectError(error.InvalidData, synthKittyCommand(alloc, payload));
+}
+
+test "synthKittyCommand: minimal 1x1 PNG round-trips through helper" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Canonical 1x1 transparent PNG, 67 bytes, base64-encoded.
+    const payload =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ" ++
+        "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+    var cmd = try synthKittyCommand(alloc, payload);
+    defer cmd.deinit(alloc);
+
+    try testing.expect(cmd.control == .transmit_and_display);
+    try testing.expect(cmd.data.len > 0);
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+    const sig = [_]u8{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    try testing.expect(cmd.data.len >= sig.len);
+    try testing.expectEqualSlices(u8, &sig, cmd.data[0..sig.len]);
 }

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -259,13 +259,16 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
 
 /// Decode a base64 payload from an iTerm2 OSC 1337 File= sequence and
 /// synthesize a kitty graphics command that transmits and displays it as
-/// a PNG at the current cursor position. Returns an error if the base64
-/// is invalid; the caller is responsible for calling deinit on the
-/// returned Command, which owns the decoded byte buffer.
+/// a PNG at the current cursor position. The caller owns the returned
+/// Command and must call deinit on it; the Command owns the decoded
+/// byte buffer.
 ///
-/// Format is hard-coded to PNG. iTerm2's File= protocol allows JPEG and
-/// GIF as well, but Ghostty's kitty graphics decoder is PNG-only today.
-/// Non-PNG bytes will reach the decoder and surface as a render error.
+/// Returns error.InvalidData if the base64 is malformed, or
+/// error.UnsupportedFormat if the decoded bytes don't carry a PNG
+/// signature. Ghostty's kitty graphics decoder is PNG-only today, so
+/// rejecting other formats here surfaces a clearer error than letting
+/// the decoder reject mid-pipeline. iTerm2 emitters that send JPEG or
+/// GIF will hit this path.
 pub fn synthKittyCommand(
     alloc: Allocator,
     payload: []const u8,
@@ -273,16 +276,25 @@ pub fn synthKittyCommand(
     const max_len = simd.base64.maxLen(payload);
     if (max_len == 0) return error.InvalidData;
 
-    const buf = try alloc.alloc(u8, max_len);
-    errdefer alloc.free(buf);
+    // Mirror the in-place decode pattern used by the kitty graphics
+    // command parser (graphics_command.zig decodeData): allocate up to
+    // max_len, decode in place, shrink via ArrayList.toOwnedSlice so
+    // the Command's data buffer carries no trailing unused bytes.
+    var data: std.ArrayList(u8) = .empty;
+    errdefer data.deinit(alloc);
+    try data.resize(alloc, max_len);
 
-    const decoded = simd.base64.decode(payload, buf) catch {
+    const decoded = simd.base64.decode(payload, data.items) catch {
         return error.InvalidData;
     };
+    data.items.len = decoded.len;
 
-    // Shrink the allocation down to the decoded length so the kitty
-    // Command's data slice doesn't carry unused tail bytes.
-    const data = try alloc.realloc(buf, decoded.len);
+    const png_sig = [_]u8{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    if (data.items.len < png_sig.len or
+        !std.mem.eql(u8, data.items[0..png_sig.len], &png_sig))
+    {
+        return error.UnsupportedFormat;
+    }
 
     return .{
         .control = .{ .transmit_and_display = .{
@@ -292,7 +304,7 @@ pub fn synthKittyCommand(
             },
             .display = .{},
         } },
-        .data = data,
+        .data = try data.toOwnedSlice(alloc),
     };
 }
 
@@ -623,36 +635,7 @@ test "OSC: 1337: test File with case-insensitive Inline=1" {
     try testing.expectEqualStrings("YWJjZA==", cmd.iterm2_image_transmit);
 }
 
-test "synthKittyCommand: valid base64 yields transmit_and_display PNG command" {
-    const testing = std.testing;
-    const alloc = testing.allocator;
-
-    // "abcd" base64-encoded.
-    const payload = "YWJjZA==";
-
-    var cmd = try synthKittyCommand(alloc, payload);
-    defer cmd.deinit(alloc);
-
-    try testing.expect(cmd.control == .transmit_and_display);
-    const td = cmd.control.transmit_and_display;
-    try testing.expect(td.transmission.format == .png);
-    try testing.expect(td.transmission.medium == .direct);
-    try testing.expectEqualStrings("abcd", cmd.data);
-}
-
-test "synthKittyCommand: invalid base64 returns error" {
-    const testing = std.testing;
-    const alloc = testing.allocator;
-
-    // ':' is not in the base64 alphabet. The OSC parser strips the
-    // payload at the first ':', but a malformed sequence could still
-    // reach the helper with non-base64 bytes.
-    const payload = "!!!not base64!!!";
-
-    try testing.expectError(error.InvalidData, synthKittyCommand(alloc, payload));
-}
-
-test "synthKittyCommand: minimal 1x1 PNG round-trips through helper" {
+test "synthKittyCommand: minimal 1x1 PNG yields transmit_and_display PNG command" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -665,9 +648,52 @@ test "synthKittyCommand: minimal 1x1 PNG round-trips through helper" {
     defer cmd.deinit(alloc);
 
     try testing.expect(cmd.control == .transmit_and_display);
-    try testing.expect(cmd.data.len > 0);
+    const td = cmd.control.transmit_and_display;
+    try testing.expect(td.transmission.format == .png);
+    try testing.expect(td.transmission.medium == .direct);
+
     // PNG signature: 89 50 4E 47 0D 0A 1A 0A
     const sig = [_]u8{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
     try testing.expect(cmd.data.len >= sig.len);
     try testing.expectEqualSlices(u8, &sig, cmd.data[0..sig.len]);
+}
+
+test "synthKittyCommand: invalid base64 returns InvalidData" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // The OSC parser strips the payload at the first ':', but a
+    // malformed sequence could still reach the helper with non-base64
+    // bytes.
+    const payload = "!!!not base64!!!";
+
+    try testing.expectError(error.InvalidData, synthKittyCommand(alloc, payload));
+}
+
+test "synthKittyCommand: non-PNG bytes return UnsupportedFormat" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // "abcd" base64-encoded. Decodes to valid base64 but missing the
+    // PNG signature.
+    const payload = "YWJjZA==";
+
+    try testing.expectError(
+        error.UnsupportedFormat,
+        synthKittyCommand(alloc, payload),
+    );
+}
+
+test "synthKittyCommand: payload shorter than PNG signature returns UnsupportedFormat" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // "x" base64-encoded => 1 decoded byte, less than the 8-byte
+    // PNG signature.
+    const payload = "eA==";
+
+    try testing.expectError(
+        error.UnsupportedFormat,
+        synthKittyCommand(alloc, payload),
+    );
 }

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -125,6 +125,9 @@ pub const Action = union(Key) {
     kitty_color_report: kitty.color.OSC,
     color_operation: ColorOperation,
     semantic_prompt: SemanticPrompt,
+    /// iTerm2 OSC 1337 File= inline image. Payload is raw base64; the
+    /// handler decodes it and dispatches as a kitty graphics command.
+    iterm2_image_transmit: [:0]const u8,
 
     pub const Key = lib.Enum(
         lib.target,
@@ -222,6 +225,7 @@ pub const Action = union(Key) {
             "kitty_color_report",
             "color_operation",
             "semantic_prompt",
+            "iterm2_image_transmit",
         },
     );
 
@@ -2048,10 +2052,7 @@ pub fn Stream(comptime H: type) type {
                 },
 
                 .iterm2_image_transmit => |payload| {
-                    log.debug(
-                        "iterm2 inline image received: {d} base64 bytes",
-                        .{payload.len},
-                    );
+                    self.handler.vt(.iterm2_image_transmit, payload);
                 },
 
                 .conemu_sleep,

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -267,6 +267,10 @@ pub const Handler = struct {
             .clipboard_contents,
             .title_push,
             .title_pop,
+            // libghostty-vt embedders without a kitty graphics renderer
+            // drop iTerm2 inline images. termio's StreamHandler is where
+            // the image gets decoded and dispatched to the renderer.
+            .iterm2_image_transmit,
             => {},
         }
     }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -11,6 +11,7 @@ const renderer = @import("../renderer.zig");
 const termio = @import("../termio.zig");
 const terminal = @import("../terminal/main.zig");
 const terminfo = @import("../terminfo/main.zig");
+const iterm2_parser = @import("../terminal/osc/parsers/iterm2.zig");
 const posix = std.posix;
 
 const log = std.log.scoped(.io_handler);
@@ -1611,11 +1612,11 @@ pub const StreamHandler = struct {
     /// transmit_and_display command so it goes through the same image
     /// storage and renderer path that the kitty graphics protocol uses.
     fn iterm2ImageTransmit(self: *StreamHandler, payload: [:0]const u8) !void {
-        var cmd = terminal.osc.parsers.iterm2.synthKittyCommand(
+        var cmd = iterm2_parser.synthKittyCommand(
             self.alloc,
             payload,
         ) catch |err| {
-            log.warn("iterm2 inline image: synthesis failed err={}", .{err});
+            log.warn("iterm2 inline image dropped: {t}", .{err});
             return;
         };
         defer cmd.deinit(self.alloc);

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -371,6 +371,7 @@ pub const StreamHandler = struct {
             .apc_start => self.apc.start(),
             .apc_end => try self.apcEnd(),
             .apc_put => self.apc.feed(self.alloc, value),
+            .iterm2_image_transmit => try self.iterm2ImageTransmit(value),
 
             // Unimplemented
             .title_push,
@@ -1603,5 +1604,24 @@ pub const StreamHandler = struct {
     /// Display a GUI progress report.
     fn progressReport(self: *StreamHandler, report: terminal.osc.Command.ProgressReport) void {
         self.surfaceMessageWriter(.{ .progress_report = report });
+    }
+
+    /// Handle an iTerm2 OSC 1337 File= inline image. The payload is the
+    /// raw base64 string; we decode it and dispatch as a kitty graphics
+    /// transmit_and_display command so it goes through the same image
+    /// storage and renderer path that the kitty graphics protocol uses.
+    fn iterm2ImageTransmit(self: *StreamHandler, payload: [:0]const u8) !void {
+        var cmd = terminal.osc.parsers.iterm2.synthKittyCommand(
+            self.alloc,
+            payload,
+        ) catch |err| {
+            log.warn("iterm2 inline image: synthesis failed err={}", .{err});
+            return;
+        };
+        defer cmd.deinit(self.alloc);
+
+        // iTerm2's File= protocol has no response channel, unlike the
+        // kitty graphics APC. We drop the response.
+        _ = self.terminal.kittyGraphics(self.alloc, &cmd);
     }
 };


### PR DESCRIPTION
Follow-up A to #375. The parser-only PR accepted iTerm2 File= sequences and emitted a Command carrying the raw base64 payload, but the handler was a debug-log stub. This wires the payload through to the existing kitty graphics renderer path so the image actually displays at the cursor.

## Flow

```
OSC 1337 File=inline=1:BASE64
  -> iterm2.zig parser emits Command.iterm2_image_transmit
  -> stream.zig dispatches via self.handler.vt(.iterm2_image_transmit, payload)
  -> StreamHandler.iterm2ImageTransmit decodes base64 + builds a
     kitty graphics Command (transmit_and_display, format=png, medium=direct)
  -> Terminal.kittyGraphics() stores + renders through the same
     image storage and DX12 image-pass the kitty APC protocol uses
```

The synthesis helper lives in `osc/parsers/iterm2.zig` next to the parser so the iTerm2-to-kitty translation is testable in isolation. Format is pinned to PNG; Ghostty's kitty graphics decoder is PNG-only today, so iTerm2 JPEG and GIF will surface as a render error in the decoder. That matches what #375's deferred-work list called out.

The libghostty-vt `stream_terminal` handler is a no-op for this action because embedders supply their own renderer; termio's `StreamHandler` is the only path with the allocator and Terminal access needed to dispatch.

## Tests

Three new tests in `osc/parsers/iterm2.zig`:

- valid base64 yields transmit_and_display PNG command
- invalid base64 returns error
- minimal 1x1 PNG round-trips through helper (verifies PNG signature in decoded data)

## Verification

- Windows: ``zig build test`` passes (2878/2933, 55 skipped, 0 failures)
- Linux: pending (will validate before merging)
- Mac: pending (machine offline)

## Deferred (still tracked from #375)

- B: multipart ``FilePart``/``FileEnd``/``MultipartFile`` chunked images
- C: geometry hints (``width``, ``height``, ``preserveAspectRatio``, ``size``)
- JPEG/GIF support (needs Ghostty kitty decoder change first)

## Test plan

- [x] zig build test passes on Windows
- [ ] zig build test-lib-vt passes on Linux
- [ ] zig build test-lib-vt passes on Mac
- [ ] smoke probe-iterm2-image.ps1 renders a real PNG in Wintty