### PR TITLE
panes: keyboard-driven split resize (resize_split)

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -74,9 +74,9 @@ public enum PaneAction
     GotoSplitNext = 43,
 
     // Keyboard-driven splitter resize. Each chord nudges the
-    // nearest matching-orientation divider by a fixed ratio delta
-    // (default 5%). Matches Ghostty's resize_split:DIRECTION
-    // binding. Direction is which way the divider moves.
+    // nearest matching-orientation divider; direction is which way
+    // the divider moves. Maps to Ghostty's resize_split:DIRECTION
+    // binding.
     ResizeSplitUp = 44,
     ResizeSplitDown = 45,
     ResizeSplitLeft = 46,

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -72,4 +72,13 @@ public enum PaneAction
     // goto_split:previous and goto_split:next bindings.
     GotoSplitPrevious = 42,
     GotoSplitNext = 43,
+
+    // Keyboard-driven splitter resize. Each chord nudges the
+    // nearest matching-orientation divider by a fixed ratio delta
+    // (default 5%). Matches Ghostty's resize_split:DIRECTION
+    // binding. Direction is which way the divider moves.
+    ResizeSplitUp = 44,
+    ResizeSplitDown = 45,
+    ResizeSplitLeft = 46,
+    ResizeSplitRight = 47,
 }

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -43,3 +43,11 @@ internal sealed class SplitPane : PaneNode
 }
 
 internal enum PaneOrientation { Vertical, Horizontal }
+
+/// <summary>
+/// Direction the split divider moves in response to a
+/// <c>resize_split</c> chord. Up/Down move a horizontal divider;
+/// Left/Right move a vertical divider. The active pane's nearest
+/// matching-orientation ancestor is the target.
+/// </summary>
+internal enum ResizeDirection { Up, Down, Left, Right }

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -31,6 +31,19 @@ internal sealed class LeafPane : PaneNode
 
 internal sealed class SplitPane : PaneNode
 {
+    /// <summary>
+    /// Minimum ratio a divider can be pushed to without making either
+    /// side too small to recover. Both mouse-drag (Splitter) and
+    /// keyboard resize (PaneTree.ResizeSplit) must clamp to this so
+    /// the two paths agree.
+    /// </summary>
+    public const double MinRatio = 0.1;
+
+    /// <summary>
+    /// Maximum ratio counterpart of <see cref="MinRatio"/>.
+    /// </summary>
+    public const double MaxRatio = 0.9;
+
     public PaneOrientation Orientation { get; }
     public PaneNode Child1 { get; set; }
     public PaneNode Child2 { get; set; }

--- a/windows/Ghostty.Core/Panes/PaneTree.cs
+++ b/windows/Ghostty.Core/Panes/PaneTree.cs
@@ -210,4 +210,62 @@ internal static class PaneTree
         Equalize(split.Child1);
         Equalize(split.Child2);
     }
+
+    /// <summary>
+    /// Move the divider of the nearest matching-orientation ancestor
+    /// of <paramref name="current"/> by <paramref name="delta"/>.
+    /// Up/Down look for a horizontal (top/bottom) split; Left/Right
+    /// look for a vertical (left/right) split. Left/Up shrink Child1,
+    /// Right/Down grow it. Ratio is clamped to [0.05, 0.95] so no
+    /// pane collapses below a usable size.
+    ///
+    /// Returns true if a target divider was found and adjusted, false
+    /// when no matching ancestor exists (e.g. resize Up but the
+    /// active leaf has no horizontal-split ancestor) or
+    /// <paramref name="current"/> is the root leaf.
+    /// </summary>
+    public static bool ResizeSplit(
+        PaneNode root,
+        LeafPane current,
+        ResizeDirection direction,
+        double delta)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(current);
+
+        var targetOrientation = direction switch
+        {
+            ResizeDirection.Up or ResizeDirection.Down => PaneOrientation.Horizontal,
+            ResizeDirection.Left or ResizeDirection.Right => PaneOrientation.Vertical,
+            _ => PaneOrientation.Vertical,
+        };
+
+        // Walk up from `current` looking for the nearest ancestor
+        // split whose orientation matches the resize direction.
+        PaneNode node = current;
+        SplitPane? target = null;
+        while (true)
+        {
+            var parent = FindParent(root, node);
+            if (parent is null) break;
+            var (split, _) = parent.Value;
+            if (split.Orientation == targetOrientation)
+            {
+                target = split;
+                break;
+            }
+            node = split;
+        }
+
+        if (target is null) return false;
+
+        var signedDelta = direction switch
+        {
+            ResizeDirection.Left or ResizeDirection.Up => -delta,
+            ResizeDirection.Right or ResizeDirection.Down => delta,
+            _ => 0.0,
+        };
+        target.Ratio = Math.Clamp(target.Ratio + signedDelta, 0.05, 0.95);
+        return true;
+    }
 }

