### PR TITLE
tab-icons: settings UI per-profile icon picker (PR 5/5)

### DIFF
--- a/windows/Ghostty.Tests/Settings/ProfileIconPickerSmokeTests.cs
+++ b/windows/Ghostty.Tests/Settings/ProfileIconPickerSmokeTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using Ghostty.Core.Config;
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+/// <summary>
+/// Round-trip smoke test for the icon picker config-write path.
+///
+/// Validates that an icon written via <see cref="IConfigFileEditor.SetValue"/>
+/// lands on disk in the expected `profile.&lt;id&gt;.icon = ...` shape and
+/// parses back to the matching <see cref="IconSpec"/> via
+/// <see cref="ProfileSourceParser.Parse"/>. Also covers
+/// <see cref="IConfigFileEditor.RemoveValue"/>, which comments out the
+/// line rather than deleting it; the parser then treats the profile as
+/// having no icon override.
+///
+/// The concrete production <c>ConfigFileEditor</c> lives in the WinUI 3
+/// project, which this net10.0 test assembly cannot reference. The fake
+/// below mirrors the production wrapper exactly: file read, delegate to
+/// the static <see cref="ConfigFileParser"/>, atomic write back.
+/// </summary>
+public sealed class ProfileIconPickerSmokeTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _configPath;
+    private readonly IConfigFileEditor _editor;
+
+    public ProfileIconPickerSmokeTests()
+    {
+        _tempDir = Path.Combine(
+            Path.GetTempPath(),
+            "GhosttyIconPickerSmoke_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _configPath = Path.Combine(_tempDir, "config");
+
+        File.WriteAllText(_configPath,
+            "profile.test.name = Test\n" +
+            "profile.test.command = pwsh.exe\n");
+
+        _editor = new TempFileEditor(_configPath);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void Set_BrandIcon_RoundTripsThroughConfig()
+    {
+        _editor.SetValue("profile.test.icon", "brand:ubuntu");
+
+        var content = File.ReadAllText(_configPath);
+        Assert.Contains("profile.test.icon = brand:ubuntu", content);
+
+        var parsed = ProfileSourceParser.Parse(content);
+        var profile = parsed.Profiles["test"];
+        Assert.Equal(new IconSpec.BrandKey("ubuntu", null), profile.Icon);
+    }
+
+    [Fact]
+    public void Set_Mdl2Icon_RoundTrips()
+    {
+        _editor.SetValue("profile.test.icon", "mdl2:E756");
+
+        var content = File.ReadAllText(_configPath);
+        Assert.Contains("profile.test.icon = mdl2:E756", content);
+
+        var parsed = ProfileSourceParser.Parse(content);
+        var profile = parsed.Profiles["test"];
+        Assert.Equal(new IconSpec.Mdl2Token(0xE756), profile.Icon);
+    }
+
+    [Fact]
+    public void Remove_RestoresDefaultIcon()
+    {
+        _editor.SetValue("profile.test.icon", "brand:ubuntu");
+        _editor.RemoveValue("profile.test.icon");
+
+        var content = File.ReadAllText(_configPath);
+
+        // RemoveValue comments the line out rather than deleting it,
+        // so the literal text "profile.test.icon" still appears, but
+        // only behind a leading "# ". Assert there is no uncommented
+        // occurrence by parsing through ProfileSourceParser (which
+        // skips comment lines) and checking the profile has no icon.
+        var parsed = ProfileSourceParser.Parse(content);
+        var profile = parsed.Profiles["test"];
+        Assert.Null(profile.Icon);
+
+        // Belt-and-braces: confirm the line was commented out, not
+        // re-written as a fresh assignment.
+        Assert.Contains("# profile.test.icon = brand:ubuntu", content);
+    }
+
+    /// <summary>
+    /// Test-only file-backed <see cref="IConfigFileEditor"/>. Mirrors the
+    /// production <c>Ghostty.Services.ConfigFileEditor</c> read-modify-write
+    /// loop using the same <see cref="ConfigFileParser"/> helpers. We can't
+    /// reference the production class because it lives in the WinUI 3
+    /// project; the logic under test is the parser + the wrapper contract,
+    /// both of which this fake exercises faithfully.
+    /// </summary>
+    private sealed class TempFileEditor : IConfigFileEditor
+    {
+        public string FilePath { get; }
+
+        public TempFileEditor(string filePath) { FilePath = filePath; }
+
+        public string ReadAll()
+            => File.Exists(FilePath) ? File.ReadAllText(FilePath) : string.Empty;
+
+        public void SetValue(string key, string value)
+        {
+            var lines = ReadLines();
+            var updated = ConfigFileParser.SetValue(lines, key, value);
+            Write(updated);
+        }
+
+        public void RemoveValue(string key)
+        {
+            var lines = ReadLines();
+            var updated = ConfigFileParser.RemoveValue(lines, key);
+            Write(updated);
+        }
+
+        public void WriteRaw(string content)
+            => File.WriteAllText(FilePath, ConfigText.NormalizeLineEndings(content));
+
+        public void SetRepeatableValues(string key, string[] values)
+        {
+            var lines = ReadLines();
+            var updated = ConfigFileParser.SetRepeatableValues(lines, key, values);
+            Write(updated);
+        }
+
+        private string[] ReadLines()
+            => File.Exists(FilePath) ? File.ReadAllLines(FilePath) : Array.Empty<string>();
+
+        private void Write(string[] lines)
+            => File.WriteAllText(FilePath, string.Join("\n", lines) + "\n");
+    }
+}

--- a/windows/Ghostty/Settings/IconPickerDialog.xaml
+++ b/windows/Ghostty/Settings/IconPickerDialog.xaml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentDialog
+    x:Class="Ghostty.Settings.IconPickerDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Choose an icon"
+    PrimaryButtonText="OK"
+    CloseButtonText="Cancel"
+    DefaultButton="Primary">
+
+    <Pivot SelectedIndex="0">
+        <PivotItem Header="Bundled brands">
+            <GridView x:Name="BundledGrid"
+                      SelectionMode="Single"
+                      IsItemClickEnabled="True"
+                      ItemClick="OnBundledItemClick">
+                <GridView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Vertical"
+                                    HorizontalAlignment="Center"
+                                    Spacing="4"
+                                    Padding="8">
+                            <Image Source="{Binding PreviewBitmap}" Width="32" Height="32"/>
+                            <TextBlock Text="{Binding Key}" FontSize="11"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+            </GridView>
+        </PivotItem>
+        <PivotItem Header="MDL2 codepoint">
+            <StackPanel Orientation="Vertical" Spacing="8" Margin="0,8,0,0">
+                <TextBox x:Name="Mdl2Input"
+                         PlaceholderText="e.g. E756"
+                         MaxLength="4"
+                         TextChanged="OnMdl2TextChanged"/>
+                <FontIcon x:Name="Mdl2Preview"
+                          FontFamily="{StaticResource SymbolThemeFontFamily}"
+                          FontSize="32"
+                          HorizontalAlignment="Left"/>
+            </StackPanel>
+        </PivotItem>
+        <PivotItem Header="From file">
+            <StackPanel Orientation="Vertical" Spacing="8" Margin="0,8,0,0">
+                <Button Content="Pick file..." Click="OnPickFileClick"/>
+                <TextBlock x:Name="PickedPathLabel"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           FontSize="12"/>
+            </StackPanel>
+        </PivotItem>
+    </Pivot>
+</ContentDialog>

--- a/windows/Ghostty/Settings/IconPickerDialog.xaml.cs
+++ b/windows/Ghostty/Settings/IconPickerDialog.xaml.cs
@@ -19,6 +19,8 @@ public sealed partial class IconPickerDialog : ContentDialog
 
     public ObservableCollection<BundledRow> BundledItems { get; } = new();
 
+    private bool _bundledLoaded;
+
     public IconPickerDialog()
     {
         InitializeComponent();
@@ -27,6 +29,12 @@ public sealed partial class IconPickerDialog : ContentDialog
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
+        // Loaded can fire more than once (DPI change, template swap,
+        // theme reload). Populate the bundled grid only the first time.
+        if (_bundledLoaded) return;
+        _bundledLoaded = true;
+        Loaded -= OnLoaded;
+
         // The set of keys this picker exposes. Keep in sync with the
         // asset bundle in IconAssets.Source.
         var keys = new[]
@@ -61,6 +69,9 @@ public sealed partial class IconPickerDialog : ContentDialog
     {
         if (e.ClickedItem is BundledRow row)
         {
+            // Persist with Dpi=null so the resolver re-picks the right size
+            // on monitor change; the gallery preview rasterized at 32 for
+            // crisp display in the picker only.
             PickedSpec = new IconSpec.BrandKey(row.Key, null);
         }
     }
@@ -72,27 +83,47 @@ public sealed partial class IconPickerDialog : ContentDialog
             Mdl2Preview.Glyph = char.ConvertFromUtf32(cp);
             PickedSpec = new IconSpec.Mdl2Token(cp);
         }
+        else
+        {
+            Mdl2Preview.Glyph = string.Empty;
+            // Clear the Mdl2 selection so an empty/invalid input doesn't return
+            // a stale value. A non-Mdl2 PickedSpec (e.g. user just clicked a
+            // bundled brand) is preserved.
+            if (PickedSpec is IconSpec.Mdl2Token)
+            {
+                PickedSpec = null;
+            }
+        }
     }
 
     private async void OnPickFileClick(object sender, RoutedEventArgs e)
     {
-        var picker = new FileOpenPicker();
-        // Window.Current is a UWP API that returns null in WinUI 3 desktop
-        // apps. The dialog's XamlRoot exposes the AppWindowId of its host
-        // window via ContentIslandEnvironment, which Win32Interop can map
-        // back to an HWND for the file-picker COM initializer.
-        var windowId = XamlRoot.ContentIslandEnvironment.AppWindowId;
-        var hwnd = Win32Interop.GetWindowFromWindowId(windowId);
-        InitializeWithWindow.Initialize(picker, hwnd);
-        picker.FileTypeFilter.Add(".png");
-        picker.FileTypeFilter.Add(".ico");
-        picker.FileTypeFilter.Add(".svg");
-        picker.FileTypeFilter.Add(".jpg");
-        var file = await picker.PickSingleFileAsync();
-        if (file is not null)
+        try
         {
-            PickedPathLabel.Text = file.Path;
-            PickedSpec = new IconSpec.Path(file.Path);
+            var picker = new FileOpenPicker();
+            // Window.Current is a UWP API that returns null in WinUI 3 desktop
+            // apps. The dialog's XamlRoot exposes the AppWindowId of its host
+            // window via ContentIslandEnvironment, which Win32Interop can map
+            // back to an HWND for the file-picker COM initializer.
+            var windowId = XamlRoot.ContentIslandEnvironment.AppWindowId;
+            var hwnd = Win32Interop.GetWindowFromWindowId(windowId);
+            InitializeWithWindow.Initialize(picker, hwnd);
+            picker.FileTypeFilter.Add(".png");
+            picker.FileTypeFilter.Add(".ico");
+            picker.FileTypeFilter.Add(".svg");
+            picker.FileTypeFilter.Add(".jpg");
+            var file = await picker.PickSingleFileAsync();
+            if (file is not null)
+            {
+                PickedPathLabel.Text = file.Path;
+                PickedSpec = new IconSpec.Path(file.Path);
+            }
+        }
+        catch (Exception ex)
+        {
+            // async void: unhandled exceptions tear down the process via
+            // the SynchronizationContext. Swallow and log instead.
+            System.Diagnostics.Debug.WriteLine($"OnPickFileClick failed: {ex}");
         }
     }
 

