### PR TITLE
config: default mouse-hide-while-typing to true on Wintty fork

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -915,11 +915,17 @@ palette: Palette = .{},
 /// behavior around edge cases is possible.
 @"cursor-click-to-move": bool = true,
 
-/// Hide the mouse immediately when typing. The mouse becomes visible again
-/// when the mouse is used (button, movement, etc.). Platform-specific behavior
-/// may dictate other scenarios where the mouse is shown. For example on macOS,
-/// the mouse is shown again when a new window, tab, or split is created.
-@"mouse-hide-while-typing": bool = false,
+/// Hide the mouse cursor immediately when typing. The cursor becomes visible
+/// again when the mouse is used (button, movement, etc.). Set to `false` to
+/// keep the cursor always visible.
+///
+/// Platform-specific behavior may dictate other scenarios where the cursor is
+/// shown. For example on macOS, the cursor is shown again when a new window,
+/// tab, or split is created.
+///
+/// Default is `true` on the Wintty fork (matches Windows Terminal, iTerm2,
+/// WezTerm, and Alacritty). Upstream Ghostty keeps the default at `false`.
+@"mouse-hide-while-typing": bool = true,
 
 /// When to scroll the surface to the bottom. The format of this is a list of
 /// options to enable separated by commas. If you prefix an option with `no-`
@@ -10545,6 +10551,16 @@ test "clone default" {
 
     // I want to do this but this doesn't work (the API doesn't work)
     // try testing.expectEqualDeep(dest, source);
+}
+
+test "default mouse-hide-while-typing is true (Wintty fork)" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    try testing.expectEqual(true, cfg.@"mouse-hide-while-typing");
 }
 
 test "clone preserves conditional state" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -915,16 +915,10 @@ palette: Palette = .{},
 /// behavior around edge cases is possible.
 @"cursor-click-to-move": bool = true,
 
-/// Hide the mouse cursor immediately when typing. The cursor becomes visible
-/// again when the mouse is used (button, movement, etc.). Set to `false` to
-/// keep the cursor always visible.
-///
-/// Platform-specific behavior may dictate other scenarios where the cursor is
-/// shown. For example on macOS, the cursor is shown again when a new window,
-/// tab, or split is created.
-///
-/// Default is `true` on the Wintty fork (matches Windows Terminal, iTerm2,
-/// WezTerm, and Alacritty). Upstream Ghostty keeps the default at `false`.
+/// Hide the mouse immediately when typing. The mouse becomes visible again
+/// when the mouse is used (button, movement, etc.). Platform-specific behavior
+/// may dictate other scenarios where the mouse is shown. For example on macOS,
+/// the mouse is shown again when a new window, tab, or split is created.
 @"mouse-hide-while-typing": bool = true,
 
 /// When to scroll the surface to the bottom. The format of this is a list of
@@ -10553,7 +10547,7 @@ test "clone default" {
     // try testing.expectEqualDeep(dest, source);
 }
 
-test "default mouse-hide-while-typing is true (Wintty fork)" {
+test "default mouse-hide-while-typing is true" {
     const testing = std.testing;
     const alloc = testing.allocator;
 

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -439,7 +439,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
             GetFileValue("cursor-style-blink", "false"),
             "true", StringComparison.OrdinalIgnoreCase);
         MouseHideWhileTyping = string.Equals(
-            GetFileValue("mouse-hide-while-typing", "false"),
+            GetFileValue("mouse-hide-while-typing", "true"),
             "true", StringComparison.OrdinalIgnoreCase);
         if (int.TryParse(
                 GetFileValue("scrollback-limit", "10000000"),


### PR DESCRIPTION
## Summary

- Flips `mouse-hide-while-typing` default from `false` to `true` on the Wintty fork (one line in `src/config/Config.zig`).
- Rewrites the doc comment to lead with the new default and call out the fork-vs-upstream divergence.
- Adds a dedicated test that asserts the default so a future accidental revert fails noisily.

## User-visible change

After upgrading, the OS mouse cursor will auto-hide on typing and re-appear on mouse motion. This matches Windows Terminal, iTerm2, WezTerm, and Alacritty. The Settings UI toggle ("Hide pointer during keyboard input" on the Terminal page) was already wired in PR # 398 - anyone who wants the old behavior flips it off, or sets `mouse-hide-while-typing = false` in `~/.config/ghostty/config.ghostty`.

## Test plan

- [x] New test asserts the default at the config-defaults level.
- [x] Full `zig build test` clean (66/67 -> 67/67 after the flip; nothing else relied on the old default).
- [x] `just build-dll build-win` clean.