--- a/windows/Ghostty.Core/Panes/PaneTree.cs
+++ b/windows/Ghostty.Core/Panes/PaneTree.cs
@@ -216,8 +216,10 @@ internal static class PaneTree
     /// of <paramref name="current"/> by <paramref name="delta"/>.
     /// Up/Down look for a horizontal (top/bottom) split; Left/Right
     /// look for a vertical (left/right) split. Left/Up shrink Child1,
-    /// Right/Down grow it. Ratio is clamped to [0.05, 0.95] so no
-    /// pane collapses below a usable size.
+    /// Right/Down grow it. Ratio is clamped to
+    /// [<see cref="SplitPane.MinRatio"/>, <see cref="SplitPane.MaxRatio"/>]
+    /// so no pane collapses below a usable size; same clamp the
+    /// mouse-drag Splitter uses.
     ///
     /// Returns true if a target divider was found and adjusted, false
     /// when no matching ancestor exists (e.g. resize Up but the
@@ -242,6 +244,10 @@ internal static class PaneTree
 
         // Walk up from `current` looking for the nearest ancestor
         // split whose orientation matches the resize direction.
+        // FindParent is itself O(n), so the loop is O(depth * n);
+        // trees are tiny in practice (depth <= 4 for typical layouts)
+        // so this is fine and beats the bookkeeping cost of parent
+        // back-pointers, consistent with the file header rationale.
         PaneNode node = current;
         SplitPane? target = null;
         while (true)
@@ -265,7 +271,10 @@ internal static class PaneTree
             ResizeDirection.Right or ResizeDirection.Down => delta,
             _ => 0.0,
         };
-        target.Ratio = Math.Clamp(target.Ratio + signedDelta, 0.05, 0.95);
+        target.Ratio = Math.Clamp(
+            target.Ratio + signedDelta,
+            SplitPane.MinRatio,
+            SplitPane.MaxRatio);
         return true;
     }
 }

--- a/windows/Ghostty.Tests/PaneTreeTests.cs
+++ b/windows/Ghostty.Tests/PaneTreeTests.cs
@@ -548,10 +548,10 @@ public sealed class PaneTreeTests
     {
         var left = new LeafPane();
         var right = new LeafPane();
-        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: 0.9);
+        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: SplitPane.MaxRatio - 0.01);
 
         Assert.True(PaneTree.ResizeSplit(root, left, ResizeDirection.Right, 0.5));
-        Assert.Equal(0.95, root.Ratio, 6);
+        Assert.Equal(SplitPane.MaxRatio, root.Ratio, 6);
     }
 
     [Fact]
@@ -559,9 +559,9 @@ public sealed class PaneTreeTests
     {
         var left = new LeafPane();
         var right = new LeafPane();
-        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: 0.1);
+        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: SplitPane.MinRatio + 0.01);
 
         Assert.True(PaneTree.ResizeSplit(root, right, ResizeDirection.Left, 0.5));
-        Assert.Equal(0.05, root.Ratio, 6);
+        Assert.Equal(SplitPane.MinRatio, root.Ratio, 6);
     }
 }

--- a/windows/Ghostty.Tests/PaneTreeTests.cs
+++ b/windows/Ghostty.Tests/PaneTreeTests.cs
@@ -458,4 +458,110 @@ public sealed class PaneTreeTests
 
         Assert.Null(PaneTree.PreviousLeafInOrder(root, orphan));
     }
