### PR TITLE
tab-icons: replace T placeholder with per-profile icons (PR 4/5)

### DIFF
--- a/windows/Ghostty.Core/Profiles/IconSpecTemplateLogic.cs
+++ b/windows/Ghostty.Core/Profiles/IconSpecTemplateLogic.cs
@@ -1,0 +1,23 @@
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Discriminator for the two presenter shapes the tab strip renders:
+/// a raster <c>Image</c> (PNG-backed icons) versus a glyph <c>FontIcon</c>
+/// (MDL2 code points). The WinUI layer maps these to actual
+/// <c>DataTemplate</c> resources.
+/// </summary>
+public enum IconTemplateKind { Image, FontIcon }
+
+/// <summary>
+/// Pure decision: given an <see cref="IconSpec"/>, which presenter
+/// template should the tab strip use. Lives in Core so it can be
+/// exercised by <c>Ghostty.Tests</c>, which never loads WinUI.
+/// </summary>
+public static class IconSpecTemplateLogic
+{
+    public static IconTemplateKind PickKind(IconSpec spec) => spec switch
+    {
+        IconSpec.Mdl2Token => IconTemplateKind.FontIcon,
+        _ => IconTemplateKind.Image,
+    };
+}

--- a/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
@@ -24,7 +24,16 @@ public sealed class TabIconViewModel : INotifyPropertyChanged
     public IconSpec Icon
     {
         get;
-        private set { if (!Equals(field, value)) { field = value; Raise(); } }
+        private set
+        {
+            if (Equals(field, value)) return;
+            field = value;
+            Raise();
+            // IsMdl2Glyph and Mdl2CodePoint are computed; classic bindings
+            // listen for the exact property name, so raise them explicitly.
+            Raise(nameof(IsMdl2Glyph));
+            Raise(nameof(Mdl2CodePoint));
+        }
     }
 
     public string TooltipText
@@ -47,9 +56,9 @@ public sealed class TabIconViewModel : INotifyPropertyChanged
     public int Mdl2CodePoint => Icon is IconSpec.Mdl2Token m ? m.CodePoint : 0;
 
     /// <summary>
