### PR TITLE
terminal/sixel: parser (PR 1/4 of Sixel stack)

### DIFF
--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -3,6 +3,7 @@ const build_options = @import("terminal_options");
 const assert = @import("../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const terminal = @import("main.zig");
+const sixel = @import("sixel.zig");
 const DCS = terminal.DCS;
 
 const log = std.log.scoped(.terminal_dcs);
@@ -71,6 +72,18 @@ pub const Handler = struct {
                             },
                         },
                         .command = .{ .tmux = .enter },
+                    };
+                },
+
+                // Sixel image (DEC DCS final='q' with no intermediates).
+                'q' => sixel_hook: {
+                    var intro: [3]?u16 = .{ null, null, null };
+                    for (dcs.params, 0..) |p, i| {
+                        if (i >= intro.len) break;
+                        intro[i] = p;
+                    }
+                    break :sixel_hook .{
+                        .state = .{ .sixel = sixel.Parser.init(alloc, intro) },
                     };
                 },
 
@@ -149,6 +162,8 @@ pub const Handler = struct {
                 buffer.data[buffer.len] = byte;
                 buffer.len += 1;
             },
+
+            .sixel => |*p| p.put(byte),
         }
 
         return null;
@@ -195,6 +210,21 @@ pub const Handler = struct {
                 },
                 else => unreachable,
             } },
+
+            .sixel => |*p| sixel: {
+                const c = p.finalize() catch |err| {
+                    log.info("sixel finalize failed err={}", .{err});
+                    p.deinit();
+                    break :sixel null;
+                };
+                // finalize transferred paint_ops and palette_ops to
+                // the returned Command, but `accum` (the working
+                // buffer for raster/color/repeat strings) stays with
+                // the parser and needs releasing. deinit on the
+                // now-empty paint/palette lists is a no-op.
+                p.deinit();
+                break :sixel .{ .sixel = c };
+            },
         };
     }
 
@@ -217,11 +247,15 @@ pub const Command = union(enum) {
     else
         void,
 
+    /// Sixel image
+    sixel: sixel.Command,
+
     pub fn deinit(self: *Command) void {
         switch (self.*) {
             .xtgettcap => |*v| v.data.deinit(),
             .decrqss => {},
             .tmux => {},
+            .sixel => |*v| v.deinit(),
         }
     }
 
@@ -280,6 +314,9 @@ const State = union(enum) {
     else
         void,
 
+    /// Sixel image (DEC DCS final='q' with no intermediates).
+    sixel: sixel.Parser,
+
     pub fn deinit(self: *State) void {
         switch (self.*) {
             .inactive,
@@ -291,6 +328,7 @@ const State = union(enum) {
             .tmux => |*v| if (comptime build_options.tmux_control_mode) {
                 v.deinit();
             } else unreachable,
+            .sixel => |*v| v.deinit(),
         }
     }
 };
@@ -427,4 +465,43 @@ test "tmux enter and implicit exit" {
         try testing.expect(cmd == .tmux);
         try testing.expect(cmd.tmux == .exit);
     }
+}
+
+test "sixel DCS command" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    defer h.deinit();
+
+    // ESC P q (no intermediates, final = 'q') is the sixel intro.
+    try testing.expect(h.hook(alloc, .{ .final = 'q' }) == null);
+    try testing.expect(h.state == .sixel);
+
+    // Feed a tiny sixel: paint one cell.
+    _ = h.put('?');
+
+    var cmd = h.unhook().?;
+    defer cmd.deinit();
+    try testing.expect(cmd == .sixel);
+    try testing.expectEqual(@as(usize, 1), cmd.sixel.paint_ops.len);
+    try testing.expect(h.state == .inactive);
+}
+
+test "sixel DCS with raster attribs" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    defer h.deinit();
+
+    try testing.expect(h.hook(alloc, .{ .params = &.{ 1, 1, 75 }, .final = 'q' }) == null);
+    for ("\"1;1;0;100;200") |b| _ = h.put(b);
+    _ = h.put('?');
+
+    var cmd = h.unhook().?;
+    defer cmd.deinit();
+    try testing.expect(cmd == .sixel);
+    try testing.expectEqual(@as(u16, 100), cmd.sixel.raster.declared_width);
+    try testing.expectEqual(@as(u16, 200), cmd.sixel.raster.declared_height);
 }

--- a/src/terminal/main.zig
+++ b/src/terminal/main.zig
@@ -21,6 +21,7 @@ pub const page = @import("page.zig");
 pub const parse_table = @import("parse_table.zig");
 pub const search = @import("search.zig");
 pub const sgr = @import("sgr.zig");
+pub const sixel = @import("sixel.zig");
 pub const size = @import("size.zig");
 pub const size_report = @import("size_report.zig");
 pub const sys = @import("sys.zig");

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -4,19 +4,15 @@
 //! escape sequences (ESC P [Pa;Pb;Ph] q ... ESC \). This module
 //! is the re-export surface; implementation lives under
 //! `src/terminal/sixel/`.
-//!
-//! Re-exports are added as submodules land.
 
+// Only types with external callers are re-exported. dcs.Handler uses
+// Parser as its DCS state and Command as the unhook output. Palette
+// stays anchored here so its tests are discovered by refAllDecls
+// even though no external caller consumes it yet — the decoder will
+// use it in a follow-on commit.
 pub const Command = @import("sixel/command.zig").Command;
-pub const PaintOp = @import("sixel/command.zig").PaintOp;
-pub const PaletteOp = @import("sixel/command.zig").PaletteOp;
-pub const Raster = @import("sixel/command.zig").Raster;
-pub const parseRasterAttribs = @import("sixel/raster.zig").parseRasterAttribs;
-pub const RasterError = @import("sixel/raster.zig").Error;
-pub const MAX_RGBA_BYTES = @import("sixel/raster.zig").MAX_RGBA_BYTES;
-pub const Palette = @import("sixel/palette.zig").Palette;
-pub const Rgba = @import("sixel/palette.zig").Rgba;
 pub const Parser = @import("sixel/parser.zig").Parser;
+pub const Palette = @import("sixel/palette.zig").Palette;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -5,8 +5,12 @@
 //! is the re-export surface; implementation lives under
 //! `src/terminal/sixel/`.
 //!
-//! Re-exports are added as each sub-module lands across the PR
-//! stack.
+//! Re-exports are added as submodules land.
+
+pub const Command = @import("sixel/command.zig").Command;
+pub const PaintOp = @import("sixel/command.zig").PaintOp;
+pub const PaletteOp = @import("sixel/command.zig").PaletteOp;
+pub const Raster = @import("sixel/command.zig").Raster;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -1,0 +1,13 @@
+//! Types and functions related to the DEC Sixel image protocol.
+//!
+//! Sixel is a DEC-defined inline image protocol delivered via DCS
+//! escape sequences (ESC P [Pa;Pb;Ph] q ... ESC \). This module
+//! is the re-export surface; implementation lives under
+//! `src/terminal/sixel/`.
+//!
+//! Re-exports are added as each sub-module lands across the PR
+//! stack.
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -16,6 +16,7 @@ pub const RasterError = @import("sixel/raster.zig").Error;
 pub const MAX_RGBA_BYTES = @import("sixel/raster.zig").MAX_RGBA_BYTES;
 pub const Palette = @import("sixel/palette.zig").Palette;
 pub const Rgba = @import("sixel/palette.zig").Rgba;
+pub const Parser = @import("sixel/parser.zig").Parser;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -14,6 +14,8 @@ pub const Raster = @import("sixel/command.zig").Raster;
 pub const parseRasterAttribs = @import("sixel/raster.zig").parseRasterAttribs;
 pub const RasterError = @import("sixel/raster.zig").Error;
 pub const MAX_RGBA_BYTES = @import("sixel/raster.zig").MAX_RGBA_BYTES;
