### PR TITLE
active-shell-icon: polish (pwsh brand, command-derived fallback, wsl default distro, pid race)

### DIFF
--- a/windows/Ghostty.Core/Profiles/Probes/PowerShellProbe.cs
+++ b/windows/Ghostty.Core/Profiles/Probes/PowerShellProbe.cs
@@ -43,7 +43,7 @@ internal sealed class PowerShellProbe(IFileSystem fs, IProcessRunner runner) : I
                 Name: "Windows PowerShell",
                 Command: ProbeUtil.QuoteIfNeeded(winps),
                 ProbeId: ProbeId,
-                Icon: new IconSpec.BundledKey("powershell")));
+                Icon: new IconSpec.BundledKey("pwsh")));
         }
 
         return list;

--- a/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
@@ -98,13 +98,53 @@ public static class ProfileOrderResolver
             Name: def.Name,
             Command: def.Command,
             WorkingDirectory: def.WorkingDirectory,
-            Icon: def.Icon ?? new IconSpec.BundledKey("default"),
+            Icon: ResolveFallbackIcon(def),
             TabTitle: def.TabTitle ?? def.Name,
             Visuals: def.Visuals,
             ProbeId: def.ProbeId,
             OrderIndex: orderIndex,
             IsDefault: isDefault,
             TabIconTracksForeground: def.TabIconTracksForeground);
+
+    // When a profile has no explicit icon, derive one from the command's
+    // exe basename via ProcessIconTable so user-defined profiles like
+    // `command = pwsh.exe` pick up the pwsh brand glyph instead of the
+    // generic wintty default.
+    private static IconSpec ResolveFallbackIcon(ProfileDef def)
+    {
+        if (def.Icon is not null) return def.Icon;
+
+        var basename = TryGetCommandBasename(def.Command);
+        if (basename is not null)
+        {
+            var mapped = ProcessIconTable.TryMap(basename, def.Command);
+            if (mapped is not null) return mapped;
+        }
+        return new IconSpec.BundledKey("default");
+    }
+
+    private static string? TryGetCommandBasename(string? command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return null;
+        // Strip leading whitespace + outer quotes; take the first token.
+        var trimmed = command.TrimStart();
+        string first;
+        if (trimmed.StartsWith('"'))
+        {
+            var endQuote = trimmed.IndexOf('"', 1);
+            if (endQuote < 0) return null;
+            first = trimmed.Substring(1, endQuote - 1);
+        }
+        else
+        {
+            var space = trimmed.IndexOfAny(new[] { ' ', '\t' });
+            first = space < 0 ? trimmed : trimmed.Substring(0, space);
+        }
+        if (first.Length == 0) return null;
+        // Path.GetFileName handles both forward and backward slashes.
+        var name = System.IO.Path.GetFileName(first);
+        return string.IsNullOrEmpty(name) ? null : name;
+    }
 
     private static string? ResolveDefault(
         string? requested,

--- a/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileOrderResolver.cs
@@ -123,10 +123,15 @@ public static class ProfileOrderResolver
         return new IconSpec.BundledKey("default");
     }
 
+    // Hoisted so each call doesn't allocate a fresh char[] for IndexOfAny.
+    private static readonly char[] s_whitespace = [' ', '\t'];
+
     private static string? TryGetCommandBasename(string? command)
     {
         if (string.IsNullOrWhiteSpace(command)) return null;
         // Strip leading whitespace + outer quotes; take the first token.
+        // Tokens after the first are intentionally ignored: the basename
+        // of argv[0] is what runs as the foreground process at exec time.
         var trimmed = command.TrimStart();
         string first;
         if (trimmed.StartsWith('"'))
@@ -137,13 +142,18 @@ public static class ProfileOrderResolver
         }
         else
         {
-            var space = trimmed.IndexOfAny(new[] { ' ', '\t' });
+            var space = trimmed.IndexOfAny(s_whitespace);
             first = space < 0 ? trimmed : trimmed.Substring(0, space);
         }
         if (first.Length == 0) return null;
         // Path.GetFileName handles both forward and backward slashes.
         var name = System.IO.Path.GetFileName(first);