-    /// Atomic update of icon + tooltip. Single call site avoids two
-    /// PropertyChanged notifications racing the template selector on
-    /// profile re-resolution.
+    /// Updates the icon spec and tooltip in one call. Fires PropertyChanged
+    /// for Icon (and its derived flags IsMdl2Glyph / Mdl2CodePoint) before
+    /// TooltipText; subscribers observe sequential notifications.
     /// </summary>
     public void SetIcon(IconSpec icon, string tooltipText)
     {

--- a/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Per-tab observable that pairs an <see cref="IconSpec"/> with the
+/// tooltip the tab strip shows. Lives in Core (no WinUI types) so it
+/// can be exercised by the test project, which only references
+/// <c>Ghostty.Core</c>.
+///
+/// INPC is hand-rolled with the C# 14 <c>field</c> keyword to match
+/// <see cref="TabModel"/> and avoid a source-generator dependency.
+/// </summary>
+public sealed class TabIconViewModel : INotifyPropertyChanged
+{
+    public TabIconViewModel(IconSpec icon, string tooltipText)
+    {
+        Icon = icon;
+        TooltipText = tooltipText;
+    }
+
+    public IconSpec Icon
+    {
+        get;
+        private set { if (!Equals(field, value)) { field = value; Raise(); } }
+    }
+
+    public string TooltipText
+    {
+        get;
+        private set { if (field != value) { field = value; Raise(); } }
+    }
+
+    /// <summary>
+    /// True when <see cref="Icon"/> is a Segoe MDL2 glyph; the tab-strip
+    /// template selector switches to a FontIcon presenter in that case.
+    /// </summary>
+    public bool IsMdl2Glyph => Icon is IconSpec.Mdl2Token;
+
+    /// <summary>
+    /// MDL2 code point when <see cref="IsMdl2Glyph"/> is true; 0 otherwise.
+    /// Bound directly by a FontIcon in the tab strip; callers don't need
+    /// to pattern-match on <see cref="Icon"/> in XAML.
+    /// </summary>
+    public int Mdl2CodePoint => Icon is IconSpec.Mdl2Token m ? m.CodePoint : 0;
+
+    /// <summary>
+    /// Atomic update of icon + tooltip. Single call site avoids two
+    /// PropertyChanged notifications racing the template selector on
+    /// profile re-resolution.
+    /// </summary>
+    public void SetIcon(IconSpec icon, string tooltipText)
+    {
+        Icon = icon;
+        TooltipText = tooltipText;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void Raise([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -64,6 +64,11 @@ internal sealed class TabModel : INotifyPropertyChanged
     /// constructed from <see cref="ProfileSnapshot"/> so tabs opened
     /// via the legacy no-profile path still get a default icon
     /// without consulting the resolver up front.
+    ///
+    /// Thread-safety: the getter is UI-thread-only. Lazy initialization
+    /// is not synchronized; concurrent access from non-UI threads could
+    /// construct two VMs and lose one. Callers from background threads
+    /// must marshal via the DispatcherQueue first.
     /// </summary>
     public TabIconViewModel TabIcon
     {

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -49,6 +49,34 @@ internal sealed class TabModel : INotifyPropertyChanged
                 "TabModel.ProfileSnapshot is set exactly once for V1; " +
                 "PR 6 introduces a hot-apply path that replaces this guard.");
         ProfileSnapshot = snapshot;
+
+        // Keep the cached TabIcon's subscribers attached across snapshot
+        // attaches; cheaper than tearing down and rebuilding the VM, and
+        // future-proofs the hot-apply path that lands when this guard
+        // becomes a no-op.
+        _tabIcon?.SetIcon(snapshot.Icon, snapshot.DisplayName);
+    }
+
+    private TabIconViewModel? _tabIcon;
+
+    /// <summary>
+    /// Per-tab icon view-model rendered by the tab strip. Lazily
+    /// constructed from <see cref="ProfileSnapshot"/> so tabs opened
+    /// via the legacy no-profile path still get a default icon
+    /// without consulting the resolver up front.
+    /// </summary>
+    public TabIconViewModel TabIcon
+    {
+        get
+        {
+            if (_tabIcon is null)
+            {
+                _tabIcon = ProfileSnapshot is { } snap
+                    ? new TabIconViewModel(snap.Icon, snap.DisplayName)
+                    : new TabIconViewModel(new IconSpec.BundledKey("default"), "Terminal");
+            }
+            return _tabIcon;
+        }
     }
 
     public string? UserOverrideTitle

--- a/windows/Ghostty.Tests/Tabs/IconSpecTemplateSelectorLogicTests.cs
+++ b/windows/Ghostty.Tests/Tabs/IconSpecTemplateSelectorLogicTests.cs
@@ -1,0 +1,49 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public sealed class IconSpecTemplateSelectorLogicTests
+{
+    [Fact]
+    public void Pick_Mdl2Token_ReturnsFontIcon()
+    {
+        var kind = IconSpecTemplateLogic.PickKind(new IconSpec.Mdl2Token(0xE756));
+        Assert.Equal(IconTemplateKind.FontIcon, kind);
+    }
+
+    [Fact]
+    public void Pick_BrandKey_ReturnsImage()
+    {
+        var kind = IconSpecTemplateLogic.PickKind(new IconSpec.BrandKey("ubuntu", 16));
+        Assert.Equal(IconTemplateKind.Image, kind);
+    }
+
+    [Fact]
+    public void Pick_BundledKey_ReturnsImage()
+    {
+        var kind = IconSpecTemplateLogic.PickKind(new IconSpec.BundledKey("pwsh"));
+        Assert.Equal(IconTemplateKind.Image, kind);
+    }
+
+    [Fact]
+    public void Pick_Path_ReturnsImage()
+    {
+        var kind = IconSpecTemplateLogic.PickKind(new IconSpec.Path(@"C:\foo.png"));
+        Assert.Equal(IconTemplateKind.Image, kind);
+    }
+
+    [Fact]
+    public void Pick_AutoForExe_ReturnsImage()
+    {
+        var kind = IconSpecTemplateLogic.PickKind(new IconSpec.AutoForExe(@"C:\foo.exe"));
+        Assert.Equal(IconTemplateKind.Image, kind);
+    }
+
+    [Fact]
+    public void Pick_AutoForWslDistro_ReturnsImage()
+    {
+        var kind = IconSpecTemplateLogic.PickKind(new IconSpec.AutoForWslDistro("Ubuntu"));
+        Assert.Equal(IconTemplateKind.Image, kind);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabIconViewModelTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabIconViewModelTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public sealed class TabIconViewModelTests
+{
+    [Fact]
+    public void Construct_FromBrandKey_ExposesSpecAndTooltip()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("ubuntu", 16), "Ubuntu (WSL)");
+        Assert.IsType<IconSpec.BrandKey>(vm.Icon);
+        Assert.Equal("Ubuntu (WSL)", vm.TooltipText);
+    }
+
+    [Fact]
+    public void Construct_FromMdl2Token_FlagsIsMdl2Glyph()
+    {
+        var vm = new TabIconViewModel(new IconSpec.Mdl2Token(0xE756), "PowerShell");
+        Assert.True(vm.IsMdl2Glyph);
+        Assert.Equal(0xE756, vm.Mdl2CodePoint);
+    }
+
+    [Fact]
+    public void Construct_FromBrandKey_IsNotMdl2Glyph()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("ubuntu", 16), "Ubuntu");
+        Assert.False(vm.IsMdl2Glyph);
+        Assert.Equal(0, vm.Mdl2CodePoint);
+    }
+
+    [Fact]
+    public void SetIcon_RaisesPropertyChangedForIconAndTooltip()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BundledKey("pwsh"), "PowerShell");
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)vm).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.SetIcon(new IconSpec.BrandKey("cmd", 16), "Command Prompt");
+
+        Assert.Contains(nameof(TabIconViewModel.Icon), raised);
+        Assert.Contains(nameof(TabIconViewModel.TooltipText), raised);
+        Assert.Equal("Command Prompt", vm.TooltipText);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabIconViewModelTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabIconViewModelTests.cs
@@ -45,4 +45,19 @@ public sealed class TabIconViewModelTests
         Assert.Contains(nameof(TabIconViewModel.TooltipText), raised);
         Assert.Equal("Command Prompt", vm.TooltipText);
     }