--- a/windows/Ghostty/Settings/IconPickerDialog.xaml.cs
+++ b/windows/Ghostty/Settings/IconPickerDialog.xaml.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Ghostty.Core.Profiles;
+using Ghostty.Tabs;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
+
+namespace Ghostty.Settings;
+
+public sealed partial class IconPickerDialog : ContentDialog
+{
+    public IconSpec? InitialSpec { get; set; }
+    public IconSpec? PickedSpec { get; private set; }
+
+    public ObservableCollection<BundledRow> BundledItems { get; } = new();
+
+    public IconPickerDialog()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        // The set of keys this picker exposes. Keep in sync with the
+        // asset bundle in IconAssets.Source.
+        var keys = new[]
+        {
+            "default",
+            "pwsh", "cmd", "bash", "fish", "nu", "zsh", "gitbash",
+            "ubuntu", "debian", "alpine", "kali", "fedora", "opensuse", "arch",
+        };
+        foreach (var k in keys)
+        {
+            var spec = new IconSpec.BrandKey(k, 32);
+            var bytes = TabIconBytesCache.GetBytesSync(spec);
+            BitmapImage? bmp = null;
+            if (bytes is not null && bytes.Length > 0)
+            {
+                bmp = new BitmapImage();
+                using var ms = new Windows.Storage.Streams.InMemoryRandomAccessStream();
+                using (var writer = new Windows.Storage.Streams.DataWriter(ms.GetOutputStreamAt(0)))
+                {
+                    writer.WriteBytes(bytes);
+                    writer.StoreAsync().GetResults();
+                }
+                ms.Seek(0);
+                bmp.SetSource(ms);
+            }
+            BundledItems.Add(new BundledRow(k, bmp));
+        }
+        BundledGrid.ItemsSource = BundledItems;
+    }
+
+    private void OnBundledItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is BundledRow row)
+        {
+            PickedSpec = new IconSpec.BrandKey(row.Key, null);
+        }
+    }
+
+    private void OnMdl2TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (int.TryParse(Mdl2Input.Text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var cp) && cp > 0)
+        {
+            Mdl2Preview.Glyph = char.ConvertFromUtf32(cp);
+            PickedSpec = new IconSpec.Mdl2Token(cp);
+        }
+    }
+
+    private async void OnPickFileClick(object sender, RoutedEventArgs e)
+    {
+        var picker = new FileOpenPicker();
+        // Window.Current is a UWP API that returns null in WinUI 3 desktop
+        // apps. The dialog's XamlRoot exposes the AppWindowId of its host
+        // window via ContentIslandEnvironment, which Win32Interop can map
+        // back to an HWND for the file-picker COM initializer.
+        var windowId = XamlRoot.ContentIslandEnvironment.AppWindowId;
+        var hwnd = Win32Interop.GetWindowFromWindowId(windowId);
+        InitializeWithWindow.Initialize(picker, hwnd);
+        picker.FileTypeFilter.Add(".png");
+        picker.FileTypeFilter.Add(".ico");
+        picker.FileTypeFilter.Add(".svg");
+        picker.FileTypeFilter.Add(".jpg");
+        var file = await picker.PickSingleFileAsync();
+        if (file is not null)
+        {
+            PickedPathLabel.Text = file.Path;
+            PickedSpec = new IconSpec.Path(file.Path);
+        }
+    }
+
+    // Plain class rather than a positional record: the WinUI 3 XAML
+    // compiler emits property setters when generating bindable type
+    // info for x:Bind / DataTemplate consumers, and init-only record
+    // properties produce CS8852.
+    public sealed class BundledRow
+    {
+        public BundledRow(string key, BitmapImage? previewBitmap)
+        {
+            Key = key;
+            PreviewBitmap = previewBitmap;
+        }
+
+        public string Key { get; set; }
+        public BitmapImage? PreviewBitmap { get; set; }
+    }
+}

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Ghostty.Controls.Settings;
 using Ghostty.Core.Config;
 using Ghostty.Core.Profiles;
