### PR TITLE
terminal/sixel: decoder + HLS (PR 2/4 of Sixel stack)

### DIFF
--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -217,11 +217,11 @@ pub const Handler = struct {
                     p.deinit();
                     break :sixel null;
                 };
-                // finalize transferred paint_ops and palette_ops to
-                // the returned Command, but `accum` (the working
-                // buffer for raster/color/repeat strings) stays with
-                // the parser and needs releasing. deinit on the
-                // now-empty paint/palette lists is a no-op.
+                // finalize transferred the ops slice to the returned
+                // Command, but `accum` (the working buffer for
+                // raster/color/repeat strings) stays with the parser
+                // and needs releasing. deinit on the now-empty ops
+                // list is a no-op.
                 p.deinit();
                 break :sixel .{ .sixel = c };
             },
@@ -484,7 +484,7 @@ test "sixel DCS command" {
     var cmd = h.unhook().?;
     defer cmd.deinit();
     try testing.expect(cmd == .sixel);
-    try testing.expectEqual(@as(usize, 1), cmd.sixel.paint_ops.len);
+    try testing.expectEqual(@as(usize, 1), cmd.sixel.ops.len);
     try testing.expect(h.state == .inactive);
 }
 

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -13,6 +13,9 @@
 pub const Command = @import("sixel/command.zig").Command;
 pub const Parser = @import("sixel/parser.zig").Parser;
 pub const Palette = @import("sixel/palette.zig").Palette;
+pub const decode = @import("sixel/decoder.zig").decode;
+pub const Image = @import("sixel/decoder.zig").Image;
+pub const DecodeCtx = @import("sixel/decoder.zig").DecodeCtx;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -6,10 +6,10 @@
 //! `src/terminal/sixel/`.
 
 // Only types with external callers are re-exported. dcs.Handler uses
-// Parser as its DCS state and Command as the unhook output. Palette
-// stays anchored here so its tests are discovered by refAllDecls
-// even though no external caller consumes it yet — the decoder will
-// use it in a follow-on commit.
+// Parser as its DCS state and Command as the unhook output. decode +
+// Image + DecodeCtx are the decoder API. Palette is consumed by
+// decoder.zig directly via its sibling import; it stays re-exported
+// here so refAllDecls reaches its tests.
 pub const Command = @import("sixel/command.zig").Command;
 pub const Parser = @import("sixel/parser.zig").Parser;
 pub const Palette = @import("sixel/palette.zig").Palette;

--- a/src/terminal/sixel/command.zig
+++ b/src/terminal/sixel/command.zig
@@ -1,29 +1,53 @@
 const std = @import("std");
 const testing = std.testing;
 
+/// A single operation in a sixel DCS stream. Paint operations
+/// (sixel bytes, color selection, cursor control) and palette
+/// definitions live in the same union because their source-order
+/// interleaving matters: `#1;2;100;0;0?#1;2;0;100;0?` paints red
+/// then green; if palette ops were applied as a separate first
+/// pass, both sixels would paint with green.
+pub const Op = union(enum) {
+    /// A sixel data byte (?..~ in source), optionally run-length-repeated.
+    /// `byte` is the raw character; the decoder maps it to 6 vertical pixels.
+    /// `count` is u16 because the `!N` run-length is unbounded in the
+    /// DEC spec — u8 would clip common encoder output, u32 wastes
+    /// memory in the op stream. The parser saturates at u16 max.
+    sixel: struct { byte: u8, count: u16 },
+    /// Select color register `idx` as the current paint color.
+    select_color: u8,
+    /// `$` — return paint cursor to leftmost column.
+    carriage_return,
+    /// `-` — advance paint cursor down 6 pixels, reset to leftmost column.
+    next_line,
+    /// `#N;2;Pr;Pg;Pb` — set register N to RGB triple.
+    /// Values are 0-100 from the DEC source (clamped/scaled downstream).
+    set_rgb: struct { idx: u8, r: u8, g: u8, b: u8 },
+    /// `#N;1;Ph;Pl;Ps` — set register N to DEC HLS triple.
+    /// H is 0-360, L is 0-100, S is 0-100. Decoder converts to RGB.
+    set_hls: struct { idx: u8, h: u16, l: u8, s: u8 },
+};
+
 /// A fully-parsed sixel image command. Output of the parser, input
-/// to the decoder (future commit).
+/// to the decoder.
 ///
