### PR TITLE
shell-integration: PowerShell (pwsh + 5.1) with OSC 133 / 7 / 9;9

### DIFF
--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -95,6 +95,27 @@ source $GHOSTTY_RESOURCES_DIR/shell-integration/nushell/vendor/autoload/ghostty.
 use ghostty *
 ```
 
+### PowerShell
+
+For [PowerShell](https://learn.microsoft.com/powershell/), wintty (the
+Windows build of Ghostty) exports the absolute path of
+`powershell/ghostty.ps1` in the `GHOSTTY_SHELL_INTEGRATION_PS1` environment
+variable. PowerShell has no equivalent of bash's `ENV` or zsh's `ZDOTDIR`
+that would let us auto-source a script, so the user opts in by adding a
+single line to their `$PROFILE`:
+
+```powershell
+if ($env:GHOSTTY_SHELL_INTEGRATION_PS1) { . $env:GHOSTTY_SHELL_INTEGRATION_PS1 }
+```
+
+The script works on both Windows PowerShell 5.1 and PowerShell 7+, has no
+external dependencies, and is safe to source more than once. See
+[`powershell/README.md`](powershell/README.md) for the full user-facing
+instructions.
+
+This shell integration is currently manual-sourcing only; we do not modify
+the PowerShell command line or inject the script automatically.
+
 ### Zsh
 
 Automatic [Zsh](https://www.zsh.org/) integration works by temporarily setting

--- a/src/shell-integration/powershell/README.md
+++ b/src/shell-integration/powershell/README.md
@@ -1,0 +1,50 @@
+# PowerShell Shell Integration
+
+Wintty (the Windows build of Ghostty) ships a PowerShell shell-integration
+script alongside the per-shell scripts for bash, zsh, fish, etc.
+
+## How it loads
+
+When wintty spawns a PowerShell child process, it exports the path to the
+script in the `GHOSTTY_SHELL_INTEGRATION_PS1` environment variable. The
+script itself is NOT auto-injected; the user opts in by adding one line to
+their `$PROFILE`:
+
+```powershell
+if ($env:GHOSTTY_SHELL_INTEGRATION_PS1) { . $env:GHOSTTY_SHELL_INTEGRATION_PS1 }
+```
+
+To find or create your profile:
+
+```powershell
+if (-not (Test-Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }
+notepad $PROFILE
+```
+
+## Manual sourcing
+
+If `GHOSTTY_SHELL_INTEGRATION_PS1` is unset (e.g. shell integration is
+disabled in the wintty config), you can source the script by absolute path:
+
+```powershell
+. "C:\path\to\ghostty\src\shell-integration\powershell\ghostty.ps1"
+```
+
+## What it does
+
+- Emits OSC 133 prompt marks (A/B/C/D) so wintty can identify prompt
+  boundaries, command input regions, and command exit codes.
+- Reports the current working directory via OSC 7 (file:// URI) and
+  OSC 9;9 (raw Windows path).
+- Wraps the user's existing `prompt` function, so Oh-My-Posh, Starship,
+  posh-git, and similar prompt customizations keep working.
+
+## Compatibility
+
+- Works on Windows PowerShell 5.1 and PowerShell 7+.
+- No external dependencies.
+- Uses PSReadLine if present (it ships with both 5.1 and 7+) to bracket
+  the running command with OSC 133;C / 133;D. If PSReadLine is absent or
+  fails to load, A/B prompt marks still work and the script does not
+  raise an error.
+- Idempotent: sourcing the script a second time is a no-op.

--- a/src/shell-integration/powershell/ghostty.ps1
+++ b/src/shell-integration/powershell/ghostty.ps1
@@ -33,7 +33,7 @@ function Get-GhosttyFileUri([string] $path) {
     $normalized = $path -replace '\\', '/'
     if ($normalized -match '^([A-Za-z]):') {
         $drive = $matches[1].ToLowerInvariant()
-        $normalized = "$drive`:" + $normalized.Substring(2)
+        $normalized = "${drive}:" + $normalized.Substring(2)
     }
     return "file://$env:COMPUTERNAME/$normalized"
 }
