### PR TITLE
branding: wire wintty.ico into AppWindow for taskbar + alt-tab

### DIFF
--- a/windows/Ghostty/Branding/WindowHelper.cs
+++ b/windows/Ghostty/Branding/WindowHelper.cs
@@ -7,19 +7,20 @@ using Microsoft.UI.Xaml;
 namespace Ghostty.Branding;
 
 /// <summary>
-/// Window-level branding helpers. Two unrelated concerns share this
-/// file because both are window-owner plumbing the rest of the shell
-/// reaches for:
-///
-///   - <see cref="GetWindow"/> resolves the owning Window for a live
-///     XAML element (used by the AppIconBadge click handler so it can
-///     pass the Window to the system-menu interop helper).
-///   - <see cref="TryApplyAppIcon"/> wires the deployed wintty.ico
-///     into the OS-level window slots (taskbar group, thumbnail-hover
-///     preview, alt-tab list, title-bar icon when WinUI 3 renders one).
+/// Window-owner helpers used by the WinUI 3 shell.
 /// </summary>
 internal static class WindowHelper
 {
+    /// <summary>
+    /// Resolves the owning Window for a live XAML element. Used by
+    /// AppIconBadge so the click handler can hand the Window to the
+    /// system-menu interop helper.
+    ///
+    /// Multi-window aware: looks up the element's XamlRoot in
+    /// <see cref="App.WindowsByRoot"/> to find the correct owning window.
+    /// Falls back to the first window in the registry if the XamlRoot
+    /// lookup misses (e.g. element not yet loaded).
+    /// </summary>
     public static Window? GetWindow(FrameworkElement element)
     {
         if (element.XamlRoot is { } root &&
@@ -34,25 +35,16 @@ internal static class WindowHelper
     }
 
     /// <summary>
-    /// Apply the deployed wintty.ico to <paramref name="window"/>'s
-    /// AppWindow so the OS renders the brand in the taskbar group,
-    /// the thumbnail-hover preview, the alt-tab list, and the
-    /// system title-bar slot (when WinUI 3 renders one). The .ico is
-    /// produced at build time by IconGen and copied into the
-    /// <c>Assets</c> directory next to the exe by Ghostty.csproj's
-    /// Content item group; the path here mirrors that Link target.
+    /// Stamp the deployed wintty.ico into <paramref name="window"/>'s
+    /// AppWindow icon slots so the taskbar group, thumbnail preview,
+    /// alt-tab list, and (when WinUI 3 renders one) the system title-bar
+    /// show the brand. ApplicationIcon embeds the same .ico as the exe
+    /// resource but does NOT wire those runtime slots; without this call
+    /// they fall back to the default WinUI 3 icon.
     ///
-    /// ApplicationIcon already embeds the same .ico as the exe
-    /// resource (which Explorer and the cold-start fallback path
-    /// use), but AppWindow.SetIcon needs a real file path on disk
-    /// to wire the runtime window-icon slots. Without this call,
-    /// taskbar and alt-tab fall back to the default WinUI 3 icon
-    /// instead of the embedded resource.
-    ///
-    /// Swallows the IO + COM failure modes that AppWindow.SetIcon
-    /// can throw (missing file, locked file, transient COM hiccup):
-    /// a missing window icon is ugly but non-fatal, so dropping to
-    /// the default beats crashing the window.
+    /// Swallows the file-not-found race (asset deleted between the
+    /// File.Exists check and the SetIcon call) and the native HRESULT
+    /// path. A missing window icon is cosmetic, not crash-worthy.
     /// </summary>
     public static void TryApplyAppIcon(Window window)
     {
@@ -63,11 +55,7 @@ internal static class WindowHelper
             if (!File.Exists(iconPath)) return;
             window.AppWindow.SetIcon(iconPath);
         }
-        catch (Exception ex) when (
-            ex is IOException
-            or UnauthorizedAccessException
-            or InvalidOperationException
-            or COMException)
+        catch (Exception ex) when (ex is FileNotFoundException or COMException)
         {
             Debug.WriteLine(
                 $"AppWindow.SetIcon failed: {ex.GetType().Name}: {ex.Message}");

--- a/windows/Ghostty/Branding/WindowHelper.cs
+++ b/windows/Ghostty/Branding/WindowHelper.cs
@@ -1,16 +1,22 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.UI.Xaml;
 
 namespace Ghostty.Branding;
 
 /// <summary>
-/// Resolves the owning Window for a live XAML element. Used by
-/// AppIconBadge so the click handler can hand the Window to the
-/// system-menu interop helper.
+/// Window-level branding helpers. Two unrelated concerns share this
+/// file because both are window-owner plumbing the rest of the shell
+/// reaches for:
 ///
-/// Multi-window aware: looks up the element's XamlRoot in
-/// <see cref="App.WindowsByRoot"/> to find the correct owning window.
-/// Falls back to the first window in the registry if the XamlRoot
-/// lookup misses (e.g. element not yet loaded).
+///   - <see cref="GetWindow"/> resolves the owning Window for a live
+///     XAML element (used by the AppIconBadge click handler so it can
+///     pass the Window to the system-menu interop helper).
+///   - <see cref="TryApplyAppIcon"/> wires the deployed wintty.ico
+///     into the OS-level window slots (taskbar group, thumbnail-hover
+///     preview, alt-tab list, title-bar icon when WinUI 3 renders one).
 /// </summary>
 internal static class WindowHelper
 {
@@ -25,5 +31,46 @@ internal static class WindowHelper
             return w;
 
         return null;
+    }
+
+    /// <summary>
+    /// Apply the deployed wintty.ico to <paramref name="window"/>'s
+    /// AppWindow so the OS renders the brand in the taskbar group,
+    /// the thumbnail-hover preview, the alt-tab list, and the
+    /// system title-bar slot (when WinUI 3 renders one). The .ico is
+    /// produced at build time by IconGen and copied into the
+    /// <c>Assets</c> directory next to the exe by Ghostty.csproj's
+    /// Content item group; the path here mirrors that Link target.
+    ///
+    /// ApplicationIcon already embeds the same .ico as the exe
+    /// resource (which Explorer and the cold-start fallback path
+    /// use), but AppWindow.SetIcon needs a real file path on disk
+    /// to wire the runtime window-icon slots. Without this call,
+    /// taskbar and alt-tab fall back to the default WinUI 3 icon
+    /// instead of the embedded resource.
+    ///
+    /// Swallows the IO + COM failure modes that AppWindow.SetIcon
+    /// can throw (missing file, locked file, transient COM hiccup):
+    /// a missing window icon is ugly but non-fatal, so dropping to
+    /// the default beats crashing the window.
+    /// </summary>
+    public static void TryApplyAppIcon(Window window)
+    {
+        try
+        {
+            var appDir = AppContext.BaseDirectory;
+            var iconPath = Path.Combine(appDir, "Assets", "wintty.ico");
+            if (!File.Exists(iconPath)) return;
+            window.AppWindow.SetIcon(iconPath);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+            or UnauthorizedAccessException
+            or InvalidOperationException
+            or COMException)
+        {
+            Debug.WriteLine(
+                $"AppWindow.SetIcon failed: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 }

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -286,5 +286,21 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>
+    <!--
+      Deploy the generated .ico alongside the runtime PNGs. ApplicationIcon
+      already embeds this same file as the exe resource (which Explorer and
+      the default-fallback path use), but AppWindow.SetIcon needs a real
+      file path on disk to wire the icon into the taskbar group, the
+      thumbnail-hover preview, the alt-tab list, and the title-bar slot
+      WinUI 3 renders when ExtendsContentIntoTitleBar is true. The Link
+      drops the channel segment from the runtime path so the SetIcon call
+      site stays channel-blind; the .ico contents already encode the
+      channel-specific glyph.
+    -->
+    <Content Include="$(GeneratedBrandingDir)wintty.ico">
+      <Link>Assets\wintty.ico</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
   </ItemGroup>
 </Project>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -247,6 +247,12 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
 
+        // Wire the brand into the taskbar group, thumbnail-hover
+        // preview, alt-tab list, and the system title-bar icon slot.
+        // ApplicationIcon embeds the same .ico as the exe resource, but
+        // AppWindow.SetIcon is what makes the OS use it at runtime.
+        Ghostty.Branding.WindowHelper.TryApplyAppIcon(this);
+
         _configService = configService;
         _configEditor = App.ConfigFileEditor
             ?? throw new InvalidOperationException(

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -247,10 +247,6 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
 
-        // Wire the brand into the taskbar group, thumbnail-hover
-        // preview, alt-tab list, and the system title-bar icon slot.
-        // ApplicationIcon embeds the same .ico as the exe resource, but
-        // AppWindow.SetIcon is what makes the OS use it at runtime.
         Ghostty.Branding.WindowHelper.TryApplyAppIcon(this);
 
         _configService = configService;

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -58,6 +58,12 @@ internal sealed partial class SettingsWindow : Window
         _theme = theme;
         InitializeComponent();
 
+        // Wire the brand into the taskbar group, thumbnail-hover
+        // preview, alt-tab list, and the system title-bar icon slot.
+        // ApplicationIcon embeds the same .ico as the exe resource, but
+        // AppWindow.SetIcon is what makes the OS use it at runtime.
+        Ghostty.Branding.WindowHelper.TryApplyAppIcon(this);
+
         // Branded window title and custom title bar. Title is used by the
         // taskbar / alt-tab; AppTitleBar.Title renders the same text inside
         // the window next to the gear FontIcon. Both read from

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -58,10 +58,6 @@ internal sealed partial class SettingsWindow : Window
         _theme = theme;
         InitializeComponent();
 
-        // Wire the brand into the taskbar group, thumbnail-hover
-        // preview, alt-tab list, and the system title-bar icon slot.
-        // ApplicationIcon embeds the same .ico as the exe resource, but
-        // AppWindow.SetIcon is what makes the OS use it at runtime.
         Ghostty.Branding.WindowHelper.TryApplyAppIcon(this);
 
         // Branded window title and custom title bar. Title is used by the


### PR DESCRIPTION
## Summary

- Deploys the generated `wintty.ico` to `<AppDir>/Assets/wintty.ico` via the same `Content` + `Link` pattern that already handles the runtime PNGs.
- Calls `AppWindow.SetIcon(...)` from a shared helper (`Ghostty.Branding.WindowHelper.TryApplyAppIcon`) right after `InitializeComponent` in both `MainWindow` and `SettingsWindow`.

`ApplicationIcon` already embeds the same `.ico` as the exe resource (which Explorer and the cold-start fallback use), but `AppWindow.SetIcon` is what wires it into the OS at runtime. Without this call, the taskbar group, the thumbnail-hover preview, the alt-tab list, and the system title-bar slot all fall back to the default WinUI 3 icon.

The helper swallows the IO + COM failure modes `SetIcon` can throw -- a missing icon is non-fatal, the default is just ugly.

## Test plan

- [ ] Hover the taskbar icon -- the thumbnail shows the wintty mark.
- [ ] Right-click the taskbar item -- the jump list shows the icon.
- [ ] Open Settings (Ctrl+,) -- both windows in alt-tab show the icon.
- [ ] Group multiple wintty windows in the taskbar -- the group icon is wintty's.