### PR TITLE
Wire MOUSE_VISIBILITY action: auto-hide cursor while typing

### DIFF
--- a/windows/Ghostty.Core/Input/MouseVisibility.cs
+++ b/windows/Ghostty.Core/Input/MouseVisibility.cs
@@ -5,6 +5,9 @@ namespace Ghostty.Core.Input;
 /// <c>include/ghostty.h</c>. Ordinals are pinned by
 /// <c>MouseVisibilityEnumTests</c>; do not renumber without updating
 /// the upstream enum first.
+///
+/// To re-verify against upstream after a rebase:
+///   grep -nE "GHOSTTY_MOUSE_(VISIBLE|HIDDEN)" include/ghostty.h
 /// </summary>
 public enum MouseVisibility
 {

--- a/windows/Ghostty.Core/Input/MouseVisibility.cs
+++ b/windows/Ghostty.Core/Input/MouseVisibility.cs
@@ -1,0 +1,13 @@
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Mirror of <c>ghostty_action_mouse_visibility_e</c> from
+/// <c>include/ghostty.h</c>. Ordinals are pinned by
+/// <c>MouseVisibilityEnumTests</c>; do not renumber without updating
+/// the upstream enum first.
+/// </summary>
+public enum MouseVisibility
+{
+    Visible = 0,
+    Hidden = 1,
+}

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -23,6 +23,7 @@ internal enum GhosttyActionTag
     Scrollbar = 26,
     SetTitle = 32,
     MouseShape = 36,
+    MouseVisibility = 37,
     MouseOverLink = 38,
     OpenConfig = 40,
     ReloadConfig = 47,

--- a/windows/Ghostty.Tests/Input/MouseVisibilityEnumTests.cs
+++ b/windows/Ghostty.Tests/Input/MouseVisibilityEnumTests.cs
@@ -1,0 +1,18 @@
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class MouseVisibilityEnumTests
+{
+    // Pin the C-enum ordinals so a future libghostty reorder cannot
+    // silently swap visible/hidden. Mirrors
+    // include/ghostty.h ghostty_action_mouse_visibility_e:
+    //   GHOSTTY_MOUSE_VISIBLE = 0,
+    //   GHOSTTY_MOUSE_HIDDEN  = 1,
+    [Theory]
+    [InlineData(MouseVisibility.Visible, 0)]
+    [InlineData(MouseVisibility.Hidden, 1)]
+    public void Enum_OrdinalsMatchGhosttyH(MouseVisibility value, int expected) =>
+        Assert.Equal(expected, (int)value);
+}

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -12,6 +12,7 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.Scrollbar, 26)]
     [InlineData((int)GhosttyActionTag.SetTitle, 32)]
     [InlineData((int)GhosttyActionTag.MouseShape, 36)]
+    [InlineData((int)GhosttyActionTag.MouseVisibility, 37)]
     [InlineData((int)GhosttyActionTag.MouseOverLink, 38)]
     [InlineData((int)GhosttyActionTag.CloseWindow, 49)]
     [InlineData((int)GhosttyActionTag.RingBell, 50)]

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -620,6 +620,21 @@ public sealed partial class TerminalControl : UserControl
         // cursorPosToPixels using the surface's content scale. Multiplying
         // by CompositionScaleX/Y here would double-scale on high DPI.
         var pt = e.GetCurrentPoint(Panel).Position;
+
+        // While the cursor is hidden by mouse-hide-while-typing,
+        // suppress sub-threshold motion so libghostty's cursorPosCallback
+        // doesn't fire showMouse for every DIP of sensor jitter. See
+        // _lastForwardedMouseX/Y comments above.
+        if (_cursorHidden)
+        {
+            var dx = pt.X - _lastForwardedMouseX;
+            var dy = pt.Y - _lastForwardedMouseY;
+            if (dx * dx + dy * dy < HiddenCursorMotionThresholdDips * HiddenCursorMotionThresholdDips)
+                return;
+        }
+
+        _lastForwardedMouseX = pt.X;
+        _lastForwardedMouseY = pt.Y;
         NativeMethods.SurfaceMousePos(_surface, pt.X, pt.Y, CurrentMods());
     }
 
