### PR TITLE
quake: honor quick-terminal-position / size / screen config

### DIFF
--- a/windows/Ghostty.Core/Hosting/MonitorBounds.cs
+++ b/windows/Ghostty.Core/Hosting/MonitorBounds.cs
@@ -9,5 +9,12 @@ internal readonly record struct MonitorBounds(int X, int Y, int Width, int Heigh
 {
     public int Right => X + Width;
     public int Bottom => Y + Height;
+
+    /// <summary>
+    /// True when the monitor is wider than (or equal to) it is tall.
+    /// Square monitors (Width == Height) intentionally land here so
+    /// the Center-position primary-axis pick is deterministic in
+    /// the tie case.
+    /// </summary>
     public bool IsLandscape => Width >= Height;
 }

--- a/windows/Ghostty.Core/Hosting/MonitorBounds.cs
+++ b/windows/Ghostty.Core/Hosting/MonitorBounds.cs
@@ -1,0 +1,13 @@
+namespace Ghostty.Core.Hosting;
+
+/// <summary>
+/// Pure-data input to <see cref="QuickTerminalGeometry"/>.
+/// The caller (Win32 adapter) fills this from `GetMonitorInfo`'s
+/// `rcWork`; values are physical pixels.
+/// </summary>
+internal readonly record struct MonitorBounds(int X, int Y, int Width, int Height)
+{
+    public int Right => X + Width;
+    public int Bottom => Y + Height;
+    public bool IsLandscape => Width >= Height;
+}

--- a/windows/Ghostty.Core/Hosting/QuickTerminalGeometry.cs
+++ b/windows/Ghostty.Core/Hosting/QuickTerminalGeometry.cs
@@ -1,0 +1,93 @@
+using System;
+
+namespace Ghostty.Core.Hosting;
+
+/// <summary>
+/// Resolved quake-window rectangle in physical pixels. Caller
+/// hands this straight to <c>AppWindow.MoveAndResize</c>.
+/// </summary>
+internal readonly record struct QuickTerminalRect(
+    int X, int Y, int Width, int Height);
+
+/// <summary>
+/// Pure-logic placement resolver for the quake window. Given a
+/// position enum, a size spec, and the target monitor's work
+/// area, returns the rectangle to position the window at.
+/// All inputs and outputs are in the same coordinate space
+/// (physical pixels in screen coordinates).
+/// </summary>
+internal static class QuickTerminalGeometry
+{
+    // Defaults match upstream: primary axis 50%, secondary 100%.
+    private const double DefaultPrimaryPercent = 50.0;
+
+    public static QuickTerminalRect Resolve(
+        QuickTerminalPosition position,
+        QuickTerminalSize size,
+        MonitorBounds monitor)
+    {
+        // Pick which monitor dimension drives each axis.
+        var primaryAxisLength = PrimaryAxisLength(position, monitor);
+        var secondaryAxisLength = SecondaryAxisLength(position, monitor);
+
+        var primaryPx = ResolveAxis(size.Primary, primaryAxisLength, isPrimary: true);
+        var secondaryPx = ResolveAxis(size.Secondary, secondaryAxisLength, isPrimary: false);
+
+        return position switch
+        {
+            QuickTerminalPosition.Top    => new(monitor.X, monitor.Y,                              secondaryPx, primaryPx),
+            QuickTerminalPosition.Bottom => new(monitor.X, monitor.Bottom - primaryPx,             secondaryPx, primaryPx),
+            QuickTerminalPosition.Left   => new(monitor.X, monitor.Y,                              primaryPx,   secondaryPx),
+            QuickTerminalPosition.Right  => new(monitor.Right - primaryPx, monitor.Y,              primaryPx,   secondaryPx),
+            QuickTerminalPosition.Center => ResolveCenter(monitor, primaryPx, secondaryPx),
+            _                            => new(monitor.X, monitor.Y, secondaryPx, primaryPx),
+        };
+    }
+
+    private static int ResolveAxis(Dimension? d, int parent, bool isPrimary)
+    {
+        if (d is { } dim)
+        {
+            return Math.Clamp(dim.ToPixels(parent), 1, parent);
+        }
+        return isPrimary
+            ? Math.Clamp((int)Math.Round(parent * DefaultPrimaryPercent / 100.0), 1, parent)
+            : parent;
+    }
+
+    private static int PrimaryAxisLength(QuickTerminalPosition position, MonitorBounds monitor) =>
+        position switch
+        {
+            QuickTerminalPosition.Top or QuickTerminalPosition.Bottom => monitor.Height,
+            QuickTerminalPosition.Left or QuickTerminalPosition.Right => monitor.Width,
+            QuickTerminalPosition.Center => monitor.IsLandscape ? monitor.Height : monitor.Width,
+            _ => monitor.Height,
+        };
+
+    private static int SecondaryAxisLength(QuickTerminalPosition position, MonitorBounds monitor) =>
+        position switch
+        {
+            QuickTerminalPosition.Top or QuickTerminalPosition.Bottom => monitor.Width,
+            QuickTerminalPosition.Left or QuickTerminalPosition.Right => monitor.Height,
+            QuickTerminalPosition.Center => monitor.IsLandscape ? monitor.Width : monitor.Height,
+            _ => monitor.Width,
+        };
+
+    private static QuickTerminalRect ResolveCenter(MonitorBounds monitor, int primaryPx, int secondaryPx)
+    {
+        // On landscape the primary axis is height; on portrait it's width.
+        if (monitor.IsLandscape)
+        {
+            return new(
+                monitor.X + (monitor.Width - secondaryPx) / 2,
+                monitor.Y + (monitor.Height - primaryPx) / 2,
+                secondaryPx,
+                primaryPx);
+        }
+        return new(
+            monitor.X + (monitor.Width - primaryPx) / 2,
+            monitor.Y + (monitor.Height - secondaryPx) / 2,
+            primaryPx,
+            secondaryPx);
+    }
+}

--- a/windows/Ghostty.Core/Hosting/QuickTerminalPosition.cs
+++ b/windows/Ghostty.Core/Hosting/QuickTerminalPosition.cs
@@ -1,0 +1,34 @@
+namespace Ghostty.Core.Hosting;
+
+/// <summary>
+/// Where the quake / drop-down terminal docks on the chosen monitor.
+/// Mirrors the upstream `quick-terminal-position` config key
+/// (top/bottom/left/right/center).
+/// </summary>
+internal enum QuickTerminalPosition
+{
+    Top,
+    Bottom,
+    Left,
+    Right,
+    Center,
+}
+
+internal static class QuickTerminalPositionExtensions
+{
+    /// <summary>
+    /// Parse a libghostty-formatted enum tag string. Unknown or
+    /// null falls back to <see cref="QuickTerminalPosition.Top"/>
+    /// (the upstream default), matching the resilient-to-config-typos
+    /// philosophy.
+    /// </summary>
+    public static QuickTerminalPosition Parse(string? raw) => raw switch
+    {
+        "top" => QuickTerminalPosition.Top,
+        "bottom" => QuickTerminalPosition.Bottom,
+        "left" => QuickTerminalPosition.Left,
+        "right" => QuickTerminalPosition.Right,
+        "center" => QuickTerminalPosition.Center,
+        _ => QuickTerminalPosition.Top,
+    };
+}

--- a/windows/Ghostty.Core/Hosting/QuickTerminalScreen.cs
+++ b/windows/Ghostty.Core/Hosting/QuickTerminalScreen.cs
@@ -1,0 +1,22 @@
+namespace Ghostty.Core.Hosting;
+
+/// <summary>
+/// Which monitor the quake terminal targets. Upstream also exposes
+/// `macos-menu-bar`; that's mac-only and not honored here.
+/// </summary>
+internal enum QuickTerminalScreen
+{
+    Main,
+    Mouse,
+}
+
+internal static class QuickTerminalScreenExtensions
+{
+    public static QuickTerminalScreen Parse(string? raw) => raw switch
+    {
+        "main" => QuickTerminalScreen.Main,
+        "mouse" => QuickTerminalScreen.Mouse,
+        "macos-menu-bar" => QuickTerminalScreen.Main, // mac-only, treat as Main
+        _ => QuickTerminalScreen.Main,
+    };
+}

--- a/windows/Ghostty.Core/Hosting/QuickTerminalSize.cs
+++ b/windows/Ghostty.Core/Hosting/QuickTerminalSize.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ghostty.Core.Hosting;
 
 internal enum DimensionKind
@@ -24,9 +26,9 @@ internal readonly record struct Dimension(DimensionKind Kind, double Value)
     public int ToPixels(int parentDimension) => Kind switch
     {
         DimensionKind.Percentage =>
-            (int)System.Math.Max(0, System.Math.Round(parentDimension * (Value / 100.0))),
+            (int)Math.Max(0, Math.Round(parentDimension * (Value / 100.0))),
         DimensionKind.Pixels =>
-            (int)System.Math.Max(0, System.Math.Round(Value)),
+            (int)Math.Max(0, Math.Round(Value)),
         _ => 0,
     };
 }

