### PR TITLE
test: mouse-protocol smoke fixtures + runner

### DIFF
--- a/dev-configs/mouse-smoke/01-wsl2-mc.conf
+++ b/dev-configs/mouse-smoke/01-wsl2-mc.conf
@@ -11,6 +11,8 @@
 # Pass criteria: each click produces expected response; on quit, shell prompt
 # returns clean with no mouse-byte echo.
 
+# Note: WSL2 cells wrap in `bash -lic` because `wsl.exe -- <bare-bin>` exits
+# Wintty before surface init. The wrapper keeps the PTY alive.
 command = wsl.exe -- bash -lic mc
 window-width = 160
 window-height = 45

--- a/dev-configs/mouse-smoke/01-wsl2-mc.conf
+++ b/dev-configs/mouse-smoke/01-wsl2-mc.conf
@@ -1,0 +1,21 @@
+# Cell 01 — WSL2 + Midnight Commander
+# Protocols exercised: DECSET 1000 (or 1002) + 1006 (SGR)
+#
+# Click checklist:
+#  1. Click a filename in the left panel  -> highlights
+#  2. Double-click a directory             -> enters
+#  3. Click the top menubar (Left/File/Command) -> drops menu
+#  4. Click an F-key label at the bottom (F5/F8) -> invokes
+#  5. (Optional) Click-drag the panel divider — supported only in some builds
+#
+# Pass criteria: each click produces expected response; on quit, shell prompt
+# returns clean with no mouse-byte echo.
+
+command = wsl.exe -- bash -lic mc
+window-width = 160
+window-height = 45
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/02-win-lazygit.conf
+++ b/dev-configs/mouse-smoke/02-win-lazygit.conf
@@ -1,0 +1,22 @@
+# Cell 02 — Native Windows + lazygit
+# Protocols exercised: DECSET 1000 + 1002 + 1003 + 1006 (full tcell stack)
+#
+# Click checklist:
+#  1. Click a panel header (Files / Branches / Commits) -> focus moves
+#  2. Click an unstaged file -> diff loads in main panel
+#  3. Click a commit in "Commits" -> diff loads
+#  4. Mouse-wheel scroll inside the diff/main panel
+#  5. Click-drag the divider between panels (resize)
+#
+# Pass criteria: each click produces expected response; on quit, shell prompt
+# returns clean — no leftover "[?1002l[?1006l"-style bytes echoed as text.
+
+command = lazygit.exe
+working-directory = inherit
+window-width = 140
+window-height = 42
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/03-wsl2-lazygit.conf
+++ b/dev-configs/mouse-smoke/03-wsl2-lazygit.conf
@@ -1,0 +1,11 @@
+# Cell 03 — WSL2 + lazygit
+# Same TUI as cell 02, different transport. Isolates ConPTY-WSL vs native-Win.
+#
+# Click checklist: identical to cell 02 (panel header / file / commit / wheel / divider).
+
+command = wsl.exe -- lazygit
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/03-wsl2-lazygit.conf
+++ b/dev-configs/mouse-smoke/03-wsl2-lazygit.conf
@@ -3,7 +3,9 @@
 #
 # Click checklist: identical to cell 02 (panel header / file / commit / wheel / divider).
 
-command = wsl.exe -- lazygit
+command = wsl.exe -- bash -lic lazygit
+window-width = 140
+window-height = 42
 quit-after-last-window-closed = true
 confirm-close-surface = false
 

