### PR TITLE
windows: seed config comment header + scroll-to-top/bottom default chords

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -50,4 +50,11 @@ public enum PaneAction
     OpenProfile7 = 34,
     OpenProfile8 = 35,
     OpenProfile9 = 36,
+
+    // Scrollback navigation. The router dispatches these as libghostty
+    // binding actions ("scroll_to_top", "scroll_to_bottom") so we reuse
+    // the existing terminal-side scrollback logic rather than driving the
+    // viewport from the C# side.
+    ScrollToTop = 37,
+    ScrollToBottom = 38,
 }

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -51,10 +51,8 @@ public enum PaneAction
     OpenProfile8 = 35,
     OpenProfile9 = 36,
 
-    // Scrollback navigation. The router dispatches these as libghostty
-    // binding actions ("scroll_to_top", "scroll_to_bottom") so we reuse
-    // the existing terminal-side scrollback logic rather than driving the
-    // viewport from the C# side.
+    // Scrollback navigation. Router dispatches via libghostty bindings;
+    // see PaneActionRouter.Invoke for the wiring.
     ScrollToTop = 37,
     ScrollToBottom = 38,
 }

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -14,6 +14,7 @@ internal static class LogEvents
         public const int ReloadFailed      = 1000; // reserved, populated in Phase 3 (ConfigService)
         public const int WriteSchedulerErr = 1001;
         public const int TimerDisposeSlow  = 1002;
+        public const int SeedFailed        = 1003;
     }
 
     // 1100-1199: Frecency / command history

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -152,6 +152,11 @@ internal sealed class KeyBindings
         // Command palette
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.P, PaneAction.ToggleCommandPalette),
 
+        // Scrollback navigation. Ctrl+Shift+Home/End matches Windows
+        // Terminal muscle memory for full-scrollback jumps.
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Home, PaneAction.ScrollToTop),
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.End, PaneAction.ScrollToBottom),
+
         // Profiles. Slot N = Profiles[N-1] (post hidden filter, ordered by
         // profile-order). Out-of-range slots silently no-op in the router.
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Number1, PaneAction.OpenProfile1),

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -31,6 +31,7 @@ internal sealed class PaneActionRouter
     private readonly TabManager _tabs;
     private readonly Func<IReadOnlyList<ResolvedProfile>>? _getProfiles = null;
     private readonly Action<string, ProfileLaunchTarget>? _openProfile = null;
+    private readonly Action<string>? _bindingAction = null;
 
     public PaneActionRouter(TabManager tabs)
     {
@@ -40,11 +41,13 @@ internal sealed class PaneActionRouter
     public PaneActionRouter(
         TabManager tabs,
         Func<IReadOnlyList<ResolvedProfile>>? getProfiles,
-        Action<string, ProfileLaunchTarget>? openProfile)
+        Action<string, ProfileLaunchTarget>? openProfile,
+        Action<string>? bindingAction = null)
         : this(tabs)
     {
         _getProfiles = getProfiles;
         _openProfile = openProfile;
+        _bindingAction = bindingAction;
     }
 
     public TabManager Tabs => _tabs;
@@ -100,6 +103,17 @@ internal sealed class PaneActionRouter
                 return;
             case PaneAction.ToggleFullscreen:
                 ToggleFullscreenRequested?.Invoke(this, EventArgs.Empty);
+                return;
+
+            // Scrollback jumps are dispatched as libghostty binding
+            // actions against the active surface. The injected delegate
+            // resolves the active leaf so we don't need to reach through
+            // the pane tree here. Silent no-op if no delegate wired.
+            case PaneAction.ScrollToTop:
+                _bindingAction?.Invoke("scroll_to_top");
+                return;
+            case PaneAction.ScrollToBottom:
+                _bindingAction?.Invoke("scroll_to_bottom");
                 return;
 
             // Profile slot chords resolve via the live registry; out-of-range

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -361,7 +361,8 @@ public sealed partial class MainWindow : Window
         _router = new PaneActionRouter(
             _tabManager,
             getProfiles: () => App.ProfileRegistry?.Profiles ?? EmptyProfiles,
-            openProfile: OpenProfile);
+            openProfile: OpenProfile,
+            bindingAction: ExecuteBindingAction);
         _windowState = WindowState.Load();
         RestoreWindowPlacement();
 

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -200,8 +200,45 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // (backslash) so the path looks clean in UI and logs.
         ConfigFilePath = Path.GetFullPath(rawPath);
 
+        SeedConfigIfEmpty();
         CacheDiagnostics();
         ReadFlags();
