### PR TITLE
terminal/sixel: render-wire (PR 3/4 of Sixel stack)

### DIFF
--- a/src/terminal/sixel.zig
+++ b/src/terminal/sixel.zig
@@ -16,6 +16,7 @@ pub const Palette = @import("sixel/palette.zig").Palette;
 pub const decode = @import("sixel/decoder.zig").decode;
 pub const Image = @import("sixel/decoder.zig").Image;
 pub const DecodeCtx = @import("sixel/decoder.zig").DecodeCtx;
+pub const synthKittyCommand = @import("sixel/image.zig").synthKittyCommand;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/sixel/image.zig
+++ b/src/terminal/sixel/image.zig
@@ -27,10 +27,8 @@ pub fn synthKittyCommand(
     ctx: decoder_mod.DecodeCtx,
 ) Error!kitty_graphics.Command {
     var img = try decoder_mod.decode(alloc, sixel_cmd, ctx);
-    // Two failure modes after decode: zero-dim images (empty op
-    // stream, oversized geometry caught upstream, etc.) and decode
-    // errors handled by the `try` above. For zero-dim we explicitly
-    // free the (empty) rgba and signal the caller to skip dispatch.
+    // Zero-dim image means there's nothing to render. Free the
+    // (empty) rgba and signal the caller to skip dispatch.
     if (img.width == 0 or img.height == 0) {
         img.deinit();
         return error.EmptyImage;

--- a/src/terminal/sixel/image.zig
+++ b/src/terminal/sixel/image.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
+const command_mod = @import("command.zig");
+const decoder_mod = @import("decoder.zig");
+const kitty_graphics = @import("../kitty/graphics.zig");
+const kitty_command = @import("../kitty/graphics_command.zig");
+
+pub const Error = error{
+    /// Decoded image had zero dimensions; nothing to render. Caller
+    /// should skip the kittyGraphics dispatch entirely.
+    EmptyImage,
+} || decoder_mod.Error;
+
+/// Decode a parsed sixel Command and synthesize a kitty graphics
+/// transmit_and_display command carrying the decoded RGBA. The
+/// returned Command owns its data slice; caller must free via
+/// `Command.deinit(alloc)`.
+///
+/// Routing sixel through the kitty graphics pipeline reuses the
+/// image storage, placement, scroll-tracking, and rendering work
+/// the kitty + iTerm2 protocols already exercise. There's no
+/// separate sixel render path.
+pub fn synthKittyCommand(
+    alloc: Allocator,
+    sixel_cmd: command_mod.Command,
+    ctx: decoder_mod.DecodeCtx,
+) Error!kitty_graphics.Command {
+    var img = try decoder_mod.decode(alloc, sixel_cmd, ctx);
+    // Two failure modes after decode: zero-dim images (empty op
+    // stream, oversized geometry caught upstream, etc.) and decode
+    // errors handled by the `try` above. For zero-dim we explicitly
+    // free the (empty) rgba and signal the caller to skip dispatch.
+    if (img.width == 0 or img.height == 0) {
+        img.deinit();
+        return error.EmptyImage;
+    }
+
+    // Transfer rgba ownership into the kitty Command. img.deinit
+    // would free what the Command now owns, so we deliberately don't
+    // call it — img.rgba is moved, not borrowed.
+    return .{
+        .control = .{ .transmit_and_display = .{
+            .transmission = .{
+                .format = .rgba,
+                .medium = .direct,
+                .width = img.width,
+                .height = img.height,
+            },
+            .display = .{},
+        } },
+        .data = img.rgba,
+    };
+}
+
+test "image: synthKittyCommand on empty Command returns EmptyImage" {
+    const alloc = testing.allocator;
+    var c = command_mod.Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.alloc(command_mod.Op, 0),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    const result = synthKittyCommand(alloc, c, .{});
+    try testing.expectError(error.EmptyImage, result);
+}
+
+test "image: synthKittyCommand wraps a single ~ as a 1x6 RGBA transmit" {
+    const alloc = testing.allocator;
+    var ops_buf = [_]command_mod.Op{
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = command_mod.Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(command_mod.Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var kcmd = try synthKittyCommand(alloc, c, .{});
+    defer kcmd.deinit(alloc);
+
+    // Action must be transmit_and_display so the kitty pipeline both
+    // stores AND immediately renders the image.
+    try testing.expect(kcmd.control == .transmit_and_display);
+    const t = kcmd.control.transmit_and_display.transmission;
+    try testing.expectEqual(kitty_command.Transmission.Format.rgba, t.format);
+    try testing.expectEqual(kitty_command.Transmission.Medium.direct, t.medium);
+    try testing.expectEqual(@as(u32, 1), t.width);
+    try testing.expectEqual(@as(u32, 6), t.height);
+
+    // Data is the raw RGBA: 1 column × 6 rows × 4 bytes = 24 bytes.
+    try testing.expectEqual(@as(usize, 24), kcmd.data.len);
+    // First pixel R/G/B/A — black (palette default entry 0).
+    try testing.expectEqual(@as(u8, 0), kcmd.data[0]);
+    try testing.expectEqual(@as(u8, 0), kcmd.data[1]);
+    try testing.expectEqual(@as(u8, 0), kcmd.data[2]);
+    try testing.expectEqual(@as(u8, 255), kcmd.data[3]);
+}
+
+test "image: synthKittyCommand respects palette mutation in source order" {
+    // Same regression as the decoder's interleaved-palette test, but
+    // verified end-to-end through the kitty Command's data buffer.
+    const alloc = testing.allocator;
+    var ops_buf = [_]command_mod.Op{
+        .{ .set_rgb = .{ .idx = 1, .r = 100, .g = 0, .b = 0 } },
+        .{ .select_color = 1 },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+        .{ .set_rgb = .{ .idx = 1, .r = 0, .g = 100, .b = 0 } },
+        .{ .sixel = .{ .byte = '~', .count = 1 } },
+    };
+    var c = command_mod.Command{
+        .alloc = alloc,
+        .raster = .{},
+        .ops = try alloc.dupe(command_mod.Op, &ops_buf),
+        .intro_params = .{ null, null, null },
+    };
+    defer c.deinit();
+
+    var kcmd = try synthKittyCommand(alloc, c, .{});
+    defer kcmd.deinit(alloc);
+
+    // 2-wide image: col 0 red, col 1 green.
+    try testing.expectEqual(@as(u32, 2), kcmd.control.transmit_and_display.transmission.width);
+    try testing.expectEqual(@as(u8, 255), kcmd.data[0]); // (0,0).r
+    try testing.expectEqual(@as(u8, 0), kcmd.data[1]); // (0,0).g
+    try testing.expectEqual(@as(u8, 0), kcmd.data[4]); // (1,0).r
+    try testing.expectEqual(@as(u8, 255), kcmd.data[5]); // (1,0).g
+}

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -568,6 +568,27 @@ pub const StreamHandler = struct {
                 tagResponse(&msg);
                 self.messageWriter(msg);
             },
+
+            .sixel => |sixel_cmd| {
+                // Sixel decode + kitty graphics dispatch. The bridge
+                // owns the decoded RGBA and hands it off to kitty.
+                // EmptyImage is the expected "nothing to render" path
+                // (empty op stream, oversized geometry caught upstream,
+                // raster clamped to 0×0); other errors are unexpected.
+                var kcmd = terminal.sixel.synthKittyCommand(
+                    self.alloc,
+                    sixel_cmd,
+                    .{},
+                ) catch |err| {
+                    if (err != error.EmptyImage)
+                        log.warn("sixel dispatch failed: {t}", .{err});
+                    return;
+                };
+                defer kcmd.deinit(self.alloc);
+                // Sixel has no response channel; drop any kitty
+                // response (DEC didn't define a query path for sixel).
+                _ = self.terminal.kittyGraphics(self.alloc, &kcmd);
+            },
         }
     }
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -572,16 +572,24 @@ pub const StreamHandler = struct {
             .sixel => |sixel_cmd| {
                 // Sixel decode + kitty graphics dispatch. The bridge
                 // owns the decoded RGBA and hands it off to kitty.
-                // EmptyImage is the expected "nothing to render" path
-                // (empty op stream, oversized geometry caught upstream,
-                // raster clamped to 0×0); other errors are unexpected.
+                // TODO: thread terminal bg color into ctx.bg so P1
+                // mode renders against the actual background instead
+                // of opaque black.
                 var kcmd = terminal.sixel.synthKittyCommand(
                     self.alloc,
                     sixel_cmd,
                     .{},
                 ) catch |err| {
-                    if (err != error.EmptyImage)
-                        log.warn("sixel dispatch failed: {t}", .{err});
+                    switch (err) {
+                        // Expected no-render paths — empty stream,
+                        // oversized geometry already dropped upstream.
+                        error.EmptyImage,
+                        error.SixelTooLarge,
+                        => log.debug("sixel skipped: {t}", .{err}),
+                        // Unexpected.
+                        error.OutOfMemory,
+                        => log.warn("sixel dispatch failed: {t}", .{err}),
+                    }
                     return;
                 };
                 defer kcmd.deinit(self.alloc);


### PR DESCRIPTION
PR 3 of 4. Builds on PR 1 (parser, f917643b0) and PR 2 (decoder + HLS, b81c55a85). Adds the bridge that wires sixel into the existing kitty graphics rendering pipeline. **Sixel is now user-visible.**

## How it works

The decoded `sixel.Image` (RGBA + dims) gets wrapped into a `kitty.graphics.Command` with `format = .rgba, medium = .direct, control = .transmit_and_display`, then handed to `terminal.kittyGraphics()`. This reuses the image storage, placement, scroll-tracking, and renderer paths that the kitty graphics + iTerm2 OSC 1337 protocols already exercise. **No separate sixel render path. No new cursor-advance code.**

Same pattern iTerm2 uses today (`iterm2.synthKittyCommand` → `terminal.kittyGraphics`) — just substituting our sixel decoder for iTerm2's base64-then-wuffs decode.

## Scope

- `src/terminal/sixel/image.zig` — new `synthKittyCommand(alloc, cmd, ctx)` bridge. Decodes, transfers RGBA ownership into the kitty Command, returns `error.EmptyImage` for the nothing-to-render case (empty stream, oversized geometry caught upstream, etc.).
- `src/termio/stream_handler.zig` — new `.sixel` arm in `dcsCommand` switch: calls the bridge, dispatches to kittyGraphics, drops responses (DEC didn't define a query path for sixel).
- 3 unit tests on the bridge.

## What this PR does NOT do

- No DA1 advertisement (PR 4) — apps still see no support advertised via DA1, so they won't probe-then-emit. They CAN emit unsolicited and the decoder will render.

## Test results

| Platform | Result |
|---|---|
| Windows full suite | exit 0 |
| macOS aarch64 sixel | exit 0 |
| Linux x86_64 sixel | exit 0 |

## Stack order

- PR 1: parser (merged f917643b0)
- PR 2: decoder + HLS (merged b81c55a85)
- **PR 3**: render-wire (this PR)
- PR 4: flip DA1 \`;4\` feature bit