+
+    [Fact]
+    public void SetIcon_FlippingKind_RaisesPropertyChangedForDerivedFlags()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("ubuntu", 16), "Ubuntu");
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)vm).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.SetIcon(new IconSpec.Mdl2Token(0xE756), "PowerShell");
+
+        Assert.Contains(nameof(TabIconViewModel.IsMdl2Glyph), raised);
+        Assert.Contains(nameof(TabIconViewModel.Mdl2CodePoint), raised);
+        Assert.True(vm.IsMdl2Glyph);
+        Assert.Equal(0xE756, vm.Mdl2CodePoint);
+    }
 }

--- a/windows/Ghostty/App.xaml
+++ b/windows/Ghostty/App.xaml
@@ -26,6 +26,38 @@
                 <controls:XamlControlsResources/>
             </ResourceDictionary.MergedDictionaries>
             <tabs:ProgressVisibilityConverter x:Key="ProgressVisibilityConverter"/>
+
+            <!-- Profile icon resources shared between the horizontal
+                 TabHost and the vertical tab strip. Lifted from
+                 VerticalTabStrip.xaml so TabHost.xaml.cs can resolve
+                 ProfileIconSelector via Application.Current.Resources
+                 and so both hosts use one set of definitions. -->
+            <tabs:IconSpecToBitmapImageConverter x:Key="IconSpecToBitmapImageConverter"/>
+            <tabs:CodePointToGlyphConverter x:Key="CodePointToGlyphConverter"/>
+
+            <DataTemplate x:Key="ProfileIconImageTemplate">
+                <Image Width="20" Height="20"
+                       Source="{Binding Icon, Converter={StaticResource IconSpecToBitmapImageConverter}}"
+                       Stretch="Uniform">
+                    <ToolTipService.ToolTip>
+                        <TextBlock Text="{Binding TooltipText}"/>
+                    </ToolTipService.ToolTip>
+                </Image>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ProfileIconFontIconTemplate">
+                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                          Glyph="{Binding Mdl2CodePoint, Converter={StaticResource CodePointToGlyphConverter}}"
+                          FontSize="16">
+                    <ToolTipService.ToolTip>
+                        <TextBlock Text="{Binding TooltipText}"/>
+                    </ToolTipService.ToolTip>
+                </FontIcon>
+            </DataTemplate>
+
+            <tabs:IconSpecTemplateSelector x:Key="ProfileIconSelector"
+                                           ImageTemplate="{StaticResource ProfileIconImageTemplate}"
+                                           FontIconTemplate="{StaticResource ProfileIconFontIconTemplate}"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -484,6 +484,12 @@ public partial class App : Application
         _iconResolver = new Ghostty.Core.Profiles.WindowsIconResolver(fileSystem);
         IconResolver = _iconResolver;
 
