### PR TITLE
Bound total log size and stop the theme-preview pipe spin loop

### DIFF
--- a/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
@@ -12,4 +12,15 @@ internal sealed record FileLoggerOptions
     public int RetentionDays { get; init; } = 14;
     public int ChannelCapacity { get; init; } = 4096;
     public int BatchMaxRecords { get; init; } = 64;
+
+    /// <summary>
+    /// Hard ceiling on the combined size of all <c>ghostty-*.log</c> files
+    /// in the directory. Date-based <see cref="RetentionDays"/> pruning
+    /// cannot bound a same-day storm: a runaway producer rolls thousands of
+    /// today-dated files that no date cutoff will ever delete. This cap is
+    /// enforced on every rollover by deleting the oldest files first, so a
+    /// logging fault in any component can never fill the disk. Default
+    /// 512 MB; normal sessions log a few MB/day and never approach it.
+    /// </summary>
+    public long MaxTotalBytes { get; init; } = 512L * 1024 * 1024;
 }

--- a/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
@@ -170,6 +170,77 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Deletes oldest <c>ghostty-*.log</c> files until the combined size of
+    /// the directory is within <see cref="FileLoggerOptions.MaxTotalBytes"/>.
+    /// Called on every rollover (no file handle is open at those points, so
+    /// deletion is safe). This is the source-agnostic backstop that bounds
+    /// disk use even when <see cref="SweepRetention"/>'s date cutoff cannot
+    /// (a same-day storm produces thousands of today-dated files).
+    /// </summary>
+    private void EnforceTotalSizeBudget()
+    {
+        if (!_fs.DirectoryExists(_opts.Directory))
+            return;
+
+        var files = new System.Collections.Generic.List<(string Path, long Length, long Order)>();
+        long total = 0;
+        foreach (var path in _fs.EnumerateFiles(_opts.Directory, "ghostty-*.log"))
+        {
+            long len;
+            try { len = _fs.FileLength(path); }
+            catch (IOException) { continue; }   // vanished between enumerate and stat
+            total += len;
+            files.Add((path, len, RollSortKey(path)));
+        }
+
+        if (total <= _opts.MaxTotalBytes)
+            return;
+
+        // Oldest-first by the logger's own naming (date, then numeric roll
+        // counter) so we evict the least useful logs and keep the newest.
+        files.Sort((a, b) => a.Order.CompareTo(b.Order));
+        foreach (var f in files)
+        {
+            if (total <= _opts.MaxTotalBytes)
+                break;
+            try
+            {
+                _fs.DeleteFile(f.Path);
+                total -= f.Length;
+            }
+            catch (IOException) { /* locked/in use: skip, try the next */ }
+        }
+    }
+
+    /// <summary>
+    /// Chronological sort key parsed from a <c>ghostty-YYYYMMDD[-N].log</c>
+    /// name: date major, numeric roll counter minor. Filesystem-timestamp
+    /// independent so behavior is deterministic and testable. Unrecognized
+    /// names sort last (pruned only as a last resort).
+    /// </summary>
+    private static long RollSortKey(string path)
+    {
+        const string prefix = "ghostty-";
+        var name = Path.GetFileNameWithoutExtension(path);
+        if (!name.StartsWith(prefix, StringComparison.Ordinal) ||
+            name.Length < prefix.Length + 8)
+            return long.MaxValue;
+
+        if (!long.TryParse(
+                name.AsSpan(prefix.Length, 8), NumberStyles.None,
+                CultureInfo.InvariantCulture, out var date))
+            return long.MaxValue;
+
+        long counter = 0;
+        var rest = name.AsSpan(prefix.Length + 8); // "" or "-N"
+        if (rest.Length > 1 && rest[0] == '-')
+            long.TryParse(rest[1..], NumberStyles.None, CultureInfo.InvariantCulture, out counter);
+
+        // date (yyyyMMdd, already monotonic) dominates; counter breaks ties.
+        return date * 100_000_000L + counter;
+    }
+
     private async Task WriterLoopAsync()
     {
         DateOnly openDate = default;
@@ -211,6 +282,12 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
                                 try { SweepRetention(); } catch { /* best-effort */ }
                             }
 
