### PR TITLE
tab-icons: build-time SVG to PNG prebake (PR 2/5)

### DIFF
--- a/build/RasterizeIcons/Program.cs
+++ b/build/RasterizeIcons/Program.cs
@@ -1,0 +1,70 @@
+using SkiaSharp;
+using Svg.Skia;
+
+if (args.Length != 2)
+{
+    Console.Error.WriteLine("usage: RasterizeIcons <sourceDir> <outputDir>");
+    return 2;
+}
+
+var sourceDir = args[0];
+var outputDir = args[1];
+Directory.CreateDirectory(outputDir);
+
+var sizes = new[] { 16, 24, 32 };
+var svgs = Directory.EnumerateFiles(sourceDir, "*.svg", SearchOption.AllDirectories).ToList();
+if (svgs.Count == 0)
+{
+    Console.Error.WriteLine($"warning: no .svg under {sourceDir}");
+    return 0;
+}
+
+var failures = 0;
+foreach (var svgPath in svgs)
+{
+    var key = Path.GetFileNameWithoutExtension(svgPath);
+    foreach (var size in sizes)
+    {
+        var outPath = Path.Combine(outputDir, $"{key}@{size}.png");
+        try
+        {
+            // Svg.Skia 3.x: Load() does not return the SKPicture; read svg.Picture
+            // after loading. Mirror SvgRasterizer.cs by going through FromSvg(string).
+            using var svg = new SKSvg();
+            var svgText = File.ReadAllText(svgPath);
+            if (svg.FromSvg(svgText) is null || svg.Picture is null)
+            {
+                Console.Error.WriteLine($"failed to load {svgPath}");
+                failures++;
+                continue;
+            }
+            var src = svg.Picture.CullRect;
+            if (src.Width <= 0 || src.Height <= 0)
+            {
+                Console.Error.WriteLine($"empty cull rect for {svgPath}");
+                failures++;
+                continue;
+            }
+            var info = new SKImageInfo(size, size, SKColorType.Bgra8888, SKAlphaType.Premul);
+            using var surface = SKSurface.Create(info);
+            var canvas = surface.Canvas;
+            canvas.Clear(SKColors.Transparent);
+            var scale = Math.Min(size / src.Width, size / src.Height);
+            canvas.Scale(scale, scale);
+            canvas.DrawPicture(svg.Picture);
+            canvas.Flush();
+            using var image = surface.Snapshot();
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var fs = File.Create(outPath);
+            data.SaveTo(fs);
+            Console.WriteLine($"wrote {outPath}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"failed {svgPath} @{size}: {ex.Message}");
+            failures++;
+        }
+    }
+}
+
+return failures == 0 ? 0 : 1;

--- a/build/RasterizeIcons/Program.cs
+++ b/build/RasterizeIcons/Program.cs
@@ -61,7 +61,7 @@ foreach (var svgPath in svgs)
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"failed {svgPath} @{size}: {ex.Message}");
+            Console.Error.WriteLine($"failed {svgPath} @{size}: {ex.GetType().Name}: {ex.Message}");
             failures++;
         }
     }

--- a/build/RasterizeIcons/RasterizeIcons.csproj
+++ b/build/RasterizeIcons/RasterizeIcons.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>RasterizeIcons</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="Svg.Skia" Version="3.0.4" />
+  </ItemGroup>
+</Project>

--- a/build/RasterizeIcons/RasterizeIcons.targets
+++ b/build/RasterizeIcons/RasterizeIcons.targets
@@ -26,7 +26,7 @@
           BeforeTargets="BeforeBuild"
           Condition="'@(IconSourceSvg)' != ''"
           Inputs="@(IconSourceSvg)"
-          Outputs="@(IconSourceSvg -> '$(IconAssetsOutputDir)\%(Filename)@32.png')">
+          Outputs="@(IconSourceSvg -> '$(IconAssetsOutputDir)\%(Filename)@16.png');@(IconSourceSvg -> '$(IconAssetsOutputDir)\%(Filename)@24.png');@(IconSourceSvg -> '$(IconAssetsOutputDir)\%(Filename)@32.png')">
     <Message Text="Prebaking SVG icons from $(IconAssetsSourceDir) -> $(IconAssetsOutputDir)" Importance="high"/>
     <Exec Command="dotnet run --project &quot;$(RasterizeIconsProj)&quot; -- &quot;$(IconAssetsSourceDir)&quot; &quot;$(IconAssetsOutputDir)&quot;" />
   </Target>

