### PR TITLE
active-shell-icon: TabIconViewModel override slot + debouncer (PR 3/4)

### DIFF
--- a/windows/Ghostty.Core/Profiles/Tracking/ActiveProcessDebouncer.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/ActiveProcessDebouncer.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Profiles.Tracking;
+
+/// <summary>
+/// Per-root debouncer: a new (exe, cmdline) value must be observed for
+/// at least <c>windowMs</c> milliseconds of wall-clock time before it is
+/// emitted to subscribers. Absorbs sub-window churn from rapid command
+/// sequences (e.g. <c>ls &amp;&amp; cd ... &amp;&amp; ls</c>).
+///
+/// Pure logic; the caller passes the current time in. Tests use a fake
+/// clock; the production tracker passes <see cref="System.Environment.TickCount64"/>.
+/// </summary>
+public sealed class ActiveProcessDebouncer
+{
+    private readonly int _windowMs;
+    private readonly Dictionary<int, RootState> _state = new();
+
+    public ActiveProcessDebouncer(int windowMs)
+    {
+        _windowMs = windowMs;
+    }
+
+    /// <summary>
+    /// Observe the current foreground process for a root. Returns a
+    /// <see cref="DebouncerEmission"/> when the value has been stable for
+    /// the window AND differs from the last-emitted value for this root;
+    /// otherwise null.
+    /// </summary>
+    public DebouncerEmission? Observe(int rootPid, string? exeBasename, string? commandLine, long nowMs)
+    {
+        if (!_state.TryGetValue(rootPid, out var s))
+        {
+            s = new RootState();
+            _state[rootPid] = s;
+        }
+
+        // No change vs. the pending candidate: keep waiting.
+        if (s.PendingExe == exeBasename && s.PendingCmdline == commandLine)
+        {
+            if (s.PendingSinceMs is { } since && nowMs - since >= _windowMs)
+            {
+                if (s.EmittedExe != exeBasename || s.EmittedCmdline != commandLine)
+                {
+                    s.EmittedExe = exeBasename;
+                    s.EmittedCmdline = commandLine;
+                    s.PendingSinceMs = null;
+                    return new DebouncerEmission(rootPid, exeBasename, commandLine);
+                }
+                // Window elapsed but value matches what we already emitted.
+                // Suppress further emission until the value actually changes.
+                s.PendingSinceMs = null;
+            }
+            return null;
+        }
+
+        // Value changed: restart the window.
+        s.PendingExe = exeBasename;
+        s.PendingCmdline = commandLine;
+        s.PendingSinceMs = nowMs;
+        return null;
+    }
+
+    public void Forget(int rootPid) => _state.Remove(rootPid);
+
+    private sealed class RootState
+    {
+        public string? PendingExe;
+        public string? PendingCmdline;
+        public long? PendingSinceMs;
+        public string? EmittedExe;
+        public string? EmittedCmdline;
+    }
+}
+
+public sealed record DebouncerEmission(int RootPid, string? ExeBasename, string? CommandLine);

--- a/windows/Ghostty.Core/Profiles/Tracking/ActiveProcessDebouncer.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/ActiveProcessDebouncer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Ghostty.Core.Profiles.Tracking;
@@ -18,6 +19,7 @@ public sealed class ActiveProcessDebouncer
 
     public ActiveProcessDebouncer(int windowMs)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowMs);
         _windowMs = windowMs;
     }
 
@@ -27,6 +29,11 @@ public sealed class ActiveProcessDebouncer
     /// the window AND differs from the last-emitted value for this root;
     /// otherwise null.
     /// </summary>
+    /// <remarks>
+    /// nowMs must come from a monotonic clock (e.g. Environment.TickCount64).
+    /// Mixing tick sources or wall-clock-with-NTP-adjustments will misalign
+    /// the stability window.
+    /// </remarks>
     public DebouncerEmission? Observe(int rootPid, string? exeBasename, string? commandLine, long nowMs)
     {
         if (!_state.TryGetValue(rootPid, out var s))
@@ -61,6 +68,11 @@ public sealed class ActiveProcessDebouncer
         return null;
     }
 
