### PR TITLE
fix(windows): wire quit-after-last-window-closed end-to-end

### DIFF
--- a/scripts/validate-transport-run-all.ps1
+++ b/scripts/validate-transport-run-all.ps1
@@ -8,7 +8,10 @@
     and exits non-zero if any row failed or timed out.
 #>
 param(
-    [int]$TimeoutMs = 15000
+    # Per-row timeout when omitted: defers to the table in
+    # scripts/validate-transport-run.ps1 (20s for fast rows, 45s for
+    # pwsh-never). Pass an explicit value to override every row uniformly.
+    [int]$TimeoutMs = -1
 )
 $ErrorActionPreference = 'Stop'
 
@@ -17,7 +20,11 @@ $results = [ordered]@{}
 
 foreach ($r in $rows) {
     Write-Host "===== $r ====="
-    pwsh -NoProfile -File scripts/validate-transport-run.ps1 -Row $r -TimeoutMs $TimeoutMs
+    if ($TimeoutMs -ge 0) {
+        pwsh -NoProfile -File scripts/validate-transport-run.ps1 -Row $r -TimeoutMs $TimeoutMs
+    } else {
+        pwsh -NoProfile -File scripts/validate-transport-run.ps1 -Row $r
+    }
     $results[$r] = switch ($LASTEXITCODE) {
         0 { 'pass' }
         1 { 'fail' }

--- a/scripts/validate-transport-run.ps1
+++ b/scripts/validate-transport-run.ps1
@@ -25,17 +25,44 @@
     One of: pwsh-auto, pwsh-always, pwsh-never, cmd-auto.
 
 .PARAMETER TimeoutMs
-    Safety timeout. Defaults to 10000 (10 seconds).
+    Safety timeout. When omitted, picks a per-row default: 20 s for
+    cmd and bypass-mode pwsh (Debug Wintty cold-start dominates here,
+    ~10-15 s on a typical dev box; child-shell exit and teardown add
+    only a few hundred ms on top), 45 s for pwsh-never. The
+    pwsh-never row force-routes pwsh through full ConPTY init,
+    which combined with pwsh.exe cold-start JIT pushes the total to
+    20-25 s in Debug builds, so we leave generous headroom for
+    contended machines. Passing -TimeoutMs explicitly overrides the
+    table for every row. The runner's job is to detect true hangs
+    (PaneHost teardown wedged on a callback, libghostty subprocess
+    never reporting exit, etc.), not to police Debug-build cold-start
+    speed, so the floor is set well above expected p99.
 
 .PARAMETER ExePath
     Path to the built Wintty.exe. Defaults to the Debug x64 output.
 #>
 param(
     [Parameter(Mandatory)][string]$Row,
-    [int]$TimeoutMs = 10000,
+    [int]$TimeoutMs = -1,
     [string]$ExePath = './windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe'
 )
 $ErrorActionPreference = 'Stop'
+
+# Per-row default timeouts. Source of truth, shared with the all-runner
+# which simply omits -TimeoutMs so these kick in.
+$RowDefaultTimeouts = @{
+    'cmd-auto'    = 20000
+    'pwsh-auto'   = 20000
+    'pwsh-always' = 20000
+    'pwsh-never'  = 45000
+}
+if ($TimeoutMs -lt 0) {
+    if ($RowDefaultTimeouts.ContainsKey($Row)) {
+        $TimeoutMs = $RowDefaultTimeouts[$Row]
+    } else {
+        $TimeoutMs = 10000
+    }
+}
 
 $fixturePath = "dev-configs/validate-transport/$Row.conf"
 if (-not (Test-Path $fixturePath)) {

--- a/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
@@ -34,6 +34,14 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
 
     private long _droppedCount;
 
+    // 0 = live, 1 = disposed. Guarded via Interlocked so Dispose and
+    // DisposeAsync can be invoked in any order or concurrently without
+    // double-completing the channel or double-disposing _cts. Both paths
+    // run during normal shutdown: App.OnAnyWindowClosedInternal calls
+    // DisposeAsync explicitly, then LoggerFactory.Dispose later calls
+    // Dispose() on every registered provider.
+    private int _disposed;
+
     // Reused across FormatRecord calls on the single writer task. Not
     // thread-safe, which is fine: only WriterLoopAsync touches it.
     // Caching it removes the per-record StringBuilder allocation the
@@ -88,10 +96,43 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         return false;
     }
 
-    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+    // Process shutdown calls Dispose() (sync) via LoggerFactory.Dispose;
+    // app teardown also calls DisposeAsync() directly. Both must drain
+    // the channel and dispose the underlying FileStream before returning,
+    // otherwise records emitted in the last few hundred ms of the
+    // process lifetime never reach disk. The synchronous path uses
+    // Task.Wait rather than sync-over-async so it cannot deadlock under
+    // a UI SynchronizationContext, and avoids the ValueTask -> Task
+    // allocation on the hot shutdown path.
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
+        _writer.TryComplete();
+        try
+        {
+            if (!_writerTask.Wait(TimeSpan.FromSeconds(2)))
+            {
+                // Writer stuck (e.g. disk hung); cancel and let it unwind
+                // so the CTS Dispose below doesn't race a still-propagating
+                // OperationCanceledException. The inner catch handles the
+                // expected OperationCanceledException-wrapped-in-
+                // AggregateException case; the outer catch below only
+                // fires on a genuine writer fault from the initial Wait,
+                // before we ever asked the writer to cancel.
+                _cts.Cancel();
+                try { _writerTask.Wait(); }
+                catch { /* expected: cancellation propagating out */ }
+            }
+        }
+        catch (AggregateException) { /* writer faulted before timeout; nothing useful we can do here */ }
+        _cts.Dispose();
+    }
 
     public async ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
         _writer.TryComplete();
         try
         {
@@ -99,12 +140,11 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         }
         catch (TimeoutException)
         {
-            // Writer stuck; force-cancel and wait for unwind so _cts.Dispose()
-            // below doesn't race the still-propagating OperationCanceledException.
             _cts.Cancel();
             try { await _writerTask.ConfigureAwait(false); }
             catch { /* expected OperationCanceledException */ }
         }
+        catch { /* writer faulted; nothing useful we can do here */ }
         _cts.Dispose();
     }
 