+pub const Palette = @import("sixel/palette.zig").Palette;
+pub const Rgba = @import("sixel/palette.zig").Rgba;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -11,6 +11,9 @@ pub const Command = @import("sixel/command.zig").Command;
 pub const PaintOp = @import("sixel/command.zig").PaintOp;
 pub const PaletteOp = @import("sixel/command.zig").PaletteOp;
 pub const Raster = @import("sixel/command.zig").Raster;
+pub const parseRasterAttribs = @import("sixel/raster.zig").parseRasterAttribs;
+pub const RasterError = @import("sixel/raster.zig").Error;
+pub const MAX_RGBA_BYTES = @import("sixel/raster.zig").MAX_RGBA_BYTES;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/sixel/command.zig
+++ b/src/terminal/sixel/command.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const testing = std.testing;
+
+/// A fully-parsed sixel image command. Output of the parser, input
+/// to the decoder (PR2).
+pub const Command = struct {
+    /// Allocator that owns palette_ops and paint_ops slices.
+    /// Set by Parser.finalize; freed by deinit.
+    alloc: std.mem.Allocator,
+
+    /// Raster attributes (geometry, aspect ratio). May be defaulted
+    /// if the sender omitted the `"` prelude.
+    raster: Raster,
+
+    /// Palette register set operations, in source order.
+    palette_ops: []const PaletteOp,
+
+    /// Paint operations (sixel bytes, color selects, CR, NL), in
+    /// source order.
+    paint_ops: []const PaintOp,
+
+    /// The `Pa;Pb;Ph` parameters from the DCS introducer
+    /// (`ESC P Pa;Pb;Ph q`). All optional; null when omitted.
+    /// Kept raw on purpose: the decoder applies DEC default semantics
+    /// (e.g. Pa=0 → 1) so this struct stays a faithful record of the
+    /// introducer bytes.
+    intro_params: [3]?u16,
+
+    pub fn deinit(self: *Command) void {
+        self.alloc.free(self.palette_ops);
+        self.alloc.free(self.paint_ops);
+    }
+};
+
+pub const Raster = struct {
+    /// Pixel aspect ratio numerator. Default 1.
+    aspect_num: u16 = 1,
+    /// Pixel aspect ratio denominator. Default 1.
+    aspect_den: u16 = 1,
+    /// Horizontal grid size (pixels per inch hint). 0 = unspecified.
+    grid_size: u16 = 0,
+    /// Declared image width in pixels (Pn3 in raster attribs). 0 = undeclared.
+    declared_width: u16 = 0,
+    /// Declared image height in pixels (Pn4). 0 = undeclared.
+    declared_height: u16 = 0,
+};
+
+pub const PaintOp = union(enum) {
+    /// A sixel data byte (?..~ in source), optionally run-length-repeated.
+    /// `byte` is the raw character; the decoder maps it to 6 vertical pixels.
+    /// `count` is u16 because the `!N` run-length is unbounded in the
+    /// DEC spec — u8 would clip common encoder output, u32 wastes
+    /// memory in the op stream. The parser saturates at u16 max.
+    sixel: struct { byte: u8, count: u16 },
+    /// Select color register `idx` as the current paint color.
+    select_color: u8,
+    /// `$` — return paint cursor to leftmost column.
+    carriage_return,
+    /// `-` — advance paint cursor down 6 pixels, reset to leftmost column.
+    next_line,
+};
+
+pub const PaletteOp = union(enum) {
+    /// `#N;2;Pr;Pg;Pb` — set register N to RGB triple.
+    /// Values normalized to 0-255 from the source 0-100 range.
+    set_rgb: struct { idx: u8, r: u8, g: u8, b: u8 },
+    /// `#N;1;Ph;Pl;Ps` — set register N to DEC HLS triple.
+    /// H is 0-360, L is 0-100, S is 0-100. Decoder converts to RGB.
+    set_hls: struct { idx: u8, h: u16, l: u8, s: u8 },
+};
+
+test "Command: deinit frees slices" {
+    const alloc = testing.allocator;
+    var cmd = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .palette_ops = try alloc.alloc(PaletteOp, 2),
+        .paint_ops = try alloc.alloc(PaintOp, 3),
+        .intro_params = .{ null, null, null },
+    };
+    cmd.deinit();
+}
+
+test "Raster: defaults match spec" {
+    const r = Raster{};
+    try testing.expectEqual(@as(u16, 1), r.aspect_num);
+    try testing.expectEqual(@as(u16, 1), r.aspect_den);
+    try testing.expectEqual(@as(u16, 0), r.grid_size);
+    try testing.expectEqual(@as(u16, 0), r.declared_width);
+    try testing.expectEqual(@as(u16, 0), r.declared_height);
+}
+
+test "PaintOp: sixel variant carries byte and count" {
+    const op = PaintOp{ .sixel = .{ .byte = '?', .count = 1 } };
+    try testing.expectEqual(@as(u8, '?'), op.sixel.byte);
+    try testing.expectEqual(@as(u16, 1), op.sixel.count);
+}
+
+test "PaletteOp: set_rgb variant carries normalized values" {
+    const op = PaletteOp{ .set_rgb = .{ .idx = 0, .r = 255, .g = 128, .b = 0 } };
+    try testing.expectEqual(@as(u8, 0), op.set_rgb.idx);
+    try testing.expectEqual(@as(u8, 255), op.set_rgb.r);
+}

--- a/src/terminal/sixel/command.zig
+++ b/src/terminal/sixel/command.zig
@@ -2,7 +2,13 @@ const std = @import("std");
 const testing = std.testing;
 
 /// A fully-parsed sixel image command. Output of the parser, input