@@ -55,6 +55,9 @@ function global:prompt {
     $lastNative = $LASTEXITCODE
     $lastOk = $?
     if ($null -eq $lastNative) { $lastNative = 0 }
+    # Cmdlet failures set $? to false without setting $LASTEXITCODE
+    # (no native process ran). Synthesize 1 for that case so the OSC
+    # 133;D consumer sees a non-zero exit and can render an error mark.
     $exitCode = if ($lastOk) { 0 } else { if ($lastNative -ne 0) { $lastNative } else { 1 } }
 
     # Close out the previous command's execution window if we opened one.

--- a/src/shell-integration/powershell/ghostty.ps1
+++ b/src/shell-integration/powershell/ghostty.ps1
@@ -1,0 +1,114 @@
+# Ghostty PowerShell shell integration.
+#
+# Wintty (the Windows build of Ghostty) exports the path to this script in
+# the GHOSTTY_SHELL_INTEGRATION_PS1 environment variable. Users opt in by
+# adding the following line to their $PROFILE:
+#
+#     if ($env:GHOSTTY_SHELL_INTEGRATION_PS1) { . $env:GHOSTTY_SHELL_INTEGRATION_PS1 }
+#
+# The script is compatible with Windows PowerShell 5.1 and PowerShell 7+.
+# It uses [char]0x1b and [char]0x07 instead of `e / `a so it works under the
+# 5.1 parser, and avoids $PSStyle which is 7+ only.
+#
+# Sourcing this script more than once is a no-op (see guard below).
+
+if ($global:__GhosttyShellIntegrationLoaded) { return }
+$global:__GhosttyShellIntegrationLoaded = $true
+
+# ESC and BEL constants. The OSC sequences we emit look like:
+#     ESC ] <ps> ; <pt> BEL
+# They live in the global scope so the PSReadLine Enter handler can read
+# them at command-execution time regardless of what scope this script is
+# dot-sourced into.
+$global:__GhosttyEsc = [char]0x1b
+$global:__GhosttyBel = [char]0x07
+
+# Convert a Windows path (e.g. C:\Users\me) to an OSC 7 file:// URI of the
+# form file://HOST/c:/Users/me. We lowercase the drive letter to match the
+# convention used by upstream Ghostty's other shells and convert backslashes
+# to forward slashes. UNC paths (\\server\share) pass through as
+# file://HOST//server/share which is intentionally lossy; consumers that
+# care about the original host can read OSC 9;9 instead.
+function Get-GhosttyFileUri([string] $path) {
+    $normalized = $path -replace '\\', '/'
+    if ($normalized -match '^([A-Za-z]):') {
+        $drive = $matches[1].ToLowerInvariant()
+        $normalized = "$drive`:" + $normalized.Substring(2)
+    }
+    return "file://$env:COMPUTERNAME/$normalized"
+}
+
+# Capture the user's existing prompt function so frameworks like
+# Oh-My-Posh, Starship, posh-git, etc. keep working. We invoke it from
+# inside our wrapper to obtain the prompt text.
+$global:__GhosttyOriginalPrompt = $function:prompt
+
+# Track whether we emitted OSC 133;C for a running command so the next
+# prompt can close it with OSC 133;D;<exitcode>. Initialized false so a
+# brand-new shell does not emit a spurious D before the first command.
+$global:__GhosttyEmittedC = $false
+
+function global:prompt {
+    # Capture exit status FIRST, before any other operation can clobber
+    # $LASTEXITCODE or $?. $LASTEXITCODE is $null until the first native
+    # process runs in the session; treat that as success (0).
+    $lastNative = $LASTEXITCODE
+    $lastOk = $?
+    if ($null -eq $lastNative) { $lastNative = 0 }
+    $exitCode = if ($lastOk) { 0 } else { if ($lastNative -ne 0) { $lastNative } else { 1 } }
+
+    # Close out the previous command's execution window if we opened one.
+    if ($global:__GhosttyEmittedC) {
+        [Console]::Write("$($global:__GhosttyEsc)]133;D;$exitCode$($global:__GhosttyBel)")
+        $global:__GhosttyEmittedC = $false
+    }
+
+    # Report cwd. OSC 7 gives a file:// URI for terminals that prefer the
+    # standard; OSC 9;9 gives the raw Windows path which is what
+    # Wintty/Windows Terminal historically consume.
+    $cwd = (Get-Location).ProviderPath
+    if ($cwd) {
+        $uri = Get-GhosttyFileUri $cwd
+        [Console]::Write("$($global:__GhosttyEsc)]7;$uri$($global:__GhosttyBel)")
+        [Console]::Write("$($global:__GhosttyEsc)]9;9;$cwd$($global:__GhosttyBel)")
+    }
+
+    # Prompt start.
+    [Console]::Write("$($global:__GhosttyEsc)]133;A$($global:__GhosttyBel)")
+
+    # Delegate to the user's previous prompt for the actual text. If they
+    # had no custom prompt, fall back to the PowerShell default form.
+    $text = if ($global:__GhosttyOriginalPrompt) {
+        & $global:__GhosttyOriginalPrompt
+    } else {
+        "PS $cwd> "
+    }
+
+    # Prompt end / command input start.
+    [Console]::Write("$($global:__GhosttyEsc)]133;B$($global:__GhosttyBel)")
+
+    # Restore $LASTEXITCODE so the next command sees the same value the
+    # user's prompt observed. PowerShell does not let us restore $?.
+    $global:LASTEXITCODE = $lastNative
+
+    return $text
+}
+
+# Hook Enter via PSReadLine to emit OSC 133;C right before the command
+# starts executing. PSReadLine ships with Windows PowerShell 5.1 and is
+# the default line editor in PowerShell 7; if it's somehow missing we
+# silently skip this and lose the C/D bracket (A/B still work).
+if (Get-Module -ListAvailable -Name PSReadLine) {
+    try {
+        Import-Module PSReadLine -ErrorAction Stop
+        Set-PSReadLineKeyHandler -Chord Enter -ScriptBlock {
+            [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+            [Console]::Write("$($global:__GhosttyEsc)]133;C$($global:__GhosttyBel)")
+            $global:__GhosttyEmittedC = $true
+        }
+    } catch {
+        # PSReadLine present in module list but failed to import or bind
+        # the key handler. Continue without C/D marks rather than
+        # breaking the user's shell.
+    }
+}

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -15,6 +15,7 @@ pub const Shell = enum {
     elvish,
     fish,
     nushell,
+    powershell,
     zsh,
 };
 
@@ -59,6 +60,13 @@ pub fn setup(
         ),
 
         .nushell => try setupNushell(
+            alloc_arena,
+            command,
+            resource_dir,
+            env,
+        ),
+
+        .powershell => try setupPowerShell(
             alloc_arena,
             command,
             resource_dir,
@@ -162,6 +170,17 @@ fn detectShell(alloc: Allocator, command: config.Command) !?Shell {
     if (std.mem.eql(u8, "nu", exe)) return .nushell;
     if (std.mem.eql(u8, "zsh", exe)) return .zsh;
 
+    // PowerShell exes on Windows literally end in `.exe`; the other
+    // shells we detect don't. Match both forms for robustness so users
+    // can spell their shell as either `pwsh` or `pwsh.exe` (likewise
+    // `powershell` for Windows PowerShell 5.1).
+    const exe_no_ext = if (std.mem.endsWith(u8, exe, ".exe"))
+        exe[0 .. exe.len - 4]
+    else
+        exe;
+    if (std.mem.eql(u8, "pwsh", exe_no_ext)) return .powershell;
+    if (std.mem.eql(u8, "powershell", exe_no_ext)) return .powershell;
+
     return null;
 }
 
@@ -182,6 +201,18 @@ test detectShell {
 
     try testing.expectEqual(.bash, try detectShell(alloc, .{ .shell = "bash -c 'command'" }));
     try testing.expectEqual(.bash, try detectShell(alloc, .{ .shell = "\"/a b/bash\"" }));
+
+    try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "pwsh" }));
+    try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "pwsh.exe" }));
+    try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "powershell" }));
+    try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "powershell.exe" }));
+
+    // std.fs.path.basename uses POSIX semantics on non-Windows hosts,
+    // so a backslash-only path is treated as a single component. Only
+    // assert the fully-qualified case where basename actually splits.
+    if (comptime builtin.target.os.tag == .windows) {
+        try testing.expectEqual(.powershell, try detectShell(alloc, .{ .shell = "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\"" }));
+    }
 }
 
 /// Set up the shell integration features environment variable.