@@ -713,6 +728,27 @@ public sealed partial class TerminalControl : UserControl
     // the WinUI default when ProtectedCursor has not been assigned.
     private MouseShapeFamily _currentMouseShapeFamily = MouseShapeFamily.Arrow;
 
+    // Whether the mouse-hide-while-typing path has driven the cursor
+    // to its invisible state. While true, SetMouseShape only tracks
+    // the requested family; the visible cursor is restored from
+    // _currentMouseShapeFamily by SetMouseVisibility(Visible).
+    private bool _cursorHidden;
+
+    // Last pointer position forwarded to libghostty via SurfaceMousePos.
+    // Used by OnPointerMoved to suppress sub-threshold motion while the
+    // cursor is hidden: libghostty's cursorPosCallback (Surface.zig:4569)
+    // calls showMouse() on ANY mouse position update, so even 1-DIP
+    // sensor jitter from a resting hand would flicker the cursor back on
+    // immediately after every keystroke. Mac sidesteps this with NSCursor
+    // OS-level filtering; on WinUI 3 we filter the forwarding ourselves.
+    private double _lastForwardedMouseX;
+    private double _lastForwardedMouseY;
+
+    // Threshold in DIPs. Real intentional mouse motion produces deltas
+    // of 10+ DIPs between PointerMoved events; sensor jitter / hand
+    // tremor is 1-2 DIPs. 5 splits the difference.
+    private const double HiddenCursorMotionThresholdDips = 5.0;
+
     /// <summary>
     /// Set the panel cursor in response to libghostty's
     /// <c>apprt.action.MouseShape</c> (typically driven by OSC 22 from
@@ -721,14 +757,45 @@ public sealed partial class TerminalControl : UserControl
     /// libghostty re-emits this action whenever the active shape
     /// changes, including transitions back to <see cref="MouseShape.Default"/>,
     /// so we don't need to reset on PointerExited.
+    ///
+    /// While <see cref="_cursorHidden"/> is true the visible shape
+    /// is only tracked; <see cref="SetMouseVisibility"/> restores it
+    /// when libghostty asks for the cursor to come back.
     /// </summary>
     internal void SetMouseShape(MouseShape shape)
     {
         var family = MouseShapeMap.ToFamily(shape);
         if (family == _currentMouseShapeFamily) return;
         _currentMouseShapeFamily = family;
-        ProtectedCursor =
-            InputSystemCursor.Create(MouseShapeAdapter.ToWinUI(family));
+        if (!_cursorHidden)
+        {
+            ProtectedCursor =
+                InputSystemCursor.Create(MouseShapeAdapter.ToWinUI(family));
+        }
+    }
+
+    /// <summary>
+    /// Set the panel cursor's visibility in response to libghostty's
+    /// <c>apprt.action.MouseVisibility</c> (driven by the
+    /// <c>mouse-hide-while-typing</c> config: hide on text-producing key
+    /// press, show on pointer motion / focus / click).
+    ///
+    /// Hiding swaps ProtectedCursor to a transparent custom cursor
+    /// (built via <see cref="Ghostty.Hosting.InvisibleCursorFactory"/>).
+    /// Showing restores ProtectedCursor to the shape that #390's
+    /// <see cref="SetMouseShape"/> last asked for. The two methods
+    /// coordinate through <see cref="_cursorHidden"/> and
+    /// <see cref="_currentMouseShapeFamily"/> so a MouseShape arriving
+    /// while hidden doesn't pop the cursor back on.
+    /// </summary>
+    internal void SetMouseVisibility(MouseVisibility visibility)
+    {
+        var newHidden = visibility == MouseVisibility.Hidden;
+        if (newHidden == _cursorHidden) return;
+        _cursorHidden = newHidden;
+        ProtectedCursor = newHidden
+            ? Ghostty.Hosting.InvisibleCursorFactory.Invisible
+            : InputSystemCursor.Create(MouseShapeAdapter.ToWinUI(_currentMouseShapeFamily));
     }
 
     // Keyboard -----------------------------------------------------------

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -624,11 +624,14 @@ public sealed partial class TerminalControl : UserControl
         // While the cursor is hidden by mouse-hide-while-typing,
         // suppress sub-threshold motion so libghostty's cursorPosCallback
         // doesn't fire showMouse for every DIP of sensor jitter. See