-/// to the decoder (PR2).
+/// to the decoder (future commit).
+///
+/// Ownership: two heap-allocated slices are released by `deinit`.
+/// We carry the allocator on the struct rather than using an arena
+/// because there are only two slices and a `Command.deinit()` is
+/// easier to chain into the existing `dcs.Command.deinit` switch arm
+/// than an arena handle.
 pub const Command = struct {
     /// Allocator that owns palette_ops and paint_ops slices.
     /// Set by Parser.finalize; freed by deinit.

--- a/src/terminal/sixel/palette.zig
+++ b/src/terminal/sixel/palette.zig
@@ -67,7 +67,9 @@ pub const Palette = struct {
 
 /// Scale a 0-100 DEC color value to 0-255. Saturates at 100.
 /// The `+ 50` rounds to nearest instead of truncating, so 50/100
-/// maps to 128 rather than 127.
+/// maps to 128 rather than 127. Matches libsixel's integer formula
+/// `(v * 255 + 50) / 100` for bit-exact round-trip with the
+/// reference encoder.
 fn scale100to255(v: u8) u8 {
     const clamped = if (v > 100) 100 else v;
     return @intCast((@as(u32, clamped) * 255 + 50) / 100);

--- a/src/terminal/sixel/palette.zig
+++ b/src/terminal/sixel/palette.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub const Rgba = packed struct(u32) {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+};
+
+/// DEC default 16-color palette.
+///
+/// These are the libsixel reference values for the VT340 palette
+/// (the de facto target every modern sixel encoder writes for).
+/// They do not round-trip through scale100to255 from the DEC VT3xx
+/// manual's percentage table — the hardware-measured values diverge
+/// slightly (e.g. red is documented as 80,13,13 but ships as
+/// 204,36,36 in libsixel). Match the reference, not the manual.
+pub const dec_default_palette: [16]Rgba = .{
+    .{ .r = 0,   .g = 0,   .b = 0,   .a = 255 }, // 0: black
+    .{ .r = 51,  .g = 51,  .b = 204, .a = 255 }, // 1: blue
+    .{ .r = 204, .g = 36,  .b = 36,  .a = 255 }, // 2: red
+    .{ .r = 51,  .g = 204, .b = 51,  .a = 255 }, // 3: green
+    .{ .r = 204, .g = 51,  .b = 204, .a = 255 }, // 4: magenta
+    .{ .r = 51,  .g = 204, .b = 204, .a = 255 }, // 5: cyan
+    .{ .r = 204, .g = 204, .b = 51,  .a = 255 }, // 6: yellow
+    .{ .r = 120, .g = 120, .b = 120, .a = 255 }, // 7: grey 50%
+    .{ .r = 69,  .g = 69,  .b = 69,  .a = 255 }, // 8: grey 25%
+    .{ .r = 92,  .g = 92,  .b = 158, .a = 255 }, // 9: blue*
+    .{ .r = 158, .g = 92,  .b = 92,  .a = 255 }, // 10: red*
+    .{ .r = 92,  .g = 158, .b = 92,  .a = 255 }, // 11: green*
+    .{ .r = 158, .g = 92,  .b = 158, .a = 255 }, // 12: magenta*
+    .{ .r = 92,  .g = 158, .b = 158, .a = 255 }, // 13: cyan*
+    .{ .r = 158, .g = 158, .b = 92,  .a = 255 }, // 14: yellow*
+    .{ .r = 204, .g = 204, .b = 204, .a = 255 }, // 15: grey 75%
+};
+
+/// 256-entry palette. Modern emitters use 256 registers per DEC
+/// private extension; baseline DEC hardware was 16 registers.
+pub const Palette = struct {
+    entries: [256]Rgba,
+
+    /// Build a fresh palette. Indices 0-15 hold the DEC default
+    /// colors; indices 16-255 default to opaque black.
+    pub fn init() Palette {
+        var p: Palette = .{ .entries = undefined };
+        for (0..16) |i| p.entries[i] = dec_default_palette[i];
+        for (16..256) |i| p.entries[i] = .{ .r = 0, .g = 0, .b = 0, .a = 255 };
+        return p;
+    }
+
+    /// Set register `idx` from a DEC RGB triple. Source values are
+    /// 0-100; this scales to 0-255.
+    pub fn setRgb(self: *Palette, idx: u8, r: u8, g: u8, b: u8) void {
+        self.entries[idx] = .{
+            .r = scale100to255(r),
+            .g = scale100to255(g),
+            .b = scale100to255(b),
+            .a = 255,
+        };
+    }
+
+    pub fn query(self: Palette, idx: u8) Rgba {
+        return self.entries[idx];
+    }
+};
+
+/// Scale a 0-100 DEC color value to 0-255. Saturates at 100.
+/// The `+ 50` rounds to nearest instead of truncating, so 50/100
+/// maps to 128 rather than 127.
+fn scale100to255(v: u8) u8 {
+    const clamped = if (v > 100) 100 else v;
+    return @intCast((@as(u32, clamped) * 255 + 50) / 100);
+}
+
+test "palette: init populates DEC 16 defaults" {
+    const p = Palette.init();
+    try testing.expectEqual(@as(u8, 0), p.entries[0].r);
+    try testing.expectEqual(@as(u8, 255), p.entries[0].a);
+    try testing.expectEqual(@as(u8, 204), p.entries[2].r); // red
+}
+
+test "palette: init zeros registers 16..255 to opaque black" {
+    const p = Palette.init();
+    try testing.expectEqual(@as(u8, 0), p.entries[16].r);
+    try testing.expectEqual(@as(u8, 0), p.entries[16].g);
+    try testing.expectEqual(@as(u8, 0), p.entries[16].b);
+    try testing.expectEqual(@as(u8, 255), p.entries[16].a);
+    try testing.expectEqual(@as(u8, 0), p.entries[255].r);
+}
+
+test "palette: setRgb scales 0-100 to 0-255" {
+    var p = Palette.init();
+    p.setRgb(0, 100, 50, 0);
+    try testing.expectEqual(@as(u8, 255), p.entries[0].r);
+    try testing.expectEqual(@as(u8, 128), p.entries[0].g);
+    try testing.expectEqual(@as(u8, 0), p.entries[0].b);
+}
+
+test "palette: setRgb saturates values above 100" {
+    var p = Palette.init();
+    p.setRgb(0, 200, 100, 100);
+    try testing.expectEqual(@as(u8, 255), p.entries[0].r);
+}
+
+test "palette: query returns set value" {
+    var p = Palette.init();
+    p.setRgb(42, 100, 100, 100);
+    const rgba = p.query(42);
+    try testing.expectEqual(@as(u8, 255), rgba.r);
+    try testing.expectEqual(@as(u8, 255), rgba.g);
+    try testing.expectEqual(@as(u8, 255), rgba.b);
+}

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -103,6 +103,10 @@ pub const Parser = struct {
                     try self.paint_ops.append(self.alloc, .next_line);
                     self.state = .data;
                 },
+                '"' => {
+                    self.accum.clearRetainingCapacity();
+                    self.state = .raster_attribs;
+                },
                 else => {
                     // Bytes outside the sixel data alphabet are
                     // silently ignored. We also promote .initial to
@@ -151,7 +155,20 @@ pub const Parser = struct {
                 },
             },
 
-            .raster_attribs => {},
+            .raster_attribs => switch (byte) {
+                '0'...'9', ';' => {
+                    try self.accum.append(self.alloc, byte);
+                },
+                else => {
+                    // End of raster — flush, then re-dispatch this
+                    // byte in data state (matches the .color_def
+                    // else-arm pattern).
+                    self.flushRaster();
+                    if (self.state == .ignore) return;
+                    self.state = .data;
+                    try self.tryPut(byte);
+                },
+            },
         }
     }
 
@@ -216,6 +233,23 @@ pub const Parser = struct {
                 // future extensions).
             },
         }
