### PR TITLE
Wire MOUSE_OVER_LINK + Ctrl+Click hyperlink open

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -23,6 +23,7 @@ internal enum GhosttyActionTag
     Scrollbar = 26,
     SetTitle = 32,
     MouseShape = 36,
+    MouseOverLink = 38,
     OpenConfig = 40,
     ReloadConfig = 47,
     CloseWindow = 49,
@@ -41,6 +42,17 @@ internal struct GhosttyActionScrollbar
     public ulong Total;
     public ulong Offset;
     public ulong Len;
+}
+
+// ghostty_action_mouse_over_link_s:
+//   { const char* url; size_t len; }
+// On x64: 16 bytes total (8 + 8). Read at actionPtr + 8 inside OnAction;
+// url=null+len=0 means "pointer left the link" (clear hover state).
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionMouseOverLink
+{
+    public nint Url;
+    public nuint Len;
 }
 
 // ghostty_action_progress_report_state_e.

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -12,6 +12,7 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.Scrollbar, 26)]
     [InlineData((int)GhosttyActionTag.SetTitle, 32)]
     [InlineData((int)GhosttyActionTag.MouseShape, 36)]
+    [InlineData((int)GhosttyActionTag.MouseOverLink, 38)]
     [InlineData((int)GhosttyActionTag.CloseWindow, 49)]
     [InlineData((int)GhosttyActionTag.RingBell, 50)]
     [InlineData((int)GhosttyActionTag.ProgressReport, 56)]
@@ -98,5 +99,20 @@ public class GhosttyActionsLayoutTests
             8,
             (int)Marshal.OffsetOf<GhosttyActionEnvelopeProbe>(
                 nameof(GhosttyActionEnvelopeProbe.Payload)));
+    }
+
+    [Fact]
+    public void MouseOverLinkStruct_Size_Is_16_Bytes()
+    {
+        // { const char* url; size_t len; } on x64 = 8 + 8 = 16
+        Assert.Equal(16, Marshal.SizeOf<GhosttyActionMouseOverLink>());
+    }
+
+    [Fact]
+    public void MouseOverLinkStruct_Field_Offsets_Match_C_Layout()
+    {
+        // Read at (actionPtr + 8); Url at struct offset 0, Len at 8.
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionMouseOverLink>(nameof(GhosttyActionMouseOverLink.Url)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<GhosttyActionMouseOverLink>(nameof(GhosttyActionMouseOverLink.Len)));
     }
 }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using Ghostty.Core.Input;
 using Ghostty.Hosting;
 using Ghostty.Input;
@@ -516,13 +517,59 @@ public sealed partial class TerminalControl : UserControl
 
     // Mouse --------------------------------------------------------------
 
+    // Hovered OSC 8 hyperlink URL (or null when the pointer is not over
+    // a link). Set by GhosttyHost in response to libghostty's
+    // apprt.action.MouseOverLink. The HoveredLinkChanged event fires
+    // only on transitions so consumers (status bar, tab strip) can
+    // avoid redundant updates.
+    internal string? HoveredLink { get; private set; }
+    internal event EventHandler<string?>? HoveredLinkChanged;
+
+    internal void SetHoveredLink(string? url)
+    {
+        if (string.Equals(HoveredLink, url, StringComparison.Ordinal)) return;
+        HoveredLink = url;
+        HoveredLinkChanged?.Invoke(this, url);
+    }
+
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
         // Take focus on the UserControl, not the panel. Guard with the
         // current focus state to avoid generating a Lost+Got pair when
         // we already have focus.
         if (!_focused) this.Focus(FocusState.Pointer);
+
+        // Ctrl+LeftClick on an OSC 8 hyperlink: open the URL in the
+        // default browser and consume the event so libghostty doesn't
+        // also see a stray button-press (which would confuse apps
+        // running mouse=a like vim/htop).
+        var props = e.GetCurrentPoint(Panel).Properties;
+        if (props.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed
+            && (CurrentMods() & GhosttyMods.Ctrl) != 0
+            && HoveredLink is { } url)
+        {
+            _ = TryLaunchHoveredLinkAsync(url);
+            e.Handled = true;
+            return;
+        }
+
         SendMouseButton(e, GhosttyMouseState.Press);
+    }
+
+    private static async Task TryLaunchHoveredLinkAsync(string url)
+    {
+        // Best-effort launch. Malformed URLs (e.g. corrupted OSC 8) or
+        // schemes the user has no handler for shouldn't crash the
+        // terminal; silently swallow the exception.
+        try
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                await Launcher.LaunchUriAsync(uri);
+        }
+        catch
+        {
+            // Intentionally swallowed — no UX surface for launch failures yet.
+        }
     }
 
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e) =>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -424,6 +424,7 @@ public sealed partial class TerminalControl : UserControl
         // after the control tears down.
         TitleChanged = null;
         CloseRequested = null;
+        HoveredLinkChanged = null;
     }
 
     private static IntPtr AllocEmptyUtf8()