+                            // Bound total on-disk size before opening the next
+                            // file. Date-based retention cannot prune same-day
+                            // files, so a storm would otherwise grow unbounded;
+                            // this deletes oldest files regardless of date.
+                            try { EnforceTotalSizeBudget(); } catch { /* best-effort */ }
+
                             try
                             {
                                 stream = _fs.OpenAppend(PathFor(openDate, rollCounter));
@@ -243,6 +320,10 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
                                 stream.Flush();
                                 stream.Dispose();
                                 rollCounter++;
+                                // Prune oldest files to honor the byte budget
+                                // before the next roll file is created. No
+                                // handle is open here, so deleting is safe.
+                                try { EnforceTotalSizeBudget(); } catch { /* best-effort */ }
                                 stream = _fs.OpenAppend(PathFor(openDate, rollCounter));
                             }
                             catch (IOException)

--- a/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerProvider.cs
@@ -219,7 +219,7 @@ internal sealed class FileLoggerProvider : ILoggerProvider, IAsyncDisposable
     /// independent so behavior is deterministic and testable. Unrecognized
     /// names sort last (pruned only as a last resort).
     /// </summary>
-    private static long RollSortKey(string path)
+    internal static long RollSortKey(string path)
     {
         const string prefix = "ghostty-";
         var name = Path.GetFileNameWithoutExtension(path);

--- a/windows/Ghostty.Core/Pipes/PipeServerRetryPolicy.cs
+++ b/windows/Ghostty.Core/Pipes/PipeServerRetryPolicy.cs
@@ -50,6 +50,10 @@ public enum PipeLoopDecision
 /// forever and filling the disk with rolled log files. This policy makes the
 /// distinctions explicit and bounds <em>both</em> failure paths so no outcome
 /// can produce an unbounded hot loop.
+///
+/// Not thread-safe: the consecutive-fault count is mutated without locking.
+/// Drive it from a single server loop (one <see cref="Decide"/> call at a
+/// time), which is how <c>ThemePreviewService</c> uses it.
 /// </summary>
 public sealed class PipeServerRetryPolicy
 {

--- a/windows/Ghostty.Core/Pipes/PipeServerRetryPolicy.cs
+++ b/windows/Ghostty.Core/Pipes/PipeServerRetryPolicy.cs
@@ -1,0 +1,99 @@
+using System;
+
+namespace Ghostty.Core.Pipes;
+
+/// <summary>
+/// What ended one iteration of a single-instance named-pipe server loop.
+/// </summary>
+public enum PipeLoopOutcome
+{
+    /// <summary>Cancellation was requested.</summary>
+    Cancelled,
+
+    /// <summary>
+    /// The server stream could not be created (e.g. the pipe name is already
+    /// owned by another instance in this process). Permanent for this loop.
+    /// </summary>
+    ServerCreationFailed,
+
+    /// <summary>A client connected and the session completed normally.</summary>
+    SessionEnded,
+
+    /// <summary>A connected session broke with an I/O error mid-stream.</summary>
+    SessionFaulted,
+}
+
+/// <summary>What the server loop should do next.</summary>
+public enum PipeLoopDecision
+{
+    /// <summary>Exit the loop (cancellation).</summary>
+    Stop,
+
+    /// <summary>Exit the loop permanently; retrying cannot succeed.</summary>
+    StandDown,
+
+    /// <summary>Accept the next connection immediately.</summary>
+    RetryImmediately,
+
+    /// <summary>Wait <see cref="PipeServerRetryPolicy.Backoff"/> then retry.</summary>
+    RetryAfterBackoff,
+}
+
+/// <summary>
+/// Decides how a single-instance named-pipe server loop reacts to each
+/// iteration outcome. Pure and stateful only in the consecutive-fault count,
+/// so it is unit-testable without any pipe or threading machinery.
+///
+/// Exists because the original inline loop treated <em>every</em>
+/// <see cref="System.IO.IOException"/> the same: a server-creation failure
+/// ("All pipe instances are busy") was retried immediately, busy-looping
+/// forever and filling the disk with rolled log files. This policy makes the
+/// distinctions explicit and bounds <em>both</em> failure paths so no outcome
+/// can produce an unbounded hot loop.
+/// </summary>
+public sealed class PipeServerRetryPolicy
+{
+    private readonly int _maxConsecutiveFaults;
+    private readonly TimeSpan _backoff;
+    private int _consecutiveFaults;
+
+    public PipeServerRetryPolicy(int maxConsecutiveFaults = 10, TimeSpan? backoff = null)
+    {
+        _maxConsecutiveFaults = maxConsecutiveFaults < 1 ? 1 : maxConsecutiveFaults;
+        _backoff = backoff ?? TimeSpan.FromSeconds(1);
+    }
+
+    /// <summary>Delay applied for a <see cref="PipeLoopDecision.RetryAfterBackoff"/>.</summary>
+    public TimeSpan Backoff => _backoff;
+
+    public PipeLoopDecision Decide(PipeLoopOutcome outcome)
+    {
+        switch (outcome)
+        {
+            case PipeLoopOutcome.Cancelled:
+                return PipeLoopDecision.Stop;
+
+            // Creation can never succeed on retry for this loop (the name is
+            // taken). Standing down is the whole point of the fix.
+            case PipeLoopOutcome.ServerCreationFailed:
+                return PipeLoopDecision.StandDown;
+
+            // A clean session resets the fault budget and we accept the next
+            // client right away.
+            case PipeLoopOutcome.SessionEnded:
+                _consecutiveFaults = 0;
+                return PipeLoopDecision.RetryImmediately;
+
+            // Faults back off, but a pipe that fails on every reconnect must
+            // eventually give up rather than retry forever.
+            case PipeLoopOutcome.SessionFaulted:
+                _consecutiveFaults++;
+                return _consecutiveFaults >= _maxConsecutiveFaults
+                    ? PipeLoopDecision.StandDown
+                    : PipeLoopDecision.RetryAfterBackoff;
+
+            default:
+                return PipeLoopDecision.Stop;
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
+++ b/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
@@ -209,6 +209,24 @@ public class FileLoggerProviderTests : IDisposable
         Assert.True(files.Length <= 10, $"expected pruning, found {files.Length} files");
     }
 
+    [Theory]
+    // Same day, ascending roll counter: 0 (unsuffixed) is oldest, then 1, 2,
+    // 9, 10. A lexical sort would wrongly place "-10" before "-2"; the numeric
+    // parse must not. This pins the one subtle property the pruner relies on
+    // to evict the genuinely-oldest files.
+    [InlineData("ghostty-20260417.log", "ghostty-20260417-1.log")]
+    [InlineData("ghostty-20260417-1.log", "ghostty-20260417-2.log")]
+    [InlineData("ghostty-20260417-2.log", "ghostty-20260417-10.log")]
+    [InlineData("ghostty-20260417-9.log", "ghostty-20260417-10.log")]
+    // Older day sorts before newer day regardless of counter.
+    [InlineData("ghostty-20260417-99.log", "ghostty-20260418.log")]
+    public void RollSortKey_OrdersChronologically_NotLexically(string older, string newer)
+    {
+        Assert.True(
+            FileLoggerProvider.RollSortKey(older) < FileLoggerProvider.RollSortKey(newer),
+            $"expected {older} to sort before {newer}");
+    }
+
     [Fact]
     public void RetentionSweep_DeletesFilesOlderThanCutoff_OnConstruction()
     {

--- a/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
+++ b/windows/Ghostty.Tests/Logging/FileLoggerProviderTests.cs
@@ -179,6 +179,37 @@ public class FileLoggerProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task PrunesOldestRollFiles_WhenTotalSizeBudgetExceeded()
+    {
+        var clock = new FakeClock(new DateTime(2026, 4, 17, 12, 0, 0, DateTimeKind.Utc));
+        // Tiny per-file cap forces a roll on nearly every record; small
+        // total budget forces oldest-file pruning. This is the runaway-
+        // producer scenario in miniature: without a byte ceiling these
+        // 200 writes would leave ~200 same-day files on disk.
+        var opts = NewOptions(_tempDir) with { MaxBytesPerFile = 60, MaxTotalBytes = 300 };
+        await using var sink = new FileLoggerProvider(opts, clock, RealFileSystem.Instance);
+        var logger = sink.CreateLogger("Cat");
+
+        for (int i = 0; i < 200; i++)
+            logger.LogWarning(new EventId(i, "E"), "message-{Index}", i);
+
+        await DrainAsync(sink);
+
+        var files = Directory.EnumerateFiles(_tempDir, "ghostty-*.log").ToArray();
+        long total = files.Sum(f => new FileInfo(f).Length);
+
+        // The budget is enforced before each new roll file opens, so the
+        // on-disk total may transiently exceed it by at most one full file.
+        Assert.True(
+            total <= opts.MaxTotalBytes + opts.MaxBytesPerFile,
+            $"total {total} bytes exceeded budget {opts.MaxTotalBytes} (+1 file {opts.MaxBytesPerFile})");
+
+        // Oldest files were pruned: nowhere near the ~200 a runaway would
+        // otherwise leave behind.
+        Assert.True(files.Length <= 10, $"expected pruning, found {files.Length} files");
+    }
+
+    [Fact]
     public void RetentionSweep_DeletesFilesOlderThanCutoff_OnConstruction()
     {
         // Today = 2026-04-17. Retention 14 days => cutoff 2026-04-03.

--- a/windows/Ghostty.Tests/Pipes/PipeServerRetryPolicyTests.cs
+++ b/windows/Ghostty.Tests/Pipes/PipeServerRetryPolicyTests.cs
@@ -1,0 +1,74 @@
+using System;
+using Ghostty.Core.Pipes;
+using Xunit;
+
+namespace Ghostty.Tests.Pipes;
+
+public class PipeServerRetryPolicyTests
+{
+    [Fact]
+    public void ServerCreationFailure_StandsDown_NeverRetries()
+    {
+        // The disk-fill bug: a server-creation IOException ("All pipe
+        // instances are busy") was treated like a client disconnect and
+        // retried immediately, busy-looping forever. Creation failure must
+        // stand the loop down instead.
+        var policy = new PipeServerRetryPolicy();
+
+        var decision = policy.Decide(PipeLoopOutcome.ServerCreationFailed);
+
+        Assert.Equal(PipeLoopDecision.StandDown, decision);
+    }
+
+    [Fact]
+    public void Cancellation_Stops()
+    {
+        var policy = new PipeServerRetryPolicy();
+        Assert.Equal(PipeLoopDecision.Stop, policy.Decide(PipeLoopOutcome.Cancelled));
+    }
+
+    [Fact]
+    public void SingleSessionFault_RetriesAfterBackoff()
+    {
+        var policy = new PipeServerRetryPolicy();
+        Assert.Equal(PipeLoopDecision.RetryAfterBackoff, policy.Decide(PipeLoopOutcome.SessionFaulted));
+    }
+
+    [Fact]
+    public void SessionEnded_RetriesImmediately()
+    {
+        var policy = new PipeServerRetryPolicy();
+        Assert.Equal(PipeLoopDecision.RetryImmediately, policy.Decide(PipeLoopOutcome.SessionEnded));
+    }
+
+    [Fact]
+    public void ConsecutiveSessionFaults_EventuallyStandDown()
+    {
+        // Even the in-session error path must be bounded: a pipe that keeps
+        // faulting on every reconnect should give up rather than retry (with
+        // backoff) forever.
+        var policy = new PipeServerRetryPolicy(maxConsecutiveFaults: 3);
+
+        Assert.Equal(PipeLoopDecision.RetryAfterBackoff, policy.Decide(PipeLoopOutcome.SessionFaulted)); // 1
+        Assert.Equal(PipeLoopDecision.RetryAfterBackoff, policy.Decide(PipeLoopOutcome.SessionFaulted)); // 2
+        Assert.Equal(PipeLoopDecision.StandDown, policy.Decide(PipeLoopOutcome.SessionFaulted));         // 3rd -> give up
+    }
+
+    [Fact]
+    public void SuccessfulSession_ResetsFaultCount()
+    {
+        var policy = new PipeServerRetryPolicy(maxConsecutiveFaults: 2);
+
+        Assert.Equal(PipeLoopDecision.RetryAfterBackoff, policy.Decide(PipeLoopOutcome.SessionFaulted)); // fault 1
+        Assert.Equal(PipeLoopDecision.RetryImmediately, policy.Decide(PipeLoopOutcome.SessionEnded));    // resets counter
+        // Back to fault 1, not 2 -- so this still backs off rather than standing down.
+        Assert.Equal(PipeLoopDecision.RetryAfterBackoff, policy.Decide(PipeLoopOutcome.SessionFaulted));
+    }
+
+    [Fact]
+    public void Backoff_IsPositive()
+    {
+        var policy = new PipeServerRetryPolicy();
+        Assert.True(policy.Backoff > TimeSpan.Zero);
+    }
+}

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -34,6 +34,7 @@ internal static class LogEvents
         public const int PreviewConfirmed  = 2203;
         public const int PipeError         = 2204;
         public const int InvalidThemeName  = 2205;
+        public const int PipeServerUnavailable = 2206;
     }
 
     // 2300-2399: WindowState + migration

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
+using Ghostty.Core.Pipes;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 
@@ -85,19 +86,67 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
         ListThemesRequested = null;
     }
 
+    // Decides what to do after each server-loop iteration. Extracted to
+    // Ghostty.Core so the retry/stand-down logic is unit-tested: the bug
+    // that filled the disk was this loop treating a server-creation failure
+    // ("All pipe instances are busy") like a client disconnect and retrying
+    // it instantly, forever.
+    private readonly PipeServerRetryPolicy _retryPolicy = new();
+
     private async Task RunServer(CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
-            try
+            var outcome = await RunOneServerSession(ct);
+            switch (_retryPolicy.Decide(outcome))
             {
-                using var server = new NamedPipeServerStream(
-                    PipeName,
-                    PipeDirection.In,
-                    1, // single instance
-                    PipeTransmissionMode.Byte,
-                    PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance);
+                case PipeLoopDecision.Stop:
+                case PipeLoopDecision.StandDown:
+                    return;
+                case PipeLoopDecision.RetryAfterBackoff:
+                    try { await Task.Delay(_retryPolicy.Backoff, ct); }
+                    catch (OperationCanceledException) { return; }
+                    break;
+                case PipeLoopDecision.RetryImmediately:
+                default:
+                    break;
+            }
+        }
+    }
 
+    /// <summary>
+    /// Runs one accept-serve cycle of the named-pipe server and classifies
+    /// how it ended. Never throws (cancellation and I/O faults are mapped to
+    /// outcomes); the caller's policy decides whether to retry, back off, or
+    /// stand down.
+    /// </summary>
+    private async Task<PipeLoopOutcome> RunOneServerSession(CancellationToken ct)
+    {
+        // Creating the server is its own failure mode. With FirstPipeInstance
+        // + a per-process PipeName, the ctor throws "All pipe instances are
+        // busy" when another ThemePreviewService in this process already owns
+        // the name -- permanent for this loop, so the policy stands it down
+        // rather than retrying.
+        NamedPipeServerStream server;
+        try
+        {
+            server = new NamedPipeServerStream(
+                PipeName,
+                PipeDirection.In,
+                1, // single instance
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogPipeServerUnavailable(ex);
+            return PipeLoopOutcome.ServerCreationFailed;
+        }
+
+        try
+        {
+            using (server)
+            {
                 _logger.LogPipeWaiting(PipeName);
                 await server.WaitForConnectionAsync(ct);
                 _logger.LogClientConnected();
@@ -145,16 +194,18 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
                     _logger.LogPreviewConfirmed();
                 }
             }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch (IOException ex)
-            {
-                // Pipe broken, client disconnected. Loop back to accept
-                // next connection.
-                _logger.LogPipeError(ex);
-            }
+
+            return PipeLoopOutcome.SessionEnded;
+        }
+        catch (OperationCanceledException)
+        {
+            return PipeLoopOutcome.Cancelled;
+        }
+        catch (IOException ex)
+        {
+            // A connected client dropped or the pipe broke mid-session.
+            _logger.LogPipeError(ex);
+            return PipeLoopOutcome.SessionFaulted;
         }
     }
 
@@ -289,6 +340,12 @@ internal static partial class ThemePreviewServiceLogExtensions
                    Level = LogLevel.Warning,
                    Message = "[theme-preview] pipe error")]
     internal static partial void LogPipeError(
+        this ILogger<ThemePreviewService> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.PipeServerUnavailable,
+                   Level = LogLevel.Information,
+                   Message = "[theme-preview] pipe server unavailable; standing down (another instance owns it)")]
+    internal static partial void LogPipeServerUnavailable(
         this ILogger<ThemePreviewService> logger, System.Exception ex);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.ThemePreview.InvalidThemeName,

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -201,9 +201,17 @@ internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
         {
             return PipeLoopOutcome.Cancelled;
         }