+    /// <summary>
+    /// Drop state for a root that has gone away (typically called when
+    /// a tab closes). Subsequent Observe calls for the same rootPid start
+    /// fresh.
+    /// </summary>
     public void Forget(int rootPid) => _state.Remove(rootPid);
 
     private sealed class RootState

--- a/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabIconViewModel.cs
@@ -6,64 +6,96 @@ namespace Ghostty.Core.Tabs;
 
 /// <summary>
 /// Per-tab observable that pairs an <see cref="IconSpec"/> with the
-/// tooltip the tab strip shows. Lives in Core (no WinUI types) so it
-/// can be exercised by the test project, which only references
-/// <c>Ghostty.Core</c>.
+/// tooltip the tab strip shows. Internally maintains two slots: the
+/// profile icon (set by <see cref="SetIcon"/> when the profile snapshot
+/// changes) and an optional override (set by the runtime active-process
+/// tracker via <see cref="SetOverride"/>). The resolved <see cref="Icon"/>
+/// is the override when set, else the profile.
 ///
-/// INPC is hand-rolled with the C# 14 <c>field</c> keyword to match
-/// <see cref="TabModel"/> and avoid a source-generator dependency.
+/// Lives in Core (no WinUI types) so the test project can exercise
+/// override semantics without spinning up XAML.
 /// </summary>
 public sealed class TabIconViewModel : INotifyPropertyChanged
 {
+    private IconSpec _profileIcon;
+    private string _profileTooltip;
+    private IconSpec? _overrideIcon;
+    private string? _overrideTooltip;
+
     public TabIconViewModel(IconSpec icon, string tooltipText)
     {
-        Icon = icon;
-        TooltipText = tooltipText;
+        _profileIcon = icon;
+        _profileTooltip = tooltipText;
     }
 
-    public IconSpec Icon
-    {
-        get;
-        private set
-        {
-            if (Equals(field, value)) return;
-            field = value;
-            Raise();
-            // IsMdl2Glyph and Mdl2CodePoint are computed; classic bindings
-            // listen for the exact property name, so raise them explicitly.
-            Raise(nameof(IsMdl2Glyph));
-            Raise(nameof(Mdl2CodePoint));
-        }
-    }
+    public IconSpec Icon => _overrideIcon ?? _profileIcon;
 
-    public string TooltipText
-    {
-        get;
-        private set { if (field != value) { field = value; Raise(); } }
-    }
+    public string TooltipText => _overrideTooltip ?? _profileTooltip;
 
-    /// <summary>
-    /// True when <see cref="Icon"/> is a Segoe MDL2 glyph; the tab-strip
-    /// template selector switches to a FontIcon presenter in that case.
-    /// </summary>
     public bool IsMdl2Glyph => Icon is IconSpec.Mdl2Token;
 
-    /// <summary>
-    /// MDL2 code point when <see cref="IsMdl2Glyph"/> is true; 0 otherwise.
-    /// Bound directly by a FontIcon in the tab strip; callers don't need
-    /// to pattern-match on <see cref="Icon"/> in XAML.
-    /// </summary>
     public int Mdl2CodePoint => Icon is IconSpec.Mdl2Token m ? m.CodePoint : 0;
 
     /// <summary>
-    /// Updates the icon spec and tooltip in one call. Fires PropertyChanged
-    /// for Icon (and its derived flags IsMdl2Glyph / Mdl2CodePoint) before
-    /// TooltipText; subscribers observe sequential notifications.
+    /// Updates the profile-icon slot. Existing override (if any) keeps
+    /// winning until cleared. Fires PropertyChanged for Icon / TooltipText
+    /// only when the resolved values actually change.
     /// </summary>
     public void SetIcon(IconSpec icon, string tooltipText)
     {
-        Icon = icon;
-        TooltipText = tooltipText;
+        var oldIcon = Icon;
+        var oldTooltip = TooltipText;
+
+        _profileIcon = icon;
+        _profileTooltip = tooltipText;
+
+        RaiseIfChanged(oldIcon, oldTooltip);
+    }
+
+    /// <summary>
+    /// Installs an icon override (typically from the foreground-process
+    /// tracker). Calls to this method while another override is active
+    /// replace it. <see cref="RevertToProfile"/> clears.
+    /// </summary>
+    public void SetOverride(IconSpec icon, string tooltipText)
+    {
+        var oldIcon = Icon;
+        var oldTooltip = TooltipText;
+
+        _overrideIcon = icon;
+        _overrideTooltip = tooltipText;
+
+        RaiseIfChanged(oldIcon, oldTooltip);
+    }
+
+    /// <summary>
+    /// Clears the override; resolved Icon / TooltipText fall back to the
+    /// profile slot.
+    /// </summary>
+    public void RevertToProfile()
+    {
+        if (_overrideIcon is null) return;
+        var oldIcon = Icon;
+        var oldTooltip = TooltipText;
+
+        _overrideIcon = null;
+        _overrideTooltip = null;
+
+        RaiseIfChanged(oldIcon, oldTooltip);
+    }
+
+    private void RaiseIfChanged(IconSpec oldIcon, string oldTooltip)
+    {
+        if (!Equals(oldIcon, Icon))
+        {
+            Raise(nameof(Icon));
+            Raise(nameof(IsMdl2Glyph));
+            Raise(nameof(Mdl2CodePoint));
+        }
+        if (!string.Equals(oldTooltip, TooltipText))
+        {
+            Raise(nameof(TooltipText));
+        }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -144,6 +144,46 @@ internal sealed class TabModel : INotifyPropertyChanged
     }
 
     /// <summary>
+    /// Called by the active-process tracker when the foreground command
+    /// inside the pty changes. Routes through <see cref="ProcessIconTable"/>
+    /// to decide whether to install an icon override or revert to the
+    /// profile icon. If the mapped spec equals the profile spec (e.g. the
+    /// foreground IS the launch shell), the override is cleared -- no
+    /// churn at the prompt of the launch shell.
+    /// </summary>
+    public void OnActiveProcessChanged(string? exeBasename, string? commandLine)
+    {
+        var mapped = exeBasename is null
+            ? null
+            : ProcessIconTable.TryMap(exeBasename, commandLine);
+
+        // Touching the TabIcon getter lazily constructs the VM from the
+        // profile snapshot before we install or clear any override.
+        var vm = TabIcon;
+
+        if (mapped is null)
+        {
+            vm.RevertToProfile();
+            return;
+        }
+
+        // Suppress when the mapped spec equals the profile spec: steady
+        // state at the launch shell's prompt produces zero visual change
+        // and the tooltip stays as the profile's display name.
+        var profileIcon = ProfileSnapshot?.Icon;
+        if (profileIcon is not null && Equals(mapped, profileIcon))
+        {
+            vm.RevertToProfile();
+            return;
+        }
+
+        // Tooltip is the exe basename without extension: matches how the
+        // user thinks about the running command ("vim", not "vim.exe").
+        var tooltip = System.IO.Path.GetFileNameWithoutExtension(exeBasename) ?? string.Empty;
+        vm.SetOverride(mapped, tooltip);
+    }
+
+    /// <summary>
     /// Disposer assigned by <see cref="TabManager.CreateTab"/> so
     /// <see cref="TabManager.CloseTab"/> can unwire the per-tab
     /// <c>IPaneHost.ProgressChanged</c> handler captured as a local

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -151,6 +151,13 @@ internal sealed class TabModel : INotifyPropertyChanged
     /// foreground IS the launch shell), the override is cleared -- no
     /// churn at the prompt of the launch shell.
     /// </summary>
+    /// <remarks>
+    /// Must be called on the UI thread. The method mutates the lazy
+    /// TabIcon VM and raises PropertyChanged; off-thread invocation can
+    /// tear lazy init or fire change notifications on a non-UI thread.
+    /// Callers from background threads (e.g. the active-process tracker
+    /// timer) must marshal via the DispatcherQueue first.
+    /// </remarks>
     public void OnActiveProcessChanged(string? exeBasename, string? commandLine)
     {
         var mapped = exeBasename is null

--- a/windows/Ghostty.Tests/Profiles/Tracking/ActiveProcessDebouncerTests.cs
+++ b/windows/Ghostty.Tests/Profiles/Tracking/ActiveProcessDebouncerTests.cs
@@ -1,0 +1,77 @@
+using Ghostty.Core.Profiles.Tracking;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles.Tracking;
+
+public sealed class ActiveProcessDebouncerTests
+{
+    [Fact]
+    public void Observe_FirstValue_EmitsAfterWindow()
+    {
+        var d = new ActiveProcessDebouncer(windowMs: 250);
+        Assert.Null(d.Observe(rootPid: 100, exeBasename: "pwsh.exe", commandLine: null, nowMs: 0));
+
+        Assert.Equal("pwsh.exe", d.Observe(rootPid: 100, exeBasename: "pwsh.exe", commandLine: null, nowMs: 250)!.ExeBasename);
+    }
+
+    [Fact]
+    public void Observe_ChangeWithinWindow_RestartsTimer()
+    {
+        var d = new ActiveProcessDebouncer(windowMs: 250);
+        Assert.Null(d.Observe(100, "pwsh.exe", null, nowMs: 0));
+        // Flip to cmd at 100 ms - restarts the 250 ms window.
+        Assert.Null(d.Observe(100, "cmd.exe", null, nowMs: 100));
+        // At 200 ms (within new window from 100), still no emit.
+        Assert.Null(d.Observe(100, "cmd.exe", null, nowMs: 200));
+        // At 350 ms (>= 100 + 250), emit cmd.exe.
+        Assert.Equal("cmd.exe", d.Observe(100, "cmd.exe", null, nowMs: 350)!.ExeBasename);
+    }
+
+    [Fact]
+    public void Observe_FlipBackToOriginal_NoEmit()
+    {
+        var d = new ActiveProcessDebouncer(windowMs: 250);
+        // Bring pwsh up to emitted state at 250 ms.
+        Assert.Null(d.Observe(100, "pwsh.exe", null, nowMs: 0));
+        Assert.Equal("pwsh.exe", d.Observe(100, "pwsh.exe", null, nowMs: 250)!.ExeBasename);
+        // Flip to cmd at 300 ms.
+        Assert.Null(d.Observe(100, "cmd.exe", null, nowMs: 300));
+        // Flip back to pwsh at 400 ms (within window).
+        Assert.Null(d.Observe(100, "pwsh.exe", null, nowMs: 400));
+        // At 700 ms with stable pwsh, no emit (pwsh is already the emitted value).
+        Assert.Null(d.Observe(100, "pwsh.exe", null, nowMs: 700));
+    }
+
+    [Fact]
+    public void Observe_MultipleRoots_IndependentTimers()
+    {
+        var d = new ActiveProcessDebouncer(windowMs: 250);
+        Assert.Null(d.Observe(100, "pwsh.exe", null, nowMs: 0));
+        Assert.Null(d.Observe(200, "bash.exe", null, nowMs: 100));
+
+        Assert.Equal("pwsh.exe", d.Observe(100, "pwsh.exe", null, nowMs: 250)!.ExeBasename);
+        Assert.Equal("bash.exe", d.Observe(200, "bash.exe", null, nowMs: 350)!.ExeBasename);
+    }
+
+    [Fact]
+    public void Observe_NullToValue_EmitsAfterWindow()
+    {
+        // Going from "no foreground process" to a value should emit.
+        var d = new ActiveProcessDebouncer(windowMs: 250);
+        Assert.Null(d.Observe(100, exeBasename: null, commandLine: null, nowMs: 0));
+        Assert.Null(d.Observe(100, "vim.exe", null, nowMs: 100));
+        Assert.Equal("vim.exe", d.Observe(100, "vim.exe", null, nowMs: 350)!.ExeBasename);
+    }
+
+    [Fact]
+    public void Observe_ValueToNull_EmitsAfterWindow()
+    {
+        var d = new ActiveProcessDebouncer(windowMs: 250);
+        Assert.Null(d.Observe(100, "vim.exe", null, nowMs: 0));
+        Assert.Equal("vim.exe", d.Observe(100, "vim.exe", null, nowMs: 250)!.ExeBasename);
+        Assert.Null(d.Observe(100, null, null, nowMs: 300));
+        var emitted = d.Observe(100, null, null, nowMs: 550);
+        Assert.NotNull(emitted);
+        Assert.Null(emitted!.ExeBasename);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabIconViewModelTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabIconViewModelTests.cs
@@ -60,4 +60,66 @@ public sealed class TabIconViewModelTests
         Assert.True(vm.IsMdl2Glyph);
         Assert.Equal(0xE756, vm.Mdl2CodePoint);
     }
+
+    [Fact]
+    public void Construct_WithProfileIcon_ResolvedIconEqualsProfile()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("pwsh", null), "PowerShell");
+        Assert.IsType<IconSpec.BrandKey>(vm.Icon);
+        Assert.Equal("pwsh", ((IconSpec.BrandKey)vm.Icon).Key);
+    }
+
+    [Fact]
+    public void SetOverride_ChangesResolvedIcon()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("pwsh", null), "PowerShell");
+        vm.SetOverride(new IconSpec.BrandKey("ubuntu", null), "Ubuntu");
+
+        var brand = Assert.IsType<IconSpec.BrandKey>(vm.Icon);
+        Assert.Equal("ubuntu", brand.Key);
+        Assert.Equal("Ubuntu", vm.TooltipText);
+    }
+
+    [Fact]
+    public void RevertToProfile_RestoresProfileIcon()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("pwsh", null), "PowerShell");
+        vm.SetOverride(new IconSpec.BrandKey("ubuntu", null), "Ubuntu");
+        vm.RevertToProfile();
+
+        var brand = Assert.IsType<IconSpec.BrandKey>(vm.Icon);
+        Assert.Equal("pwsh", brand.Key);
+        Assert.Equal("PowerShell", vm.TooltipText);
+    }
+
+    [Fact]
+    public void SetIcon_UpdatesProfileSlot_NotOverride()
+    {
+        // SetIcon represents a profile snapshot change.
+        // If an override is active, the resolved Icon stays the override.
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("pwsh", null), "PowerShell");
+        vm.SetOverride(new IconSpec.BrandKey("ubuntu", null), "Ubuntu");
+        vm.SetIcon(new IconSpec.BrandKey("cmd", null), "Command Prompt");
+
+        var brand = Assert.IsType<IconSpec.BrandKey>(vm.Icon);
+        Assert.Equal("ubuntu", brand.Key);
+        Assert.Equal("Ubuntu", vm.TooltipText);
+
+        vm.RevertToProfile();
+        Assert.Equal("cmd", ((IconSpec.BrandKey)vm.Icon).Key);
+        Assert.Equal("Command Prompt", vm.TooltipText);
+    }
+
+    [Fact]
+    public void SetOverride_FiresPropertyChanged()
+    {
+        var vm = new TabIconViewModel(new IconSpec.BrandKey("pwsh", null), "PowerShell");
+        var raised = new System.Collections.Generic.List<string?>();
+        ((System.ComponentModel.INotifyPropertyChanged)vm).PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.SetOverride(new IconSpec.BrandKey("ubuntu", null), "Ubuntu");
+
+        Assert.Contains(nameof(TabIconViewModel.Icon), raised);
+        Assert.Contains(nameof(TabIconViewModel.TooltipText), raised);
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/TabModelTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabModelTests.cs
@@ -1,0 +1,65 @@
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class TabModelTests
+{
+    [Fact]
+    public void OnActiveProcessChanged_UnknownExe_RevertsToProfile()
+    {
+        var tab = MakeTab(profileIcon: new IconSpec.BrandKey("pwsh", null), profileTooltip: "PowerShell");
+        tab.OnActiveProcessChanged("never-shipped.exe", commandLine: null);
+
+        Assert.Equal("pwsh", ((IconSpec.BrandKey)tab.TabIcon.Icon).Key);
+    }
+
+    [Fact]
+    public void OnActiveProcessChanged_KnownExe_AppliesOverride()
+    {
+        var tab = MakeTab(profileIcon: new IconSpec.BrandKey("pwsh", null), profileTooltip: "PowerShell");
+        tab.OnActiveProcessChanged("vim.exe", commandLine: null);
+
+        var brand = Assert.IsType<IconSpec.BrandKey>(tab.TabIcon.Icon);
+        Assert.Equal("vim", brand.Key);
+        Assert.Equal("vim", tab.TabIcon.TooltipText);
+    }
+
+    [Fact]
+    public void OnActiveProcessChanged_NullExe_RevertsToProfile()
+    {
+        var tab = MakeTab(profileIcon: new IconSpec.BrandKey("pwsh", null), profileTooltip: "PowerShell");
+        tab.OnActiveProcessChanged("vim.exe", commandLine: null);
+        tab.OnActiveProcessChanged(null, commandLine: null);
+
+        Assert.Equal("pwsh", ((IconSpec.BrandKey)tab.TabIcon.Icon).Key);
+        Assert.Equal("PowerShell", tab.TabIcon.TooltipText);
+    }
+
+    [Fact]
+    public void OnActiveProcessChanged_ToProfileExe_SuppressesOverride()
+    {
+        // When the active process IS the profile's launch shell, no override.
+        var tab = MakeTab(profileIcon: new IconSpec.BrandKey("pwsh", null), profileTooltip: "PowerShell");
+        tab.OnActiveProcessChanged("pwsh.exe", commandLine: null);
+
+        var brand = Assert.IsType<IconSpec.BrandKey>(tab.TabIcon.Icon);
+        Assert.Equal("pwsh", brand.Key);
+        Assert.Equal("PowerShell", tab.TabIcon.TooltipText);
+    }
+
+    private static TabModel MakeTab(IconSpec profileIcon, string profileTooltip)
+    {
+        var tab = new TabModel(new FakePaneHost());
+        var snapshot = ProfileSnapshotStore.From(
+            new ResolvedProfile(
+                Id: "test", Name: profileTooltip, Command: "cmd.exe",
+                WorkingDirectory: null, Icon: profileIcon,
+                TabTitle: profileTooltip, Visuals: EffectiveVisualOverrides.Empty,
+                ProbeId: null, OrderIndex: 0, IsDefault: true),
+            version: 1);
+        tab.AttachProfileSnapshot(snapshot);
+        return tab;
+    }
+}


### PR DESCRIPTION
## Summary
- TabIconViewModel gains a separate override slot. Resolved Icon = override ?? profile; resolved TooltipText similarly. SetOverride / RevertToProfile, all on Core (no platform deps).
- TabModel.OnActiveProcessChanged(exeBasename, commandLine) routes through ProcessIconTable.TryMap and installs / clears the override. When the mapped spec equals the profile spec, the override is suppressed so steady-state-at-prompt produces zero churn.
- ActiveProcessDebouncer (pure logic, fake-clock-tested): 250 ms stability window collapses rapid command-line churn.

IMPORTANT: stacked on top of #408 (2/4). Merge order: ... #408 ... then this PR.

## Test plan
- [x] TabIconViewModelTests: 10/10 (5 pre-existing + 5 new).
- [x] TabModelTests: 4 new OnActiveProcessChanged tests alongside the existing tests.
- [x] ActiveProcessDebouncerTests: 6/6.
- [x] Full suite 972 passed / 0 failed / 1 pre-existing skip.