### PR TITLE
renderer/image: drop placement after upload failure

### DIFF
--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -58,9 +58,14 @@ pub const State = struct {
     /// Upload any images to the GPU that need to be uploaded,
     /// and remove any images that are no longer needed on the GPU.
     ///
-    /// If any uploads fail, they are ignored. The return value
-    /// can be used to detect if upload was a total success (true)
-    /// or not (false).
+    /// A failed upload (e.g. wuffs decode error, DX12 UploadFailed)
+    /// flips the image to its unload state so the next iteration
+    /// sweeps it. Without this, a persistently-failing image
+    /// retries every frame and floods the log; the placement
+    /// can't render anyway, so dropping it is the correct outcome.
+    ///
+    /// Returns true if every pending image uploaded successfully,
+    /// false if any failed.
     pub fn upload(
         self: *State,
         alloc: Allocator,
@@ -81,7 +86,11 @@ pub const State = struct {
                     alloc,
                     api,
                 ) catch |err| {
-                    log.warn("error uploading image to GPU err={}", .{err});
+                    log.warn(
+                        "error uploading image to GPU err={t}, dropping placement",
+                        .{err},
+                    );
+                    img.markForUnload();
                     success = false;
                 };
             }
@@ -979,3 +988,54 @@ pub const Image = union(enum) {
         };
     }
 };
+
+test "Image.markForUnload pending -> unload_pending" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // A four-byte RGBA pixel buffer the .pending state takes
+    // ownership of; deinit frees it.
+    const data = try alloc.alloc(u8, 4);
+    var img: Image = .{ .pending = .{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .rgba,
+        .data = data.ptr,
+    } };
+    defer img.deinit(alloc);
+
+    try testing.expect(img.isPending());
+    try testing.expect(!img.isUnloading());
+
+    img.markForUnload();
+
+    try testing.expectEqual(
+        @as(std.meta.Tag(Image), .unload_pending),
+        std.meta.activeTag(img),
+    );
+    // isUnloading() being true is what State.upload checks first;
+    // the unload sweep deinits + removes the image before the
+    // retry-via-isPending branch fires, so the failed image only
+    // logs once instead of every frame.
+    try testing.expect(img.isUnloading());
+}
+
+test "Image.markForUnload is idempotent on already-unloading states" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const data = try alloc.alloc(u8, 4);
+    var img: Image = .{ .unload_pending = .{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .rgba,
+        .data = data.ptr,
+    } };
+    defer img.deinit(alloc);
+
+    img.markForUnload();
+    try testing.expectEqual(
+        @as(std.meta.Tag(Image), .unload_pending),
+        std.meta.activeTag(img),
+    );
+}


### PR DESCRIPTION
## Summary

Fix the persistent-retry loop called out in [#382](https://github.com/deblasis/wintty/pull/382)'s known-limitations section. When `Image.upload` fails (wuffs decode error, DX12 `UploadFailed`, etc.), the image was previously left in `.pending` state. `State.upload`'s next iteration saw the same pending image, retried, logged the same warn, and so on every frame.

Mark the image for unload in the catch arm. The Image state machine already has `unload_pending` / `unload_replace` transitions via `Image.markForUnload`, and the per-frame sweep at the top of `State.upload` runs the `isUnloading()` check before the `isPending()` retry branch, so the failed image is freed on the next iteration and the log fires exactly once.

## What changes

- [`State.upload` catch arm](src/renderer/image.zig:79): adds `img.markForUnload()` after the existing warn log. The warn message gains "dropping placement" so it's clear what happened.
- Updated doc comment on `State.upload` describing the new behavior.
- Two pure-Zig tests cover the markForUnload state-transition contract (no existing image.zig tests — these are the first):
  - `Image.markForUnload pending -> unload_pending`: builds an Image in `.pending`, asserts markForUnload flips the tag and `isUnloading()` becomes true.
  - `Image.markForUnload is idempotent on already-unloading states`: the early-return arms preserve the active tag.

## Behavior change

| Before | After |
|---|---|
| Image upload fails | Image upload fails |
| Log: `error uploading image to GPU err=UploadFailed` | Log: `error uploading image to GPU err=UploadFailed, dropping placement` |
| Image stays `.pending` | Image flipped to `.unload_pending` |
| Next frame: retry → same log | Next frame: `isUnloading()` true → deinit + remove from map |
| Repeats every frame forever | Single log line per failed upload |

## Test plan

- [x] `zig build test` passes on Windows (1992 tests, +2 new)
- [x] `zig build test` passes on macOS (via SSH bundle)

## Out of scope

- A user-visible signal (toast / InfoBar in the WinUI 3 host) for image-render failures — would need a new FFI channel.
- Tracking the failure cause back to the kitty/iTerm2 emitter via a kitty graphics protocol error response — separate concern; the kitty graphics executor already has its own error-response path for invalid data.