@@ -887,6 +918,59 @@ test "nushell: missing resources" {
 
     try testing.expect(try setupNushell(alloc, .{ .shell = "nu" }, resources_dir, &env) == null);
     try testing.expectEqual(0, env.count());
+}
+
+/// Setup PowerShell shell integration. PowerShell has no equivalent
+/// of bash's `ENV` or zsh's `ZDOTDIR` to auto-source a script, so we
+/// only export the absolute path to our integration script via the
+/// `GHOSTTY_SHELL_INTEGRATION_PS1` environment variable. Users opt in
+/// by adding a one-liner to their `$PROFILE` that dot-sources it.
+///
+/// We deliberately don't modify the command line (no `-NoProfile`, no
+/// `-Command . path`) so the user's existing profile execution
+/// semantics are preserved.
+fn setupPowerShell(
+    alloc_arena: Allocator,
+    command: config.Command,
+    resource_dir: []const u8,
+    env: *EnvMap,
+) !?config.Command {
+    // Use forward slashes for path composition to match the style of the
+    // other shell-integration setup functions. PowerShell on Windows
+    // accepts forward slashes in paths just fine.
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const script_path = try std.fmt.bufPrint(
+        &path_buf,
+        "{s}/shell-integration/powershell/ghostty.ps1",
+        .{resource_dir},
+    );
+
+    try env.put("GHOSTTY_SHELL_INTEGRATION_PS1", script_path);
+
+    return try command.clone(alloc_arena);
+}
+
+test "powershell" {
+    const testing = std.testing;
+
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var res: TmpResourcesDir = try .init(alloc, .powershell);
+    defer res.deinit();
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+
+    const command = try setupPowerShell(alloc, .{ .shell = "pwsh" }, res.path, &env);
+    try testing.expectEqualStrings("pwsh", command.?.shell);
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(
+        try std.fmt.bufPrint(&path_buf, "{s}/ghostty.ps1", .{res.shell_path}),
+        env.get("GHOSTTY_SHELL_INTEGRATION_PS1").?,
+    );
 }
 
 /// Setup the zsh automatic shell integration. This works by setting

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -173,13 +173,15 @@ fn detectShell(alloc: Allocator, command: config.Command) !?Shell {
     // PowerShell exes on Windows literally end in `.exe`; the other
     // shells we detect don't. Match both forms for robustness so users
     // can spell their shell as either `pwsh` or `pwsh.exe` (likewise
-    // `powershell` for Windows PowerShell 5.1).
-    const exe_no_ext = if (std.mem.endsWith(u8, exe, ".exe"))
+    // `powershell` for Windows PowerShell 5.1). Windows filesystems
+    // are case-insensitive, so a Start Menu shortcut spelled
+    // `PWSH.EXE` or `Pwsh.Exe` still needs to detect.
+    const exe_no_ext = if (std.ascii.endsWithIgnoreCase(exe, ".exe"))
         exe[0 .. exe.len - 4]
     else
         exe;
-    if (std.mem.eql(u8, "pwsh", exe_no_ext)) return .powershell;
-    if (std.mem.eql(u8, "powershell", exe_no_ext)) return .powershell;
+    if (std.ascii.eqlIgnoreCase("pwsh", exe_no_ext)) return .powershell;
+    if (std.ascii.eqlIgnoreCase("powershell", exe_no_ext)) return .powershell;
 
     return null;
 }