@@ -235,6 +275,30 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         catch (OperationCanceledException) { /* shutdown */ }
         finally
         {
+            // Force the OS write cache to commit before releasing the
+            // handle. Without this, FileStream.Dispose returns once the
+            // managed buffer is in the OS cache, but the OS may take
+            // hundreds of ms to push to disk. Cross-process readers that
+            // open the file the instant Wintty.exe exits (validate-
+            // transport smoke runner, third-party log tailers) then see
+            // a truncated view. Flush(true) calls FlushFileBuffers on
+            // Windows which is synchronous and forces commit. We only
+            // pay it once per writer-task lifetime so the cost is
+            // negligible compared to the per-batch Flush() that already
+            // runs in the steady-state loop.
+            // Cast guard: IFileSystem.OpenAppend's return type is the
+            // base Stream so test fakes can plug in MemoryStream, but
+            // the production RealFileSystem hands back a FileStream
+            // whose Flush(bool) overload calls FlushFileBuffers when
+            // flushToDisk=true. Fall back to the parameterless Flush
+            // for fakes; in-memory writes are already disk-equivalent
+            // for them.
+            try
+            {
+                if (stream is FileStream fs) fs.Flush(flushToDisk: true);
+                else stream?.Flush();
+            }
+            catch (IOException) { /* drop */ }
             stream?.Dispose();
             ArrayPool<byte>.Shared.Return(buffer);
         }

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -230,7 +230,19 @@ internal sealed class TabManager
         // without needing a shared dictionary.
         EventHandler<TabProgressState> progressHandler = (_, state) => tab.Progress = state;
         host.ProgressChanged += progressHandler;
-        tab.OnClose = () => host.ProgressChanged -= progressHandler;
+        // Bridge "the last leaf in this tab closed" (e.g. the only shell
+        // in this tab exited via `exit`, or libghostty's close-surface
+        // callback fired for the sole pane) into a tab-level close. The
+        // window-close → quit-after-last-window-closed chain relies on
+        // CloseTab firing, which won't happen on its own when the close
+        // originates from the surface rather than from a manager call.
+        EventHandler lastLeafHandler = (_, _) => CloseTab(tab);
+        host.LastLeafClosed += lastLeafHandler;
+        tab.OnClose = () =>
+        {
+            host.ProgressChanged -= progressHandler;
+            host.LastLeafClosed -= lastLeafHandler;
+        };
         tab.PropertyChanged += OnTabPropertyChanged;
         return tab;
     }
@@ -340,29 +352,41 @@ internal sealed class TabManager
         tab.PaneHost.LeafFocused += OnLeafFocused;
         EventHandler<TabProgressState> progressHandler = (_, state) => tab.Progress = state;
         tab.PaneHost.ProgressChanged += progressHandler;
