### PR TITLE
branding: distinct gear icon for the Settings window taskbar slot

### DIFF
--- a/dist/windows/IconGen.Tests/EndToEndTests.cs
+++ b/dist/windows/IconGen.Tests/EndToEndTests.cs
@@ -25,13 +25,15 @@ public class EndToEndTests
     [Fact]
     public void SettingsIcoIsRenderedFromGearGlyph()
     {
-        // The gear glyph is hollow in the centre by design (it's a
-        // ring with teeth), so a centre-pixel check would fail on the
-        // intentional cutout. Instead, count total non-transparent
-        // pixels in the largest .ico frame: the gear should fill
-        // 8-30% of the canvas. Below that, GearMasters fell through
-        // to a font without E713 (or no font at all) and rendered
-        // empty / a placeholder rectangle.
+        // The gear glyph is hollow in the centre by design (a ring
+        // with teeth), so a centre-pixel check would fail on the
+        // intentional cutout. Instead, count non-transparent pixels
+        // in the largest .ico frame and assert coverage is in the
+        // band a real gear lands in. Lower bound 0.08 excludes the
+        // empty / placeholder-rectangle outline a font without E713
+        // would draw (~5-8% area at the 78% canvas fill we use);
+        // upper bound 0.35 excludes a solid filled rectangle from a
+        // .notdef fallback.
         using var tempDir = new TempDir();
         var repoRoot = TempDir.FindRepoRoot();
 
@@ -44,8 +46,8 @@ public class EndToEndTests
         int total = img.Width * img.Height;
         int opaque = CountOpaquePixels(img);
         double coverage = (double)opaque / total;
-        Assert.True(coverage is > 0.05 and < 0.5,
-            $"Expected gear glyph coverage in [5%, 50%] in wintty-settings.ico; " +
+        Assert.True(coverage is > 0.08 and < 0.35,
+            $"Expected gear glyph coverage in [8%, 35%] in wintty-settings.ico; " +
             $"got {coverage:P1}. Likely cause: Segoe Fluent Icons / Segoe MDL2 " +
             $"Assets font missing or wrong glyph code point.");
     }
@@ -160,5 +162,13 @@ public class EndToEndTests
         var bytes1 = File.ReadAllBytes(Path.Combine(dir1.Path, "wintty.ico"));
         var bytes2 = File.ReadAllBytes(Path.Combine(dir2.Path, "wintty.ico"));
         Assert.Equal(bytes1, bytes2);
+
+        // Same caveat applies to the gear .ico: GDI+ DrawString is
+        // deterministic on a given GDI+ build but may drift across
+        // Windows versions. Pinning both files catches a regression in
+        // either rendering path with one assertion run.
+        var settings1 = File.ReadAllBytes(Path.Combine(dir1.Path, "wintty-settings.ico"));
+        var settings2 = File.ReadAllBytes(Path.Combine(dir2.Path, "wintty-settings.ico"));
+        Assert.Equal(settings1, settings2);
     }
 }

--- a/dist/windows/IconGen.Tests/EndToEndTests.cs
+++ b/dist/windows/IconGen.Tests/EndToEndTests.cs
@@ -17,8 +17,84 @@ public class EndToEndTests
 
         Assert.Equal(0, exitCode);
         Assert.True(File.Exists(Path.Combine(tempDir.Path, "wintty.ico")));
+        Assert.True(File.Exists(Path.Combine(tempDir.Path, "wintty-settings.ico")));
         Assert.True(File.Exists(Path.Combine(tempDir.Path, "AppIcon.scale-100.png")));
         Assert.True(File.Exists(Path.Combine(tempDir.Path, "AppIcon.scale-400.png")));
