### PR TITLE
termio: force conpty for wsl.exe so Linux PTY is allocated

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2891,10 +2891,13 @@ keybind: Keybinds = .{},
 
 /// Controls how Windows terminal sessions communicate with the child
 /// shell. `auto` picks the bypass path (raw stdin/stdout/stderr
-/// pipes, no CreatePseudoConsole) for VT-aware shells like pwsh,
-/// wsl, ssh, bash, and nu, and keeps ConPTY for cmd.exe and
-/// PowerShell 5.1. `always` forces the bypass path; `never` forces
-/// ConPTY. Has no effect on non-Windows platforms.
+/// pipes, no CreatePseudoConsole) for VT-aware shells like ssh,
+/// bash, and nu, and keeps ConPTY for cmd.exe, PowerShell 5.1,
+/// pwsh.exe (PSReadLine needs a real console handle for input),
+/// and wsl.exe (the WSL launcher inspects stdio handle types to
+/// decide whether to allocate a Linux PTY, and pipes get no PTY).
+/// `always` forces the bypass path; `never` forces ConPTY. Has no
+/// effect on non-Windows platforms.
 ///
 /// Bypass enables Kitty graphics and avoids conhost's VT mangling,
 /// at the cost of losing ConPTY's compatibility shims for Win32

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -392,10 +392,8 @@ test "utf8Preamble: powershell 5.1 returns .pwsh" {
 }
 
 test "utf8Preamble: vt-aware non-powershell shells return .none" {
-    // bash/wsl/ssh/nu don't observe the Windows console CP the same way
-    // powershell does, and auto-mode routes them through the bypass
-    // path anyway. Only powershell-family shells need the preamble
-    // under forced conpty-mode=never.
+    // bash/wsl/ssh/nu don't observe the Windows console CP the way
+    // powershell does. Only powershell-family shells need the preamble.
     try testing.expectEqual(Preamble.none, utf8Preamble("bash.exe"));
     try testing.expectEqual(Preamble.none, utf8Preamble("wsl.exe"));
     try testing.expectEqual(Preamble.none, utf8Preamble("ssh.exe"));

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -157,21 +157,32 @@ pub fn awarenessOf(kind: Kind) Awareness {
     };
 }
 
-/// Returns true if this shell relies on a real console handle for
-/// interactive input (PSReadLine, line-editing) and breaks under raw
-/// pipe stdin on Windows. Used to force ConPTY transport for these
-/// shells regardless of the user's `conpty-mode = auto` preference.
+/// Returns true if this shell relies on a real console handle on
+/// Windows and breaks under raw pipe stdio. Used to force ConPTY
+/// transport for these shells regardless of the user's
+/// `conpty-mode = auto` preference.
 ///
-/// Currently only pwsh.exe (PowerShell 7+) qualifies. PSReadLine
-/// throws InvalidOperationException when stdin is not a console
-/// handle, and pwsh falls back to Console.ReadLine which has no
-/// backspace, no arrow-key history, no tab completion.
+/// pwsh.exe (PowerShell 7+) qualifies because PSReadLine throws
+/// InvalidOperationException when stdin is not a console handle,
+/// and pwsh falls back to Console.ReadLine which has no backspace,
+/// no arrow-key history, no tab completion.
+///
+/// wsl.exe qualifies because the launcher inspects its standard
+/// handles to decide whether to allocate a Linux PTY for the inner
+/// session: console attached -> pty allocated, raw pipes -> pipes
+/// forwarded straight through with no controlling terminal. The
+/// pipe path makes any TUI inside WSL (btop, htop, mc, vim,
+/// neovim, ...) see `isatty(STDOUT) = false` and exit immediately,
+/// which under `quit-after-last-window-closed = true` looks like
+/// Wintty exiting on its own. Bare `wsl.exe` is in the same boat:
+/// the user's login shell starts without a tty and editing /
+/// prompt rendering silently degrade.
 ///
 /// powershell.exe (5.1) is .console_api in `awarenessOf` so it
 /// already routes to ConPTY without needing this gate.
 pub fn requiresConsoleInput(kind: Kind) bool {
     return switch (kind) {
-        .pwsh => true,
+        .pwsh, .wsl => true,
         // else explicit so adding a new Kind doesn't silently flip
         // its console-input requirement.
         else => false,
@@ -337,6 +348,27 @@ test "classify: handles very long path safely" {
     var long_path: [128]u8 = undefined;
     @memset(&long_path, 'a');
     try testing.expectEqual(Awareness.unknown, classify(&long_path));
+}
+
+test "requiresConsoleInput: pwsh and wsl require console" {
+    try testing.expect(requiresConsoleInput(.pwsh));
+    try testing.expect(requiresConsoleInput(.wsl));
+}
+
+test "requiresConsoleInput: other VT-aware shells stay on bypass" {
+    try testing.expect(!requiresConsoleInput(.ssh));
+    try testing.expect(!requiresConsoleInput(.bash));
+    try testing.expect(!requiresConsoleInput(.nu));
+    try testing.expect(!requiresConsoleInput(.zsh));
+    try testing.expect(!requiresConsoleInput(.fish));
+    try testing.expect(!requiresConsoleInput(.elvish));
+    try testing.expect(!requiresConsoleInput(.xonsh));
+}
+
+test "requiresConsoleInput: console-API and unknown stay false (routed via awareness)" {
+    try testing.expect(!requiresConsoleInput(.cmd));
+    try testing.expect(!requiresConsoleInput(.powershell));
+    try testing.expect(!requiresConsoleInput(.unknown));
 }
 
 test "utf8Preamble: cmd.exe returns .cmd" {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2783,8 +2783,8 @@ test "resolveConptyMode: always forces bypass" {
 
 test "resolveConptyMode: auto picks bypass for vt_aware" {
     try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "bash.exe"));
-    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "wsl.exe"));
     try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "bash"));