-/// Ownership: two heap-allocated slices are released by `deinit`.
-/// We carry the allocator on the struct rather than using an arena
-/// because there are only two slices and a `Command.deinit()` is
-/// easier to chain into the existing `dcs.Command.deinit` switch arm
-/// than an arena handle.
+/// Ownership: one heap-allocated slice released by `deinit`. We carry
+/// the allocator on the struct rather than using an arena because
+/// `Command.deinit()` chains cleanly into the existing
+/// `dcs.Command.deinit` switch arm without an arena handle.
 pub const Command = struct {
-    /// Allocator that owns palette_ops and paint_ops slices.
-    /// Set by Parser.finalize; freed by deinit.
+    /// Allocator that owns the ops slice. Set by Parser.finalize;
+    /// freed by deinit.
     alloc: std.mem.Allocator,
 
     /// Raster attributes (geometry, aspect ratio). May be defaulted
     /// if the sender omitted the `"` prelude.
     raster: Raster,
 
-    /// Palette register set operations, in source order.
-    palette_ops: []const PaletteOp,
-
-    /// Paint operations (sixel bytes, color selects, CR, NL), in
-    /// source order.
-    paint_ops: []const PaintOp,
+    /// All operations in source order. Paint and palette ops mixed,
+    /// applied by the decoder in stream order so mid-stream palette
+    /// mutation has the correct effect.
+    ops: []const Op,
 
     /// The `Pa;Pb;Ph` parameters from the DCS introducer
     /// (`ESC P Pa;Pb;Ph q`). All optional; null when omitted.
@@ -33,8 +57,7 @@ pub const Command = struct {
     intro_params: [3]?u16,
 
     pub fn deinit(self: *Command) void {
-        self.alloc.free(self.palette_ops);
-        self.alloc.free(self.paint_ops);
+        self.alloc.free(self.ops);
     }
 };
 
@@ -51,37 +74,12 @@ pub const Raster = struct {
     declared_height: u16 = 0,
 };
 
-pub const PaintOp = union(enum) {
-    /// A sixel data byte (?..~ in source), optionally run-length-repeated.
-    /// `byte` is the raw character; the decoder maps it to 6 vertical pixels.
-    /// `count` is u16 because the `!N` run-length is unbounded in the
-    /// DEC spec — u8 would clip common encoder output, u32 wastes
-    /// memory in the op stream. The parser saturates at u16 max.
-    sixel: struct { byte: u8, count: u16 },
-    /// Select color register `idx` as the current paint color.
-    select_color: u8,
-    /// `$` — return paint cursor to leftmost column.
-    carriage_return,
-    /// `-` — advance paint cursor down 6 pixels, reset to leftmost column.
-    next_line,
-};
-
-pub const PaletteOp = union(enum) {
-    /// `#N;2;Pr;Pg;Pb` — set register N to RGB triple.
-    /// Values normalized to 0-255 from the source 0-100 range.
-    set_rgb: struct { idx: u8, r: u8, g: u8, b: u8 },
-    /// `#N;1;Ph;Pl;Ps` — set register N to DEC HLS triple.
-    /// H is 0-360, L is 0-100, S is 0-100. Decoder converts to RGB.
-    set_hls: struct { idx: u8, h: u16, l: u8, s: u8 },
-};
-
-test "Command: deinit frees slices" {
+test "Command: deinit frees ops slice" {
     const alloc = testing.allocator;
     var cmd = Command{
         .alloc = alloc,
         .raster = .{},
-        .palette_ops = try alloc.alloc(PaletteOp, 2),
-        .paint_ops = try alloc.alloc(PaintOp, 3),
+        .ops = try alloc.alloc(Op, 3),
         .intro_params = .{ null, null, null },
     };
     cmd.deinit();
@@ -96,14 +94,20 @@ test "Raster: defaults match spec" {
     try testing.expectEqual(@as(u16, 0), r.declared_height);
 }
 
-test "PaintOp: sixel variant carries byte and count" {
-    const op = PaintOp{ .sixel = .{ .byte = '?', .count = 1 } };
+test "Op: sixel variant carries byte and count" {
+    const op = Op{ .sixel = .{ .byte = '?', .count = 1 } };
     try testing.expectEqual(@as(u8, '?'), op.sixel.byte);
     try testing.expectEqual(@as(u16, 1), op.sixel.count);
 }
 
-test "PaletteOp: set_rgb variant carries normalized values" {
-    const op = PaletteOp{ .set_rgb = .{ .idx = 0, .r = 255, .g = 128, .b = 0 } };
+test "Op: set_rgb variant carries values" {
+    const op = Op{ .set_rgb = .{ .idx = 0, .r = 100, .g = 50, .b = 0 } };
     try testing.expectEqual(@as(u8, 0), op.set_rgb.idx);
-    try testing.expectEqual(@as(u8, 255), op.set_rgb.r);
+    try testing.expectEqual(@as(u8, 100), op.set_rgb.r);
+}
+
+test "Op: set_hls variant carries values with u16 hue" {
+    const op = Op{ .set_hls = .{ .idx = 1, .h = 240, .l = 50, .s = 100 } };
+    try testing.expectEqual(@as(u16, 240), op.set_hls.h);
+    try testing.expectEqual(@as(u8, 50), op.set_hls.l);
 }

--- a/src/terminal/sixel/decoder.zig
+++ b/src/terminal/sixel/decoder.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
+const Command = @import("command.zig").Command;
+const Op = @import("command.zig").Op;
+const palette_mod = @import("palette.zig");
+const Palette = palette_mod.Palette;
+const Rgba = palette_mod.Rgba;
+const raster = @import("raster.zig");
+
+const log = std.log.scoped(.terminal_sixel);
+
+/// A decoded sixel image. Owns its RGBA buffer; caller releases via
+/// `deinit`. Layout is row-major, 4 bytes per pixel (R, G, B, A).
+pub const Image = struct {
+    alloc: Allocator,
+    rgba: []u8,
+    width: u32,
+    height: u32,
+
+    pub fn deinit(self: *Image) void {
+        self.alloc.free(self.rgba);
+    }
+};
+
+/// Decoder context — environment data the decoder needs that isn't
+/// in the Command itself.
+pub const DecodeCtx = struct {
+    /// Background color used by P1 mode for unpainted pixels.
+    /// Defaults to opaque black if not set by caller.
+    bg: Rgba = .{ .r = 0, .g = 0, .b = 0, .a = 255 },
+    /// Maximum total RGBA bytes the decoder may allocate. Defaults
+    /// to MAX_RGBA_BYTES (the same per-image cap raster.zig enforces).
+    budget: usize = raster.MAX_RGBA_BYTES,
+};
+
+pub const Error = error{
+    SixelTooLarge,
+    OutOfMemory,
+};
+
+/// Decode a parsed sixel Command into an RGBA Image. The Palette
+/// starts in its DEC default state; set_rgb/set_hls ops in the
+/// stream mutate it as encountered.
+pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
+    if (cmd.ops.len == 0) {
+        return .{
+            .alloc = alloc,
+            .rgba = try alloc.alloc(u8, 0),
+            .width = 0,
+            .height = 0,
+        };
+    }
+    _ = ctx;
+    // Full implementation lands in a follow-on commit.
+    return .{
+        .alloc = alloc,
+        .rgba = try alloc.alloc(u8, 0),
+        .width = 0,
+        .height = 0,
+    };
+}
+
+test "decoder: empty Command yields 0x0 image" {
+    const alloc = testing.allocator;
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.alloc(Op, 0),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 0), img.width);
+    try testing.expectEqual(@as(u32, 0), img.height);
+    try testing.expectEqual(@as(usize, 0), img.rgba.len);
+}

--- a/src/terminal/sixel/decoder.zig
+++ b/src/terminal/sixel/decoder.zig
@@ -39,6 +39,25 @@ pub const Error = error{
     OutOfMemory,
 };
 
+/// Background-pixel mode from the DCS introducer Pb parameter.
+const BgMode = enum { p1, p2, p3 };
+
+/// Decode the background-pixel mode from the DCS introducer Pb
+/// parameter (`ESC P Pa;Pb;Ph q`):
+///   Pb=0 (or missing) → P1: unpainted pixels show current bg color
+///   Pb=1              → P2: unpainted pixels are transparent (alpha=0)
+///   Pb=2              → P3: unpainted pixels show the raster-declared
+///                            bg from the device-attributes register
+/// Unknown Pb values fall back to P1.
+fn decodeBgMode(intro_params: [3]?u16) BgMode {
+    const pb = intro_params[1] orelse 0;
+    return switch (pb) {
+        2 => .p3,
+        1 => .p2,
+        else => .p1,
+    };
+}
+
 /// Decode a parsed sixel Command into an RGBA Image. The Palette
 /// starts in its DEC default state; set_rgb/set_hls ops in the
 /// stream mutate it as encountered.
@@ -80,9 +99,19 @@ pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
 
     var rgba = try alloc.alloc(u8, total_bytes);
     errdefer alloc.free(rgba);
-    // Initial fill: P1 (default) uses ctx.bg; P2 and P3 modes land
-    // in later commits.
-    fillBg(rgba, ctx.bg);
+
+    const bg_mode = decodeBgMode(cmd.intro_params);
+    switch (bg_mode) {
+        .p1 => fillBg(rgba, ctx.bg),
+        .p2 => fillBg(rgba, .{ .r = 0, .g = 0, .b = 0, .a = 0 }),
+        .p3 => {
+            // True P3 expects a raster-declared bg from a DEC
+            // device-attributes register; we don't carry that field
+            // yet (PR 3 territory). Fall back to ctx.bg so P3
+            // streams render without crashing.
+            fillBg(rgba, ctx.bg);
+        },
+    }
 
     var palette = Palette.init();
     var paint_x: u32 = 0;
@@ -106,7 +135,10 @@ pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
                     rgba[off] = color.r;
                     rgba[off + 1] = color.g;
                     rgba[off + 2] = color.b;
-                    rgba[off + 3] = color.a;
+                    // In P2 mode the palette entry's alpha is ignored;
+                    // any painted pixel becomes fully opaque. P1/P3
+                    // honor the palette alpha (defaults to 255).
+                    rgba[off + 3] = if (bg_mode == .p2) 255 else color.a;
                 }
             }
             paint_x +|= s.count;
@@ -491,4 +523,153 @@ test "decoder: raster larger than paint bounds doesn't expand output" {
     defer img.deinit();
     try testing.expectEqual(@as(u32, 1), img.width);
     try testing.expectEqual(@as(u32, 6), img.height);
+}
+
+// ---- BgMode dispatch + P1/P2/P3 modes ----
+
+test "decoder: BgMode helper recognizes Pb correctly" {
+    try testing.expectEqual(BgMode.p1, decodeBgMode(.{ null, null, null }));
+    try testing.expectEqual(BgMode.p1, decodeBgMode(.{ null, 0, null }));
+    try testing.expectEqual(BgMode.p2, decodeBgMode(.{ null, 1, null }));
+    try testing.expectEqual(BgMode.p3, decodeBgMode(.{ null, 2, null }));
+    try testing.expectEqual(BgMode.p1, decodeBgMode(.{ null, 99, null }));
+}
+
+test "decoder: P1 mode (default) unpainted pixels show ctx.bg" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '?', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null }, // missing Pb = P1
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 255, .g = 165, .b = 0, .a = 255 }, // orange
+    });
+    defer img.deinit();
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 255), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 165), img.rgba[off + 1]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 2]);
+        try testing.expectEqual(@as(u8, 255), img.rgba[off + 3]);
+    }
+}
+
+test "decoder: P1 explicit (Pb=0) matches default behavior" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '?', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, 0, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 255, .g = 165, .b = 0, .a = 255 },
+    });
+    defer img.deinit();
+    try testing.expectEqual(@as(u8, 255), img.rgba[0]);
+    try testing.expectEqual(@as(u8, 165), img.rgba[1]);
+}
+
+test "decoder: P2 mode unpainted pixels have alpha=0" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '?', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, 1, null }, // P2
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 255, .g = 0, .b = 0, .a = 255 }, // red bg ignored in P2
+    });
+    defer img.deinit();
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 3]); // alpha
+    }
+}
+
+test "decoder: P2 mode painted pixels have alpha=255" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '~', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, 1, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 255), img.rgba[off + 3]);
+    }
+}
+
+test "decoder: P2 mode preserves painted pixels through subsequent zero-pattern" {
+    // Paint red, $ (CR), then ? (no bits set) at the same position.
+    // The bit-check in the walk loop already prevents zero-pattern
+    // from writing, so red pixels survive.
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 0, .b = 0 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+        .{ .carriage_return = {} },
+        .{ .sixel = .{ .byte = '?', .count = 1 } },
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, 1, null }, // P2
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 255), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 1]);
+        try testing.expectEqual(@as(u8, 255), img.rgba[off + 3]);
+    }
+}
+
+test "decoder: P3 mode falls back to ctx.bg without a declared bg" {
+    // Our Raster doesn't carry a declared bg color (the DEC spec
+    // stores it in a device-attributes register that's outside this
+    // PR's scope). For now P3 mirrors P1.
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '?', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, 2, null }, // P3
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 100, .g = 50, .b = 200, .a = 255 },
+    });
+    defer img.deinit();
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 100), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 50), img.rgba[off + 1]);
+        try testing.expectEqual(@as(u8, 200), img.rgba[off + 2]);
+    }
 }