--- a/build/RasterizeIcons/RasterizeIcons.targets
+++ b/build/RasterizeIcons/RasterizeIcons.targets
@@ -1,0 +1,33 @@
+<Project>
+  <!--
+    Imported by Ghostty.Core.csproj. Runs the RasterizeIcons console tool
+    before Core compiles, ensuring every <key>.svg under IconAssets.Source
+    has matching <key>@16.png, <key>@24.png, <key>@32.png under IconAssets.
+    Outputs are tracked as inputs to the EmbeddedResource glob so MSBuild
+    incrementally rebuilds only when sources change.
+  -->
+  <PropertyGroup>
+    <IconAssetsSourceDir>$(MSBuildThisFileDirectory)..\..\windows\Ghostty.Core\Profiles\IconAssets.Source</IconAssetsSourceDir>
+    <IconAssetsOutputDir>$(MSBuildThisFileDirectory)..\..\windows\Ghostty.Core\Profiles\IconAssets</IconAssetsOutputDir>
+    <RasterizeIconsProj>$(MSBuildThisFileDirectory)RasterizeIcons.csproj</RasterizeIconsProj>
+  </PropertyGroup>
+
+  <!--
+    Populate at project-evaluation time so Inputs/Outputs on the target
+    below resolve before MSBuild's up-to-date check. Items defined inside
+    the target run too late: MSBuild would skip the target as "no outputs"
+    on the first build, leaving the prebake un-invoked.
+  -->
+  <ItemGroup>
+    <IconSourceSvg Include="$(IconAssetsSourceDir)\**\*.svg"/>
+  </ItemGroup>
+
+  <Target Name="PrebakeIconAssets"
+          BeforeTargets="BeforeBuild"
+          Condition="'@(IconSourceSvg)' != ''"
+          Inputs="@(IconSourceSvg)"
+          Outputs="@(IconSourceSvg -> '$(IconAssetsOutputDir)\%(Filename)@32.png')">
+    <Message Text="Prebaking SVG icons from $(IconAssetsSourceDir) -> $(IconAssetsOutputDir)" Importance="high"/>
+    <Exec Command="dotnet run --project &quot;$(RasterizeIconsProj)&quot; -- &quot;$(IconAssetsSourceDir)&quot; &quot;$(IconAssetsOutputDir)&quot;" />
+  </Target>
+</Project>

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -85,7 +85,8 @@
       at build time but noisy in the evaluated item graph.
     -->
     <None Remove="Profiles\IconAssets\*.png" />
-    <EmbeddedResource Include="Profiles\IconAssets\*.png">
+    <EmbeddedResource Include="Profiles\IconAssets\*.png"
+                      Exclude="Profiles\IconAssets\*@*.png">
       <LogicalName>Ghostty.Core.Profiles.IconAssets.%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
     <!--

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -171,6 +171,8 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\RasterizeIcons\RasterizeIcons.targets" />
 
   <ItemGroup>
-    <EmbeddedResource Include="Profiles\IconAssets\*@*.png" />
+    <EmbeddedResource Include="Profiles\IconAssets\*@*.png">
+      <LogicalName>Ghostty.Core.Profiles.IconAssets.%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -166,4 +166,10 @@
       <Compile Include="$(_GeneratedBuildInfoFile)" Visible="false"/>
     </ItemGroup>
   </Target>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\RasterizeIcons\RasterizeIcons.targets" />
+
+  <ItemGroup>
+    <EmbeddedResource Include="Profiles\IconAssets\*@*.png" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Adds `build/RasterizeIcons` console tool (SkiaSharp + Svg.Skia) that rasterizes every SVG under `IconAssets.Source/` into `<key>@16.png`, `<key>@24.png`, `<key>@32.png` outputs.
- Imports `RasterizeIcons.targets` into `Ghostty.Core.csproj` so the prebake runs before `BeforeBuild`.
- Adds `EmbeddedResource Include="Profiles\IconAssets\*@*.png"` so the generated PNGs ship in the assembly, and scopes the legacy `*.png` glob to exclude DPI-suffixed names so the two globs are non-overlapping.
- Outputs in the MSBuild target track all three sizes, so a deleted `@16` or `@24` also re-triggers the prebake.

IMPORTANT: stacked on top of #399 (PR 1/5). Merge order: 1/5 then 2/5.

## Test plan
- [x] Smoke: dropped a fixture SVG, ran \`dotnet build\`, confirmed three PNG outputs.
- [x] Removed only \`@16.png\`, rebuilt, prebake re-ran and restored the file.
- [x] Removed fixture, confirmed clean build with 0 warnings / 0 errors.