### PR TITLE
panes: tree-order focus navigation (goto_split previous / next)

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -65,4 +65,11 @@ public enum PaneAction
     // positive N is next.
     JumpToPreviousPrompt = 40,
     JumpToNextPrompt = 41,
+
+    // Tree-order pane navigation. Complements the spatial focus
+    // (FocusLeft/Right/Up/Down): these always advance even when no
+    // leaf lies in any spatial direction, matching Ghostty's
+    // goto_split:previous and goto_split:next bindings.
+    GotoSplitPrevious = 42,
+    GotoSplitNext = 43,
 }

--- a/windows/Ghostty.Core/Panes/PaneTree.cs
+++ b/windows/Ghostty.Core/Panes/PaneTree.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Ghostty.Core.Panes;
 
@@ -159,18 +160,16 @@ internal static class PaneTree
     /// <paramref name="current"/> is not in the tree or the tree
     /// contains a single leaf.
     ///
-    /// Tree-order navigation is the complement to spatial focus
-    /// (Alt+Arrows): it always advances even when no leaf lies in
-    /// any spatial direction, which is the discoverable model
-    /// upstream Ghostty uses for goto_split:next.
+    /// Tree-order navigation complements spatial focus (Alt+Arrows):
+    /// it always advances even when no leaf lies in any spatial
+    /// direction. Matches Ghostty's goto_split:next semantics.
     /// </summary>
     public static LeafPane? NextLeafInOrder(PaneNode root, LeafPane current)
     {
         ArgumentNullException.ThrowIfNull(root);
         ArgumentNullException.ThrowIfNull(current);
 
-        var ordered = new List<LeafPane>();
-        foreach (var l in Leaves(root)) ordered.Add(l);
+        var ordered = Leaves(root).ToList();
         if (ordered.Count <= 1) return null;
 
         var idx = ordered.IndexOf(current);
@@ -190,8 +189,7 @@ internal static class PaneTree
         ArgumentNullException.ThrowIfNull(root);
         ArgumentNullException.ThrowIfNull(current);
 
-        var ordered = new List<LeafPane>();
-        foreach (var l in Leaves(root)) ordered.Add(l);
+        var ordered = Leaves(root).ToList();
         if (ordered.Count <= 1) return null;
 
         var idx = ordered.IndexOf(current);

--- a/windows/Ghostty.Core/Panes/PaneTree.cs
+++ b/windows/Ghostty.Core/Panes/PaneTree.cs
@@ -153,6 +153,53 @@ internal static class PaneTree
     }
 
     /// <summary>
+    /// Return the leaf that follows <paramref name="current"/> in
+    /// left-to-right depth-first traversal order, wrapping back to
+    /// the first leaf when called on the last one. Returns null if
+    /// <paramref name="current"/> is not in the tree or the tree
+    /// contains a single leaf.
+    ///
+    /// Tree-order navigation is the complement to spatial focus
+    /// (Alt+Arrows): it always advances even when no leaf lies in
+    /// any spatial direction, which is the discoverable model
+    /// upstream Ghostty uses for goto_split:next.
+    /// </summary>
+    public static LeafPane? NextLeafInOrder(PaneNode root, LeafPane current)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(current);
+
+        var ordered = new List<LeafPane>();
+        foreach (var l in Leaves(root)) ordered.Add(l);
+        if (ordered.Count <= 1) return null;
+
+        var idx = ordered.IndexOf(current);
+        if (idx < 0) return null;
+        return ordered[(idx + 1) % ordered.Count];
+    }
+
+    /// <summary>
+    /// Return the leaf that precedes <paramref name="current"/> in
+    /// left-to-right depth-first traversal order, wrapping back to
+    /// the last leaf when called on the first one. Returns null if
+    /// <paramref name="current"/> is not in the tree or the tree
+    /// contains a single leaf. Mirror of <see cref="NextLeafInOrder"/>.
+    /// </summary>
+    public static LeafPane? PreviousLeafInOrder(PaneNode root, LeafPane current)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(current);
+
+        var ordered = new List<LeafPane>();
+        foreach (var l in Leaves(root)) ordered.Add(l);
+        if (ordered.Count <= 1) return null;
+
+        var idx = ordered.IndexOf(current);
+        if (idx < 0) return null;
+        return ordered[(idx - 1 + ordered.Count) % ordered.Count];
+    }
+
+    /// <summary>
     /// Reset every <see cref="SplitPane.Ratio"/> in the tree to 0.5,
     /// giving all leaves equal space. No-op for parity with Zig/Swift
     /// on a single leaf.

--- a/windows/Ghostty.Tests/PaneTreeTests.cs
+++ b/windows/Ghostty.Tests/PaneTreeTests.cs
@@ -360,4 +360,102 @@ public sealed class PaneTreeTests
         Assert.Equal(0.5, mid.Ratio);
         Assert.Equal(0.5, deep.Ratio);
     }
