### PR TITLE
active-shell-icon: ProcessIconTable mapping exe to IconSpec (PR 1/4)

### DIFF
--- a/windows/Ghostty.Core/Profiles/ProcessIconTable.cs
+++ b/windows/Ghostty.Core/Profiles/ProcessIconTable.cs
@@ -26,6 +26,7 @@ public static class ProcessIconTable
             ["fish.exe"]       = _ => new IconSpec.BrandKey("fish", null),
             ["nu.exe"]         = _ => new IconSpec.BrandKey("nu", null),
             ["zsh.exe"]        = _ => new IconSpec.BrandKey("zsh", null),
+            ["wsl.exe"]        = cmd => new IconSpec.AutoForWslDistro(ParseWslDistro(cmd)),
 
             // Languages
             ["python.exe"]     = _ => new IconSpec.BrandKey("python", null),
@@ -62,5 +63,34 @@ public static class ProcessIconTable
         return _table.TryGetValue(exeBasename, out var factory)
             ? factory(commandLine)
             : null;
+    }
+
+    /// <summary>
+    /// Extracts the distro from a wsl.exe command line. Recognized forms:
+    /// <c>--distribution &lt;name&gt;</c>, <c>--distribution=&lt;name&gt;</c>,
+    /// <c>-d &lt;name&gt;</c>. Returns empty string if no flag is present;
+    /// the resolver treats that as "use the legacy wsl bundle."
+    /// </summary>
+    private static string ParseWslDistro(string? commandLine)
+    {
+        if (string.IsNullOrEmpty(commandLine)) return string.Empty;
+
+        var tokens = commandLine.Split(
+            new[] { ' ', '\t' },
+            StringSplitOptions.RemoveEmptyEntries);
+        // The first token is the program name; argv parsing starts at 1.
+        for (var i = 1; i < tokens.Length; i++)
+        {
+            var t = tokens[i];
+            if (t.StartsWith("--distribution=", StringComparison.OrdinalIgnoreCase))
+                return t.Substring("--distribution=".Length);
+            if ((t.Equals("--distribution", StringComparison.OrdinalIgnoreCase)
+                 || t.Equals("-d", StringComparison.OrdinalIgnoreCase))
+                && i + 1 < tokens.Length)
+            {
+                return tokens[i + 1];
+            }
+        }
+        return string.Empty;
     }
 }

--- a/windows/Ghostty.Core/Profiles/ProcessIconTable.cs
+++ b/windows/Ghostty.Core/Profiles/ProcessIconTable.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Maps a foreground process's executable basename (and, when relevant,
+/// its command line) to the <see cref="IconSpec"/> a tab should show
+/// while that process is in the foreground. Pure dictionary, no
+/// platform deps; the runtime tracker passes data in.
+///
+/// Unknown executables return null so the caller can revert to the
+/// tab's profile icon rather than show a placeholder.
+/// </summary>
+public static class ProcessIconTable
+{
+    private static readonly FrozenDictionary<string, Func<string?, IconSpec>> _table =
+        new Dictionary<string, Func<string?, IconSpec>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["pwsh.exe"]       = _ => new IconSpec.BrandKey("pwsh", null),
+            ["powershell.exe"] = _ => new IconSpec.BrandKey("pwsh", null),
+            ["cmd.exe"]        = _ => new IconSpec.BrandKey("cmd", null),
+            ["bash.exe"]       = _ => new IconSpec.BrandKey("bash", null),
+            ["fish.exe"]       = _ => new IconSpec.BrandKey("fish", null),
+            ["nu.exe"]         = _ => new IconSpec.BrandKey("nu", null),
+            ["zsh.exe"]        = _ => new IconSpec.BrandKey("zsh", null),
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    public static IconSpec? TryMap(string exeBasename) =>
+        TryMap(exeBasename, commandLine: null);
+
+    public static IconSpec? TryMap(string exeBasename, string? commandLine)
+    {
+        if (string.IsNullOrEmpty(exeBasename)) return null;
+        return _table.TryGetValue(exeBasename, out var factory)
+            ? factory(commandLine)
+            : null;
+    }
+}