+    }
+
+    [Fact]
+    public void SettingsIcoIsRenderedFromGearGlyph()
+    {
+        // The gear glyph is hollow in the centre by design (it's a
+        // ring with teeth), so a centre-pixel check would fail on the
+        // intentional cutout. Instead, count total non-transparent
+        // pixels in the largest .ico frame: the gear should fill
+        // 8-30% of the canvas. Below that, GearMasters fell through
+        // to a font without E713 (or no font at all) and rendered
+        // empty / a placeholder rectangle.
+        using var tempDir = new TempDir();
+        var repoRoot = TempDir.FindRepoRoot();
+
+        Program.Run(new[] { "--channel", "stable", "--out", tempDir.Path }, repoRoot);
+
+        var icoPath = Path.Combine(tempDir.Path, "wintty-settings.ico");
+        Assert.True(File.Exists(icoPath));
+
+        using var img = LoadLargestIcoFrame(icoPath);
+        int total = img.Width * img.Height;
+        int opaque = CountOpaquePixels(img);
+        double coverage = (double)opaque / total;
+        Assert.True(coverage is > 0.05 and < 0.5,
+            $"Expected gear glyph coverage in [5%, 50%] in wintty-settings.ico; " +
+            $"got {coverage:P1}. Likely cause: Segoe Fluent Icons / Segoe MDL2 " +
+            $"Assets font missing or wrong glyph code point.");
+    }
+
+    private static int CountOpaquePixels(Bitmap bitmap)
+    {
+        int n = 0;
+        for (int y = 0; y < bitmap.Height; y++)
+            for (int x = 0; x < bitmap.Width; x++)
+                if (bitmap.GetPixel(x, y).A > 0) n++;
+        return n;
+    }
+
+    private static Bitmap LoadLargestIcoFrame(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+        using var ms = new MemoryStream(bytes);
+        using var br = new BinaryReader(ms);
+        br.ReadUInt16();                  // reserved
+        br.ReadUInt16();                  // type
+        ushort count = br.ReadUInt16();
+
+        int bestPx = 0;
+        uint bestOffset = 0;
+        uint bestSize = 0;
+        for (int i = 0; i < count; i++)
+        {
+            byte w = br.ReadByte();
+            br.ReadByte();                // height (== width for our writer)
+            br.ReadByte();                // palette
+            br.ReadByte();                // reserved
+            br.ReadUInt16();              // planes
+            br.ReadUInt16();              // bpp
+            uint size = br.ReadUInt32();
+            uint off = br.ReadUInt32();
+            int px = w == 0 ? 256 : w;    // 0 means 256 in the .ico spec
+            if (px > bestPx)
+            {
+                bestPx = px;
+                bestOffset = off;
+                bestSize = size;
+            }
+        }
+
+        var pngBytes = new byte[bestSize];
+        ms.Position = bestOffset;
+        ms.ReadExactly(pngBytes);
+        using var pngMs = new MemoryStream(pngBytes);
+        return new Bitmap(pngMs);
     }
 
     [Fact]

