### PR TITLE
cli: brand standalone exe resources as wintty

### DIFF
--- a/dist/windows/ghostty.rc
+++ b/dist/windows/ghostty.rc
@@ -4,8 +4,8 @@ LANGUAGE 0, 0
 #define RT_MANIFEST 1
 RT_MANIFEST 24 "ghostty.manifest"
 
-#define ID_ICON_GHOSTTY 1
-ID_ICON_GHOSTTY ICON "ghostty.ico"
+#define ID_ICON_WINTTY 1
+ID_ICON_WINTTY ICON "wintty.ico"
 
 VS_VERSION_INFO VERSIONINFO
 //FILEVERSION     VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_COMMIT_HEIGHT
@@ -25,7 +25,7 @@ BEGIN
         //VALUE "FileVersion",        VERSION
         //VALUE "LegalCopyright",     "(C) 2024 ???"
         VALUE "OriginalFilename", "ghostty.exe"
-        VALUE "ProductName",        "Ghostty"
+        VALUE "ProductName",        "Wintty"
         //VALUE "ProductVersion",     VERSION
         END
     END


### PR DESCRIPTION
PR # 411 renamed the WinUI 3 shell to Wintty but missed the embedded
Windows resources on the standalone CLI exe (built from
src/build/GhosttyExe.zig). Reviewer flagged the gap as a followup.

This updates dist/windows/ghostty.rc so Explorer's right-click
Properties / Task Manager show "Wintty" for ghostty.exe:

- ProductName: Ghostty -> Wintty
- IDI_ICON ref: ghostty.ico -> wintty.ico (matches the filename
  IconGen has been emitting since PR # 411)
- ID_ICON_GHOSTTY symbol renamed for consistency

Kept untouched:

- Filename `ghostty.rc` (only the contents change)
- `OriginalFilename` field stays `ghostty.exe` because the binary
  name on disk is still ghostty.exe

Note: the standalone CLI exe build path (-Demit-exe -Dapp-runtime!=none)
is currently broken at the resource-compile step because no .ico
gets staged into dist/windows/ before resinator runs. That predates
this PR (it broke when PR # 411 renamed the IconGen output and was
already broken before that since #commit 65ed4cb4 removed the
checked-in placeholder ghostty.ico). Fixing that wiring is out of
scope here.

## Test plan

- [x] `zig build -Dapp-runtime=none` succeeds (libghostty path,
  unchanged)
- [ ] Manual: build a standalone ghostty.exe once the icon-staging
  wiring is fixed, right-click -> Properties shows ProductName "Wintty"