### PR TITLE
Address review feedback on URL hover banner (#395 follow-up)

### DIFF
--- a/windows/Ghostty.Core/Input/HoverLinkText.cs
+++ b/windows/Ghostty.Core/Input/HoverLinkText.cs
@@ -15,13 +15,13 @@ public static class HoverLinkText
     /// Picked to fit comfortably below a typical pane width without
     /// running the banner across the whole surface.
     /// </summary>
-    public const int DefaultMaxUrlChars = 80;
+    internal const int DefaultMaxUrlChars = 80;
 
     /// <summary>
     /// Hint prefix shown ahead of the URL. Discoverability aid for
     /// Windows users; upstream macOS / GTK banners show URL only.
     /// </summary>
-    public const string HintPrefix = "Ctrl+Click to open: ";
+    internal const string HintPrefix = "Ctrl+Click to open: ";
 
     /// <summary>
     /// Produce the full banner text: <c>"Ctrl+Click to open: &lt;url&gt;"</c>,
@@ -48,7 +48,7 @@ public static class HoverLinkText
     /// is too small for the ellipsis to fit (degrades to a hard prefix
     /// truncation in that pathological case).
     /// </summary>
-    public static string TruncateMid(string s, int maxChars)
+    internal static string TruncateMid(string s, int maxChars)
     {
         if (string.IsNullOrEmpty(s)) return s;
         if (maxChars <= 0) return string.Empty;
@@ -59,8 +59,12 @@ public static class HoverLinkText
 
         // Bias slightly toward the END of the URL: the path tail is more
         // informative than the host prefix once we're already past
-        // truncation. (maxChars - 1) / 2 keeps the start, the remainder
-        // goes to the end.
+        // truncation. Integer division floors keepStart; the remainder
+        // accrues to keepEnd, so on odd splits the tail gets the extra
+        // character. Examples:
+        //   max=9  -> keepStart=4, keepEnd=4
+        //   max=10 -> keepStart=4, keepEnd=5
+        //   max=11 -> keepStart=5, keepEnd=5
         int keepStart = (maxChars - 1) / 2;
         int keepEnd = maxChars - 1 - keepStart;
         return string.Concat(s.AsSpan(0, keepStart), "…", s.AsSpan(s.Length - keepEnd));

--- a/windows/Ghostty.Tests/Input/HoverLinkTextTests.cs
+++ b/windows/Ghostty.Tests/Input/HoverLinkTextTests.cs
@@ -21,6 +21,22 @@ public class HoverLinkTextTests
     }
 
     [Fact]
+    public void Format_AtDefaultMaxBoundary_NoTruncation()
+    {
+        // Pins the s.Length <= maxChars off-by-one boundary in TruncateMid.
+        // The URL is exactly DefaultMaxUrlChars (80) chars, so it should
+        // pass through Format unchanged after the "Ctrl+Click to open: "
+        // prefix - no ellipsis.
+        var eightyCharUrl = "https://" + new string('a', 72);
+        Assert.Equal(80, eightyCharUrl.Length);
+
+        var actual = HoverLinkText.Format(eightyCharUrl);
+
+        Assert.Equal("Ctrl+Click to open: " + eightyCharUrl, actual);
+        Assert.DoesNotContain("…", actual);
+    }
+
+    [Fact]
     public void Format_LongUrl_TruncatesWithEllipsis()
     {
         var longUrl = "https://github.com/deblasis/wintty/pull/394/files#diff-1234567890abcdef1234567890abcdef";

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -97,6 +97,16 @@
             events from the SwapChainPanel underneath - terminal apps
             running mouse=a keep seeing every mouse move through the
             banner's footprint.
+
+            BorderThickness "1,1,1,0" drops the bottom edge: the banner is
+            anchored to VerticalAlignment=Bottom and sits flush with the
+            control's bottom boundary, so a bottom-edge stroke would draw
+            a doubled border with the surrounding chrome.
+
+            CornerRadius "0,8,0,0" (TopLeft, TopRight, BottomRight,
+            BottomLeft) rounds only the top-right corner: bottom-left
+            anchor + top-right "lift" mirrors how the macOS URLHoverBanner
+            tucks itself into the corner.
         -->
         <Border
             x:Name="UrlHoverBanner"
@@ -110,10 +120,15 @@
             MaxWidth="640"
             Visibility="Collapsed"
             IsHitTestVisible="False">
+            <!--
+                No TextTrimming: HoverLinkText.Format already mid-ellipsis-
+                truncates at 80 chars in C# (which is more informative for
+                URLs than a right-side render-layer ellipsis). MaxLines=1
+                stays as a defensive cap against multi-line text.
+            -->
             <TextBlock
                 x:Name="UrlHoverBannerText"
                 Style="{ThemeResource CaptionTextBlockStyle}"
-                TextTrimming="CharacterEllipsis"
                 MaxLines="1" />
         </Border>
     </Grid>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -515,6 +515,13 @@ public sealed partial class TerminalControl : UserControl
         NativeMethods.SurfaceSetFocus(_surface, focused);
         var app = Host?.App ?? default;
         if (app.Handle != IntPtr.Zero) NativeMethods.AppSetFocus(app, focused);
+
+        // Banner can only hide via libghostty re-emitting MouseOverLink with
+        // a null URL — which requires the pointer to actually move out of
+        // the link cell. Focus loss (Alt+Tab, click another pane) doesn't
+        // move the pointer, so without this the banner would stay frozen
+        // on screen until the user returned and moved the mouse.
+        if (!focused) UpdateUrlHoverBanner(null);
     }
 
     // Mouse --------------------------------------------------------------