+using Ghostty.Settings;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Ghostty.Settings.Pages;
@@ -103,7 +106,9 @@ internal sealed partial class ProfilesPage : Page
             foreach (var id in stale)
             {
                 var card = _cardsByProfileId[id];
-                if (card.Control is ToggleSwitch t) t.Toggled -= OnHiddenToggled;
+                if (FindToggle(card) is ToggleSwitch t) t.Toggled -= OnHiddenToggled;
+                if (FindPicker(card) is ProfileIconPickerControl picker)
+                    picker.IconChanged -= OnProfileIconChanged;
                 ProfilesGroup.Cards.Remove(card);
                 _cardsByProfileId.Remove(id);
             }
@@ -118,8 +123,10 @@ internal sealed partial class ProfilesPage : Page
                 {
                     card.Header = profile.Name;
                     card.Description = profile.Command;
-                    if (card.Control is ToggleSwitch toggle && toggle.IsOn != isHidden)
+                    if (FindToggle(card) is ToggleSwitch toggle && toggle.IsOn != isHidden)
                         toggle.IsOn = isHidden;
+                    if (FindPicker(card) is ProfileIconPickerControl picker)
+                        picker.CurrentIcon = profile.Icon;
 
                     var currentIdx = ProfilesGroup.Cards.IndexOf(card);
                     if (currentIdx != i) ProfilesGroup.Cards.Move(currentIdx, i);
@@ -135,11 +142,19 @@ internal sealed partial class ProfilesPage : Page
         finally { _loading = false; }
     }
 