--- a/windows/Ghostty.Core/Profiles/ProcessIconTable.cs
+++ b/windows/Ghostty.Core/Profiles/ProcessIconTable.cs
@@ -18,6 +18,7 @@ public static class ProcessIconTable
     private static readonly FrozenDictionary<string, Func<string?, IconSpec>> _table =
         new Dictionary<string, Func<string?, IconSpec>>(StringComparer.OrdinalIgnoreCase)
         {
+            // Shells
             ["pwsh.exe"]       = _ => new IconSpec.BrandKey("pwsh", null),
             ["powershell.exe"] = _ => new IconSpec.BrandKey("pwsh", null),
             ["cmd.exe"]        = _ => new IconSpec.BrandKey("cmd", null),
@@ -25,6 +26,31 @@ public static class ProcessIconTable
             ["fish.exe"]       = _ => new IconSpec.BrandKey("fish", null),
             ["nu.exe"]         = _ => new IconSpec.BrandKey("nu", null),
             ["zsh.exe"]        = _ => new IconSpec.BrandKey("zsh", null),
+
+            // Languages
+            ["python.exe"]     = _ => new IconSpec.BrandKey("python", null),
+            ["python3.exe"]    = _ => new IconSpec.BrandKey("python", null),
+            ["node.exe"]       = _ => new IconSpec.BrandKey("node", null),
+            ["deno.exe"]       = _ => new IconSpec.BrandKey("deno", null),
+            ["bun.exe"]        = _ => new IconSpec.BrandKey("bun", null),
+            ["cargo.exe"]      = _ => new IconSpec.BrandKey("rust", null),
+            ["rustc.exe"]      = _ => new IconSpec.BrandKey("rust", null),
+            ["dotnet.exe"]     = _ => new IconSpec.BrandKey("dotnet", null),
+            ["go.exe"]         = _ => new IconSpec.BrandKey("go", null),
+
+            // Tools
+            ["vim.exe"]        = _ => new IconSpec.BrandKey("vim", null),
+            ["nvim.exe"]       = _ => new IconSpec.BrandKey("vim", null),
+            ["git.exe"]        = _ => new IconSpec.BrandKey("git", null),
+            ["ssh.exe"]        = _ => new IconSpec.BrandKey("ssh", null),
+            ["docker.exe"]     = _ => new IconSpec.BrandKey("docker", null),
+            ["kubectl.exe"]    = _ => new IconSpec.BrandKey("k8s", null),
+            ["make.exe"]       = _ => new IconSpec.BrandKey("make", null),
+
+            // System monitors (all map to the same generic glyph)
+            ["htop.exe"]       = _ => new IconSpec.BrandKey("monitor", null),
+            ["btop.exe"]       = _ => new IconSpec.BrandKey("monitor", null),
+            ["top.exe"]        = _ => new IconSpec.BrandKey("monitor", null),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     public static IconSpec? TryMap(string exeBasename) =>

--- a/windows/Ghostty.Tests/Profiles/ProcessIconTableTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProcessIconTableTests.cs
@@ -1,0 +1,36 @@
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProcessIconTableTests
+{
+    [Fact]
+    public void TryMap_UnknownExe_ReturnsNull()
+    {
+        Assert.Null(ProcessIconTable.TryMap("never-shipped.exe"));
+    }
+
+    [Fact]
+    public void TryMap_PwshExe_ReturnsBrandKey()
+    {
+        var spec = ProcessIconTable.TryMap("pwsh.exe");
+        var brand = Assert.IsType<IconSpec.BrandKey>(spec);
+        Assert.Equal("pwsh", brand.Key);
+    }
+
+    [Fact]
+    public void TryMap_PwshExe_IsCaseInsensitive()
+    {
+        var spec = ProcessIconTable.TryMap("Pwsh.EXE");
+        var brand = Assert.IsType<IconSpec.BrandKey>(spec);
+        Assert.Equal("pwsh", brand.Key);
+    }
+
+    [Fact]
+    public void TryMap_NullOrEmpty_ReturnsNull()
+    {
+        Assert.Null(ProcessIconTable.TryMap(null!));
+        Assert.Null(ProcessIconTable.TryMap(""));
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProcessIconTableTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProcessIconTableTests.cs
@@ -68,4 +68,36 @@ public sealed class ProcessIconTableTests
         // descendant tree but is not what the user is interacting with.
         Assert.Null(ProcessIconTable.TryMap("wslhost.exe"));
     }
+
+    [Fact]
+    public void TryMap_Wsl_WithDistributionFlag_ReturnsAutoForWslDistro()
+    {
+        var spec = ProcessIconTable.TryMap("wsl.exe", "wsl.exe --distribution Ubuntu-22.04");
+        var auto = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
+        Assert.Equal("Ubuntu-22.04", auto.DistroName);
+    }
+
+    [Fact]
+    public void TryMap_Wsl_ShortFlag_ReturnsAutoForWslDistro()
+    {
+        var spec = ProcessIconTable.TryMap("wsl.exe", "wsl.exe -d Debian");
+        var auto = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
+        Assert.Equal("Debian", auto.DistroName);
+    }
+
+    [Fact]
+    public void TryMap_Wsl_NoCmdline_ReturnsAutoForWslDistroEmpty()
+    {
+        var spec = ProcessIconTable.TryMap("wsl.exe", null);
+        var auto = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
+        Assert.Equal(string.Empty, auto.DistroName);
+    }
+
+    [Fact]
+    public void TryMap_Wsl_EqualsFlag_ReturnsAutoForWslDistro()
+    {
+        var spec = ProcessIconTable.TryMap("wsl.exe", "wsl.exe --distribution=kali-linux");
+        var auto = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
+        Assert.Equal("kali-linux", auto.DistroName);
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/ProcessIconTableTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProcessIconTableTests.cs
@@ -33,4 +33,39 @@ public sealed class ProcessIconTableTests
         Assert.Null(ProcessIconTable.TryMap(null!));
         Assert.Null(ProcessIconTable.TryMap(""));
     }
+
+    [Theory]
+    [InlineData("python.exe",  "python")]
+    [InlineData("python3.exe", "python")]
+    [InlineData("node.exe",    "node")]
+    [InlineData("deno.exe",    "deno")]
+    [InlineData("bun.exe",     "bun")]
+    [InlineData("vim.exe",     "vim")]
+    [InlineData("nvim.exe",    "vim")]
+    [InlineData("git.exe",     "git")]
+    [InlineData("ssh.exe",     "ssh")]
+    [InlineData("docker.exe",  "docker")]
+    [InlineData("kubectl.exe", "k8s")]
+    [InlineData("cargo.exe",   "rust")]
+    [InlineData("rustc.exe",   "rust")]
+    [InlineData("dotnet.exe",  "dotnet")]
+    [InlineData("go.exe",      "go")]
+    [InlineData("make.exe",    "make")]
+    [InlineData("htop.exe",    "monitor")]
+    [InlineData("btop.exe",    "monitor")]
+    [InlineData("top.exe",     "monitor")]
+    public void TryMap_KnownExe_ReturnsExpectedBrand(string exe, string expectedKey)
+    {
+        var spec = ProcessIconTable.TryMap(exe);
+        var brand = Assert.IsType<IconSpec.BrandKey>(spec);
+        Assert.Equal(expectedKey, brand.Key);
+    }
+
+    [Fact]
+    public void TryMap_WslHostExe_ReturnsNull()
+    {
+        // wslhost.exe is the WSL broker; it appears in every WSL tab's
+        // descendant tree but is not what the user is interacting with.
+        Assert.Null(ProcessIconTable.TryMap("wslhost.exe"));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds \`Ghostty.Core.Profiles.ProcessIconTable\` — pure dictionary mapping a foreground process's exe basename (and optional command line) to an \`IconSpec\`.
- Covers 28 cases: 7 shells, 8 languages/build tools, 7 dev tools, 3 monitors, 1 WSL with \`--distribution\`/\`-d\`/\`--distribution=\` parsing, plus null / empty / unknown / case-insensitive handling.
- Unknown exes return null; consumers (the future runtime tracker, also future notifications + command palette work) interpret null as "no override, use the profile icon."
- Pure logic, no platform deps, fully tested in Ghostty.Tests.

IMPORTANT: stacked on top of #406. Merge order: 1/5 ... 5/5 ... #406 ... then this PR.

## Test plan
- [x] xunit ProcessIconTableTests: 28/28 pass.
- [x] Build clean.
- Asset keys this table emits (python, node, deno, bun, vim, git, ssh, docker, k8s, rust, dotnet, go, monitor, make) are NOT yet bundled — that's PR 2/4. ProcessIconTable returns the spec regardless; the resolver falls back to the default glyph until the assets land.