+
+    // ResizeSplit ------------------------------------------------------
+
+    [Fact]
+    public void ResizeSplit_SingleLeafRoot_ReturnsFalse()
+    {
+        var leaf = new LeafPane();
+        Assert.False(PaneTree.ResizeSplit(leaf, leaf, ResizeDirection.Right, 0.1));
+    }
+
+    [Fact]
+    public void ResizeSplit_VerticalSplit_RightGrowsChild1()
+    {
+        var left = new LeafPane();
+        var right = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: 0.5);
+
+        Assert.True(PaneTree.ResizeSplit(root, left, ResizeDirection.Right, 0.1));
+        Assert.Equal(0.6, root.Ratio, 6);
+    }
+
+    [Fact]
+    public void ResizeSplit_VerticalSplit_LeftShrinksChild1()
+    {
+        var left = new LeafPane();
+        var right = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: 0.5);
+
+        Assert.True(PaneTree.ResizeSplit(root, right, ResizeDirection.Left, 0.1));
+        Assert.Equal(0.4, root.Ratio, 6);
+    }
+
+    [Fact]
+    public void ResizeSplit_HorizontalSplit_DownGrowsChild1()
+    {
+        var top = new LeafPane();
+        var bottom = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Horizontal, top, bottom, ratio: 0.5);
+
+        Assert.True(PaneTree.ResizeSplit(root, top, ResizeDirection.Down, 0.1));
+        Assert.Equal(0.6, root.Ratio, 6);
+    }
+
+    [Fact]
+    public void ResizeSplit_HorizontalSplit_UpShrinksChild1()
+    {
+        var top = new LeafPane();
+        var bottom = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Horizontal, top, bottom, ratio: 0.5);
+
+        Assert.True(PaneTree.ResizeSplit(root, bottom, ResizeDirection.Up, 0.1));
+        Assert.Equal(0.4, root.Ratio, 6);
+    }
+
+    [Fact]
+    public void ResizeSplit_NoMatchingAncestor_ReturnsFalse()
+    {
+        // Vertical split only. Pressing Up/Down has no horizontal
+        // ancestor to act on; should no-op.
+        var left = new LeafPane();
+        var right = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: 0.5);
+
+        Assert.False(PaneTree.ResizeSplit(root, left, ResizeDirection.Up, 0.1));
+        Assert.Equal(0.5, root.Ratio);
+    }
+
+    [Fact]
+    public void ResizeSplit_WalksToNearestMatchingAncestor()
+    {
+        // Active leaf is `leafB`, sitting inside an inner vertical
+        // split. Pressing Down should walk past the vertical parent
+        // to find the outer horizontal split and adjust IT.
+        var leafA = new LeafPane();
+        var leafB = new LeafPane();
+        var leafC = new LeafPane();
+        var innerVert = new SplitPane(PaneOrientation.Vertical, leafB, leafC, ratio: 0.5);
+        var outerHorz = new SplitPane(PaneOrientation.Horizontal, leafA, innerVert, ratio: 0.5);
+
+        Assert.True(PaneTree.ResizeSplit(outerHorz, leafB, ResizeDirection.Down, 0.1));
+        // Inner vertical untouched, outer horizontal grew Child1 (leafA).
+        Assert.Equal(0.5, innerVert.Ratio);
+        Assert.Equal(0.6, outerHorz.Ratio, 6);
+    }
+
+    [Fact]
+    public void ResizeSplit_ClampsToMaxRatio()
+    {
+        var left = new LeafPane();
+        var right = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: 0.9);
+
+        Assert.True(PaneTree.ResizeSplit(root, left, ResizeDirection.Right, 0.5));
+        Assert.Equal(0.95, root.Ratio, 6);
+    }
+
+    [Fact]
+    public void ResizeSplit_ClampsToMinRatio()
+    {
+        var left = new LeafPane();
+        var right = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, left, right, ratio: 0.1);
+
+        Assert.True(PaneTree.ResizeSplit(root, right, ResizeDirection.Left, 0.5));
+        Assert.Equal(0.05, root.Ratio, 6);
+    }
 }

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -47,6 +47,10 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.FocusDown, "Focus Pane Down", "Move focus to the pane below", CommandCategory.Pane);
         AddPaneCommand(commands, PaneAction.GotoSplitPrevious, "Focus Previous Pane", "Move focus to the previous pane in tree order", CommandCategory.Pane);
         AddPaneCommand(commands, PaneAction.GotoSplitNext, "Focus Next Pane", "Move focus to the next pane in tree order", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.ResizeSplitUp, "Resize Split Up", "Move the nearest horizontal split divider up", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.ResizeSplitDown, "Resize Split Down", "Move the nearest horizontal split divider down", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.ResizeSplitLeft, "Resize Split Left", "Move the nearest vertical split divider left", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.ResizeSplitRight, "Resize Split Right", "Move the nearest vertical split divider right", CommandCategory.Pane);
         AddPaneCommand(commands, PaneAction.MoveTabRight, "Move Tab Right", "Move the active tab one position right", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.MoveTabLeft, "Move Tab Left", "Move the active tab one position left", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.ToggleVerticalTabsPinned, "Toggle Vertical Tabs Pinned", "Pin or unpin the vertical tab sidebar", CommandCategory.Tab);

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -173,6 +173,14 @@ internal sealed class KeyBindings
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu, (VirtualKey)219, PaneAction.GotoSplitPrevious),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu, (VirtualKey)221, PaneAction.GotoSplitNext),
 