-        return string.IsNullOrEmpty(name) ? null : name;
+        if (string.IsNullOrEmpty(name)) return null;
+        // ProcessIconTable keys end in .exe; treat a bare `command = pwsh`
+        // (no extension) as if the user wrote `pwsh.exe`. This is the
+        // PATH-resolution case where the shell would append .exe anyway.
+        if (!name.Contains('.')) name += ".exe";
+        return name;
     }
 
     private static string? ResolveDefault(

--- a/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
@@ -59,11 +59,24 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         IconSpec.AutoForExe a => ExtractExeIconAsPng(a.ExePath),
         // Unknown distros fall back to the legacy flat wsl.png; a generic
         // tux block is preferable to nothing when we can't pick a brand.
-        IconSpec.AutoForWslDistro w => DistroBrandKey(w.DistroName) is { } k
+        // Empty distro name (bare `wsl.exe` with no -d flag) consults the
+        // registry for the user's default distro before falling back.
+        IconSpec.AutoForWslDistro w => DistroBrandKey(EffectiveDistroName(w.DistroName)) is { } k
             ? ReadBrandedOrDefault(k, 32)
             : ReadBundledOrDefault("wsl"),
         _ => ReadBundledOrDefault(DefaultBundledKey),
     };
+
+    // For bare `wsl.exe` (no -d), the active-shell tracker emits
+    // AutoForWslDistro("") and we should pick the brand of whichever
+    // distro WSL would actually launch. The registry default is the
+    // best signal we have without spawning a probe process.
+    private static string EffectiveDistroName(string distroName)
+    {
+        if (!string.IsNullOrEmpty(distroName)) return distroName;
+        if (!OperatingSystem.IsWindows()) return distroName;
+        return WslDefaultDistro.Resolve() ?? distroName;
+    }
 
     private static string? DistroBrandKey(string distroName)
     {
@@ -156,7 +169,7 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
             IconSpec.Mdl2Token m => "mdl2:" + m.CodePoint.ToString("x"),
             IconSpec.BundledKey b => "bundled-v2:" + b.Key,
             IconSpec.AutoForExe a => "exe:" + a.ExePath,
-            IconSpec.AutoForWslDistro w => "wsl-distro-v2:" + (DistroBrandKey(w.DistroName) ?? "wsl") + ":" + w.DistroName,
+            IconSpec.AutoForWslDistro w => "wsl-distro-v2:" + (DistroBrandKey(EffectiveDistroName(w.DistroName)) ?? "wsl") + ":" + EffectiveDistroName(w.DistroName),
             _ => "unknown",
         };
         var mtime = MtimeTokenFor(spec);

--- a/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
@@ -61,11 +61,17 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         // tux block is preferable to nothing when we can't pick a brand.
         // Empty distro name (bare `wsl.exe` with no -d flag) consults the
         // registry for the user's default distro before falling back.
-        IconSpec.AutoForWslDistro w => DistroBrandKey(EffectiveDistroName(w.DistroName)) is { } k
-            ? ReadBrandedOrDefault(k, 32)
-            : ReadBundledOrDefault("wsl"),
+        IconSpec.AutoForWslDistro w => ResolveWslDistro(w.DistroName),
         _ => ReadBundledOrDefault(DefaultBundledKey),
     };
+
+    private byte[] ResolveWslDistro(string distroName)
+    {
+        var effective = EffectiveDistroName(distroName);
+        return DistroBrandKey(effective) is { } k
+            ? ReadBrandedOrDefault(k, 32)
+            : ReadBundledOrDefault("wsl");
+    }
 
     // For bare `wsl.exe` (no -d), the active-shell tracker emits
     // AutoForWslDistro("") and we should pick the brand of whichever
@@ -169,7 +175,7 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
             IconSpec.Mdl2Token m => "mdl2:" + m.CodePoint.ToString("x"),
             IconSpec.BundledKey b => "bundled-v2:" + b.Key,
             IconSpec.AutoForExe a => "exe:" + a.ExePath,
-            IconSpec.AutoForWslDistro w => "wsl-distro-v2:" + (DistroBrandKey(EffectiveDistroName(w.DistroName)) ?? "wsl") + ":" + EffectiveDistroName(w.DistroName),
+            IconSpec.AutoForWslDistro w => BuildWslCacheToken(w.DistroName),
             _ => "unknown",
         };
         var mtime = MtimeTokenFor(spec);
