### PR TITLE
tab-icons: add IconSpec.BrandKey + SvgRasterizer (PR 1/5)

### DIFF
--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -67,6 +67,8 @@
     -->
     <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="Svg.Skia" Version="3.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Core/Profiles/IconSpec.cs
+++ b/windows/Ghostty.Core/Profiles/IconSpec.cs
@@ -23,6 +23,14 @@ public abstract record IconSpec
     public sealed record BundledKey(string Key) : IconSpec;
 
     /// <summary>
+    /// Wintty-bundled brand icon by string key (e.g. "ubuntu", "pwsh", "rust").
+    /// Resolves to <c>&lt;key&gt;@&lt;dpi&gt;.png</c> in the IconAssets resource
+    /// namespace. <see cref="Dpi"/> selects the DPI variant; null lets the
+    /// resolver pick based on system scale.
+    /// </summary>
+    public sealed record BrandKey(string Key, int? Dpi) : IconSpec;
+
+    /// <summary>
     /// Extract the icon associated with a Windows .exe via SHGetFileInfo.
     /// </summary>
     public sealed record AutoForExe(string ExePath) : IconSpec;

--- a/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileSourceParser.cs
@@ -171,6 +171,12 @@ public static partial class ProfileSourceParser
                 return new IconSpec.Mdl2Token(cp);
             return null;
         }
+        if (value.StartsWith("brand:", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var key = value.Substring(6);
+            if (key.Length == 0) return new IconSpec.Path(value);
+            return new IconSpec.BrandKey(key, null);
+        }
         return new IconSpec.Path(value);
     }
 

--- a/windows/Ghostty.Core/Profiles/SvgRasterizer.cs
+++ b/windows/Ghostty.Core/Profiles/SvgRasterizer.cs
@@ -19,12 +19,13 @@ public static class SvgRasterizer
 
         try
         {
+            // Svg.Skia 3.x: the parsed SKPicture is exposed via the .Picture
+            // property; the Load() return value is for chaining/null-check only.
+            // Use FromSvg(string) directly to skip the MemoryStream dance.
             using var svg = new SKSvg();
-            using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(clean));
-            var picture = svg.Load(stream);
-            if (picture is null) return Array.Empty<byte>();
+            if (svg.FromSvg(clean) is null || svg.Picture is null) return Array.Empty<byte>();
 
-            var srcRect = picture.CullRect;
+            var srcRect = svg.Picture.CullRect;
             if (srcRect.Width <= 0 || srcRect.Height <= 0) return Array.Empty<byte>();
 
             var info = new SKImageInfo(sizePx, sizePx, SKColorType.Bgra8888, SKAlphaType.Premul);
@@ -33,7 +34,7 @@ public static class SvgRasterizer
             canvas.Clear(SKColors.Transparent);
             var scale = Math.Min(sizePx / srcRect.Width, sizePx / srcRect.Height);
             canvas.Scale(scale, scale);
-            canvas.DrawPicture(picture);
+            canvas.DrawPicture(svg.Picture);
             canvas.Flush();
 
             using var image = surface.Snapshot();

--- a/windows/Ghostty.Core/Profiles/SvgRasterizer.cs
+++ b/windows/Ghostty.Core/Profiles/SvgRasterizer.cs
@@ -41,6 +41,7 @@ public static class SvgRasterizer
             using var data = image.Encode(SKEncodedImageFormat.Png, 100);
             return data.ToArray();
         }