--- a/dev-configs/mouse-smoke/04-wsl2-btop.conf
+++ b/dev-configs/mouse-smoke/04-wsl2-btop.conf
@@ -1,0 +1,21 @@
+# Cell 04 — WSL2 + btop
+# Protocols exercised: DECSET 1002 + 1015 + 1006, +1003 (any-event) for hover.
+# This is the highest-risk cell — microsoft/terminal#18712 documents ConPTY
+# any-event final-byte mangling. Watch byte log carefully if hover behavior
+# is wrong.
+#
+# Click checklist:
+#  1. Click "cpu" / "mem" / "net" / "proc" box headers -> collapse/expand
+#  2. Click a process row in the "proc" box -> highlights
+#  3. Right-click selected process -> options/signal menu opens
+#  4. Wheel-scroll inside the proc list -> moves selection
+#  5. Click sort arrows or filter field in proc box -> resorts
+
+command = wsl.exe -- bash -lic btop
+window-width = 160
+window-height = 45
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/05-wsl2-htop.conf
+++ b/dev-configs/mouse-smoke/05-wsl2-htop.conf
@@ -1,0 +1,24 @@
+# Cell 05 — WSL2 + htop
+# Protocols exercised: X10 / DECSET 1000 only via ncurses terminfo
+#   (no SGR — htop relies on terminfo's kmous/XM negotiation, which
+#   defaults to X10 unless terminfo is patched).
+# Risk: X10 coordinates overflow at column 224+. Test both narrow and
+# very-wide Wintty windows.
+#
+# Click checklist:
+#  1. Click a column header (CPU%, MEM%, TIME+) -> resorts
+#  2. Click a process row -> selects
+#  3. Click an F-key label at bottom (F6 Sort, F9 Kill) -> opens panel
+#  4. Wheel-scroll the process list -> moves selection
+#  5. (Test twice: at default width ~80 cols; then drag Wintty window
+#     so it exceeds 224 cols and repeat clicks 1-2 on the rightmost
+#     columns. Expect breakage at width > 224 if htop is on pure X10.)
+
+command = wsl.exe -- bash -lic htop
+window-width = 160
+window-height = 45
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/06-win-btop4win.conf
+++ b/dev-configs/mouse-smoke/06-win-btop4win.conf
@@ -1,0 +1,18 @@
+# Cell 06 — Native Windows + btop4win
+# Separate codebase from Linux btop (uses Win32 console APIs differently).
+# Historically had wheel/click quirks under ConPTY when launched from an
+# outer terminal.
+#
+# Click checklist: identical to cell 04.
+
+# NOTE: btop4win.exe must be on PATH. If installed via winget
+# (`winget install aristocratos.btop4win`), add the WinGet Packages dir to PATH
+# or symlink the exe into a PATH directory before running this cell.
+command = btop4win.exe
+window-width = 160
+window-height = 45
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/06-win-btop4win.conf
+++ b/dev-configs/mouse-smoke/06-win-btop4win.conf
@@ -5,9 +5,6 @@
 #
 # Click checklist: identical to cell 04.
 
-# NOTE: btop4win.exe must be on PATH. If installed via winget
-# (`winget install aristocratos.btop4win`), add the WinGet Packages dir to PATH
-# or symlink the exe into a PATH directory before running this cell.
 command = btop4win.exe
 window-width = 160
 window-height = 45

--- a/dev-configs/mouse-smoke/07-win-neovim.conf
+++ b/dev-configs/mouse-smoke/07-win-neovim.conf
@@ -1,0 +1,27 @@
+# Cell 07 — Native Windows + neovim
+# First cell that exercises focus events (DECSET 1004). Neovim sets mouse=a
+# (all modes) and an autocmd on FocusGained/FocusLost.
+#
+# Click checklist:
+#  1. In normal mode, click anywhere in the buffer -> cursor moves to click
+#  2. Click-drag to make a visual selection
+#  3. Click in the status line -> no crash (some bindings may no-op)
+#  4. Alt+Tab away from Wintty, wait 1s, Alt+Tab back -> FocusLost/FocusGained
+#     fire (verify via :messages or echo statement set in autocmd, see below)
+#  5. Wheel-scroll in the buffer
+#
+# Test setup before clicking: in neovim run these commands once:
+#   :set mouse=a
+#   :set ttymouse=sgr      " (vim only; nvim is always sgr)
+#   :autocmd FocusGained * echom "GAINED " .. localtime()
+#   :autocmd FocusLost   * echom "LOST   " .. localtime()
+#   :messages              " to see what fired
+
+command = "C:\Program Files\Neovim\bin\nvim.exe"
+window-width = 140
+window-height = 42
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/08-wsl2-neovim.conf
+++ b/dev-configs/mouse-smoke/08-wsl2-neovim.conf
@@ -1,0 +1,11 @@
+# Cell 08 — WSL2 + neovim
+# Tests that focus events survive the wsl.exe -> ConPTY -> Linux nvim hop.
+
+command = wsl.exe -- bash -lic nvim
+window-width = 140
+window-height = 42
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/09-msys2-mc.conf
+++ b/dev-configs/mouse-smoke/09-msys2-mc.conf
@@ -6,6 +6,8 @@
 # Prereq: MSYS2 has mc installed: pacman -S mc (run once from MSYS2 shell).
 
 command = "C:\Program Files\Git\bin\bash.exe" --login -i -c mc