-        // _lastForwardedMouseX/Y comments above.
-        if (_cursorHidden)
+        // _lastForwardedMouseX/Y comments above. A null anchor means we
+        // haven't seen a real pointer event yet, so the current position
+        // becomes the anchor without forwarding (no genuine motion to
+        // report).
+        if (_cursorHidden && _lastForwardedMouseX is double ax && _lastForwardedMouseY is double ay)
         {
-            var dx = pt.X - _lastForwardedMouseX;
-            var dy = pt.Y - _lastForwardedMouseY;
+            var dx = pt.X - ax;
+            var dy = pt.Y - ay;
             if (dx * dx + dy * dy < HiddenCursorMotionThresholdDips * HiddenCursorMotionThresholdDips)
                 return;
         }
@@ -736,13 +739,19 @@ public sealed partial class TerminalControl : UserControl
 
     // Last pointer position forwarded to libghostty via SurfaceMousePos.
     // Used by OnPointerMoved to suppress sub-threshold motion while the
-    // cursor is hidden: libghostty's cursorPosCallback (Surface.zig:4569)
+    // cursor is hidden: libghostty's cursorPosCallback in Surface.zig
     // calls showMouse() on ANY mouse position update, so even 1-DIP
     // sensor jitter from a resting hand would flicker the cursor back on
     // immediately after every keystroke. Mac sidesteps this with NSCursor
     // OS-level filtering; on WinUI 3 we filter the forwarding ourselves.
-    private double _lastForwardedMouseX;
-    private double _lastForwardedMouseY;
+    //
+    // Nullable so the first OnPointerMoved seeds the anchor instead of
+    // comparing to a literal (0, 0) origin -- a cold launch where the
+    // user types before ever moving the mouse would otherwise blow past
+    // the threshold immediately and un-hide the cursor on the first
+    // genuine pointer event.
+    private double? _lastForwardedMouseX;
+    private double? _lastForwardedMouseY;
 
     // Threshold in DIPs. Real intentional mouse motion produces deltas
     // of 10+ DIPs between PointerMoved events; sensor jitter / hand
@@ -782,8 +791,8 @@ public sealed partial class TerminalControl : UserControl
     ///
     /// Hiding swaps ProtectedCursor to a transparent custom cursor
     /// (built via <see cref="Ghostty.Hosting.InvisibleCursorFactory"/>).
-    /// Showing restores ProtectedCursor to the shape that #390's
-    /// <see cref="SetMouseShape"/> last asked for. The two methods
+    /// Showing restores ProtectedCursor to the shape that
+    /// <see cref="SetMouseShape"/> last requested. The two methods
     /// coordinate through <see cref="_cursorHidden"/> and
     /// <see cref="_currentMouseShapeFamily"/> so a MouseShape arriving
     /// while hidden doesn't pop the cursor back on.

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -50,6 +50,8 @@ internal sealed class GhosttyHost : IDisposable
     // Dispose consults this instead of a bare _sharesApp bool.
     private readonly IAppHandleOwnership _ownership;
 
+    private readonly ILogger<GhosttyHost> _logger;
+
     /// <summary>
     /// UTC timestamp of the most recent key event seen by any
     /// <see cref="Ghostty.Controls.TerminalControl"/> bound to this
@@ -124,6 +126,7 @@ internal sealed class GhosttyHost : IDisposable
             supervisor.RegisterBootstrap(),
             supervisor);
         _config = config;
+        _logger = loggerFactory.CreateLogger<GhosttyHost>();
 
         _wakeupCb = OnWakeup;
         _actionCb = OnAction;
@@ -187,6 +190,7 @@ internal sealed class GhosttyHost : IDisposable
         _ownership = new SupervisedOwnership(
             supervisor.RegisterPerWindow(),
             supervisor);