+        // Process-wide bytes cache for the tab strip's IValueConverter.
+        // The converter is synchronous (XAML binding contract); the cache
+        // memoizes the first resolve so subsequent reads do not block the
+        // UI thread.
+        Ghostty.Tabs.TabIconBytesCache.Install(_iconResolver);
+
         _profileRegistry = new Ghostty.Core.Profiles.ProfileRegistry(
             source: _configService,
             discover: (bypass, ct) => _discoveryService.DiscoverAsync(bypass, ct),

--- a/windows/Ghostty/Tabs/CodePointToGlyphConverter.cs
+++ b/windows/Ghostty/Tabs/CodePointToGlyphConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.UI.Xaml.Data;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// XAML value converter that turns an MDL2 / Fluent code point (int)
+/// into the one- or two-char string FontIcon.Glyph expects. Empty
+/// string for zero / negative, which keeps the FontIcon harmlessly
+/// blank when bound against a non-glyph icon spec.
+/// </summary>
+public sealed partial class CodePointToGlyphConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is int codePoint && codePoint > 0)
+            return char.ConvertFromUtf32(codePoint);
+        return string.Empty;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
+}

--- a/windows/Ghostty/Tabs/IconSpecTemplateSelector.cs
+++ b/windows/Ghostty/Tabs/IconSpecTemplateSelector.cs
@@ -1,0 +1,34 @@
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Picks the Image template for PNG-backed icon specs and the FontIcon
+/// template for MDL2 codepoints. Selection logic lives in
+/// <see cref="IconSpecTemplateLogic"/> so it stays testable from
+/// <c>Ghostty.Tests</c>, which doesn't reference WinUI.
+/// </summary>
+public sealed partial class IconSpecTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? ImageTemplate { get; set; }
+    public DataTemplate? FontIconTemplate { get; set; }
+
+    protected override DataTemplate? SelectTemplateCore(object item)
+    {
+        if (item is TabIconViewModel vm)
+        {
+            return IconSpecTemplateLogic.PickKind(vm.Icon) switch
+            {
+                IconTemplateKind.FontIcon => FontIconTemplate,
+                _ => ImageTemplate,
+            };
+        }
+        return null;
+    }
+
+    protected override DataTemplate? SelectTemplateCore(object item, DependencyObject container)
+        => SelectTemplateCore(item);
+}

--- a/windows/Ghostty/Tabs/IconSpecToBitmapImageConverter.cs
+++ b/windows/Ghostty/Tabs/IconSpecToBitmapImageConverter.cs
@@ -1,0 +1,38 @@
+using System;
+using Ghostty.Core.Profiles;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage.Streams;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// XAML value converter that turns an <see cref="IconSpec"/> into a
+/// <see cref="BitmapImage"/> backed by PNG bytes returned by the
+/// process-wide <see cref="TabIconBytesCache"/>. Used by the tab
+/// strip's image template when the spec is anything other than an
+/// MDL2 glyph; MDL2 glyphs flow through the FontIcon template.
+/// </summary>
+public sealed partial class IconSpecToBitmapImageConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not IconSpec spec) return null;
+        var bytes = TabIconBytesCache.GetBytesSync(spec);
+        if (bytes is null || bytes.Length == 0) return null;
+
+        var bmp = new BitmapImage();
+        using var stream = new InMemoryRandomAccessStream();
+        using (var writer = new DataWriter(stream.GetOutputStreamAt(0)))
+        {
+            writer.WriteBytes(bytes);
+            writer.StoreAsync().GetResults();
+        }
+        stream.Seek(0);
+        bmp.SetSource(stream);
+        return bmp;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
+}

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -92,7 +92,36 @@ internal sealed partial class TabHost : UserControl, ITabHost
             Margin = new Thickness(0, 1, 0, 0),
         };
         var headerPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 0 };