+        // Keyboard-driven splitter resize. Alt+Shift+Arrow moves the
+        // nearest matching-orientation divider by 5% per press. Matches
+        // Windows Terminal muscle memory for keyboard pane resize.
+        new KeyBinding(VirtualKeyModifiers.Menu | VirtualKeyModifiers.Shift, VirtualKey.Up, PaneAction.ResizeSplitUp),
+        new KeyBinding(VirtualKeyModifiers.Menu | VirtualKeyModifiers.Shift, VirtualKey.Down, PaneAction.ResizeSplitDown),
+        new KeyBinding(VirtualKeyModifiers.Menu | VirtualKeyModifiers.Shift, VirtualKey.Left, PaneAction.ResizeSplitLeft),
+        new KeyBinding(VirtualKeyModifiers.Menu | VirtualKeyModifiers.Shift, VirtualKey.Right, PaneAction.ResizeSplitRight),
+
         // Scrollback search. Ctrl+Shift+F matches Windows Terminal
         // muscle memory; plain Ctrl+F is reserved for in-find inside
         // the Settings raw editor.

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -160,6 +160,10 @@ internal sealed class PaneActionRouter
             case PaneAction.ToggleSplitZoom: concrete.ToggleSplitZoom(); break;
             case PaneAction.GotoSplitPrevious: concrete.GotoPreviousSplit(); break;
             case PaneAction.GotoSplitNext:     concrete.GotoNextSplit(); break;
+            case PaneAction.ResizeSplitUp:     concrete.ResizeSplit(ResizeDirection.Up); break;
+            case PaneAction.ResizeSplitDown:   concrete.ResizeSplit(ResizeDirection.Down); break;
+            case PaneAction.ResizeSplitLeft:   concrete.ResizeSplit(ResizeDirection.Left); break;
+            case PaneAction.ResizeSplitRight:  concrete.ResizeSplit(ResizeDirection.Right); break;
 
             // Tabs
             case PaneAction.NewTab: _tabs.NewTab(); break;

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -540,6 +540,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         if (_zoomedLeaf is not null) return;
         Rebuild();
         UpdateHighlightPosition();
+        // Rebuild detaches every TerminalControl and re-parents into
+        // a fresh Grid; without restoring focus the user lands in a
+        // focus-less window. Same restore path as ToggleSplitZoom +
+        // ResizeSplit.
+        DispatcherQueue.TryEnqueue(() => _activeLeaf.Terminal().Focus(FocusState.Programmatic));
     }
 
     /// <summary>

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -674,6 +674,29 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         target?.Terminal().Focus(FocusState.Keyboard);
     }
 