+    }
+
+    fn flushRaster(self: *Parser) void {
+        const r = raster.parseRasterAttribs(self.accum.items) catch |err| {
+            switch (err) {
+                error.SixelTooLarge => {
+                    log.warn("sixel raster oversized, dropping image", .{});
+                    self.state = .ignore;
+                    return;
+                },
+                error.Malformed => {
+                    log.debug("sixel raster malformed, using defaults", .{});
+                    return;
+                },
+            }
+        };
+        self.raster = r;
     }
 
     fn parseU8(s: []const u8) ?u8 {
@@ -462,4 +496,42 @@ test "sixel parser: ?$-? emits sixel/CR/NL/sixel" {
     try testing.expect(c.paint_ops[1] == .carriage_return);
     try testing.expect(c.paint_ops[2] == .next_line);
     try testing.expect(c.paint_ops[3] == .sixel);
+}
+
+test "sixel parser: \" then 1;1;0;100;200 sets raster" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("\"1;1;0;100;200?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(u16, 100), c.raster.declared_width);
+    try testing.expectEqual(@as(u16, 200), c.raster.declared_height);
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+}
+
+test "sixel parser: oversized raster transitions to ignore" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("\"1;1;0;8192;8192") |b| p.put(b);
+    p.put('?'); // would normally paint, but parser is in .ignore
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
+}
+
+test "sixel parser: malformed raster falls back to defaults" {
+    // 99999 overflows u16 and trips parseRasterAttribs's Malformed
+    // branch. The `<` (0x3C, below the `?..~` sixel data alphabet)
+    // terminates raster mode and re-dispatches as a silently-dropped
+    // byte. `?` then paints.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("\"99999<?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    // Raster defaults preserved
+    try testing.expectEqual(@as(u16, 1), c.raster.aspect_num);
+    try testing.expectEqual(@as(u16, 0), c.raster.declared_width);
+    // Painting continues after malformed raster
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -182,6 +182,10 @@ pub const Parser = struct {
     /// Finalize the accumulated state into a `Command`. Caller owns
     /// the returned slices via `Command.deinit`. After `finalize`,
     /// the parser is consumed — do not call `put` or `finalize` again.
+    ///
+    /// Partial mid-state at end-of-stream (an incomplete color def or
+    /// raster prelude that never received a terminator) is silently
+    /// discarded; matches foot/libsixel's behavior for truncated DCS.
     pub fn finalize(self: *Parser) Allocator.Error!Command {
         return .{
             .alloc = self.alloc,
@@ -534,4 +538,40 @@ test "sixel parser: malformed raster falls back to defaults" {
     try testing.expectEqual(@as(u16, 0), c.raster.declared_width);
     // Painting continues after malformed raster
     try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+}
+
+test "sixel parser: ignore state drops all subsequent bytes" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    p.state = .ignore;
+    p.put('?');
+    p.put('#');
+    p.put('!');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
+    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+}
+
+test "sixel parser: incomplete color def at finalize is dropped" {
+    // No terminator byte after `#1;2;100` — flushColorDef never runs.
+    // The accumulated buffer is silently discarded by finalize.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("#1;2;100") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+}
+
+test "sixel parser: incomplete raster attribs at finalize is dropped" {
+    // No terminator byte after `"1;1;0;100` — flushRaster never runs.
+    // The accumulated buffer is silently discarded; raster stays default.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("\"1;1;0;100") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(u16, 1), c.raster.aspect_num);
+    try testing.expectEqual(@as(u16, 0), c.raster.declared_width);
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -1,0 +1,114 @@
+const std = @import("std");
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
+const cmd = @import("command.zig");
+const Command = cmd.Command;
+const PaintOp = cmd.PaintOp;
+const PaletteOp = cmd.PaletteOp;
+const Raster = cmd.Raster;
+const raster = @import("raster.zig");
+
+const log = std.log.scoped(.terminal_sixel);
+
+/// Parser state. Modeled on foot's `enum sixel_state`.
+const State = enum {
+    /// Expecting either a `"` prelude (raster attribs) or first
+    /// paint byte.
+    initial,
+    /// Inside the `"..` raster-attribs body, accumulating bytes
+    /// until a non-attribute byte arrives.
+    raster_attribs,
+    /// Normal sixel data: ?..~, #, !, $, -.
+    data,
+    /// After `!`, accumulating decimal digits for the repeat count.
+    repeat_count,
+    /// After `#`, accumulating "N" or "N;Pu;Pa;Pb;Pc" for color def
+    /// or selection.
+    color_def,
+    /// Permanently ignoring remaining bytes due to a non-recoverable
+    /// error mid-stream.
+    ignore,
+};
+
+/// Streaming sixel parser. Consume bytes via `put`, finalize with
+/// `finalize` to extract the `Command`.
+pub const Parser = struct {
+    alloc: Allocator,
+    state: State,
+    raster: Raster,
+    intro_params: [3]?u16,
+
+    paint_ops: std.ArrayListUnmanaged(PaintOp),
+    palette_ops: std.ArrayListUnmanaged(PaletteOp),
+
+    /// Working buffer for raster_attribs / color_def / repeat_count.
+    accum: std.ArrayListUnmanaged(u8),
+
+    /// Initialize a parser. `intro_params` are the `Pa;Pb;Ph`
+    /// parameters from the DCS introducer (`ESC P Pa;Pb;Ph q`).
+    pub fn init(alloc: Allocator, intro_params: [3]?u16) Parser {
+        return .{
+            .alloc = alloc,
+            .state = .initial,
+            .raster = .{},
+            .intro_params = intro_params,
+            .paint_ops = .empty,
+            .palette_ops = .empty,
+            .accum = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Parser) void {
+        self.paint_ops.deinit(self.alloc);
+        self.palette_ops.deinit(self.alloc);
+        self.accum.deinit(self.alloc);
+    }
+
+    /// Consume one byte. Errors are non-fatal: the parser transitions
+    /// to `.ignore` on internal errors and silently drops remaining
+    /// bytes until `finalize`.
+    pub fn put(self: *Parser, byte: u8) void {
+        _ = self;
+        _ = byte;
+        // State-machine body lands as the parser grows; see follow-on
+        // commits in this module.
+    }
+
+    /// Finalize the accumulated state into a `Command`. Caller owns
+    /// the returned slices via `Command.deinit`. After `finalize`,
+    /// the parser is consumed — do not call `put` or `finalize` again.
+    pub fn finalize(self: *Parser) Allocator.Error!Command {
+        return .{
+            .alloc = self.alloc,
+            .raster = self.raster,
+            .palette_ops = try self.palette_ops.toOwnedSlice(self.alloc),
+            .paint_ops = try self.paint_ops.toOwnedSlice(self.alloc),
+            .intro_params = self.intro_params,
+        };
+    }
+};
+
+test "sixel parser: init and deinit do not leak" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    try testing.expect(p.state == .initial);
+}
+
+test "sixel parser: empty finalize yields empty Command" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
+    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+}
+
+test "sixel parser: intro params round-trip" {
+    var p = Parser.init(testing.allocator, .{ 7, 1, 75 });
+    defer p.deinit();
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(?u16, 7), c.intro_params[0]);
+    try testing.expectEqual(@as(?u16, 1), c.intro_params[1]);
+    try testing.expectEqual(@as(?u16, 75), c.intro_params[2]);
+}

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -91,6 +91,10 @@ pub const Parser = struct {
                     self.repeat_acc = 0;
                     self.state = .repeat_count;
                 },
+                '#' => {
+                    self.accum.clearRetainingCapacity();
+                    self.state = .color_def;
+                },
                 else => {
                     // Bytes outside the sixel data alphabet are
                     // silently ignored. We also promote .initial to
@@ -117,16 +121,29 @@ pub const Parser = struct {
                 },
                 else => {
                     // Non-digit, non-alphabet byte after `!` — abandon
-                    // the repeat and drop back to .data. Caveat: this
-                    // also drops the byte itself, so `!3#5` will lose
-                    // the `#`. Revisit when the # color-def arm lands
-                    // (either re-dispatch here or whitelist command
-                    // bytes for fall-through).
+                    // the pending count, drop back to .data, and
+                    // re-dispatch the byte so command bytes (#, $, -,
+                    // ", !) get their own handling.
                     self.state = .data;
+                    try self.tryPut(byte);
                 },
             },
 
-            .raster_attribs, .color_def => {},
+            .color_def => switch (byte) {
+                '0'...'9', ';' => {
+                    try self.accum.append(self.alloc, byte);
+                },
+                else => {
+                    // End of color def — flush, then re-dispatch this
+                    // byte in data state so it gets interpreted
+                    // (e.g. a sixel byte after `#5?` should paint).
+                    try self.flushColorDef();
+                    self.state = .data;
+                    try self.tryPut(byte);
+                },
+            },
+
+            .raster_attribs => {},
         }
     }
 
@@ -148,6 +165,57 @@ pub const Parser = struct {
             .paint_ops = try self.paint_ops.toOwnedSlice(self.alloc),
             .intro_params = self.intro_params,
         };
+    }
+
+    fn flushColorDef(self: *Parser) Allocator.Error!void {
+        var it = std.mem.splitScalar(u8, self.accum.items, ';');
+        const idx_str = it.next() orelse return;
+        const idx = parseU8(idx_str) orelse return;
+
+        // Selection form: bare "#N" with no further fields.
+        const pu_str = it.next() orelse {
+            try self.paint_ops.append(self.alloc, .{ .select_color = idx });
+            return;
+        };
+
+        const pu = parseU8(pu_str) orelse return;
+        const a_str = it.next() orelse return;
+        const b_str = it.next() orelse return;
+        const c_str = it.next() orelse return;
+        const a = parseU16(a_str) orelse return;
+        const b = parseU8(b_str) orelse return;
+        const c = parseU8(c_str) orelse return;
+
+        switch (pu) {
+            1 => try self.palette_ops.append(self.alloc, .{
+                .set_hls = .{ .idx = idx, .h = a, .l = b, .s = c },
+            }),
+            2 => try self.palette_ops.append(self.alloc, .{
+                .set_rgb = .{
+                    .idx = idx,
+                    // r is narrowed from u16, so we clamp explicitly to
+                    // keep @intCast safe. g and b come from parseU8
+                    // already in u8 range; out-of-spec values >100 pass
+                    // through here and get clamped downstream in
+                    // palette.setRgb's scale100to255.
+                    .r = @intCast(@min(a, 100)),
+                    .g = b,
+                    .b = c,
+                },
+            }),
+            else => {
+                // Unknown Pu — silently drop (spec leaves room for
+                // future extensions).
+            },
+        }
+    }
+
+    fn parseU8(s: []const u8) ?u8 {
+        return std.fmt.parseInt(u8, s, 10) catch null;
+    }
+
+    fn parseU16(s: []const u8) ?u16 {
+        return std.fmt.parseInt(u16, s, 10) catch null;
     }
 };
 
