### PR TITLE
terminal/osc: accept iTerm2 OSC 1337 ReportCellSize query

### DIFF
--- a/include/ghostty/vt/size_report.h
+++ b/include/ghostty/vt/size_report.h
@@ -10,8 +10,9 @@
 /** @defgroup size_report Size Report Encoding
  *
  * Utilities for encoding terminal size reports into escape sequences,
- * supporting in-band size reports (mode 2048) and XTWINOPS responses
- * (CSI 14 t, CSI 16 t, CSI 18 t).
+ * supporting in-band size reports (mode 2048), XTWINOPS responses
+ * (CSI 14 t, CSI 16 t, CSI 18 t), and the iTerm2 OSC 1337
+ * ReportCellSize response.
  *
  * ## Basic Usage
  *
@@ -49,6 +50,8 @@ typedef enum GHOSTTY_ENUM_TYPED {
     GHOSTTY_SIZE_REPORT_CSI_16_T = 2,
     /** XTWINOPS text area size in characters: ESC [ 8 ; rows ; cols t */
     GHOSTTY_SIZE_REPORT_CSI_18_T = 3,
+    /** iTerm2 OSC 1337 ReportCellSize response: OSC 1337 ; ReportCellSize=height;width;1.0 ST */
+    GHOSTTY_SIZE_REPORT_ITERM2_REPORT_CELL_SIZE = 4,
     GHOSTTY_SIZE_REPORT_STYLE_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttySizeReportStyle;
 

--- a/src/terminal/csi.zig
+++ b/src/terminal/csi.zig
@@ -44,10 +44,9 @@ pub const SizeReportStyle = lib.Enum(
         "csi_18_t",
         "csi_21_t",
         // iTerm2 OSC 1337 ReportCellSize. Triggered by OSC, but the
-        // response shape (cell pixel dimensions written to the pty)
-        // shares the size-report dispatch path with the XTWINOPS
-        // forms, so it lives on this enum alongside csi_21_t which
-        // is similarly OSC-driven.
+        // response (cell pixel dimensions written to the pty) shares
+        // the size-report dispatch path with the XTWINOPS forms, so
+        // it lives on this enum.
         "iterm2_report_cell_size",
     },
 );

--- a/src/terminal/csi.zig
+++ b/src/terminal/csi.zig
@@ -43,6 +43,12 @@ pub const SizeReportStyle = lib.Enum(
         "csi_16_t",
         "csi_18_t",
         "csi_21_t",
+        // iTerm2 OSC 1337 ReportCellSize. Triggered by OSC, but the
+        // response shape (cell pixel dimensions written to the pty)
+        // shares the size-report dispatch path with the XTWINOPS
+        // forms, so it lives on this enum alongside csi_21_t which
+        // is similarly OSC-driven.
+        "iterm2_report_cell_size",
     },
 );
 

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -172,6 +172,13 @@ pub const Command = union(Key) {
     /// strictly serialized.
     iterm2_multipart_image: Iterm2MultipartEvent,
 
+    /// iTerm2 OSC 1337 ReportCellSize query. The terminal replies with
+    /// `OSC 1337;ReportCellSize=H;W;scale ST` where H and W are cell
+    /// pixel height and width. iTerm2's bare-key query carries no
+    /// payload; the parser rejects any `=value` form because it would
+    /// collide with the response wire format.
+    iterm2_report_cell_size,
+
     pub const SemanticPrompt = parsers.semantic_prompt.Command;
 
     /// iTerm2 OSC 1337 File= inline image payload + parsed geometry hints.
@@ -259,6 +266,7 @@ pub const Command = union(Key) {
             "context_signal",
             "iterm2_image_transmit",
             "iterm2_multipart_image",
+            "iterm2_report_cell_size",
         },
     );
 
@@ -490,6 +498,7 @@ pub const Parser = struct {
             .context_signal,
             .iterm2_image_transmit,
             .iterm2_multipart_image,
+            .iterm2_report_cell_size,
             => {},
         }
 

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -331,6 +331,24 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
             return &parser.command;
         },
 
+        .ReportCellSize => {
+            // iTerm2's documented form is the bare key
+            // `OSC 1337;ReportCellSize ST`. A trailing `=` with no
+            // value is accepted defensively (matches the FileEnd
+            // path's tolerance for emitters built around naive
+            // `key=value` formatters). Any `=non-empty` form would
+            // collide with the response shape
+            // `ReportCellSize=H;W;scale`, so we reject it.
+            if (value_) |v| {
+                if (v.len > 0) {
+                    parser.command = .invalid;
+                    return null;
+                }
+            }
+            parser.command = .iterm2_report_cell_size;
+            return &parser.command;
+        },
+
         .AddAnnotation,
         .AddHiddenAnnotation,
         .Block,
@@ -347,7 +365,6 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
         .PopKeyLabels,
         .PushKeyLabels,
         .RemoteHost,
-        .ReportCellSize,
         .ReportVariable,
         .RequestAttention,
         .RequestUpload,