--- a/src/terminal/sixel/decoder.zig
+++ b/src/terminal/sixel/decoder.zig
@@ -673,3 +673,114 @@ test "decoder: P3 mode falls back to ctx.bg without a declared bg" {
         try testing.expectEqual(@as(u8, 200), img.rgba[off + 2]);
     }
 }
+
+// ---- Golden multi-feature compositions ----
+
+test "decoder: 2-stripe palette switch produces alternating columns" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 100, .b = 100 } }, // white
+        .{ .sixel = .{ .byte = '~', .count = 1 } }, // col 0: black (default)
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } }, // col 1: white
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 2), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+    // Col 0 = black, col 1 = white.
+    try testing.expectEqual(@as(u8, 0), img.rgba[0]);
+    try testing.expectEqual(@as(u8, 255), img.rgba[4]);
+    try testing.expectEqual(@as(u8, 255), img.rgba[5]);
+    try testing.expectEqual(@as(u8, 255), img.rgba[6]);
+}
+
+test "decoder: partial-bit sixel paints only y=0 and y=5" {
+    // '`' = 0x60. 0x60 - '?' = 0x21 = 0b100001 (bits 0 and 5 set).
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '`', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 200, .g = 200, .b = 200, .a = 255 },
+    });
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 1), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+    try testing.expectEqual(@as(u8, 0), img.rgba[0]); // y=0 black
+    try testing.expectEqual(@as(u8, 200), img.rgba[4]); // y=1 gray
+    try testing.expectEqual(@as(u8, 200), img.rgba[8]); // y=2 gray
+    try testing.expectEqual(@as(u8, 200), img.rgba[12]); // y=3 gray
+    try testing.expectEqual(@as(u8, 200), img.rgba[16]); // y=4 gray
+    try testing.expectEqual(@as(u8, 0), img.rgba[20]); // y=5 black
+}
+
+test "decoder: two-row CR/NL composition" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 0, .b = 0 } },
+        .{ .set_rgb = .{ .idx = 2, .r = 0, .g = 0, .b = 100 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } }, // row 0 red
+        .{ .next_line = {} },
+        .{ .select_color = 2 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } }, // row 1 blue
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 1), img.width);
+    try testing.expectEqual(@as(u32, 12), img.height);
+    for (0..6) |y| {
+        try testing.expectEqual(@as(u8, 255), img.rgba[y * 4]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[y * 4 + 2]);
+    }
+    for (6..12) |y| {
+        try testing.expectEqual(@as(u8, 0), img.rgba[y * 4]);
+        try testing.expectEqual(@as(u8, 255), img.rgba[y * 4 + 2]);
+    }
+}
+
+test "decoder: HLS palette entry produces correct color end-to-end" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_hls = .{ .idx = 1, .h = 120, .l = 50, .s = 100 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    // DEC red (H=120 L=50 S=100): RGB (255, 0, 0).
+    try testing.expectEqual(@as(u8, 255), img.rgba[0]);
+    try testing.expectEqual(@as(u8, 0), img.rgba[1]);
+    try testing.expectEqual(@as(u8, 0), img.rgba[2]);
+}

--- a/src/terminal/sixel/decoder.zig
+++ b/src/terminal/sixel/decoder.zig
@@ -42,6 +42,10 @@ pub const Error = error{
 /// Decode a parsed sixel Command into an RGBA Image. The Palette
 /// starts in its DEC default state; set_rgb/set_hls ops in the
 /// stream mutate it as encountered.
+///
+/// Two-pass algorithm: first pass measures the bounding box without
+/// allocating, second pass allocates the RGBA buffer and walks the
+/// op stream painting each sixel byte's 6-pixel vertical column.
 pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
     if (cmd.ops.len == 0) {
         return .{
@@ -51,14 +55,116 @@ pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
             .height = 0,
         };
     }
-    _ = ctx;
-    // Full implementation lands in a follow-on commit.
+
+    const bounds = measureBounds(cmd);
+    const w: u32 = if (cmd.raster.declared_width > 0)
+        @min(bounds.w, cmd.raster.declared_width)
+    else
+        bounds.w;
+    const h: u32 = if (cmd.raster.declared_height > 0)
+        @min(bounds.h, cmd.raster.declared_height)
+    else
+        bounds.h;
+
+    if (w == 0 or h == 0) {
+        return .{
+            .alloc = alloc,
+            .rgba = try alloc.alloc(u8, 0),
+            .width = 0,
+            .height = 0,
+        };
+    }
+
+    const total_bytes: usize = @as(usize, w) * @as(usize, h) * 4;
+    if (total_bytes > ctx.budget) return error.SixelTooLarge;
+
+    var rgba = try alloc.alloc(u8, total_bytes);
+    errdefer alloc.free(rgba);
+    // Initial fill: P1 (default) uses ctx.bg; P2 and P3 modes land
+    // in later commits.
+    fillBg(rgba, ctx.bg);
+
+    var palette = Palette.init();
+    var paint_x: u32 = 0;
+    var paint_y: u32 = 0;
+    var current_color: u8 = 0;
+
+    for (cmd.ops) |op| switch (op) {
+        .sixel => |s| {
+            const color = palette.query(current_color);
+            const bits: u8 = s.byte -% '?';
+            var col: u32 = 0;
+            while (col < s.count) : (col += 1) {
+                const px = paint_x + col;
+                if (px >= w) break;
+                var bit: u3 = 0;
+                while (bit < 6) : (bit += 1) {
+                    if ((bits >> bit) & 1 == 0) continue;
+                    const py = paint_y + bit;
+                    if (py >= h) continue;
+                    const off = (@as(usize, py) * @as(usize, w) + @as(usize, px)) * 4;
+                    rgba[off] = color.r;
+                    rgba[off + 1] = color.g;
+                    rgba[off + 2] = color.b;
+                    rgba[off + 3] = color.a;
+                }
+            }
+            paint_x +|= s.count;
+        },
+        .select_color => |idx| current_color = idx,
+        .carriage_return => paint_x = 0,
+        .next_line => {
+            paint_x = 0;
+            paint_y +|= 6;
+        },
+        .set_rgb => |rgb| palette.setRgb(rgb.idx, rgb.r, rgb.g, rgb.b),
+        .set_hls => |hls| palette.setHls(hls.idx, hls.h, hls.l, hls.s),
+    };
+
     return .{
         .alloc = alloc,
-        .rgba = try alloc.alloc(u8, 0),
-        .width = 0,
-        .height = 0,
+        .rgba = rgba,
+        .width = w,
+        .height = h,
     };
+}
+
+const Bounds = struct { w: u32, h: u32 };
+
+/// First pass: walk the op stream tracking the max x and max y
+/// reached. Doesn't allocate.
+fn measureBounds(cmd: Command) Bounds {
+    var paint_x: u32 = 0;
+    var paint_y: u32 = 0;
+    var max_x: u32 = 0;
+    var max_y: u32 = 0;
+
+    for (cmd.ops) |op| switch (op) {
+        .sixel => |s| {
+            paint_x +|= s.count;
+            if (paint_x > max_x) max_x = paint_x;
+            const reach_y = paint_y + 6;
+            if (reach_y > max_y) max_y = reach_y;
+        },
+        .carriage_return => paint_x = 0,
+        .next_line => {
+            paint_x = 0;
+            paint_y +|= 6;
+        },
+        .select_color, .set_rgb, .set_hls => {},
+    };
+
+    return .{ .w = max_x, .h = max_y };
+}
+
+fn fillBg(rgba: []u8, bg: Rgba) void {
+    var i: usize = 0;
+    while (i < rgba.len) : (i += 4) {
+        rgba[i] = bg.r;
+        rgba[i + 1] = bg.g;
+        rgba[i + 2] = bg.b;
+        rgba[i + 3] = bg.a;
+    }
 }
 
 test "decoder: empty Command yields 0x0 image" {
@@ -76,4 +182,57 @@ test "decoder: empty Command yields 0x0 image" {
     try testing.expectEqual(@as(u32, 0), img.width);
     try testing.expectEqual(@as(u32, 0), img.height);
     try testing.expectEqual(@as(usize, 0), img.rgba.len);
+}
+
+test "decoder: single ? paints a 1x6 column of background" {
+    // '?' = 0x3F. byte - '?' = 0, so no bits set → all 6 pixels
+    // stay at background (P1 default = ctx.bg = black).
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '?', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 1), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 0), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 1]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 2]);
+        try testing.expectEqual(@as(u8, 255), img.rgba[off + 3]);
+    }
+}
+
+test "decoder: ~ paints a 1x6 column of foreground (all bits set)" {
+    // '~' = 0x7E. byte - '?' = 0x3F = 0b111111 → all 6 pixels painted.
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '~', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 255, .g = 255, .b = 255, .a = 255 }, // white bg
+    });
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 1), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+    // All 6 pixels should be black (palette default entry 0).
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 0), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 1]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 2]);
+    }
 }