-        headerPanel.Children.Add(headerText);
+
+        // Profile icon slot. ContentTemplateSelector picks between the
+        // bundled-image template and the MDL2 FontIcon template based
+        // on the TabIconViewModel kind. Resources live in App.xaml so
+        // both this host and VerticalTabStrip resolve the same selector.
+        // Application.Current.Resources is used rather than this.Resources
+        // because the host UserControl has no local resource dictionary
+        // entry for these keys.
+        var iconRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 0 };
+        var iconHost = new ContentControl
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 6, 0),
+        };
+        iconHost.SetBinding(
+            ContentControl.ContentProperty,
+            new Microsoft.UI.Xaml.Data.Binding
+            {
+                Source = tab,
+                Path = new PropertyPath("TabIcon"),
+            });
+        if (Application.Current.Resources.TryGetValue("ProfileIconSelector", out var sel)
+            && sel is DataTemplateSelector dts)
+        {
+            iconHost.ContentTemplateSelector = dts;
+        }
+        iconRow.Children.Add(iconHost);
+        iconRow.Children.Add(headerText);
+
+        headerPanel.Children.Add(iconRow);
         headerPanel.Children.Add(headerBar);
 
         // Tab color tint. We paint headerPanel.Background, not

--- a/windows/Ghostty/Tabs/TabIconBytesCache.cs
+++ b/windows/Ghostty/Tabs/TabIconBytesCache.cs
@@ -27,20 +27,16 @@ internal static class TabIconBytesCache
     {
         if (_resolver is null) return null;
         var key = SpecKey(spec);
-        if (!_cache.TryGetValue(key, out var bytes))
-        {
-            bytes = Task.Run(() => _resolver.ResolveAsync(spec, default)).GetAwaiter().GetResult();
-            _cache[key] = bytes;
-        }
-        return bytes;
+        return _cache.GetOrAdd(key, _ =>
+            Task.Run(() => _resolver.ResolveAsync(spec, default)).GetAwaiter().GetResult());
     }
 
     private static string SpecKey(IconSpec spec) => spec switch
     {
         IconSpec.BrandKey b => $"brand-{b.Key}-{b.Dpi ?? 0}",
         IconSpec.BundledKey b => $"bundled-{b.Key}",
-        IconSpec.Path p => $"path-{p.FilePath.GetHashCode():x}",
-        IconSpec.AutoForExe a => $"exe-{a.ExePath.GetHashCode():x}",
+        IconSpec.Path p => $"path-{p.FilePath}",
+        IconSpec.AutoForExe a => $"exe-{a.ExePath}",
         IconSpec.AutoForWslDistro w => $"wsl-{w.DistroName}",
         IconSpec.Mdl2Token m => $"mdl2-{m.CodePoint:x}",
         _ => "default",

--- a/windows/Ghostty/Tabs/TabIconBytesCache.cs
+++ b/windows/Ghostty/Tabs/TabIconBytesCache.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Process-wide cache mapping resolved <see cref="IconSpec"/> values to
+/// their PNG bytes. <see cref="GetBytesSync"/> blocks the UI thread for
+/// the first miss per spec; subsequent hits are O(1). Bundled keys and
+/// PNG paths resolve in well under a millisecond; SVG rasterization is
+/// one-shot per cache miss. The bytes-converter consumed by the tab
+/// strip's IValueConverter has no async hook, which forces the sync
+/// shape here.
+/// </summary>
+internal static class TabIconBytesCache
+{
+    private static readonly ConcurrentDictionary<string, byte[]> _cache = new();
+    private static IIconResolver? _resolver;
+
+    public static void Install(IIconResolver resolver)
+    {
+        _resolver = resolver;
+    }
+
+    public static byte[]? GetBytesSync(IconSpec spec)
+    {
+        if (_resolver is null) return null;
+        var key = SpecKey(spec);
+        if (!_cache.TryGetValue(key, out var bytes))
+        {
+            bytes = Task.Run(() => _resolver.ResolveAsync(spec, default)).GetAwaiter().GetResult();
+            _cache[key] = bytes;
+        }
+        return bytes;
+    }
+
+    private static string SpecKey(IconSpec spec) => spec switch
+    {
+        IconSpec.BrandKey b => $"brand-{b.Key}-{b.Dpi ?? 0}",
+        IconSpec.BundledKey b => $"bundled-{b.Key}",
+        IconSpec.Path p => $"path-{p.FilePath.GetHashCode():x}",
+        IconSpec.AutoForExe a => $"exe-{a.ExePath.GetHashCode():x}",
+        IconSpec.AutoForWslDistro w => $"wsl-{w.DistroName}",
+        IconSpec.Mdl2Token m => $"mdl2-{m.CodePoint:x}",
+        _ => "default",
+    };
+}

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml
@@ -10,36 +10,11 @@
 
         <SolidColorBrush x:Key="StripAccentBrush" Color="{ThemeResource SystemAccentColor}" />
 
-        <tabs:IconSpecToBitmapImageConverter x:Key="IconSpecToBitmapImageConverter"/>
-        <tabs:CodePointToGlyphConverter x:Key="CodePointToGlyphConverter"/>
-
-        <!-- Icon presenters: chosen at runtime by ProfileIconSelector
-             from the TabIconViewModel bound through TabModel.TabIcon.
-             Image template handles bundled / brand / path / exe / WSL
-             specs; FontIcon template handles MDL2 code points. -->
-        <DataTemplate x:Key="ProfileIconImageTemplate">
-            <Image Width="20" Height="20"
-                   Source="{Binding Icon, Converter={StaticResource IconSpecToBitmapImageConverter}}"
-                   Stretch="Uniform">
-                <ToolTipService.ToolTip>
-                    <TextBlock Text="{Binding TooltipText}"/>
-                </ToolTipService.ToolTip>
-            </Image>
-        </DataTemplate>
-
-        <DataTemplate x:Key="ProfileIconFontIconTemplate">
-            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
-                      Glyph="{Binding Mdl2CodePoint, Converter={StaticResource CodePointToGlyphConverter}}"
-                      FontSize="16">
-                <ToolTipService.ToolTip>
-                    <TextBlock Text="{Binding TooltipText}"/>
-                </ToolTipService.ToolTip>
-            </FontIcon>
-        </DataTemplate>
-
-        <tabs:IconSpecTemplateSelector x:Key="ProfileIconSelector"
-                                       ImageTemplate="{StaticResource ProfileIconImageTemplate}"
-                                       FontIconTemplate="{StaticResource ProfileIconFontIconTemplate}"/>
+        <!-- Icon converters / templates / selector live in App.xaml so
+             both this strip and the horizontal TabHost share one set
+             of definitions. StaticResource walks the parent chain up
+             to the application dictionary, so the collapsed/expanded
+             row templates below still resolve ProfileIconSelector. -->
 
         <!--
             Collapsed row: 40x40 centered icon, nothing else.

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml
@@ -10,27 +10,55 @@
 
         <SolidColorBrush x:Key="StripAccentBrush" Color="{ThemeResource SystemAccentColor}" />
 
+        <tabs:IconSpecToBitmapImageConverter x:Key="IconSpecToBitmapImageConverter"/>
+        <tabs:CodePointToGlyphConverter x:Key="CodePointToGlyphConverter"/>
+
+        <!-- Icon presenters: chosen at runtime by ProfileIconSelector
+             from the TabIconViewModel bound through TabModel.TabIcon.
+             Image template handles bundled / brand / path / exe / WSL
+             specs; FontIcon template handles MDL2 code points. -->
+        <DataTemplate x:Key="ProfileIconImageTemplate">
+            <Image Width="20" Height="20"
+                   Source="{Binding Icon, Converter={StaticResource IconSpecToBitmapImageConverter}}"
+                   Stretch="Uniform">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="{Binding TooltipText}"/>
+                </ToolTipService.ToolTip>
+            </Image>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ProfileIconFontIconTemplate">
+            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                      Glyph="{Binding Mdl2CodePoint, Converter={StaticResource CodePointToGlyphConverter}}"
+                      FontSize="16">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="{Binding TooltipText}"/>
+                </ToolTipService.ToolTip>
+            </FontIcon>
+        </DataTemplate>
+
+        <tabs:IconSpecTemplateSelector x:Key="ProfileIconSelector"
+                                       ImageTemplate="{StaticResource ProfileIconImageTemplate}"
+                                       FontIconTemplate="{StaticResource ProfileIconFontIconTemplate}"/>
+
         <!--
-            Collapsed row: 40x40 centered glyph, nothing else. The "T"
-            placeholder stays until plan 3 wires real per-profile icons.
-            TODO(plan3): replace the "T" with ProfileEntry icon glyph.
+            Collapsed row: 40x40 centered icon, nothing else.
         -->
         <DataTemplate x:Key="CollapsedRowTemplate">
             <!-- Width pinned to the collapsed strip width (40px) with
                  HorizontalAlignment=Left so the row content sits in
                  the same place whether the ListView is 40 or 220 wide.
                  Without this, the row's content area grows with the
-                 ListView and TextBlock HorizontalAlignment=Center ends
+                 ListView and the icon HorizontalAlignment=Center ends
                  up at x≈110 once the strip is ever expanded. -->
             <Grid Width="40" Height="40"
                   HorizontalAlignment="Left"
                   Background="Transparent">
-                <TextBlock Text="T"
-                           FontSize="16"
-                           FontWeight="SemiBold"
-                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"/>
+                <ContentControl Content="{Binding TabIcon}"
+                                ContentTemplateSelector="{StaticResource ProfileIconSelector}"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                IsTabStop="False"/>
             </Grid>
         </DataTemplate>
 
@@ -49,13 +77,12 @@
                     <ColumnDefinition Width="28"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0"
-                           Text="T"
-                           FontSize="14"
-                           FontWeight="SemiBold"
-                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"/>
+                <ContentControl Grid.Column="0"
+                                Content="{Binding TabIcon}"
+                                ContentTemplateSelector="{StaticResource ProfileIconSelector}"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                IsTabStop="False"/>
 
                 <TextBlock Grid.Column="1"
                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"


### PR DESCRIPTION
## Summary
- Replaces the literal "T" placeholder in `VerticalTabStrip` (both collapsed and expanded row templates) with a per-tab icon driven by `TabModel.TabIcon`.
- Adds `TabIconViewModel` in `Ghostty.Core.Tabs` (observable: icon spec + tooltip + derived MDL2 flags) so it stays testable from `Ghostty.Tests`.
- Adds `IconSpecTemplateLogic` (pure switch in Core) and `IconSpecTemplateSelector` (XAML adapter) so the template choice (Image vs FontIcon) is unit-tested.
- Adds `TabIconBytesCache` (process-wide PNG byte cache backed by `IIconResolver`), `IconSpecToBitmapImageConverter`, and `CodePointToGlyphConverter`.
- Wires the horizontal `TabHost` header to also show the icon (icon + title in an inner Horizontal StackPanel, progress bar still below).
- Shared converter / template / selector resources live in `App.xaml` so the vertical strip and horizontal host pull from the same definitions.

IMPORTANT: stacked on top of #401 (PR 3/5). Merge order: 1/5 then 2/5 then 3/5 then 4/5.

## Test plan
- [x] xunit: TabIconViewModel (5 tests, including derived-prop notifications), IconSpecTemplateLogic (6 tests), and the existing resolver suite all green.
- [x] Build succeeds (`dotnet build windows/Ghostty/Ghostty.csproj -p:Platform=x64`), no new warnings.
- [ ] Manual smoke (\`just run-win\`): open multiple tabs from different profiles; confirm vertical-strip collapsed + expanded rows show real icons, horizontal headers show icons to the left of titles, tooltips show profile names.