+window-width = 140
+window-height = 42
 quit-after-last-window-closed = true
 confirm-close-surface = false
 

--- a/dev-configs/mouse-smoke/09-msys2-mc.conf
+++ b/dev-configs/mouse-smoke/09-msys2-mc.conf
@@ -1,0 +1,13 @@
+# Cell 09 — MSYS2 / Git Bash + mc
+# Tests the MSYS2 pty inheritance gotcha noted in memory:
+# project_conpty_msys2_pty_blocker. If mc launches but mouse does not respond,
+# the MSYS2 pty layer may be eating the input bytes.
+#
+# Prereq: MSYS2 has mc installed: pacman -S mc (run once from MSYS2 shell).
+
+command = "C:\Program Files\Git\bin\bash.exe" --login -i -c mc
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/10-msys2-lazygit.conf
+++ b/dev-configs/mouse-smoke/10-msys2-lazygit.conf
@@ -1,0 +1,10 @@
+# Cell 10 — MSYS2 / Git Bash + lazygit
+# lazygit is a static Windows binary; running it from MSYS2 bash exercises
+# whether MSYS2's argv/env translation breaks anything mouse-related.
+
+command = "C:\Program Files\Git\bin\bash.exe" --login -i -c lazygit
+quit-after-last-window-closed = true
+confirm-close-surface = false
+
+log-level = warn
+log-filter = Ghostty.Zig.mouse=debug,Ghostty.Zig.termio=debug,Ghostty.Zig.input=debug

--- a/dev-configs/mouse-smoke/README.md
+++ b/dev-configs/mouse-smoke/README.md
@@ -1,0 +1,33 @@
+# Mouse-TUI smoke fixtures
+
+Per-cell Ghostty `.conf` fixtures for the 2026-05-24 mouse-protocol smoke pass.
+Each fixture pins a `command =` that launches a target TUI directly so Wintty
+opens straight into the app under test (sidesteps the typing-into-terminal
+restriction of automation tooling).
+
+Each fixture also enables mouse / termio / input debug log scopes so byte-level
+evidence is available when a click misbehaves.
+
+Run a cell:
+
+```pwsh
+just build-dll build-win
+pwsh -NoProfile -File scripts/mouse-smoke-run.ps1 -Cell 01-wsl2-mc
+```
+
+The runner copies the fixture into an isolated `XDG_CONFIG_HOME` and launches
+Wintty.exe — this matches the existing `validate-transport-run.ps1` pattern
+because the WinUI shell does not honor `--config-file` on the CLI.
+
+| Cell | Env | TUI | Protocols |
+|---|---|---|---|
+| 01 | WSL2 | mc | 1000/1002 + 1006 |
+| 02 | Native Win | lazygit | 1000+1002+1003+1006 (tcell) |
+| 03 | WSL2 | lazygit | same as 02 |
+| 04 | WSL2 | btop | 1002+1015+1006, +1003 hover |
+| 05 | WSL2 | htop | X10 only (ncurses terminfo) |
+| 06 | Native Win | btop4win | Win32 console path |
+| 07 | Native Win | neovim | 1004 focus + mouse=a |
+| 08 | WSL2 | neovim | same as 07 |
+| 09 | MSYS2 | mc | Git Bash + MSYS2 pty path (gated) |
+| 10 | MSYS2 | lazygit | gated |

--- a/dev-configs/mouse-smoke/README.md
+++ b/dev-configs/mouse-smoke/README.md
@@ -1,14 +1,14 @@
 # Mouse-TUI smoke fixtures
 
-Per-cell Ghostty `.conf` fixtures for the 2026-05-24 mouse-protocol smoke pass.
-Each fixture pins a `command =` that launches a target TUI directly so Wintty
-opens straight into the app under test (sidesteps the typing-into-terminal
-restriction of automation tooling).
+Per-cell Ghostty `.conf` fixtures for the mouse-protocol smoke pass. Each
+fixture pins a `command =` that launches a target TUI directly so Wintty opens
+straight into the app under test, so the operator only needs to click, not
+type.
 
 Each fixture also enables mouse / termio / input debug log scopes so byte-level
 evidence is available when a click misbehaves.
 