@@ -540,15 +547,23 @@ public sealed partial class TerminalControl : UserControl
     // gates this on Ctrl/Cmd-hover (Surface.zig:linkAtPos requires
     // ctrlOrSuper for OSC 8 hyperlink detection), so the banner only
     // appears at the "I'm about to interact with this link" moment.
+    //
+    // Also sets AutomationProperties.Name on the Border so screen readers
+    // announce the full "Ctrl+Click to open: <url>" string instead of the
+    // raw TextBlock type name. IsHitTestVisible=false in XAML keeps the
+    // banner out of the pointer-event chain but does NOT remove it from
+    // the UIA tree.
     private void UpdateUrlHoverBanner(string? url)
     {
         if (string.IsNullOrEmpty(url))
         {
             UrlHoverBanner.Visibility = Visibility.Collapsed;
-            UrlHoverBannerText.Text = string.Empty;
             return;
         }
-        UrlHoverBannerText.Text = HoverLinkText.Format(url);
+        var formatted = HoverLinkText.Format(url);
+        UrlHoverBannerText.Text = formatted;
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+            UrlHoverBanner, formatted);
         UrlHoverBanner.Visibility = Visibility.Visible;
     }
 


### PR DESCRIPTION
## Summary

Retroactive review pass on #395 by both `ghostty-reviewer` and `dotnet-windows-reviewer` surfaced five Important issues and three minor polish items. All fixes folded here.

## Convergent findings (both reviewers flagged)

| # | Issue | Fix |
|---|---|---|
| 1 | Constants `public const` → `internal` (binary-compat surface) | `HintPrefix`, `DefaultMaxUrlChars`, `TruncateMid` narrowed; `Format` stays public |
| 2 | Dual truncation contract (C# `TruncateMid` + XAML `CharacterEllipsis`) | Drop `TextTrimming`; rely on Core-side mid-ellipsis (more informative for URLs) |
| 3 | Redundant `Text = string.Empty` on hide | Removed; collapsed `TextBlock` doesn't render anyway |

## Unique findings

| Source | Issue | Fix |
|---|---|---|
| **ghostty-reviewer** | Banner sticks on focus loss (Alt+Tab) | `SetFocusState` now clears banner on `focused=false` — libghostty stops emitting `MouseOverLink` without pointer transitions, and focus loss doesn't move the pointer |
| **dotnet-windows-reviewer** | No `AutomationProperties.Name` on banner | Set imperatively in `UpdateUrlHoverBanner` so Narrator announces the URL instead of raw TextBlock type name |

## Minor polish

- New test `Format_AtDefaultMaxBoundary_NoTruncation` pins the `s.Length <= maxChars` boundary
- Why-comments on `BorderThickness="1,1,1,0"` and `CornerRadius="0,8,0,0"`
- `TruncateMid` bias comment now shows arithmetic examples

## Test plan

- [x] `dotnet test Ghostty.Tests -p:Platform=x64`: 888 passed (+1 vs #395), 1 pre-existing skip, 0 failed
- [ ] Manual smoke: Ctrl+hover an OSC 8 link → banner shows; Alt+Tab away → banner disappears (the focus-loss fix)
- [ ] Narrator on the banner pane reads "Ctrl+Click to open: <url>"