+
+    // NextLeafInOrder / PreviousLeafInOrder ----------------------------
+
+    [Fact]
+    public void NextLeafInOrder_SingleLeaf_ReturnsNull()
+    {
+        var leaf = new LeafPane();
+        Assert.Null(PaneTree.NextLeafInOrder(leaf, leaf));
+    }
+
+    [Fact]
+    public void PreviousLeafInOrder_SingleLeaf_ReturnsNull()
+    {
+        var leaf = new LeafPane();
+        Assert.Null(PaneTree.PreviousLeafInOrder(leaf, leaf));
+    }
+
+    [Fact]
+    public void NextLeafInOrder_TwoLeaves_AlternatesAndWraps()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, a, b);
+
+        Assert.Same(b, PaneTree.NextLeafInOrder(root, a));
+        // Wraps back to the first leaf from the last.
+        Assert.Same(a, PaneTree.NextLeafInOrder(root, b));
+    }
+
+    [Fact]
+    public void PreviousLeafInOrder_TwoLeaves_AlternatesAndWraps()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, a, b);
+
+        Assert.Same(a, PaneTree.PreviousLeafInOrder(root, b));
+        // Wraps from the first leaf back to the last.
+        Assert.Same(b, PaneTree.PreviousLeafInOrder(root, a));
+    }
+
+    [Fact]
+    public void NextLeafInOrder_DeepTree_FollowsLeftToRightTraversal()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var c = new LeafPane();
+        var d = new LeafPane();
+        var root = new SplitPane(
+            PaneOrientation.Vertical,
+            new SplitPane(PaneOrientation.Horizontal, a, b),
+            new SplitPane(PaneOrientation.Horizontal, c, d));
+
+        Assert.Same(b, PaneTree.NextLeafInOrder(root, a));
+        Assert.Same(c, PaneTree.NextLeafInOrder(root, b));
+        Assert.Same(d, PaneTree.NextLeafInOrder(root, c));
+        Assert.Same(a, PaneTree.NextLeafInOrder(root, d));
+    }
+
+    [Fact]
+    public void PreviousLeafInOrder_DeepTree_WalksBackwards()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var c = new LeafPane();
+        var d = new LeafPane();
+        var root = new SplitPane(
+            PaneOrientation.Vertical,
+            new SplitPane(PaneOrientation.Horizontal, a, b),
+            new SplitPane(PaneOrientation.Horizontal, c, d));
+
+        Assert.Same(c, PaneTree.PreviousLeafInOrder(root, d));
+        Assert.Same(b, PaneTree.PreviousLeafInOrder(root, c));
+        Assert.Same(a, PaneTree.PreviousLeafInOrder(root, b));
+        Assert.Same(d, PaneTree.PreviousLeafInOrder(root, a));
+    }
+
+    [Fact]
+    public void NextLeafInOrder_LeafNotInTree_ReturnsNull()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, a, b);
+        var orphan = new LeafPane();
+
+        Assert.Null(PaneTree.NextLeafInOrder(root, orphan));
+    }
+
+    [Fact]
+    public void PreviousLeafInOrder_LeafNotInTree_ReturnsNull()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, a, b);
+        var orphan = new LeafPane();
+
+        Assert.Null(PaneTree.PreviousLeafInOrder(root, orphan));
+    }
 }

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -45,6 +45,8 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.FocusRight, "Focus Pane Right", "Move focus to the right pane", CommandCategory.Pane);
         AddPaneCommand(commands, PaneAction.FocusUp, "Focus Pane Up", "Move focus to the pane above", CommandCategory.Pane);
         AddPaneCommand(commands, PaneAction.FocusDown, "Focus Pane Down", "Move focus to the pane below", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.GotoSplitPrevious, "Focus Previous Pane", "Move focus to the previous pane in tree order", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.GotoSplitNext, "Focus Next Pane", "Move focus to the next pane in tree order", CommandCategory.Pane);
         AddPaneCommand(commands, PaneAction.MoveTabRight, "Move Tab Right", "Move the active tab one position right", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.MoveTabLeft, "Move Tab Left", "Move the active tab one position left", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.ToggleVerticalTabsPinned, "Toggle Vertical Tabs Pinned", "Pin or unpin the vertical tab sidebar", CommandCategory.Tab);

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -166,7 +166,10 @@ internal sealed class KeyBindings
         // Tree-order pane navigation. Ctrl+Alt+[ / Ctrl+Alt+] match
         // Ghostty mac/linux conventions for goto_split:previous /
         // goto_split:next. Spatial Alt+Arrows (above) cover the