--- a/dist/windows/IconGen/GearMasters.cs
+++ b/dist/windows/IconGen/GearMasters.cs
@@ -1,0 +1,94 @@
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Drawing.Text;
+
+namespace Ghostty.IconGen;
+
+/// <summary>
+/// Renders the Settings gear glyph (Segoe Fluent Icons E713) to
+/// multi-size bitmap masters at the exact frame sizes IcoWriter packs
+/// into the final .ico. The same code point already drives
+/// SettingsWindow's in-chrome TitleBar.IconSource, so the OS-level
+/// slots (taskbar group, alt-tab) end up with the same affordance as
+/// the title bar.
+///
+/// Rendering happens at build time on a Windows host (CA1416 is
+/// suppressed for IconGen). Segoe Fluent Icons ships with Win11 22H2+;
+/// we fall back to Segoe MDL2 Assets (Win10+) when Fluent is absent.
+/// Both fonts carry E713 at the same code point and render visually
+/// identically at icon sizes.
+/// </summary>
+internal static class GearMasters
+{
+    // Mirrors IcoWriter.FrameSizes so each .ico frame has a master
+    // rendered directly at the target px. Downscaling from a single
+    // 256-px master loses the gear-tooth detail at 16/20/24, which is
+    // exactly where the taskbar lives.
+    private static readonly int[] MasterSizes = { 16, 20, 24, 32, 40, 48, 64, 256 };
+
+    // U+E713 = "Settings" in both Segoe Fluent Icons and the older
+    // Segoe MDL2 Assets. Matches SettingsWindow.xaml's FontIconSource.
+    private const string GearGlyph = "\uE713";
+
+    // Soft off-white so the gear stays readable on the default dark
+    // taskbar; pure white loses subpixel definition once GDI+
+    // antialiases against the dark background, pure black is invisible
+    // there. The alt-tab pane uses a translucent panel that this tone
+    // also reads against. We deliberately do not theme this to the OS
+    // accent color: the taskbar background tone is not theme-bound
+    // (it tracks the wallpaper), so a single tone that survives both
+    // ends is more reliable than two themed variants.
+    private static readonly Color GearColor = Color.FromArgb(0xFF, 0xE6, 0xE6, 0xE6);
+
+    public static MasterRasters Render()
+    {
+        var fontName = ResolveIconFontName();
+        var dict = new Dictionary<int, Bitmap>();
+        foreach (var px in MasterSizes)
+            dict[px] = RenderOne(px, fontName);
+        return MasterRasters.FromDictionary(dict);
+    }
+
+    private static Bitmap RenderOne(int px, string fontName)
+    {
+        var bmp = new Bitmap(px, px, PixelFormat.Format32bppArgb);
+        using var g = Graphics.FromImage(bmp);
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.TextRenderingHint = TextRenderingHint.AntiAlias;
+        g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+        g.Clear(Color.Transparent);
+
+        // Glyph fills ~78% of the canvas so the gear teeth retain a
+        // pixel of padding from the edge at the 16 px frame (otherwise
+        // they clip when GDI+ rounds the layout box).
+        var fontPx = px * 0.78f;
+        using var font = new Font(fontName, fontPx, FontStyle.Regular, GraphicsUnit.Pixel);
+        using var brush = new SolidBrush(GearColor);
+        using var fmt = new StringFormat(StringFormat.GenericTypographic)
+        {
+            Alignment = StringAlignment.Center,
+            LineAlignment = StringAlignment.Center,
+        };
+
+        g.DrawString(GearGlyph, font, brush, new RectangleF(0, 0, px, px), fmt);
+        return bmp;
+    }
+
+    private static string ResolveIconFontName()
+    {
+        using var installed = new InstalledFontCollection();
+        var families = installed.Families
+            .Select(f => f.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (families.Contains("Segoe Fluent Icons")) return "Segoe Fluent Icons";
+        if (families.Contains("Segoe MDL2 Assets")) return "Segoe MDL2 Assets";
+
+        throw new InvalidOperationException(
+            "Cannot render the Settings gear .ico: neither 'Segoe Fluent Icons' " +
+            "nor 'Segoe MDL2 Assets' is installed on this build host. " +
+            "Install one (both ship with Windows 10+ by default) or update " +
+            "GearMasters to ship its own glyph asset.");
+    }
+}

--- a/dist/windows/IconGen/GearMasters.cs
+++ b/dist/windows/IconGen/GearMasters.cs
@@ -21,31 +21,24 @@ namespace Ghostty.IconGen;
 /// </summary>
 internal static class GearMasters
 {
-    // Mirrors IcoWriter.FrameSizes so each .ico frame has a master
-    // rendered directly at the target px. Downscaling from a single
-    // 256-px master loses the gear-tooth detail at 16/20/24, which is
-    // exactly where the taskbar lives.
-    private static readonly int[] MasterSizes = { 16, 20, 24, 32, 40, 48, 64, 256 };
-
     // U+E713 = "Settings" in both Segoe Fluent Icons and the older
     // Segoe MDL2 Assets. Matches SettingsWindow.xaml's FontIconSource.
     private const string GearGlyph = "\uE713";
 
-    // Soft off-white so the gear stays readable on the default dark
-    // taskbar; pure white loses subpixel definition once GDI+
-    // antialiases against the dark background, pure black is invisible
-    // there. The alt-tab pane uses a translucent panel that this tone
-    // also reads against. We deliberately do not theme this to the OS
-    // accent color: the taskbar background tone is not theme-bound
-    // (it tracks the wallpaper), so a single tone that survives both
-    // ends is more reliable than two themed variants.
+    // Off-white reads on both the default dark taskbar and the
+    // translucent alt-tab pane.
     private static readonly Color GearColor = Color.FromArgb(0xFF, 0xE6, 0xE6, 0xE6);
 
     public static MasterRasters Render()
     {
         var fontName = ResolveIconFontName();
         var dict = new Dictionary<int, Bitmap>();
-        foreach (var px in MasterSizes)
+        // Render one master per IcoWriter frame size so each frame is
+        // rasterized directly at its target px; downscaling from a
+        // single 256-px master loses the gear-tooth detail at 16/20/24
+        // (exactly where the taskbar lives). Shared array prevents the
+        // two size lists from drifting silently.
+        foreach (var px in IcoWriter.FrameSizes)
             dict[px] = RenderOne(px, fontName);
         return MasterRasters.FromDictionary(dict);
     }

--- a/dist/windows/IconGen/IcoWriter.cs
+++ b/dist/windows/IconGen/IcoWriter.cs
@@ -7,7 +7,10 @@ internal static class IcoWriter
 {
     // Standard Windows icon sizes for an app .ico. Covers taskbar (16,
     // 20, 24, 32, 40, 48), larger icon views (64), and full-size (256).
-    private static readonly int[] FrameSizes = { 16, 20, 24, 32, 40, 48, 64, 256 };
+    // Exposed internally so procedural-master generators (GearMasters)
+    // can render directly at each frame size and avoid downscale-loss
+    // on fine detail, without the two arrays drifting silently.
+    internal static readonly int[] FrameSizes = { 16, 20, 24, 32, 40, 48, 64, 256 };
 
     public static void Write(MasterRasters masters, string outPath)
     {

--- a/dist/windows/IconGen/Program.cs
+++ b/dist/windows/IconGen/Program.cs
@@ -31,6 +31,18 @@ internal static class Program
                 IcoWriter.Write(masters, Path.Combine(options.OutputDir, "wintty.ico"));
             }
 
+            // The Settings window uses a separate gear .ico so the
+            // taskbar / alt-tab distinguish it from a terminal window.
+            // The glyph matches SettingsWindow.xaml's TitleBar.IconSource;
+            // channel-independent because the gear is a UI affordance,
+            // not a brand mark.
+            using (var gearMasters = GearMasters.Render())
+            {
+                IcoWriter.Write(
+                    gearMasters,
+                    Path.Combine(options.OutputDir, "wintty-settings.ico"));
+            }
+
             return 0;
         }
         catch (Exception ex)

--- a/windows/Ghostty/Branding/WindowHelper.cs
+++ b/windows/Ghostty/Branding/WindowHelper.cs
@@ -35,21 +35,18 @@ internal static class WindowHelper
     }
 
     /// <summary>
-    /// Stamp the brand .ico (wintty.ico) into <paramref name="window"/>'s
-    /// AppWindow icon slots so the taskbar group, thumbnail preview,
-    /// alt-tab list, and (when WinUI 3 renders one) the system title-bar
-    /// show the brand. ApplicationIcon embeds the same .ico as the exe
-    /// resource but does NOT wire those runtime slots; without this call
-    /// they fall back to the default WinUI 3 icon.
+    /// Stamp the brand .ico into the AppWindow icon slots (taskbar
+    /// group, thumbnail preview, alt-tab list, system title-bar when
+    /// WinUI 3 renders one). ApplicationIcon embeds the same .ico as
+    /// the exe resource but does NOT wire those runtime slots.
     /// </summary>
     public static void TryApplyAppIcon(Window window)
         => TryApplyIcon(window, "wintty.ico");
 
     /// <summary>
-    /// Settings-window variant: stamps the gear .ico
-    /// (wintty-settings.ico) so the OS slots visually match
-    /// SettingsWindow.xaml's TitleBar.IconSource and are
-    /// distinguishable from terminal windows in alt-tab.
+    /// Settings-window variant. Uses the gear .ico so the OS slots
+    /// visually match SettingsWindow.xaml's TitleBar.IconSource and
+    /// the window is distinguishable from terminal windows in alt-tab.
     /// </summary>
     public static void TryApplySettingsIcon(Window window)
         => TryApplyIcon(window, "wintty-settings.ico");

--- a/windows/Ghostty/Branding/WindowHelper.cs
+++ b/windows/Ghostty/Branding/WindowHelper.cs
@@ -35,23 +35,36 @@ internal static class WindowHelper
     }
 
     /// <summary>
