### PR TITLE
Null events in teardown across per-window/per-tab classes

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -425,6 +425,7 @@ public sealed partial class TerminalControl : UserControl
         TitleChanged = null;
         CloseRequested = null;
         HoveredLinkChanged = null;
+        ProgressChanged = null;
     }
 
     private static IntPtr AllocEmptyUtf8()

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -364,11 +364,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public void DisposeAllLeaves()
     {
-        // Every leaf was already disposed one-by-one as the tree
-        // collapsed; _root still references the last-closed leaf but
-        // walking it here would double-dispose (DisposeSurface is
-        // idempotent, but the walk is wasted work and a trap for the
-        // next reader).
+        // Tree walk is gated on _allLeavesClosed: every leaf was
+        // already disposed one-by-one as the tree collapsed; _root
+        // still references the last-closed leaf but walking it here
+        // would double-dispose (DisposeSurface is idempotent, but the
+        // walk is wasted work and a trap for the next reader).
         if (!_allLeavesClosed)
         {
             foreach (var leaf in PaneTree.Leaves(_root))
@@ -377,9 +377,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             }
         }
 
-        // Drop subscribers so MainWindow / TabModel / VerticalTabHost
-        // are not rooted via these events after the tab tears down.
-        // Matches the pattern in TerminalControl.DisposeSurface.
+        // Event-nulling intentionally runs unconditionally: the gate
+        // above only controls whether we re-walk the tree, not whether
+        // this PaneHost is going away. Both code paths (tree-collapsed
+        // and not) reach here as part of tab teardown, so subscribers
+        // must always be dropped. Matches TerminalControl.DisposeSurface.
         LeafFocused = null;
         ProgressChanged = null;
         LastLeafClosed = null;

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -369,11 +369,20 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // walking it here would double-dispose (DisposeSurface is
         // idempotent, but the walk is wasted work and a trap for the
         // next reader).
-        if (_allLeavesClosed) return;
-        foreach (var leaf in PaneTree.Leaves(_root))
+        if (!_allLeavesClosed)
         {
-            leaf.Terminal().DisposeSurface();
+            foreach (var leaf in PaneTree.Leaves(_root))
+            {
+                leaf.Terminal().DisposeSurface();
+            }
         }
+
+        // Drop subscribers so MainWindow / TabModel / VerticalTabHost
+        // are not rooted via these events after the tab tears down.
+        // Matches the pattern in TerminalControl.DisposeSurface.
+        LeafFocused = null;
+        ProgressChanged = null;
+        LastLeafClosed = null;
     }
 
     /// <summary>

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -79,6 +79,10 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
         try { _serverTask?.GetAwaiter().GetResult(); }
         catch { /* expected OCE or pipe error */ }
         _cts.Dispose();
+
+        // Drop subscribers so MainWindow is not rooted via this event
+        // after the service tears down at window-close.
+        ListThemesRequested = null;
     }
 
     private async Task RunServer(CancellationToken ct)

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -65,6 +65,10 @@ internal sealed class WindowThemeManager : IDisposable
     {
         _configService.ConfigChanged -= OnConfigChanged;
         _uiSettings.ColorValuesChanged -= OnSystemThemeChanged;
+
+        // Drop subscribers so the owning window/control isn't rooted
+        // via this event after teardown.
+        ThemeChanged = null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes the leak class both reviewers caught on #392: events declared on classes with shorter-than-app lifetime that aren't nulled in teardown root their subscribers (typically `MainWindow`) past the owner's disposal. Audit found four such gaps across `TerminalControl`, `PaneHost`, `WindowThemeManager`, and `ThemePreviewService`.

## Audit + fixes

| Class | Teardown | Events newly nulled |
|---|---|---|
| `TerminalControl` | `DisposeSurface` | `ProgressChanged` |
| `PaneHost` | `DisposeAllLeaves` | `LeafFocused`, `ProgressChanged`, `LastLeafClosed` |
| `WindowThemeManager` | `Dispose` | `ThemeChanged` |
| `ThemePreviewService` | `Dispose` | `ListThemesRequested` |

## Out of scope

- App singletons (`GhosttyHost`, `ConfigService`, `WindowsPowerStateMonitor`) - `Dispose` runs once at process shutdown, nulling is defensive only.
- Event-emitting classes without any teardown today (`VerticalTabStrip`, `VerticalTabHost`, `TabColorPalettePicker`, `ColorPickerControl`, `GradientPointsEditor`) - adding lifecycle is a larger refactor.

## Test plan

- [x] `dotnet test Ghostty.Tests -p:Platform=x64` - 873 passed, 1 pre-existing skip, 0 failed
- [x] No semantic change to dispatch order or subscriber notification