+        _logger = loggerFactory.CreateLogger<GhosttyHost>();
         _app = new GhosttyApp(sharedApp);
         // Per-window hosts do not own or read _config; the bootstrap host
         // manages the single GhosttyConfig. Left as default intentionally.
@@ -406,6 +410,12 @@ internal sealed class GhosttyHost : IDisposable
                         ReloadConfigRequested?.Invoke(this, EventArgs.Empty));
                     return 1;
 
+                case GhosttyActionTag.MouseVisibility:
+                    // Mirror mac/GTK: mouse visibility against an app target is a
+                    // libghostty bug; log and absorb so we still report "handled".
+                    _logger.LogWarning("MouseVisibility action received with app target; ignoring");
+                    return 1;
+
                 default:
                     return 0;
             }
@@ -445,6 +455,21 @@ internal sealed class GhosttyHost : IDisposable
                 {
                     if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                         c.SetMouseShape(shape);
+                });
+                return 1;
+            }
+
+            case GhosttyActionTag.MouseVisibility:
+            {
+                // ghostty_action_mouse_visibility_e is a single c_int payload;
+                // read it at +8 (skipping the 4-byte tag + 4-byte padding before
+                // the union, same offset as MouseShape and ProgressReport).
+                var raw = Marshal.ReadInt32(actionPtr, 8);
+                var visibility = (MouseVisibility)raw;
+                _dispatcher.TryEnqueue(() =>
+                {
+                    if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                        c.SetMouseVisibility(visibility);
                 });
                 return 1;
             }

--- a/windows/Ghostty/Hosting/InvisibleCursorFactory.cs
+++ b/windows/Ghostty/Hosting/InvisibleCursorFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.UI.Input;
 using Windows.Win32;
@@ -42,6 +41,11 @@ internal static partial class InvisibleCursorFactory
     [LibraryImport("combase.dll", EntryPoint = "RoGetActivationFactory")]
     private static partial int RoGetActivationFactory(nint activatableClassId, in Guid iid, out nint factory);
 
+    // Lazily-built, process-wide. Not thread-safe: today the only
+    // caller is TerminalControl.SetMouseVisibility which runs on the
+    // UI dispatcher thread, so concurrent first reads cannot race.
+    // If that ever changes, wrap in Lazy<InputCursor> with
+    // LazyThreadSafetyMode.ExecutionAndPublication.
     private static InputCursor? _invisible;
 
     /// <summary>

