### PR TITLE
branding: dual-tone Settings gear so it reads in light theme too

### DIFF
--- a/dist/windows/IconGen.Tests/EndToEndTests.cs
+++ b/dist/windows/IconGen.Tests/EndToEndTests.cs
@@ -31,7 +31,7 @@ public class EndToEndTests
         // in the largest .ico frame and assert coverage is in the
         // band a real gear lands in. Lower bound 0.08 excludes the
         // empty / placeholder-rectangle outline a font without E713
-        // would draw (~5-8% area at the 78% canvas fill we use);
+        // would draw (~5-8% area at the 72% canvas fill we use);
         // upper bound 0.35 excludes a solid filled rectangle from a
         // .notdef fallback.
         using var tempDir = new TempDir();

--- a/dist/windows/IconGen/GearMasters.cs
+++ b/dist/windows/IconGen/GearMasters.cs
@@ -63,12 +63,22 @@ internal static class GearMasters
         // the outer teeth at the canvas edge.
         var fontPx = px * 0.72f;
         using var family = new FontFamily(fontName);
-        using var path = new GraphicsPath();
+        using var path = new GraphicsPath
+        {
+            // Glyph paths use non-zero winding; the default Alternate
+            // mode would hollow out the inner contours (the gear arms
+            // and hub), leaving FillPath painting only the thin
+            // outline rim.
+            FillMode = FillMode.Winding,
+        };
         using var fmt = new StringFormat(StringFormat.GenericTypographic)
         {
             Alignment = StringAlignment.Center,
             LineAlignment = StringAlignment.Center,
         };
+        // GDI+ AddString predates the FontStyle enum: the style
+        // parameter is typed as int. Keep the explicit cast --
+        // dropping it to FontStyle.Regular fails to compile.
         path.AddString(
             GearGlyph,
             family,
@@ -76,25 +86,22 @@ internal static class GearMasters
             fontPx,
             new RectangleF(0, 0, px, px),
             fmt);
-        // Glyph paths use non-zero winding; the default Alternate
-        // mode would hollow out the inner contours (the gear arms and
-        // hub), leaving FillPath painting only the thin outline rim.
-        path.FillMode = FillMode.Winding;
 
         // Fill first, stroke on top so the dark outline sits at the
         // glyph edge rather than under the fill.
         using (var brush = new SolidBrush(FillColor))
             g.FillPath(brush, path);
 
-        // Stroke scales with canvas, clamped >= 1 px so the small
-        // frames don't antialias the outline into nothing. The 2.2%
-        // ratio gives a halo that's perceptible on a light taskbar
-        // without eating the arm interior on the 256 frame.
+        // The 2.2% ratio crosses 1 px at ~46 px canvas, so for every
+        // sub-46 frame (16/20/24/32/40) the floor wins and the stroke
+        // is a flat 1 px. That's the design: the floor keeps the
+        // outline visible at small sizes; the ratio only kicks in on
+        // the 48/64/256 frames so the halo doesn't eat the arm
+        // interior on the 256 frame.
         var strokePx = MathF.Max(px * 0.022f, 1f);
         using var pen = new Pen(StrokeColor, strokePx)
         {
             LineJoin = LineJoin.Round,
-            MiterLimit = 1f,
         };
         g.DrawPath(pen, path);
 

--- a/dist/windows/IconGen/GearMasters.cs
+++ b/dist/windows/IconGen/GearMasters.cs
@@ -25,9 +25,15 @@ internal static class GearMasters
     // Segoe MDL2 Assets. Matches SettingsWindow.xaml's FontIconSource.
     private const string GearGlyph = "\uE713";
 