@@ -925,10 +927,7 @@ test "nushell: missing resources" {
 /// only export the absolute path to our integration script via the
 /// `GHOSTTY_SHELL_INTEGRATION_PS1` environment variable. Users opt in
 /// by adding a one-liner to their `$PROFILE` that dot-sources it.
-///
-/// We deliberately don't modify the command line (no `-NoProfile`, no
-/// `-Command . path`) so the user's existing profile execution
-/// semantics are preserved.
+/// We do not modify the command line; users opt in via their $PROFILE.
 fn setupPowerShell(
     alloc_arena: Allocator,
     command: config.Command,


### PR DESCRIPTION
Adds PowerShell as a sixth Shell variant in `src/termio/shell_integration.zig`. First piece of OSS roadmap § 4.2 — the gutter PR (next) needs OSC 133 to actually fire from the user's shell, and pwsh is wintty's most-likely default.

### What lands

- **`src/shell-integration/powershell/ghostty.ps1`** (113 LOC) — emits OSC 133 A/B/C/D + OSC 7 + OSC 9;9. Compatible with Windows PowerShell 5.1 and PowerShell 7+ (no `$PSStyle`, `[char]0x1b` for ESC, `[char]0x07` for BEL).
- Wraps the user's existing `prompt` function so Oh-My-Posh / Starship / posh-git keep working.
- OSC 133 C via a `Set-PSReadLineKeyHandler -Chord Enter` that preserves the original `AcceptLine`.
- Idempotent (re-source guard).
- **`src/termio/shell_integration.zig`** — adds `.powershell` enum variant, `.exe`-tolerant detection (`pwsh` / `pwsh.exe` / `powershell` / `powershell.exe`), `setupPowerShell` exports `GHOSTTY_SHELL_INTEGRATION_PS1` pointing at the bundled script.
- **`src/shell-integration/powershell/README.md`** + root README updates with the one-liner users add to `$PROFILE`.

### Distribution

No auto-injection in this PR. Users add this one line to `$PROFILE`:
```powershell
if ($env:GHOSTTY_SHELL_INTEGRATION_PS1) { . $env:GHOSTTY_SHELL_INTEGRATION_PS1 }
```

Auto-injection via `-Command "& '...'"` is a follow-up if user feedback shows the manual one-liner is friction.

### Test plan

- `zig build test -Dtest-filter=shell_integration` — green (5 new `detectShell` PowerShell variants + automatic coverage from the existing `force shell` inline-for over Shell enum).
- `pwsh -NoProfile -Command ". 'src/shell-integration/powershell/ghostty.ps1'; if (Get-Command prompt) { 'prompt-installed' }"` — emits `prompt-installed`.

### Scope

Closes the PowerShell 7+ and Windows PowerShell 5.1 boxes on # 80. CMD, WSL deep validation, Git Bash, MSYS2, and Clink remain follow-ups on that umbrella.