+    try std.testing.expectEqual(ptypkg.Mode.bypass, resolveConptyMode(.auto, "ssh.exe"));
 }
 
 test "resolveConptyMode: auto picks conpty for pwsh (requires console for PSReadLine)" {
@@ -2792,6 +2792,13 @@ test "resolveConptyMode: auto picks conpty for pwsh (requires console for PSRead
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "pwsh.exe"));
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "pwsh"));
     try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+}
+
+test "resolveConptyMode: auto picks conpty for wsl (requires console for Linux PTY)" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "wsl.exe"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "wsl"));
+    try std.testing.expectEqual(ptypkg.Mode.conpty, resolveConptyMode(.auto, "C:\\Windows\\System32\\wsl.exe"));
 }
 
 test "resolveConptyMode: auto picks conpty for console_api" {

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2345,8 +2345,10 @@ fn resolveConptyMode(
         .always => .bypass,
         .auto => blk: {
             const kind = internal_os.windows_shell.identify(exe_path);
-            // Force ConPTY for shells whose interactive input layer
-            // (e.g. PSReadLine for pwsh) requires a real console handle.
+            // Force ConPTY for shells that need a real console handle:
+            // pwsh for PSReadLine's input layer, wsl because its
+            // launcher uses the parent handle type to decide whether
+            // to allocate a Linux PTY.
             if (internal_os.windows_shell.requiresConsoleInput(kind)) {
                 break :blk .conpty;
             }

--- a/windows/Ghostty.Core/Shell/ShellDetector.cs
+++ b/windows/Ghostty.Core/Shell/ShellDetector.cs
@@ -22,7 +22,7 @@ public static class ShellDetector
         {
             // VT-aware: safe to bypass ConPTY.
             ["pwsh.exe"]   = ShellCapability.VtAware,   // PowerShell 7+
-            ["wsl.exe"]    = ShellCapability.VtAware,   // WSL launcher (distro owns its PTY)
+            ["wsl.exe"]    = ShellCapability.VtAware,   // WSL launcher; speaks VT, but Zig side forces ConPTY so wsl.exe sees a console handle and allocates a Linux PTY
             ["ssh.exe"]    = ShellCapability.VtAware,   // OpenSSH client
             ["bash.exe"]   = ShellCapability.VtAware,   // Git Bash / MSYS2 / Cygwin / legacy WSL1 stub
             ["nu.exe"]     = ShellCapability.VtAware,   // Nushell


### PR DESCRIPTION
## Why

`command = wsl.exe -- <bare-linux-cmd>` (btop, htop, mc, vim, neovim, ...) opens a Wintty window that closes after a flash. Under `quit-after-last-window-closed = true` the whole app exits, so it looks like Wintty quitting on its own.

The root cause is the transport pick: `wsl.exe` is classified `.vt_aware`, so `resolveConptyMode(.auto, "wsl.exe")` returns `.bypass`. Under bypass the child inherits raw pipes for stdin/stdout. wsl.exe then forwards those pipes straight through to the inner Linux session and never asks WSL to allocate a controlling terminal. Any TUI inside sees `isatty(STDOUT) = false` and exits immediately; the IO thread sees EOF and tears the surface down.

`wsl.exe -- bash -lic <cmd>` *appears* to work because the parent bash keeps running even when the inner TUI dies - the window stays open, but the TUI never actually rendered.

## Change

Mirror the existing pwsh handling (PR # 341): mark `wsl.exe` as `requiresConsoleInput` so `resolveConptyMode` picks `.conpty` under the default `conpty-mode = auto`. wsl.exe now spawns with a real ConPTY console handle, WSL allocates a Linux PTY, TUIs render.

Bare `command = wsl.exe` benefits too: under bypass the user's login shell was running without a tty (broken line editing, no prompt rendering); under ConPTY it gets a proper tty.

`conpty-mode = always` still forces bypass for users who explicitly opt in.

## Verification

- `zig build test`: 2944 passed / 55 skipped / 0 failed
- Empirical, on this box: `command = wsl.exe -- bash -c "[ -t 1 ] && echo TTY > /tmp/p; sleep 12"` writes `TTY` (Linux PTY allocated). Forcing `conpty-mode = always` on the same config never produces the probe file - the child exits before bash can run.

## Test plan

- [ ] Build: `just build-dll build-win`
- [ ] `command = wsl.exe -- btop` renders btop and stays open
- [ ] `command = wsl.exe -- htop` renders htop and stays open
- [ ] `command = wsl.exe` opens the user's default WSL login shell with a working prompt + line editing
- [ ] `command = pwsh.exe -NoExit` still works (regression check, unrelated path)
- [ ] `command = bash.exe` (Git Bash) still uses bypass (`bash.exe` is `.vt_aware`, `requiresConsoleInput` still false)