--- a/src/terminal/sixel/decoder.zig
+++ b/src/terminal/sixel/decoder.zig
@@ -8,8 +8,6 @@ const Palette = palette_mod.Palette;
 const Rgba = palette_mod.Rgba;
 const raster = @import("raster.zig");
 
-const log = std.log.scoped(.terminal_sixel);
-
 /// A decoded sixel image. Owns its RGBA buffer; caller releases via
 /// `deinit`. Layout is row-major, 4 bytes per pixel (R, G, B, A).
 pub const Image = struct {
@@ -48,7 +46,10 @@ const BgMode = enum { p1, p2, p3 };
 ///   Pb=1              → P2: unpainted pixels are transparent (alpha=0)
 ///   Pb=2              → P3: unpainted pixels show the raster-declared
 ///                            bg from the device-attributes register
-/// Unknown Pb values fall back to P1.
+///
+/// Unknown Pb values fall back to P1. xterm and libsixel apply the
+/// same "treat unknown as P1" default; the spec doesn't require it
+/// but no real-world emitter relies on a stricter behavior.
 fn decodeBgMode(intro_params: [3]?u16) BgMode {
     const pb = intro_params[1] orelse 0;
     return switch (pb) {
@@ -66,14 +67,7 @@ fn decodeBgMode(intro_params: [3]?u16) BgMode {
 /// allocating, second pass allocates the RGBA buffer and walks the
 /// op stream painting each sixel byte's 6-pixel vertical column.
 pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
-    if (cmd.ops.len == 0) {
-        return .{
-            .alloc = alloc,
-            .rgba = try alloc.alloc(u8, 0),
-            .width = 0,
-            .height = 0,
-        };
-    }
+    if (cmd.ops.len == 0) return emptyImage(alloc);
 
     const bounds = measureBounds(cmd);
     const w: u32 = if (cmd.raster.declared_width > 0)
@@ -85,14 +79,7 @@ pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
     else
         bounds.h;
 
-    if (w == 0 or h == 0) {
-        return .{
-            .alloc = alloc,
-            .rgba = try alloc.alloc(u8, 0),
-            .width = 0,
-            .height = 0,
-        };
-    }
+    if (w == 0 or h == 0) return emptyImage(alloc);
 
     const total_bytes: usize = @as(usize, w) * @as(usize, h) * 4;
     if (total_bytes > ctx.budget) return error.SixelTooLarge;
@@ -106,9 +93,10 @@ pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
         .p2 => fillBg(rgba, .{ .r = 0, .g = 0, .b = 0, .a = 0 }),
         .p3 => {
             // True P3 expects a raster-declared bg from a DEC
-            // device-attributes register; we don't carry that field
-            // yet (PR 3 territory). Fall back to ctx.bg so P3
-            // streams render without crashing.
+            // device-attributes register; Raster doesn't carry that
+            // field yet. Fall back to ctx.bg so P3 streams render
+            // without crashing. TODO: thread the declared bg
+            // through once Raster grows the field.
             fillBg(rgba, ctx.bg);
         },
     }
@@ -141,7 +129,14 @@ pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
                     rgba[off + 3] = if (bg_mode == .p2) 255 else color.a;
                 }
             }
-            paint_x +|= s.count;
+            // Advance only by the columns actually painted, capped
+            // at the canvas width. Without the clamp, a `!10 ~` on
+            // a 5-wide raster would leave paint_x=10 and silently
+            // discard a subsequent paint at "col 11"; with the clamp
+            // it stays at the right edge so a following `$` + paint
+            // restarts correctly.
+            const painted: u32 = @min(s.count, w -| paint_x);
+            paint_x +|= painted;
         },
         .select_color => |idx| current_color = idx,
         .carriage_return => paint_x = 0,
@@ -158,6 +153,17 @@ pub fn decode(alloc: Allocator, cmd: Command, ctx: DecodeCtx) Error!Image {
         .rgba = rgba,
         .width = w,
         .height = h,
+    };
+}
+
+/// Build a 0x0 Image without allocating. Avoids the inconsistent
+/// behavior of `alloc.alloc(u8, 0)` across allocators.
+fn emptyImage(alloc: Allocator) Image {
+    return .{
+        .alloc = alloc,
+        .rgba = &[_]u8{},
+        .width = 0,
+        .height = 0,
     };
 }
 
@@ -506,6 +512,40 @@ test "decoder: raster.declared_height clamps output height" {
     defer img.deinit();
     try testing.expectEqual(@as(u32, 1), img.width);
     try testing.expectEqual(@as(u32, 6), img.height);
+}
+
+test "decoder: paint_x clamps after raster-truncated paint" {
+    // Regression: a 10-wide run-length on a 5-wide raster used to
+    // saturate paint_x to 10, so a subsequent $-then-paint started
+    // at the wrong column relative to a clamped width.
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 0, .b = 0 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 10 } }, // would-be 10-wide red
+        .{ .carriage_return = {} },
+        .{ .set_rgb = .{ .idx = 1, .r = 0, .g = 100, .b = 0 } },
+        .{ .sixel = .{ .byte = '~', .count = 2 } }, // 2-wide green
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{ .declared_width = 5, .declared_height = 6 },
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 5), img.width);
+    // Col 0-1 should be green (overpainted), cols 2-4 red.
+    try testing.expectEqual(@as(u8, 0), img.rgba[0]);
+    try testing.expectEqual(@as(u8, 255), img.rgba[1]);
+    try testing.expectEqual(@as(u8, 0), img.rgba[4]);
+    try testing.expectEqual(@as(u8, 255), img.rgba[5]);
+    // Col 2 should still be red (not overpainted).
+    try testing.expectEqual(@as(u8, 255), img.rgba[8]);
+    try testing.expectEqual(@as(u8, 0), img.rgba[9]);
 }
 
 test "decoder: raster larger than paint bounds doesn't expand output" {

--- a/src/terminal/sixel/decoder.zig
+++ b/src/terminal/sixel/decoder.zig
@@ -236,3 +236,259 @@ test "decoder: ~ paints a 1x6 column of foreground (all bits set)" {
         try testing.expectEqual(@as(u8, 0), img.rgba[off + 2]);
     }
 }