--- a/windows/Ghostty/Hosting/InvisibleCursorFactory.cs
+++ b/windows/Ghostty/Hosting/InvisibleCursorFactory.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Input;
+using Windows.Win32;
+
+namespace Ghostty.Hosting;
+
+/// <summary>
+/// Builds a Microsoft.UI.Input.InputCursor whose underlying HCURSOR is a
+/// 32x32 fully-transparent bitmap. Used by the mouse-hide-while-typing
+/// path: assigning this cursor to a UIElement's ProtectedCursor makes
+/// the pointer visually disappear over that element, while libghostty's
+/// (synthetic) showMouse re-assertions through the WinUI Lifted Input
+/// stack remain harmless (they re-apply the same transparent HCURSOR).
+///
+/// Why not InputDesktopResourceCursor.Create or InputSystemCursor: the
+/// resource-cursor path requires baking a .cur into the apphost's Win32
+/// resources, which conflicts with the .NET SDK's ApplicationManifest +
+/// ApplicationIcon auto-generation. The system-cursor enum has no
+/// "invisible" value. CreateFromHCursor on IInputCursorStaticsInterop
+/// is the documented public path that sidesteps both.
+///
+/// API contract: IInputCursorStaticsInterop COPIES the HCURSOR, so we
+/// destroy the source HCURSOR immediately after wrapping. See
+/// https://learn.microsoft.com/windows/windows-app-sdk/api/win32/microsoft.ui.input.inputcursor.interop/nf-microsoft-ui-input-inputcursor-interop-iinputcursorstaticsinterop-createfromhcursor
+/// </summary>
+internal static partial class InvisibleCursorFactory
+{
+    // IID for IInputCursorStaticsInterop (microsoft.ui.input.inputcursor.interop.h).
+    private static readonly Guid IID_IInputCursorStaticsInterop =
+        new("ac6f5065-90c4-46ce-beb7-05e138e54117");
+
+    private const string InputCursorClassName = "Microsoft.UI.Input.InputCursor";
+
+    [LibraryImport("combase.dll", EntryPoint = "WindowsCreateString", StringMarshalling = StringMarshalling.Utf16)]
+    private static partial int WindowsCreateString(string sourceString, int length, out nint hstring);
+
+    [LibraryImport("combase.dll", EntryPoint = "WindowsDeleteString")]
+    private static partial int WindowsDeleteString(nint hstring);
+
+    [LibraryImport("combase.dll", EntryPoint = "RoGetActivationFactory")]
+    private static partial int RoGetActivationFactory(nint activatableClassId, in Guid iid, out nint factory);
+
+    private static InputCursor? _invisible;
+
+    /// <summary>
+    /// Lazily-built, process-wide transparent cursor. Throws on first
+    /// access if the COM interop or HCURSOR construction fails; callers
+    /// should fall back to leaving the cursor visible if so.
+    /// </summary>
+    public static InputCursor Invisible
+    {
+        get
+        {
+            if (_invisible is not null) return _invisible;
+            _invisible = Build();
+            return _invisible;
+        }
+    }
+
+    private static unsafe InputCursor Build()
+    {
+        // 32x32 1bpp cursor:
+        //   AND mask = all 1s  -> use existing screen pixel (transparent)
+        //   XOR mask = all 0s  -> no XOR contribution (irrelevant since AND=1)
+        // Each scanline is 32 bits = 4 bytes; 32 scanlines = 128 bytes per mask.
+        Span<byte> andMask = stackalloc byte[128];
+        Span<byte> xorMask = stackalloc byte[128];
+        andMask.Fill(0xFF);
+        xorMask.Clear();
+
+        nint hCursor;
+        fixed (byte* pAnd = andMask)
+        fixed (byte* pXor = xorMask)
+        {
+            hCursor = (nint)PInvoke.CreateCursor((Windows.Win32.Foundation.HINSTANCE)IntPtr.Zero, 0, 0, 32, 32, pAnd, pXor).Value;
+        }
+        if (hCursor == 0)
+            throw new InvalidOperationException("Win32 CreateCursor returned NULL");
+
+        try
+        {
+            int hr = WindowsCreateString(InputCursorClassName, InputCursorClassName.Length, out nint classId);
+            if (hr != 0) throw Marshal.GetExceptionForHR(hr) ?? new InvalidOperationException($"WindowsCreateString hr=0x{hr:X8}");
+
+            try
+            {
+                hr = RoGetActivationFactory(classId, IID_IInputCursorStaticsInterop, out nint factoryAbi);
+                if (hr != 0) throw Marshal.GetExceptionForHR(hr) ?? new InvalidOperationException($"RoGetActivationFactory hr=0x{hr:X8}");
+
+                try
+                {
+                    // IInputCursorStaticsInterop vtable layout:
+                    //   [0] IUnknown.QueryInterface
+                    //   [1] IUnknown.AddRef
+                    //   [2] IUnknown.Release
+                    //   [3] IInspectable.GetIids
+                    //   [4] IInspectable.GetRuntimeClassName
+                    //   [5] IInspectable.GetTrustLevel
+                    //   [6] IInputCursorStaticsInterop.CreateFromHCursor
+                    nint* vtable = *(nint**)factoryAbi;
+                    var createFromHCursor =
+                        (delegate* unmanaged[Stdcall]<nint, nint, nint*, int>)vtable[6];
+
+                    nint cursorAbi;
+                    hr = createFromHCursor(factoryAbi, hCursor, &cursorAbi);
+                    if (hr != 0) throw Marshal.GetExceptionForHR(hr) ?? new InvalidOperationException($"CreateFromHCursor hr=0x{hr:X8}");
+
+                    try
+                    {
+                        // CsWinRT projection wraps the IInputCursor ABI pointer into
+                        // the strongly-typed Microsoft.UI.Input.InputCursor.
+                        return WinRT.MarshalInspectable<InputCursor>.FromAbi(cursorAbi);
+                    }
+                    finally
+                    {
+                        Marshal.Release(cursorAbi);
+                    }
+                }
+                finally
+                {
+                    Marshal.Release(factoryAbi);
+                }
+            }
+            finally
+            {
+                WindowsDeleteString(classId);
+            }
+        }
+        finally
+        {
+            // CreateFromHCursor copied the bits; safe to destroy our source.
+            PInvoke.DestroyCursor(new Windows.Win32.UI.WindowsAndMessaging.HCURSOR(hCursor));
+        }
+    }
+}

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -17,6 +17,8 @@ GetWindowPlacement
 LoadImage
 MapVirtualKey
 MessageBeep