--- a/windows/Ghostty.Core/Hosting/QuickTerminalSize.cs
+++ b/windows/Ghostty.Core/Hosting/QuickTerminalSize.cs
@@ -1,0 +1,42 @@
+namespace Ghostty.Core.Hosting;
+
+internal enum DimensionKind
+{
+    Percentage = 1,
+    Pixels = 2,
+}
+
+/// <summary>
+/// One axis of a quick-terminal size specification. Either a
+/// percentage of the relevant monitor dimension (0-100) or an
+/// absolute pixel count.
+/// </summary>
+internal readonly record struct Dimension(DimensionKind Kind, double Value)
+{
+    public static Dimension Percentage(double v) => new(DimensionKind.Percentage, v);
+    public static Dimension Pixels(uint v) => new(DimensionKind.Pixels, v);
+
+    /// <summary>
+    /// Resolve to an absolute pixel count against the parent
+    /// dimension (the relevant monitor work-area span).
+    /// Percentage values are clamped non-negative.
+    /// </summary>
+    public int ToPixels(int parentDimension) => Kind switch
+    {
+        DimensionKind.Percentage =>
+            (int)System.Math.Max(0, System.Math.Round(parentDimension * (Value / 100.0))),
+        DimensionKind.Pixels =>
+            (int)System.Math.Max(0, System.Math.Round(Value)),
+        _ => 0,
+    };
+}
+
+/// <summary>
+/// Two-axis quick-terminal size. Either axis can be null which
+/// the resolver fills with a sensible default (50% on the primary
+/// axis, 100% on the secondary). Mirrors the upstream
+/// `quick-terminal-size` config key.
+/// </summary>
+internal readonly record struct QuickTerminalSize(
+    Dimension? Primary,
+    Dimension? Secondary);