@@ -249,4 +317,108 @@ test "sixel parser: ! with no digits then sixel emits count=1" {
     defer c.deinit();
     try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
     try testing.expectEqual(@as(u16, 1), c.paint_ops[0].sixel.count);
+}
+
+test "sixel parser: #5 selects color register 5" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("#5?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .select_color);
+    try testing.expectEqual(@as(u8, 5), c.paint_ops[0].select_color);
+    try testing.expect(c.paint_ops[1] == .sixel);
+}
+
+test "sixel parser: #1;2;100;50;0 defines RGB" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("#1;2;100;50;0") |b| p.put(b);
+    // Color def needs a terminator byte to flush; feed a sixel byte.
+    p.put('?');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.palette_ops.len);
+    try testing.expect(c.palette_ops[0] == .set_rgb);
+    const op = c.palette_ops[0].set_rgb;
+    try testing.expectEqual(@as(u8, 1), op.idx);
+    try testing.expectEqual(@as(u8, 100), op.r);
+    try testing.expectEqual(@as(u8, 50), op.g);
+    try testing.expectEqual(@as(u8, 0), op.b);
+}
+
+test "sixel parser: #1;1;180;50;75 defines HLS" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("#1;1;180;50;75") |b| p.put(b);
+    p.put('?');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.palette_ops.len);
+    try testing.expect(c.palette_ops[0] == .set_hls);
+    const op = c.palette_ops[0].set_hls;
+    try testing.expectEqual(@as(u8, 1), op.idx);
+    try testing.expectEqual(@as(u16, 180), op.h);
+    try testing.expectEqual(@as(u8, 50), op.l);
+    try testing.expectEqual(@as(u8, 75), op.s);
+}
+
+test "sixel parser: #N with invalid Pu silently ignored" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    // Pu=3 is invalid (only 1=HLS, 2=RGB defined).
+    for ("#1;3;0;0;0") |b| p.put(b);
+    p.put('?');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+}
+
+test "sixel parser: #N followed by sixel byte selects then paints" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("#7~") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
+    try testing.expectEqual(@as(u8, 7), c.paint_ops[0].select_color);
+    try testing.expectEqual(@as(u8, '~'), c.paint_ops[1].sixel.byte);
+}
+
+test "sixel parser: !3#5 re-dispatches # into color_def" {
+    // Regression: previously `#` was swallowed by the .repeat_count
+    // else-arm. Now the else-arm re-dispatches the byte after dropping
+    // the pending count.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("!3#5?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    // !3 had no terminator paint byte (the next byte was #), so the
+    // pending repeat is discarded entirely. The #5 selects color 5,
+    // and the trailing ? paints with count=1.
+    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .select_color);
+    try testing.expectEqual(@as(u8, 5), c.paint_ops[0].select_color);
+    try testing.expect(c.paint_ops[1] == .sixel);
+    try testing.expectEqual(@as(u8, '?'), c.paint_ops[1].sixel.byte);
+    try testing.expectEqual(@as(u16, 1), c.paint_ops[1].sixel.count);
+}
+
+test "sixel parser: #1;2;200;200;200 clamps r but passes g/b through" {
+    // Documents the intentional asymmetry: r is clamped at the parser
+    // because the u16→u8 narrowing requires it; g and b pass through
+    // unclamped and get scaled by palette.setRgb downstream.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("#1;2;200;200;200") |b| p.put(b);
+    p.put('?');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.palette_ops.len);
+    const op = c.palette_ops[0].set_rgb;
+    try testing.expectEqual(@as(u8, 100), op.r);  // clamped
+    try testing.expectEqual(@as(u8, 200), op.g);  // not clamped here
+    try testing.expectEqual(@as(u8, 200), op.b);  // not clamped here
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -68,10 +68,37 @@ pub const Parser = struct {
     /// to `.ignore` on internal errors and silently drops remaining
     /// bytes until `finalize`.
     pub fn put(self: *Parser, byte: u8) void {
-        _ = self;
-        _ = byte;
-        // State-machine body lands as the parser grows; see follow-on
-        // commits in this module.
+        self.tryPut(byte) catch |err| {
+            log.debug("sixel parser error, ignoring rest: {}", .{err});
+            self.state = .ignore;
+        };
+    }
+
+    fn tryPut(self: *Parser, byte: u8) Allocator.Error!void {
+        switch (self.state) {
+            .ignore => return,
+
+            .initial, .data => switch (byte) {
+                '?'...'~' => try self.appendSixel(byte, 1),
+                else => {
+                    // Bytes outside the sixel data alphabet are
+                    // silently ignored. We also promote .initial to
+                    // .data so subsequent non-alphabet bytes stay
+                    // anchored in the data phase rather than waiting
+                    // for a raster prelude that will never arrive.
+                    self.state = .data;
+                },
+            },
+
+            .raster_attribs, .repeat_count, .color_def => {},
+        }
+    }
+
+    fn appendSixel(self: *Parser, byte: u8, count: u16) Allocator.Error!void {
+        try self.paint_ops.append(self.alloc, .{
+            .sixel = .{ .byte = byte, .count = count },
+        });
+        self.state = .data;
     }
 
     /// Finalize the accumulated state into a `Command`. Caller owns
@@ -111,4 +138,39 @@ test "sixel parser: intro params round-trip" {
     try testing.expectEqual(@as(?u16, 7), c.intro_params[0]);
     try testing.expectEqual(@as(?u16, 1), c.intro_params[1]);
     try testing.expectEqual(@as(?u16, 75), c.intro_params[2]);
+}
+
+test "sixel parser: single sixel byte appends count=1" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    p.put('?');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .sixel);
+    try testing.expectEqual(@as(u8, '?'), c.paint_ops[0].sixel.byte);
+    try testing.expectEqual(@as(u16, 1), c.paint_ops[0].sixel.count);
+}
+
+test "sixel parser: multiple sixel bytes append separately" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("?@AB") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 4), c.paint_ops.len);
+    for (c.paint_ops, "?@AB") |op, expected| {
+        try testing.expectEqual(@as(u8, expected), op.sixel.byte);
+    }
+}
+
+test "sixel parser: byte outside ?..~ in data state is ignored" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    p.put('?');
+    p.put(0x07); // bell, not a valid sixel byte
+    p.put('@');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -10,7 +10,7 @@ const raster = @import("raster.zig");
 
 const log = std.log.scoped(.terminal_sixel);
 