@@ -177,6 +183,15 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
         Span<byte> hash = stackalloc byte[32];
         SHA256.HashData(Encoding.UTF8.GetBytes(token), hash);
         return Convert.ToHexStringLower(hash);
+    }
+
+    // Cache key for AutoForWslDistro. Resolves the effective distro once
+    // so an empty incoming name shares the same cache entry as the
+    // explicitly-named default distro (one PNG decode per process).
+    private static string BuildWslCacheToken(string distroName)
+    {
+        var effective = EffectiveDistroName(distroName);
+        return "wsl-distro-v2:" + (DistroBrandKey(effective) ?? "wsl") + ":" + effective;
     }
 
     private async Task<byte[]?> TryReadCacheAsync(string sha, CancellationToken ct)

--- a/windows/Ghostty.Core/Profiles/WslDefaultDistro.cs
+++ b/windows/Ghostty.Core/Profiles/WslDefaultDistro.cs
@@ -1,0 +1,64 @@
+using System;
+using Microsoft.Win32;
+
+namespace Ghostty.Core.Profiles;
+
+/// <summary>
+/// Reads the user's default WSL distribution from the registry. Cached
+/// for the process lifetime — distros change at install time, not at
+/// runtime. Returns null if WSL isn't installed or the registry shape
+/// changes.
+///
+/// The default-distro lookup feeds <see cref="WindowsIconResolver"/>'s
+/// AutoForWslDistro fallback: when a profile resolves to
+/// <c>AutoForWslDistro("")</c> (e.g., the active-shell tracker sees a
+/// bare <c>wsl.exe</c> command line with no <c>-d</c> flag), the icon
+/// should still show the brand of whichever distro WSL launches.
+/// </summary>
+[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+internal static class WslDefaultDistro
+{
+    // Modern WSL (Store / winget installs and Windows 11 inbox WSL)
+    // stores distros under Software\Microsoft\Windows\CurrentVersion\Lxss.
+    // Older third-party docs point at the NT\ subpath which is unused
+    // on current Windows; stick to the modern path.
+    private const string LxssRoot = @"Software\Microsoft\Windows\CurrentVersion\Lxss";
+
+    private static string? _cached;
+    private static bool _resolved;
+    private static readonly object _lock = new();
+
+    public static string? Resolve()
+    {
+        lock (_lock)
+        {
+            if (_resolved) return _cached;
+            _resolved = true;
+            _cached = TryReadFromRegistry();
+            return _cached;
+        }
+    }
+
+    private static string? TryReadFromRegistry()
+    {
+        try
+        {
+            using var root = Registry.CurrentUser.OpenSubKey(LxssRoot);
+            if (root is null) return null;
+
+            var defaultGuid = root.GetValue("DefaultDistribution") as string;
+            if (string.IsNullOrEmpty(defaultGuid)) return null;
+
+            using var distro = root.OpenSubKey(defaultGuid);
+            if (distro is null) return null;
+
+            return distro.GetValue("DistributionName") as string;
+        }
+        catch
+        {
+            // Registry access denied / shape changed / WSL uninstalled mid-session.
+            // Silent fallback: caller sees null and lands on the legacy wsl.png.
+            return null;
+        }
+    }
+}

--- a/windows/Ghostty.Core/Profiles/WslDefaultDistro.cs
+++ b/windows/Ghostty.Core/Profiles/WslDefaultDistro.cs
@@ -4,10 +4,11 @@ using Microsoft.Win32;
 namespace Ghostty.Core.Profiles;
 
 /// <summary>
-/// Reads the user's default WSL distribution from the registry. Cached
-/// for the process lifetime — distros change at install time, not at
-/// runtime. Returns null if WSL isn't installed or the registry shape
-/// changes.
+/// Reads the user's default WSL distribution from the registry. Successful
+/// lookups are cached for the process lifetime because distros change at
+/// install time, not at runtime. A null result is intentionally NOT cached:
+/// a user who installs WSL after wintty launched would otherwise see the
+/// generic wsl.png until app restart, so we retry on the next call instead.
 ///
 /// The default-distro lookup feeds <see cref="WindowsIconResolver"/>'s
 /// AutoForWslDistro fallback: when a profile resolves to
@@ -25,17 +26,16 @@ internal static class WslDefaultDistro
     private const string LxssRoot = @"Software\Microsoft\Windows\CurrentVersion\Lxss";
 
     private static string? _cached;
-    private static bool _resolved;
     private static readonly object _lock = new();
 
     public static string? Resolve()
     {
         lock (_lock)
         {
-            if (_resolved) return _cached;
-            _resolved = true;
-            _cached = TryReadFromRegistry();
-            return _cached;
+            if (_cached is not null) return _cached;
+            var fresh = TryReadFromRegistry();
+            if (fresh is not null) _cached = fresh;
+            return fresh;
         }
     }
 
@@ -46,18 +46,30 @@ internal static class WslDefaultDistro
             using var root = Registry.CurrentUser.OpenSubKey(LxssRoot);
             if (root is null) return null;
 
-            var defaultGuid = root.GetValue("DefaultDistribution") as string;
-            if (string.IsNullOrEmpty(defaultGuid)) return null;
+            if (root.GetValue("DefaultDistribution") is not string defaultGuid
+                || defaultGuid.Length == 0)
+            {
+                return null;
+            }
 
             using var distro = root.OpenSubKey(defaultGuid);
             if (distro is null) return null;
 
             return distro.GetValue("DistributionName") as string;
         }