--- a/windows/Ghostty.Core/Interop/QuickTerminalSizeC.cs
+++ b/windows/Ghostty.Core/Interop/QuickTerminalSizeC.cs
@@ -3,16 +3,14 @@ using Ghostty.Core.Hosting;
 
 namespace Ghostty.Core.Interop;
 
-// Mirrors the ghostty_qt_size_s C ABI from
-// src/config/Config.zig:9484-9517.
+// Mirrors the ghostty_qt_size_s C ABI surfaced by libghostty.
 //
 // Layout:
 //   { tag: c_int; value: union { f32, u32 } }   per axis = 8 bytes
 //   { primary: per-axis; secondary: per-axis }  total    = 16 bytes
 //
-// QuickTerminalSizeCLayoutTests in Ghostty.Tests pins size +
-// offsets at build time; an upstream layout drift will trip
-// the FFI suite there before runtime.
+// QuickTerminalSizeCLayoutTests pins size + offsets at build time;
+// an ABI drift will trip the FFI suite before runtime.
 
 internal enum QuickTerminalSizeTag : int
 {

--- a/windows/Ghostty.Core/Interop/QuickTerminalSizeC.cs
+++ b/windows/Ghostty.Core/Interop/QuickTerminalSizeC.cs
@@ -1,0 +1,54 @@
+using System.Runtime.InteropServices;
+using Ghostty.Core.Hosting;
+
+namespace Ghostty.Core.Interop;
+
+// Mirrors the ghostty_qt_size_s C ABI from
+// src/config/Config.zig:9484-9517.
+//
+// Layout:
+//   { tag: c_int; value: union { f32, u32 } }   per axis = 8 bytes
+//   { primary: per-axis; secondary: per-axis }  total    = 16 bytes
+//
+// QuickTerminalSizeCLayoutTests in Ghostty.Tests pins size +
+// offsets at build time; an upstream layout drift will trip
+// the FFI suite there before runtime.
+
+internal enum QuickTerminalSizeTag : int
+{
+    None = 0,
+    Percentage = 1,
+    Pixels = 2,
+}
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct QuickTerminalSizeValueC
+{
+    [FieldOffset(0)] public float Percentage;
+    [FieldOffset(0)] public uint Pixels;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct QuickTerminalSizeOneC
+{
+    public QuickTerminalSizeTag Tag;
+    public QuickTerminalSizeValueC Value;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct QuickTerminalSizeC
+{
+    public QuickTerminalSizeOneC Primary;
+    public QuickTerminalSizeOneC Secondary;
+
+    public QuickTerminalSize ToManaged() => new(
+        ToDimension(Primary),
+        ToDimension(Secondary));
+
+    private static Dimension? ToDimension(QuickTerminalSizeOneC one) => one.Tag switch
+    {
+        QuickTerminalSizeTag.Percentage => Dimension.Percentage(one.Value.Percentage),
+        QuickTerminalSizeTag.Pixels     => Dimension.Pixels(one.Value.Pixels),
+        _                                => null,
+    };
+}

--- a/windows/Ghostty.Tests/Hosting/QuickTerminalGeometryTests.cs
+++ b/windows/Ghostty.Tests/Hosting/QuickTerminalGeometryTests.cs
@@ -1,0 +1,277 @@
+using Ghostty.Core.Hosting;
+using Xunit;
+
+namespace Ghostty.Tests.Hosting;
+
+// Pure-logic placement coverage for the quake window resolver.
+// Reference monitor is 1920x1080 at the origin; tests that need a
+// portrait monitor or a negative origin construct their own.
+public class QuickTerminalGeometryTests
+{
+    // Default monitor: 1920x1080 work-area at (0, 0).
+    private static readonly MonitorBounds Hd = new(0, 0, 1920, 1080);
+
+    // No size specified -> primary=50%, secondary=100%.
+    private static readonly QuickTerminalSize Default = new(Primary: null, Secondary: null);
+
+    // ---- Defaults across all five positions --------------------------------
+
+    [Fact]
+    public void Top_Default_Spans_Full_Width_And_Half_Height_At_Top()
+    {
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Top, Default, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 0, 1920, 540), rect);
+    }
+
+    [Fact]
+    public void Bottom_Default_Spans_Full_Width_And_Half_Height_At_Bottom()
+    {
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Bottom, Default, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 540, 1920, 540), rect);
+    }
+
+    [Fact]
+    public void Left_Default_Spans_Half_Width_And_Full_Height_At_Left()
+    {
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Left, Default, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 0, 960, 1080), rect);
+    }
+
+    [Fact]
+    public void Right_Default_Spans_Half_Width_And_Full_Height_At_Right()
+    {
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Right, Default, Hd);
+        Assert.Equal(new QuickTerminalRect(960, 0, 960, 1080), rect);
+    }
+
+    [Fact]
+    public void Center_Default_On_Landscape_Is_Half_Height_Full_Width_Centered()
+    {
+        // Landscape monitor: primary axis is height, so default
+        // primary=50% of 1080 = 540, secondary=100% of 1920 = 1920.
+        // Both axes are centered in the monitor's work area.
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Center, Default, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 270, 1920, 540), rect);
+    }
+
+    // ---- Primary-only Percentage across positions --------------------------
+
+    [Theory]
+    [InlineData(25.0, 270)]
+    [InlineData(50.0, 540)]
+    [InlineData(75.0, 810)]
+    public void Top_Primary_Percentage_Sets_Height(double pct, int expectedHeight)
+    {
+        var size = new QuickTerminalSize(Primary: Dimension.Percentage(pct), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Top, size, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 0, 1920, expectedHeight), rect);
+    }
+
+    [Theory]
+    [InlineData(25.0, 480)]
+    [InlineData(50.0, 960)]
+    public void Left_Primary_Percentage_Sets_Width(double pct, int expectedWidth)
+    {
+        var size = new QuickTerminalSize(Primary: Dimension.Percentage(pct), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Left, size, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 0, expectedWidth, 1080), rect);
+    }
+
+    // ---- Primary-only Pixels ----------------------------------------------
+
+    [Fact]
+    public void Top_Primary_Pixels_Sets_Height_To_Exact_Value()
+    {
+        var size = new QuickTerminalSize(Primary: Dimension.Pixels(300), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Top, size, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 0, 1920, 300), rect);
+    }
+
+    [Fact]
+    public void Bottom_Primary_Pixels_Anchors_Window_To_Bottom_Edge()
+    {
+        var size = new QuickTerminalSize(Primary: Dimension.Pixels(200), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Bottom, size, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 880, 1920, 200), rect);
+    }
+
+    [Fact]
+    public void Right_Primary_Pixels_Anchors_Window_To_Right_Edge()
+    {
+        var size = new QuickTerminalSize(Primary: Dimension.Pixels(500), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Right, size, Hd);
+        Assert.Equal(new QuickTerminalRect(1420, 0, 500, 1080), rect);
+    }
+
+    // ---- Both axes specified ----------------------------------------------
+
+    [Fact]
+    public void Top_Primary_And_Secondary_Both_Honored()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(400),
+            Secondary: Dimension.Pixels(1200));
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Top, size, Hd);
+        Assert.Equal(new QuickTerminalRect(0, 0, 1200, 400), rect);
+    }
+
+    [Fact]
+    public void Left_Both_Axes_Honored_As_Percentages()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Percentage(30),
+            Secondary: Dimension.Percentage(80));
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Left, size, Hd);
+        // Primary axis = width = 30% of 1920 = 576.
+        // Secondary axis = height = 80% of 1080 = 864.
+        Assert.Equal(new QuickTerminalRect(0, 0, 576, 864), rect);
+    }
+
+    // ---- Center: landscape vs portrait -------------------------------------
+
+    [Fact]
+    public void Center_On_Portrait_Monitor_Primary_Axis_Is_Width()
+    {
+        var portrait = new MonitorBounds(0, 0, 1080, 1920);
+        // Primary defaults to 50% of width (540), secondary to full height (1920).
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Center, Default, portrait);
+        Assert.Equal(new QuickTerminalRect(270, 0, 540, 1920), rect);
+    }
+
+    [Fact]
+    public void Center_On_Portrait_Both_Axes_Specified()
+    {
+        var portrait = new MonitorBounds(0, 0, 1080, 1920);
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(800),    // primary = width
+            Secondary: Dimension.Pixels(1200)); // secondary = height
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Center, size, portrait);
+        // Centered: x = (1080 - 800)/2 = 140, y = (1920 - 1200)/2 = 360.
+        Assert.Equal(new QuickTerminalRect(140, 360, 800, 1200), rect);
+    }
+
+    [Fact]
+    public void Center_On_Square_Monitor_Behaves_As_Landscape()
+    {
+        // Width == Height ties the IsLandscape branch toward landscape.
+        var square = new MonitorBounds(0, 0, 1000, 1000);
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(400),
+            Secondary: Dimension.Pixels(800));
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Center, size, square);
+        // Landscape: primary = height = 400, secondary = width = 800.
+        // x = (1000 - 800)/2 = 100, y = (1000 - 400)/2 = 300.
+        Assert.Equal(new QuickTerminalRect(100, 300, 800, 400), rect);
+    }
+
+    // ---- Clamping ---------------------------------------------------------
+
+    [Fact]
+    public void Oversize_Percentage_Saturates_To_Full_Parent_Dimension()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Percentage(150), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Top, size, Hd);
+        // 150% of 1080 -> clamped to 1080.
+        Assert.Equal(new QuickTerminalRect(0, 0, 1920, 1080), rect);
+    }
+
+    [Fact]
+    public void Oversize_Pixels_Saturates_To_Full_Parent_Dimension()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(9999), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Top, size, Hd);
+        // 9999 clamped to 1080.
+        Assert.Equal(new QuickTerminalRect(0, 0, 1920, 1080), rect);
+    }
+
+    [Fact]
+    public void Oversize_Secondary_Pixels_Saturates_To_Full_Parent_Dimension()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(300),
+            Secondary: Dimension.Pixels(9999));
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Top, size, Hd);
+        // Secondary 9999 (width) clamped to 1920.
+        Assert.Equal(new QuickTerminalRect(0, 0, 1920, 300), rect);
+    }
+
+    [Fact]
+    public void Zero_Percentage_Clamps_Up_To_Minimum_Of_One_Pixel()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Percentage(0), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Top, size, Hd);
+        // 0% clamped to floor of 1 px so the window stays addressable.
+        Assert.Equal(new QuickTerminalRect(0, 0, 1920, 1), rect);
+    }
+
+    // ---- Negative monitor origin (multi-monitor) --------------------------
+
+    [Fact]
+    public void Negative_Origin_Bottom_Anchors_To_Negative_Monitor_Bottom()
+    {
+        // Secondary monitor to the left of primary: top-left at (-1920, 0).
+        var left = new MonitorBounds(-1920, 0, 1920, 1080);
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(200), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Bottom, size, left);
+        // X stays at monitor.X = -1920; Y = bottom (1080) - 200 = 880.
+        Assert.Equal(new QuickTerminalRect(-1920, 880, 1920, 200), rect);
+    }
+
+    [Fact]
+    public void Negative_Origin_Right_Anchors_To_Negative_Monitor_Right_Edge()
+    {
+        var left = new MonitorBounds(-1920, 0, 1920, 1080);
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(500), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Right, size, left);
+        // Right edge of this monitor is 0; window starts at 0 - 500 = -500.
+        Assert.Equal(new QuickTerminalRect(-500, 0, 500, 1080), rect);
+    }
+
+    [Fact]
+    public void Negative_Origin_Center_Stays_Inside_Monitor_Bounds()
+    {
+        var left = new MonitorBounds(-1920, 0, 1920, 1080);
+        var rect = QuickTerminalGeometry.Resolve(
+            QuickTerminalPosition.Center, Default, left);
+        // Default landscape center: secondary=full width (1920), primary=540
+        // vertically centered. X = -1920 + (1920-1920)/2 = -1920.
+        Assert.Equal(new QuickTerminalRect(-1920, 270, 1920, 540), rect);
+    }
+
+    // ---- Position-anchoring sanity ----------------------------------------
+
+    [Fact]
+    public void Bottom_X_Equals_Monitor_X_Regardless_Of_Size()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(300),
+            Secondary: Dimension.Pixels(500));
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Bottom, size, Hd);
+        // X stays at monitor.X because secondary axis is independent of position.
+        Assert.Equal(Hd.X, rect.X);
+    }
+
+    [Fact]
+    public void Right_Width_Equals_Primary_Pixels()
+    {
+        var size = new QuickTerminalSize(
+            Primary: Dimension.Pixels(600), Secondary: null);
+        var rect = QuickTerminalGeometry.Resolve(QuickTerminalPosition.Right, size, Hd);
+        Assert.Equal(600, rect.Width);
+    }
+}