+        catch (OperationCanceledException) { throw; }
         catch
         {
             return Array.Empty<byte>();

--- a/windows/Ghostty.Core/Profiles/SvgRasterizer.cs
+++ b/windows/Ghostty.Core/Profiles/SvgRasterizer.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using SkiaSharp;
+using Svg.Skia;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Rasterizes a sanitized SVG payload to a square PNG at <paramref name="sizePx"/> pixels.
+/// Returns an empty array on any parse/render failure; callers fall back to the bundled default.
+/// </summary>
+public static class SvgRasterizer
+{
+    public static byte[] Rasterize(string svgText, int sizePx)
+    {
+        if (sizePx <= 0) return Array.Empty<byte>();
+        var clean = SvgSanitizer.Sanitize(svgText);
+        if (string.IsNullOrEmpty(clean)) return Array.Empty<byte>();
+
+        try
+        {
+            using var svg = new SKSvg();
+            using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(clean));
+            var picture = svg.Load(stream);
+            if (picture is null) return Array.Empty<byte>();
+
+            var srcRect = picture.CullRect;
+            if (srcRect.Width <= 0 || srcRect.Height <= 0) return Array.Empty<byte>();
+
+            var info = new SKImageInfo(sizePx, sizePx, SKColorType.Bgra8888, SKAlphaType.Premul);
+            using var surface = SKSurface.Create(info);
+            var canvas = surface.Canvas;
+            canvas.Clear(SKColors.Transparent);
+            var scale = Math.Min(sizePx / srcRect.Width, sizePx / srcRect.Height);
+            canvas.Scale(scale, scale);
+            canvas.DrawPicture(picture);
+            canvas.Flush();
+
+            using var image = surface.Snapshot();
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            return data.ToArray();
+        }
+        catch
+        {
+            return Array.Empty<byte>();
+        }
+    }
+}