-    /// Stamp the deployed wintty.ico into <paramref name="window"/>'s
+    /// Stamp the brand .ico (wintty.ico) into <paramref name="window"/>'s
     /// AppWindow icon slots so the taskbar group, thumbnail preview,
     /// alt-tab list, and (when WinUI 3 renders one) the system title-bar
     /// show the brand. ApplicationIcon embeds the same .ico as the exe
     /// resource but does NOT wire those runtime slots; without this call
     /// they fall back to the default WinUI 3 icon.
-    ///
+    /// </summary>
+    public static void TryApplyAppIcon(Window window)
+        => TryApplyIcon(window, "wintty.ico");
+
+    /// <summary>
+    /// Settings-window variant: stamps the gear .ico
+    /// (wintty-settings.ico) so the OS slots visually match
+    /// SettingsWindow.xaml's TitleBar.IconSource and are
+    /// distinguishable from terminal windows in alt-tab.
+    /// </summary>
+    public static void TryApplySettingsIcon(Window window)
+        => TryApplyIcon(window, "wintty-settings.ico");
+
+    /// <summary>
     /// Swallows the file-not-found race (asset deleted between the
     /// File.Exists check and the SetIcon call) and the native HRESULT
     /// path. A missing window icon is cosmetic, not crash-worthy.
     /// </summary>