-        catch
+        catch (Exception ex) when (
+            ex is System.Security.SecurityException
+            or System.IO.IOException
+            or UnauthorizedAccessException
+            or ObjectDisposedException)
         {
-            // Registry access denied / shape changed / WSL uninstalled mid-session.
-            // Silent fallback: caller sees null and lands on the legacy wsl.png.
+            // Registry access denied, shape changed, or WSL uninstalled
+            // mid-session. Silent fallback: caller sees null and lands on
+            // the legacy wsl.png. Surfaced to Debug so a regressed
+            // resolver is diagnosable from a devenv-attached run without
+            // pulling ILogger into a pure-Core helper.
+            System.Diagnostics.Debug.WriteLine(
+                $"WslDefaultDistro: registry read failed: {ex.GetType().Name}: {ex.Message}");
             return null;
         }
     }

--- a/windows/Ghostty.Tests/Profiles/ProfileOrderResolverIconFallbackTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileOrderResolverIconFallbackTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Profiles;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles;
+
+public sealed class ProfileOrderResolverIconFallbackTests
+{
+    [Fact]
+    public void Resolve_ProfileWithExplicitIcon_KeepsIt()
+    {
+        var def = MakeDef(command: "pwsh.exe", icon: new IconSpec.BrandKey("ubuntu", null));
+        var resolved = ResolveSingle(def);
+        var brand = Assert.IsType<IconSpec.BrandKey>(resolved.Icon);
+        Assert.Equal("ubuntu", brand.Key);
+    }
+
+    [Fact]
+    public void Resolve_NoIcon_PwshCommand_FallsBackToPwshBrand()
+    {
+        var def = MakeDef(command: "pwsh.exe", icon: null);
+        var resolved = ResolveSingle(def);
+        var brand = Assert.IsType<IconSpec.BrandKey>(resolved.Icon);
+        Assert.Equal("pwsh", brand.Key);
+    }
+
+    [Fact]
+    public void Resolve_NoIcon_QuotedAbsolutePwshPath_FallsBackToPwshBrand()
+    {
+        var def = MakeDef(command: "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\"", icon: null);
+        var resolved = ResolveSingle(def);
+        var brand = Assert.IsType<IconSpec.BrandKey>(resolved.Icon);
+        Assert.Equal("pwsh", brand.Key);
+    }
+
+    [Fact]
+    public void Resolve_NoIcon_CmdCommand_FallsBackToCmdBrand()
+    {
+        var def = MakeDef(command: "cmd.exe", icon: null);
+        var resolved = ResolveSingle(def);
+        var brand = Assert.IsType<IconSpec.BrandKey>(resolved.Icon);
+        Assert.Equal("cmd", brand.Key);
+    }
+
+    [Fact]
+    public void Resolve_NoIcon_UnknownCommand_FallsBackToDefault()
+    {
+        var def = MakeDef(command: "totally-bespoke-shell.exe", icon: null);
+        var resolved = ResolveSingle(def);
+        var bundled = Assert.IsType<IconSpec.BundledKey>(resolved.Icon);
+        Assert.Equal("default", bundled.Key);
+    }
+
+    [Fact]
+    public void Resolve_NoIcon_EmptyCommand_FallsBackToDefault()
+    {
+        var def = MakeDef(command: "", icon: null);
+        var resolved = ResolveSingle(def);
+        var bundled = Assert.IsType<IconSpec.BundledKey>(resolved.Icon);
+        Assert.Equal("default", bundled.Key);
+    }
+
+    private static ProfileDef MakeDef(string command, IconSpec? icon) =>
+        new(Id: "test", Name: "Test", Command: command, Icon: icon);
+
+    private static ResolvedProfile ResolveSingle(ProfileDef def)
+    {
+        var set = ProfileOrderResolver.Resolve(
+            user: new[] { def },
+            discovered: System.Array.Empty<DiscoveredProfile>(),
+            profileOrder: null,
+            defaultProfileId: null,
+            hiddenIds: new HashSet<string>());
+        return set.Visible.Single();
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/ProfileOrderResolverIconFallbackTests.cs
+++ b/windows/Ghostty.Tests/Profiles/ProfileOrderResolverIconFallbackTests.cs
@@ -61,6 +61,18 @@ public sealed class ProfileOrderResolverIconFallbackTests
         Assert.Equal("default", bundled.Key);
     }
 
+    [Fact]
+    public void Resolve_NoIcon_BareCommandWithoutExtension_FallsBackToBrand()
+    {
+        // PATH-resolution case: user writes `command = pwsh` and relies on
+        // the shell to append .exe. ProcessIconTable keys end in .exe, so
+        // the fallback parser should treat the basename as if it did.
+        var def = MakeDef(command: "pwsh", icon: null);
+        var resolved = ResolveSingle(def);
+        var brand = Assert.IsType<IconSpec.BrandKey>(resolved.Icon);
+        Assert.Equal("pwsh", brand.Key);
+    }
+
     private static ProfileDef MakeDef(string command, IconSpec? icon) =>
         new(Id: "test", Name: "Test", Command: command, Icon: icon);
 

--- a/windows/Ghostty.Tests/Profiles/WindowsIconResolverWslDistroTests.cs
+++ b/windows/Ghostty.Tests/Profiles/WindowsIconResolverWslDistroTests.cs
@@ -38,4 +38,26 @@ public sealed class WindowsIconResolverWslDistroTests
         var bytes = await resolver.ResolveAsync(new IconSpec.AutoForWslDistro("Nixos"), CancellationToken.None);
         Assert.NotEmpty(bytes);
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Resolve_WslDistro_EmptyDistro_FallsBackThroughResolver()
+    {
+        // When distro name is empty, the resolver consults the registry for
+        // the default distro. The test machine may or may not have WSL
+        // configured: if it does, we get the matching brand; if not, we
+        // fall back to the legacy wsl.png. Either way the result is a
+        // non-empty PNG, which is the user-visible contract.
+        var fs = new FakeFileSystem();
+        fs.SetKnownFolder(KnownFolderId.LocalAppData, @"C:\cache");
+        var resolver = new WindowsIconResolver(fs);
+
+        var bytes = await resolver.ResolveAsync(
+            new IconSpec.AutoForWslDistro(string.Empty),
+            CancellationToken.None);
+
+        Assert.NotEmpty(bytes);
+        // PNG signature: 89 50 4E 47.
+        Assert.Equal(0x89, bytes[0]);
+        Assert.Equal(0x50, bytes[1]);
+    }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1023,13 +1023,19 @@ public sealed partial class MainWindow : Window
     /// <c>TryGetShellPid</c> every 500 ms for up to 10 s once a leaf
     /// has been focused, stopping on the first non-null result.
     /// </summary>
+    // 500 ms tick × 20 ticks = 10 s budget. Surfaced as named constants so
+    // the interval / budget relationship is legible at a glance and a future
+    // adjustment doesn't have to keep them in sync mentally.
+    private static readonly TimeSpan ShellPidPollInterval = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan ShellPidPollBudget = TimeSpan.FromSeconds(10);
+
     private void AttachProcessTracking(TabModel tab)
     {
         ((App)Application.Current).RegisterTabForProcessTracking(tab);
 
         Microsoft.UI.Dispatching.DispatcherQueueTimer? pidPoll = null;
         int pollTicks = 0;
-        const int MaxPollTicks = 20;  // 20 * 500 ms = 10 s
+        int maxPollTicks = (int)(ShellPidPollBudget.TotalMilliseconds / ShellPidPollInterval.TotalMilliseconds);
 
         void TryAssignPid(Ghostty.Core.Panes.LeafPane leaf)
         {
@@ -1047,13 +1053,27 @@ public sealed partial class MainWindow : Window
             if (pidPoll is not null) return;       // already polling
             if (tab.ShellPid is not null) return;  // race-won by the immediate path
             pidPoll = DispatcherQueue.CreateTimer();
-            pidPoll.Interval = TimeSpan.FromMilliseconds(500);
+            pidPoll.Interval = ShellPidPollInterval;
             pidPoll.Tick += (_, _) =>
             {
                 pollTicks++;
                 TryAssignPid(leaf);
-                if (tab.ShellPid is not null || pollTicks >= MaxPollTicks)
+                if (tab.ShellPid is not null)
                 {
+                    pidPoll?.Stop();
+                    pidPoll = null;
+                    return;
+                }
+                if (pollTicks >= maxPollTicks)
+                {
+                    // Budget exhausted without a pid. Most likely cause is a
+                    // libghostty regression where ghostty_surface_foreground_pid
+                    // never publishes a non-zero value, leaving the active-shell
+                    // icon stuck on the profile glyph. Logged so the regression
+                    // is visible without attaching a debugger.
+                    _logger.LogWarning(
+                        "Active-shell tracker: shell pid never resolved for tab {TabId} within {BudgetMs} ms",
+                        tab.Id, (int)ShellPidPollBudget.TotalMilliseconds);
                     pidPoll?.Stop();
                     pidPoll = null;
                 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1008,32 +1008,78 @@ public sealed partial class MainWindow : Window
     /// populated once libghostty has spawned the surface's shell. Hook
     /// PaneHost.LeafFocused (the first fire lands from PaneHost.Loaded,
     /// at which point the TerminalControl's libghostty surface exists)
-    /// and query <c>ghostty_surface_foreground_pid</c>. Re-fires on
-    /// every focus change so split/zoom retains the tab's root pid;
-    /// the assignment is idempotent when the value is unchanged.
+    /// and query <c>ghostty_surface_foreground_pid</c>. The first leaf's
+    /// surface drives the tracker root; we keep the first-spawned shell
+    /// as the lineage the user originally opened (e.g. a "Bash" tab
+    /// whose split panes spawn PowerShell shouldn't re-root the icon
+    /// onto pwsh).
+    ///
+    /// Race: libghostty's <c>ghostty_surface_foreground_pid</c> returns
+    /// 0 between surface init and the Termio thread completing
+    /// <c>CreateProcessW</c> for the spawned shell. LeafFocused is a
+    /// one-shot snapshot (focus does not change again on a cold start
+    /// with a single pane), so a single failed query would leave the
+    /// tab pid-less forever. We absorb the race by polling
+    /// <c>TryGetShellPid</c> every 500 ms for up to 10 s once a leaf
+    /// has been focused, stopping on the first non-null result.
     /// </summary>
     private void AttachProcessTracking(TabModel tab)
     {
         ((App)Application.Current).RegisterTabForProcessTracking(tab);
 
-        // First leaf's surface drives the pid. If the tab grows splits
-        // later, we keep the first-spawned shell as the tracker root
-        // because that is the lineage the user originally opened (e.g.
-        // a "Bash" tab whose split panes spawned PowerShell shouldn't
-        // re-root the icon onto pwsh). Re-querying on every LeafFocused
-        // would race: by the time we sample, the pid we'd grab could be
-        // the wrong leaf's. Instead we snapshot exactly once.
-        void OnLeafFocused(object? _, Ghostty.Core.Panes.LeafPane leaf)
+        Microsoft.UI.Dispatching.DispatcherQueueTimer? pidPoll = null;
+        int pollTicks = 0;
+        const int MaxPollTicks = 20;  // 20 * 500 ms = 10 s
+
+        void TryAssignPid(Ghostty.Core.Panes.LeafPane leaf)
         {
             if (tab.ShellPid is not null) return;
             var pid = leaf.Terminal().TryGetShellPid();
             if (pid is null) return;
             tab.ShellPid = pid;
+            // Stop polling once we have it.
+            pidPoll?.Stop();
+            pidPoll = null;
+        }
+
+        void StartPollingFor(Ghostty.Core.Panes.LeafPane leaf)
+        {
+            if (pidPoll is not null) return;       // already polling
+            if (tab.ShellPid is not null) return;  // race-won by the immediate path
+            pidPoll = DispatcherQueue.CreateTimer();
+            pidPoll.Interval = TimeSpan.FromMilliseconds(500);
+            pidPoll.Tick += (_, _) =>
+            {
+                pollTicks++;
+                TryAssignPid(leaf);
+                if (tab.ShellPid is not null || pollTicks >= MaxPollTicks)
+                {
+                    pidPoll?.Stop();
+                    pidPoll = null;
+                }
+            };
+            pidPoll.Start();
+        }
+
+        void OnLeafFocused(object? _, Ghostty.Core.Panes.LeafPane leaf)
+        {
+            // Immediate attempt first (fast path: libghostty already done
+            // with CreateProcessW by the time the leaf gains focus).
+            TryAssignPid(leaf);
+            // If still null, start (or keep) polling until libghostty
+            // catches up or we hit the 10 s budget.
+            if (tab.ShellPid is null) StartPollingFor(leaf);
         }
         tab.PaneHost.LeafFocused += OnLeafFocused;
         // Stash the unsubscriber so DetachProcessTracking can walk back
-        // the LeafFocused handler without a side dictionary.
-        _processTrackingDetach[tab] = () => tab.PaneHost.LeafFocused -= OnLeafFocused;
+        // the LeafFocused handler without a side dictionary, and stop
+        // any in-flight poll when the tab is removed before we resolved.
+        _processTrackingDetach[tab] = () =>
+        {
+            tab.PaneHost.LeafFocused -= OnLeafFocused;
+            pidPoll?.Stop();
+            pidPoll = null;
+        };
     }
 
     private void DetachProcessTracking(TabModel tab)


### PR DESCRIPTION
## Summary
Five small fixes after the active-shell-icon stack landed on windows:

- **Windows PowerShell profile** uses the `pwsh` brand glyph (no `powershell` asset exists).
- **Profiles with `command` but no `icon`** derive an icon from the exe basename via `ProcessIconTable`, so `command = pwsh.exe` picks up the pwsh brand instead of the generic default.
- **Bare `wsl.exe` (no `-d`)** consults `HKCU\Software\Microsoft\Windows\CurrentVersion\Lxss` for the default distribution and routes that name through `DistroBrandKey`. Default Ubuntu shows the Ubuntu glyph; unknown distros fall back to the legacy wsl bundle.
- `EffectiveDistroName` is also folded into the resolver cache key so two `AutoForWslDistro("")` specs share one entry keyed by the resolved distro brand.
- `MainWindow.AttachProcessTracking` polls `TryGetShellPid` every 500ms for up to 10s on first `LeafFocused`, absorbing the race where libghostty's surface is up but the Termio thread has not yet completed `CreateProcessW`.

## Test plan
- [x] `dotnet test windows/Ghostty.Tests` 1000 passing
- [x] Primary profile (command=`pwsh.exe`, no icon) shows pwsh brand
- [x] Windows PowerShell profile shows pwsh brand
- [x] Plain `wsl` (no `-d` arg) shows ubuntu brand on a default-Ubuntu machine
- [x] `pwsh -> cmd -> pwsh` mid-session swap
- [x] `node` / `go` / `git` mid-session swap
- [x] Per-tab routing isolation across 4 concurrent tabs (verified via runtime diag)