-    // Off-white reads on both the default dark taskbar and the
-    // translucent alt-tab pane.
-    private static readonly Color GearColor = Color.FromArgb(0xFF, 0xE6, 0xE6, 0xE6);
+    // Dual-tone palette: a single tone in either direction goes
+    // invisible against the opposite Windows theme (the taskbar
+    // tracks dark/light mode and the alt-tab pane tints with the
+    // wallpaper). FillColor carries the icon on a dark taskbar;
+    // StrokeColor reads on a light-theme one. StrokeColor is not
+    // pure black so it does not bloom on ClearType-style subpixel
+    // rendering at the 16 px frame.
+    private static readonly Color FillColor = Color.FromArgb(0xFF, 0xF5, 0xF5, 0xF5);
+    private static readonly Color StrokeColor = Color.FromArgb(0xFF, 0x1A, 0x1A, 0x1A);
 
     public static MasterRasters Render()
     {
@@ -48,23 +54,50 @@ internal static class GearMasters
         var bmp = new Bitmap(px, px, PixelFormat.Format32bppArgb);
         using var g = Graphics.FromImage(bmp);
         g.SmoothingMode = SmoothingMode.AntiAlias;
-        g.TextRenderingHint = TextRenderingHint.AntiAlias;
         g.PixelOffsetMode = PixelOffsetMode.HighQuality;
         g.Clear(Color.Transparent);
 
-        // Glyph fills ~78% of the canvas so the gear teeth retain a
-        // pixel of padding from the edge at the 16 px frame (otherwise
-        // they clip when GDI+ rounds the layout box).
-        var fontPx = px * 0.78f;
-        using var font = new Font(fontName, fontPx, FontStyle.Regular, GraphicsUnit.Pixel);
-        using var brush = new SolidBrush(GearColor);
+        // Glyph fills ~72% of the canvas. Slightly tighter than a
+        // single-tone render because the stroke adds a halo on top:
+        // at the 16 px frame, a 78% glyph + 1 px stroke would clip
+        // the outer teeth at the canvas edge.
+        var fontPx = px * 0.72f;
+        using var family = new FontFamily(fontName);
+        using var path = new GraphicsPath();
         using var fmt = new StringFormat(StringFormat.GenericTypographic)
         {
             Alignment = StringAlignment.Center,
             LineAlignment = StringAlignment.Center,
         };
+        path.AddString(
+            GearGlyph,
+            family,
+            (int)FontStyle.Regular,
+            fontPx,
+            new RectangleF(0, 0, px, px),
+            fmt);
+        // Glyph paths use non-zero winding; the default Alternate
+        // mode would hollow out the inner contours (the gear arms and
+        // hub), leaving FillPath painting only the thin outline rim.
+        path.FillMode = FillMode.Winding;
 
-        g.DrawString(GearGlyph, font, brush, new RectangleF(0, 0, px, px), fmt);
+        // Fill first, stroke on top so the dark outline sits at the
+        // glyph edge rather than under the fill.
+        using (var brush = new SolidBrush(FillColor))
+            g.FillPath(brush, path);
+
+        // Stroke scales with canvas, clamped >= 1 px so the small
+        // frames don't antialias the outline into nothing. The 2.2%
+        // ratio gives a halo that's perceptible on a light taskbar
+        // without eating the arm interior on the 256 frame.
+        var strokePx = MathF.Max(px * 0.022f, 1f);
+        using var pen = new Pen(StrokeColor, strokePx)
+        {
+            LineJoin = LineJoin.Round,
+            MiterLimit = 1f,
+        };
+        g.DrawPath(pen, path);
+
         return bmp;
     }
 


### PR DESCRIPTION
## Summary

The single-tone off-white gear from the last PR was invisible against the light-theme taskbar background (and the alt-tab pane that picks up wallpaper tint). A static .ico cannot follow the OS theme, so the icon has to carry contrast on its own.

- Switch \`GearMasters\` from \`DrawString\` to \`GraphicsPath\` fill+stroke: light \`F5F5F5\` fill for the dark-taskbar case, dark \`1A1A1A\` stroke for the light-taskbar case.
- Stroke is 2.2% of canvas, clamped to >= 1 px so the 16 px frame doesn't antialias the outline into nothing.
- \`FillMode.Winding\` because the default \`Alternate\` hollows out the gear's inner contours and leaves \`FillPath\` painting only the outline rim.
- Glyph fill tightened to 72% of canvas so the stroke halo doesn't push the outer teeth past the canvas edge at the 16 px frame.

Existing IconGen tests (coverage band, determinism) still pass.

## Test plan

- \`dotnet test dist/windows/IconGen.Tests/IconGen.Tests.csproj\` passes 20/20.
- [x] Visually verified at 16/32/64/256 px from the deployed .ico.
- [x] User-smoked in the running wintty.