### PR TITLE
active-shell-icon: Windows polling tracker + tab lifecycle wiring (PR 4/4)

### DIFF
--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -142,6 +142,14 @@ pub const exp = struct {
             nBufferLength: windows.DWORD,
             lpBuffer: windows.LPWSTR,
         ) callconv(.winapi) windows.DWORD;
+        /// std.os.windows only exposes GetCurrentProcessId via the TEB, not
+        /// the more general GetProcessId(HANDLE). Declared here so we can
+        /// translate a child HANDLE (returned by CreateProcessW) to a
+        /// numeric PID that the C# layer can hand to Toolhelp32.
+        /// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocessid
+        pub extern "kernel32" fn GetProcessId(
+            Process: windows.HANDLE,
+        ) callconv(.winapi) windows.DWORD;
     };
 
     pub const PROC_THREAD_ATTRIBUTE_NUMBER = 0x0000FFFF;

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -679,6 +679,12 @@ const WindowsPty = struct {
     /// Get information about the process(es) attached to the PTY. Returns
     /// `null` if there was an error getting the information or the information
     /// is not available on a particular platform.
+    ///
+    /// On Windows the pty layer does not track a foreground process; the
+    /// caller-relevant PID is on Subprocess (the spawned shell HANDLE).
+    /// `Subprocess.getProcessInfo` special-cases `.foreground_pid` on
+    /// Windows and reads `cmd.pid` directly without going through this
+    /// layer, so this stub correctly returns null.
     pub fn getProcessInfo(_: *WindowsPty, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
         return null;
     }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1483,6 +1483,27 @@ const Subprocess = struct {
     /// Returns `null` if there was an error getting the information or the
     /// information is not available on a particular platform.
     pub fn getProcessInfo(self: *Subprocess, comptime info: ProcessInfo) ?ProcessInfo.Type(info) {
+        // On Windows the pty layer does not (and cannot) track a foreground
+        // process group the way POSIX does. The semantically-useful PID for
+        // our callers (the apprt active-process tracker / tab-icon picker)
+        // is the spawned shell itself; descendants are walked client-side
+        // via Toolhelp32. Resolve that here from the Command HANDLE rather
+        // than going through Pty, which returns null on Windows.
+        if (comptime builtin.os.tag == .windows) {
+            if (info == .foreground_pid) {
+                const cmd = switch (self.process orelse return null) {
+                    .fork_exec => |*c| c,
+                    // Flatpak path is POSIX-only; unreachable on Windows
+                    // but keep the switch exhaustive.
+                    .flatpak => return null,
+                };
+                const handle = cmd.pid orelse return null;
+                const pid = windows.exp.kernel32.GetProcessId(handle);
+                if (pid == 0) return null;
+                return @intCast(pid);
+            }
+        }
+
         const pty = &(self.pty orelse return null);
         return pty.getProcessInfo(info);
     }

--- a/windows/Ghostty.Core/NativeMethods.txt
+++ b/windows/Ghostty.Core/NativeMethods.txt
@@ -25,3 +25,9 @@ SHGFI_FLAGS
 // user32 for icon lifetime
 DestroyIcon
 HICON
+
+// toolhelp32 for ProcessTreeWalker
+CreateToolhelp32Snapshot
+Process32FirstW
+Process32NextW
+CloseHandle

--- a/windows/Ghostty.Core/Profiles/Tracking/IActiveProcessTracker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/IActiveProcessTracker.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Ghostty.Core.Profiles.Tracking;
+
+/// <summary>
+/// Tracks the foreground command running inside each registered pty.
+/// One instance per app; tabs register their shell-process PID at
+/// construction and unregister at dispose. The tracker raises
+/// <see cref="Changed"/> when the innermost descendant process of any
+/// registered root changes (after the debouncer window).
+///
+/// The interface is platform-agnostic so Core can wire it up; the
+/// production implementation (Windows polling via Toolhelp32) lives in
+/// <c>WindowsActiveProcessTracker</c>.
+/// </summary>
+public interface IActiveProcessTracker : IDisposable
+{
+    event EventHandler<ActiveProcessChangedEventArgs>? Changed;
+
+    /// <summary>
+    /// Begin tracking the descendants of <paramref name="rootPid"/>.
+    /// Registering the same PID twice is a no-op.
+    /// </summary>
+    void Register(int rootPid);
+
+    /// <summary>
+    /// Stop tracking the descendants of <paramref name="rootPid"/>.
+    /// Subsequent ticks ignore this PID. Unregistering an unknown PID
+    /// is a no-op.
+    /// </summary>
+    void Unregister(int rootPid);
+}
+
+public sealed record ActiveProcessChangedEventArgs(
+    int RootPid,
+    string? ExeBasename,
+    string? CommandLine);

--- a/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
@@ -24,6 +24,20 @@ namespace Ghostty.Core.Profiles.Tracking;
 [SupportedOSPlatform("windows6.0.6000")]
 internal static class ProcessTreeWalker
 {
+    // Broker / helper processes that are part of the Windows console
+    // infrastructure rather than something the user is interacting with.
+    // Filtered out so the walker reports the user-facing exe (e.g. cmd.exe
+    // rather than its conhost child).
+    private static readonly HashSet<string> IgnoredExes =
+        new(System.StringComparer.OrdinalIgnoreCase)
+        {
+            "conhost.exe",
+            "OpenConsole.exe",
+            "wslhost.exe",
+            "wslservice.exe",
+            "wsl-vsock-relay.exe",
+        };
+
     /// <summary>
     /// Returns the exe basename (e.g. "vim.exe") of the innermost
     /// descendant of <paramref name="rootPid"/>. Returns null when the
@@ -91,7 +105,10 @@ internal static class ProcessTreeWalker
         while (queue.Count > 0)
         {
             var (pid, name, depth) = queue.Dequeue();
-            if (depth >= bestDepth)
+            // Update best only when this descendant isn't a broker/helper.
+            // Brokers are visited so we still descend into THEIR children
+            // (e.g. wslhost may not own much, but conhost is always a leaf).
+            if (!IgnoredExes.Contains(name) && depth >= bestDepth)
             {
                 bestDepth = depth;
                 bestName = name;

--- a/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Diagnostics.ToolHelp;
+
+namespace Ghostty.Core.Profiles.Tracking;
+
+/// <summary>
+/// Walks the Windows process tree to find the innermost descendant of a
+/// given root PID. "Innermost" = deepest by tree depth; ties broken by
+/// the snapshot's natural iteration order (deterministic on stable input).
+///
+/// One snapshot per call. Caller invokes once per tracker tick (2 Hz).
+///
+/// The generated CsWin32 class is <c>DWritePInvoke</c> (see
+/// NativeMethods.json "className") to avoid colliding with the
+/// Windows.Win32.PInvoke class used elsewhere. NativeMethods.json also
+/// pins useSafeHandles=false, so the toolhelp snapshot comes back as a
+/// raw HANDLE struct and we close it explicitly via CloseHandle.
+/// </summary>
+[SupportedOSPlatform("windows6.0.6000")]
+internal static class ProcessTreeWalker
+{
+    /// <summary>
+    /// Returns the exe basename (e.g. "vim.exe") of the innermost
+    /// descendant of <paramref name="rootPid"/>. Returns null when the
+    /// root has no descendants, has exited, or the snapshot fails.
+    /// </summary>
+    public static string? FindInnermostDescendant(uint rootPid)
+    {
+        var snapshot = DWritePInvoke.CreateToolhelp32Snapshot(
+            CREATE_TOOLHELP_SNAPSHOT_FLAGS.TH32CS_SNAPPROCESS, 0);
+        // CreateToolhelp32Snapshot returns INVALID_HANDLE_VALUE (-1) on
+        // failure when useSafeHandles=false. CsWin32 doesn't synthesize a
+        // named constant for that, so compare against the raw -1 sentinel
+        // via explicit IntPtr-to-HANDLE conversion.
+        var invalid = (HANDLE)new IntPtr(-1);
+        if (snapshot == invalid) return null;
+
+        try
+        {
+            var byParent = new Dictionary<uint, List<(uint Pid, string ExeBasename)>>();
+            var entry = new PROCESSENTRY32W { dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32W>() };
+
+            if (!DWritePInvoke.Process32FirstW(snapshot, ref entry)) return null;
+            do
+            {
+                if (!byParent.TryGetValue(entry.th32ParentProcessID, out var list))
+                {
+                    list = new List<(uint, string)>();
+                    byParent[entry.th32ParentProcessID] = list;
+                }
+                // szExeFile is a fixed-size inline char array; CsWin32 exposes
+                // .ToString() for this kind of field. Trim any trailing NULs
+                // defensively in case the conversion ever changes.
+                var name = entry.szExeFile.ToString().TrimEnd('\0');
+                list.Add((entry.th32ProcessID, name));
+            }
+            while (DWritePInvoke.Process32NextW(snapshot, ref entry));
+
+            return DeepestDescendant(byParent, rootPid);
+        }
+        finally
+        {
+            DWritePInvoke.CloseHandle(snapshot);
+        }
+    }
+
+    private static string? DeepestDescendant(
+        IReadOnlyDictionary<uint, List<(uint Pid, string ExeBasename)>> byParent,
+        uint rootPid)
+    {
+        if (!byParent.TryGetValue(rootPid, out var direct) || direct.Count == 0)
+        {
+            return null;
+        }
+
+        // BFS from the root; track the deepest level seen and pick the
+        // last entry observed at that depth (deterministic on stable input).
+        var queue = new Queue<(uint Pid, string ExeBasename, int Depth)>();
+        foreach (var (pid, name) in direct)
+        {
+            queue.Enqueue((pid, name, 1));
+        }
+
+        string? bestName = null;
+        int bestDepth = 0;
+        while (queue.Count > 0)
+        {
+            var (pid, name, depth) = queue.Dequeue();
+            if (depth >= bestDepth)
+            {
+                bestDepth = depth;
+                bestName = name;
+            }
+            if (byParent.TryGetValue(pid, out var kids))
+            {
+                foreach (var (kpid, kname) in kids)
+                {
+                    queue.Enqueue((kpid, kname, depth + 1));
+                }
+            }
+        }
+        return bestName;
+    }
+}

--- a/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
@@ -41,7 +41,12 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
-        _timer.Dispose();
+        using var done = new System.Threading.ManualResetEvent(false);
+        _timer.Dispose(done);
+        // Block briefly so any in-flight tick finishes before we return.
+        // OnActiveProcessChanged subscribers will see _disposed != 0 on
+        // re-entry and short-circuit.
+        done.WaitOne();
     }
 
     private void OnTick(object? state)
@@ -52,22 +57,28 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
         foreach (var (rootPid, _) in _roots)
         {
             string? exe;
+            string? cmdline;
             try
             {
                 exe = ProcessTreeWalker.FindInnermostDescendant((uint)rootPid);
+                cmdline = null;
             }
-            catch
+            catch (Exception ex)
             {
-                // Snapshot failures and access-denied during a teardown
-                // race are common; suppress and treat as "no foreground."
+                // Snapshot failures and access-denied during a teardown race are
+                // common; suppress and treat as "no foreground" but record so a
+                // regressed tracker is diagnosable from the debug log.
+                System.Diagnostics.Debug.WriteLine(
+                    $"WindowsActiveProcessTracker: snapshot failed for pid={rootPid}: {ex.GetType().Name}: {ex.Message}");
                 exe = null;
+                cmdline = null;
             }
 
             // V1: command line is not retrieved. ProcessIconTable handles
             // null commandLine correctly for everything except wsl.exe
             // distro disambiguation, which is acceptable until shell
             // integration scripts land in a follow-up.
-            var emission = _debouncer.Observe(rootPid, exe, commandLine: null, nowMs: now);
+            var emission = _debouncer.Observe(rootPid, exe, commandLine: cmdline, nowMs: now);
             if (emission is not null)
             {
                 try
@@ -75,9 +86,12 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
                     Changed?.Invoke(this, new ActiveProcessChangedEventArgs(
                         emission.RootPid, emission.ExeBasename, emission.CommandLine));
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Subscribers must not crash the tracker.
+                    // Subscribers must not crash the tracker. Log the failing handler
+                    // so it doesn't decay silently.
+                    System.Diagnostics.Debug.WriteLine(
+                        $"WindowsActiveProcessTracker: Changed subscriber threw: {ex.GetType().Name}: {ex.Message}");
                 }
             }
         }

--- a/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Ghostty.Core.Profiles.Tracking;
+
+/// <summary>
+/// Polling implementation of <see cref="IActiveProcessTracker"/>. One
+/// <see cref="Timer"/>, two ticks per second. Each tick:
+///  1. Snapshots the registered root PIDs.
+///  2. Walks the tree once per root via <see cref="ProcessTreeWalker"/>.
+///  3. Runs each result through <see cref="ActiveProcessDebouncer"/>.
+///  4. Raises <see cref="Changed"/> for every emission.
+/// </summary>
+[System.Runtime.Versioning.SupportedOSPlatform("windows6.0.6000")]
+public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
+{
+    private const int TickIntervalMs = 500;
+    private const int DebounceWindowMs = 250;
+
+    private readonly Timer _timer;
+    private readonly ConcurrentDictionary<int, byte> _roots = new();
+    private readonly ActiveProcessDebouncer _debouncer = new(DebounceWindowMs);
+    private int _disposed;
+
+    public event EventHandler<ActiveProcessChangedEventArgs>? Changed;
+
+    public WindowsActiveProcessTracker()
+    {
+        _timer = new Timer(OnTick, state: null, dueTime: TickIntervalMs, period: TickIntervalMs);
+    }
+
+    public void Register(int rootPid) => _roots.TryAdd(rootPid, 0);
+
+    public void Unregister(int rootPid)
+    {
+        _roots.TryRemove(rootPid, out _);
+        _debouncer.Forget(rootPid);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _timer.Dispose();
+    }
+
+    private void OnTick(object? state)
+    {
+        if (_disposed != 0) return;
+        var now = Environment.TickCount64;
+
+        foreach (var (rootPid, _) in _roots)
+        {
+            string? exe;
+            try
+            {
+                exe = ProcessTreeWalker.FindInnermostDescendant((uint)rootPid);
+            }
+            catch
+            {
+                // Snapshot failures and access-denied during a teardown
+                // race are common; suppress and treat as "no foreground."
+                exe = null;
+            }
+
+            // V1: command line is not retrieved. ProcessIconTable handles
+            // null commandLine correctly for everything except wsl.exe
+            // distro disambiguation, which is acceptable until shell
+            // integration scripts land in a follow-up.
+            var emission = _debouncer.Observe(rootPid, exe, commandLine: null, nowMs: now);
+            if (emission is not null)
+            {
+                try
+                {
+                    Changed?.Invoke(this, new ActiveProcessChangedEventArgs(
+                        emission.RootPid, emission.ExeBasename, emission.CommandLine));
+                }
+                catch
+                {
+                    // Subscribers must not crash the tracker.
+                }
+            }
+        }
+    }
+}

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -198,6 +198,38 @@ internal sealed class TabModel : INotifyPropertyChanged
     /// </summary>
     internal Action? OnClose { get; set; }
 
+    private int? _shellPid;
+
+    /// <summary>
+    /// Process id of the shell rooted at this tab's first leaf, or null
+    /// before the surface has spawned (or after teardown). Set by the
+    /// WinUI layer once <c>ghostty_surface_foreground_pid</c> returns a
+    /// non-zero value; raises <see cref="ShellPidChanged"/> so the
+    /// process tracker can register / unregister its descendant walk.
+    /// Today's Windows pty layer returns 0 for the foreground pid, so
+    /// this stays null on Windows until libghostty exposes the spawned
+    /// child pid; the lifecycle wiring here is the same shape we'll need
+    /// once that lands.
+    /// </summary>
+    public int? ShellPid
+    {
+        get => _shellPid;
+        internal set
+        {
+            if (_shellPid == value) return;
+            _shellPid = value;
+            ShellPidChanged?.Invoke(this, value);
+        }
+    }
+
+    /// <summary>
+    /// Fired when <see cref="ShellPid"/> changes. The active-process
+    /// tracker subscribes per tab to register the new pid and unregister
+    /// the old one; null means "no pid right now" (pre-spawn or
+    /// post-exit).
+    /// </summary>
+    public event Action<TabModel, int?>? ShellPidChanged;
+
     public event PropertyChangedEventHandler? PropertyChanged;
     private void Raise([CallerMemberName] string? name = null) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles.Tracking;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ghostty.Tests.Windows.Tracking;
+
+public sealed class WindowsActiveProcessTrackerSmokeTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public WindowsActiveProcessTrackerSmokeTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task Track_PwshThenCmd_ReportsTransition()
+    {
+        // Spawn pwsh and have it run a long-lived cmd child that waits on
+        // ping. ProcessTreeWalker returns the innermost descendant, so we
+        // expect to see "cmd.exe" appear briefly and then "ping.exe" (or
+        // "PING.EXE") as the leaf, depending on tick timing relative to
+        // cmd's exec of ping. Either is acceptable proof that the
+        // walker+tracker end-to-end picked up pwsh's descendants.
+        //
+        // We DO NOT use "timeout" as the inner command because cmd.exe /c
+        // can exec it quickly enough that we skip past cmd in the snapshot
+        // window. ping -n 30 is reliably long and reliably a separate exe.
+        using var pwsh = Process.Start(new ProcessStartInfo
+        {
+            FileName = "pwsh.exe",
+            Arguments = "-NoLogo -NoProfile -Command \"& cmd.exe /c ping -n 30 127.0.0.1 >$null\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(pwsh);
+
+        using var tracker = new WindowsActiveProcessTracker();
+        var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observed = new List<string>();
+        var sw = Stopwatch.StartNew();
+
+        // Accept any cmd-tree leaf as proof of the transition: cmd.exe
+        // itself (caught between cmd start and exec of ping) or one of
+        // cmd's known descendants. conhost.exe is the console host that
+        // wraps cmd; ping.exe is cmd's child. We do NOT want to accept
+        // pwsh.exe (the root) or null (no descendant) as a transition.
+        var acceptedExes = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
+        {
+            "cmd.exe",
+            "conhost.exe",
+            "ping.exe",
+        };
+
+        tracker.Changed += (_, e) =>
+        {
+            lock (observed)
+            {
+                observed.Add($"{sw.ElapsedMilliseconds}ms pid={e.RootPid} exe={e.ExeBasename ?? "<null>"}");
+            }
+            if (e.ExeBasename is not null
+                && acceptedExes.Contains(e.ExeBasename)
+                && !tcs.Task.IsCompleted)
+            {
+                tcs.SetResult(e.ExeBasename);
+            }
+        };
+        tracker.Register(pwsh!.Id);
+
+        // pwsh.exe startup is heavy (~1-2s cold). Allow up to 8 seconds for
+        // the tracker to observe a cmd-tree descendant: pwsh launch + JIT +
+        // tick interval 500 ms + debounce 250 ms + slop.
+        var winner = await Task.WhenAny(tcs.Task, Task.Delay(8000));
+        lock (observed)
+        {
+            foreach (var line in observed)
+                _output.WriteLine(line);
+        }
+        Assert.True(
+            winner == tcs.Task,
+            $"tracker did not report a cmd-tree descendant within 8s; observed: [{string.Join(", ", observed)}]");
+        var reported = await tcs.Task;
+        Assert.NotNull(reported);
+        Assert.Contains(reported!, acceptedExes);
+        _output.WriteLine($"tracker reported {reported} after {sw.ElapsedMilliseconds}ms");
+
+        try { pwsh.Kill(entireProcessTree: true); } catch { }
+    }
+}

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerSmokeTests.cs
@@ -44,16 +44,20 @@ public sealed class WindowsActiveProcessTrackerSmokeTests
         var observed = new List<string>();
         var sw = Stopwatch.StartNew();
 
-        // Accept any cmd-tree leaf as proof of the transition: cmd.exe
-        // itself (caught between cmd start and exec of ping) or one of
-        // cmd's known descendants. conhost.exe is the console host that
-        // wraps cmd; ping.exe is cmd's child. We do NOT want to accept
-        // pwsh.exe (the root) or null (no descendant) as a transition.
+        // Acceptable: the test scenario spawns pwsh -> cmd -> ping; with the
+        // broker filter (conhost / OpenConsole) the walker reports the deepest
+        // non-broker descendant. cmd or ping both prove pwsh's descendants are
+        // being walked; conhost / OpenConsole appearing means the filter regressed.
         var acceptedExes = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
         {
             "cmd.exe",
-            "conhost.exe",
             "ping.exe",
+            "PING.EXE",
+        };
+        var brokerExes = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
+        {
+            "conhost.exe",
+            "OpenConsole.exe",
         };
 
         tracker.Changed += (_, e) =>
@@ -63,6 +67,13 @@ public sealed class WindowsActiveProcessTrackerSmokeTests
                 observed.Add($"{sw.ElapsedMilliseconds}ms pid={e.RootPid} exe={e.ExeBasename ?? "<null>"}");
             }
             if (e.ExeBasename is not null
+                && brokerExes.Contains(e.ExeBasename)
+                && !tcs.Task.IsCompleted)
+            {
+                tcs.SetException(new Xunit.Sdk.XunitException(
+                    $"tracker reported broker exe {e.ExeBasename}; filter regressed"));
+            }
+            else if (e.ExeBasename is not null
                 && acceptedExes.Contains(e.ExeBasename)
                 && !tcs.Task.IsCompleted)
             {

--- a/windows/Ghostty.Tests/Profiles/Tracking/FakeActiveProcessTracker.cs
+++ b/windows/Ghostty.Tests/Profiles/Tracking/FakeActiveProcessTracker.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Profiles.Tracking;
+
+namespace Ghostty.Tests.Profiles.Tracking;
+
+/// <summary>
+/// Test double: tests drive change events by hand via <see cref="Raise"/>.
+/// Tracks which root PIDs have been registered so tests can assert the
+/// caller is wiring registration / unregistration correctly.
+/// </summary>
+public sealed class FakeActiveProcessTracker : IActiveProcessTracker
+{
+    private readonly HashSet<int> _registered = new();
+
+    public event EventHandler<ActiveProcessChangedEventArgs>? Changed;
+
+    public IReadOnlyCollection<int> Registered => _registered;
+    public bool IsDisposed { get; private set; }
+
+    public void Register(int rootPid) => _registered.Add(rootPid);
+    public void Unregister(int rootPid) => _registered.Remove(rootPid);
+
+    public void Raise(int rootPid, string? exeBasename, string? commandLine) =>
+        Changed?.Invoke(this, new ActiveProcessChangedEventArgs(rootPid, exeBasename, commandLine));
+
+    public void Dispose() => IsDisposed = true;
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -36,6 +36,12 @@ public partial class App : Application
     private Ghostty.Core.Profiles.ProfileRegistry? _profileRegistry;
     private Ghostty.Input.Win32ModifierKeyState? _modifierKeyState;
     private Ghostty.Core.Profiles.WindowsIconResolver? _iconResolver;
+    private Ghostty.Core.Profiles.Tracking.IActiveProcessTracker? _activeProcessTracker;
+    // Reverse lookup so the tracker's Changed event (which only knows the
+    // root pid) can find the TabModel to route into. ConcurrentDictionary
+    // because the Changed event fires from the tracker's timer thread.
+    private readonly ConcurrentDictionary<int, Ghostty.Core.Tabs.TabModel> _tabsByPid = new();
+    private DispatcherQueue? _uiDispatcher;
     private GhosttyHost? _bootstrapHost;
     private HostLifetimeSupervisor? _lifetimeSupervisor;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
@@ -72,6 +78,17 @@ public partial class App : Application
     internal static Ghostty.Core.Profiles.IProfileRegistry? ProfileRegistry { get; private set; }
     internal static Ghostty.Core.Input.IModifierKeyState? ModifierKeyState { get; private set; }
     internal static Ghostty.Core.Profiles.IIconResolver? IconResolver { get; private set; }
+
+    /// <summary>
+    /// Process-wide tracker that watches each tab's shell process tree
+    /// for foreground command changes. Per-window <see cref="MainWindow"/>
+    /// instances enrol their <see cref="Ghostty.Core.Tabs.TabModel"/>s
+    /// via <see cref="RegisterTabForProcessTracking"/> on
+    /// <see cref="Ghostty.Core.Tabs.TabManager.TabAdded"/> and remove
+    /// them on <see cref="Ghostty.Core.Tabs.TabManager.TabRemoved"/>.
+    /// Null before OnLaunched runs; null after the last window closes.
+    /// </summary>
+    internal static Ghostty.Core.Profiles.Tracking.IActiveProcessTracker? ActiveProcessTracker { get; private set; }
 
     /// <summary>
     /// Process-wide power-saving-mode monitor. Null before OnLaunched
@@ -490,6 +507,15 @@ public partial class App : Application
         // UI thread.
         Ghostty.Tabs.TabIconBytesCache.Install(_iconResolver);
 
+        // Cache the UI dispatcher up front: the active-process tracker
+        // fires Changed from a Timer threadpool callback, and the handler
+        // touches TabIconViewModel which raises PropertyChanged consumed
+        // by WinUI bindings — those need the UI thread.
+        _uiDispatcher = uiDispatcher;
+        _activeProcessTracker = new Ghostty.Core.Profiles.Tracking.WindowsActiveProcessTracker();
+        _activeProcessTracker.Changed += OnActiveProcessChanged;
+        ActiveProcessTracker = _activeProcessTracker;
+
         _profileRegistry = new Ghostty.Core.Profiles.ProfileRegistry(
             source: _configService,
             discover: (bypass, ct) => _discoveryService.DiscoverAsync(bypass, ct),
@@ -557,6 +583,79 @@ public partial class App : Application
         window.Activate();
     }
 
+    /// <summary>
+    /// Enrol <paramref name="tab"/> with the process tracker. Idempotent:
+    /// re-registering the same tab is a no-op for the tracker and only
+    /// re-installs the <see cref="Ghostty.Core.Tabs.TabModel.ShellPidChanged"/>
+    /// subscription once via the underlying event's reentrancy semantics.
+    /// Called from <see cref="MainWindow"/> on <c>TabManager.TabAdded</c>;
+    /// the shell pid may be null at this point (the libghostty surface
+    /// has not loaded yet) so we hook ShellPidChanged for the late path.
+    /// </summary>
+    internal void RegisterTabForProcessTracking(Ghostty.Core.Tabs.TabModel tab)
+    {
+        if (_activeProcessTracker is null) return;
+        tab.ShellPidChanged += OnTabShellPidChanged;
+        // Pick up a pid already set before we subscribed (e.g. a future
+        // path that resolves the pid synchronously at TabManager.NewTab).
+        if (tab.ShellPid is int pid)
+        {
+            _tabsByPid[pid] = tab;
+            _activeProcessTracker.Register(pid);
+        }
+    }
+
+    /// <summary>
+    /// Reverse of <see cref="RegisterTabForProcessTracking"/>. Detaches
+    /// the ShellPidChanged subscription and removes any registered pid
+    /// from the tracker. Called from <see cref="MainWindow"/> on
+    /// <c>TabManager.TabRemoved</c>.
+    /// </summary>
+    internal void UnregisterTabForProcessTracking(Ghostty.Core.Tabs.TabModel tab)
+    {
+        tab.ShellPidChanged -= OnTabShellPidChanged;
+        if (tab.ShellPid is int pid)
+        {
+            _activeProcessTracker?.Unregister(pid);
+            _tabsByPid.TryRemove(pid, out _);
+        }
+    }
+
+    private void OnTabShellPidChanged(Ghostty.Core.Tabs.TabModel tab, int? newPid)
+    {
+        if (_activeProcessTracker is null) return;
+        // Old pid may still be registered if the shell respawned without
+        // an explicit unregister; drop it before adopting the new one.
+        // Snapshot the entries that point at this tab so we don't leak
+        // stale rows when a tab cycles through pids.
+        foreach (var kv in _tabsByPid)
+        {
+            if (!ReferenceEquals(kv.Value, tab)) continue;
+            if (newPid is int np && np == kv.Key) continue;
+            _activeProcessTracker.Unregister(kv.Key);
+            _tabsByPid.TryRemove(kv.Key, out _);
+        }
+
+        if (newPid is int pid)
+        {
+            _tabsByPid[pid] = tab;
+            _activeProcessTracker.Register(pid);
+        }
+    }
+
+    private void OnActiveProcessChanged(
+        object? sender,
+        Ghostty.Core.Profiles.Tracking.ActiveProcessChangedEventArgs e)
+    {
+        if (!_tabsByPid.TryGetValue(e.RootPid, out var tab)) return;
+        // The tracker fires Changed from a Timer threadpool callback.
+        // TabModel.OnActiveProcessChanged mutates TabIconViewModel, which
+        // raises PropertyChanged consumed by WinUI bindings, so marshal
+        // onto the UI thread before invoking it. Null dispatcher means we
+        // are mid-shutdown; drop the event.
+        _uiDispatcher?.TryEnqueue(() => tab.OnActiveProcessChanged(e.ExeBasename, e.CommandLine));
+    }
+
     private void OnConfigChanged_ApplyLogFilters(Ghostty.Core.Config.IConfigService cfg)
     {
         if (_logFilters is null) return;
@@ -594,6 +693,18 @@ public partial class App : Application
         {
             try
             {
+                // Stop the process tracker before any tab teardown could
+                // race its Timer callback. Dispose unsubscribes the
+                // Changed handler in addition to cancelling the timer,
+                // so straggler tab.OnActiveProcessChanged enqueues stop
+                // here. The reverse-lookup dictionary is cleared in the
+                // finally block below alongside the static accessor.
+                if (_activeProcessTracker is not null)
+                {
+                    _activeProcessTracker.Changed -= OnActiveProcessChanged;
+                    _activeProcessTracker.Dispose();
+                }
+
                 // Dispose the registry first: its Dispose cancels any
                 // pending discovery and unsubscribes from
                 // _configService's ProfileConfigChanged event. The
@@ -664,6 +775,10 @@ public partial class App : Application
                 _modifierKeyState = null;
                 IconResolver = null;
                 _iconResolver = null;
+                ActiveProcessTracker = null;
+                _activeProcessTracker = null;
+                _tabsByPid.Clear();
+                _uiDispatcher = null;
                 _discoveryService = null;
                 _configWriteScheduler = null;
                 ConfigWriteScheduler = null;

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -121,6 +121,28 @@ public sealed partial class TerminalControl : UserControl
     internal IntPtr SurfaceHandle => _surface.Handle;
 
     /// <summary>
+    /// Returns the pid of the shell process attached to this surface, or
+    /// null when libghostty cannot report one (surface not yet created,
+    /// already disposed, or the platform's pty layer is a stub). The
+    /// active-process tracker uses this to root its descendant walk.
+    /// On Windows today this currently returns null because
+    /// <c>WindowsPty.getProcessInfo</c> upstream still returns 0; the
+    /// wiring is in place so the tracker picks up the pid automatically
+    /// once libghostty exposes it.
+    /// </summary>
+    internal int? TryGetShellPid()
+    {
+        if (_surface.Handle == IntPtr.Zero) return null;
+        var pid = NativeMethods.SurfaceForegroundPid(_surface);
+        if (pid == 0) return null;
+        // The C api uses u64 to match macOS/Linux pids in unsigned form;
+        // Windows process ids are DWORDs and Toolhelp32 takes uint, but
+        // .NET's Process.Id is int and our tracker stores int, so cast
+        // through int for the contract. Clamp to int.MaxValue defensively.
+        return pid > int.MaxValue ? null : (int)pid;
+    }
+
+    /// <summary>
     /// Last title pushed by libghostty for this surface, or null if no
     /// title has been set yet. Used by MainWindow to update the window
     /// chrome immediately on focus change without waiting for the next

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -427,6 +427,15 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial GhosttySurfaceSize SurfaceSize(GhosttySurface surface);
 
+    // Returns the pid of the foreground process attached to the pty, or
+    // 0 when the platform-specific pty layer cannot report it. On
+    // Windows today this returns 0 (WindowsPty.getProcessInfo is a
+    // stub); the binding still lives here so the active-process tracker
+    // can poll without owning the libghostty call site.
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_foreground_pid")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial ulong SurfaceForegroundPid(GhosttySurface surface);
+
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_shared_texture")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     private static partial byte SurfaceSharedTextureNative(

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -401,16 +401,30 @@ public sealed partial class MainWindow : Window
         // container declared in MainWindow.xaml. This is the single
         // owner for PaneHost lifetime in the visual tree — both tab
         // hosts read from it without ever reparenting.
-        foreach (var t in _tabManager.Tabs) AddPaneHost(t);
+        foreach (var t in _tabManager.Tabs)
+        {
+            AddPaneHost(t);
+            // The seed tab does NOT raise TabManager.TabAdded (see
+            // TabManager ctor comment), so attach the process-tracker
+            // bridge here for every pre-existing tab before subscribing
+            // to TabAdded below. AttachProcessTracking is idempotent
+            // against TabAdded re-firing for the same tab.
+            AttachProcessTracking(t);
+        }
         SwapActivePane();
         _tabManager.TabAdded += (_, t) =>
         {
             AddPaneHost(t);
+            AttachProcessTracking(t);
             SwapActivePane();
             // Apply current cursor color to new tabs' pane borders.
             UpdateCursorAccentColors();
         };
-        _tabManager.TabRemoved += (_, t) => RemovePaneHost(t);
+        _tabManager.TabRemoved += (_, t) =>
+        {
+            DetachProcessTracking(t);
+            RemovePaneHost(t);
+        };
         _tabManager.ActiveTabChanged += (_, _) => SwapActivePane();
 
         // Apply initial cursor-color-derived pane border.
@@ -987,6 +1001,55 @@ public sealed partial class MainWindow : Window
         var paneHost = (PaneHost)tab.PaneHost;
         PaneHostContainer.Children.Remove(paneHost);
     }
+
+    /// <summary>
+    /// Register <paramref name="tab"/> with the process-global tracker
+    /// and arrange for its <see cref="TabModel.ShellPid"/> to be
+    /// populated once libghostty has spawned the surface's shell. Hook
+    /// PaneHost.LeafFocused (the first fire lands from PaneHost.Loaded,
+    /// at which point the TerminalControl's libghostty surface exists)
+    /// and query <c>ghostty_surface_foreground_pid</c>. Re-fires on
+    /// every focus change so split/zoom retains the tab's root pid;
+    /// the assignment is idempotent when the value is unchanged.
+    /// </summary>
+    private void AttachProcessTracking(TabModel tab)
+    {
+        ((App)Application.Current).RegisterTabForProcessTracking(tab);
+
+        // First leaf's surface drives the pid. If the tab grows splits
+        // later, we keep the first-spawned shell as the tracker root
+        // because that is the lineage the user originally opened (e.g.
+        // a "Bash" tab whose split panes spawned PowerShell shouldn't
+        // re-root the icon onto pwsh). Re-querying on every LeafFocused
+        // would race: by the time we sample, the pid we'd grab could be
+        // the wrong leaf's. Instead we snapshot exactly once.
+        void OnLeafFocused(object? _, Ghostty.Core.Panes.LeafPane leaf)
+        {
+            if (tab.ShellPid is not null) return;
+            var pid = leaf.Terminal().TryGetShellPid();
+            if (pid is null) return;
+            tab.ShellPid = pid;
+        }
+        tab.PaneHost.LeafFocused += OnLeafFocused;
+        // Stash the unsubscriber so DetachProcessTracking can walk back
+        // the LeafFocused handler without a side dictionary.
+        _processTrackingDetach[tab] = () => tab.PaneHost.LeafFocused -= OnLeafFocused;
+    }
+
+    private void DetachProcessTracking(TabModel tab)
+    {
+        if (_processTrackingDetach.TryGetValue(tab, out var detach))
+        {
+            detach();
+            _processTrackingDetach.Remove(tab);
+        }
+        ((App)Application.Current).UnregisterTabForProcessTracking(tab);
+    }
+
+    // Per-tab cleanup map for the LeafFocused subscription installed by
+    // AttachProcessTracking. TabModel is unique per tab so reference
+    // equality is the natural key.
+    private readonly Dictionary<TabModel, Action> _processTrackingDetach = new();
 
     private void SwapActivePane()
     {


### PR DESCRIPTION
## Summary

The runtime side of active-shell icon tracking. Together with the prior PRs in this stack, the tab icon now follows the foreground command running inside the pty.

- IActiveProcessTracker interface in Core; FakeActiveProcessTracker in the test project for unit tests.
- ProcessTreeWalker: CreateToolhelp32Snapshot + BFS to find the innermost descendant of a root PID. CsWin32 bindings via NativeMethods.txt. Filters Windows console-infrastructure exes (conhost, OpenConsole, wslhost, wslservice, wsl-vsock-relay) so the user-interacting process surfaces.
- WindowsActiveProcessTracker: 500 ms polling Timer, debounced through ActiveProcessDebouncer. Thread-safe registrations.
- App.xaml.cs constructs the tracker, registers each tab's shell PID, routes Changed events (marshalled onto the UI dispatcher) to TabModel.OnActiveProcessChanged.
- ShellPid carried on TabModel; populated via TerminalControl.TryGetShellPid -> ghostty_surface_foreground_pid.
- Real-process smoke test in Ghostty.Tests.Windows: spawn pwsh, spawn cmd-ping under it, assert the tracker reports ping (not conhost) within 8s.

IMPORTANT: stacked on top of #409 (3/4).

## Zig dependency

The C# wiring relies on libghostty exposing the spawned shell PID via ghostty_surface_foreground_pid. The Windows pty layer in src returned null; this PR also fills it in by special-casing Subprocess.getProcessInfo on Windows to read cmd.pid directly via GetProcessId. Two-file Zig change in src/termio/Exec.zig + src/os/windows.zig. **The Windows libghostty.dll must be rebuilt with Zig 0.15.2 for the runtime path to fire**; the C# wiring is inert until then.

## Test plan

- [x] xunit (Core): ProcessIconTableTests + ActiveProcessDebouncerTests + TabIconViewModelTests + TabModelTests — all green.
- [x] xunit smoke (Tests.Windows): WindowsActiveProcessTrackerSmokeTests passes, reports ping.exe (not conhost) within ~2-5s.
- [x] Build clean (Core + Ghostty + Tests + Tests.Windows).
- [ ] Manual smoke (post Zig rebuild): open pwsh tab, run cmd or vim, observe icon swap; on exit, icon reverts to pwsh.