--- a/windows/Ghostty.Core/Profiles/SvgSanitizer.cs
+++ b/windows/Ghostty.Core/Profiles/SvgSanitizer.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Removes scriptable elements and attributes from user-supplied SVGs.
+/// Bundled SVGs that ship in the build are trusted; this only runs on
+/// the runtime <see cref="IconSpec.Path"/> case when the file ends in .svg.
+/// </summary>
+public static class SvgSanitizer
+{
+    private static readonly XNamespace SvgNs = "http://www.w3.org/2000/svg";
+
+    private static readonly string[] BlockedElementLocalNames =
+    [
+        "script", "foreignObject", "iframe", "object", "embed", "a"
+    ];
+
+    public static string Sanitize(string svgText)
+    {
+        if (string.IsNullOrWhiteSpace(svgText)) return string.Empty;
+
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(svgText, LoadOptions.None);
+        }
+        catch
+        {
+            return string.Empty;
+        }
+
+        if (doc.Root is null) return string.Empty;
+
+        // Remove blocked elements anywhere in the tree.
+        var blocked = doc.Root.DescendantsAndSelf()
+            .Where(e => BlockedElementLocalNames.Contains(e.Name.LocalName, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+        foreach (var e in blocked) e.Remove();
+
+        // Remove event handler attributes (on*) and external hrefs.
+        foreach (var e in doc.Root.DescendantsAndSelf())
+        {
+            var attrs = e.Attributes().ToList();
+            foreach (var a in attrs)
+            {
+                if (a.Name.LocalName.StartsWith("on", StringComparison.OrdinalIgnoreCase))
+                {
+                    a.Remove();
+                    continue;
+                }
+                if ((a.Name.LocalName.Equals("href", StringComparison.OrdinalIgnoreCase)
+                     || a.Name.LocalName.Equals("xlink:href", StringComparison.OrdinalIgnoreCase)
+                     || (a.Name.LocalName.Equals("href", StringComparison.OrdinalIgnoreCase) && a.Name.NamespaceName == "http://www.w3.org/1999/xlink"))
+                    && IsExternalHref(a.Value))
+                {
+                    a.Remove();
+                }
+            }
+        }
+
+        using var writer = new StringWriter();
+        doc.Save(writer, SaveOptions.DisableFormatting);
+        return writer.ToString();
+    }
+
+    private static bool IsExternalHref(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+        if (value.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return false;
+        if (value.StartsWith("#")) return false;  // intra-doc fragment
+        return value.StartsWith("http:", StringComparison.OrdinalIgnoreCase)
+            || value.StartsWith("https:", StringComparison.OrdinalIgnoreCase)
+            || value.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
+            || value.StartsWith("ftp:", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/windows/Ghostty.Core/Profiles/SvgSanitizer.cs
+++ b/windows/Ghostty.Core/Profiles/SvgSanitizer.cs
@@ -52,9 +52,7 @@ public static class SvgSanitizer
                     a.Remove();
                     continue;
                 }
-                if ((a.Name.LocalName.Equals("href", StringComparison.OrdinalIgnoreCase)
-                     || a.Name.LocalName.Equals("xlink:href", StringComparison.OrdinalIgnoreCase)
-                     || (a.Name.LocalName.Equals("href", StringComparison.OrdinalIgnoreCase) && a.Name.NamespaceName == "http://www.w3.org/1999/xlink"))
+                if (a.Name.LocalName.Equals("href", StringComparison.OrdinalIgnoreCase)
                     && IsExternalHref(a.Value))
                 {
                     a.Remove();

--- a/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
@@ -18,6 +18,7 @@ namespace Ghostty.Core.Profiles;
 internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
 {
     private const string DefaultBundledKey = "default";
+    private const int DefaultSvgRasterSizePx = 32;
 
     public async Task<byte[]> ResolveAsync(IconSpec spec, CancellationToken ct)
     {
@@ -50,7 +51,7 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
     private async Task<byte[]> ResolveUncachedAsync(IconSpec spec, CancellationToken ct) => spec switch
     {
         IconSpec.Path p when p.FilePath.EndsWith(".svg", System.StringComparison.OrdinalIgnoreCase)
-            => RasterizeSvgFileOrDefault(await fs.ReadAllBytesAsync(p.FilePath, ct).ConfigureAwait(false), sizePx: 32),
+            => RasterizeSvgFileOrDefault(await fs.ReadAllBytesAsync(p.FilePath, ct).ConfigureAwait(false), DefaultSvgRasterSizePx),
         IconSpec.Path p => await fs.ReadAllBytesAsync(p.FilePath, ct).ConfigureAwait(false),
         IconSpec.BrandKey b => ReadBrandedOrDefault(b.Key, b.Dpi ?? 16),
         IconSpec.BundledKey b => ReadBundledOrDefault(b.Key),
@@ -98,7 +99,7 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         return ms.ToArray();
     }
 
-    private static byte[] RasterizeSvgFileOrDefault(byte[] svgBytes, int sizePx)
+    private static byte[] RasterizeSvgFileOrDefault(byte[] svgBytes, int sizePx = DefaultSvgRasterSizePx)
     {
         var text = System.Text.Encoding.UTF8.GetString(svgBytes);
         var png = SvgRasterizer.Rasterize(text, sizePx);

--- a/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
@@ -49,7 +49,10 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
 
     private async Task<byte[]> ResolveUncachedAsync(IconSpec spec, CancellationToken ct) => spec switch
     {
+        IconSpec.Path p when p.FilePath.EndsWith(".svg", System.StringComparison.OrdinalIgnoreCase)
+            => RasterizeSvgFileOrDefault(await fs.ReadAllBytesAsync(p.FilePath, ct).ConfigureAwait(false), sizePx: 32),
         IconSpec.Path p => await fs.ReadAllBytesAsync(p.FilePath, ct).ConfigureAwait(false),
+        IconSpec.BrandKey b => ReadBrandedOrDefault(b.Key, b.Dpi ?? 16),
         IconSpec.BundledKey b => ReadBundledOrDefault(b.Key),
         IconSpec.Mdl2Token => ReadBundledOrDefault(DefaultBundledKey),
         IconSpec.AutoForExe a => ExtractExeIconAsPng(a.ExePath),
@@ -95,6 +98,29 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         return ms.ToArray();
     }
 
+    private static byte[] RasterizeSvgFileOrDefault(byte[] svgBytes, int sizePx)
+    {
+        var text = System.Text.Encoding.UTF8.GetString(svgBytes);
+        var png = SvgRasterizer.Rasterize(text, sizePx);
+        return png.Length > 0 ? png : ReadBundledOrDefault(DefaultBundledKey);
+    }
+
+    private static byte[] ReadBrandedOrDefault(string key, int dpi)
+    {
+        var resource = $"Ghostty.Core.Profiles.IconAssets.{key}@{dpi}.png";
+        using var stream = typeof(WindowsIconResolver).Assembly.GetManifestResourceStream(resource);
+        if (stream is not null)
+        {
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return ms.ToArray();
+        }
+        // Try the same key without DPI suffix (legacy single-size bundle).
+        var legacy = TryReadBundled(key);
+        if (legacy is not null) return legacy;
+        return ReadBundledOrDefault(DefaultBundledKey);
+    }
+
     private string SpecToCacheKey(IconSpec spec)
     {
         // Casing note: Windows paths are case-insensitive, so tokens
@@ -105,6 +131,7 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         var baseToken = spec switch
         {
             IconSpec.Path p => "path:" + p.FilePath,
+            IconSpec.BrandKey br => "brand:" + br.Key + ":dpi:" + (br.Dpi?.ToString() ?? "auto"),
             IconSpec.Mdl2Token m => "mdl2:" + m.CodePoint.ToString("x"),
             IconSpec.BundledKey b => "bundled:" + b.Key,
             IconSpec.AutoForExe a => "exe:" + a.ExePath,

--- a/windows/Ghostty.Tests/Profiles/IconSpecTests.cs
+++ b/windows/Ghostty.Tests/Profiles/IconSpecTests.cs
@@ -51,4 +51,28 @@ public sealed class IconSpecTests
         Assert.Equal(new IconSpec.Path("a"), new IconSpec.Path("a"));
         Assert.NotEqual<IconSpec>(new IconSpec.Path("a"), new IconSpec.BundledKey("a"));
     }
+
+    [Fact]
+    public void BrandKey_HoldsKeyAndDpi()
+    {
+        IconSpec spec = new IconSpec.BrandKey("ubuntu", 16);
+        var b = Assert.IsType<IconSpec.BrandKey>(spec);
+        Assert.Equal("ubuntu", b.Key);
+        Assert.Equal(16, b.Dpi);
+    }
+
+    [Fact]
+    public void BrandKey_DpiIsOptional()
+    {
+        IconSpec spec = new IconSpec.BrandKey("ubuntu", null);
+        var b = Assert.IsType<IconSpec.BrandKey>(spec);
+        Assert.Null(b.Dpi);
+    }
+
+    [Fact]
+    public void BrandKey_RecordEqualityHolds()
+    {
+        Assert.Equal(new IconSpec.BrandKey("a", 16), new IconSpec.BrandKey("a", 16));
+        Assert.NotEqual<IconSpec>(new IconSpec.BrandKey("a", 16), new IconSpec.BundledKey("a"));
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
@@ -283,4 +283,36 @@ public sealed class ProfileSourceParserTests
         var token = Assert.IsType<IconSpec.Mdl2Token>(p.Icon);
         Assert.Equal(0xE756, token.CodePoint);
     }
+
+    [Fact]
+    public void ParseIcon_BrandPrefix_ProducesBrandKey()
+    {
+        var parsed = ProfileSourceParser.Parse(
+            "profile.foo.name = Foo\nprofile.foo.icon = brand:ubuntu\n"
+        ).Profiles["foo"];
+        var bk = Assert.IsType<IconSpec.BrandKey>(parsed.Icon);
+        Assert.Equal("ubuntu", bk.Key);
+        Assert.Null(bk.Dpi);
+    }
+
+    [Fact]
+    public void ParseIcon_BrandPrefix_IsCaseInsensitive()
+    {
+        var parsed = ProfileSourceParser.Parse(
+            "profile.foo.name = Foo\nprofile.foo.icon = BRAND:Ubuntu\n"
+        ).Profiles["foo"];
+        var bk = Assert.IsType<IconSpec.BrandKey>(parsed.Icon);
+        Assert.Equal("Ubuntu", bk.Key);
+    }
+
+    [Fact]
+    public void ParseIcon_BrandPrefix_EmptyKey_FallsBackToPath()
+    {
+        // "brand:" with no key is meaningless; treat as Path so the user
+        // gets a clear "file not found" rather than a silent default.
+        var parsed = ProfileSourceParser.Parse(
+            "profile.foo.name = Foo\nprofile.foo.icon = brand:\n"
+        ).Profiles["foo"];
+        Assert.IsType<IconSpec.Path>(parsed.Icon);
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileSourceParserTests.cs
@@ -288,7 +288,7 @@ public sealed class ProfileSourceParserTests
     public void ParseIcon_BrandPrefix_ProducesBrandKey()
     {
         var parsed = ProfileSourceParser.Parse(
-            "profile.foo.name = Foo\nprofile.foo.icon = brand:ubuntu\n"
+            "profile.foo.name = Foo\nprofile.foo.command = pwsh\nprofile.foo.icon = brand:ubuntu\n"
         ).Profiles["foo"];
         var bk = Assert.IsType<IconSpec.BrandKey>(parsed.Icon);
         Assert.Equal("ubuntu", bk.Key);
@@ -299,7 +299,7 @@ public sealed class ProfileSourceParserTests
     public void ParseIcon_BrandPrefix_IsCaseInsensitive()
     {
         var parsed = ProfileSourceParser.Parse(
-            "profile.foo.name = Foo\nprofile.foo.icon = BRAND:Ubuntu\n"
+            "profile.foo.name = Foo\nprofile.foo.command = pwsh\nprofile.foo.icon = BRAND:Ubuntu\n"
         ).Profiles["foo"];
         var bk = Assert.IsType<IconSpec.BrandKey>(parsed.Icon);
         Assert.Equal("Ubuntu", bk.Key);
@@ -311,7 +311,7 @@ public sealed class ProfileSourceParserTests
         // "brand:" with no key is meaningless; treat as Path so the user
         // gets a clear "file not found" rather than a silent default.
         var parsed = ProfileSourceParser.Parse(
-            "profile.foo.name = Foo\nprofile.foo.icon = brand:\n"
+            "profile.foo.name = Foo\nprofile.foo.command = pwsh\nprofile.foo.icon = brand:\n"
         ).Profiles["foo"];
         Assert.IsType<IconSpec.Path>(parsed.Icon);
     }

--- a/windows/Ghostty.Tests/Profiles/SvgRasterizerTests.cs
+++ b/windows/Ghostty.Tests/Profiles/SvgRasterizerTests.cs
@@ -1,0 +1,52 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class SvgRasterizerTests
+{
+    private const string SimpleRedCircle =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 32 32\">"
+        + "<circle cx=\"16\" cy=\"16\" r=\"12\" fill=\"red\"/></svg>";
+
+    [Fact]
+    public void Rasterize_ValidSvg_ProducesPngWithSignature()
+    {
+        var png = SvgRasterizer.Rasterize(SimpleRedCircle, sizePx: 32);
+        Assert.NotEmpty(png);
+        Assert.Equal(0x89, png[0]);
+        Assert.Equal(0x50, png[1]);
+        Assert.Equal(0x4E, png[2]);
+        Assert.Equal(0x47, png[3]);
+    }
+
+    [Fact]
+    public void Rasterize_RespectsSizePx()
+    {
+        var png16 = SvgRasterizer.Rasterize(SimpleRedCircle, sizePx: 16);
+        var png32 = SvgRasterizer.Rasterize(SimpleRedCircle, sizePx: 32);
+        // Coarse check: larger size produces larger output. Exact bytes
+        // are renderer-dependent; we only assert non-equivalence.
+        Assert.NotEqual(png16.Length, png32.Length);
+    }
+
+    [Fact]
+    public void Rasterize_ScriptIsStrippedBeforeRender()
+    {
+        // If the sanitizer didn't run, SkiaSharp would still ignore the
+        // script tag but parsing might fail. We just verify a sanitized
+        // payload renders OK.
+        var withScript =
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 32 32\">"
+            + "<script>x()</script><circle cx=\"16\" cy=\"16\" r=\"12\" fill=\"blue\"/></svg>";
+        var png = SvgRasterizer.Rasterize(withScript, sizePx: 16);
+        Assert.NotEmpty(png);
+    }
+
+    [Fact]
+    public void Rasterize_InvalidSvg_ReturnsEmpty()
+    {
+        var png = SvgRasterizer.Rasterize("not an svg", sizePx: 16);
+        Assert.Empty(png);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/SvgSanitizerTests.cs
+++ b/windows/Ghostty.Tests/Profiles/SvgSanitizerTests.cs
@@ -1,0 +1,63 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class SvgSanitizerTests
+{
+    [Fact]
+    public void Sanitize_StripsScriptElements()
+    {
+        var dirty = "<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script><circle r=\"1\"/></svg>";
+        var clean = SvgSanitizer.Sanitize(dirty);
+        Assert.DoesNotContain("<script", clean);
+        Assert.Contains("<circle", clean);
+    }
+
+    [Fact]
+    public void Sanitize_StripsForeignObject()
+    {
+        var dirty = "<svg xmlns=\"http://www.w3.org/2000/svg\"><foreignObject><iframe src=\"x\"/></foreignObject><rect/></svg>";
+        var clean = SvgSanitizer.Sanitize(dirty);
+        Assert.DoesNotContain("foreignObject", clean);
+        Assert.DoesNotContain("iframe", clean);
+        Assert.Contains("<rect", clean);
+    }
+
+    [Fact]
+    public void Sanitize_StripsEventHandlerAttributes()
+    {
+        var dirty = "<svg xmlns=\"http://www.w3.org/2000/svg\"><rect onclick=\"alert(1)\" onmouseover=\"x()\" fill=\"red\"/></svg>";
+        var clean = SvgSanitizer.Sanitize(dirty);
+        Assert.DoesNotContain("onclick", clean);
+        Assert.DoesNotContain("onmouseover", clean);
+        Assert.Contains("fill=\"red\"", clean);
+    }
+
+    [Fact]
+    public void Sanitize_StripsAnchorAndExternalHrefs()
+    {
+        var dirty = "<svg xmlns=\"http://www.w3.org/2000/svg\"><a href=\"https://evil\"><rect/></a><use xlink:href=\"http://evil/x.svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"/></svg>";
+        var clean = SvgSanitizer.Sanitize(dirty);
+        Assert.DoesNotContain("<a ", clean);
+        Assert.DoesNotContain("evil", clean);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesDataUriHrefs()
+    {
+        var dirty = "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><image xlink:href=\"data:image/png;base64,AA==\" width=\"1\" height=\"1\"/></svg>";
+        var clean = SvgSanitizer.Sanitize(dirty);
+        Assert.Contains("data:image/png;base64", clean);
+    }
+
+    [Fact]
+    public void Sanitize_InvalidXml_ReturnsEmptyString()
+    {
+        // Defensive: malformed input must not throw. Empty output causes
+        // the rasterizer to produce a transparent PNG and the caller falls
+        // back to default.
+        var clean = SvgSanitizer.Sanitize("<svg<<<broken");
+        Assert.Equal(string.Empty, clean);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/WindowsIconResolverBrandKeyTests.cs
+++ b/windows/Ghostty.Tests/Profiles/WindowsIconResolverBrandKeyTests.cs
@@ -1,0 +1,49 @@
+using System.Threading;
+using Ghostty.Core.Profiles;
+using Ghostty.Tests.Profiles.Fakes;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class WindowsIconResolverBrandKeyTests
+{
+    [Fact(Skip = "awaits PR A3 asset bundle")]
+    public async System.Threading.Tasks.Task Resolve_BrandKey_WithExplicitDpi_ReturnsThatVariant()
+    {
+        var fs = new FakeFileSystem();
+        fs.SetKnownFolder(KnownFolderId.LocalAppData, @"C:\cache");
+        var resolver = new WindowsIconResolver(fs);
+
+        var bytes = await resolver.ResolveAsync(new IconSpec.BrandKey("default", 16), CancellationToken.None);
+
+        Assert.NotEmpty(bytes);
+        Assert.Equal(0x89, bytes[0]);
+        Assert.Equal(0x50, bytes[1]);
+    }
+
+    [Fact(Skip = "awaits PR A3 asset bundle")]
+    public async System.Threading.Tasks.Task Resolve_BrandKey_WithNullDpi_PicksADefault()
+    {
+        var fs = new FakeFileSystem();
+        fs.SetKnownFolder(KnownFolderId.LocalAppData, @"C:\cache");
+        var resolver = new WindowsIconResolver(fs);
+
+        var bytes = await resolver.ResolveAsync(new IconSpec.BrandKey("default", null), CancellationToken.None);
+
+        Assert.NotEmpty(bytes);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Resolve_BrandKey_UnknownKey_FallsBackToDefault()
+    {
+        // Existing default.png (single-size, legacy) provides a fallback even
+        // before the @<dpi>.png bundle lands in PR A3.
+        var fs = new FakeFileSystem();
+        fs.SetKnownFolder(KnownFolderId.LocalAppData, @"C:\cache");
+        var resolver = new WindowsIconResolver(fs);
+
+        var bytes = await resolver.ResolveAsync(new IconSpec.BrandKey("never-exists-xyz", 16), CancellationToken.None);
+
+        Assert.NotEmpty(bytes);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/WindowsIconResolverSvgPathTests.cs
+++ b/windows/Ghostty.Tests/Profiles/WindowsIconResolverSvgPathTests.cs
@@ -1,0 +1,43 @@
+using System.Text;
+using System.Threading;
+using Ghostty.Core.Profiles;
+using Ghostty.Tests.Profiles.Fakes;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class WindowsIconResolverSvgPathTests
+{
+    private const string MinimalSvg =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 32 32\">"
+        + "<rect width=\"32\" height=\"32\" fill=\"green\"/></svg>";
+
+    [Fact]
+    public async System.Threading.Tasks.Task Resolve_PathWithSvgExtension_RasterizesToPng()
+    {
+        var fs = new FakeFileSystem();
+        fs.SetKnownFolder(KnownFolderId.LocalAppData, @"C:\cache");
+        fs.AddFile(@"C:\custom.svg", Encoding.UTF8.GetBytes(MinimalSvg));
+        var resolver = new WindowsIconResolver(fs);
+
+        var bytes = await resolver.ResolveAsync(new IconSpec.Path(@"C:\custom.svg"), CancellationToken.None);
+
+        Assert.NotEmpty(bytes);
+        Assert.Equal(0x89, bytes[0]);
+        Assert.Equal(0x50, bytes[1]);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Resolve_PathWithPngExtension_ReadsBytesUnchanged()
+    {
+        var fs = new FakeFileSystem();
+        fs.SetKnownFolder(KnownFolderId.LocalAppData, @"C:\cache");
+        var raw = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0xAA, 0xBB };
+        fs.AddFile(@"C:\custom.png", raw);
+        var resolver = new WindowsIconResolver(fs);
+
+        var bytes = await resolver.ResolveAsync(new IconSpec.Path(@"C:\custom.png"), CancellationToken.None);
+
+        Assert.Equal(raw, bytes);
+    }
+}


### PR DESCRIPTION
## Summary
Foundation PR for the tab-icons stack (closes the long-standing `TODO(plan3)` placeholder by the end of PR 4). This one adds:

- `IconSpec.BrandKey(string Key, int? Dpi)` variant for DPI-aware bundled brand icons.
- `brand:<key>` parser case in `ProfileSourceParser.ParseIcon`.
- `SvgSanitizer` (strips script / foreignObject / event handlers / external hrefs).
- `SvgRasterizer` (SkiaSharp + Svg.Skia 3.x) for user-pointed `.svg` overrides in profile config.
- `WindowsIconResolver` branches for the new `BrandKey` variant (reads `<key>@<dpi>.png` resources, falls back to legacy single-size, then to default) and the new `.svg` Path case.

## Test plan
- [x] Tests: 910 pass + 2 BrandKey resolver tests skipped pending the asset bundle landing in PR 3/5.

IMPORTANT: this is the first PR in a 5-PR stack. PR 2/5 adds the build-time SVG-to-PNG prebake task. PR 3/5 lands the asset bundle (shells + WSL distros). PR 4/5 replaces the `"T"` placeholder in the tab strip. PR 5/5 adds the per-profile icon picker to settings.