+
+// ---- Run-length expansion ----
+
+test "decoder: !4 ~ produces 4-wide column" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '~', .count = 4 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 200, .g = 200, .b = 200, .a = 255 },
+    });
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 4), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+    // Every cell should be black (current_color), not gray bg.
+    for (0..6) |y| for (0..4) |x| {
+        const off = (y * 4 + x) * 4;
+        try testing.expectEqual(@as(u8, 0), img.rgba[off]);
+    };
+}
+
+test "decoder: count at u16 max produces 65535-wide image" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '?', .count = 65535 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 65535), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+}
+
+test "decoder: budget rejection on oversized image" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '?', .count = 65535 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    const result = decode(alloc, c, .{ .budget = 1024 });
+    try testing.expectError(error.SixelTooLarge, result);
+}
+
+// ---- Color selection + interleaved palette mutation ----
+
+test "decoder: select_color switches active paint color" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 0, .b = 0 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 255), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 1]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 2]);
+    }
+}
+
+test "decoder: interleaved palette mutation respects source order" {
+    // Regression test for the ops-unification refactor: without it,
+    // both columns would render green.
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 0, .b = 0 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+        .{ .set_rgb = .{ .idx = 1, .r = 0, .g = 100, .b = 0 } },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 2), img.width);
+    // Column 0 = red, column 1 = green.
+    try testing.expectEqual(@as(u8, 255), img.rgba[0]);
+    try testing.expectEqual(@as(u8, 0), img.rgba[1]);
+    try testing.expectEqual(@as(u8, 0), img.rgba[4]);
+    try testing.expectEqual(@as(u8, 255), img.rgba[5]);
+}
+
+test "decoder: set_hls applies HLS color" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_hls = .{ .idx = 1, .h = 0, .l = 50, .s = 100 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    // DEC blue (H=0): RGB (0, 0, 255).
+    for (0..6) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 0), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 1]);
+        try testing.expectEqual(@as(u8, 255), img.rgba[off + 2]);
+    }
+}
+
+// ---- Carriage return + next line ----
+
+test "decoder: $ resets paint cursor to column 0" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 100, .b = 100 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 3 } }, // 3 white cells
+        .{ .carriage_return = {} },
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 0, .b = 0 } },
+        .{ .sixel = .{ .byte = '~', .count = 2 } }, // overpaint cols 0-1 red
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 3), img.width);
+    // Col 0, row 0: red (overpainted).
+    try testing.expectEqual(@as(u8, 255), img.rgba[0]);
+    try testing.expectEqual(@as(u8, 0), img.rgba[1]);
+    // Col 2, row 0: white (not overpainted).
+    try testing.expectEqual(@as(u8, 255), img.rgba[8]);
+    try testing.expectEqual(@as(u8, 255), img.rgba[9]);
+}
+
+test "decoder: - advances paint cursor down 6 pixels and resets x" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+        .{ .next_line = {} },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{
+        .bg = .{ .r = 200, .g = 200, .b = 200, .a = 255 },
+    });
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 1), img.width);
+    try testing.expectEqual(@as(u32, 12), img.height);
+    for (0..12) |y| {
+        const off = y * 4;
+        try testing.expectEqual(@as(u8, 0), img.rgba[off]);
+        try testing.expectEqual(@as(u8, 0), img.rgba[off + 1]);
+    }
+}
+
+// ---- Raster bounds clamping ----
+
+test "decoder: raster.declared_width clamps output width" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '~', .count = 10 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{ .declared_width = 5, .declared_height = 6 },
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 5), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+}
+
+test "decoder: raster.declared_height clamps output height" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+        .{ .next_line = {} },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{ .declared_width = 1, .declared_height = 6 },
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 1), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+}
+
+test "decoder: raster larger than paint bounds doesn't expand output" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]Op{.{ .sixel = .{ .byte = '~', .count = 1 } }};
+    var c = Command{
+        .alloc = alloc,
+        .raster = .{ .declared_width = 100, .declared_height = 100 },
+        .ops = try alloc.dupe(Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var img = try decode(alloc, c, .{});
+    defer img.deinit();
+    try testing.expectEqual(@as(u32, 1), img.width);
+    try testing.expectEqual(@as(u32, 6), img.height);
+}

--- a/src/terminal/sixel/palette.zig
+++ b/src/terminal/sixel/palette.zig
@@ -60,6 +60,21 @@ pub const Palette = struct {
         };
     }
 
+    /// Set register `idx` from a DEC HLS triple.
+    ///
+    /// DEC HLS conventions:
+    ///   H: 0-359 degrees canonical; taken mod 360 (so H=360 wraps to 0).
+    ///      Hue 0=blue, 120=red, 240=green — rotated 120° from standard
+    ///      HSL where 0=red.
+    ///   L: 0-100, where 0=black, 50=full chroma, 100=white
+    ///   S: 0-100, where 0=grayscale
+    ///
+    /// Source: DEC VT3xx Programmer Reference, libsixel reference impl.
+    pub fn setHls(self: *Palette, idx: u8, h: u16, l: u8, s: u8) void {
+        self.entries[idx] = hlsToRgba(h, l, s);
+    }
+
+    /// Look up register `idx`. u8 indexing guarantees in-range access.
     pub fn query(self: Palette, idx: u8) Rgba {
         return self.entries[idx];
     }