+    }
+
+    /// <summary>
+    /// Mac Ghostty seeds a comment header when it creates the config
+    /// file for the first time. On Windows, ghostty_config_open_path()
+    /// creates the file empty -- so on first launch (or whenever the
+    /// user has deleted the contents) we drop in the same starter
+    /// header so they don't stare at a blank file. Failures are
+    /// swallowed: an unwritable config dir is the user's problem to
+    /// notice via diagnostics, not ours to crash on.
+    /// </summary>
+    private void SeedConfigIfEmpty()
+    {
+        try
+        {
+            if (!File.Exists(ConfigFilePath)) return;
+            if (new FileInfo(ConfigFilePath).Length != 0) return;
+
+            var seed =
+                "# This is the configuration file for Wintty (a Windows fork of Ghostty).\n" +
+                "#\n" +
+                "# All available options and their defaults can be listed with\n" +
+                "# `wintty +show-config --default --docs`. Each option below is\n" +
+                "# commented out with the default value. Uncomment it and set\n" +
+                "# your preferred value to change it.\n" +
+                "#\n" +
+                "# Config docs:  https://ghostty.org/docs/config\n" +
+                "# Config path:  " + ConfigFilePath + "\n";
+
+            File.WriteAllText(ConfigFilePath, seed);
+        }
+        catch
+        {
+            // Diagnostics surface the real error to the user via the
+            // settings UI; we don't want a startup crash here.
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -210,9 +210,13 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// file for the first time. On Windows, ghostty_config_open_path()
     /// creates the file empty -- so on first launch (or whenever the
     /// user has deleted the contents) we drop in the same starter
-    /// header so they don't stare at a blank file. Failures are
-    /// swallowed: an unwritable config dir is the user's problem to
-    /// notice via diagnostics, not ours to crash on.
+    /// header so they don't stare at a blank file.
+    ///
+    /// Sequencing note: libghostty already loaded the (empty) file at
+    /// ConfigNew+LoadDefaultFiles above, so the seeded comments only
+    /// take effect on the next reload. That's fine -- every seeded
+    /// line is a comment, so the loaded config is functionally
+    /// identical to "no file" anyway.
     /// </summary>
     private void SeedConfigIfEmpty()
     {
@@ -234,10 +238,12 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
             File.WriteAllText(ConfigFilePath, seed);
         }
-        catch
+        catch (Exception ex)
         {
-            // Diagnostics surface the real error to the user via the
-            // settings UI; we don't want a startup crash here.
+            // Don't crash startup over a writable-config-dir hiccup;
+            // the diagnostic still lands in the log stream so it's
+            // discoverable.
+            StaticLoggers.ConfigService.LogSeedFailed(ex);
         }
     }
 
@@ -995,6 +1001,15 @@ internal static partial class ConfigServiceLogExtensions
                    Level = LogLevel.Error,
                    Message = "[ConfigService] Reload failed to create new config")]
     internal static partial void LogReloadFailed(
+        this ILogger<ConfigService> logger, System.Exception ex);
+
+    // Warning, not Error: the user just loses the first-launch comment
+    // header. Functionally the config still loads and the file is
+    // still editable.
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Config.SeedFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[ConfigService] Could not seed comment header into empty config file")]
+    internal static partial void LogSeedFailed(
         this ILogger<ConfigService> logger, System.Exception ex);
 
     // Surfaces each warning string returned by


### PR DESCRIPTION
Three small Ghostty mac/linux parity items, bundled as the OSS roadmap warmup batch.

### What lands

- **# 190** — Seed a comment header into a brand-new (empty) config file on first launch. Mirrors what mac Ghostty does. Surfaced through `ConfigService.SeedConfigIfEmpty()`; swallowed errors so an unwritable config dir cannot crash startup.
- **# 277** — Bind `Ctrl+Shift+Home` to `scroll_to_top`.
- **# 278** — Bind `Ctrl+Shift+End` to `scroll_to_bottom`.

### Implementation note

The two scroll actions are dispatched as libghostty binding strings (the same surface the command palette already uses), not as native pane operations. `PaneActionRouter` gained an optional `bindingAction` delegate so it can route a `PaneAction` to a libghostty binding without touching the active leaf directly. This is the cleanest path I found that keeps the router testable and reuses the single existing `ExecuteBindingAction` entry point in `MainWindow`.

Chord choice (`Ctrl+Shift+Home/End`) matches Windows Terminal muscle memory.

Closes #190
Closes #277
Closes #278