@@ -560,15 +561,17 @@ public sealed partial class TerminalControl : UserControl
     {
         // Best-effort launch. Malformed URLs (e.g. corrupted OSC 8) or
         // schemes the user has no handler for shouldn't crash the
-        // terminal; silently swallow the exception.
+        // terminal; swallow but log to Debug so a regression where valid
+        // URLs stop launching doesn't disappear silently.
         try
         {
             if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
                 await Launcher.LaunchUriAsync(uri);
         }
-        catch
+        catch (Exception ex)
         {
-            // Intentionally swallowed — no UX surface for launch failures yet.
+            System.Diagnostics.Debug.WriteLine(
+                $"[TerminalControl] TryLaunchHoveredLinkAsync failed for '{url}': {ex}");
         }
     }
 

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -459,10 +459,28 @@ internal sealed class GhosttyHost : IDisposable
                 }
                 // libghostty sends url=null+len=0 when the pointer leaves a link;
                 // surface that as a null hovered-URL so the C# side can clear its
-                // own hover state cleanly.
-                string? url = payload.Url == IntPtr.Zero
-                    ? null
-                    : Marshal.PtrToStringUTF8(payload.Url, (int)payload.Len);
+                // own hover state cleanly. Use the length-aware PtrToStringUTF8
+                // overload (vs SetTitle's null-terminated variant) because this
+                // payload carries an explicit length and the string is NOT
+                // guaranteed null-terminated. Guard the nuint -> int cast: OSC 8
+                // URLs are typically <2 KB but libghostty makes no upper-bound
+                // guarantee, and Marshal.PtrToStringUTF8(IntPtr, int) takes a
+                // signed length — silent truncation would corrupt the URL.
+                string? url;
+                if (payload.Url == IntPtr.Zero)
+                {
+                    url = null;
+                }
+                else if (payload.Len > int.MaxValue)
+                {
+                    // Pathologically long URL — drop the hover update rather
+                    // than truncate. Realistic OSC 8 URLs never approach this.
+                    return 1;
+                }
+                else
+                {
+                    url = Marshal.PtrToStringUTF8(payload.Url, (int)payload.Len);
+                }
                 _dispatcher.TryEnqueue(() =>
                 {
                     if (TryResolveControl(surfaceHandle, out var c) && c is not null)

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -449,6 +449,28 @@ internal sealed class GhosttyHost : IDisposable
                 return 1;
             }
 
+            case GhosttyActionTag.MouseOverLink:
+            {
+                GhosttyActionMouseOverLink payload;
+                unsafe
+                {
+                    payload = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyActionMouseOverLink>(
+                        (void*)(actionPtr + 8));
+                }
+                // libghostty sends url=null+len=0 when the pointer leaves a link;
+                // surface that as a null hovered-URL so the C# side can clear its
+                // own hover state cleanly.
+                string? url = payload.Url == IntPtr.Zero
+                    ? null
+                    : Marshal.PtrToStringUTF8(payload.Url, (int)payload.Len);
+                _dispatcher.TryEnqueue(() =>
+                {
+                    if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                        c.SetHoveredLink(url);
+                });
+                return 1;
+            }
+
             case GhosttyActionTag.RingBell:
             {
                 PInvoke.MessageBeep(MESSAGEBOX_STYLE.MB_OK);


### PR DESCRIPTION
## Summary

Routes libghostty's `apprt.action.MouseOverLink` (action tag 38) through to a new `TerminalControl.HoveredLink` property + `HoveredLinkChanged` event, and wires Ctrl+LeftClick on the hovered URL to `Windows.System.Launcher.LaunchUriAsync`. Second of three Tier-1 fixes from the 2026-05-22 mouse-protocol gap survey; follows the exact dispatch shape proven by #390 (MOUSE_SHAPE).

## Architecture

- `MouseOverLink = 38` added to `GhosttyActionTag`; struct mirror `GhosttyActionMouseOverLink { nint Url; nuint Len; }` (16 bytes on x64).
- `GhosttyHost.OnAction` reads the struct at `actionPtr + 8`, marshals UTF-8 with explicit length, dispatches to UI thread.
- `null` URL (libghostty's "pointer left the link" signal) clears the hover state.
- Ctrl+LeftClick + non-null `HoveredLink` consumes the event (so libghostty doesn't see a stray click) and launches via `Launcher.LaunchUriAsync`.

## Out of scope

- Status-bar / tab-strip surfacing of hovered URL — `HoveredLinkChanged` event is in place for future consumers.
- Cursor-shape coordination — libghostty already emits OSC 22 `pointer` when hovering a link; the cursor change is already wired via #390.

## Test plan

- [x] `dotnet test Ghostty.Tests` — all green (873 passed, 1 skipped)
- [x] New layout tests: `MouseOverLinkStruct_Size_Is_16_Bytes`, `MouseOverLinkStruct_Field_Offsets_Match_C_Layout`, ordinal pin 38
- [ ] Manual smoke: `printf '\e]8;;https://example.com\e\example\e]8;;\e\'` in Wintty; hover the underlined word + Ctrl+Click → opens in default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)