@@ -73,6 +88,55 @@ pub const Palette = struct {
 fn scale100to255(v: u8) u8 {
     const clamped = if (v > 100) 100 else v;
     return @intCast((@as(u32, clamped) * 255 + 50) / 100);
+}
+
+/// Convert a DEC HLS triple to RGBA. The DEC hue space is rotated
+/// 120° from standard HSL so that hue=0 maps to DEC's blue. L=0
+/// always returns black, L=100 always returns white, S=0 returns
+/// grayscale at the requested L.
+fn hlsToRgba(h_in: u16, l: u8, s: u8) Rgba {
+    const h_mod: u16 = h_in % 360;
+    const l_c: u32 = @min(l, 100);
+    const s_c: u32 = @min(s, 100);
+
+    if (l_c == 0) return .{ .r = 0, .g = 0, .b = 0, .a = 255 };
+    if (l_c == 100) return .{ .r = 255, .g = 255, .b = 255, .a = 255 };
+    if (s_c == 0) {
+        const v = scale100to255(@intCast(l_c));
+        return .{ .r = v, .g = v, .b = v, .a = 255 };
+    }
+
+    // Rotate DEC hue into standard HSL coordinate space. DEC hue 0
+    // is blue; standard HSL blue lives at 240°. Adding 240 (mod 360)
+    // maps DEC→HSL: 0→240 (blue), 120→0 (red), 240→120 (green).
+    const h_std: f64 = @floatFromInt((h_mod + 240) % 360);
+    const l_f: f64 = @as(f64, @floatFromInt(l_c)) / 100.0;
+    const s_f: f64 = @as(f64, @floatFromInt(s_c)) / 100.0;
+
+    const c: f64 = (1.0 - @abs(2.0 * l_f - 1.0)) * s_f;
+    const h_sector: f64 = h_std / 60.0;
+    const x: f64 = c * (1.0 - @abs(@mod(h_sector, 2.0) - 1.0));
+    const m: f64 = l_f - c / 2.0;
+
+    var r1: f64 = 0;
+    var g1: f64 = 0;
+    var b1: f64 = 0;
+    if (h_sector < 1) { r1 = c; g1 = x; b1 = 0; }
+    else if (h_sector < 2) { r1 = x; g1 = c; b1 = 0; }
+    else if (h_sector < 3) { r1 = 0; g1 = c; b1 = x; }
+    else if (h_sector < 4) { r1 = 0; g1 = x; b1 = c; }
+    else if (h_sector < 5) { r1 = x; g1 = 0; b1 = c; }
+    else { r1 = c; g1 = 0; b1 = x; }
+
+    // The L/S clamps above mean (r1+m)*255 etc. can't escape [0, 255]
+    // mathematically; the saturating min/max here is defensive against
+    // float-rounding spillover near the bounds.
+    return .{
+        .r = @intFromFloat(@max(0.0, @min(255.0, @round((r1 + m) * 255.0)))),
+        .g = @intFromFloat(@max(0.0, @min(255.0, @round((g1 + m) * 255.0)))),
+        .b = @intFromFloat(@max(0.0, @min(255.0, @round((b1 + m) * 255.0)))),
+        .a = 255,
+    };
 }
 
 test "palette: init populates DEC 16 defaults" {
@@ -112,4 +176,94 @@ test "palette: query returns set value" {
     try testing.expectEqual(@as(u8, 255), rgba.r);
     try testing.expectEqual(@as(u8, 255), rgba.g);
     try testing.expectEqual(@as(u8, 255), rgba.b);
+}
+
+test "palette: setHls H=0 L=0 S=0 is black" {
+    var p = Palette.init();
+    p.setHls(0, 0, 0, 0);
+    const c = p.query(0);
+    try testing.expectEqual(@as(u8, 0), c.r);
+    try testing.expectEqual(@as(u8, 0), c.g);
+    try testing.expectEqual(@as(u8, 0), c.b);
+}
+
+test "palette: setHls L=100 is white regardless of H,S" {
+    var p = Palette.init();
+    p.setHls(0, 180, 100, 100);
+    const c = p.query(0);
+    try testing.expectEqual(@as(u8, 255), c.r);
+    try testing.expectEqual(@as(u8, 255), c.g);
+    try testing.expectEqual(@as(u8, 255), c.b);
+}
+
+test "palette: setHls S=0 produces grayscale" {
+    var p = Palette.init();
+    p.setHls(0, 90, 50, 0);
+    const c = p.query(0);
+    try testing.expectEqual(@as(u8, 128), c.r);
+    try testing.expectEqual(@as(u8, 128), c.g);
+    try testing.expectEqual(@as(u8, 128), c.b);
+}
+
+test "palette: setHls H=0 L=50 S=100 is DEC blue" {
+    var p = Palette.init();
+    p.setHls(0, 0, 50, 100);
+    const c = p.query(0);
+    try testing.expectEqual(@as(u8, 0), c.r);
+    try testing.expectEqual(@as(u8, 0), c.g);
+    try testing.expectEqual(@as(u8, 255), c.b);
+}
+
+test "palette: setHls H=120 L=50 S=100 is DEC red" {
+    var p = Palette.init();
+    p.setHls(0, 120, 50, 100);
+    const c = p.query(0);
+    try testing.expectEqual(@as(u8, 255), c.r);
+    try testing.expectEqual(@as(u8, 0), c.g);
+    try testing.expectEqual(@as(u8, 0), c.b);
+}
+
+test "palette: setHls H=240 L=50 S=100 is DEC green" {
+    var p = Palette.init();
+    p.setHls(0, 240, 50, 100);
+    const c = p.query(0);
+    try testing.expectEqual(@as(u8, 0), c.r);
+    try testing.expectEqual(@as(u8, 255), c.g);
+    try testing.expectEqual(@as(u8, 0), c.b);
+}
+
+test "palette: setHls H=360 wraps to H=0" {
+    var p = Palette.init();
+    p.setHls(0, 360, 50, 100);
+    const c = p.query(0);
+    try testing.expectEqual(@as(u8, 0), c.r);
+    try testing.expectEqual(@as(u8, 0), c.g);
+    try testing.expectEqual(@as(u8, 255), c.b);
+}
+
+test "palette: setHls H=60 sits between DEC blue and red" {
+    // H=60 in DEC is halfway between blue (0) and red (120) — should
+    // produce a purple/magenta. Pins the rotation direction beyond the
+    // primary hues.
+    var p = Palette.init();
+    p.setHls(0, 60, 50, 100);
+    const c = p.query(0);
+    // Both red and blue channels active, green absent.
+    try testing.expect(c.r > 0);
+    try testing.expect(c.b > 0);
+    try testing.expectEqual(@as(u8, 0), c.g);
+}
+
+test "palette: setHls L=25 darker than L=50 at same hue" {
+    var p1 = Palette.init();
+    p1.setHls(0, 120, 50, 100);
+    const c1 = p1.query(0);
+
+    var p2 = Palette.init();
+    p2.setHls(0, 120, 25, 100);
+    const c2 = p2.query(0);
+
+    try testing.expect(c2.r < c1.r);
+    try testing.expectEqual(@as(u8, 0), c2.g);
+    try testing.expectEqual(@as(u8, 0), c2.b);
 }

--- a/src/terminal/sixel/parser.zig
+++ b/src/terminal/sixel/parser.zig
@@ -3,8 +3,7 @@ const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const cmd = @import("command.zig");
 const Command = cmd.Command;
-const PaintOp = cmd.PaintOp;
-const PaletteOp = cmd.PaletteOp;
+const Op = cmd.Op;
 const Raster = cmd.Raster;
 const raster = @import("raster.zig");
 
@@ -41,11 +40,14 @@ pub const Parser = struct {
     /// Accumulator for repeat-count digits (after `!`). Cleared when
     /// `!` is seen, applied when the next sixel byte arrives.
     /// Saturating add/multiply keep this clamped at u16::MAX, which
-    /// matches PaintOp.sixel.count's width.
+    /// matches Op.sixel.count's width.
     repeat_acc: u16,
 
-    paint_ops: std.ArrayListUnmanaged(PaintOp),
-    palette_ops: std.ArrayListUnmanaged(PaletteOp),
+    /// All paint and palette operations in source order. The decoder
+    /// applies them in stream order so mid-stream palette mutation
+    /// has the spec-correct effect (rather than all palette ops
+    /// applying as a separate pre-pass).
+    ops: std.ArrayListUnmanaged(Op),
 
     /// Working buffer for raster_attribs / color_def / repeat_count.
     accum: std.ArrayListUnmanaged(u8),
@@ -59,15 +61,13 @@ pub const Parser = struct {
             .raster = .{},
             .intro_params = intro_params,
             .repeat_acc = 0,
-            .paint_ops = .empty,
-            .palette_ops = .empty,
+            .ops = .empty,
             .accum = .empty,
         };
     }
 
     pub fn deinit(self: *Parser) void {
-        self.paint_ops.deinit(self.alloc);
-        self.palette_ops.deinit(self.alloc);
+        self.ops.deinit(self.alloc);
         self.accum.deinit(self.alloc);
     }
 
@@ -99,11 +99,11 @@ pub const Parser = struct {
                     self.state = .color_def;
                 },
                 '$' => {
-                    try self.paint_ops.append(self.alloc, .carriage_return);
+                    try self.ops.append(self.alloc, .carriage_return);
                     self.state = .data;
                 },
                 '-' => {
-                    try self.paint_ops.append(self.alloc, .next_line);
+                    try self.ops.append(self.alloc, .next_line);
                     self.state = .data;
                 },
                 '"' => {
@@ -184,7 +184,7 @@ pub const Parser = struct {
     }
 
     fn appendSixel(self: *Parser, byte: u8, count: u16) Allocator.Error!void {
-        try self.paint_ops.append(self.alloc, .{
+        try self.ops.append(self.alloc, .{
             .sixel = .{ .byte = byte, .count = count },
         });
         self.state = .data;
@@ -201,8 +201,7 @@ pub const Parser = struct {
         return .{
             .alloc = self.alloc,
             .raster = self.raster,
-            .palette_ops = try self.palette_ops.toOwnedSlice(self.alloc),
-            .paint_ops = try self.paint_ops.toOwnedSlice(self.alloc),
+            .ops = try self.ops.toOwnedSlice(self.alloc),
             .intro_params = self.intro_params,
         };
     }
@@ -224,7 +223,7 @@ pub const Parser = struct {
 
         // Selection form: bare "#N" with no further fields.
         const pu_str = it.next() orelse {
-            try self.paint_ops.append(self.alloc, .{ .select_color = idx });
+            try self.ops.append(self.alloc, .{ .select_color = idx });
             return;
         };
 
@@ -258,10 +257,10 @@ pub const Parser = struct {
         };
 
         switch (pu) {
-            1 => try self.palette_ops.append(self.alloc, .{
+            1 => try self.ops.append(self.alloc, .{
                 .set_hls = .{ .idx = idx, .h = a, .l = b, .s = c },
             }),
-            2 => try self.palette_ops.append(self.alloc, .{
+            2 => try self.ops.append(self.alloc, .{
                 .set_rgb = .{
                     .idx = idx,
                     // r is narrowed from u16, so we clamp explicitly to
@@ -319,8 +318,7 @@ test "sixel parser: empty finalize yields empty Command" {
     defer p.deinit();
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
-    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+    try testing.expectEqual(@as(usize, 0), c.ops.len);
 }
 
 test "sixel parser: intro params round-trip" {
@@ -339,10 +337,10 @@ test "sixel parser: single sixel byte appends count=1" {
     p.put('?');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .sixel);
-    try testing.expectEqual(@as(u8, '?'), c.paint_ops[0].sixel.byte);
-    try testing.expectEqual(@as(u16, 1), c.paint_ops[0].sixel.count);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expect(c.ops[0] == .sixel);
+    try testing.expectEqual(@as(u8, '?'), c.ops[0].sixel.byte);
+    try testing.expectEqual(@as(u16, 1), c.ops[0].sixel.count);
 }
 
 test "sixel parser: multiple sixel bytes append separately" {
@@ -351,8 +349,8 @@ test "sixel parser: multiple sixel bytes append separately" {
     for ("?@AB") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 4), c.paint_ops.len);
-    for (c.paint_ops, "?@AB") |op, expected| {
+    try testing.expectEqual(@as(usize, 4), c.ops.len);
+    for (c.ops, "?@AB") |op, expected| {
         try testing.expectEqual(@as(u8, expected), op.sixel.byte);
     }
 }
@@ -365,7 +363,7 @@ test "sixel parser: byte outside ?..~ in data state is ignored" {
     p.put('@');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
 }
 
 test "sixel parser: !3 ? produces count=3" {
@@ -374,9 +372,9 @@ test "sixel parser: !3 ? produces count=3" {
     for ("!3?") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
-    try testing.expectEqual(@as(u16, 3), c.paint_ops[0].sixel.count);
-    try testing.expectEqual(@as(u8, '?'), c.paint_ops[0].sixel.byte);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expectEqual(@as(u16, 3), c.ops[0].sixel.count);
+    try testing.expectEqual(@as(u8, '?'), c.ops[0].sixel.byte);
 }
 
 test "sixel parser: !65535 saturates at u16 max" {
@@ -385,7 +383,7 @@ test "sixel parser: !65535 saturates at u16 max" {
     for ("!65535~") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(u16, 65535), c.paint_ops[0].sixel.count);
+    try testing.expectEqual(@as(u16, 65535), c.ops[0].sixel.count);
 }
 
 test "sixel parser: !99999 saturates without overflow" {
@@ -395,7 +393,7 @@ test "sixel parser: !99999 saturates without overflow" {
     var c = try p.finalize();
     defer c.deinit();
     // Saturated to u16 max
-    try testing.expectEqual(@as(u16, 65535), c.paint_ops[0].sixel.count);
+    try testing.expectEqual(@as(u16, 65535), c.ops[0].sixel.count);
 }
 
 test "sixel parser: ! with no digits then sixel emits count=1" {
@@ -404,8 +402,8 @@ test "sixel parser: ! with no digits then sixel emits count=1" {
     for ("!?") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
-    try testing.expectEqual(@as(u16, 1), c.paint_ops[0].sixel.count);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expectEqual(@as(u16, 1), c.ops[0].sixel.count);
 }
 
 test "sixel parser: #5 selects color register 5" {
@@ -414,10 +412,10 @@ test "sixel parser: #5 selects color register 5" {
     for ("#5?") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .select_color);
-    try testing.expectEqual(@as(u8, 5), c.paint_ops[0].select_color);
-    try testing.expect(c.paint_ops[1] == .sixel);
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
+    try testing.expect(c.ops[0] == .select_color);
+    try testing.expectEqual(@as(u8, 5), c.ops[0].select_color);
+    try testing.expect(c.ops[1] == .sixel);
 }
 
 test "sixel parser: #1;2;100;50;0 defines RGB" {
@@ -428,13 +426,14 @@ test "sixel parser: #1;2;100;50;0 defines RGB" {
     p.put('?');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.palette_ops.len);
-    try testing.expect(c.palette_ops[0] == .set_rgb);
-    const op = c.palette_ops[0].set_rgb;
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
+    try testing.expect(c.ops[0] == .set_rgb);
+    const op = c.ops[0].set_rgb;
     try testing.expectEqual(@as(u8, 1), op.idx);
     try testing.expectEqual(@as(u8, 100), op.r);
     try testing.expectEqual(@as(u8, 50), op.g);
     try testing.expectEqual(@as(u8, 0), op.b);
+    try testing.expect(c.ops[1] == .sixel);
 }
 
 test "sixel parser: #1;1;180;50;75 defines HLS" {
@@ -444,13 +443,14 @@ test "sixel parser: #1;1;180;50;75 defines HLS" {
     p.put('?');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.palette_ops.len);
-    try testing.expect(c.palette_ops[0] == .set_hls);
-    const op = c.palette_ops[0].set_hls;
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
+    try testing.expect(c.ops[0] == .set_hls);
+    const op = c.ops[0].set_hls;
     try testing.expectEqual(@as(u8, 1), op.idx);
     try testing.expectEqual(@as(u16, 180), op.h);
     try testing.expectEqual(@as(u8, 50), op.l);
     try testing.expectEqual(@as(u8, 75), op.s);
+    try testing.expect(c.ops[1] == .sixel);
 }
 
 test "sixel parser: #N with invalid Pu silently ignored" {
@@ -461,7 +461,9 @@ test "sixel parser: #N with invalid Pu silently ignored" {
     p.put('?');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+    // Only the trailing ? produces an op; the bad color def is dropped.
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expect(c.ops[0] == .sixel);
 }
 
 test "sixel parser: #N followed by sixel byte selects then paints" {
@@ -470,9 +472,9 @@ test "sixel parser: #N followed by sixel byte selects then paints" {
     for ("#7~") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
-    try testing.expectEqual(@as(u8, 7), c.paint_ops[0].select_color);
-    try testing.expectEqual(@as(u8, '~'), c.paint_ops[1].sixel.byte);
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
+    try testing.expectEqual(@as(u8, 7), c.ops[0].select_color);
+    try testing.expectEqual(@as(u8, '~'), c.ops[1].sixel.byte);
 }
 
 test "sixel parser: !3#5 re-dispatches # into color_def" {
@@ -487,12 +489,12 @@ test "sixel parser: !3#5 re-dispatches # into color_def" {
     // !3 had no terminator paint byte (the next byte was #), so the
     // pending repeat is discarded entirely. The #5 selects color 5,
     // and the trailing ? paints with count=1.
-    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .select_color);
-    try testing.expectEqual(@as(u8, 5), c.paint_ops[0].select_color);
-    try testing.expect(c.paint_ops[1] == .sixel);
-    try testing.expectEqual(@as(u8, '?'), c.paint_ops[1].sixel.byte);
-    try testing.expectEqual(@as(u16, 1), c.paint_ops[1].sixel.count);
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
+    try testing.expect(c.ops[0] == .select_color);
+    try testing.expectEqual(@as(u8, 5), c.ops[0].select_color);
+    try testing.expect(c.ops[1] == .sixel);
+    try testing.expectEqual(@as(u8, '?'), c.ops[1].sixel.byte);
+    try testing.expectEqual(@as(u16, 1), c.ops[1].sixel.count);
 }
 
 test "sixel parser: #1;2;200;200;200 clamps r but passes g/b through" {
@@ -505,11 +507,12 @@ test "sixel parser: #1;2;200;200;200 clamps r but passes g/b through" {
     p.put('?');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.palette_ops.len);
-    const op = c.palette_ops[0].set_rgb;
-    try testing.expectEqual(@as(u8, 100), op.r);  // clamped
-    try testing.expectEqual(@as(u8, 200), op.g);  // not clamped here
-    try testing.expectEqual(@as(u8, 200), op.b);  // not clamped here
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
+    try testing.expect(c.ops[0] == .set_rgb);
+    const op = c.ops[0].set_rgb;
+    try testing.expectEqual(@as(u8, 100), op.r); // clamped
+    try testing.expectEqual(@as(u8, 200), op.g); // not clamped here
+    try testing.expectEqual(@as(u8, 200), op.b); // not clamped here
 }
 
 test "sixel parser: $ emits carriage_return" {
@@ -518,8 +521,8 @@ test "sixel parser: $ emits carriage_return" {
     p.put('$');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .carriage_return);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expect(c.ops[0] == .carriage_return);
 }
 
 test "sixel parser: - emits next_line" {
@@ -528,8 +531,8 @@ test "sixel parser: - emits next_line" {
     p.put('-');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .next_line);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expect(c.ops[0] == .next_line);
 }
 
 test "sixel parser: ?$-? emits sixel/CR/NL/sixel" {
@@ -538,11 +541,11 @@ test "sixel parser: ?$-? emits sixel/CR/NL/sixel" {
     for ("?$-?") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 4), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .sixel);
-    try testing.expect(c.paint_ops[1] == .carriage_return);
-    try testing.expect(c.paint_ops[2] == .next_line);
-    try testing.expect(c.paint_ops[3] == .sixel);
+    try testing.expectEqual(@as(usize, 4), c.ops.len);
+    try testing.expect(c.ops[0] == .sixel);
+    try testing.expect(c.ops[1] == .carriage_return);
+    try testing.expect(c.ops[2] == .next_line);
+    try testing.expect(c.ops[3] == .sixel);
 }
 
 test "sixel parser: \" then 1;1;0;100;200 sets raster" {
@@ -553,7 +556,7 @@ test "sixel parser: \" then 1;1;0;100;200 sets raster" {
     defer c.deinit();
     try testing.expectEqual(@as(u16, 100), c.raster.declared_width);
     try testing.expectEqual(@as(u16, 200), c.raster.declared_height);
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
 }
 
 test "sixel parser: oversized raster transitions to ignore" {
@@ -563,7 +566,7 @@ test "sixel parser: oversized raster transitions to ignore" {
     p.put('?'); // would normally paint, but parser is in .ignore
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
+    try testing.expectEqual(@as(usize, 0), c.ops.len);
 }
 
 test "sixel parser: malformed raster falls back to defaults" {
@@ -580,7 +583,7 @@ test "sixel parser: malformed raster falls back to defaults" {
     try testing.expectEqual(@as(u16, 1), c.raster.aspect_num);
     try testing.expectEqual(@as(u16, 0), c.raster.declared_width);
     // Painting continues after malformed raster
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
 }
 
 test "sixel parser: ignore state drops all subsequent bytes" {
@@ -592,8 +595,7 @@ test "sixel parser: ignore state drops all subsequent bytes" {
     p.put('!');
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
-    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+    try testing.expectEqual(@as(usize, 0), c.ops.len);
 }
 
 test "sixel parser: incomplete color def at finalize is dropped" {
@@ -604,7 +606,7 @@ test "sixel parser: incomplete color def at finalize is dropped" {
     for ("#1;2;100") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
+    try testing.expectEqual(@as(usize, 0), c.ops.len);
 }
 
 test "sixel parser: incomplete raster attribs at finalize is dropped" {
@@ -627,7 +629,7 @@ test "sixel parser: incomplete repeat count at finalize is dropped" {
     for ("!42") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 0), c.paint_ops.len);
+    try testing.expectEqual(@as(usize, 0), c.ops.len);
 }
 
 test "sixel parser: empty color def #? produces no op" {
@@ -639,10 +641,9 @@ test "sixel parser: empty color def #? produces no op" {
     for ("#?") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 0), c.palette_ops.len);
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .sixel);
-    try testing.expectEqual(@as(u8, '?'), c.paint_ops[0].sixel.byte);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expect(c.ops[0] == .sixel);
+    try testing.expectEqual(@as(u8, '?'), c.ops[0].sixel.byte);
 }
 
 test "sixel parser: back-to-back # # is dropped" {
@@ -656,10 +657,10 @@ test "sixel parser: back-to-back # # is dropped" {
     var c = try p.finalize();
     defer c.deinit();
     // One select_color from the second #5, then the paint byte.
-    try testing.expectEqual(@as(usize, 2), c.paint_ops.len);
-    try testing.expect(c.paint_ops[0] == .select_color);
-    try testing.expectEqual(@as(u8, 5), c.paint_ops[0].select_color);
-    try testing.expect(c.paint_ops[1] == .sixel);
+    try testing.expectEqual(@as(usize, 2), c.ops.len);
+    try testing.expect(c.ops[0] == .select_color);
+    try testing.expectEqual(@as(u8, 5), c.ops[0].select_color);
+    try testing.expect(c.ops[1] == .sixel);
 }
 
 test "sixel parser: !0 ? coerces to count=1" {
@@ -670,6 +671,6 @@ test "sixel parser: !0 ? coerces to count=1" {
     for ("!0?") |b| p.put(b);
     var c = try p.finalize();
     defer c.deinit();
-    try testing.expectEqual(@as(usize, 1), c.paint_ops.len);
-    try testing.expectEqual(@as(u16, 1), c.paint_ops[0].sixel.count);
+    try testing.expectEqual(@as(usize, 1), c.ops.len);
+    try testing.expectEqual(@as(u16, 1), c.ops[0].sixel.count);
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1491,8 +1491,11 @@ const Subprocess = struct {
         // than going through Pty, which returns null on Windows.
         if (comptime builtin.os.tag == .windows) {
             if (info == .foreground_pid) {
+                // Local capture intentionally named differently from the
+                // file-level `c = @cImport(...)` to avoid a shadow error
+                // under Zig 0.15.
                 const cmd = switch (self.process orelse return null) {
-                    .fork_exec => |*c| c,
+                    .fork_exec => |*sub| sub,
                     // Flatpak path is POSIX-only; unreachable on Windows
                     // but keep the switch exhaustive.
                     .flatpak => return null,


### PR DESCRIPTION
PR 2 of the 4-PR Sixel image protocol stack. Builds on PR 1 (parser, merged as f917643b0). Adds the decoder, DEC HLS color support, and comprehensive end-to-end tests. **No render integration; nothing visible to users yet.**

## Scope

- **Refactor** PR 1's `Command.paint_ops` + `palette_ops` split into a single ordered `ops: []const Op` slice. Necessary for spec-correct interleaving (a stream like `#1;2;100;0;0?#1;2;0;100;0?` previously lost the order between palette mutations and paints).
- **HLS support** in `palette.setHls`. DEC HLS has hue rotated 120° from standard HSL (DEC: H=0 blue, H=120 red, H=240 green). 9 reference-point tests pin the conversion.
- **Decoder** in new `sixel/decoder.zig`. Walks the op stream in a two-pass algorithm (measure bounds, then allocate + paint). Handles sixel data bytes, run-length, color selection, palette mutation, CR/NL cursor control, raster bounds clamping, and P1/P2/P3 background modes.
- **Budget enforcement**: `DecodeCtx.budget` caps total RGBA bytes (defaults to MAX_RGBA_BYTES = 48 MiB). Oversized images return `error.SixelTooLarge` before allocating.
- **Incidental fix** in `termio/Exec.zig`: a pre-existing shadow error on origin/windows (`|*c|` shadowed file-level `const c = @cImport(...)`) blocked the build under Zig 0.15.2. Renamed the capture to `|*sub|`.

## What this PR does NOT do

- No render integration (PR 3 — wires `decode()` output through `terminal.image.State`)
- No DA1 advertisement (PR 4)
- No libsixel-generated `@embedFile` test corpus (spec §4.7 deferred to a follow-up)

## Test results

| Platform | Result |
|---|---|
| Windows | exit 0 |
| macOS aarch64 | exit 0 |
| Linux x86_64 | exit 0 |

~30 new tests across `terminal.sixel.decoder.*` + `terminal.sixel.palette.*`, plus PR-1 tests renamed to assert against `c.ops` instead of `c.paint_ops` / `c.palette_ops`.

## Stack order

- PR 1: parser (merged f917643b0)
- **PR 2**: decoder + HLS + tests (this PR)
- PR 3: render-wire + cursor advance via terminal.image.State
- PR 4: flip DA1 `;4` advertisement