### PR TITLE
active-shell-icon: wsl distro resolution via cmdline retrieval

### DIFF
--- a/windows/Ghostty.Core/NativeMethods.txt
+++ b/windows/Ghostty.Core/NativeMethods.txt
@@ -31,3 +31,8 @@ CreateToolhelp32Snapshot
 Process32FirstW
 Process32NextW
 CloseHandle
+
+// kernel32 for opening other processes to read their command line
+// (ProcessTreeWalker + NtProcessInterop)
+OpenProcess
+PROCESS_ACCESS_RIGHTS

--- a/windows/Ghostty.Core/Profiles/Tracking/NtProcessInterop.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/NtProcessInterop.cs
@@ -68,7 +68,9 @@ internal static partial class NtProcessInterop
             PROCESS_ACCESS_RIGHTS.PROCESS_QUERY_LIMITED_INFORMATION,
             false,
             pid);
-        if (handle == default(HANDLE) || handle.IsNull) return null;
+        // OpenProcess returns NULL (not INVALID_HANDLE_VALUE) on failure, unlike
+        // CreateToolhelp32Snapshot in ProcessTreeWalker.cs which uses the latter.
+        if (handle.IsNull) return null;
         try
         {
             return GetCommandLine(handle);
@@ -94,8 +96,9 @@ internal static partial class NtProcessInterop
         var status = NtQueryInformationProcess(
             ntHandle, ProcessCommandLineInformation, IntPtr.Zero, 0, out var required);
         if (status != STATUS_INFO_LENGTH_MISMATCH && status != 0) return null;
-        if (required == 0) return null;
-
+        // Class 60 payload is bounded by a UNICODE_STRING (ushort.MaxValue header)
+        // plus a few bytes; cap defensively so a bogus kernel response can't OOM us.
+        if (required is 0 or > 65 * 1024) return null;
         var buffer = Marshal.AllocHGlobal((int)required);
         try
         {

--- a/windows/Ghostty.Core/Profiles/Tracking/NtProcessInterop.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/NtProcessInterop.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Threading;
+
+namespace Ghostty.Core.Profiles.Tracking;
+
+/// <summary>
+/// Reads another process's command line via the documented
+/// <c>NtQueryInformationProcess</c>(ProcessCommandLineInformation, class 60)
+/// path. Available since Windows 8.1 and far simpler than the alternative
+/// PEB + ReadProcessMemory walk: one syscall, returns a UNICODE_STRING
+/// header followed inline by the wide-char data.
+///
+/// CsWin32's ntdll metadata coverage is thin (class 60 in particular is
+/// not surfaced as a named PROCESSINFOCLASS constant in older Win32
+/// metadata packs), so we keep ntdll's surface as a hand-written DllImport
+/// here and only borrow OpenProcess / CloseHandle from CsWin32's
+/// <c>DWritePInvoke</c> generated class.
+/// </summary>
+[SupportedOSPlatform("windows6.0.6000")]
+internal static partial class NtProcessInterop
+{
+    // ProcessInformationClass value documented on MSDN for retrieving the
+    // target process's command line in one call. Added in Windows 8.1.
+    private const int ProcessCommandLineInformation = 60;
+
+    // NTSTATUS sentinel: the initial probing call passes a zero-length
+    // buffer to discover the required size, which legitimately fails with
+    // this status. Treat it as "size known, retry" rather than an error.
+    private const int STATUS_INFO_LENGTH_MISMATCH = unchecked((int)0xC0000004);
+
+    // LibraryImport (not DllImport) so the source-generated stub is
+    // forward-compatible with [assembly: DisableRuntimeMarshalling] on
+    // Ghostty.Core. The "out uint" parameter is blittable and needs no
+    // marshalling, so the generated stub is a thin wrapper.
+    [LibraryImport("ntdll.dll")]
+    private static partial int NtQueryInformationProcess(
+        IntPtr ProcessHandle,
+        int ProcessInformationClass,
+        IntPtr ProcessInformation,
+        uint ProcessInformationLength,
+        out uint ReturnLength);
+
+    // UNICODE_STRING is laid out as { ushort Length, ushort MaximumLength,
+    // IntPtr Buffer } on every Windows architecture. The Buffer field
+    // points at the inline wide-char data that follows the header in the
+    // returned block. Length is in BYTES, not chars.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UNICODE_STRING
+    {
+        public ushort Length;
+        public ushort MaximumLength;
+        public IntPtr Buffer;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="pid"/> with PROCESS_QUERY_LIMITED_INFORMATION
+    /// (sufficient for class 60), queries the command line, and closes the
+    /// handle. Returns null on any failure - exited process, access denied
+    /// (e.g. protected processes like csrss.exe), or empty cmdline.
+    /// </summary>
+    public static string? TryGetCommandLine(uint pid)
+    {
+        var handle = DWritePInvoke.OpenProcess(
+            PROCESS_ACCESS_RIGHTS.PROCESS_QUERY_LIMITED_INFORMATION,
+            false,
+            pid);
+        if (handle == default(HANDLE) || handle.IsNull) return null;
+        try
+        {
+            return GetCommandLine(handle);
+        }
+        finally
+        {
+            DWritePInvoke.CloseHandle(handle);
+        }
+    }
+
+    /// <summary>
+    /// Queries class 60 on an already-open handle. Two-call pattern: probe
+    /// for required length, allocate, then read.
+    /// </summary>
+    private static unsafe string? GetCommandLine(HANDLE handle)
+    {
+        // HANDLE.Value is a void* with useSafeHandles=false; convert to
+        // IntPtr for the hand-written p/invoke signature.
+        var ntHandle = (IntPtr)handle.Value;
+
+        // Probe: zero-length call returns STATUS_INFO_LENGTH_MISMATCH and
+        // sets ReturnLength to the buffer size we need.
+        var status = NtQueryInformationProcess(
+            ntHandle, ProcessCommandLineInformation, IntPtr.Zero, 0, out var required);
+        if (status != STATUS_INFO_LENGTH_MISMATCH && status != 0) return null;
+        if (required == 0) return null;
+
+        var buffer = Marshal.AllocHGlobal((int)required);
+        try
+        {
+            status = NtQueryInformationProcess(
+                ntHandle, ProcessCommandLineInformation, buffer, required, out required);
+            if (status != 0) return null;
+
+            var u = Marshal.PtrToStructure<UNICODE_STRING>(buffer);
+            if (u.Length == 0 || u.Buffer == IntPtr.Zero) return null;
+            // Length is in bytes; PtrToStringUni wants char count.
+            return Marshal.PtrToStringUni(u.Buffer, u.Length / 2);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+}

--- a/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/ProcessTreeWalker.cs
@@ -9,6 +9,14 @@ using Windows.Win32.System.Diagnostics.ToolHelp;
 namespace Ghostty.Core.Profiles.Tracking;
 
 /// <summary>
+/// Innermost-descendant info returned by <see cref="ProcessTreeWalker"/>.
+/// <c>ExeBasename</c> is always populated; <c>CommandLine</c> is the raw
+/// command line of the same process when readable, else null (e.g. exited,
+/// access denied, protected process).
+/// </summary>
+internal readonly record struct DescendantInfo(string ExeBasename, string? CommandLine);
+
+/// <summary>
 /// Walks the Windows process tree to find the innermost descendant of a
 /// given root PID. "Innermost" = deepest by tree depth; ties broken by
 /// the snapshot's natural iteration order (deterministic on stable input).
@@ -39,11 +47,13 @@ internal static class ProcessTreeWalker
         };
 
     /// <summary>
-    /// Returns the exe basename (e.g. "vim.exe") of the innermost
-    /// descendant of <paramref name="rootPid"/>. Returns null when the
-    /// root has no descendants, has exited, or the snapshot fails.
+    /// Returns the exe basename + command line of the innermost descendant
+    /// of <paramref name="rootPid"/>. Returns null when the root has no
+    /// descendants, has exited, or the snapshot fails. The command line
+    /// component is null when it could not be read (access denied, race
+    /// with process exit, etc.) but the basename is still reported.
     /// </summary>
-    public static string? FindInnermostDescendant(uint rootPid)
+    public static DescendantInfo? FindInnermostDescendant(uint rootPid)
     {
         var snapshot = DWritePInvoke.CreateToolhelp32Snapshot(
             CREATE_TOOLHELP_SNAPSHOT_FLAGS.TH32CS_SNAPPROCESS, 0);
@@ -83,7 +93,7 @@ internal static class ProcessTreeWalker
         }
     }
 
-    private static string? DeepestDescendant(
+    private static DescendantInfo? DeepestDescendant(
         IReadOnlyDictionary<uint, List<(uint Pid, string ExeBasename)>> byParent,
         uint rootPid)
     {
@@ -101,6 +111,7 @@ internal static class ProcessTreeWalker
         }
 
         string? bestName = null;
+        uint bestPid = 0;
         int bestDepth = 0;
         while (queue.Count > 0)
         {
@@ -112,6 +123,7 @@ internal static class ProcessTreeWalker
             {
                 bestDepth = depth;
                 bestName = name;
+                bestPid = pid;
             }
             if (byParent.TryGetValue(pid, out var kids))
             {
@@ -121,6 +133,13 @@ internal static class ProcessTreeWalker
                 }
             }
         }
-        return bestName;
+
+        if (bestName is null) return null;
+
+        // Command line retrieval is best-effort: a NULL here just means we
+        // fall back to exe-only icon mapping. Callers (e.g. wsl distro
+        // disambiguation) already handle null gracefully.
+        var cmdline = NtProcessInterop.TryGetCommandLine(bestPid);
+        return new DescendantInfo(bestName, cmdline);
     }
 }

--- a/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
@@ -72,11 +72,8 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
             }
 
             var exe = info?.ExeBasename;