-        // direction-based variants.
+        // direction-based variants. On non-US layouts Ctrl+Alt is
+        // the AltGr modifier and may need to be rebound; the chord
+        // table is the single source of truth so a future
+        // config-driven loader can override.
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu, (VirtualKey)219, PaneAction.GotoSplitPrevious),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu, (VirtualKey)221, PaneAction.GotoSplitNext),
 

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -163,6 +163,13 @@ internal sealed class KeyBindings
         new KeyBinding(VirtualKeyModifiers.Control, VirtualKey.Up, PaneAction.JumpToPreviousPrompt),
         new KeyBinding(VirtualKeyModifiers.Control, VirtualKey.Down, PaneAction.JumpToNextPrompt),
 
+        // Tree-order pane navigation. Ctrl+Alt+[ / Ctrl+Alt+] match
+        // Ghostty mac/linux conventions for goto_split:previous /
+        // goto_split:next. Spatial Alt+Arrows (above) cover the
+        // direction-based variants.
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu, (VirtualKey)219, PaneAction.GotoSplitPrevious),
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu, (VirtualKey)221, PaneAction.GotoSplitNext),
+
         // Scrollback search. Ctrl+Shift+F matches Windows Terminal
         // muscle memory; plain Ctrl+F is reserved for in-find inside
         // the Settings raw editor.

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -158,6 +158,8 @@ internal sealed class PaneActionRouter
             case PaneAction.FocusDown:       concrete.FocusDirection(FocusDirection.Down); break;
             case PaneAction.EqualizeSplits:  concrete.EqualizeSplits(); break;
             case PaneAction.ToggleSplitZoom: concrete.ToggleSplitZoom(); break;
+            case PaneAction.GotoSplitPrevious: concrete.GotoPreviousSplit(); break;
+            case PaneAction.GotoSplitNext:     concrete.GotoNextSplit(); break;
 
             // Tabs
             case PaneAction.NewTab: _tabs.NewTab(); break;

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -648,6 +648,32 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         best?.Terminal().Focus(FocusState.Keyboard);
     }
 
+    /// <summary>
+    /// Move focus to the next leaf in left-to-right depth-first
+    /// tree-order, wrapping back to the first leaf from the last.
+    /// Complements the spatial <see cref="FocusDirection"/>: this one
+    /// always advances even when no leaf lies in any spatial direction,
+    /// matching Ghostty's <c>goto_split:next</c> binding.
+    /// No-op while zoomed or with a single leaf.
+    /// </summary>
+    public void GotoNextSplit()
+    {
+        if (_zoomedLeaf is not null) return;
+        var target = PaneTree.NextLeafInOrder(_root, _activeLeaf);
+        target?.Terminal().Focus(FocusState.Keyboard);
+    }
+
+    /// <summary>
+    /// Mirror of <see cref="GotoNextSplit"/> walking in reverse.
+    /// Maps to Ghostty's <c>goto_split:previous</c> binding.
+    /// </summary>
+    public void GotoPreviousSplit()
+    {
+        if (_zoomedLeaf is not null) return;
+        var target = PaneTree.PreviousLeafInOrder(_root, _activeLeaf);
+        target?.Terminal().Focus(FocusState.Keyboard);
+    }
+
     // Internals ---------------------------------------------------------
 
     private TerminalControl CreateTerminal(ProfileSnapshot? snapshot)


### PR DESCRIPTION
Adds the third leg of pane-focus navigation alongside the existing spatial Alt+Arrows: tree-order traversal that always advances even when no leaf lies in any spatial direction. Mirrors Ghostty mac/linux `goto_split:previous` and `goto_split:next` bindings.

### What lands

- `PaneTree.NextLeafInOrder(root, current)` — left-to-right depth-first traversal, wraps from last to first
- `PaneTree.PreviousLeafInOrder(root, current)` — mirror walking backwards
- 8 new xUnit tests (single-leaf, two-leaf wrap, deep-tree, orphan-leaf)
- `PaneHost.GotoNextSplit` / `GotoPreviousSplit` — no-op while zoomed or with a single leaf
- `PaneAction.GotoSplitPrevious` / `GotoSplitNext` routed via `concrete.GotoXxxSplit()` (no libghostty roundtrip; matches the existing FocusDirection precedent)
- `Ctrl+Alt+[` / `Ctrl+Alt+]` default chords (mac/linux convention)
- Two `BuiltInCommandSource` palette entries

### Scope correction

`wintty# 166` listed `toggle_split_zoom`, `equalize_splits`, `goto_split`, `resize_split`, and `undo` / `redo` as gaps. Investigation showed zoom and equalize are already fully shipped end-to-end (model + host + router + chords). This PR closes the tree-order navigation gap. Remaining `# 166` gaps after this lands: `resize_split` and `undo` / `redo`.

### Tests + smoke

- `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj` — 1037 passed, 0 failed, 1 skipped (up from 1029).
- Manual smoke (deferred): split into 4 panes, confirm `Ctrl+Alt+]` cycles through them in tree-order and wraps; `Ctrl+Alt+[` walks the same path in reverse.