-    public static void TryApplyAppIcon(Window window)
+    private static void TryApplyIcon(Window window, string iconFileName)
     {
         try
         {
             var appDir = AppContext.BaseDirectory;
-            var iconPath = Path.Combine(appDir, "Assets", "wintty.ico");
+            var iconPath = Path.Combine(appDir, "Assets", iconFileName);
             if (!File.Exists(iconPath)) return;
             window.AppWindow.SetIcon(iconPath);
         }

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -261,7 +261,7 @@
   <Target Name="GenerateBrandingAssets"
           BeforeTargets="BeforeBuild"
           Inputs="..\..\dist\windows\IconGen\**\*.cs;..\..\images\icons\icon_*.png"
-          Outputs="$(GeneratedBrandingDir)wintty.ico">
+          Outputs="$(GeneratedBrandingDir)wintty.ico;$(GeneratedBrandingDir)wintty-settings.ico">
     <MakeDir Directories="$(GeneratedBrandingDir)" />
     <Exec Command="dotnet run --project ..\..\dist\windows\IconGen --no-launch-profile -c Release -- --channel $(Channel) --out &quot;$(GeneratedBrandingDir.TrimEnd('\'))&quot;"
           WorkingDirectory="$(MSBuildThisFileDirectory)" />
@@ -299,6 +299,18 @@
     -->
     <Content Include="$(GeneratedBrandingDir)wintty.ico">
       <Link>Assets\wintty.ico</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+    <!--
+      Settings-window variant. Generated procedurally from the
+      Segoe Fluent Icons gear glyph (U+E713) by IconGen so the
+      taskbar / alt-tab icon for SettingsWindow visually matches the
+      in-chrome TitleBar.IconSource and is distinguishable from the
+      branded terminal-window icon.
+    -->
+    <Content Include="$(GeneratedBrandingDir)wintty-settings.ico">
+      <Link>Assets\wintty-settings.ico</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -58,7 +58,7 @@ internal sealed partial class SettingsWindow : Window
         _theme = theme;
         InitializeComponent();
 
-        Ghostty.Branding.WindowHelper.TryApplyAppIcon(this);
+        Ghostty.Branding.WindowHelper.TryApplySettingsIcon(this);
 
         // Branded window title and custom title bar. Title is used by the
         // taskbar / alt-tab; AppTitleBar.Title renders the same text inside


### PR DESCRIPTION
## Summary

- Generates a sibling \`wintty-settings.ico\` at build time by rendering the Segoe Fluent Icons gear glyph (U+E713) at each \`IcoWriter\` frame size (16/20/24/32/40/48/64/256). Falls back from Segoe Fluent Icons to Segoe MDL2 Assets if the former is not installed.
- \`SettingsWindow\` calls a new \`WindowHelper.TryApplySettingsIcon\` variant that points at the new asset; the brand .ico still drives \`MainWindow\`.

Without this, the Settings window and a terminal window were indistinguishable in the taskbar / alt-tab list after the previous branding PR. The in-chrome \`TitleBar.IconSource\` already used the same gear glyph for exactly this reason -- but \`TitleBar.IconSource\` does not propagate to the OS-level window-icon slots.

Renderer rasterizes one bitmap per frame size directly rather than scaling down from a single 256 master, so the gear teeth stay crisp at 16/20.

## Test plan

- \`dotnet test dist/windows/IconGen.Tests/IconGen.Tests.csproj\` passes (20/20, includes a new coverage check on the generated .ico).
- [ ] Open Settings (Ctrl+,) and confirm the alt-tab thumbnail shows a gear, not the wintty mark.
- [ ] Hover the Settings entry in the taskbar -- the thumbnail shows the gear.
- [ ] Pin a terminal + a Settings window: the taskbar shows them as distinct items.