### PR TITLE
Forward XButton1/XButton2 thumb buttons to libghostty

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -609,6 +609,13 @@ public sealed partial class TerminalControl : UserControl
             PointerUpdateKind.RightButtonReleased => GhosttyMouseButton.Right,
             PointerUpdateKind.MiddleButtonPressed or
             PointerUpdateKind.MiddleButtonReleased => GhosttyMouseButton.Middle,
+            // Mouse thumb buttons (back/forward). xterm SGR mouse convention
+            // encodes these as button 8 and 9; libghostty's input/mouse.zig
+            // enum has Eight=8 (back) and Nine=9 (forward) reserved for this.
+            PointerUpdateKind.XButton1Pressed or
+            PointerUpdateKind.XButton1Released => GhosttyMouseButton.Eight,
+            PointerUpdateKind.XButton2Pressed or
+            PointerUpdateKind.XButton2Released => GhosttyMouseButton.Nine,
             _ => GhosttyMouseButton.Unknown,
         };
         if (btn == GhosttyMouseButton.Unknown) return;


### PR DESCRIPTION
## Summary

Forwards Windows mouse thumb buttons (XButton1 / XButton2) through `SendMouseButton` as libghostty `GhosttyMouseButton.Eight` / `Nine` — the values reserved for xterm SGR mouse convention buttons 8 (back) and 9 (forward). Third of three Tier-1 fixes from the 2026-05-22 mouse-protocol gap survey.

Before this PR the existing switch in `SendMouseButton` only covered Left/Right/Middle; XButton1/2 fell through to `GhosttyMouseButton.Unknown` and were silently dropped. Now tmux/vim/htop bindings on buttons 8/9 fire correctly.

## Architecture

Single switch extension. The `GhosttyMouseButton` enum and the `ghostty_input_mouse_button_e` C enum already define `Eight = 8` and `Nine = 9` — no FFI/ABI changes needed.

## Out of scope

- Forwarding mouse buttons 6/7 (horizontal wheel as button events) — separate concern.
- Touch / stylus / pressure-sensitive input — separate concerns.

## Test plan

- [x] `dotnet test Ghostty.Tests` — all green
- [ ] Manual smoke (requires a mouse with thumb buttons): in Wintty, run `printf '\e[?1006h\e[?1003h'` then click thumb buttons → terminal echoes `\e[<8;X;YM` and `\e[<9;X;YM` events. Or test in tmux with `set -g mouse on` plus a binding on `MouseDown1` / `MouseDown2` (modes vary by terminal-multiplexer mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)