-        catch (IOException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // A connected client dropped or the pipe broke mid-session.
+            // A connected client dropped, the pipe broke mid-session, or the
+            // stream was disposed under a teardown race. Map every such fault
+            // to an outcome so this method honors its "never throws" contract
+            // and the policy's fault bound always applies -- an escaping
+            // exception would otherwise propagate into the fire-and-forget
+            // server task and skip the bounded retry entirely. A cancellation
+            // that surfaces as a non-OCE here (it can, depending on pipe
+            // state) is treated as a fault: harmless, since the next loop turn
+            // observes the token and the backoff delay cancels immediately.
             _logger.LogPipeError(ex);
             return PipeLoopOutcome.SessionFaulted;
         }


### PR DESCRIPTION
## What

A redundant app instance could busy-loop in `ThemePreviewService` when it failed to create the named-pipe server. With `FirstPipeInstance` and a per-process pipe name, the constructor throws "All pipe instances are busy" once another instance already owns the name; that failure was retried with no delay, so the loser logged about 16 MB/s. Over a day it rolled ~9,800 files and filled the disk, because date-based retention never prunes same-day files.

## Changes

- **`FileLoggerProvider`**: enforces a total-size budget (`MaxTotalBytes`, default 512 MB), deleting the oldest files on each rollover. Source-agnostic backstop so no logging fault can fill the disk.
- **`PipeServerRetryPolicy`** (new, in `Ghostty.Core`): a creation failure stands the loop down; in-session faults back off and give up after repeated failures. Both paths are bounded.
- `ThemePreviewService` now drives its server loop through that policy.

## Tests

900 total: 899 pass, 1 unrelated skip. Adds 7 policy tests and 1 logger total-size-budget test (both watched fail first). WinUI app project builds with 0 errors.