+    // Default ratio delta per resize_split chord. 0.05 = 5% of the
+    // split per press, giving the user 18-19 presses to slide the
+    // divider from edge to edge. Tuned by feel; configurable later.
+    private const double ResizeSplitDelta = 0.05;
+
+    /// <summary>
+    /// Move the divider closest to the active leaf in the requested
+    /// direction. No-op while zoomed, with a single leaf, or when
+    /// the active leaf has no ancestor split of the matching
+    /// orientation (e.g. resize Up but all ancestors are vertical).
+    /// Maps to Ghostty's <c>resize_split:DIRECTION</c> binding.
+    /// </summary>
+    public void ResizeSplit(ResizeDirection direction)
+    {
+        if (_zoomedLeaf is not null) return;
+        if (PaneTree.Leaves(_root).Take(2).Count() <= 1) return;
+
+        if (!PaneTree.ResizeSplit(_root, _activeLeaf, direction, ResizeSplitDelta)) return;
+        Rebuild();
+        UpdateHighlightPosition();
+        DispatcherQueue.TryEnqueue(() => _activeLeaf.Terminal().Focus(FocusState.Programmatic));
+    }
+
     // Internals ---------------------------------------------------------
 
     private TerminalControl CreateTerminal(ProfileSnapshot? snapshot)

--- a/windows/Ghostty/Panes/Splitter.cs
+++ b/windows/Ghostty/Panes/Splitter.cs
@@ -27,12 +27,6 @@ namespace Ghostty.Panes;
 /// </summary>
 internal sealed partial class Splitter : Grid
 {
-    // Clamp range: prevents either side from being dragged to zero,
-    // which would lose the pane visually and make it impossible to
-    // recover with the mouse.
-    private const double MinRatio = 0.1;
-    private const double MaxRatio = 0.9;
-
     private readonly SplitPane _split;
     private readonly Action _onRatioChanged;
     private bool _capturing;
@@ -128,7 +122,7 @@ internal sealed partial class Splitter : Grid
             newRatio = pInParent.Y / parent.ActualHeight;
         }
 
-        newRatio = Math.Clamp(newRatio, MinRatio, MaxRatio);
+        newRatio = Math.Clamp(newRatio, SplitPane.MinRatio, SplitPane.MaxRatio);
         if (Math.Abs(newRatio - _split.Ratio) < 0.0005) return;
 
         _split.Ratio = newRatio;


### PR DESCRIPTION
Closes the resize_split gap from # 166. Alt+Shift+Arrow nudges the nearest matching-orientation divider by 5% per press. Only undo/redo remains open on # 166 after this lands.

### What lands

- `PaneTree.ResizeSplit(root, current, direction, delta)` — walks up to find the nearest ancestor split whose orientation matches the resize direction (Up/Down → Horizontal, Left/Right → Vertical), adjusts its Ratio, clamps to `[0.05, 0.95]`. Returns `false` (no-op) when no matching ancestor exists.
- New `ResizeDirection` enum in `Ghostty.Core/Panes/`.
- `PaneHost.ResizeSplit(direction)` — no-op while zoomed / single leaf; otherwise mutates the tree and triggers a `Rebuild` (matches `EqualizeSplits` precedent).
- 4 new `PaneAction` enum entries + 4 router cases.
- `Alt+Shift+Up/Down/Left/Right` chords (matches Windows Terminal muscle memory).
- 4 new `BuiltInCommandSource` palette entries.

### Semantic note

Direction = **which way the divider moves**, not which way the active pane grows. This matches WT's `Pane.Resize` action and is unambiguous regardless of which side of the split the active leaf sits on:

- `Left`/`Up` → divider moves left/up → Child1 shrinks
- `Right`/`Down` → divider moves right/down → Child1 grows

### Tests + smoke

- `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj` — 1046 passed, 0 failed, 1 skipped (up from 1037: 9 new ResizeSplit tests covering both orientations both directions, no-matching-ancestor no-op, deep-tree ancestor walk, ratio clamping at both ends).
- Manual smoke (deferred): split into a 2x2 grid, confirm Alt+Shift+Right shrinks the column with the active pane's vertical neighbor, etc.