-            // The walker can now retrieve the command line of the leaf;
-            // wiring it through the debouncer is intentionally deferred
-            // to the next commit so this change stays purely about the
-            // walker's API surface.
-            var emission = _debouncer.Observe(rootPid, exe, commandLine: null, nowMs: now);
+            var cmdline = info?.CommandLine;
+            var emission = _debouncer.Observe(rootPid, exe, commandLine: cmdline, nowMs: now);
             if (emission is not null)
             {
                 try

--- a/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
+++ b/windows/Ghostty.Core/Profiles/Tracking/WindowsActiveProcessTracker.cs
@@ -56,12 +56,10 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
 
         foreach (var (rootPid, _) in _roots)
         {
-            string? exe;
-            string? cmdline;
+            DescendantInfo? info;
             try
             {
-                exe = ProcessTreeWalker.FindInnermostDescendant((uint)rootPid);
-                cmdline = null;
+                info = ProcessTreeWalker.FindInnermostDescendant((uint)rootPid);
             }
             catch (Exception ex)
             {
@@ -70,15 +68,15 @@ public sealed class WindowsActiveProcessTracker : IActiveProcessTracker
                 // regressed tracker is diagnosable from the debug log.
                 System.Diagnostics.Debug.WriteLine(
                     $"WindowsActiveProcessTracker: snapshot failed for pid={rootPid}: {ex.GetType().Name}: {ex.Message}");
-                exe = null;
-                cmdline = null;
+                info = null;
             }
 
-            // V1: command line is not retrieved. ProcessIconTable handles
-            // null commandLine correctly for everything except wsl.exe
-            // distro disambiguation, which is acceptable until shell
-            // integration scripts land in a follow-up.
-            var emission = _debouncer.Observe(rootPid, exe, commandLine: cmdline, nowMs: now);
+            var exe = info?.ExeBasename;
+            // The walker can now retrieve the command line of the leaf;
+            // wiring it through the debouncer is intentionally deferred
+            // to the next commit so this change stays purely about the
+            // walker's API surface.
+            var emission = _debouncer.Observe(rootPid, exe, commandLine: null, nowMs: now);
             if (emission is not null)
             {
                 try

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Profiles.Tracking;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ghostty.Tests.Windows.Tracking;
+
+public sealed class WindowsActiveProcessTrackerWslSmokeTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public WindowsActiveProcessTrackerWslSmokeTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task Track_WslWithDistribution_ReportsAutoForWslDistro()
+    {
+        // Probe wsl: CI runners often lack it. Silent early-out keeps CI green
+        // while still exercising the full path on a dev machine with wsl set up.
+        var (ok, distro) = ProbeWsl();
+        if (!ok || string.IsNullOrEmpty(distro))
+        {
+            _output.WriteLine("wsl not available - skipping");
+            return;
+        }
+        _output.WriteLine($"probed distro: {distro}");
+
+        // Spawn pwsh -> wsl.exe --distribution <distro> -- sleep 5
+        // pwsh is the root we register; wsl.exe is the descendant the walker
+        // should observe. The 5s sleep gives the 500 ms tick + 250 ms debounce
+        // a comfortable window to fire while wsl.exe is still alive.
+        using var pwsh = Process.Start(new ProcessStartInfo
+        {
+            FileName = "pwsh.exe",
+            Arguments = $"-NoLogo -NoProfile -Command \"& wsl.exe --distribution {distro} -- sleep 5\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        Assert.NotNull(pwsh);
+
+        using var tracker = new WindowsActiveProcessTracker();
+        var tcs = new TaskCompletionSource<(string exe, string? cmd)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observed = new List<string>();
+        var sw = Stopwatch.StartNew();
+
+        tracker.Changed += (_, e) =>
+        {
+            lock (observed)
+            {
+                observed.Add($"{sw.ElapsedMilliseconds}ms pid={e.RootPid} exe={e.ExeBasename ?? "<null>"} cmd={e.CommandLine ?? "<null>"}");
+            }
+            // We want wsl.exe specifically. The broker filter already removes
+            // wslhost / conhost / OpenConsole. Anything deeper (the linux side)
+            // is invisible to the Win32 walker.
+            if (string.Equals(e.ExeBasename, "wsl.exe", StringComparison.OrdinalIgnoreCase)
+                && !tcs.Task.IsCompleted)
+            {
+                tcs.SetResult((e.ExeBasename!, e.CommandLine));
+            }
+        };
+        tracker.Register(pwsh!.Id);
+
+        var winner = await Task.WhenAny(tcs.Task, Task.Delay(8000));
+        lock (observed)
+        {
+            foreach (var line in observed)
+                _output.WriteLine(line);
+        }
+        Assert.True(
+            winner == tcs.Task,
+            $"tracker did not report wsl.exe within 8s; observed: [{string.Join(", ", observed)}]");
+
+        var (exe, cmd) = await tcs.Task;
+        Assert.Equal("wsl.exe", exe, ignoreCase: true);
+        Assert.NotNull(cmd);
+        Assert.Contains(distro, cmd, StringComparison.OrdinalIgnoreCase);
+        _output.WriteLine($"tracker reported {exe} cmd=[{cmd}] after {sw.ElapsedMilliseconds}ms");
+
+        // Full chain: ProcessIconTable.TryMap maps wsl.exe + cmdline to
+        // AutoForWslDistro(<distro>). This is the icon UX contract that
+        // TabIconViewModel relies on.
+        var spec = ProcessIconTable.TryMap(exe, cmd);
+        var auto = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
+        Assert.Equal(distro, auto.DistroName, ignoreCase: true);
+
+        try { pwsh.Kill(entireProcessTree: true); } catch { }
+    }
+
+    /// <summary>
+    /// Probes whether wsl is installed and at least one distro exists.
+    /// <c>wsl --list --quiet</c> emits UTF-16 LE with a BOM on Windows, so the
+    /// raw stdout has interleaved null bytes when read as the default encoding.
+    /// We strip those before splitting; the result is the first non-empty line.
+    /// </summary>
+    private static (bool ok, string? distro) ProbeWsl()
+    {
+        try
+        {
+            var p = Process.Start(new ProcessStartInfo
+            {
+                FileName = "wsl.exe",
+                Arguments = "--list --quiet",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            if (p is null) return (false, null);
+            if (!p.WaitForExit(2000)) return (false, null);
+            if (p.ExitCode != 0) return (false, null);
+
+            var raw = p.StandardOutput.ReadToEnd();
+            var cleaned = new string(raw.Where(c => c != '\0' && c != '﻿').ToArray());
+            var first = cleaned
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => s.Trim())
+                .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s));
+            return string.IsNullOrEmpty(first) ? (false, null) : (true, first);
+        }
+        catch
+        {
+            return (false, null);
+        }
+    }
+}

--- a/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Tracking/WindowsActiveProcessTrackerWslSmokeTests.cs
@@ -46,52 +46,56 @@ public sealed class WindowsActiveProcessTrackerWslSmokeTests
         });
         Assert.NotNull(pwsh);
 
-        using var tracker = new WindowsActiveProcessTracker();
-        var tcs = new TaskCompletionSource<(string exe, string? cmd)>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var observed = new List<string>();
-        var sw = Stopwatch.StartNew();
-
-        tracker.Changed += (_, e) =>
+        try
         {
+            using var tracker = new WindowsActiveProcessTracker();
+            var tcs = new TaskCompletionSource<(string exe, string? cmd)>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var observed = new List<string>();
+            var sw = Stopwatch.StartNew();
+
+            tracker.Changed += (_, e) =>
+            {
+                lock (observed)
+                {
+                    observed.Add($"{sw.ElapsedMilliseconds}ms pid={e.RootPid} exe={e.ExeBasename ?? "<null>"} cmd={e.CommandLine ?? "<null>"}");
+                }
+                // We want wsl.exe specifically. The broker filter already removes
+                // wslhost / conhost / OpenConsole. Anything deeper (the linux side)
+                // is invisible to the Win32 walker.
+                if (string.Equals(e.ExeBasename, "wsl.exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    tcs.TrySetResult((e.ExeBasename!, e.CommandLine));
+                }
+            };
+            tracker.Register(pwsh!.Id);
+
+            var winner = await Task.WhenAny(tcs.Task, Task.Delay(8000));
             lock (observed)
             {
-                observed.Add($"{sw.ElapsedMilliseconds}ms pid={e.RootPid} exe={e.ExeBasename ?? "<null>"} cmd={e.CommandLine ?? "<null>"}");
+                foreach (var line in observed)
+                    _output.WriteLine(line);
             }
-            // We want wsl.exe specifically. The broker filter already removes
-            // wslhost / conhost / OpenConsole. Anything deeper (the linux side)
-            // is invisible to the Win32 walker.
-            if (string.Equals(e.ExeBasename, "wsl.exe", StringComparison.OrdinalIgnoreCase)
-                && !tcs.Task.IsCompleted)
-            {
-                tcs.SetResult((e.ExeBasename!, e.CommandLine));
-            }
-        };
-        tracker.Register(pwsh!.Id);
+            Assert.True(
+                winner == tcs.Task,
+                $"tracker did not report wsl.exe within 8s; observed: [{string.Join(", ", observed)}]");
 
-        var winner = await Task.WhenAny(tcs.Task, Task.Delay(8000));
-        lock (observed)
-        {
-            foreach (var line in observed)
-                _output.WriteLine(line);
+            var (exe, cmd) = await tcs.Task;
+            Assert.Equal("wsl.exe", exe, ignoreCase: true);
+            Assert.NotNull(cmd);
+            Assert.Contains(distro, cmd, StringComparison.OrdinalIgnoreCase);
+            _output.WriteLine($"tracker reported {exe} cmd=[{cmd}] after {sw.ElapsedMilliseconds}ms");
+
+            // Full chain: ProcessIconTable.TryMap maps wsl.exe + cmdline to
+            // AutoForWslDistro(<distro>). This is the icon UX contract that
+            // TabIconViewModel relies on.
+            var spec = ProcessIconTable.TryMap(exe, cmd);
+            var auto = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
+            Assert.Equal(distro, auto.DistroName, ignoreCase: true);
         }
-        Assert.True(
-            winner == tcs.Task,
-            $"tracker did not report wsl.exe within 8s; observed: [{string.Join(", ", observed)}]");
-
-        var (exe, cmd) = await tcs.Task;
-        Assert.Equal("wsl.exe", exe, ignoreCase: true);
-        Assert.NotNull(cmd);
-        Assert.Contains(distro, cmd, StringComparison.OrdinalIgnoreCase);
-        _output.WriteLine($"tracker reported {exe} cmd=[{cmd}] after {sw.ElapsedMilliseconds}ms");
-
-        // Full chain: ProcessIconTable.TryMap maps wsl.exe + cmdline to
-        // AutoForWslDistro(<distro>). This is the icon UX contract that
-        // TabIconViewModel relies on.
-        var spec = ProcessIconTable.TryMap(exe, cmd);
-        var auto = Assert.IsType<IconSpec.AutoForWslDistro>(spec);
-        Assert.Equal(distro, auto.DistroName, ignoreCase: true);
-
-        try { pwsh.Kill(entireProcessTree: true); } catch { }
+        finally
+        {
+            try { pwsh.Kill(entireProcessTree: true); } catch { }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes the V1 limitation noted in PR #413: when a user types \`wsl -d Ubuntu\` (or any distro) inside a tab, the tracker now passes the wsl.exe command line through to ProcessIconTable, which maps it to \`IconSpec.AutoForWslDistro("Ubuntu")\`. The resolver then surfaces the Ubuntu brand icon instead of the legacy wsl.png fallback.

## Implementation
- NtProcessInterop in Ghostty.Core.Profiles.Tracking — LibraryImport for \`NtQueryInformationProcess\` with \`ProcessCommandLineInformation\` (class 60). Two-call probe-then-read for cmdline retrieval; handles access-denied / exited-process / short-lived-process cleanly. Capped allocation against bogus kernel responses (≤ 64 KiB).
- ProcessTreeWalker returns \`DescendantInfo(string ExeBasename, string? CommandLine)\` instead of bare basename. Fetches cmdline only for the best descendant the walker picks, not every node — cheap per tick.
- WindowsActiveProcessTracker threads cmdline through the debouncer all the way to ActiveProcessChangedEventArgs.CommandLine and TabModel.OnActiveProcessChanged.
- Real-process smoke test in Ghostty.Tests.Windows: spawns \`pwsh -> wsl --distribution <local-distro> -- sleep 5\`, asserts the tracker reports wsl.exe with a cmdline that ProcessIconTable maps to AutoForWslDistro(distroName). Probes wsl availability and skips cleanly on CI runners without WSL.

Observed locally: tracker reports wsl.exe at ~3.4s from spawn with cmdline \`"C:\Windows\system32\wsl.exe" --distribution Ubuntu-24.04 -- sleep 5\`; ProcessIconTable.TryMap returns AutoForWslDistro("Ubuntu-24.04"), which the resolver maps to the bundled ubuntu brand icon.

This re-targets #415 (which was merged into the wrong base branch during the stack rebase).

## Test plan
- [x] xunit smoke (Ghostty.Tests.Windows): WindowsActiveProcessTrackerWslSmokeTests passes locally with Ubuntu-24.04. Skips on systems without wsl installed.
- [x] Full Ghostty.Tests suite: 993 passed, 1 pre-existing skip, 0 failed.
- [x] Build clean (Core + Ghostty + Tests + Tests.Windows).