-/// Parser state. Modeled on foot's `enum sixel_state`.
+/// Parser state.
 const State = enum {
     /// Expecting either a `"` prelude (raster attribs) or first
     /// paint byte.
@@ -77,6 +77,9 @@ pub const Parser = struct {
     pub fn put(self: *Parser, byte: u8) void {
         self.tryPut(byte) catch |err| {
             log.debug("sixel parser error, ignoring rest: {}", .{err});
+            // Drop any partially-accumulated state so we don't sit on
+            // up to max_bytes of accum until deinit.
+            self.accum.clearAndFree(self.alloc);
             self.state = .ignore;
         };
     }
@@ -126,8 +129,10 @@ pub const Parser = struct {
                     self.repeat_acc +|= byte - '0';
                 },
                 '?'...'~' => {
-                    // DEC spec: missing repeat count means 1. Matches
-                    // foot and libsixel.
+                    // DEC spec: missing repeat count means 1. Also
+                    // applies when the user explicitly typed `!0`, which
+                    // foot and libsixel both coerce to 1 rather than
+                    // emitting nothing.
                     const count: u16 = if (self.repeat_acc == 0) 1 else self.repeat_acc;
                     try self.appendSixel(byte, count);
                 },
@@ -163,6 +168,12 @@ pub const Parser = struct {
                     // End of raster — flush, then re-dispatch this
                     // byte in data state (matches the .color_def
                     // else-arm pattern).
+                    //
+                    // Note: flushRaster may set self.state = .ignore
+                    // on oversized geometry. The guard below skips the
+                    // .data transition + re-dispatch in that case.
+                    // flushColorDef has no analogous failure mode (no
+                    // size check there), so it doesn't need the guard.
                     self.flushRaster();
                     if (self.state == .ignore) return;
                     self.state = .data;
@@ -197,9 +208,19 @@ pub const Parser = struct {
     }
 
     fn flushColorDef(self: *Parser) Allocator.Error!void {
+        // Empty accumulator (e.g. `##` or `#?` arrived back-to-back)
+        // produces no op at all — there's no register index to act on.
+        if (self.accum.items.len == 0) {
+            log.debug("sixel color def empty, dropped", .{});
+            return;
+        }
+
         var it = std.mem.splitScalar(u8, self.accum.items, ';');
         const idx_str = it.next() orelse return;
-        const idx = parseU8(idx_str) orelse return;
+        const idx = parseU8(idx_str) orelse {
+            log.debug("sixel color def malformed: bad register idx, dropped", .{});
+            return;
+        };
 
         // Selection form: bare "#N" with no further fields.
         const pu_str = it.next() orelse {
@@ -207,13 +228,34 @@ pub const Parser = struct {
             return;
         };
 
-        const pu = parseU8(pu_str) orelse return;
-        const a_str = it.next() orelse return;
-        const b_str = it.next() orelse return;
-        const c_str = it.next() orelse return;
-        const a = parseU16(a_str) orelse return;
-        const b = parseU8(b_str) orelse return;
-        const c = parseU8(c_str) orelse return;
+        const pu = parseU8(pu_str) orelse {
+            log.debug("sixel color def malformed: bad Pu, dropped", .{});
+            return;
+        };
+        const a_str = it.next() orelse {
+            log.debug("sixel color def malformed: missing Pa, dropped", .{});
+            return;
+        };
+        const b_str = it.next() orelse {
+            log.debug("sixel color def malformed: missing Pb, dropped", .{});
+            return;
+        };
+        const c_str = it.next() orelse {
+            log.debug("sixel color def malformed: missing Pc, dropped", .{});
+            return;
+        };
+        const a = parseU16(a_str) orelse {
+            log.debug("sixel color def malformed: bad Pa, dropped", .{});
+            return;
+        };
+        const b = parseU8(b_str) orelse {
+            log.debug("sixel color def malformed: bad Pb, dropped", .{});
+            return;
+        };
+        const c = parseU8(c_str) orelse {
+            log.debug("sixel color def malformed: bad Pc, dropped", .{});
+            return;
+        };
 
         switch (pu) {
             1 => try self.palette_ops.append(self.alloc, .{
@@ -235,6 +277,7 @@ pub const Parser = struct {
             else => {
                 // Unknown Pu — silently drop (spec leaves room for
                 // future extensions).
+                log.debug("sixel color def unknown Pu={d}, dropped", .{pu});
             },
         }
     }
@@ -574,4 +617,59 @@ test "sixel parser: incomplete raster attribs at finalize is dropped" {
     defer c.deinit();
     try testing.expectEqual(@as(u16, 1), c.raster.aspect_num);
     try testing.expectEqual(@as(u16, 0), c.raster.declared_width);
+}
+
+test "sixel parser: incomplete repeat count at finalize is dropped" {
+    // The parser sits in .repeat_count with repeat_acc=42 but never
+    // sees a terminator. The orphan count produces no op.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("!42") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
+}
+
+test "sixel parser: empty color def #? produces no op" {
+    // `#` enters .color_def with empty accum; `?` terminates and triggers
+    // flushColorDef with an empty buffer. Must not append a spurious
+    // select_color=0; must then re-dispatch ? as a paint byte.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("#?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .sixel);
+    try testing.expectEqual(@as(u8, '?'), c.paint_ops[0].sixel.byte);
+}
+
+test "sixel parser: back-to-back # # is dropped" {
+    // `##` — first # enters .color_def, second # terminates with empty
+    // accum (no op) then re-dispatches as a fresh color_def entry.
+    // Followed by `5?` to verify the second # actually re-armed
+    // color_def correctly.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("##5?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    // One select_color from the second #5, then the paint byte.
+    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .select_color);
+    try testing.expectEqual(@as(u8, 5), c.paint_ops[0].select_color);
+    try testing.expect(c.paint_ops[1] == .sixel);
+}
+
+test "sixel parser: !0 ? coerces to count=1" {
+    // DEC spec is silent on `!0`; foot and libsixel both treat it as
+    // count=1 rather than emitting nothing. Pin that behavior.
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("!0?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expectEqual(@as(u16, 1), c.paint_ops[0].sixel.count);
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -38,6 +38,12 @@ pub const Parser = struct {
     raster: Raster,
     intro_params: [3]?u16,
 
+    /// Accumulator for repeat-count digits (after `!`). Cleared when
+    /// `!` is seen, applied when the next sixel byte arrives.
+    /// Saturating add/multiply keep this clamped at u16::MAX, which
+    /// matches PaintOp.sixel.count's width.
+    repeat_acc: u16,
+
     paint_ops: std.ArrayListUnmanaged(PaintOp),
     palette_ops: std.ArrayListUnmanaged(PaletteOp),
 
@@ -52,6 +58,7 @@ pub const Parser = struct {
             .state = .initial,
             .raster = .{},
             .intro_params = intro_params,
+            .repeat_acc = 0,
             .paint_ops = .empty,
             .palette_ops = .empty,
             .accum = .empty,
@@ -80,6 +87,10 @@ pub const Parser = struct {
 
             .initial, .data => switch (byte) {
                 '?'...'~' => try self.appendSixel(byte, 1),
+                '!' => {
+                    self.repeat_acc = 0;
+                    self.state = .repeat_count;
+                },
                 else => {
                     // Bytes outside the sixel data alphabet are
                     // silently ignored. We also promote .initial to
@@ -90,7 +101,32 @@ pub const Parser = struct {
                 },
             },
 
-            .raster_attribs, .repeat_count, .color_def => {},
+            .repeat_count => switch (byte) {
+                '0'...'9' => {
+                    // Saturating ops match Parser.zig's CSI param
+                    // accumulator; once we hit u16::MAX further digits
+                    // are absorbed without overflow.
+                    self.repeat_acc *|= 10;
+                    self.repeat_acc +|= byte - '0';
+                },
+                '?'...'~' => {
+                    // DEC spec: missing repeat count means 1. Matches
+                    // foot and libsixel.
+                    const count: u16 = if (self.repeat_acc == 0) 1 else self.repeat_acc;
+                    try self.appendSixel(byte, count);
+                },
+                else => {
+                    // Non-digit, non-alphabet byte after `!` — abandon
+                    // the repeat and drop back to .data. Caveat: this
+                    // also drops the byte itself, so `!3#5` will lose
+                    // the `#`. Revisit when the # color-def arm lands
+                    // (either re-dispatch here or whitelist command
+                    // bytes for fall-through).
+                    self.state = .data;
+                },
+            },
+
+            .raster_attribs, .color_def => {},
         }
     }
 
@@ -173,4 +209,44 @@ test "sixel parser: byte outside ?..~ in data state is ignored" {
     var c = try p.finalize();
     defer c.deinit();
     try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
+}
+
+test "sixel parser: !3 ? produces count=3" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("!3?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expectEqual(@as(u16, 3), c.paint_ops[0].sixel.count);
+    try testing.expectEqual(@as(u8, '?'), c.paint_ops[0].sixel.byte);
+}
+
+test "sixel parser: !65535 saturates at u16 max" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("!65535~") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(u16, 65535), c.paint_ops[0].sixel.count);
+}
+
+test "sixel parser: !99999 saturates without overflow" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("!99999~") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    // Saturated to u16 max
+    try testing.expectEqual(@as(u16, 65535), c.paint_ops[0].sixel.count);
+}
+
+test "sixel parser: ! with no digits then sixel emits count=1" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("!?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expectEqual(@as(u16, 1), c.paint_ops[0].sixel.count);
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -95,6 +95,14 @@ pub const Parser = struct {
                     self.accum.clearRetainingCapacity();
                     self.state = .color_def;
                 },
+                '$' => {
+                    try self.paint_ops.append(self.alloc, .carriage_return);
+                    self.state = .data;
+                },
+                '-' => {
+                    try self.paint_ops.append(self.alloc, .next_line);
+                    self.state = .data;
+                },
                 else => {
                     // Bytes outside the sixel data alphabet are
                     // silently ignored. We also promote .initial to
@@ -421,4 +429,37 @@ test "sixel parser: #1;2;200;200;200 clamps r but passes g/b through" {
     try testing.expectEqual(@as(u8, 100), op.r);  // clamped
     try testing.expectEqual(@as(u8, 200), op.g);  // not clamped here
     try testing.expectEqual(@as(u8, 200), op.b);  // not clamped here
+}
+
+test "sixel parser: $ emits carriage_return" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    p.put('$');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .carriage_return);
+}
+
+test "sixel parser: - emits next_line" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    p.put('-');
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .next_line);
+}
+
+test "sixel parser: ?$-? emits sixel/CR/NL/sixel" {
+    var p = Parser.init(testing.allocator, .{ null, null, null });
+    defer p.deinit();
+    for ("?$-?") |b| p.put(b);
+    var c = try p.finalize();
+    defer c.deinit();
+    try testing.expectEqual(@as(usize, 4), c.paint_ops.len);
+    try testing.expect(c.paint_ops[0] == .sixel);
+    try testing.expect(c.paint_ops[1] == .carriage_return);
+    try testing.expect(c.paint_ops[2] == .next_line);
+    try testing.expect(c.paint_ops[3] == .sixel);
 }

--- a/src/terminal/sixel/raster.zig
+++ b/src/terminal/sixel/raster.zig
@@ -20,8 +20,8 @@ pub const Error = error{
 
 /// Parse a raster-attribs body — the bytes between `"` and the next
 /// non-attribute byte. Caller passes the slice WITHOUT the leading
-/// `"`. Format: `Pa;Pb;Ph;Pn3;Pn4` (all optional, trailing terminated
-/// by caller).
+/// `"` AND WITHOUT the terminating non-digit byte (the parser
+/// upstream strips both). Format: `Pa;Pb;Ph;Pn3;Pn4` (all optional).
 ///
 /// On `error.SixelTooLarge`, the declared geometry exceeded the
 /// budget; the caller should reject the whole sixel image.
@@ -99,10 +99,19 @@ test "raster: trailing semicolons leave fields null" {
     try testing.expectEqual(@as(u16, 0), r.grid_size);
 }
 
-test "raster: leading semicolon leaves first field default" {
-    // ";1;1" — empty first field maps to default (aspect_num=1), not 0.
+test "raster: null first field is skipped" {
+    // ";1;1" — empty first field stays at struct default (no field
+    // write); only the second and third fields populate.
     const r = try parseRasterAttribs(";1;1");
-    try testing.expectEqual(@as(u16, 1), r.aspect_num);
+    try testing.expectEqual(@as(u16, 1), r.aspect_num); // struct default
+    try testing.expectEqual(@as(u16, 1), r.aspect_den);
+}
+
+test "raster: zero-coerce first field exercises v==0 branch" {
+    // "0;1;1" — explicit 0 trips the if (v == 0) 1 else v coercion,
+    // distinct from the null path above.
+    const r = try parseRasterAttribs("0;1;1");
+    try testing.expectEqual(@as(u16, 1), r.aspect_num); // coerced from 0
     try testing.expectEqual(@as(u16, 1), r.aspect_den);
 }
 

--- a/src/terminal/sixel/raster.zig
+++ b/src/terminal/sixel/raster.zig
@@ -1,0 +1,141 @@
+const std = @import("std");
+const testing = std.testing;
+const Raster = @import("command.zig").Raster;
+
+/// Per-image RGBA byte budget. 48 MiB ≈ 3500×3500 RGBA, the upper
+/// bound we're willing to allocate per inline image. The DCS layer's
+/// 1 MiB source-byte cap (`dcs.Handler.max_bytes`) already bounds
+/// pathological inputs; this catches large *declared* geometries
+/// before the decoder allocates.
+pub const MAX_RGBA_BYTES: usize = 48 * 1024 * 1024;
+
+pub const Error = error{
+    /// Declared geometry would exceed MAX_RGBA_BYTES.
+    SixelTooLarge,
+    /// Raster attribs had a malformed parameter (non-digit, overflow,
+    /// etc.). Parser recovers by ignoring the raster and emitting
+    /// defaults.
+    Malformed,
+};
+
+/// Parse a raster-attribs body — the bytes between `"` and the next
+/// non-attribute byte. Caller passes the slice WITHOUT the leading
+/// `"`. Format: `Pa;Pb;Ph;Pn3;Pn4` (all optional, trailing terminated
+/// by caller).
+///
+/// On `error.SixelTooLarge`, the declared geometry exceeded the
+/// budget; the caller should reject the whole sixel image.
+///
+/// On `error.Malformed`, the raster header was unparseable; the
+/// caller should emit a default `Raster{}` and continue parsing
+/// paint ops.
+pub fn parseRasterAttribs(body: []const u8) Error!Raster {
+    var r = Raster{};
+    var fields: [5]?u16 = .{ null, null, null, null, null };
+    var field_idx: usize = 0;
+    var acc: u32 = 0;
+    var has_digit: bool = false;
+
+    for (body) |b| {
+        switch (b) {
+            '0'...'9' => {
+                acc = acc * 10 + (b - '0');
+                if (acc > std.math.maxInt(u16)) return error.Malformed;
+                has_digit = true;
+            },
+            ';' => {
+                if (field_idx >= fields.len) return error.Malformed;
+                fields[field_idx] = if (has_digit) @intCast(acc) else null;
+                field_idx += 1;
+                acc = 0;
+                has_digit = false;
+            },
+            else => return error.Malformed,
+        }
+    }
+    if (field_idx < fields.len) {
+        fields[field_idx] = if (has_digit) @intCast(acc) else null;
+    } else if (has_digit) {
+        // All five slots filled and there's still digit content waiting
+        // — the input declared a sixth field, which is not valid DEC.
+        // Without this branch the loop's `field_idx >= fields.len`
+        // guard never fires (it only triggers on a sixth `;`), so the
+        // trailing digits would be silently dropped.
+        return error.Malformed;
+    }
+
+    if (fields[0]) |v| r.aspect_num = if (v == 0) 1 else v;
+    if (fields[1]) |v| r.aspect_den = if (v == 0) 1 else v;
+    if (fields[2]) |v| r.grid_size = v;
+    if (fields[3]) |v| r.declared_width = v;
+    if (fields[4]) |v| r.declared_height = v;
+
+    // Geometry budget check (only applies if both dims declared).
+    if (r.declared_width > 0 and r.declared_height > 0) {
+        const bytes = @as(usize, r.declared_width) *
+            @as(usize, r.declared_height) * 4;
+        if (bytes > MAX_RGBA_BYTES) return error.SixelTooLarge;
+    }
+
+    return r;
+}
+
+test "raster: empty body returns defaults" {
+    const r = try parseRasterAttribs("");
+    try testing.expectEqual(@as(u16, 1), r.aspect_num);
+    try testing.expectEqual(@as(u16, 1), r.aspect_den);
+}
+
+test "raster: 1;1;0;100;200 sets declared dims" {
+    const r = try parseRasterAttribs("1;1;0;100;200");
+    try testing.expectEqual(@as(u16, 100), r.declared_width);
+    try testing.expectEqual(@as(u16, 200), r.declared_height);
+}
+
+test "raster: trailing semicolons leave fields null" {
+    const r = try parseRasterAttribs("2;1");
+    try testing.expectEqual(@as(u16, 2), r.aspect_num);
+    try testing.expectEqual(@as(u16, 1), r.aspect_den);
+    try testing.expectEqual(@as(u16, 0), r.grid_size);
+}
+
+test "raster: leading semicolon leaves first field default" {
+    // ";1;1" — empty first field maps to default (aspect_num=1), not 0.
+    const r = try parseRasterAttribs(";1;1");
+    try testing.expectEqual(@as(u16, 1), r.aspect_num);
+    try testing.expectEqual(@as(u16, 1), r.aspect_den);
+}
+
+test "raster: zero aspect coerces to 1" {
+    const r = try parseRasterAttribs("0;0");
+    try testing.expectEqual(@as(u16, 1), r.aspect_num);
+    try testing.expectEqual(@as(u16, 1), r.aspect_den);
+}
+
+test "raster: oversized geometry returns SixelTooLarge" {
+    // 8192 × 8192 × 4 = 256 MiB > 48 MiB cap
+    const err = parseRasterAttribs("1;1;0;8192;8192");
+    try testing.expectError(error.SixelTooLarge, err);
+}
+
+test "raster: at-cap geometry succeeds" {
+    // 3500 × 3500 × 4 ≈ 46.7 MiB, under 48 MiB
+    const r = try parseRasterAttribs("1;1;0;3500;3500");
+    try testing.expectEqual(@as(u16, 3500), r.declared_width);
+}
+
+test "raster: malformed non-digit returns Malformed" {
+    const err = parseRasterAttribs("1;abc");
+    try testing.expectError(error.Malformed, err);
+}
+
+test "raster: u16 overflow returns Malformed" {
+    // 99999 > u16 max
+    const err = parseRasterAttribs("99999");
+    try testing.expectError(error.Malformed, err);
+}
+
+test "raster: too many fields returns Malformed" {
+    const err = parseRasterAttribs("1;2;3;4;5;6");
+    try testing.expectError(error.Malformed, err);
+}


### PR DESCRIPTION
First PR of a 4-PR stack that adds the DEC Sixel image protocol to wintty.

## Scope

DCS-byte → `sixel.Command` parser with full unit-test coverage. **No decoder, no render, no DA1 advertisement.** Sixel-emitting apps still see no support after this lands; nothing in user-visible behavior changes.

New module `src/terminal/sixel/`:
- `command.zig` — value types (`Command`, `Raster`, `PaintOp`, `PaletteOp`)
- `raster.zig` — raster-attribs parse + 48 MiB geometry budget gate
- `palette.zig` — 256-register table + libsixel VT340 defaults (RGB only; HLS lands with the decoder in PR 2)
- `parser.zig` — state-machine parser modeled on foot's `enum sixel_state`

DCS hook arm in `src/terminal/dcs.zig` matches `intermediates.len == 0, final == 'q'` (the DEC sixel introducer).

## Stack order

- **PR 1**: parser (this PR)
- PR 2: decoder + HLS + golden-RGBA test corpus
- PR 3: render-wire + cursor advance via `terminal.image.State`
- PR 4: flip the DA1 `;4` feature bit so apps probe and emit

## Test results

| Platform | Result |
|---|---|
| Windows | exit 0 |
| macOS aarch64 | exit 0 |
| Linux x86_64 | exit 0 |

52 new tests across `terminal.sixel.*` + `terminal.dcs.*`:
- 31 parser tests covering every DEC op (`?..~`, `!N`, `#N`, `#N;Pu;Pa;Pb;Pc`, `$`, `-`, `"...`) and error recovery edges
- 10 raster tests (happy path, geometry budget rejection, malformed input, u16 overflow, leading/trailing empty fields)
- 5 palette tests (defaults, register-16 fallback, rounding, saturation)
- 4 command value-type tests
- 2 DCS integration tests (minimal hook→put→unhook and with raster prelude)

## Notable design pins

- **Recursive re-dispatch** in the `.repeat_count` and `.color_def` else-arms keeps command bytes like `#` and `"` from being swallowed when they arrive mid-state. Depth bounded at 2 (re-dispatch lands in `.data`, which only transitions; never recurses).
- **u16-saturating run-length** matches `Parser.zig`'s CSI param accumulator idiom (`*|=` / `+|=` rather than manual cap).
- **48 MiB geometry budget** matches the existing per-image cap used by the Kitty graphics and iTerm2 inline-image paths. The DCS layer's 1 MiB source-byte cap still bounds adversarial input.
- **`Command` carries its own allocator** so `dcs.Command.deinit` doesn't have to thread one through.
- **Parser `accum` working buffer** is freed by `dcs.Handler.unhook` even on successful `finalize` (the slices are transferred to Command via `toOwnedSlice` but `accum` isn't). Memory leak caught by the test allocator during integration verification.

## Smoke

No runtime smoke probes apply yet — apps emitting sixel hit a parser that produces a `Command` which the unchanged `stream_handler` drops on the floor. End-to-end smoke ships with PR 3 (render-wire).

## Followups for PR 2

- DEC HLS → RGB conversion in `palette.setHls`
- Decoder allocates RGBA from `Command.paint_ops` / `palette_ops`
- Golden-RGBA test corpus from libsixel + DEC manual probes

## What this PR does NOT do

- No RGBA decoder (PR 2)
- No render integration (PR 3)
- No DA1 `;4` advertisement (PR 4)