+        // Re-attach the last-leaf-closed bridge in the adopter's event
+        // graph. See CreateTab for why the bridge exists; without it,
+        // a tab detached to a new window would no longer close that
+        // window when its shell exits.
+        EventHandler lastLeafHandler = (_, _) => CloseTab(tab);
+        tab.PaneHost.LastLeafClosed += lastLeafHandler;
         // OnClose stores the unsubscribe action so DetachTab /
-        // CloseTab can walk back the progress wiring without needing
-        // to re-capture the handler delegate.
-        tab.OnClose = () => tab.PaneHost.ProgressChanged -= progressHandler;
+        // CloseTab can walk back both wirings without needing to
+        // re-capture the handler delegates.
+        tab.OnClose = () =>
+        {
+            tab.PaneHost.ProgressChanged -= progressHandler;
+            tab.PaneHost.LastLeafClosed -= lastLeafHandler;
+        };
         tab.PropertyChanged += OnTabPropertyChanged;
     }
 
     /// <summary>
-    /// Walk back the progress-forwarder subscription installed by
-    /// <see cref="CreateTab"/> or <see cref="WireAdoptedTab"/>. Shared
+    /// Walk back the per-tab subscriptions installed by
+    /// <see cref="CreateTab"/> or <see cref="WireAdoptedTab"/>: today
+    /// the progress forwarder and the last-leaf-closed bridge. Shared
     /// between <see cref="CloseTab"/> and <see cref="DetachTab"/> so
-    /// neither path has to spell out "invoke OnClose and null it";
-    /// in particular, <see cref="DetachTab"/> must NOT invoke OnClose
-    /// (per spec) because OnClose is the close-signal hook,
-    /// not the detach hook.
+    /// neither path has to spell out "invoke OnClose and null it"; in
+    /// particular, <see cref="DetachTab"/> must NOT touch OnClose itself
+    /// because the adopter overwrites it in <see cref="WireAdoptedTab"/>.
     /// </summary>
     private void UnsubscribeProgressForwarder(TabModel tab)
     {
-        // OnClose is the unsubscribe action. Running it detaches the
-        // progress handler from PaneHost.ProgressChanged. On DetachTab
-        // we run this helper instead of tab.OnClose?.Invoke() at the
-        // call site so the semantics are obvious: we are dismantling
-        // ONE specific subscription, not running the full close.
+        // Name is historical; OnClose now also unhooks LastLeafClosed.
+        // OnClose is the aggregated unsubscribe action; running it
+        // detaches every handler this manager attached to the pane
+        // host. On DetachTab we go through this helper rather than
+        // tab.OnClose?.Invoke() at the call site so the semantics
+        // stay obvious: this is the per-tab teardown, not the full
+        // close sequence.
         tab.OnClose?.Invoke();
     }
 }

--- a/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
+++ b/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
@@ -105,6 +105,80 @@ public class FileLoggerProviderTests : IDisposable
     }
 
     [Fact]