-    // Builds one SettingsCard with a ToggleSwitch on the right. Tag
-    // carries the profile id so the handler does not need a per-row
-    // closure capture.
+    // Builds one SettingsCard with the icon picker + hidden toggle on
+    // the right. SettingsCard.Control is a single UIElement slot, so we
+    // wrap both into a horizontal StackPanel. Tag on the toggle carries
+    // the profile id; the picker resolves its id via the shared
+    // StackPanel.Tag walked through FindPicker / FindToggle in Rebind.
     private SettingsCard BuildRow(ResolvedProfile profile, bool isHidden)
     {
+        var picker = new ProfileIconPickerControl
+        {
+            CurrentIcon = profile.Icon,
+        };
+        picker.IconChanged += OnProfileIconChanged;
+
         var toggle = new ToggleSwitch
         {
             IsOn = isHidden,
@@ -148,12 +163,49 @@ internal sealed partial class ProfilesPage : Page
             Tag = profile.Id,
         };
         toggle.Toggled += OnHiddenToggled;
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            // Stash the profile id on the panel so the picker handler
+            // can recover it from the picker's parent without a per-row
+            // closure capture (matches the toggle's Tag pattern).
+            Tag = profile.Id,
+        };
+        panel.Children.Add(picker);
+        panel.Children.Add(toggle);
+
         return new SettingsCard
         {
             Header = profile.Name,
             Description = profile.Command,
-            Control = toggle,
+            Control = panel,
         };