-Run a cell:
+## Run a cell
 
 ```pwsh
 just build-dll build-win
@@ -16,8 +16,14 @@ pwsh -NoProfile -File scripts/mouse-smoke-run.ps1 -Cell 01-wsl2-mc
 ```
 
 The runner copies the fixture into an isolated `XDG_CONFIG_HOME` and launches
-Wintty.exe — this matches the existing `validate-transport-run.ps1` pattern
-because the WinUI shell does not honor `--config-file` on the CLI.
+`Wintty.exe`. It restores any pre-existing `XDG_CONFIG_HOME` on exit. This
+mirrors `validate-transport-run.ps1` because the WinUI shell does not honor
+`--config-file` on the CLI.
+
+Exit codes: `0` = Wintty exited normally, `2` = setup error (fixture or exe
+not found) or watchdog timeout, otherwise Wintty's own exit code.
+
+## Cells
 
 | Cell | Env | TUI | Protocols |
 |---|---|---|---|
@@ -31,3 +37,17 @@ because the WinUI shell does not honor `--config-file` on the CLI.
 | 08 | WSL2 | neovim | same as 07 |
 | 09 | MSYS2 | mc | Git Bash + MSYS2 pty path (gated) |
 | 10 | MSYS2 | lazygit | gated |
+
+## Prerequisites
+
+- **Native cells** (02, 06, 07): `lazygit.exe`, `btop4win.exe`, and `nvim.exe`
+  must be on PATH. Cell 06 uses winget's btop4win — install via
+  `winget install aristocratos.btop4win` and add the WinGet Packages dir to
+  PATH (or symlink the exe into an existing PATH directory).
+- **WSL2 cells** (01, 03, 04, 05, 08): the matching binaries must be installed
+  inside your default WSL2 distro. The cells wrap their command in
+  `bash -lic` because `wsl.exe -- <bare-bin>` exits Wintty before surface init.
+- **MSYS2 cells** (09, 10): require Git for Windows installed at the standard
+  path. Cell 09 additionally requires Midnight Commander in MSYS2 (`pacman -S mc`
+  from a full MSYS2 install — Git Bash's bundled MSYS2 ships only the message
+  compiler `mc.exe`, not Midnight Commander).