+    public void Dispose_FlushesSingleVerdictRecord_WrittenJustBeforeDispose()
+    {
+        // Regression: smoke runner spawns Wintty with a one-shot shell
+        // (cmd.exe /c exit). Zig writes one "transport resolved:" line,
+        // then the shell exits and the WinUI shell calls Dispose() within
+        // ~200ms. Without a flush-on-Dispose contract the verdict line
+        // can sit unwritten on the bounded channel when the file handle
+        // is released; the assertion script then fails with "no verdict
+        // line in ghostty-YYYYMMDD.log".
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
+        var sink = new FileLoggerProvider(NewOptions(_tempDir), clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("Ghostty.Zig.validate_transport");
+
+        logger.LogInformation(
+            new EventId(1, "Verdict"),
+            "transport resolved: shell=\"cmd.exe\" config_mode=auto resolved=conpty");
+
+        // No drain wait: dispose immediately so the test fails unless
+        // Dispose synchronously drains the channel and flushes the stream.
+        sink.Dispose();
+
+        var body = ReadAllTextShared(Path.Combine(_tempDir, "ghostty-20260417.log"));
+        Assert.Contains("transport resolved:", body);
+        Assert.Contains("resolved=conpty", body);
+    }
+
+    [Fact]
+    public void Dispose_DrainsBurst_BeforeReleasingHandle()
+    {
+        // Heavier variant: many records produced back-to-back, dispose
+        // called immediately. If Dispose returns before the writer
+        // task has processed the queue, the late records are lost.
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
+        var sink = new FileLoggerProvider(NewOptions(_tempDir), clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("Burst");
+
+        const int count = 500;
+        for (int i = 0; i < count; i++)
+            logger.LogInformation(new EventId(i, "E"), "record-{Index}", i);
+
+        sink.Dispose();
+
+        var body = ReadAllTextShared(Path.Combine(_tempDir, "ghostty-20260417.log"));
+        // Count "record-" occurrences rather than asserting a specific
+        // index: BoundedChannel + DropOldest may discard records under
+        // burst, but every successfully-enqueued record must reach disk.
+        var lines = body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.True(lines.Length >= 1, $"expected at least one record on disk, got {lines.Length}");
+        Assert.Contains($"record-{count - 1}\n", body); // last record must land
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent_WhenInvokedByBothExplicitAndFactoryPath()
+    {
+        // App.OnAnyWindowClosedInternal calls DisposeAsync explicitly,
+        // then LoggerFactory.Dispose (via AddProvider registration)
+        // calls Dispose on the same instance. Both paths must succeed
+        // without throwing and without corrupting state on the second
+        // invocation.
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
+        var sink = new FileLoggerProvider(NewOptions(_tempDir), clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("Idem");
+
+        logger.LogInformation(new EventId(1, "E"), "single-line");
+
+        sink.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        sink.Dispose(); // second teardown via LoggerFactory.Dispose path
+        sink.Dispose(); // tolerate a third pass too
+
+        var body = ReadAllTextShared(Path.Combine(_tempDir, "ghostty-20260417.log"));
+        Assert.Contains("single-line", body);
+    }
+
+    [Fact]
     public void RetentionSweep_DeletesFilesOlderThanCutoff_OnConstruction()
     {
         // Today = 2026-04-17. Retention 14 days => cutoff 2026-04-03.

--- a/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
+++ b/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
@@ -56,4 +56,17 @@ internal sealed class FakePaneHost : IPaneHost
 
     public void SetPaneCount(int n) => PaneCount = n;
     public void RaiseLeafFocused() => LeafFocused?.Invoke(this, ActiveLeaf);
+
+    /// <summary>
+    /// Raise <see cref="LastLeafClosed"/> directly, without going
+    /// through <see cref="CloseActive"/>. Mirrors what the real
+    /// <c>PaneHost.CloseLeaf</c> does when the surface's child
+    /// process exits (libghostty fires close-surface → the C# side
+    /// raises LastLeafClosed inside <c>CloseLeaf</c>).
+    /// </summary>
+    public void RaiseLastLeafClosed()
+    {
+        PaneCount = 0;
+        LastLeafClosed?.Invoke(this, EventArgs.Empty);
+    }
 }

--- a/windows/Ghostty.Tests/Tabs/TabManagerTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerTests.cs
@@ -169,4 +169,83 @@ public class TabManagerTests
         mgr.Activate(mgr.ActiveTab);
         Assert.Equal(0, count);
     }
+
+    // Regression: PaneHost.LastLeafClosed must drive a tab close. When
+    // the shell auto-exits (cmd /c exit under quit-after-last-window-
+    // closed), libghostty's close-surface callback raises this event
+    // and TabManager owns the bridge into CloseTab. Without the bridge
+    // the tab leaks, the window stays open, and validate-transport-
+    // smoke times out instead of exiting cleanly.
+    [Fact]
+    public void PaneHost_LastLeafClosed_closes_the_owning_tab()
+    {
+        var mgr = NewManager(out var hosts);
+        mgr.NewTab(); // 2 tabs; close the first via its pane host
+        var first = mgr.Tabs[0];
+        TabModel? removed = null;
+        mgr.TabRemoved += (_, t) => removed = t;
+
+        hosts[0].RaiseLastLeafClosed();
+
+        Assert.Single(mgr.Tabs);
+        Assert.Same(first, removed);
+    }
+
+    [Fact]
+    public void PaneHost_LastLeafClosed_on_only_tab_raises_LastTabClosed()
+    {
+        var mgr = NewManager(out var hosts);
+        bool fired = false;
+        mgr.LastTabClosed += (_, _) => fired = true;
+
+        hosts[0].RaiseLastLeafClosed();
+
+        Assert.Empty(mgr.Tabs);
+        Assert.True(fired);
+    }
+
+    // After DetachTab the source manager must stop reacting to the
+    // detached tab's pane-host events: the adopter owns the lifecycle.
+    [Fact]
+    public void DetachTab_unwires_LastLeafClosed_bridge_on_source()
+    {
+        var mgr = NewManager(out var hosts);
+        mgr.NewTab(); // need >=2 tabs so DetachTab is legal
+        var detached = mgr.DetachTab(mgr.Tabs[0]);
+        int removedCount = 0;
+        mgr.TabRemoved += (_, _) => removedCount++;
+
+        // Fire on the now-orphaned pane host. The source manager must
+        // not touch its tab list in response.
+        hosts[0].RaiseLastLeafClosed();
+
+        Assert.Equal(0, removedCount);
+        Assert.Single(mgr.Tabs);
+        Assert.NotNull(detached);
+    }
+
+    // The adopter must take over the bridge so a tab moved to a new
+    // window still closes its tab when the shell exits.
+    [Fact]
+    public void AdoptTab_wires_LastLeafClosed_bridge_on_adopter()
+    {
+        var source = NewManager(out var sourceHosts);
+        source.NewTab(); // 2 tabs in source
+        var detached = source.DetachTab(source.Tabs[0]);
+
+        var adopter = NewManager(out _);
+        adopter.AdoptTab(detached);
+        // adopter has its own seed tab plus the adopted one.
+        Assert.Equal(2, adopter.Tabs.Count);
+
+        TabModel? removed = null;
+        adopter.TabRemoved += (_, t) => removed = t;
+
+        // sourceHosts[0] is the detached tab's pane host; raising
+        // LastLeafClosed on it must remove the tab from the adopter.
+        sourceHosts[0].RaiseLastLeafClosed();
+
+        Assert.Same(detached, removed);
+        Assert.Single(adopter.Tabs);
+    }
 }

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -120,8 +120,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         => ProgressChanged?.Invoke(this, state);
 
     /// <summary>
-    /// Raised when the last leaf in the tree closes. Subscribers should
-    /// close the window.
+    /// Raised when the last leaf in the tree closes. The owning
+    /// <c>TabManager</c> subscribes and routes to
+    /// <c>TabManager.CloseTab</c>; window-close then cascades via
+    /// <c>LastTabClosed</c> when this was the last tab.
     /// </summary>
     public event EventHandler? LastLeafClosed;
 
@@ -423,7 +425,9 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         {
             // Last leaf - flag the host so DisposeAllLeaves on window
             // close skips iterating a tree whose only node is already
-            // disposed, and tell MainWindow to close the window.
+            // disposed, and tell TabManager to close this tab. Window
+            // close then cascades through TabManager.LastTabClosed to
+            // MainWindow.Close when this was the only tab.
             _allLeavesClosed = true;
             LastLeafClosed?.Invoke(this, EventArgs.Empty);
             return;


### PR DESCRIPTION
## Summary

- `PaneHost.LastLeafClosed` had no production subscriber: the smoke runner papered over it with a timeout-and-kill workaround that was later removed under the assumption a sibling termio fix had closed the loop, but the C# bridge was never built. `cmd.exe /c exit` (and any other auto-exit shell) left Wintty alive past child exit. Wired `TabManager.CreateTab` and `WireAdoptedTab` to subscribe to `LastLeafClosed` and route to `CloseTab(tab)`; unhook through `tab.OnClose` so close and detach paths walk it back uniformly.
- `FileLoggerProvider.Dispose` was sync-over-async on a UI SynchronizationContext, and the writer loop released the `FileStream` handle without forcing the OS write cache. Cross-process readers opening the log the instant Wintty exited saw a truncated view. Rewrote `Dispose` to `Task.Wait` directly, added an `Interlocked.Exchange` idempotency guard for the explicit `DisposeAsync` + `LoggerFactory.Dispose` double-call path, and `Flush(flushToDisk: true)` the stream before close.
- `validate-transport-run.ps1` 10 s timeout was tight for cmd-auto and the bypass-pwsh rows (Debug cold-start ~10-15 s) and impossibly tight for pwsh-never (ConPTY + pwsh JIT ~20-25 s). Replaced with a per-row defaults table.

## Test plan

- [x] `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj /p:Platform=x64` - 898 pass, 1 pre-existing skip
- [x] New regression coverage: `TabManagerTests.PaneHost_LastLeafClosed_*` (4 tests), `FileLoggerProviderTests.Dispose_*` (3 tests)
- [x] `pwsh -NoProfile -File scripts/validate-transport-run.ps1 -Row cmd-auto` from a clean shell - app exits with code 0, assertion passes
- [ ] Operator verification of remaining rows in a clean shell (Claude shell hits known MSYS2-pty interference per memory)

## Notes for reviewer

The pwsh-auto and pwsh-never assertion-content failures the runner now reports (wrong transport / OSC 11 leak under ConPTY) are pre-existing Zig-side bugs surfaced by the now-working infra, not regressions from this change.