+    }
+
+    // The SettingsCard.Control slot is a horizontal StackPanel
+    // (picker + toggle), so finding either child means walking the
+    // panel's Children rather than pattern-matching the slot directly.
+    private static ToggleSwitch? FindToggle(SettingsCard card)
+    {
+        if (card.Control is not StackPanel panel) return null;
+        foreach (var child in panel.Children)
+        {
+            if (child is ToggleSwitch t) return t;
+        }
+        return null;
+    }
+
+    private static ProfileIconPickerControl? FindPicker(SettingsCard card)
+    {
+        if (card.Control is not StackPanel panel) return null;
+        foreach (var child in panel.Children)
+        {
+            if (child is ProfileIconPickerControl p) return p;
+        }
+        return null;
     }
 
     private void OnHiddenToggled(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -179,6 +231,39 @@ internal sealed partial class ProfilesPage : Page
         {
             if (toggle.IsOn) _editor.SetValue(key, "true");
             else _editor.RemoveValue(key);
+        }
+        finally { _configService.SuppressWatcher(false); }
+        _configService.Reload();
+    }
+
+    private void OnProfileIconChanged(object? sender, IconSpec? newSpec)
+    {
+        if (_loading) return;
+        if (sender is not ProfileIconPickerControl picker) return;
+        // Recover the profile id from the row's StackPanel Tag (set in
+        // BuildRow), the same path FindPicker walks in Rebind.
+        if (picker.Parent is not StackPanel panel) return;
+        if (panel.Tag is not string id) return;
+
+        var key = $"profile.{id}.icon";
+        var value = newSpec switch
+        {
+            // Persisted format mirrors ProfileSourceParser.ParseIcon so
+            // a written value round-trips back to the same IconSpec.
+            // Dpi is intentionally dropped: the resolver picks DPI from
+            // the monitor at render time; storing 32 here would freeze
+            // a stale value into the config.
+            IconSpec.BrandKey b => $"brand:{b.Key}",
+            IconSpec.Mdl2Token m => "mdl2:" + m.CodePoint.ToString("X4", CultureInfo.InvariantCulture),
+            IconSpec.Path p => p.FilePath,
+            _ => null,
+        };
+
+        _configService.SuppressWatcher(true);
+        try
+        {
+            if (value is null) _editor.RemoveValue(key);
+            else _editor.SetValue(key, value);
         }
         finally { _configService.SuppressWatcher(false); }
         _configService.Reload();

--- a/windows/Ghostty/Settings/ProfileIconPickerControl.xaml
+++ b/windows/Ghostty/Settings/ProfileIconPickerControl.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Settings.ProfileIconPickerControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:tabs="using:Ghostty.Tabs">
+
+    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+        <Border Width="28" Height="28"
+                Background="{ThemeResource SubtleFillColorTertiaryBrush}"
+                CornerRadius="4"
+                Padding="4">
+            <ContentControl x:Name="PreviewHost"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            ContentTemplateSelector="{StaticResource ProfileIconSelector}"/>
+        </Border>
+        <TextBlock x:Name="SpecLabel"
+                   FontFamily="Consolas"
+                   FontSize="12"
+                   VerticalAlignment="Center"
+                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+        <Button x:Name="ChangeButton"
+                Content="Change..."
+                Click="OnChangeClick"/>
+        <Button x:Name="ResetButton"
+                Content="Reset"
+                Click="OnResetClick"/>
+    </StackPanel>
+</UserControl>

--- a/windows/Ghostty/Settings/ProfileIconPickerControl.xaml.cs
+++ b/windows/Ghostty/Settings/ProfileIconPickerControl.xaml.cs
@@ -54,16 +54,25 @@ public sealed partial class ProfileIconPickerControl : UserControl
 
     private async void OnChangeClick(object sender, RoutedEventArgs e)
     {
-        var dialog = new IconPickerDialog
+        try
         {
-            XamlRoot = this.XamlRoot,
-            InitialSpec = CurrentIcon,
-        };
-        var result = await dialog.ShowAsync();
-        if (result == ContentDialogResult.Primary && dialog.PickedSpec is { } picked)
+            var dialog = new IconPickerDialog
+            {
+                XamlRoot = this.XamlRoot,
+                InitialSpec = CurrentIcon,
+            };
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary && dialog.PickedSpec is { } picked)
+            {
+                CurrentIcon = picked;
+                IconChanged?.Invoke(this, picked);
+            }
+        }
+        catch (Exception ex)
         {
-            CurrentIcon = picked;
-            IconChanged?.Invoke(this, picked);
+            // async void: unhandled exceptions tear down the process via
+            // the SynchronizationContext. Swallow and log instead.
+            System.Diagnostics.Debug.WriteLine($"OnChangeClick failed: {ex}");
         }
     }
 