--- a/scripts/mouse-smoke-run.ps1
+++ b/scripts/mouse-smoke-run.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    Run one mouse-smoke cell.
+
+.DESCRIPTION
+    Copies dev-configs/mouse-smoke/<Cell>.conf into an isolated
+    XDG_CONFIG_HOME (as ghostty/config.ghostty), launches Wintty.exe
+    pointed at it, and waits for the user to manually exercise the
+    cell's click checklist and quit the TUI. Exit code reflects clean
+    process teardown only; click pass/fail is recorded by the tester.
+
+    Mirrors scripts/validate-transport-run.ps1 — WinUI shell does NOT
+    honor --config-file; isolation must go through env.
+
+.PARAMETER Cell
+    Cell stem (no extension), e.g. "01-wsl2-mc". Must match a file in
+    dev-configs/mouse-smoke/.
+
+.PARAMETER TimeoutMs
+    Safety timeout. Default 900000 (15 minutes) — generous because the
+    tester drives the TUI manually.
+
+.PARAMETER ExePath
+    Path to built Wintty.exe.
+#>
+param(
+    [Parameter(Mandatory)][string]$Cell,
+    [int]$TimeoutMs = 900000,
+    [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe'
+)
+$ErrorActionPreference = 'Stop'
+
+$fixture = "dev-configs/mouse-smoke/$Cell.conf"
+if (-not (Test-Path $fixture)) {
+    Write-Host "ERROR: fixture not found: $fixture"; exit 2
+}
+if (-not (Test-Path $ExePath)) {
+    Write-Host "ERROR: exe not found: $ExePath (run 'just build-dll build-win' first)"; exit 2
+}
+
+$xdg = Join-Path $env:TEMP "wintty-mouse-smoke-$Cell-$(Get-Random)"
+$ghosttyDir = Join-Path $xdg 'ghostty'
+New-Item -ItemType Directory -Path $ghosttyDir -Force | Out-Null
+Copy-Item $fixture (Join-Path $ghosttyDir 'config.ghostty')
+
+$env:XDG_CONFIG_HOME = $xdg
+Write-Host "Launching cell '$Cell' with XDG_CONFIG_HOME=$xdg"
+Write-Host "Click checklist for this cell is in dev-configs/mouse-smoke/$Cell.conf header."
+Write-Host "Quit the TUI when done; the runner returns when Wintty exits."
+
+$proc = Start-Process -FilePath $ExePath -PassThru
+if (-not $proc.WaitForExit($TimeoutMs)) {
+    Write-Host "TIMEOUT after ${TimeoutMs}ms — killing process"
+    try { $proc.Kill() } catch {}
+    Remove-Item -Recurse -Force $xdg
+    exit 2
+}
+
+Remove-Item -Recurse -Force $xdg
+Write-Host "Wintty exit code: $($proc.ExitCode)"
+exit $proc.ExitCode

--- a/scripts/mouse-smoke-run.ps1
+++ b/scripts/mouse-smoke-run.ps1
@@ -5,57 +5,87 @@
 .DESCRIPTION
     Copies dev-configs/mouse-smoke/<Cell>.conf into an isolated
     XDG_CONFIG_HOME (as ghostty/config.ghostty), launches Wintty.exe
-    pointed at it, and waits for the user to manually exercise the
+    pointed at it, and waits for the operator to manually exercise the
     cell's click checklist and quit the TUI. Exit code reflects clean
-    process teardown only; click pass/fail is recorded by the tester.
+    process teardown only; click pass/fail is recorded by the operator.
 
-    Mirrors scripts/validate-transport-run.ps1 — WinUI shell does NOT
-    honor --config-file; isolation must go through env.
+    Mirrors scripts/validate-transport-run.ps1 - WinUI shell does NOT
+    honor --config-file; isolation must go through env. The caller's
+    pre-existing XDG_CONFIG_HOME is restored on exit.
 
 .PARAMETER Cell
     Cell stem (no extension), e.g. "01-wsl2-mc". Must match a file in
     dev-configs/mouse-smoke/.
 
 .PARAMETER TimeoutMs
-    Safety timeout. Default 900000 (15 minutes) — generous because the
-    tester drives the TUI manually.
+    Safety timeout. Default 900000 (15 minutes) - generous because the
+    operator drives the TUI manually.
 
 .PARAMETER ExePath
-    Path to built Wintty.exe.
+    Path to built Wintty.exe. Defaults to the Debug x64 output resolved
+    relative to this script's location, so the runner works from any cwd.
+
+.OUTPUTS
+    Exit code 0 when Wintty exits cleanly. Exit code 2 on setup error
+    (fixture or exe not found) or timeout. Otherwise propagates Wintty's
+    own exit code.
 #>
 param(
     [Parameter(Mandatory)][string]$Cell,
     [int]$TimeoutMs = 900000,
-    [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe'
+    [string]$ExePath
 )
 $ErrorActionPreference = 'Stop'
 
-$fixture = "dev-configs/mouse-smoke/$Cell.conf"
-if (-not (Test-Path $fixture)) {
-    Write-Host "ERROR: fixture not found: $fixture"; exit 2
-}
-if (-not (Test-Path $ExePath)) {
-    Write-Host "ERROR: exe not found: $ExePath (run 'just build-dll build-win' first)"; exit 2
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+if (-not $ExePath) {
+    $ExePath = Join-Path $repoRoot 'windows\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'
 }
 
-$xdg = Join-Path $env:TEMP "wintty-mouse-smoke-$Cell-$(Get-Random)"
-$ghosttyDir = Join-Path $xdg 'ghostty'
-New-Item -ItemType Directory -Path $ghosttyDir -Force | Out-Null
-Copy-Item $fixture (Join-Path $ghosttyDir 'config.ghostty')
-
-$env:XDG_CONFIG_HOME = $xdg
-Write-Host "Launching cell '$Cell' with XDG_CONFIG_HOME=$xdg"
-Write-Host "Click checklist for this cell is in dev-configs/mouse-smoke/$Cell.conf header."
-Write-Host "Quit the TUI when done; the runner returns when Wintty exits."
-
-$proc = Start-Process -FilePath $ExePath -PassThru
-if (-not $proc.WaitForExit($TimeoutMs)) {
-    Write-Host "TIMEOUT after ${TimeoutMs}ms — killing process"
-    try { $proc.Kill() } catch {}
-    Remove-Item -Recurse -Force $xdg
+$fixturePath = Join-Path $repoRoot "dev-configs\mouse-smoke\$Cell.conf"
+if (-not (Test-Path -LiteralPath $fixturePath)) {
+    Write-Error "fixture not found: $fixturePath"
+    exit 2
+}
+if (-not (Test-Path -LiteralPath $ExePath)) {
+    Write-Error "exe not found: $ExePath (run ``just build-dll build-win`` first)"
     exit 2
 }
 
-Remove-Item -Recurse -Force $xdg
-Write-Host "Wintty exit code: $($proc.ExitCode)"
-exit $proc.ExitCode
+$tempXdg = Join-Path $env:TEMP "wintty-mouse-smoke-$Cell-$((New-Guid).Guid)"
+$ghosttyDir = Join-Path $tempXdg 'ghostty'
+New-Item -ItemType Directory -Path $ghosttyDir -Force | Out-Null
+$configPath = Join-Path $ghosttyDir 'config.ghostty'
+Copy-Item -LiteralPath $fixturePath -Destination $configPath -Force
+
+$originalXdgSet = Test-Path Env:XDG_CONFIG_HOME
+$originalXdg = if ($originalXdgSet) { $env:XDG_CONFIG_HOME } else { $null }
+
+try {
+    $env:XDG_CONFIG_HOME = $tempXdg
+    Write-Host "Launching cell '$Cell' with XDG_CONFIG_HOME=$tempXdg"
+    Write-Host "Click checklist for this cell is in dev-configs/mouse-smoke/$Cell.conf header."
+    Write-Host "Quit the TUI when done; the runner returns when Wintty exits."
+
+    $proc = Start-Process -FilePath $ExePath -PassThru
+    $exited = $proc.WaitForExit($TimeoutMs)
+    if (-not $exited) {
+        Write-Error "TIMEOUT after ${TimeoutMs}ms - killing process"
+        try { Stop-Process -Id $proc.Id -Force }
+        catch [System.InvalidOperationException] {}
+        exit 2
+    }
+
+    Write-Host "Wintty exit code: $($proc.ExitCode)"
+    exit $proc.ExitCode
+}
+finally {
+    if ($originalXdgSet) {
+        $env:XDG_CONFIG_HOME = $originalXdg
+    } else {
+        Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue
+    }
+    if (Test-Path -LiteralPath $tempXdg) {
+        Remove-Item -LiteralPath $tempXdg -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary

- 10 per-cell `.conf` fixtures under `dev-configs/mouse-smoke/` that pin `command =` to launch a target TUI directly (lazygit, btop4win, btop, mc, htop, neovim) across native Windows, WSL2, and Git Bash MSYS2.
- `scripts/mouse-smoke-run.ps1` mirrors `scripts/validate-transport-run.ps1` to isolate each cell via XDG_CONFIG_HOME (WinUI shell does not honor `--config-file`).
- WSL2 cells use `bash -lic` wrapper because direct `wsl.exe -- <bare-bin>` causes Wintty to exit before surface init (separate follow-up task).

## Test plan

- [x] 9 of 10 cells PASS on 2026-05-24 smoke pass; mouse Tier-1 (X10/normal/SGR/urxvt/SGR-Pixels/motion 1002+1003/focus 1004) works end-to-end against all tested TUIs.
- [x] Cell 09 (mc-in-Git-Bash) skipped — Git Bash MSYS2 does not ship Midnight Commander.
- [x] No ConPTY 1003 hover-byte mangling observed under btop on WSL2 (the bug zone we expected to hit).
- [x] Transport comparison cell 02 vs cell 03 (native vs WSL2 lazygit): no divergence.

## Follow-ups outside this PR

- `quit-after-last-window-closed` teardown regression — pre-existing, separate task.
- `wsl.exe -- <bare-bin>` Wintty-exit launcher bug — separate task.