### PR TITLE
Add URL hover banner for Ctrl+hover link preview

### DIFF
--- a/windows/Ghostty.Core/Input/HoverLinkText.cs
+++ b/windows/Ghostty.Core/Input/HoverLinkText.cs
@@ -1,0 +1,68 @@
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Pure-logic helpers for the URL hover-banner UI (per-surface bottom-
+/// corner overlay shown when the user hovers an OSC 8 hyperlink or
+/// URL-matched text while holding Ctrl).
+///
+/// Lives in Ghostty.Core so the formatting + truncation rules can be
+/// unit-tested without pulling WinAppSDK into Ghostty.Tests.
+/// </summary>
+public static class HoverLinkText
+{
+    /// <summary>
+    /// Default character cap before mid-ellipsis truncation kicks in.
+    /// Picked to fit comfortably below a typical pane width without
+    /// running the banner across the whole surface.
+    /// </summary>
+    public const int DefaultMaxUrlChars = 80;
+
+    /// <summary>
+    /// Hint prefix shown ahead of the URL. Discoverability aid for
+    /// Windows users; upstream macOS / GTK banners show URL only.
+    /// </summary>
+    public const string HintPrefix = "Ctrl+Click to open: ";
+
+    /// <summary>
+    /// Produce the full banner text: <c>"Ctrl+Click to open: &lt;url&gt;"</c>,
+    /// with the URL mid-ellipsis-truncated if it exceeds
+    /// <paramref name="maxUrlChars"/>. Returns <see cref="string.Empty"/>
+    /// when <paramref name="url"/> is null or empty — caller should
+    /// suppress the banner in that case.
+    /// </summary>
+    public static string Format(string? url, int maxUrlChars = DefaultMaxUrlChars)
+    {
+        if (string.IsNullOrEmpty(url)) return string.Empty;
+        return HintPrefix + TruncateMid(url, maxUrlChars);
+    }
+
+    /// <summary>
+    /// Mid-ellipsis truncation: keep the start and end of the string,
+    /// replace the middle with a single Unicode horizontal ellipsis
+    /// (<c>…</c>). Designed for URLs where the scheme + host (start) and
+    /// the resource path tail (end) carry the most information; the
+    /// middle of a deep path is the cheapest part to drop.
+    ///
+    /// Returns the original string unchanged if its length is &lt;=
+    /// <paramref name="maxChars"/> or if <paramref name="maxChars"/>
+    /// is too small for the ellipsis to fit (degrades to a hard prefix
+    /// truncation in that pathological case).
+    /// </summary>
+    public static string TruncateMid(string s, int maxChars)
+    {
+        if (string.IsNullOrEmpty(s)) return s;
+        if (maxChars <= 0) return string.Empty;
+        if (s.Length <= maxChars) return s;
+
+        // Need at least 3 chars to fit "x…y"; below that, just hard-cut.
+        if (maxChars < 3) return s[..maxChars];
+
+        // Bias slightly toward the END of the URL: the path tail is more
+        // informative than the host prefix once we're already past
+        // truncation. (maxChars - 1) / 2 keeps the start, the remainder
+        // goes to the end.
+        int keepStart = (maxChars - 1) / 2;
+        int keepEnd = maxChars - 1 - keepStart;
+        return string.Concat(s.AsSpan(0, keepStart), "…", s.AsSpan(s.Length - keepEnd));
+    }
+}

--- a/windows/Ghostty.Tests/Input/HoverLinkTextTests.cs
+++ b/windows/Ghostty.Tests/Input/HoverLinkTextTests.cs
@@ -1,0 +1,75 @@
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class HoverLinkTextTests
+{
+    [Theory]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void Format_NullOrEmpty_ReturnsEmpty(string? url, string expected)
+    {
+        Assert.Equal(expected, HoverLinkText.Format(url));
+    }
+
+    [Fact]
+    public void Format_ShortUrl_PrependsPrefixWithoutTruncation()
+    {
+        var actual = HoverLinkText.Format("https://example.com");
+        Assert.Equal("Ctrl+Click to open: https://example.com", actual);
+    }
+
+    [Fact]
+    public void Format_LongUrl_TruncatesWithEllipsis()
+    {
+        var longUrl = "https://github.com/deblasis/wintty/pull/394/files#diff-1234567890abcdef1234567890abcdef";
+        var actual = HoverLinkText.Format(longUrl, maxUrlChars: 40);
+
+        Assert.StartsWith("Ctrl+Click to open: ", actual);
+        var truncatedTail = actual["Ctrl+Click to open: ".Length..];
+        Assert.Contains("…", truncatedTail);
+        Assert.Equal(40, truncatedTail.Length);
+        // Preserves scheme/host prefix.
+        Assert.StartsWith("https://", truncatedTail);
+        // Preserves resource tail.
+        Assert.EndsWith("abcdef", truncatedTail);
+    }
+
+    [Theory]
+    [InlineData("", 10, "")]
+    [InlineData("abc", 10, "abc")]
+    [InlineData("abcdefghij", 10, "abcdefghij")]
+    public void TruncateMid_AtOrUnderLimit_ReturnsUnchanged(string input, int max, string expected)
+    {
+        Assert.Equal(expected, HoverLinkText.TruncateMid(input, max));
+    }
+
+    [Theory]
+    [InlineData("abcdefghijk", 10, "abcd…ghijk")]
+    [InlineData("abcdefghijkl", 11, "abcde…hijkl")]
+    [InlineData("12345678901234567890", 9, "1234…7890")]
+    public void TruncateMid_OverLimit_PreservesStartAndEndWithEllipsis(string input, int max, string expected)
+    {
+        var actual = HoverLinkText.TruncateMid(input, max);
+        Assert.Equal(expected, actual);
+        Assert.Equal(max, actual.Length);
+    }
+
+    [Theory]
+    [InlineData("abcdef", 0, "")]
+    [InlineData("abcdef", -1, "")]
+    public void TruncateMid_NonPositiveMax_ReturnsEmpty(string input, int max, string expected)
+    {
+        Assert.Equal(expected, HoverLinkText.TruncateMid(input, max));
+    }
+
+    [Theory]
+    [InlineData("abcdef", 1, "a")]
+    [InlineData("abcdef", 2, "ab")]
+    public void TruncateMid_TooSmallForEllipsis_HardTruncates(string input, int max, string expected)
+    {
+        // maxChars < 3 can't fit "x…y", so we just take a prefix.
+        Assert.Equal(expected, HoverLinkText.TruncateMid(input, max));
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -83,5 +83,38 @@
             Visibility="Collapsed"
             Scroll="OnScrollBarScroll"
             PointerWheelChanged="OnScrollBarPointerWheelChanged" />
+
+        <!--
+            URL hover banner. Bottom-left overlay shown while libghostty's
+            apprt.action.MouseOverLink action is active (i.e. the user is
+            holding Ctrl and hovering an OSC 8 hyperlink or URL-matched
+            text). Matches macOS URLHoverBanner and the GTK url_left
+            widget; on Windows we also prepend "Ctrl+Click to open:" as
+            a discoverability hint because Windows users come from
+            Windows Terminal (which has no equivalent URL preview at all).
+
+            IsHitTestVisible=False so the banner never steals pointer
+            events from the SwapChainPanel underneath - terminal apps
+            running mouse=a keep seeing every mouse move through the
+            banner's footprint.
+        -->
+        <Border
+            x:Name="UrlHoverBanner"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Bottom"
+            Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
+            BorderBrush="{ThemeResource ControlElevationBorderBrush}"
+            BorderThickness="1,1,1,0"
+            CornerRadius="0,8,0,0"
+            Padding="8,4,8,4"
+            MaxWidth="640"
+            Visibility="Collapsed"
+            IsHitTestVisible="False">
+            <TextBlock
+                x:Name="UrlHoverBannerText"
+                Style="{ThemeResource CaptionTextBlockStyle}"
+                TextTrimming="CharacterEllipsis"
+                MaxLines="1" />
+        </Border>
     </Grid>
 </UserControl>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -532,6 +532,24 @@ public sealed partial class TerminalControl : UserControl
         if (string.Equals(HoveredLink, url, StringComparison.Ordinal)) return;
         HoveredLink = url;
         HoveredLinkChanged?.Invoke(this, url);
+        UpdateUrlHoverBanner(url);
+    }
+
+    // Show / hide the bottom-left URL hover banner that mirrors macOS's
+    // URLHoverBanner and the GTK url_left widget. libghostty already
+    // gates this on Ctrl/Cmd-hover (Surface.zig:linkAtPos requires
+    // ctrlOrSuper for OSC 8 hyperlink detection), so the banner only
+    // appears at the "I'm about to interact with this link" moment.
+    private void UpdateUrlHoverBanner(string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            UrlHoverBanner.Visibility = Visibility.Collapsed;
+            UrlHoverBannerText.Text = string.Empty;
+            return;
+        }
+        UrlHoverBannerText.Text = HoverLinkText.Format(url);
+        UrlHoverBanner.Visibility = Visibility.Visible;
     }
 
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
## Summary

Adds the URL preview banner that macOS and GTK/Linux already have, bringing Wintty up to parity. When the user holds Ctrl while hovering an OSC 8 hyperlink or a URL-matched piece of text, a small banner appears at the bottom-left of the terminal showing the link's destination.

On Windows we prepend "Ctrl+Click to open:" to the URL as a discoverability hint - Windows users mostly come from Windows Terminal (which has no URL preview at all), and the explicit modifier-action callout matches the Files/Settings-app convention for hyperlinked text.

## Reference

| Platform | URL preview today |
|---|---|
| macOS | `URLHoverBanner.swift` (bottom-left, slides on hover) |
| GTK/Linux | `url_left` widget in `surface.zig` (corner) |
| Wintty (before this PR) | none |
| Wintty (with this PR) | bottom-left banner, "Ctrl+Click to open: <url>" |

## How it works

- libghostty fires `apprt.action.MouseOverLink` when the user holds Ctrl/Cmd and hovers an OSC 8 hyperlink (or any URL-matched cell, depending on `link-previews` config). Both paths already wired by # 392.
- `TerminalControl.SetHoveredLink` (added in # 392) calls a new `UpdateUrlHoverBanner` that flips a `Border` overlay's visibility on/off and formats the text via `HoverLinkText.Format`.
- `HoverLinkText.Format` lives in `Ghostty.Core.Input` so all the URL-truncation logic is unit-testable without WinAppSDK in the test project.
- Banner has `IsHitTestVisible=false` so it never steals pointer events from the `SwapChainPanel` below - terminal apps running `mouse=a` keep seeing every mouse move through the banner's footprint.

## Files

- New: `windows/Ghostty.Core/Input/HoverLinkText.cs` (mid-ellipsis URL truncation + format with hint prefix)
- New: `windows/Ghostty.Tests/Input/HoverLinkTextTests.cs` (14 cases)
- Modified: `windows/Ghostty/Controls/TerminalControl.xaml` (Border + TextBlock overlay)
- Modified: `windows/Ghostty/Controls/TerminalControl.xaml.cs` (new `UpdateUrlHoverBanner`)

## Out of scope

- **No slide-to-other-side-on-hover behavior** (macOS does this; would require `IsHitTestVisible=true` and lose the pointer-passthrough property)
- **No animation** (banner just shows/hides; could add a fade later)
- **No config knob** (the banner mirrors `link-previews` upstream gating - users who don't want it set `link-previews = false`)

## Test plan

- [x] `dotnet test Ghostty.Tests -p:Platform=x64`: 887 passed, 1 pre-existing skip, 0 failed
- [x] 14 new `HoverLinkText` tests cover formatting + mid-ellipsis truncation edge cases
- [ ] Manual smoke: Ctrl+hover an OSC 8 hyperlink in Wintty -> banner appears at bottom-left with "Ctrl+Click to open: <url>"