--- a/windows/Ghostty.Tests/Interop/QuickTerminalSizeCLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/QuickTerminalSizeCLayoutTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Ghostty.Tests.Interop;
 
-// Pins ghostty_qt_size_s ABI shape (FFI with src/config/Config.zig:9484-9517).
+// Pins ghostty_qt_size_s ABI shape (FFI with libghostty).
 public class QuickTerminalSizeCLayoutTests
 {
     [Fact]

--- a/windows/Ghostty.Tests/Interop/QuickTerminalSizeCLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/QuickTerminalSizeCLayoutTests.cs
@@ -1,0 +1,48 @@
+using System.Runtime.InteropServices;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+// Pins ghostty_qt_size_s ABI shape (FFI with src/config/Config.zig:9484-9517).
+public class QuickTerminalSizeCLayoutTests
+{
+    [Fact]
+    public void QuickTerminalSizeC_Size_Is_16_Bytes()
+    {
+        // Two ghostty_qt_size_one_s structs end-to-end.
+        Assert.Equal(16, Marshal.SizeOf<QuickTerminalSizeC>());
+    }
+
+    [Fact]
+    public void QuickTerminalSizeOneC_Size_Is_8_Bytes()
+    {
+        // c_int tag (4) + union { f32 | u32 } (4).
+        Assert.Equal(8, Marshal.SizeOf<QuickTerminalSizeOneC>());
+    }
+
+    [Fact]
+    public void QuickTerminalSizeC_Primary_Secondary_Offsets()
+    {
+        Assert.Equal(0, (int)Marshal.OffsetOf<QuickTerminalSizeC>(nameof(QuickTerminalSizeC.Primary)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<QuickTerminalSizeC>(nameof(QuickTerminalSizeC.Secondary)));
+    }
+
+    [Fact]
+    public void QuickTerminalSizeOneC_Tag_Value_Offsets()
+    {
+        Assert.Equal(0, (int)Marshal.OffsetOf<QuickTerminalSizeOneC>(nameof(QuickTerminalSizeOneC.Tag)));
+        Assert.Equal(4, (int)Marshal.OffsetOf<QuickTerminalSizeOneC>(nameof(QuickTerminalSizeOneC.Value)));
+    }
+
+    // int (not enum) parameter: xUnit needs public test class, internal enum
+    // can't leak through [InlineData]. Same pattern as ActionTag_Ordinal_*.
+    [Theory]
+    [InlineData((int)QuickTerminalSizeTag.None, 0)]
+    [InlineData((int)QuickTerminalSizeTag.Percentage, 1)]
+    [InlineData((int)QuickTerminalSizeTag.Pixels, 2)]
+    public void QuickTerminalSizeTag_Ordinal_Matches_Upstream(int tag, int expected)
+    {
+        Assert.Equal(expected, tag);
+    }
+}

--- a/windows/Ghostty/Hosting/QuickTerminalMonitorResolver.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalMonitorResolver.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Runtime.InteropServices;
+using Ghostty.Core.Hosting;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Ghostty.Hosting;
+
+/// <summary>
+/// Adapter that turns a <see cref="QuickTerminalScreen"/> + the
+/// quake window's HWND into a <see cref="MonitorBounds"/> the
+/// pure-logic resolver consumes. Caller passes the resulting
+/// bounds plus the position + size config into
+/// <see cref="QuickTerminalGeometry.Resolve"/>.
+/// </summary>
+internal static class QuickTerminalMonitorResolver
+{
+    public static MonitorBounds Resolve(IntPtr hwnd, QuickTerminalScreen screen)
+    {
+        HMONITOR monitor = screen switch
+        {
+            QuickTerminalScreen.Mouse => ResolveMouseMonitor(),
+            _                          => PInvoke.MonitorFromWindow(
+                                              new HWND(hwnd),
+                                              MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY),
+        };
+        return ReadBounds(monitor);
+    }
+
+    private static HMONITOR ResolveMouseMonitor()
+    {
+        if (!PInvoke.GetCursorPos(out var pt))
+        {
+            // GetCursorPos failure is exceptional; fall back to the
+            // primary monitor rather than throwing from the toggle
+            // path.
+            return PInvoke.MonitorFromWindow(
+                new HWND(IntPtr.Zero),
+                MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY);
+        }
+        return PInvoke.MonitorFromPoint(pt, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
+    }
+
+    private static MonitorBounds ReadBounds(HMONITOR monitor)
+    {
+        var info = new MONITORINFO { cbSize = (uint)Marshal.SizeOf<MONITORINFO>() };
+        if (!PInvoke.GetMonitorInfo(monitor, ref info))
+        {
+            // Same fallback as Mouse failure: a full HD primary
+            // monitor at the origin. The user sees a wrongly-placed
+            // window once instead of a crash.
+            return new MonitorBounds(0, 0, 1920, 1080);
+        }
+        var rc = info.rcWork;
+        return new MonitorBounds(rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top);
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1786,27 +1786,27 @@ public sealed partial class MainWindow : Window
     private bool _hardCloseQuake;
 
     /// <summary>
-    /// Position the window at the top of the primary monitor's work area,
-    /// full width and half height. V1 hardcoded geometry; the
-    /// quick-terminal-position / size / screen config knobs that drive
-    /// per-user placement land separately.
+    /// Position the window per <c>quick-terminal-position</c>,
+    /// <c>quick-terminal-size</c>, and <c>quick-terminal-screen</c>.
+    /// The monitor adapter handles the Win32 lookup and the pure-logic
+    /// resolver in <see cref="Ghostty.Core.Hosting.QuickTerminalGeometry"/>
+    /// turns the config plus monitor work area into the final rect.
     /// </summary>
     public void MoveToQuakePosition()
     {
-        var hwnd = new HWND(WindowNative.GetWindowHandle(this));
-        var monitor = PInvoke.MonitorFromWindow(hwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY);
-        if (monitor == IntPtr.Zero) return;
-
-        var info = new MONITORINFO { cbSize = (uint)Marshal.SizeOf<MONITORINFO>() };
-        if (!PInvoke.GetMonitorInfo(monitor, ref info)) return;
-
-        var work = info.rcWork;
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var bounds = QuickTerminalMonitorResolver.Resolve(
+            hwnd, _configService.QuickTerminalScreen);
+        var rect = Ghostty.Core.Hosting.QuickTerminalGeometry.Resolve(
+            _configService.QuickTerminalPosition,
+            _configService.QuickTerminalSize,
+            bounds);
         AppWindow.MoveAndResize(new Windows.Graphics.RectInt32
         {
-            X = work.left,
-            Y = work.top,
-            Width = work.right - work.left,
-            Height = (work.bottom - work.top) / 2,
+            X = rect.X,
+            Y = rect.Y,
+            Width = rect.Width,
+            Height = rect.Height,
         });
     }
 

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -22,6 +22,7 @@ MapVirtualKey
 MessageBeep
 MONITORINFO
 MONITOR_FROM_FLAGS
+MonitorFromPoint
 MonitorFromWindow
 RegisterHotKey
 SendMessage

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -94,6 +94,29 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     public double FontSize { get; private set; } = 13.0;
 
     /// <summary>
+    /// Where the quake window docks on the chosen monitor.
+    /// Default `top` matches upstream Ghostty.
+    /// </summary>
+    public Ghostty.Core.Hosting.QuickTerminalPosition QuickTerminalPosition =>
+        Ghostty.Core.Hosting.QuickTerminalPositionExtensions.Parse(
+            GetString("quick-terminal-position", "top"));
+
+    /// <summary>
+    /// Which monitor the quake window targets.
+    /// Default `main` matches upstream Ghostty.
+    /// </summary>
+    public Ghostty.Core.Hosting.QuickTerminalScreen QuickTerminalScreen =>
+        Ghostty.Core.Hosting.QuickTerminalScreenExtensions.Parse(
+            GetString("quick-terminal-screen", "main"));
+
+    /// <summary>
+    /// Size of the quake window on each axis. Either axis can be
+    /// null in which case the resolver uses sensible defaults
+    /// (50% primary, 100% secondary).
+    /// </summary>
+    public Ghostty.Core.Hosting.QuickTerminalSize QuickTerminalSize => ReadQuickTerminalSize();
+
+    /// <summary>
     /// Parsed light theme name from a conditional theme pair, or null
     /// if the theme is a single (non-conditional) value.
     /// </summary>
@@ -610,6 +633,35 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
                 (UIntPtr)keyBytes.Length);
             return found ? result : defaultValue;
         }
+    }
+
+    /// <summary>
+    /// Read the <c>quick-terminal-size</c> two-axis struct via
+    /// <c>ghostty_config_get</c>. libghostty writes a
+    /// <c>ghostty_qt_size_s</c> (two axes, each tagged percentage /
+    /// pixels / none) into the supplied buffer. Returns a
+    /// <see cref="Ghostty.Core.Hosting.QuickTerminalSize"/> with both
+    /// axes null when the key is unset, which the placement resolver
+    /// then fills with its defaults (50% primary, 100% secondary).
+    /// </summary>
+    private unsafe Ghostty.Core.Hosting.QuickTerminalSize ReadQuickTerminalSize()
+    {
+        Ghostty.Core.Interop.QuickTerminalSizeC raw = default;
+        var keyBytes = System.Text.Encoding.UTF8.GetBytes("quick-terminal-size");
+        fixed (byte* keyPtr = keyBytes)
+        {
+            var found = NativeMethods.ConfigGet(
+                _config,
+                (IntPtr)(&raw),
+                (IntPtr)keyPtr,
+                (UIntPtr)keyBytes.Length);
+            if (!found)
+            {
+                return new Ghostty.Core.Hosting.QuickTerminalSize(
+                    Primary: null, Secondary: null);
+            }
+        }
+        return raw.ToManaged();
     }
 
     /// <summary>


### PR DESCRIPTION
Second of three PRs for OSS roadmap section 4.4. Replaces the hardcoded "top of primary monitor, 50% height, full width" geometry from PR # 436 with a config-driven resolver.

### What lands

**`Ghostty.Core.Hosting` (pure logic, fully testable):**
- `QuickTerminalPosition` (top/bottom/left/right/center) + Parse
- `QuickTerminalScreen` (main/mouse); mac-only `macos-menu-bar` treated as `main`
- `QuickTerminalSize` with two-axis `Dimension?` (percentage or pixels); either axis nullable for "use default" semantics
- `MonitorBounds` pure-data struct + `IsLandscape` helper
- `QuickTerminalGeometry.Resolve(position, size, monitor)`: resolves to a `QuickTerminalRect`. Defaults to 50% primary axis / 100% secondary. Top/Bottom drive horizontal; Left/Right drive vertical; Center picks primary axis by monitor orientation. Output clamped to `[1, monitor.dimension]`.

**`Ghostty.Core.Interop.QuickTerminalSizeC`** mirrors libghostty's `ghostty_qt_size_s` C ABI (16 bytes: two 8-byte per-axis records, each `{ c_int tag; union { f32 percentage; u32 pixels } }`). `ToManaged()` converts to the managed type.

**`QuickTerminalSizeCLayoutTests`** pins size + offsets + tag ordinals — layout drift trips the FFI suite at build time.

**`Ghostty.Hosting.QuickTerminalMonitorResolver`** is the thin Win32 adapter: `Mouse` screen path uses `GetCursorPos` + `MonitorFromPoint`; `Main` uses `MonitorFromWindow` with `DEFAULTTOPRIMARY`. Failures fall back to a sane primary-monitor default rather than throwing from the toggle path.

**`ConfigService`** exposes `QuickTerminalPosition` / `Screen` / `Size` properties. Position and Screen go through `GetString`; Size uses an `unsafe` `ConfigGet` call with a stack-allocated `QuickTerminalSizeC` buffer. Computed-on-access so config reloads pick up changes.

**`MainWindow.MoveToQuakePosition`** delegates to the resolver instead of computing the rect inline.

### Tests

- 34 new xUnit tests: 22 geometry (all 5 positions × defaults / primary-only / both-axes / percentage / pixels / oversize clamping / negative-origin monitors / square-monitor center) + 5 ABI layout pins + 7 [Theory] expansions
- `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj` — 1081 passed, 0 failed, 1 skipped (up from 1047)

### Smoke

Default config (no `quick-terminal-*` keys): behaviour matches PR # 436 (top of primary, 50% height, full width).

With:
```
quick-terminal-position = right
quick-terminal-size = 600px,80%
```
the window docks on the right edge, 600 px wide, 80% of monitor height.

### What's still pending

PR C ships `quick-terminal-autohide`, `quick-terminal-animation-duration`, and the wintty-only `quick-terminal-key` chord override.