@@ -1172,6 +1189,63 @@ test "OSC: 1337: test FileEnd with trailing equals also emits end" {
 
     const cmd = p.end('\x1b').?.*;
     try testing.expect(cmd.iterm2_multipart_image == .end);
+}
+
+test "OSC: 1337: test ReportCellSize bare key emits iterm2_report_cell_size" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;ReportCellSize";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_report_cell_size);
+}
+
+test "OSC: 1337: test reportcellsize lowercase emits iterm2_report_cell_size" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    const input = "1337;reportcellsize";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_report_cell_size);
+}
+
+test "OSC: 1337: test ReportCellSize with stray value is rejected" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    // The iTerm2 spec defines ReportCellSize as a bare-key query.
+    // Any `=value` form would collide with the terminal's response
+    // wire format, so we reject it.
+    const input = "1337;ReportCellSize=foo";
+    for (input) |ch| p.next(ch);
+
+    try testing.expect(p.end('\x1b') == null);
+}
+
+test "OSC: 1337: test ReportCellSize with empty value also emits query" {
+    const testing = std.testing;
+
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+
+    // A trailing `=` with no value is accepted defensively, mirroring
+    // the FileEnd path: emitters built around naive `key=value`
+    // formatters can hit this without intending to send a response.
+    const input = "1337;ReportCellSize=";
+    for (input) |ch| p.next(ch);
+
+    const cmd = p.end('\x1b').?.*;
+    try testing.expect(cmd == .iterm2_report_cell_size);
 }
 
 test "Iterm2MultipartAssembler: happy path assembles chunks" {

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -334,11 +334,11 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
         .ReportCellSize => {
             // iTerm2's documented form is the bare key
             // `OSC 1337;ReportCellSize ST`. A trailing `=` with no
-            // value is accepted defensively (matches the FileEnd
-            // path's tolerance for emitters built around naive
-            // `key=value` formatters). Any `=non-empty` form would
-            // collide with the response shape
-            // `ReportCellSize=H;W;scale`, so we reject it.
+            // value is accepted defensively because the upstream
+            // `key=value` split happily produces an empty value for
+            // such input. Any `=non-empty` form would collide with
+            // the response shape `ReportCellSize=H;W;scale`, so we
+            // reject it.
             if (value_) |v| {
                 if (v.len > 0) {
                     parser.command = .invalid;
@@ -1238,9 +1238,10 @@ test "OSC: 1337: test ReportCellSize with empty value also emits query" {
     var p: Parser = .init(testing.allocator);
     defer p.deinit();
 
-    // A trailing `=` with no value is accepted defensively, mirroring
-    // the FileEnd path: emitters built around naive `key=value`
-    // formatters can hit this without intending to send a response.
+    // A trailing `=` with no value is accepted defensively: the
+    // upstream key=value split produces an empty value for such
+    // input, and emitters built around naive `key=value` formatters
+    // can hit this without intending to send a response.
     const input = "1337;ReportCellSize=";
     for (input) |ch| p.next(ch);
 

--- a/src/terminal/size_report.zig
+++ b/src/terminal/size_report.zig
@@ -12,6 +12,8 @@ pub const Style = lib.Enum(lib.target, &.{
     "csi_16_t",
     // XTWINOPS: report text area size in characters
     "csi_18_t",
+    // iTerm2 OSC 1337 ReportCellSize response.
+    "iterm2_report_cell_size",
 });
 
 /// Runtime size values used to encode terminal size reports.
@@ -77,6 +79,22 @@ pub fn encode(
                 size.columns,
             },
         ),
+
+        .iterm2_report_cell_size => try writer.print(
+            // iTerm2's response shape is `ReportCellSize=H;W;scale`
+            // where scale is the device-pixel ratio and H,W are the
+            // cell dimensions at that scale. Ghostty's cell metrics
+            // are already in backing pixels; reporting scale=1.0 so
+            // that H*scale = backing pixels gives clients the cell
+            // pixel size they need without requiring DPR plumbing.
+            // Clients that parse the legacy two-field form ignore
+            // the trailing scale.
+            "\x1b]1337;ReportCellSize={};{};1.0\x1b\\",
+            .{
+                size.cell_height,
+                size.cell_width,
+            },
+        ),
     }
 }
 
@@ -121,6 +139,21 @@ test "encode csi 18 t" {
     try std.testing.expectEqualStrings("\x1b[8;24;80t", writer.buffered());
 }
 
+test "encode iterm2 report cell size" {
+    var buf: [64]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try encode(&writer, .iterm2_report_cell_size, testSize());
+
+    // iTerm2 OSC 1337 ReportCellSize response. Order is H;W;scale and
+    // the scale field is reported as 1.0 because Ghostty's cell metrics
+    // are already in logical pixels on retina displays; clients that
+    // parse the legacy two-field form ignore the trailing scale.
+    try std.testing.expectEqualStrings(
+        "\x1b]1337;ReportCellSize=18;9;1.0\x1b\\",
+        writer.buffered(),
+    );
+}
+
 test "encode max values for all fields" {
     const max_size: Size = .{
         .rows = std.math.maxInt(@FieldType(Size, "rows")),
@@ -150,6 +183,10 @@ test "encode max values for all fields" {
         .{
             .style = .csi_18_t,
             .expected = "\x1b[8;65535;65535t",
+        },
+        .{
+            .style = .iterm2_report_cell_size,
+            .expected = "\x1b]1337;ReportCellSize=4294967295;4294967295;1.0\x1b\\",
         },
     }) |case| {
         var buf: [128]u8 = undefined;

--- a/src/terminal/size_report.zig
+++ b/src/terminal/size_report.zig
@@ -146,8 +146,8 @@ test "encode iterm2 report cell size" {
 
     // iTerm2 OSC 1337 ReportCellSize response. Order is H;W;scale and
     // the scale field is reported as 1.0 because Ghostty's cell metrics
-    // are already in logical pixels on retina displays; clients that
-    // parse the legacy two-field form ignore the trailing scale.
+    // are already in backing pixels; clients that parse the legacy
+    // two-field form ignore the trailing scale.
     try std.testing.expectEqualStrings(
         "\x1b]1337;ReportCellSize=18;9;1.0\x1b\\",
         writer.buffered(),

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2066,6 +2066,10 @@ pub fn Stream(comptime H: type) type {
                     self.handler.vt(.iterm2_multipart_image, event);
                 },
 
+                .iterm2_report_cell_size => {
+                    self.handler.vt(.size_report, .iterm2_report_cell_size);
+                },
+
                 .conemu_sleep,
                 .conemu_show_message_box,
                 .conemu_change_tab_title,

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -380,13 +380,18 @@ pub const Handler = struct {
                 aw.writer.print("\x1b]l{s}\x1b\\", .{title}) catch return;
             },
 
-            .csi_14_t, .csi_16_t, .csi_18_t => {
+            .csi_14_t,
+            .csi_16_t,
+            .csi_18_t,
+            .iterm2_report_cell_size,
+            => {
                 const get_size = self.effects.size orelse return;
                 const s = get_size(self) orelse return;
                 const report_style: size_report.Style = switch (style) {
                     .csi_14_t => .csi_14_t,
                     .csi_16_t => .csi_16_t,
                     .csi_18_t => .csi_18_t,
+                    .iterm2_report_cell_size => .iterm2_report_cell_size,
                     .csi_21_t => unreachable,
                 };
                 size_report.encode(

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1514,6 +1514,9 @@ pub const StreamHandler = struct {
             .csi_16_t => self.messageWriter(.{ .size_report = .csi_16_t }),
             .csi_18_t => self.messageWriter(.{ .size_report = .csi_18_t }),
             .csi_21_t => self.surfaceMessageWriter(.{ .report_title = .csi_21_t }),
+            .iterm2_report_cell_size => self.messageWriter(.{
+                .size_report = .iterm2_report_cell_size,
+            }),
         }
     }
 


### PR DESCRIPTION
## Summary

Accept iTerm2's `OSC 1337;ReportCellSize` bare-key query and reply with the cell pixel size on the pty. Sixth PR in the iTerm2 OSC 1337 series (after #375 #376 #377 #378), and the smallest by design.

Emitters like `imgcat` use this to compute image-cell scaling. With the prior PRs we accept and render inline images; this PR closes the loop so clients can ask the terminal "how big is a cell?" before sending an image.

## Wire format

- Request: `\x1b]1337;ReportCellSize\x1b\` (bare key)
- Response: `\x1b]1337;ReportCellSize={cell_height};{cell_width};1.0\x1b\`

The trailing `1.0` is iTerm2's HiDPI scale field. Ghostty reports cell metrics already in backing pixels, so `scale=1.0` lets clients compute `H * scale = backing_pixels` without us threading device-pixel ratio through the size-report pipeline. Clients that parse the legacy two-field form ignore the trailing scale.

## Architecture

Reuses the existing `size_report.Action` dispatch:

- New `iterm2_report_cell_size` variant on `csi.SizeReportStyle` (alongside `csi_21_t` which is similarly OSC-driven, so this is not a new pattern)
- New `iterm2_report_cell_size` variant on `size_report.Style` (encoder-side enum) and an encoder branch
- Parser arm in `parsers/iterm2.zig` emitting `Command.iterm2_report_cell_size` (void)
- Stream OSC dispatch emits `.size_report` with the new style
- `sendSizeReport` (termio) and `reportSize` (libghostty-vt embedders) both pick up the new variant through their existing switches

Result: libghostty-vt embedders that implement `effects.size` get the ReportCellSize response without any C-side or apprt-side work.

## Parser permissiveness

- `ReportCellSize` -> emit query
- `ReportCellSize=` -> emit query (defensive, matches `FileEnd=` precedent)
- `ReportCellSize=non-empty` -> reject (would collide with the response shape)

## Tests

- 4 parser tests: bare key, lowercase, `=` empty value accepted, `=non-empty` rejected
- 1 encoder test plus the existing exhaustive max-values test extended to cover the new variant
- Full suite green on Windows (1984 tests) and macOS

## Test plan

- [x] `zig build test` passes on Windows
- [x] `zig build test` passes on macOS (via SSH bundle)
- [ ] Interactive probe with `imgcat` once we have a Wintty.exe build