### PR TITLE
terminal/osc: support iTerm2 OSC 1337 multipart File= transfers

### DIFF
--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -164,13 +164,24 @@ pub const Command = union(Key) {
     /// https://iterm2.com/documentation-images.html
     iterm2_image_transmit: Iterm2ImageTransmit,
 
+    /// iTerm2 OSC 1337 multipart inline image transmission. The wire
+    /// format is a sequence of three OSC kinds (MultipartFile, FilePart
+    /// repeated, FileEnd); the parser emits one event per OSC and the
+    /// consumer (a multipart assembler in the stream handler) stitches
+    /// them. iTerm2 has no session identifier, so transfers are
+    /// strictly serialized.
+    iterm2_multipart_image: Iterm2MultipartEvent,
+
     pub const SemanticPrompt = parsers.semantic_prompt.Command;
 
     /// iTerm2 OSC 1337 File= inline image payload + parsed geometry hints.
     pub const Iterm2ImageTransmit = struct {
         /// Raw base64-encoded image bytes. The consumer is responsible
-        /// for decode + format sniff.
-        payload: [:0]const u8,
+        /// for decode + format sniff. The slice is not null-terminated;
+        /// the multipart assembler produces it from heap concatenation
+        /// and the single-shot parser produces it as an interior slice
+        /// of its capture buffer.
+        payload: []const u8,
 
         /// Geometry hints parsed from the options block. Defaults
         /// preserve the image's native sizing.
@@ -194,6 +205,25 @@ pub const Command = union(Key) {
         /// both columns and rows are non-zero, because Kitty stretches
         /// only when both display dimensions are supplied.
         preserve_aspect_ratio: bool = true,
+    };
+
+    /// One step of an iTerm2 multipart File= transfer.
+    pub const Iterm2MultipartEvent = union(enum) {
+        /// `OSC 1337;MultipartFile=options` started a new transfer.
+        /// The hints are parsed from the options block. inline=1 is
+        /// required at this layer; the parser rejects MultipartFile
+        /// without it as .invalid rather than emitting this event.
+        start: Iterm2ImageHints,
+
+        /// `OSC 1337;FilePart=BASE64_CHUNK` continued the active
+        /// transfer with one more base64 chunk. The slice points into
+        /// the parser's capture buffer; the assembler must copy it
+        /// before the next OSC resets the buffer.
+        chunk: []const u8,
+
+        /// `OSC 1337;FileEnd` terminated the active transfer. The
+        /// assembler decodes + dispatches the accumulated payload.
+        end,
     };
 
     pub const KittyClipboardProtocol = parsers.kitty_clipboard_protocol.OSC;
@@ -228,6 +258,7 @@ pub const Command = union(Key) {
             "kitty_clipboard_protocol",
             "context_signal",
             "iterm2_image_transmit",
+            "iterm2_multipart_image",
         },
     );
 
@@ -458,6 +489,7 @@ pub const Parser = struct {
             .kitty_clipboard_protocol,
             .context_signal,
             .iterm2_image_transmit,
+            .iterm2_multipart_image,
             => {},
         }
 

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -6,6 +6,7 @@ const simd = @import("../../../simd/main.zig");
 
 const Parser = @import("../../osc.zig").Parser;
 const Command = @import("../../osc.zig").Command;
+const apc = @import("../../apc.zig");
 const kitty_graphics = @import("../../kitty/graphics.zig");
 
 const log = std.log.scoped(.osc_iterm2);
@@ -258,8 +259,10 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
 
         .FileEnd => {
             // Terminator. iTerm2's documented form is `FileEnd` with
-            // no `=value`, but tolerate a trailing `=` (some emitters
-            // round-trip the key as `key=`).
+            // no `=value`; we accept `FileEnd=` defensively since the
+            // upstream `key=value` parse loop happily produces an
+            // empty value for the bare key and we don't gain anything
+            // by rejecting it.
             parser.command = .{ .iterm2_multipart_image = .end };
             return &parser.command;
         },
@@ -455,10 +458,10 @@ pub const Iterm2MultipartAssembler = struct {
     /// flight.
     state: ?State = null,
 
-    /// Maximum accumulated base64 payload. 64 MiB matches the default
-    /// max bytes the APC kitty graphics path enforces (see
-    /// src/terminal/apc.zig Protocol.defaultMaxBytes for kitty).
-    pub const max_payload_bytes: usize = 64 * 1024 * 1024;
+    /// Maximum accumulated base64 payload. Sourced from the APC kitty
+    /// graphics path so the two image-transport ceilings stay in
+    /// lockstep without manual drift.
+    pub const max_payload_bytes: usize = apc.Protocol.defaultMaxBytes(.kitty);
 
     pub const State = struct {
         hints: Command.Iterm2ImageHints,
@@ -1254,10 +1257,11 @@ test "Iterm2MultipartAssembler: oversize transfer is dropped" {
 
     _ = try assembler.handleEvent(alloc, .{ .start = .{} });
 
-    // Build a chunk that, when combined with the cap-1 already in the
-    // buffer, would exceed max_payload_bytes by one byte. We can't
-    // afford to actually allocate 64 MiB in the test, so we cheat by
-    // pre-loading the assembler state with a fake size.
+    // Pre-load the assembler state up to the cap, then push one more
+    // byte and assert the transfer is aborted. The resize does a real
+    // allocation of max_payload_bytes; that's deliberately the full
+    // 65 MiB so the boundary check exercises the same arithmetic
+    // production sees, and the test is cheap enough at this size.
     if (assembler.state) |*s| {
         try s.payload.resize(alloc, Iterm2MultipartAssembler.max_payload_bytes);
     }

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -109,6 +109,41 @@ fn parseCellDim(key: []const u8, value: []const u8) u32 {
     return n;
 }
 
+/// Parsed view of the options block from a File= or MultipartFile=
+/// sequence: which `inline=1` toggle the emitter requested, plus the
+/// geometry hints we know how to honor. Used by both the single-shot
+/// and multipart entry points so the recognized keys stay in lockstep.
+const FileOptions = struct {
+    inline_display: bool = false,
+    hints: Command.Iterm2ImageHints = .{},
+};
+
+fn parseFileOptions(options: []const u8) FileOptions {
+    var result: FileOptions = .{};
+    var it = std.mem.splitScalar(u8, options, ';');
+    while (it.next()) |kv| {
+        const eq = std.mem.indexOfScalar(u8, kv, '=') orelse continue;
+        const k = kv[0..eq];
+        const v = kv[eq + 1 ..];
+
+        if (std.ascii.eqlIgnoreCase(k, "inline")) {
+            // iTerm2's documented values for `inline` are exactly `1`
+            // and `0`; match literally.
+            if (std.mem.eql(u8, v, "1")) result.inline_display = true;
+        } else if (std.ascii.eqlIgnoreCase(k, "width")) {
+            result.hints.columns = parseCellDim(k, v);
+        } else if (std.ascii.eqlIgnoreCase(k, "height")) {
+            result.hints.rows = parseCellDim(k, v);
+        } else if (std.ascii.eqlIgnoreCase(k, "preserveAspectRatio")) {
+            // iTerm2 default is 1; only flip to false on explicit `0`.
+            if (std.mem.eql(u8, v, "0")) result.hints.preserve_aspect_ratio = false;
+        }
+        // Unknown keys (name, size, type, ...) are silently ignored.
+        // iTerm2 and WezTerm do the same in practice.
+    }
+    return result;
+}
+
 /// Parse OSC 1337
 /// https://iterm2.com/documentation-escape-codes.html
 pub fn parse(parser: *Parser, _: ?u8) ?*Command {
@@ -162,7 +197,7 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
             };
 
             const options = value[0..colon];
-            const payload = value[colon + 1 .. value.len :0];
+            const payload = value[colon + 1 ..];
 
             if (payload.len == 0) {
                 log.debug("OSC 1337 File= rejected: empty payload", .{});
@@ -170,34 +205,8 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
                 return null;
             }
 
-            // Single pass over the options: pick up inline=1 and the
-            // geometry hints in one walk. Key match is case-insensitive;
-            // `inline` value is matched literally because iTerm2's
-            // documented values are exactly `1` and `0`.
-            var inline_display = false;
-            var hints: Command.Iterm2ImageHints = .{};
-            var it = std.mem.splitScalar(u8, options, ';');
-            while (it.next()) |kv| {
-                const eq = std.mem.indexOfScalar(u8, kv, '=') orelse continue;
-                const k = kv[0..eq];
-                const v = kv[eq + 1 ..];
-
-                if (std.ascii.eqlIgnoreCase(k, "inline")) {
-                    if (std.mem.eql(u8, v, "1")) inline_display = true;
-                } else if (std.ascii.eqlIgnoreCase(k, "width")) {
-                    hints.columns = parseCellDim(k, v);
-                } else if (std.ascii.eqlIgnoreCase(k, "height")) {
-                    hints.rows = parseCellDim(k, v);
-                } else if (std.ascii.eqlIgnoreCase(k, "preserveAspectRatio")) {
-                    // iTerm2 default is 1. Only flip to false on an
-                    // explicit `0`.
-                    if (std.mem.eql(u8, v, "0")) hints.preserve_aspect_ratio = false;
-                }
-                // Unknown keys (name, size, type, ...) are silently
-                // ignored. iTerm2 and WezTerm do the same in practice.
-            }
-
-            if (!inline_display) {
+            const parsed = parseFileOptions(options);
+            if (!parsed.inline_display) {
                 // iTerm2 treats non-inline File= as a download to disk;
                 // we have no equivalent in wintty.
                 log.debug("OSC 1337 File= rejected: missing inline=1", .{});
@@ -207,8 +216,51 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
 
             parser.command = .{ .iterm2_image_transmit = .{
                 .payload = payload,
-                .hints = hints,
+                .hints = parsed.hints,
             } };
+            return &parser.command;
+        },
+
+        .MultipartFile => {
+            // Start of a multipart inline image transfer. The wire
+            // format is `MultipartFile=key=value;key=value...` with no
+            // payload here; the chunks arrive in subsequent FilePart=
+            // sequences and the transfer ends on FileEnd.
+            //
+            // We require inline=1 to match the single-shot File= path,
+            // so a download-style multipart never enters our state
+            // machine.
+            const options = value_ orelse "";
+            const parsed = parseFileOptions(options);
+            if (!parsed.inline_display) {
+                log.debug("OSC 1337 MultipartFile= rejected: missing inline=1", .{});
+                parser.command = .invalid;
+                return null;
+            }
+            parser.command = .{ .iterm2_multipart_image = .{
+                .start = parsed.hints,
+            } };
+            return &parser.command;
+        },
+
+        .FilePart => {
+            // One more base64 chunk for the in-flight multipart
+            // transfer. The assembler is responsible for orphan-chunk
+            // handling (FilePart with no preceding MultipartFile), so
+            // we forward the raw bytes (including empty) and let the
+            // assembler decide.
+            const chunk = value_ orelse "";
+            parser.command = .{ .iterm2_multipart_image = .{
+                .chunk = chunk,
+            } };
+            return &parser.command;
+        },
+
+        .FileEnd => {
+            // Terminator. iTerm2's documented form is `FileEnd` with
+            // no `=value`, but tolerate a trailing `=` (some emitters
+            // round-trip the key as `key=`).
+            parser.command = .{ .iterm2_multipart_image = .end };
             return &parser.command;
         },
 
@@ -287,10 +339,7 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
         .Custom,
         .Disinter,
         .EndCopy,
-        .FileEnd,
-        .FilePart,
         .HighlightCursorLine,
-        .MultipartFile,
         .OpenURL,
         .PopKeyLabels,
         .PushKeyLabels,
@@ -389,6 +438,113 @@ pub fn synthKittyCommand(
         .data = try data.toOwnedSlice(alloc),
     };
 }
+
+/// Cross-OSC state for iTerm2 multipart File= transfers. iTerm2's wire
+/// format has no session identifier, so transfers are strictly
+/// serialized: at most one assembler `state` is active at a time.
+///
+/// Lifetime: lives on the stream handler for the duration of the
+/// terminal session. `deinit` releases any in-flight payload buffer.
+///
+/// Sequence: `start` initializes a fresh buffer carrying the hints.
+/// `chunk` appends a base64 chunk. `end` returns the accumulated
+/// `Iterm2ImageTransmit` and clears the in-progress state; the caller
+/// owns the returned payload string and is responsible for freeing it.
+pub const Iterm2MultipartAssembler = struct {
+    /// Active multipart accumulation, or null when no transfer is in
+    /// flight.
+    state: ?State = null,
+
+    /// Maximum accumulated base64 payload. 64 MiB matches the default
+    /// max bytes the APC kitty graphics path enforces (see
+    /// src/terminal/apc.zig Protocol.defaultMaxBytes for kitty).
+    pub const max_payload_bytes: usize = 64 * 1024 * 1024;
+
+    pub const State = struct {
+        hints: Command.Iterm2ImageHints,
+        payload: std.ArrayList(u8),
+    };
+
+    /// Release the in-flight payload, if any. Safe to call repeatedly.
+    pub fn deinit(self: *Iterm2MultipartAssembler, alloc: Allocator) void {
+        if (self.state) |*s| s.payload.deinit(alloc);
+        self.state = null;
+    }
+
+    /// Feed one parser event. Returns a populated transmit on `.end`
+    /// when the transfer assembled cleanly; the caller owns the
+    /// returned `payload` slice (allocated with `alloc`) and must
+    /// free it (passing the transmit to `Command.deinit` is the usual
+    /// disposal path). Returns null on `.start`, `.chunk`, or on any
+    /// rejected event.
+    pub fn handleEvent(
+        self: *Iterm2MultipartAssembler,
+        alloc: Allocator,
+        event: Command.Iterm2MultipartEvent,
+    ) !?Command.Iterm2ImageTransmit {
+        switch (event) {
+            .start => |hints| {
+                if (self.state != null) {
+                    log.warn(
+                        "iTerm2 multipart overrun: new MultipartFile while one was in flight, dropping previous",
+                        .{},
+                    );
+                    self.deinit(alloc);
+                }
+                self.state = .{
+                    .hints = hints,
+                    .payload = .empty,
+                };
+                return null;
+            },
+
+            .chunk => |chunk| {
+                const s = if (self.state) |*ptr| ptr else {
+                    log.warn(
+                        "iTerm2 multipart: FilePart with no active transfer, dropping {d} bytes",
+                        .{chunk.len},
+                    );
+                    return null;
+                };
+
+                if (s.payload.items.len + chunk.len > max_payload_bytes) {
+                    log.warn(
+                        "iTerm2 multipart: payload would exceed {d} bytes, dropping transfer",
+                        .{max_payload_bytes},
+                    );
+                    self.deinit(alloc);
+                    return null;
+                }
+
+                try s.payload.appendSlice(alloc, chunk);
+                return null;
+            },
+
+            .end => {
+                const s = if (self.state) |*ptr| ptr else {
+                    log.warn(
+                        "iTerm2 multipart: FileEnd with no active transfer, ignoring",
+                        .{},
+                    );
+                    return null;
+                };
+
+                // Hand ownership of the payload buffer off to the
+                // caller. The caller must free `payload` after use
+                // (typically right after the synthKittyCommand call,
+                // which copies the bytes via base64 decode).
+                const hints = s.hints;
+                const payload = try s.payload.toOwnedSlice(alloc);
+                self.state = null;
+
+                return .{
+                    .payload = payload,
+                    .hints = hints,
+                };
+            },
+        }
+    }
+};
 
 test "OSC: 1337: test valid unimplemented key with no value" {
     const testing = std.testing;
@@ -929,4 +1085,187 @@ test "synthKittyCommand: preserve_aspect_ratio=false with both dims allows stret
     // Both dims set => Kitty stretches without preserving aspect.
     try testing.expectEqual(@as(u32, 8), td.display.columns);
     try testing.expectEqual(@as(u32, 4), td.display.rows);
+}
+
+test "OSC: 1337: test MultipartFile inline=1 emits start with hints" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;MultipartFile=inline=1;width=10;height=5";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_multipart_image);
+    try testing.expect(cmd.iterm2_multipart_image == .start);
+    const hints = cmd.iterm2_multipart_image.start;
+    try testing.expectEqual(@as(u32, 10), hints.columns);
+    try testing.expectEqual(@as(u32, 5), hints.rows);
+}
+
+test "OSC: 1337: test MultipartFile without inline=1 is rejected" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;MultipartFile=name=foo";
+    for (input) |ch| p.next(ch);
+
+    try testing.expect(p.end('\x1b') == null);
+}
+
+test "OSC: 1337: test FilePart emits chunk with raw bytes" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;FilePart=YWJjZA==";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_multipart_image);
+    try testing.expect(cmd.iterm2_multipart_image == .chunk);
+    try testing.expectEqualStrings("YWJjZA==", cmd.iterm2_multipart_image.chunk);
+}
+
+test "OSC: 1337: test FilePart with no value emits empty chunk" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;FilePart";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd.iterm2_multipart_image == .chunk);
+    try testing.expectEqualStrings("", cmd.iterm2_multipart_image.chunk);
+}
+
+test "OSC: 1337: test FileEnd emits end" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;FileEnd";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd.iterm2_multipart_image == .end);
+}
+
+test "OSC: 1337: test FileEnd with trailing equals also emits end" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;FileEnd=";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd.iterm2_multipart_image == .end);
+}
+
+test "Iterm2MultipartAssembler: happy path assembles chunks" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var assembler: Iterm2MultipartAssembler = .{};
+    defer assembler.deinit(alloc);
+
+    try testing.expectEqual(
+        @as(?Command.Iterm2ImageTransmit, null),
+        try assembler.handleEvent(alloc, .{ .start = .{ .columns = 7 } }),
+    );
+    try testing.expectEqual(
+        @as(?Command.Iterm2ImageTransmit, null),
+        try assembler.handleEvent(alloc, .{ .chunk = "YWJj" }),
+    );
+    try testing.expectEqual(
+        @as(?Command.Iterm2ImageTransmit, null),
+        try assembler.handleEvent(alloc, .{ .chunk = "ZA==" }),
+    );
+
+    const out = (try assembler.handleEvent(alloc, .end)).?;
+    defer alloc.free(out.payload);
+
+    try testing.expectEqualStrings("YWJjZA==", out.payload);
+    try testing.expectEqual(@as(u32, 7), out.hints.columns);
+    try testing.expect(assembler.state == null);
+}
+
+test "Iterm2MultipartAssembler: orphan chunk is dropped" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var assembler: Iterm2MultipartAssembler = .{};
+    defer assembler.deinit(alloc);
+
+    try testing.expectEqual(
+        @as(?Command.Iterm2ImageTransmit, null),
+        try assembler.handleEvent(alloc, .{ .chunk = "YWJj" }),
+    );
+    try testing.expect(assembler.state == null);
+}
+
+test "Iterm2MultipartAssembler: orphan end is dropped" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var assembler: Iterm2MultipartAssembler = .{};
+    defer assembler.deinit(alloc);
+
+    try testing.expectEqual(
+        @as(?Command.Iterm2ImageTransmit, null),
+        try assembler.handleEvent(alloc, .end),
+    );
+    try testing.expect(assembler.state == null);
+}
+
+test "Iterm2MultipartAssembler: overlapping start discards previous" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var assembler: Iterm2MultipartAssembler = .{};
+    defer assembler.deinit(alloc);
+
+    _ = try assembler.handleEvent(alloc, .{ .start = .{ .columns = 1 } });
+    _ = try assembler.handleEvent(alloc, .{ .chunk = "WA==" });
+    _ = try assembler.handleEvent(alloc, .{ .start = .{ .columns = 99 } });
+    _ = try assembler.handleEvent(alloc, .{ .chunk = "YQ==" });
+    const out = (try assembler.handleEvent(alloc, .end)).?;
+    defer alloc.free(out.payload);
+
+    try testing.expectEqualStrings("YQ==", out.payload);
+    try testing.expectEqual(@as(u32, 99), out.hints.columns);
+}
+
+test "Iterm2MultipartAssembler: oversize transfer is dropped" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var assembler: Iterm2MultipartAssembler = .{};
+    defer assembler.deinit(alloc);
+
+    _ = try assembler.handleEvent(alloc, .{ .start = .{} });
+
+    // Build a chunk that, when combined with the cap-1 already in the
+    // buffer, would exceed max_payload_bytes by one byte. We can't
+    // afford to actually allocate 64 MiB in the test, so we cheat by
+    // pre-loading the assembler state with a fake size.
+    if (assembler.state) |*s| {
+        try s.payload.resize(alloc, Iterm2MultipartAssembler.max_payload_bytes);
+    }
+
+    // One more byte must push past the cap and abort the transfer.
+    try testing.expectEqual(
+        @as(?Command.Iterm2ImageTransmit, null),
+        try assembler.handleEvent(alloc, .{ .chunk = "X" }),
+    );
+    try testing.expect(assembler.state == null);
 }

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -129,6 +129,11 @@ pub const Action = union(Key) {
     /// base64 payload plus parsed geometry hints; the handler decodes
     /// the payload and dispatches as a kitty graphics command.
     iterm2_image_transmit: osc.Command.Iterm2ImageTransmit,
+    /// One step of an iTerm2 OSC 1337 multipart File= transfer
+    /// (MultipartFile start, FilePart chunk, or FileEnd terminator).
+    /// The handler accumulates chunks across OSCs and dispatches a
+    /// kitty graphics command on the terminator.
+    iterm2_multipart_image: osc.Command.Iterm2MultipartEvent,
 
     pub const Key = lib.Enum(
         lib.target,
@@ -227,6 +232,7 @@ pub const Action = union(Key) {
             "color_operation",
             "semantic_prompt",
             "iterm2_image_transmit",
+            "iterm2_multipart_image",
         },
     );
 
@@ -2054,6 +2060,10 @@ pub fn Stream(comptime H: type) type {
 
                 .iterm2_image_transmit => |transmit| {
                     self.handler.vt(.iterm2_image_transmit, transmit);
+                },
+
+                .iterm2_multipart_image => |event| {
+                    self.handler.vt(.iterm2_multipart_image, event);
                 },
 
                 .conemu_sleep,

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -271,6 +271,7 @@ pub const Handler = struct {
             // drop iTerm2 inline images. termio's StreamHandler is where
             // the image gets decoded and dispatched to the renderer.
             .iterm2_image_transmit,
+            .iterm2_multipart_image,
             => {},
         }
     }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -72,6 +72,12 @@ pub const StreamHandler = struct {
     /// such as XTGETTCAP.
     dcs: terminal.dcs.Handler = .{},
 
+    /// In-flight iTerm2 multipart File= image accumulation. iTerm2 has
+    /// no session identifier so transfers are strictly serialized;
+    /// this carries the active transfer's hints + buffer between OSC
+    /// sequences.
+    multipart_iterm2: iterm2_parser.Iterm2MultipartAssembler = .{},
+
     /// The tmux control mode viewer state.
     tmux_viewer: if (tmux_enabled) ?*terminal.tmux.Viewer else void = if (tmux_enabled) null else {},
 
@@ -92,6 +98,7 @@ pub const StreamHandler = struct {
     pub fn deinit(self: *StreamHandler) void {
         self.apc.deinit();
         self.dcs.deinit();
+        self.multipart_iterm2.deinit(self.alloc);
         if (comptime tmux_enabled) tmux: {
             const viewer = self.tmux_viewer orelse break :tmux;
             viewer.deinit();
@@ -373,6 +380,7 @@ pub const StreamHandler = struct {
             .apc_end => try self.apcEnd(),
             .apc_put => self.apc.feed(self.alloc, value),
             .iterm2_image_transmit => try self.iterm2ImageTransmit(value),
+            .iterm2_multipart_image => try self.iterm2MultipartImage(value),
 
             // Unimplemented
             .title_push,
@@ -1628,5 +1636,28 @@ pub const StreamHandler = struct {
         // iTerm2's File= protocol has no response channel, unlike the
         // kitty graphics APC. We drop the response.
         _ = self.terminal.kittyGraphics(self.alloc, &cmd);
+    }
+
+    /// Handle one event from an iTerm2 OSC 1337 multipart File=
+    /// transfer. The assembler stitches chunks across OSCs; on FileEnd
+    /// it returns an Iterm2ImageTransmit whose payload we own and
+    /// must free. We hand it straight to the same synth + dispatch
+    /// path the single-shot File= handler uses.
+    fn iterm2MultipartImage(
+        self: *StreamHandler,
+        event: terminal.osc.Command.Iterm2MultipartEvent,
+    ) !void {
+        const assembled = self.multipart_iterm2.handleEvent(
+            self.alloc,
+            event,
+        ) catch |err| {
+            log.warn("iterm2 multipart image dropped: {t}", .{err});
+            return;
+        };
+
+        const transmit = assembled orelse return;
+        defer self.alloc.free(transmit.payload);
+
+        try self.iterm2ImageTransmit(transmit);
     }
 };


### PR DESCRIPTION
Follow-up B to #377. The single-shot ``File=`` path can only carry images that fit in a single OSC payload (~2 KiB after base64); larger images use the multipart split:

```
OSC 1337;MultipartFile=options    -- start, options only, no chunk
OSC 1337;FilePart=base64_chunk    -- continue, repeat as needed
OSC 1337;FileEnd                  -- terminator
```

iTerm2's spec has no session identifier, so transfers are strictly serialized: one in flight at a time.

## Wire-up

- New ``osc.Command.Iterm2MultipartEvent`` union ``{ start: hints, chunk: bytes, end }`` emitted one-per-OSC by the parser.
- New ``Iterm2MultipartAssembler`` in ``osc/parsers/iterm2.zig`` stitches events across OSCs: stashes hints + ``ArrayList(u8)`` on start, appends chunks, returns an ``Iterm2ImageTransmit`` on end. Owned by the stream handler via a ``multipart_iterm2`` field with deinit on shutdown.
- The ``MultipartFile`` arm rejects without ``inline=1``, matching the single-shot ``File=`` path; the parser walks options through the same shared ``parseFileOptions`` helper so the geometry hints from #377 work on multipart too.
- The single-shot ``iterm2ImageTransmit`` handler is reused unchanged. After ``FileEnd`` the multipart handler frees the assembled buffer immediately after the inner call returns, because ``synthKittyCommand`` copies the bytes through base64 decode into a fresh kitty Command buffer.

The payload type on ``Iterm2ImageTransmit`` relaxed from ``[:0]const u8`` to ``[]const u8``. The single-shot parser still produces a slice into the parser's null-terminated capture buffer, and the multipart assembler now produces a heap-allocated slice without an artificial sentinel. No consumer used the sentinel (``simd.base64`` takes ``[]const u8``).

## Error / edge cases

| Case | Behavior |
|---|---|
| ``FilePart`` with no active transfer | ``log.warn``, drop chunk |
| ``FileEnd`` with no active transfer | ``log.warn``, no-op |
| ``MultipartFile`` while one is in flight | ``log.warn``, discard previous, start fresh |
| Accumulated payload above 64 MiB (matches APC kitty cap) | ``log.warn``, drop entire transfer |
| ``StreamHandler.deinit`` | frees the in-flight payload via the assembler |

## Tests

Parser (6 new):
- ``MultipartFile`` with inline+hints
- ``MultipartFile`` without inline rejected
- ``FilePart`` with chunk
- ``FilePart`` with empty value
- ``FileEnd``
- ``FileEnd=`` tolerated

Assembler (5 new):
- happy path stitches chunks + preserves hints
- orphan chunk dropped
- orphan end ignored
- overlapping start discards previous
- oversize transfer rejected

## Verification

- Windows: ``zig build test`` -> 2900/2955 pass, 55 skipped, 0 failures
- Mac (alessandros-macbook-air, arm64, Zig 0.15.2): ``zig build test-lib-vt -Dtest-filter=iterm2`` -> 145/147 pass, 2 skipped
- Linux (ubuntinovm): offline at commit time

## Deferred (still tracked from #375)

- JPEG/GIF: needs Ghostty kitty image decoder extension (PNG-only today)
- iTerm2 query/response sequences

## Test plan

- [x] zig build test passes on Windows
- [x] zig build test-lib-vt -Dtest-filter=iterm2 passes on Mac
- [ ] zig build test-lib-vt passes on Linux (when VM is back online)
- [ ] smoke probe-iterm2-multipart.ps1 emits a 3-OSC chunked PNG and Wintty.exe renders it