### PR TITLE
build: move TERM_PROGRAM literal into build_config

### DIFF
--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -57,6 +57,13 @@ pub const i18n: bool = config.i18n;
 /// avoid it in Zig coe as much as possible.
 pub const bundle_id = "com.mitchellh.ghostty";
 
+/// The value we publish as `TERM_PROGRAM` to child processes. Programs like
+/// neovim, tmux, and various shells use it to detect which terminal emulator
+/// they're running under. Keeping this in build_config (and not as a literal
+/// in src/termio/Exec.zig) means upstream Ghostty rebases don't conflict on
+/// the brand string -- the fork only diverges in this one file.
+pub const term_program: []const u8 = "wintty";
+
 /// True if we should have "slow" runtime safety checks. The initial motivation
 /// for this was terminal page/pagelist integrity checks. These were VERY
 /// slow but very thorough. But they made it so slow that the terminal couldn't

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -58,11 +58,10 @@ pub const i18n: bool = config.i18n;
 pub const bundle_id = "com.mitchellh.ghostty";
 
 /// The value we publish as `TERM_PROGRAM` to child processes. Programs like
-/// neovim, tmux, and various shells use it to detect which terminal emulator
-/// they're running under. Keeping this in build_config (and not as a literal
-/// in src/termio/Exec.zig) means upstream Ghostty rebases don't conflict on
-/// the brand string -- the fork only diverges in this one file.
-pub const term_program: []const u8 = "wintty";
+/// neovim, tmux, and various shells read this to detect which terminal
+/// emulator they're running under. Hardcoded here rather than at call sites
+/// so there's one authoritative spelling of the brand string.
+pub const term_program = "wintty";
 
 /// True if we should have "slow" runtime safety checks. The initial motivation
 /// for this was terminal page/pagelist integrity checks. These were VERY

--- a/src/cli/kitty_logo.zig
+++ b/src/cli/kitty_logo.zig
@@ -12,6 +12,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const build_config = @import("../build_config.zig");
 
 const logo_png = @embedFile("wintty_logo.png");
 
@@ -25,11 +26,11 @@ pub fn supported(alloc: Allocator, stdout: std.fs.File) bool {
     var env = std.process.getEnvMap(alloc) catch return false;
     defer env.deinit();
 
-    // Wintty sets TERM_PROGRAM=wintty (and upstream Ghostty sets =ghostty)
-    // when spawning a shell. Accept both so already-running shells from
+    // Wintty sets TERM_PROGRAM=<build_config.term_program> when spawning a
+    // shell; "ghostty" stays in the match list so shells inherited from
     // pre-rebrand binaries still get the logo. WezTerm uses the same var.
     if (env.get("TERM_PROGRAM")) |v| {
-        if (std.mem.eql(u8, v, "wintty")) return true;
+        if (std.mem.eql(u8, v, build_config.term_program)) return true;
         if (std.mem.eql(u8, v, "ghostty")) return true;
         if (std.mem.eql(u8, v, "WezTerm")) return true;
     }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -913,7 +913,7 @@ const Subprocess = struct {
 
         // Set environment variables used by some programs (such as neovim) to detect
         // which terminal emulator and version they're running under.
-        try env.put("TERM_PROGRAM", "wintty");
+        try env.put("TERM_PROGRAM", build_config.term_program);
         try env.put("TERM_PROGRAM_VERSION", build_config.version_string);
 
         // VTE_VERSION is set by gnome-terminal and other VTE-based terminals.


### PR DESCRIPTION
PR # 411 changed src/termio/Exec.zig:916 from
\`try env.put(\"TERM_PROGRAM\", \"ghostty\");\` to
\`try env.put(\"TERM_PROGRAM\", \"wintty\");\` -- a hardcoded literal that
will conflict with the Ghostty parent repo on every rebase.

This PR introduces \`build_config.term_program\` alongside the existing
\`bundle_id\` const (same pattern: hardcoded brand string in
build_config), and references it from Exec.zig. The fork's brand
divergence now lives in one well-known place.

Compile-time const, not a build option -- this is a Windows fork that
deliberately never builds with the Ghostty brand, so a \`-Dbrand=\`
knob would be machinery for a switch we'd never flip.

## Test plan
- [ ] \`zig build -Dapp-runtime=none\` clean
- [ ] \`\$env:TERM_PROGRAM\` inside a freshly-spawned wintty shell still
      returns \`wintty\`