--- a/windows/Ghostty/Settings/ProfileIconPickerControl.xaml.cs
+++ b/windows/Ghostty/Settings/ProfileIconPickerControl.xaml.cs
@@ -1,0 +1,75 @@
+using System;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings;
+
+public sealed partial class ProfileIconPickerControl : UserControl
+{
+    public event EventHandler<IconSpec?>? IconChanged;
+
+    public static readonly DependencyProperty CurrentIconProperty =
+        DependencyProperty.Register(
+            nameof(CurrentIcon), typeof(IconSpec), typeof(ProfileIconPickerControl),
+            new PropertyMetadata(null, OnCurrentIconChanged));
+
+    public IconSpec? CurrentIcon
+    {
+        get => (IconSpec?)GetValue(CurrentIconProperty);
+        set => SetValue(CurrentIconProperty, value);
+    }
+
+    public ProfileIconPickerControl()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnCurrentIconChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ProfileIconPickerControl ctrl) return;
+        if (e.NewValue is IconSpec spec)
+        {
+            ctrl.PreviewHost.Content = new TabIconViewModel(spec, ctrl.LabelForSpec(spec));
+            ctrl.SpecLabel.Text = ctrl.LabelForSpec(spec);
+        }
+        else
+        {
+            ctrl.PreviewHost.Content = null;
+            ctrl.SpecLabel.Text = "(default)";
+        }
+    }
+
+    private string LabelForSpec(IconSpec spec) => spec switch
+    {
+        IconSpec.BrandKey b => $"brand:{b.Key}",
+        IconSpec.BundledKey b => $"bundled:{b.Key}",
+        IconSpec.Mdl2Token m => $"mdl2:{m.CodePoint:X4}",
+        IconSpec.Path p => p.FilePath,
+        IconSpec.AutoForExe => "auto (exe)",
+        IconSpec.AutoForWslDistro => "auto (wsl)",
+        _ => "default",
+    };
+
+    private async void OnChangeClick(object sender, RoutedEventArgs e)
+    {
+        var dialog = new IconPickerDialog
+        {
+            XamlRoot = this.XamlRoot,
+            InitialSpec = CurrentIcon,
+        };
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary && dialog.PickedSpec is { } picked)
+        {
+            CurrentIcon = picked;
+            IconChanged?.Invoke(this, picked);
+        }
+    }
+
+    private void OnResetClick(object sender, RoutedEventArgs e)
+    {
+        CurrentIcon = null;
+        IconChanged?.Invoke(this, null);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ProfileIconPickerControl` (preview tile + Change.../Reset buttons) under each profile row on the Profiles settings page.
- Adds `IconPickerDialog` (ContentDialog with three pivots: bundled brands gallery, MDL2 codepoint entry, file picker).
- ProfilesPage builds rows imperatively, so the picker is added in code-behind alongside the existing toggle inside a horizontal StackPanel within `SettingsCard.Content`.
- IconChanged writes through the project's `IConfigFileEditor` (`SetValue` / `RemoveValue`), bracketed with `SuppressWatcher` + `Reload` to match the existing config-mutation pattern.
- Adds a round-trip smoke test (3 cases: brand, mdl2, remove) using a `TempFileEditor` fake that delegates to the same `ConfigFileParser` statics production uses.

IMPORTANT: stacked on top of #402 (PR 4/5). Merge order: 1/5 then 2/5 then 3/5 then 4/5 then 5/5.

## Test plan
- [x] xunit: ProfileIconPickerSmokeTests (3/3) covers \`brand:ubuntu\` and \`mdl2:E756\` SetValue round-trip plus RemoveValue commenting.
- [x] Build succeeds (\`dotnet build windows/Ghostty/Ghostty.csproj -p:Platform=x64\`), no new warnings.
- [ ] Manual smoke (\`just run-win\`): open Settings -> Profiles, click Change... on a profile, pick a bundled brand, confirm tab strip + config file reflect the choice; click Reset, confirm the override is removed.