### PR TITLE
renderer: per-frame DX12 upload-budget guard

### DIFF
--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -87,6 +87,12 @@ state: d3d12.D3D12_RESOURCE_STATES = d3d12.D3D12_RESOURCE_STATES.PIXEL_SHADER_RE
 /// stays signature-compatible with the value-receiver call sites
 /// (Image switch captures, generic.zig front/back texture fields).
 pending_staging: std.ArrayListUnmanaged(*d3d12.ID3D12Resource) = .empty,
+/// Running sum of band-staging bytes currently held by `pending_staging`.
+/// Mirrors the list contents so callers (image.zig State.upload) can
+/// query the UPLOAD-heap pressure of an individual texture without
+/// COM-querying each ID3D12Resource's size. Incremented in uploadRegion
+/// per band; reset in replaceRegion's release loop.
+pending_staging_bytes: u64 = 0,
 
 const TEXTURE_DATA_PITCH_ALIGNMENT: u32 = 256;
 
@@ -239,6 +245,7 @@ pub fn replaceRegion(self: *Texture, x: usize, y: usize, width: usize, height: u
         _ = prev.Release();
     }
     self.pending_staging.clearRetainingCapacity();
+    self.pending_staging_bytes = 0;
 
     // Transition to COPY_DEST if needed.
     if (self.state != d3d12.D3D12_RESOURCE_STATES.COPY_DEST) {
@@ -364,6 +371,7 @@ fn uploadRegion(self: *Texture, x: u32, y: u32, width: u32, height: u32, data: [
             log.warn("failed to track staging buffer for chunked upload", .{});
             return error.UploadFailed;
         };
+        self.pending_staging_bytes += band_size;
     }
 }
 
@@ -669,6 +677,11 @@ test "Texture struct fields" {
 test "Texture pending_staging defaults to empty" {
     const tex = Texture{};
     try std.testing.expectEqual(@as(usize, 0), tex.pending_staging.items.len);
+}
+
+test "Texture pending_staging_bytes defaults to 0" {
+    const tex = Texture{};
+    try std.testing.expectEqual(@as(u64, 0), tex.pending_staging_bytes);
 }
 
 test "Texture.Options defaults" {

--- a/src/renderer/directx12/Texture.zig
+++ b/src/renderer/directx12/Texture.zig
@@ -94,7 +94,10 @@ pending_staging: std.ArrayListUnmanaged(*d3d12.ID3D12Resource) = .empty,
 /// per band; reset in replaceRegion's release loop.
 pending_staging_bytes: u64 = 0,
 
-const TEXTURE_DATA_PITCH_ALIGNMENT: u32 = 256;
+/// Row-pitch alignment that DX12's CopyTextureRegion requires for staging
+/// buffers (D3D12_TEXTURE_DATA_PITCH_ALIGNMENT). `pub` so image.zig can
+/// `comptime assert` its mirror constant stays in lockstep.
+pub const TEXTURE_DATA_PITCH_ALIGNMENT: u32 = 256;
 
 /// Target size in bytes for each per-band staging buffer. Chosen to keep
 /// individual UPLOAD-heap allocations small enough to succeed under

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -12,6 +12,31 @@ const Overlay = @import("Overlay.zig");
 
 const log = std.log.scoped(.renderer_image);
 
+/// Default per-frame UPLOAD-heap budget for image uploads. The State
+/// loop defers any pending image whose chunked-upload total would push
+/// the in-flight sum past this number; the deferred image stays in
+/// .pending and retries on the next frame. 128 MiB leaves headroom for
+/// two ~48 MiB images concurrent with smaller atlases/overlays without
+/// pressuring Windows shared-memory.
+const TEXTURE_UPLOAD_BUDGET_DEFAULT_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Pitch alignment used by DX12 texture uploads. Must stay in sync with
+/// Texture.TEXTURE_DATA_PITCH_ALIGNMENT (256) so the budget estimate
+/// matches the actual staging buffer size.
+const TEXTURE_UPLOAD_PITCH_ALIGNMENT: u32 = 256;
+
+/// Compute the UPLOAD-heap bytes that will be consumed when uploading
+/// an RGBA image of the given dimensions. Mirrors the math inside
+/// Texture.uploadRegion (post-swizzle, 256-byte row alignment); kept
+/// here as a pure function so State.upload can size-check images
+/// without touching the DX12 layer.
+fn imageStagingBytes(width: u32, height: u32) u64 {
+    const row_bytes: u32 = width * 4;
+    const aligned: u32 = (row_bytes + TEXTURE_UPLOAD_PITCH_ALIGNMENT - 1) &
+        ~(TEXTURE_UPLOAD_PITCH_ALIGNMENT - 1);
+    return @as(u64, aligned) * @as(u64, height);
+}
+
 /// Generic image rendering state for the renderer. This stores all
 /// images and their placements and exposes only a limited public API
 /// for adding images and placements and drawing them.
@@ -1042,4 +1067,24 @@ test "Image.markForUnload is idempotent on already-unloading states" {
         @as(std.meta.Tag(Image), .unload_pending),
         std.meta.activeTag(img),
     );
+}
+
+test "imageStagingBytes aligns row pitch to 256" {
+    // 1x1 RGBA -> aligned row pitch is 256, height 1 -> 256 bytes.
+    try std.testing.expectEqual(@as(u64, 256), imageStagingBytes(1, 1));
+}
+
+test "imageStagingBytes for 64x64 RGBA" {
+    // 64 * 4 = 256, already aligned. 256 * 64 = 16384.
+    try std.testing.expectEqual(@as(u64, 16384), imageStagingBytes(64, 64));
+}
+
+test "imageStagingBytes pads to next 256 for non-aligned widths" {
+    // 65 * 4 = 260, pads to 512. 512 * 65 = 33280.
+    try std.testing.expectEqual(@as(u64, 33280), imageStagingBytes(65, 65));
+}
+
+test "imageStagingBytes for typical 4096x3072 RGBA upload" {
+    // 4096 * 4 = 16384, already aligned. 16384 * 3072 = 50331648 (~48 MiB).
+    try std.testing.expectEqual(@as(u64, 50331648), imageStagingBytes(4096, 3072));
 }

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -848,6 +848,32 @@ pub const Image = union(enum) {
         }
     }
 