+CreateCursor
+DestroyCursor
 SendMessage
 SetForegroundWindow
 ShowWindow

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -8,6 +8,8 @@
 
 // user32
 ClientToScreen
+CreateCursor
+DestroyCursor
 GetCursorPos
 GetForegroundWindow
 GetKeyState
@@ -17,8 +19,6 @@ GetWindowPlacement
 LoadImage
 MapVirtualKey
 MessageBeep
-CreateCursor
-DestroyCursor
 SendMessage
 SetForegroundWindow
 ShowWindow


### PR DESCRIPTION
Closes the last Tier-1 mouse-protocol gap on Wintty. libghostty has implemented the "hide cursor while typing" policy upstream for some time (gated by `mouse-hide-while-typing`, default off). The Windows apprt was silently dropping the resulting `MOUSE_VISIBILITY` apprt action — this PR makes the existing Settings toggle in `TerminalPage.xaml` actually do something.

## What's new

- `MouseVisibility` enum + ordinal pin (`GhosttyActionTag.MouseVisibility = 37`)
- `InvisibleCursorFactory` — builds a transparent `Microsoft.UI.Input.InputCursor` at runtime via Win32 `CreateCursor` + `IInputCursorStaticsInterop::CreateFromHCursor`. No `.rc` pipeline, no manifest/icon merge conflict
- `TerminalControl.SetMouseVisibility` swaps `ProtectedCursor` between the system shape (#390's `SetMouseShape`) and the transparent cursor, coordinating via `_cursorHidden` + `_currentMouseShapeFamily` so a `MouseShape` arriving mid-hide doesn't pop the cursor back on
- 5-DIP motion threshold in `OnPointerMoved` while hidden, so libghostty's `cursorPosCallback` doesn't fire `showMouse` on every pixel of sensor jitter. Anchor is nullable to handle cold-start cleanly
- `GhosttyHost.OnAction` dispatches per-surface (mirrors `MouseShape`)

## Why this mechanism

`ShowCursor(FALSE)` and `WM_SETCURSOR` HWND subclassing both fail over WinUI 3 SwapChainPanel: WinUI's Lifted Input runs its own input thread and re-asserts the `InputCursor` (resolved via `IInputCursorStaticsInterop`) on every pointer event, overwriting any Win32-layer override within a frame. Setting `ProtectedCursor` to a transparent `InputCursor` via the same `IInputCursorStaticsInterop` path is the only mechanism Lifted Input honors. See `reference_winui3_cursor_hide_lifted_input.md` for the longer dead-end log.

## Test plan

- [x] Unit: `MouseVisibility` enum ordinals pinned to ghostty.h
- [x] Unit: `GhosttyActionTag.MouseVisibility = 37` pinned in layout test
- [x] Smoke: cursor hides on typing, stays hidden through sensor jitter, reappears on intentional motion (>5 DIP)
- [x] Smoke: cold-start case (type before ever moving the mouse) hides cleanly
- [x] Smoke: Settings toggle on/off respected immediately via ConfigService reload
- [x] Smoke: cursor visible outside the terminal pane (only the SwapChainPanel hit-test region is governed by our ProtectedCursor)
- [x] Smoke: `printf '\e]22;wait\e\'` (MouseShape from #390) still works