+    /// UPLOAD-heap bytes this image's currently-held texture is holding
+    /// alive in `pending_staging`. Returns 0 for variants that have no
+    /// uploaded texture yet.
+    pub fn pendingStagingBytes(self: Image) u64 {
+        return switch (self) {
+            .pending, .unload_pending => 0,
+            .ready, .unload_ready => |t| t.pending_staging_bytes,
+            .replace, .unload_replace => |r| r.texture.pending_staging_bytes,
+        };
+    }
+
+    /// UPLOAD-heap bytes the next `upload()` call will require for this
+    /// image. Returns 0 for already-uploaded or unload-marked variants
+    /// because they won't trigger a new staging allocation.
+    pub fn estimatedUploadStagingBytes(self: Image) u64 {
+        return switch (self) {
+            .pending => |p| imageStagingBytes(p.width, p.height),
+            .replace => |r| imageStagingBytes(r.pending.width, r.pending.height),
+            .ready,
+            .unload_ready,
+            .unload_pending,
+            .unload_replace,
+            => 0,
+        };
+    }
+
     /// Mark this image for unload whatever state it is in.
     pub fn markForUnload(self: *Image) void {
         self.* = switch (self.*) {
@@ -1112,4 +1138,51 @@ test "wouldExceedBudget false when in_flight already at budget and est is 0" {
 test "wouldExceedBudget true when in_flight already over budget" {
     // Already over (somehow) -- any non-zero est should exceed.
     try std.testing.expect(wouldExceedBudget(200, 1, 128));
+}
+
+test "Image.estimatedUploadStagingBytes returns imageStagingBytes for .pending" {
+    var data: [16]u8 = .{0} ** 16;
+    const img: Image = .{ .pending = .{
+        .width = 2,
+        .height = 2,
+        .pixel_format = .rgba,
+        .data = &data,
+    } };
+    // 2x2 RGBA -> aligned pitch 256 * height 2 = 512.
+    try std.testing.expectEqual(@as(u64, 512), img.estimatedUploadStagingBytes());
+}
+
+test "Image.estimatedUploadStagingBytes returns 0 for .ready" {
+    const img: Image = .{ .ready = .{} };
+    try std.testing.expectEqual(@as(u64, 0), img.estimatedUploadStagingBytes());
+}
+
+test "Image.estimatedUploadStagingBytes returns imageStagingBytes for .replace" {
+    var data: [16]u8 = .{0} ** 16;
+    const img: Image = .{ .replace = .{
+        .texture = .{},
+        .pending = .{
+            .width = 2,
+            .height = 2,
+            .pixel_format = .rgba,
+            .data = &data,
+        },
+    } };
+    try std.testing.expectEqual(@as(u64, 512), img.estimatedUploadStagingBytes());
+}
+
+test "Image.pendingStagingBytes returns texture.pending_staging_bytes for .ready" {
+    const img: Image = .{ .ready = .{ .pending_staging_bytes = 12345 } };
+    try std.testing.expectEqual(@as(u64, 12345), img.pendingStagingBytes());
+}
+
+test "Image.pendingStagingBytes returns 0 for .pending (no texture yet)" {
+    var data: [4]u8 = .{0} ** 4;
+    const img: Image = .{ .pending = .{
+        .width = 1,
+        .height = 1,
+        .pixel_format = .rgba,
+        .data = &data,
+    } };
+    try std.testing.expectEqual(@as(u64, 0), img.pendingStagingBytes());
 }

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -37,6 +37,13 @@ fn imageStagingBytes(width: u32, height: u32) u64 {
     return @as(u64, aligned) * @as(u64, height);
 }
 
+/// Budget boundary check: does adding `new_est` bytes to the current
+/// `in_flight` total push past `budget`? Strict greater-than so the
+/// budget is the exact ceiling (in_flight + est == budget is allowed).
+fn wouldExceedBudget(in_flight: u64, new_est: u64, budget: u64) bool {
+    return in_flight + new_est > budget;
+}
+
 /// Generic image rendering state for the renderer. This stores all
 /// images and their placements and exposes only a limited public API
 /// for adding images and placements and drawing them.
@@ -1087,4 +1094,22 @@ test "imageStagingBytes pads to next 256 for non-aligned widths" {
 test "imageStagingBytes for typical 4096x3072 RGBA upload" {
     // 4096 * 4 = 16384, already aligned. 16384 * 3072 = 50331648 (~48 MiB).
     try std.testing.expectEqual(@as(u64, 50331648), imageStagingBytes(4096, 3072));
+}
+
+test "wouldExceedBudget false when sum fits exactly" {
+    // 100 + 28 == 128, fits at the boundary.
+    try std.testing.expect(!wouldExceedBudget(100, 28, 128));
+}
+
+test "wouldExceedBudget true when sum overshoots by one" {
+    try std.testing.expect(wouldExceedBudget(100, 29, 128));
+}
+
+test "wouldExceedBudget false when in_flight already at budget and est is 0" {
+    try std.testing.expect(!wouldExceedBudget(128, 0, 128));
+}
+
+test "wouldExceedBudget true when in_flight already over budget" {
+    // Already over (somehow) -- any non-zero est should exceed.
+    try std.testing.expect(wouldExceedBudget(200, 1, 128));
 }

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -68,6 +68,12 @@ pub const State = struct {
     /// Overlays
     overlay_placements: std.ArrayListUnmanaged(Placement),
 
+    /// Per-frame UPLOAD-heap budget for image uploads. State.upload
+    /// defers any pending image whose chunked upload would push the
+    /// running in-flight total past this. Tunable per-State instance;
+    /// defaults to TEXTURE_UPLOAD_BUDGET_DEFAULT_BYTES (128 MiB).
+    upload_budget_bytes: u64 = TEXTURE_UPLOAD_BUDGET_DEFAULT_BYTES,
+
     pub const empty: State = .{
         .images = .empty,
         .kitty_placements = .empty,
@@ -75,6 +81,7 @@ pub const State = struct {
         .kitty_text_end = 0,
         .kitty_virtual = false,
         .overlay_placements = .empty,
+        .upload_budget_bytes = TEXTURE_UPLOAD_BUDGET_DEFAULT_BYTES,
     };
 
     pub fn deinit(self: *State, alloc: Allocator) void {
@@ -103,17 +110,41 @@ pub const State = struct {
         alloc: Allocator,
         api: *GraphicsAPI,
     ) bool {
+        // Compute the current UPLOAD-heap staging total across all
+        // already-uploaded textures once at the start of the call. We
+        // incrementally bump this as new uploads succeed; that's still
+        // a strict upper bound because a successful upload only adds
+        // bytes (it never frees, until the next replaceRegion/deinit
+        // which happens in a different code path).
+        var bytes_in_flight: u64 = 0;
+        {
+            var image_it = self.images.iterator();
+            while (image_it.next()) |kv| {
+                bytes_in_flight += kv.value_ptr.image.pendingStagingBytes();
+            }
+        }
+
         var success: bool = true;
         var image_it = self.images.iterator();
         while (image_it.next()) |kv| {
             const img = &kv.value_ptr.image;
             if (img.isUnloading()) {
+                bytes_in_flight -|= img.pendingStagingBytes();
                 img.deinit(alloc);
                 self.images.removeByPtr(kv.key_ptr);
                 continue;
             }
 
             if (img.isPending()) {
+                const est = img.estimatedUploadStagingBytes();
+                if (est > 0 and wouldExceedBudget(bytes_in_flight, est, self.upload_budget_bytes)) {
+                    log.debug(
+                        "deferring image upload est={d} in_flight={d} budget={d}",
+                        .{ est, bytes_in_flight, self.upload_budget_bytes },
+                    );
+                    continue;
+                }
+
                 img.upload(
                     alloc,
                     api,
@@ -124,7 +155,9 @@ pub const State = struct {
                     );
                     img.markForUnload();
                     success = false;
+                    continue;
                 };
+                bytes_in_flight += est;
             }
         }
 
@@ -1185,4 +1218,12 @@ test "Image.pendingStagingBytes returns 0 for .pending (no texture yet)" {
         .data = &data,
     } };
     try std.testing.expectEqual(@as(u64, 0), img.pendingStagingBytes());
+}
+
+test "State.upload_budget_bytes defaults to TEXTURE_UPLOAD_BUDGET_DEFAULT_BYTES" {
+    const state = State.empty;
+    try std.testing.expectEqual(
+        TEXTURE_UPLOAD_BUDGET_DEFAULT_BYTES,
+        state.upload_budget_bytes,
+    );
 }

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -20,21 +20,33 @@ const log = std.log.scoped(.renderer_image);
 /// pressuring Windows shared-memory.
 const TEXTURE_UPLOAD_BUDGET_DEFAULT_BYTES: u64 = 128 * 1024 * 1024;
 
-/// Pitch alignment used by DX12 texture uploads. Must stay in sync with
-/// Texture.TEXTURE_DATA_PITCH_ALIGNMENT (256) so the budget estimate
-/// matches the actual staging buffer size.
-const TEXTURE_UPLOAD_PITCH_ALIGNMENT: u32 = 256;
+/// Mirror of directx12/Texture.zig TEXTURE_DATA_PITCH_ALIGNMENT. Kept
+/// local so the budget math stays renderer-agnostic; the comptime
+/// block below catches drift on DX12 builds, and on backends without
+/// the constant (Metal/OpenGL) the assert is skipped.
+const TEXTURE_UPLOAD_PITCH_ALIGNMENT: u64 = 256;
 
-/// Compute the UPLOAD-heap bytes that will be consumed when uploading
-/// an RGBA image of the given dimensions. Mirrors the math inside
-/// Texture.uploadRegion (post-swizzle, 256-byte row alignment); kept
-/// here as a pure function so State.upload can size-check images
-/// without touching the DX12 layer.
+comptime {
+    if (@hasDecl(Texture, "TEXTURE_DATA_PITCH_ALIGNMENT")) {
+        std.debug.assert(
+            TEXTURE_UPLOAD_PITCH_ALIGNMENT == Texture.TEXTURE_DATA_PITCH_ALIGNMENT,
+        );
+    }
+}
+
+/// Compute the UPLOAD-heap bytes that will be consumed when uploading an
+/// image of the given dimensions to a DX12 texture. The destination is
+/// always RGBA (Image.convert() swizzles gray/rgb/bgr/etc. to 4 bpp
+/// before upload), and Texture.uploadRegion aligns each row to
+/// TEXTURE_UPLOAD_PITCH_ALIGNMENT (256 bytes). Pure function so
+/// State.upload can size-check without touching the DX12 layer; the
+/// arithmetic is u64 throughout to keep multi-GB hypotheticals from
+/// silently wrapping the u32 intermediate.
 fn imageStagingBytes(width: u32, height: u32) u64 {
-    const row_bytes: u32 = width * 4;
-    const aligned: u32 = (row_bytes + TEXTURE_UPLOAD_PITCH_ALIGNMENT - 1) &
-        ~(TEXTURE_UPLOAD_PITCH_ALIGNMENT - 1);
-    return @as(u64, aligned) * @as(u64, height);
+    const row_bytes: u64 = @as(u64, width) * 4;
+    const align_mask: u64 = TEXTURE_UPLOAD_PITCH_ALIGNMENT - 1;
+    const aligned: u64 = (row_bytes + align_mask) & ~align_mask;
+    return aligned * @as(u64, height);
 }
 
 /// Budget boundary check: does adding `new_est` bytes to the current
@@ -110,55 +122,60 @@ pub const State = struct {
         alloc: Allocator,
         api: *GraphicsAPI,
     ) bool {
-        // Compute the current UPLOAD-heap staging total across all
-        // already-uploaded textures once at the start of the call. We
-        // incrementally bump this as new uploads succeed; that's still
-        // a strict upper bound because a successful upload only adds
-        // bytes (it never frees, until the next replaceRegion/deinit
-        // which happens in a different code path).
+        // Backends whose Texture tracks staging-heap pressure (DX12) run
+        // the budget gate; everything else falls through to a straight
+        // upload loop. The flag is comptime so dead branches drop out.
+        const budgeted = comptime @hasField(Texture, "pending_staging_bytes");
+
+        // Pass 1: sweep unloads + accumulate in-flight from survivors.
+        // Done first so deferral checks in pass 2 see the post-unload
+        // total (an unloaded image's staging is about to be Released).
         var bytes_in_flight: u64 = 0;
         {
             var image_it = self.images.iterator();
             while (image_it.next()) |kv| {
-                bytes_in_flight += kv.value_ptr.image.pendingStagingBytes();
+                const img = &kv.value_ptr.image;
+                if (img.isUnloading()) {
+                    img.deinit(alloc);
+                    self.images.removeByPtr(kv.key_ptr);
+                    continue;
+                }
+                if (budgeted) bytes_in_flight += img.pendingStagingBytes();
             }
         }
 
+        // Pass 2: upload pending images, gating on DX12's budget.
         var success: bool = true;
         var image_it = self.images.iterator();
         while (image_it.next()) |kv| {
             const img = &kv.value_ptr.image;
-            if (img.isUnloading()) {
-                bytes_in_flight -|= img.pendingStagingBytes();
-                img.deinit(alloc);
-                self.images.removeByPtr(kv.key_ptr);
+            if (!img.isPending()) continue;
+
+            const est: u64 = if (budgeted) img.estimatedUploadStagingBytes() else 0;
+            if (budgeted and wouldExceedBudget(bytes_in_flight, est, self.upload_budget_bytes)) {
+                log.debug(
+                    "deferring image upload est={d} in_flight={d} budget={d}",
+                    .{ est, bytes_in_flight, self.upload_budget_bytes },
+                );
                 continue;
             }
 
-            if (img.isPending()) {
-                const est = img.estimatedUploadStagingBytes();
-                if (est > 0 and wouldExceedBudget(bytes_in_flight, est, self.upload_budget_bytes)) {
-                    log.debug(
-                        "deferring image upload est={d} in_flight={d} budget={d}",
-                        .{ est, bytes_in_flight, self.upload_budget_bytes },
-                    );
-                    continue;
-                }
-
-                img.upload(
-                    alloc,
-                    api,
-                ) catch |err| {
-                    log.warn(
-                        "error uploading image to GPU err={t}, dropping placement",
-                        .{err},
-                    );
-                    img.markForUnload();
-                    success = false;
-                    continue;
-                };
-                bytes_in_flight += est;
-            }
+            img.upload(
+                alloc,
+                api,
+            ) catch |err| {
+                log.warn(
+                    "error uploading image to GPU err={t}, dropping placement",
+                    .{err},
+                );
+                // markForUnload moves the image to .unload_pending whose
+                // pendingStagingBytes() returns 0, so next frame's in-flight
+                // total drops by `est` naturally. No manual decrement needed.
+                img.markForUnload();
+                success = false;
+                continue;
+            };
+            if (budgeted) bytes_in_flight += est;
         }
 
         return success;
@@ -882,29 +899,40 @@ pub const Image = union(enum) {
     }
 
     /// UPLOAD-heap bytes this image's currently-held texture is holding
-    /// alive in `pending_staging`. Returns 0 for variants that have no
-    /// uploaded texture yet.
+    /// alive in `pending_staging`. Returns 0 on backends whose Texture
+    /// doesn't track staging-heap pressure (Metal, OpenGL); only DX12
+    /// keeps per-call staging buffers around for fence-gated release.
+    /// The field-access switch is wrapped in a comptime `if` so the
+    /// Metal/OpenGL builds never see `t.pending_staging_bytes` -- a
+    /// post-return version would still type-check the unreachable body.
     pub fn pendingStagingBytes(self: Image) u64 {
-        return switch (self) {
-            .pending, .unload_pending => 0,
-            .ready, .unload_ready => |t| t.pending_staging_bytes,
-            .replace, .unload_replace => |r| r.texture.pending_staging_bytes,
-        };
+        if (comptime @hasField(Texture, "pending_staging_bytes")) {
+            return switch (self) {
+                .pending, .unload_pending => 0,
+                .ready, .unload_ready => |t| t.pending_staging_bytes,
+                .replace, .unload_replace => |r| r.texture.pending_staging_bytes,
+            };
+        }
+        return 0;
     }
 
     /// UPLOAD-heap bytes the next `upload()` call will require for this
     /// image. Returns 0 for already-uploaded or unload-marked variants
-    /// because they won't trigger a new staging allocation.
+    /// because they won't trigger a new staging allocation, and 0 on
+    /// backends without staging-heap tracking.
     pub fn estimatedUploadStagingBytes(self: Image) u64 {
-        return switch (self) {
-            .pending => |p| imageStagingBytes(p.width, p.height),
-            .replace => |r| imageStagingBytes(r.pending.width, r.pending.height),
-            .ready,
-            .unload_ready,
-            .unload_pending,
-            .unload_replace,
-            => 0,
-        };
+        if (comptime @hasField(Texture, "pending_staging_bytes")) {
+            return switch (self) {
+                .pending => |p| imageStagingBytes(p.width, p.height),
+                .replace => |r| imageStagingBytes(r.pending.width, r.pending.height),
+                .ready,
+                .unload_ready,
+                .unload_pending,
+                .unload_replace,
+                => 0,
+            };
+        }
+        return 0;
     }
 
     /// Mark this image for unload whatever state it is in.
@@ -1186,27 +1214,45 @@ test "Image.estimatedUploadStagingBytes returns imageStagingBytes for .pending" 
 }
 
 test "Image.estimatedUploadStagingBytes returns 0 for .ready" {
-    const img: Image = .{ .ready = .{} };
-    try std.testing.expectEqual(@as(u64, 0), img.estimatedUploadStagingBytes());
+    // .ready carries a Texture, and OpenGL's Texture has no default-init
+    // fields, so `.ready = .{}` only compiles where Texture is all-defaults.
+    // Gating on the DX12-only marker keeps the test active where it matters.
+    if (comptime @hasField(Texture, "pending_staging_bytes")) {
+        const img: Image = .{ .ready = .{} };
+        try std.testing.expectEqual(@as(u64, 0), img.estimatedUploadStagingBytes());
+    } else {
+        return error.SkipZigTest;
+    }
 }
 
 test "Image.estimatedUploadStagingBytes returns imageStagingBytes for .replace" {
-    var data: [16]u8 = .{0} ** 16;
-    const img: Image = .{ .replace = .{
-        .texture = .{},
-        .pending = .{
-            .width = 2,
-            .height = 2,
-            .pixel_format = .rgba,
-            .data = &data,
-        },
-    } };
-    try std.testing.expectEqual(@as(u64, 512), img.estimatedUploadStagingBytes());
+    if (comptime @hasField(Texture, "pending_staging_bytes")) {
+        var data: [16]u8 = .{0} ** 16;
+        const img: Image = .{ .replace = .{
+            .texture = .{},
+            .pending = .{
+                .width = 2,
+                .height = 2,
+                .pixel_format = .rgba,
+                .data = &data,
+            },
+        } };
+        try std.testing.expectEqual(@as(u64, 512), img.estimatedUploadStagingBytes());
+    } else {
+        return error.SkipZigTest;
+    }
 }
 
 test "Image.pendingStagingBytes returns texture.pending_staging_bytes for .ready" {
-    const img: Image = .{ .ready = .{ .pending_staging_bytes = 12345 } };
-    try std.testing.expectEqual(@as(u64, 12345), img.pendingStagingBytes());
+    // Only the DX12 Texture has the staging-bytes counter. The outer
+    // comptime branch keeps the field access out of Metal/OpenGL
+    // analysis; the inner runtime skip surfaces in the test report.
+    if (comptime @hasField(Texture, "pending_staging_bytes")) {
+        const img: Image = .{ .ready = .{ .pending_staging_bytes = 12345 } };
+        try std.testing.expectEqual(@as(u64, 12345), img.pendingStagingBytes());
+    } else {
+        return error.SkipZigTest;
+    }
 }
 
 test "Image.pendingStagingBytes returns 0 for .pending (no texture yet)" {


### PR DESCRIPTION
## Summary

Cap peak DX12 UPLOAD-heap staging-buffer pressure with a per-frame budget. Closes audit followup #3 from `project_dx12_image_upload_audit.md`, layering on the chunked-upload infrastructure from #386.

## How it works

- `Texture` gains a running `pending_staging_bytes: u64` counter mirroring the live `pending_staging` list (incremented per band in `uploadRegion`, reset in `replaceRegion`).
- `image.zig` adds pure helpers `imageStagingBytes(w, h)` (post-swizzle RGBA + 256-byte aligned) and `wouldExceedBudget(in_flight, est, budget)`.
- `State` gets `upload_budget_bytes: u64` (default 128 MiB) and `Image` exposes `pendingStagingBytes()` + `estimatedUploadStagingBytes()`.
- `State.upload` computes the current in-flight total once at the start of the call, then walks the image map gating each pending image against the budget. Over-budget images are skipped (`continue`); they stay `.pending` and retry on a later frame.

Deferral is NOT counted as failure — the bool return still only tracks markForUnload failures. The caller (`generic.zig:1667`) discards the value either way.

## Test plan

- [x] `zig build test` passes — adds 13 new pure-function tests:
  - 1 for `Texture.pending_staging_bytes` default
  - 4 for `imageStagingBytes` (1x1, 64x64, 65x65, 4096x3072)
  - 4 for `wouldExceedBudget` (exact fit, overshoot-by-one, in-flight at budget + est=0, in-flight already over)
  - 3 for `Image.estimatedUploadStagingBytes` (.pending, .ready, .replace)
  - 2 for `Image.pendingStagingBytes` (.ready with synthetic counter, .pending returns 0)
  - 1 for `State.upload_budget_bytes` default
- [x] `zig build` clean (full libghostty binary build path)
- [ ] Manual smoke: stream multiple large kitty images simultaneously, confirm `[renderer_image] (debug): deferring image upload est=... in_flight=... budget=...` appears under pressure and individual uploads still complete across subsequent frames

## Notes

- `TEXTURE_UPLOAD_PITCH_ALIGNMENT = 256` is duplicated from `Texture.TEXTURE_DATA_PITCH_ALIGNMENT` because `image.zig` deliberately doesn't depend on `directx12/*` (the budget is renderer-generic, even if Metal/OpenGL don't enforce it today). A cross-platform assertion that the two stay in lockstep would be a nice future safeguard.
- The config-knob path mentioned in the audit ("128 MiB or read from a config knob") is deferred — `State.upload_budget_bytes` is a per-instance field that's easy to wire to config later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)