### PR TITLE
quake: autohide, animation, key override, and minimal chrome

### DIFF
--- a/windows/Ghostty.Core/Input/QuickTerminalKeyChord.cs
+++ b/windows/Ghostty.Core/Input/QuickTerminalKeyChord.cs
@@ -1,0 +1,170 @@
+using System;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// A global-hotkey chord resolved to the Win32 <c>RegisterHotKey</c>
+/// surface: a set of <c>fsModifiers</c> bits plus a virtual-key code.
+/// Pure logic (no Win32 calls, no I/O) so it unit-tests without the
+/// XAML/Win32 runtime; <c>App</c> feeds the resolved pair straight into
+/// <c>WindowsGlobalHotKey.Register</c>.
+///
+/// The accepted string vocabulary mirrors Ghostty's trigger tokens
+/// (so the knob feels native to Ghostty users) but maps to Win32 VK
+/// codes rather than Ghostty's internal <c>Key</c> enum, because this
+/// drives the OS global-hotkey API, not libghostty's keymap.
+/// </summary>
+public readonly record struct QuickTerminalKeyChord(uint Modifiers, uint VirtualKey)
+{
+    // Win32 fsModifiers (winuser.h). NoRepeat stops Windows from
+    // auto-firing WM_HOTKEY repeatedly while the chord is held.
+    public const uint ModAlt = 0x0001;
+    public const uint ModControl = 0x0002;
+    public const uint ModShift = 0x0004;
+    public const uint ModWin = 0x0008;
+    public const uint ModNoRepeat = 0x4000;
+
+    /// <summary>
+    /// The built-in chord (Ctrl+backtick) used when the config key is
+    /// unset or fails to parse. VK_OEM_3 (0xC0) is the US-layout
+    /// backtick / tilde key.
+    /// </summary>
+    public static QuickTerminalKeyChord Default { get; } =
+        new(ModControl | ModNoRepeat, 0xC0);
+
+    /// <summary>
+    /// Parse a <c>quick-terminal-key</c> value (e.g. "ctrl+backquote",
+    /// "alt+space", "ctrl+shift+f1", "f12"). Returns <c>null</c> on any
+    /// malformed or unrecognized input so the caller can fall back to
+    /// <see cref="Default"/> and log. <see cref="ModNoRepeat"/> is always
+    /// included in the result.
+    ///
+    /// Guard: a modifier-less chord is only accepted for function keys
+    /// (F1-F24). Binding a bare printable key (e.g. "a") as a global
+    /// hotkey would hijack that key system-wide, which is never what the
+    /// user wants from a single config typo, so it is rejected.
+    /// </summary>
+    public static QuickTerminalKeyChord? Parse(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        uint mods = ModNoRepeat;
+        uint? vk = null;
+
+        foreach (var part in raw.Split('+', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var token = part.Trim().ToLowerInvariant();
+            if (token.Length == 0) return null;
+
+            switch (token)
+            {
+                case "ctrl":
+                case "control":
+                    mods |= ModControl;
+                    continue;
+                case "alt":
+                case "opt":
+                case "option":
+                    mods |= ModAlt;
+                    continue;
+                case "shift":
+                    mods |= ModShift;
+                    continue;
+                case "super":
+                case "cmd":
+                case "win":
+                case "meta":
+                    mods |= ModWin;
+                    continue;
+            }
+
+            // Non-modifier token: must be the (single) key.
+            if (vk is not null) return null; // two keys in one chord
+            var resolved = ResolveKey(token);
+            if (resolved is null) return null;
+            vk = resolved;
+        }
+
+        if (vk is null) return null; // modifiers only, no key
+
+        var hasRealModifier = (mods & (ModControl | ModAlt | ModShift | ModWin)) != 0;
+        if (!hasRealModifier && !IsFunctionKey(vk.Value)) return null; // foot-gun guard
+
+        return new QuickTerminalKeyChord(mods, vk.Value);
+    }
+
+    private static bool IsFunctionKey(uint vk) => vk is >= 0x70 and <= 0x87; // VK_F1..VK_F24
+
+    /// <summary>
+    /// Map a single Ghostty-flavoured key token to a Win32 VK code, or
+    /// <c>null</c> if unrecognized. Accepts literal single characters
+    /// (letters, digits, common punctuation), Ghostty's W3C enum names
+    /// (e.g. <c>backquote</c>, <c>bracket_left</c>, <c>arrow_up</c>), and
+    /// a handful of friendly aliases (<c>grave_accent</c>, <c>up</c>,
+    /// <c>esc</c>, <c>return</c>).
+    /// </summary>
+    private static uint? ResolveKey(string token)
+    {
+        // Single literal character (the Ghostty "unicode" trigger path).
+        if (token.Length == 1)
+        {
+            char c = token[0];
+            if (c is >= 'a' and <= 'z') return (uint)(0x41 + (c - 'a')); // VK_A..VK_Z
+            if (c is >= '0' and <= '9') return (uint)(0x30 + (c - '0')); // VK_0..VK_9
+            switch (c)
+            {
+                case '`': return 0xC0; // VK_OEM_3
+                case '-': return 0xBD; // VK_OEM_MINUS
+                case '=': return 0xBB; // VK_OEM_PLUS
+                case '[': return 0xDB; // VK_OEM_4
+                case ']': return 0xDD; // VK_OEM_6
+                case '\\': return 0xDC; // VK_OEM_5
+                case ';': return 0xBA; // VK_OEM_1
+                case '\'': return 0xDE; // VK_OEM_7
+                case ',': return 0xBC; // VK_OEM_COMMA
+                case '.': return 0xBE; // VK_OEM_PERIOD
+                case '/': return 0xBF; // VK_OEM_2
+                default: return null;
+            }
+        }
+
+        // Function keys f1..f24.
+        if (token.Length is 2 or 3 && token[0] == 'f'
+            && uint.TryParse(token.AsSpan(1), out var fn) && fn is >= 1 and <= 24)
+        {
+            return 0x70 + (fn - 1); // VK_F1 = 0x70
+        }
+
+        // Named keys (Ghostty W3C enum names + aliases).
+        return token switch
+        {
+            "backquote" or "grave_accent" => 0xC0,
+            "minus" => 0xBD,
+            "equal" => 0xBB,
+            "bracket_left" or "left_bracket" => 0xDB,
+            "bracket_right" or "right_bracket" => 0xDD,
+            "backslash" => 0xDC,
+            "semicolon" => 0xBA,
+            "quote" or "apostrophe" => 0xDE,
+            "comma" => 0xBC,
+            "period" => 0xBE,
+            "slash" => 0xBF,
+            "space" => 0x20,
+            "enter" or "return" => 0x0D,
+            "escape" or "esc" => 0x1Bu,
+            "tab" => 0x09,
+            "backspace" => 0x08,
+            "delete" => 0x2E,
+            "insert" => 0x2D,
+            "home" => 0x24,
+            "end" => 0x23,
+            "page_up" => 0x21,
+            "page_down" => 0x22,
+            "arrow_up" or "up" => 0x26,
+            "arrow_down" or "down" => 0x28,
+            "arrow_left" or "left" => 0x25,
+            "arrow_right" or "right" => 0x27,
+            _ => null,
+        };
+    }
+}

--- a/windows/Ghostty.Core/Input/QuickTerminalKeyChord.cs
+++ b/windows/Ghostty.Core/Input/QuickTerminalKeyChord.cs
@@ -135,7 +135,7 @@ public readonly record struct QuickTerminalKeyChord(uint Modifiers, uint Virtual
             return 0x70 + (fn - 1); // VK_F1 = 0x70
         }
 
-        // Named keys (Ghostty W3C enum names + aliases).
+        // Named keys -> Win32 virtual-key codes (winuser.h VK_*).
         return token switch
         {
             "backquote" or "grave_accent" => 0xC0,

--- a/windows/Ghostty.Core/Input/QuickTerminalKeyChord.cs
+++ b/windows/Ghostty.Core/Input/QuickTerminalKeyChord.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace Ghostty.Core.Input;
 
@@ -51,10 +52,9 @@ public readonly record struct QuickTerminalKeyChord(uint Modifiers, uint Virtual
         uint mods = ModNoRepeat;
         uint? vk = null;
 
-        foreach (var part in raw.Split('+', StringSplitOptions.RemoveEmptyEntries))
+        foreach (var part in raw.Split('+', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
         {
-            var token = part.Trim().ToLowerInvariant();
-            if (token.Length == 0) return null;
+            var token = part.ToLowerInvariant();
 
             switch (token)
             {
@@ -130,7 +130,7 @@ public readonly record struct QuickTerminalKeyChord(uint Modifiers, uint Virtual
 
         // Function keys f1..f24.
         if (token.Length is 2 or 3 && token[0] == 'f'
-            && uint.TryParse(token.AsSpan(1), out var fn) && fn is >= 1 and <= 24)
+            && uint.TryParse(token.AsSpan(1), NumberStyles.None, CultureInfo.InvariantCulture, out var fn) && fn is >= 1 and <= 24)
         {
             return 0x70 + (fn - 1); // VK_F1 = 0x70
         }

--- a/windows/Ghostty.Tests.Windows/QuickTerminal/QuickTerminalSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/QuickTerminal/QuickTerminalSmokeTests.cs
@@ -41,4 +41,46 @@ public class QuickTerminalSmokeTests
     public void CtrlBacktick_SummonsAndDismissesQuakeWindow()
     {
     }
+
+    // PR C adds three config-driven behaviours on top of the foundation
+    // above. Each needs a real HWND + compositor + the user watching, so
+    // they stay manual. Validate by editing the wintty config and
+    // reloading (Ctrl+Shift+R) between each:
+    //
+    //  Animation (quick-terminal-animation-duration, default 0.2):
+    //   - default: Ctrl+` slides the window down from the top over ~0.2s,
+    //     and slides back up on the second press.
+    //   - quick-terminal-position = bottom + duration = 0.4 -> slides up
+    //     from the bottom over ~0.4s.
+    //   - quick-terminal-position = center + duration = 0.3 -> fades in
+    //     centered (no slide).
+    //   - duration = 0 -> appears/disappears instantly (PR B behaviour).
+    //   - Rapidly mashing Ctrl+` must never leave the window stuck
+    //     half-on-screen, and must not hide-after-show / show-after-hide
+    //     (the animator's monotonic token guards superseded completions).
+    //
+    //  Autohide (quick-terminal-autohide, default true):
+    //   - default: summon the window, then click another app -> it hides.
+    //   - quick-terminal-autohide = false -> it stays open when clicked
+    //     away from.
+    //
+    //  Key override (quick-terminal-key, default ctrl+backquote):
+    //   - quick-terminal-key = alt+space -> after reload, Ctrl+` no longer
+    //     toggles; Alt+Space does.
+    //   - quick-terminal-key = ctrl+nonsense (invalid) -> after reload,
+    //     falls back to Ctrl+` (a parse-fallback the log notes).
+    [Fact(Skip = "Manual smoke; compositor slide/fade over quick-terminal-animation-duration, plus 0=instant and rapid-toggle stability.")]
+    public void Animation_SlidesOrFades_FromConfiguredEdge()
+    {
+    }
+
+    [Fact(Skip = "Manual smoke; quick-terminal-autohide=true hides on focus loss, =false keeps the window open.")]
+    public void Autohide_HidesOnFocusLoss_WhenEnabled()
+    {
+    }
+
+    [Fact(Skip = "Manual smoke; quick-terminal-key rebinds the global hotkey on reload; invalid values fall back to Ctrl+`.")]
+    public void KeyOverride_RebindsGlobalHotkey_OnReload()
+    {
+    }
 }

--- a/windows/Ghostty.Tests/Input/QuickTerminalKeyChordTests.cs
+++ b/windows/Ghostty.Tests/Input/QuickTerminalKeyChordTests.cs
@@ -1,0 +1,74 @@
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class QuickTerminalKeyChordTests
+{
+    // Win32 fsModifiers, repeated here so the test is independent of the
+    // type under test (a copy-paste bug in the constants is caught).
+    private const uint Alt = 0x0001;
+    private const uint Control = 0x0002;
+    private const uint Shift = 0x0004;
+    private const uint Win = 0x0008;
+    private const uint NoRepeat = 0x4000;
+
+    [Fact]
+    public void Default_Is_Ctrl_Backquote_NoRepeat()
+    {
+        var d = QuickTerminalKeyChord.Default;
+        Assert.Equal(Control | NoRepeat, d.Modifiers);
+        Assert.Equal(0xC0u, d.VirtualKey); // VK_OEM_3
+    }
+
+    [Theory]
+    [InlineData("ctrl+backquote", Control | NoRepeat, 0xC0u)]
+    [InlineData("ctrl+grave_accent", Control | NoRepeat, 0xC0u)] // alias
+    [InlineData("ctrl+`", Control | NoRepeat, 0xC0u)]            // literal char
+    [InlineData("control+backquote", Control | NoRepeat, 0xC0u)] // long modifier name
+    [InlineData("alt+space", Alt | NoRepeat, 0x20u)]
+    [InlineData("ctrl+shift+f1", Control | Shift | NoRepeat, 0x70u)]
+    [InlineData("super+a", Win | NoRepeat, 0x41u)]
+    [InlineData("win+a", Win | NoRepeat, 0x41u)]
+    [InlineData("ctrl+1", Control | NoRepeat, 0x31u)]
+    [InlineData("ctrl+escape", Control | NoRepeat, 0x1Bu)]
+    [InlineData("ctrl+arrow_up", Control | NoRepeat, 0x26u)]
+    [InlineData("ctrl+up", Control | NoRepeat, 0x26u)]           // arrow alias
+    [InlineData("CTRL+BackQuote", Control | NoRepeat, 0xC0u)]    // case-insensitive
+    [InlineData("ctrl + backquote", Control | NoRepeat, 0xC0u)]  // surrounding spaces
+    [InlineData("f12", NoRepeat, 0x7Bu)]                         // modifier-less function key OK
+    public void Parse_Valid(string input, uint expectedMods, uint expectedVk)
+    {
+        var chord = QuickTerminalKeyChord.Parse(input);
+        Assert.NotNull(chord);
+        Assert.Equal(expectedMods, chord!.Value.Modifiers);
+        Assert.Equal(expectedVk, chord.Value.VirtualKey);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("ctrl")]              // modifier only, no key
+    [InlineData("ctrl+shift")]        // modifiers only
+    [InlineData("ctrl+nonsense")]     // unknown key token
+    [InlineData("ctrl+a+b")]          // two non-modifier keys
+    [InlineData("a")]                 // modifier-less printable key (foot-gun guard)
+    [InlineData("ctrl+ctrl+a")]       // see note: short-circuited, asserted in dedicated fact
+    public void Parse_Invalid_Returns_Null(string? input)
+    {
+        // "ctrl+ctrl+a" is intentionally valid (dup modifier, key a); it is
+        // excluded here and asserted in the dedicated fact below.
+        if (input == "ctrl+ctrl+a") return;
+        Assert.Null(QuickTerminalKeyChord.Parse(input));
+    }
+
+    [Fact]
+    public void Parse_Duplicate_Modifier_Is_Idempotent()
+    {
+        var chord = QuickTerminalKeyChord.Parse("ctrl+ctrl+a");
+        Assert.NotNull(chord);
+        Assert.Equal(Control | NoRepeat, chord!.Value.Modifiers);
+        Assert.Equal(0x41u, chord.Value.VirtualKey);
+    }
+}

--- a/windows/Ghostty.Tests/Input/QuickTerminalKeyChordTests.cs
+++ b/windows/Ghostty.Tests/Input/QuickTerminalKeyChordTests.cs
@@ -37,6 +37,9 @@ public class QuickTerminalKeyChordTests
     [InlineData("CTRL+BackQuote", Control | NoRepeat, 0xC0u)]    // case-insensitive
     [InlineData("ctrl + backquote", Control | NoRepeat, 0xC0u)]  // surrounding spaces
     [InlineData("f12", NoRepeat, 0x7Bu)]                         // modifier-less function key OK
+    [InlineData("ctrl+f24", Control | NoRepeat, 0x87u)]
+    [InlineData("ctrl+bracket_left", Control | NoRepeat, 0xDBu)]
+    [InlineData("alt+page_up", Alt | NoRepeat, 0x21u)]
     public void Parse_Valid(string input, uint expectedMods, uint expectedVk)
     {
         var chord = QuickTerminalKeyChord.Parse(input);
@@ -54,12 +57,10 @@ public class QuickTerminalKeyChordTests
     [InlineData("ctrl+nonsense")]     // unknown key token
     [InlineData("ctrl+a+b")]          // two non-modifier keys
     [InlineData("a")]                 // modifier-less printable key (foot-gun guard)
-    [InlineData("ctrl+ctrl+a")]       // see note: short-circuited, asserted in dedicated fact
+    [InlineData("f0")]
+    [InlineData("f25")]
     public void Parse_Invalid_Returns_Null(string? input)
     {
-        // "ctrl+ctrl+a" is intentionally valid (dup modifier, key a); it is
-        // excluded here and asserted in the dedicated fact below.
-        if (input == "ctrl+ctrl+a") return;
         Assert.Null(QuickTerminalKeyChord.Parse(input));
     }
 

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -64,14 +64,10 @@ public partial class App : Application
     private MainWindow? _quakeWindow;
     private Ghostty.Hosting.WindowsGlobalHotKey? _quakeHotKey;
 
-    // Win32 RegisterHotKey constants for the default quake chord
-    // (Ctrl+backtick, no auto-fire while held). MOD_CONTROL = 0x0002,
-    // MOD_NOREPEAT = 0x4000, VK_OEM_3 = 0xC0. CsWin32 doesn't expose
-    // these as a single typed enum we'd want to combine, so naming
-    // them locally keeps the call site readable. The quick-terminal-key
-    // config override will replace these in a later PR.
-    private const uint QuakeHotKeyModifiers = 0x0002 | 0x4000;
-    private const uint QuakeHotKeyVirtualKey = 0xC0;
+    // The quake chord comes from the quick-terminal-key config value
+    // (read via ConfigService.QuickTerminalKeyChord). QuickTerminalKeyChord.Default
+    // is Ctrl+backtick (MOD_CONTROL|MOD_NOREPEAT, VK_OEM_3) when the
+    // user has not set the key explicitly.
 
     // Top-level window registry keyed by XamlRoot. Replaces the old
     // singular RootWindow and the earlier List<Window> draft: XamlRoot
@@ -609,17 +605,17 @@ public partial class App : Application
         _quakeWindow.Activate();          // creates the HWND
         _quakeWindow.AppWindow.Hide();    // immediately hide
 
-        // Default chord Ctrl+` (VK_OEM_3). MOD_NOREPEAT (0x4000)
-        // prevents auto-fire while the user holds the chord;
-        // MOD_CONTROL (0x0002) is the modifier. The
-        // quick-terminal-key config override lands in a later PR.
+        // Chord comes from quick-terminal-key config (Default = Ctrl+`).
+        // MOD_NOREPEAT prevents auto-fire while the user holds the chord.
         _quakeHotKey = new Ghostty.Hosting.WindowsGlobalHotKey(
             DispatcherQueue.GetForCurrentThread(),
             factory.CreateLogger<Ghostty.Hosting.WindowsGlobalHotKey>());
         _quakeHotKey.Pressed += (_, _) => ToggleQuickTerminal();
-        _quakeHotKey.Register(
-            modifiers: QuakeHotKeyModifiers,
-            virtualKey: QuakeHotKeyVirtualKey);
+        RegisterQuakeHotKey();
+
+        // Re-claim the chord whenever the config changes so an edited
+        // quick-terminal-key takes effect without a restart.
+        _configService.ConfigChanged += OnConfigReloaded_ReRegisterHotKey;
     }
 
     /// <summary>
@@ -641,6 +637,25 @@ public partial class App : Application
         {
             _quakeWindow?.ToggleVisibility();
         });
+    }
+
+    private void RegisterQuakeHotKey()
+    {
+        if (_quakeHotKey is null) return;
+        var chord = _configService.QuickTerminalKeyChord;
+        // Register already logs a warning + returns false when another
+        // process holds the chord; the app stays usable (command-palette
+        // entry + in-window chord still toggle the quake window), so there
+        // is nothing to do on failure here.
+        _quakeHotKey.Register(chord.Modifiers, chord.VirtualKey);
+    }
+
+    private void OnConfigReloaded_ReRegisterHotKey(Ghostty.Core.Config.IConfigService cfg)
+    {
+        // Register is idempotent (drops the prior chord first), so calling it
+        // on every reload is safe even when the chord did not change. Marshal
+        // to the UI thread (the thread that created the message-only window).
+        _uiDispatcher?.TryEnqueue(RegisterQuakeHotKey);
     }
 
     /// <summary>
@@ -782,6 +797,7 @@ public partial class App : Application
                 // bootstrap host tears down. WindowsGlobalHotKey.Dispose
                 // calls UnregisterHotKey on the UI thread (same thread
                 // that registered it).
+                _configService.ConfigChanged -= OnConfigReloaded_ReRegisterHotKey;
                 _quakeHotKey?.Dispose();
 
                 // Force-close the quake window. It does not participate

--- a/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
@@ -24,12 +24,23 @@ namespace Ghostty.Hosting;
 /// user re-toggles mid-animation, the stale batch's Completed handler is
 /// ignored so a half-finished hide does not call Hide() after a new show.
 /// </summary>
-internal sealed class QuickTerminalSlideAnimator
+internal sealed class QuickTerminalSlideAnimator : IDisposable
 {
     private readonly UIElement _content;
     private readonly Visual _visual;
     private readonly Compositor _compositor;
     private long _token;
+
+    // Cached easing functions (constants) created once and reused across
+    // toggles, disposed in Dispose(). Avoids per-toggle allocation.
+    private CubicBezierEasingFunction? _easeIn;
+    private CubicBezierEasingFunction? _easeOut;
+
+    // The most recent run's compositor objects. Disposed at the start of the
+    // next run (and in Dispose()), so at most one batch+animation lingers
+    // between toggles rather than accumulating one pair per toggle.
+    private CompositionScopedBatch? _batch;
+    private CompositionAnimation? _anim;
 
     public QuickTerminalSlideAnimator(UIElement content)
     {
@@ -86,12 +97,19 @@ internal sealed class QuickTerminalSlideAnimator
         };
         var isCenter = position == QuickTerminalPosition.Center;
 
+        // Dispose the previous run's compositor objects before starting a
+        // new one, so at most one batch+animation lingers between toggles.
+        _anim?.Dispose();
+        _batch?.Dispose();
+
         // Ease-out on appear (decelerate into place), ease-in on hide.
-        var easing = appearing
-            ? _compositor.CreateCubicBezierEasingFunction(new Vector2(0.1f, 0.9f), new Vector2(0.2f, 1.0f))
-            : _compositor.CreateCubicBezierEasingFunction(new Vector2(0.8f, 0.0f), new Vector2(0.9f, 0.1f));
+        // Cached: the bezier control points are constants.
+        _easeIn ??= _compositor.CreateCubicBezierEasingFunction(new Vector2(0.1f, 0.9f), new Vector2(0.2f, 1.0f));
+        _easeOut ??= _compositor.CreateCubicBezierEasingFunction(new Vector2(0.8f, 0.0f), new Vector2(0.9f, 0.1f));
+        var easing = appearing ? _easeIn : _easeOut;
 
         var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+        CompositionAnimation anim;
 
         if (isCenter)
         {
@@ -102,6 +120,7 @@ internal sealed class QuickTerminalSlideAnimator
             fade.InsertKeyFrame(1f, appearing ? 1f : 0f, easing);
             fade.Duration = duration;
             _visual.StartAnimation("Opacity", fade);
+            anim = fade;
         }
         else
         {
@@ -110,7 +129,11 @@ internal sealed class QuickTerminalSlideAnimator
             slide.InsertKeyFrame(1f, appearing ? Vector3.Zero : off, easing);
             slide.Duration = duration;
             _visual.StartAnimation("Translation", slide);
+            anim = slide;
         }
+
+        _batch = batch;
+        _anim = anim;
 
         batch.End();
         batch.Completed += (_, _) =>
@@ -132,7 +155,21 @@ internal sealed class QuickTerminalSlideAnimator
         _token++;
         _visual.StopAnimation("Translation");
         _visual.StopAnimation("Opacity");
+        _anim?.Dispose();
+        _batch?.Dispose();
+        _anim = null;
+        _batch = null;
         _visual.Properties.InsertVector3("Translation", Vector3.Zero);
         _visual.Opacity = 1f;
+    }
+
+    public void Dispose()
+    {
+        _visual.StopAnimation("Translation");
+        _visual.StopAnimation("Opacity");
+        _anim?.Dispose();
+        _batch?.Dispose();
+        _easeIn?.Dispose();
+        _easeOut?.Dispose();
     }
 }

--- a/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Numerics;
+using Ghostty.Core.Hosting;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Hosting;
+
+namespace Ghostty.Hosting;
+
+/// <summary>
+/// Runs the quake show/hide animation on a window's root content visual
+/// using <see cref="Microsoft.UI.Composition"/> (the lifted
+/// DirectComposition API). The window is always placed at its final rect
+/// first (by the caller); this only translates / fades the *content*, so
+/// no swap-chain resize occurs and the SwapChainPanel-bound DX12 terminal
+/// rides along on the compositor thread.
+///
+/// Edge positions (top/bottom/left/right) slide via the element's
+/// <c>Translation</c> facade (enabled once with
+/// <see cref="ElementCompositionPreview.SetIsTranslationEnabled"/>).
+/// Center has no edge to slide from, so it fades opacity 0..1.
+///
+/// A monotonically increasing token guards completion callbacks: if the
+/// user re-toggles mid-animation, the stale batch's Completed handler is
+/// ignored so a half-finished hide does not call Hide() after a new show.
+/// </summary>
+internal sealed class QuickTerminalSlideAnimator
+{
+    private readonly UIElement _content;
+    private readonly Visual _visual;
+    private readonly Compositor _compositor;
+    private long _token;
+
+    public QuickTerminalSlideAnimator(UIElement content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        _content = content;
+        // Translation composes WITH XAML layout (unlike Offset, which
+        // replaces it), so animating it never fights the layout pass.
+        ElementCompositionPreview.SetIsTranslationEnabled(content, true);
+        _visual = ElementCompositionPreview.GetElementVisual(content);
+        _compositor = _visual.Compositor;
+    }
+
+    /// <summary>Slide / fade the content into view from the docked edge.</summary>
+    public void AnimateIn(
+        QuickTerminalPosition position,
+        double width,
+        double height,
+        TimeSpan duration,
+        Action? onCompleted)
+    {
+        Run(position, width, height, duration, appearing: true, onCompleted);
+    }
+
+    /// <summary>Slide / fade the content out, then invoke onCompleted (Hide()).</summary>
+    public void AnimateOut(
+        QuickTerminalPosition position,
+        double width,
+        double height,
+        TimeSpan duration,
+        Action? onCompleted)
+    {
+        Run(position, width, height, duration, appearing: false, onCompleted);
+    }
+
+    private void Run(
+        QuickTerminalPosition position,
+        double width,
+        double height,
+        TimeSpan duration,
+        bool appearing,
+        Action? onCompleted)
+    {
+        var token = ++_token;
+
+        // Off-screen translation vector for the docked edge. Center uses
+        // opacity instead, so its offset is zero.
+        var off = position switch
+        {
+            QuickTerminalPosition.Top => new Vector3(0f, -(float)height, 0f),
+            QuickTerminalPosition.Bottom => new Vector3(0f, (float)height, 0f),
+            QuickTerminalPosition.Left => new Vector3(-(float)width, 0f, 0f),
+            QuickTerminalPosition.Right => new Vector3((float)width, 0f, 0f),
+            _ => Vector3.Zero, // Center
+        };
+        var isCenter = position == QuickTerminalPosition.Center;
+
+        // Ease-out on appear (decelerate into place), ease-in on hide.
+        var easing = appearing
+            ? _compositor.CreateCubicBezierEasingFunction(new Vector2(0.1f, 0.9f), new Vector2(0.2f, 1.0f))
+            : _compositor.CreateCubicBezierEasingFunction(new Vector2(0.8f, 0.0f), new Vector2(0.9f, 0.1f));
+
+        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
+
+        if (isCenter)
+        {
+            // Fade. Set the start opacity explicitly so a re-toggle from a
+            // partial state still animates the full range.
+            _visual.Opacity = appearing ? 0f : 1f;
+            var fade = _compositor.CreateScalarKeyFrameAnimation();
+            fade.InsertKeyFrame(1f, appearing ? 1f : 0f, easing);
+            fade.Duration = duration;
+            _visual.StartAnimation("Opacity", fade);
+        }
+        else
+        {
+            var slide = _compositor.CreateVector3KeyFrameAnimation();
+            slide.InsertKeyFrame(0f, appearing ? off : Vector3.Zero);
+            slide.InsertKeyFrame(1f, appearing ? Vector3.Zero : off, easing);
+            slide.Duration = duration;
+            _visual.StartAnimation("Translation", slide);
+        }
+
+        batch.End();
+        batch.Completed += (_, _) =>
+        {
+            if (token != _token) return; // superseded by a newer toggle
+            // Normalize to the resting state so the next show starts clean.
+            if (isCenter) _visual.Opacity = appearing ? 1f : 0f;
+            onCompleted?.Invoke();
+        };
+    }
+
+    /// <summary>
+    /// Snap to the fully-shown resting state with no animation (used when
+    /// duration == 0, or to clear a half-finished animation). Bumps the
+    /// token so any in-flight batch completion is ignored.
+    /// </summary>
+    public void SnapToShown()
+    {
+        _token++;
+        _visual.StopAnimation("Translation");
+        _visual.StopAnimation("Opacity");
+        _visual.Properties.InsertVector3("Translation", Vector3.Zero);
+        _visual.Opacity = 1f;
+    }
+}

--- a/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
@@ -124,6 +124,10 @@ internal sealed class QuickTerminalSlideAnimator : IDisposable
         }
         else
         {
+            // Seed the start translation synchronously (mirrors the fade
+            // path's Opacity pre-set) so no frame renders at the resting
+            // position before the compositor applies keyframe 0.
+            _visual.Properties.InsertVector3("Translation", appearing ? off : Vector3.Zero);
             var slide = _compositor.CreateVector3KeyFrameAnimation();
             slide.InsertKeyFrame(0f, appearing ? off : Vector3.Zero);
             slide.InsertKeyFrame(1f, appearing ? Vector3.Zero : off, easing);
@@ -135,7 +139,6 @@ internal sealed class QuickTerminalSlideAnimator : IDisposable
         _batch = batch;
         _anim = anim;
 
-        batch.End();
         batch.Completed += (_, _) =>
         {
             if (token != _token) return; // superseded by a newer toggle
@@ -143,6 +146,7 @@ internal sealed class QuickTerminalSlideAnimator : IDisposable
             if (isCenter) _visual.Opacity = appearing ? 1f : 0f;
             onCompleted?.Invoke();
         };
+        batch.End();
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -141,5 +141,33 @@
                   Visibility="Collapsed"
                   ToolTipService.ToolTip="Power saving mode active."/>
 
+        <!--
+            Quake pin toggle. Always-visible top-right toggle shown only
+            on the singleton quake window (made Visible in
+            ApplyQuickTerminalBehaviour). While pinned, the window does
+            not auto-hide on focus loss. Session-only: not persisted.
+            Spans both rows so it stays anchored to the window top-right
+            even when the tab strip (row 0) is collapsed at one tab. Sits
+            where the OS caption buttons used to be.
+        -->
+        <ToggleButton x:Name="QuakePinButton"
+                      Grid.Row="0" Grid.RowSpan="2"
+                      Grid.Column="0" Grid.ColumnSpan="2"
+                      HorizontalAlignment="Right"
+                      VerticalAlignment="Top"
+                      Margin="0,6,8,0"
+                      Width="32" Height="28"
+                      Padding="0"
+                      Background="Transparent"
+                      BorderThickness="0"
+                      Visibility="Collapsed"
+                      Checked="OnQuakePinChanged"
+                      Unchecked="OnQuakePinChanged"
+                      ToolTipService.ToolTip="Pin: keep open on focus loss">
+            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                      Glyph="&#xE718;"
+                      FontSize="14"/>
+        </ToggleButton>
+
     </Grid>
 </Window>

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -163,6 +163,7 @@
                       Visibility="Collapsed"
                       Checked="OnQuakePinChanged"
                       Unchecked="OnQuakePinChanged"
+                      AutomationProperties.Name="Pin quick terminal open"
                       ToolTipService.ToolTip="Pin: keep open on focus loss">
             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
                       Glyph="&#xE718;"

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1004,6 +1004,7 @@ public sealed partial class MainWindow : Window
 
         _gradientVisual?.Dispose();
         _gradientVisual = null;
+        _slideAnimator?.Dispose();
         _taskbar.Dispose();
         _themeManager.Dispose();
 
@@ -1882,6 +1883,7 @@ public sealed partial class MainWindow : Window
     /// <summary>
     /// Hide the quake window, animating the slide-out first when a non-zero
     /// animation duration is configured. Used by the toggle and by autohide.
+    /// (Hides the AppWindow; this is not a Window override -- Window has no Hide().)
     /// </summary>
     private void Hide()
     {
@@ -1898,7 +1900,12 @@ public sealed partial class MainWindow : Window
             AppWindow.Size.Width,
             AppWindow.Size.Height,
             TimeSpan.FromSeconds(duration),
-            onCompleted: () => AppWindow.Hide());
+            onCompleted: () =>
+            {
+                // Completed fires on the UI thread (same context as the
+                // GetElementVisual visual), so AppWindow.Hide() is safe here.
+                AppWindow.Hide();
+            });
     }
 
     private void FocusActiveLeaf()

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -958,9 +958,18 @@ public sealed partial class MainWindow : Window
             powerMonitor.LowPowerChanged -= OnLowPowerChanged;
         }
 
-        // Persist window placement for next launch. Skip when
-        // fullscreen -- restore to the normal size instead.
-        if (AppWindow.Presenter.Kind != Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen)
+        if (IsQuickTerminal)
+        {
+            // Persist only the session-resized height, via read-modify-write
+            // so we never clobber the regular window placement other windows
+            // save. The quake window's X/Y/Width are config-driven
+            // (MoveToQuakePosition), so its geometry must NOT become the
+            // restore placement.
+            var quakeState = WindowState.Load();
+            quakeState.QuakeHeight = _quakeSessionHeight;
+            quakeState.Save();
+        }
+        else if (AppWindow.Presenter.Kind != Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen)
         {
             var hwnd = new HWND(WindowNative.GetWindowHandle(this));
             var style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
@@ -1818,6 +1827,10 @@ public sealed partial class MainWindow : Window
         _tabManager.TabAdded += (_, _) => UpdateQuakeStripVisibility();
         _tabManager.TabRemoved += (_, _) => UpdateQuakeStripVisibility();
         UpdateQuakeStripVisibility();
+
+        // Restore the per-user remembered quake height so the first show after
+        // login uses it (MoveToQuakePosition applies it for top/bottom docking).
+        _quakeSessionHeight = _windowState.QuakeHeight;
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1780,6 +1780,10 @@ public sealed partial class MainWindow : Window
         // and drop the vertical-mode title text.
         _titleBar.SetCaptionless(true);
 
+        // Show the session-only pin button so the user can keep the quake
+        // window open on focus loss. Invisible on regular windows by default.
+        QuakePinButton.Visibility = Visibility.Visible;
+
         AppWindow.Closing += (_, args) =>
         {
             // The shutdown path in App.OnAnyWindowClosedInternal sets
@@ -1818,9 +1822,15 @@ public sealed partial class MainWindow : Window
         _layout.SetStripHidden(_tabManager.Tabs.Count <= 1, _verticalTabsVisible);
     }
 
+    private void OnQuakePinChanged(object sender, RoutedEventArgs e)
+    {
+        _quakePinned = QuakePinButton.IsChecked == true;
+    }
+
     private void OnQuakeActivated(object sender, WindowActivatedEventArgs args)
     {
         if (args.WindowActivationState != WindowActivationState.Deactivated) return;
+        if (_quakePinned) return;   // user pinned the window open this session
         if (!_autohideArmed) return;
         if (!AppWindow.IsVisible) return;
         if (!_configService.QuickTerminalAutohide) return;
@@ -1846,6 +1856,11 @@ public sealed partial class MainWindow : Window
     // transient activation churn during Show()/focus does not immediately
     // trigger a hide.
     private bool _autohideArmed;
+
+    // Session-only pin: while true, the quake window does not auto-hide on
+    // focus loss. Toggled by the top-right pin button (quake window only).
+    // Not persisted; resets on app restart.
+    private bool _quakePinned;
 
     /// <summary>
     /// Position the window per <c>quick-terminal-position</c>,

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1784,6 +1784,11 @@ public sealed partial class MainWindow : Window
         // and drop the vertical-mode title text.
         _titleBar.SetCaptionless(true);
 
+        // Quake never shows the top vertical title bar; the strip's own wintty
+        // icon sits above the tabs instead. Layout toggle stays available via
+        // the Ctrl+Shift+, chord.
+        _layout.SuppressVerticalTitleBar(true, _verticalTabsVisible);
+
         // Show the session-only pin button so the user can keep the quake
         // window open on focus loss. Invisible on regular windows by default.
         QuakePinButton.Visibility = Visibility.Visible;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1795,6 +1795,23 @@ public sealed partial class MainWindow : Window
         // _autohideArmed so the activation churn during Show()/focus does not
         // self-trigger.
         Activated += OnQuakeActivated;
+
+        // Hide the tab strip while a single tab is open; show it at 2+.
+        // Tab count is already updated when these events fire.
+        _tabManager.TabAdded += (_, _) => UpdateQuakeStripVisibility();
+        _tabManager.TabRemoved += (_, _) => UpdateQuakeStripVisibility();
+        UpdateQuakeStripVisibility();
+    }
+
+    /// <summary>
+    /// Quake-only: hide the tab strip when a single tab is open, show it
+    /// at two or more. Routed through the LayoutCoordinator so it honors
+    /// the current horizontal/vertical mode and survives layout toggles.
+    /// </summary>
+    private void UpdateQuakeStripVisibility()
+    {
+        if (!IsQuickTerminal) return;
+        _layout.SetStripHidden(_tabManager.Tabs.Count <= 1, _verticalTabsVisible);
     }
 
     private void OnQuakeActivated(object sender, WindowActivatedEventArgs args)

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1879,6 +1879,11 @@ public sealed partial class MainWindow : Window
     // trigger a hide.
     private bool _autohideArmed;
 
+    // True while a slide-out is in flight (window still IsVisible until the
+    // animation completes). A toggle during this window means "bring it
+    // back", so ToggleVisibility must re-show rather than hide again.
+    private bool _hiding;
+
     // Session-only pin: while true, the quake window does not auto-hide on
     // focus loss. Toggled by the top-right pin button (quake window only).
     // Not persisted; resets on app restart.
@@ -1949,14 +1954,26 @@ public sealed partial class MainWindow : Window
     /// </summary>
     public void ToggleVisibility()
     {
-        if (AppWindow.IsVisible)
+        // Shown and not already sliding out -> hide. If mid-slide-out, a
+        // toggle means "bring it back", so fall through to Show(), which
+        // cancels the hide (the animator's token guard suppresses the
+        // superseded slide-out completion) and animates back in.
+        if (AppWindow.IsVisible && !_hiding)
         {
             Hide();
             return;
         }
+        Show();
+    }
 
-        MoveToQuakePosition();
-        AppWindow.Show();
+    private void Show()
+    {
+        _hiding = false;
+        if (!AppWindow.IsVisible)
+        {
+            MoveToQuakePosition();
+            AppWindow.Show();
+        }
 
         var duration = _configService.QuickTerminalAnimationDuration;
         if (duration <= 0)
@@ -1999,6 +2016,7 @@ public sealed partial class MainWindow : Window
             return;
         }
 
+        _hiding = true;
         _slideAnimator.AnimateOut(
             _configService.QuickTerminalPosition,
             AppWindow.Size.Width,
@@ -2006,9 +2024,17 @@ public sealed partial class MainWindow : Window
             TimeSpan.FromSeconds(duration),
             onCompleted: () =>
             {
-                // Completed fires on the UI thread (same context as the
-                // GetElementVisual visual), so AppWindow.Hide() is safe here.
-                AppWindow.Hide();
+                // A re-show during the slide-out clears _hiding to cancel the
+                // hide (the animator token guard already suppresses a
+                // superseded Completed; this is belt-and-suspenders). Also
+                // skip when the window is hard-closing on shutdown.
+                if (!_hiding || _hardCloseQuake) return;
+                _hiding = false;
+                // Completed fires on the UI thread (same context as
+                // GetElementVisual), so AppWindow.Hide() is safe; guard
+                // against a COM teardown race during shutdown.
+                try { AppWindow.Hide(); }
+                catch (System.Runtime.InteropServices.COMException) { }
             });
     }
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -488,10 +488,14 @@ public sealed partial class MainWindow : Window
 
         _taskbar = new TaskbarHost(this, _tabManager, loggerFactory.CreateLogger<TaskbarHost>());
 
-        AppWindow.Changed += (_, _) =>
+        AppWindow.Changed += (_, args) =>
         {
             _taskbar.OnAppWindowChanged(AppWindow);
             _titleBar.SyncCaptionInset();
+            if (IsQuickTerminal && args.DidSizeChange && !_movingQuake && AppWindow.IsVisible)
+            {
+                _quakeSessionHeight = AppWindow.Size.Height;
+            }
         };
 
         InstallPaneAccelerators();
@@ -1765,13 +1769,13 @@ public sealed partial class MainWindow : Window
 
         // Borderless: a quake terminal is positioned by config and toggled by
         // the global hotkey, so it needs no title bar, border, caption buttons,
-        // or user resize/min/max. Keep it activatable so autohide's
-        // Activated/Deactivated still fire, and keep the close->hide intercept
-        // (Alt+F4 still routes through Closing).
+        // or min/max. IsResizable=true keeps the (unpainted) resize frame so
+        // the user can drag the bottom edge to change height; the docked
+        // top/side edges sit at the monitor bounds and stay fixed.
         if (AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
         {
             presenter.SetBorderAndTitleBar(hasBorder: false, hasTitleBar: false);
-            presenter.IsResizable = false;
+            presenter.IsResizable = true;
             presenter.IsMinimizable = false;
             presenter.IsMaximizable = false;
         }
@@ -1862,6 +1866,17 @@ public sealed partial class MainWindow : Window
     // Not persisted; resets on app restart.
     private bool _quakePinned;
 
+    // User-resized height for the quake window, remembered for the session
+    // so toggling hide/show preserves it instead of snapping back to the
+    // quick-terminal-size config. Null until the user first resizes. Resets
+    // on app restart (session-only, like the pin).
+    private int? _quakeSessionHeight;
+
+    // True while MoveToQuakePosition is programmatically moving/resizing the
+    // window, so the AppWindow.Changed size-capture below ignores our own
+    // resize and only records genuine user drags.
+    private bool _movingQuake;
+
     /// <summary>
     /// Position the window per <c>quick-terminal-position</c>,
     /// <c>quick-terminal-size</c>, and <c>quick-terminal-screen</c>.
@@ -1871,20 +1886,42 @@ public sealed partial class MainWindow : Window
     /// </summary>
     public void MoveToQuakePosition()
     {
-        var hwnd = WindowNative.GetWindowHandle(this);
-        var bounds = QuickTerminalMonitorResolver.Resolve(
-            hwnd, _configService.QuickTerminalScreen);
-        var rect = Ghostty.Core.Hosting.QuickTerminalGeometry.Resolve(
-            _configService.QuickTerminalPosition,
-            _configService.QuickTerminalSize,
-            bounds);
-        AppWindow.MoveAndResize(new Windows.Graphics.RectInt32
+        _movingQuake = true;
+        try
         {
-            X = rect.X,
-            Y = rect.Y,
-            Width = rect.Width,
-            Height = rect.Height,
-        });
+            var hwnd = WindowNative.GetWindowHandle(this);
+            var bounds = QuickTerminalMonitorResolver.Resolve(
+                hwnd, _configService.QuickTerminalScreen);
+            var position = _configService.QuickTerminalPosition;
+            var rect = Ghostty.Core.Hosting.QuickTerminalGeometry.Resolve(
+                position,
+                _configService.QuickTerminalSize,
+                bounds);
+
+            // Apply a session resize (height only) for top/bottom docking.
+            // Top keeps Y at the monitor top and grows downward; bottom keeps
+            // its bottom edge pinned and grows upward.
+            if (_quakeSessionHeight is int sessionH &&
+                (position == Ghostty.Core.Hosting.QuickTerminalPosition.Top ||
+                 position == Ghostty.Core.Hosting.QuickTerminalPosition.Bottom))
+            {
+                var h = Math.Clamp(sessionH, 100, bounds.Height);
+                rect = position == Ghostty.Core.Hosting.QuickTerminalPosition.Bottom
+                    ? rect with { Y = bounds.Bottom - h, Height = h }
+                    : rect with { Height = h };
+            }
+
+            AppWindow.MoveAndResize(new Windows.Graphics.RectInt32
+            {
+                X = rect.X, Y = rect.Y, Width = rect.Width, Height = rect.Height,
+            });
+        }
+        finally
+        {
+            // Reset on the dispatcher so any queued AppWindow.Changed from our
+            // own MoveAndResize is still guarded (it can fire after this returns).
+            DispatcherQueue.TryEnqueue(() => _movingQuake = false);
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1763,6 +1763,19 @@ public sealed partial class MainWindow : Window
             WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE,
             unchecked((int)(ex | WINDOW_EX_STYLE.WS_EX_TOOLWINDOW)));
 
+        // Borderless: a quake terminal is positioned by config and toggled by
+        // the global hotkey, so it needs no title bar, border, caption buttons,
+        // or user resize/min/max. Keep it activatable so autohide's
+        // Activated/Deactivated still fire, and keep the close->hide intercept
+        // (Alt+F4 still routes through Closing).
+        if (AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+        {
+            presenter.SetBorderAndTitleBar(hasBorder: false, hasTitleBar: false);
+            presenter.IsResizable = false;
+            presenter.IsMinimizable = false;
+            presenter.IsMaximizable = false;
+        }
+
         AppWindow.Closing += (_, args) =>
         {
             // The shutdown path in App.OnAnyWindowClosedInternal sets

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1773,6 +1773,23 @@ public sealed partial class MainWindow : Window
             args.Cancel = true;
             AppWindow.Hide();
         };
+
+        // Autohide: when the quake window loses activation to another window,
+        // hide it (unless the user opted out). In-window overlays (command
+        // palette, ContentDialog) do NOT deactivate the window, so this only
+        // fires on a genuine switch to another app/window. Gated on
+        // _autohideArmed so the activation churn during Show()/focus does not
+        // self-trigger.
+        Activated += OnQuakeActivated;
+    }
+
+    private void OnQuakeActivated(object sender, WindowActivatedEventArgs args)
+    {
+        if (args.WindowActivationState != WindowActivationState.Deactivated) return;
+        if (!_autohideArmed) return;
+        if (!AppWindow.IsVisible) return;
+        if (!_configService.QuickTerminalAutohide) return;
+        Hide();
     }
 
     /// <summary>
@@ -1784,6 +1801,16 @@ public sealed partial class MainWindow : Window
     /// </summary>
     internal void RequestHardClose() => _hardCloseQuake = true;
     private bool _hardCloseQuake;
+
+    // Lazily-built slide/fade animator for the quake window. Null until the
+    // first show (the XAML content visual must exist first). Only used when
+    // IsQuickTerminal and animation duration > 0.
+    private QuickTerminalSlideAnimator? _slideAnimator;
+
+    // Autohide is only armed once a show animation has fully settled, so the
+    // transient activation churn during Show()/focus does not immediately
+    // trigger a hide.
+    private bool _autohideArmed;
 
     /// <summary>
     /// Position the window per <c>quick-terminal-position</c>,
@@ -1819,11 +1846,63 @@ public sealed partial class MainWindow : Window
     {
         if (AppWindow.IsVisible)
         {
+            Hide();
+            return;
+        }
+
+        MoveToQuakePosition();
+        AppWindow.Show();
+
+        var duration = _configService.QuickTerminalAnimationDuration;
+        if (duration <= 0)
+        {
+            _slideAnimator?.SnapToShown();
+            _autohideArmed = true;
+            FocusActiveLeaf();
+            return;
+        }
+
+        _autohideArmed = false;
+        _slideAnimator ??= new QuickTerminalSlideAnimator(RootGrid);
+        _slideAnimator.AnimateIn(
+            _configService.QuickTerminalPosition,
+            AppWindow.Size.Width,
+            AppWindow.Size.Height,
+            TimeSpan.FromSeconds(duration),
+            onCompleted: () =>
+            {
+                _autohideArmed = true;
+                FocusActiveLeaf();
+            });
+        // Focus immediately too so typing works during the slide; the
+        // onCompleted re-focus is a no-op if focus already landed.
+        FocusActiveLeaf();
+    }
+
+    /// <summary>
+    /// Hide the quake window, animating the slide-out first when a non-zero
+    /// animation duration is configured. Used by the toggle and by autohide.
+    /// </summary>
+    private void Hide()
+    {
+        _autohideArmed = false;
+        var duration = _configService.QuickTerminalAnimationDuration;
+        if (duration <= 0 || _slideAnimator is null)
+        {
             AppWindow.Hide();
             return;
         }
-        MoveToQuakePosition();
-        AppWindow.Show();
+
+        _slideAnimator.AnimateOut(
+            _configService.QuickTerminalPosition,
+            AppWindow.Size.Width,
+            AppWindow.Size.Height,
+            TimeSpan.FromSeconds(duration),
+            onCompleted: () => AppWindow.Hide());
+    }
+
+    private void FocusActiveLeaf()
+    {
         DispatcherQueue.TryEnqueue(() =>
             _tabManager.ActiveTab?.PaneHost?.ActiveLeaf?.Terminal()
                 .Focus(FocusState.Programmatic));

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1776,6 +1776,10 @@ public sealed partial class MainWindow : Window
             presenter.IsMaximizable = false;
         }
 
+        // Borderless quake has no OS caption buttons; collapse the dead inset
+        // and drop the vertical-mode title text.
+        _titleBar.SetCaptionless(true);
+
         AppWindow.Closing += (_, args) =>
         {
             // The shutdown path in App.OnAnyWindowClosedInternal sets

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -117,6 +117,36 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     public Ghostty.Core.Hosting.QuickTerminalSize QuickTerminalSize => ReadQuickTerminalSize();
 
     /// <summary>
+    /// Hide the quake window when it loses focus. libghostty defaults this
+    /// to <c>false</c> on Windows (the non-mac/non-linux branch), but the
+    /// canonical quake behaviour (and macOS) is hide-on-focus-loss, so we
+    /// read it from the raw config file with a wintty default of <c>true</c>.
+    /// An explicit <c>quick-terminal-autohide = false</c> still disables it.
+    /// </summary>
+    public bool QuickTerminalAutohide =>
+        WindowsOnlyKeyParsers.ParseBool(
+            GetFileValue("quick-terminal-autohide", ""),
+            defaultValue: true);
+
+    /// <summary>
+    /// Slide/fade duration in seconds. libghostty key (f64, default 0.2,
+    /// platform-independent). 0 disables animation (instant show/hide).
+    /// Clamped to a sane ceiling so a typo can't freeze the window mid-slide.
+    /// </summary>
+    public double QuickTerminalAnimationDuration =>
+        Math.Clamp(GetDouble("quick-terminal-animation-duration", 0.2), 0.0, 2.0);
+
+    /// <summary>
+    /// Global hotkey that toggles the quake window. Wintty-only key, read
+    /// from the raw config file. Parse failure falls back to the built-in
+    /// Ctrl+backtick chord so the user is never left without a hotkey.
+    /// </summary>
+    public Ghostty.Core.Input.QuickTerminalKeyChord QuickTerminalKeyChord =>
+        Ghostty.Core.Input.QuickTerminalKeyChord.Parse(
+            GetFileValue("quick-terminal-key", ""))
+        ?? Ghostty.Core.Input.QuickTerminalKeyChord.Default;
+
+    /// <summary>
     /// Parsed light theme name from a conditional theme pair, or null
     /// if the theme is a single (non-conditional) value.
     /// </summary>

--- a/windows/Ghostty/Settings/WindowState.cs
+++ b/windows/Ghostty/Settings/WindowState.cs
@@ -36,6 +36,12 @@ internal sealed class WindowState
     public int? WindowHeight { get; set; }
     public bool WindowMaximized { get; set; }
 
+    // User-resized height of the quake / drop-down window, remembered
+    // per-user so a manual resize survives restarts. Null until the user
+    // first resizes. Distinct from WindowHeight (regular window placement);
+    // the quake window's X/Y/Width come from quick-terminal-* config.
+    public int? QuakeHeight { get; set; }
+
     private static string Dir
     {
         get

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -41,6 +41,11 @@ internal sealed class LayoutCoordinator
     private readonly Grid _verticalTitleBar;
 
     private bool _switching;
+    // When true (quake window with a single tab), the strip + vertical
+    // title bar are forced hidden regardless of layout mode, leaving only
+    // the pane host. Snap and Animate both honor it so the layout toggle
+    // cannot resurrect the strip.
+    private bool _stripHidden;
     private DispatcherTimer? _columnTimer;
 
     public LayoutCoordinator(
@@ -101,6 +106,30 @@ internal sealed class LayoutCoordinator
         GetOrCreateTranslate(_verticalHost).Y = 0;
         GetOrCreateTranslate(_horizontalHost).X = 0;
         GetOrCreateTranslate(_horizontalHost).Y = 0;
+
+        if (_stripHidden)
+        {
+            // Collapse everything in the strip/title row + column,
+            // leaving only the pane host (row 1, col 1) visible.
+            _stripColumn.Width = new GridLength(0);
+            _titleBarStripMirror.Width = new GridLength(0);
+            _horizontalHost.Visibility = Visibility.Collapsed;
+            _horizontalHost.IsHitTestVisible = false;
+            _verticalHost.Visibility = Visibility.Collapsed;
+            _verticalHost.IsHitTestVisible = false;
+            _verticalTitleBar.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    /// <summary>
+    /// Force the tab strip (and vertical title bar) hidden or restore it
+    /// to the normal end-state for the current layout. Used by the quake
+    /// window to hide tab chrome when only one tab is open.
+    /// </summary>
+    public void SetStripHidden(bool hidden, bool verticalTabs)
+    {
+        _stripHidden = hidden;
+        Snap(verticalTabs);
     }
 
     /// <summary>
@@ -114,6 +143,12 @@ internal sealed class LayoutCoordinator
     /// </summary>
     public void Animate(bool verticalTabs, Action? onCompleted = null)
     {
+        if (_stripHidden)
+        {
+            Snap(verticalTabs);
+            onCompleted?.Invoke();
+            return;
+        }
         if (_switching) return;
         _switching = true;
 

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -46,6 +46,11 @@ internal sealed class LayoutCoordinator
     // the pane host. Snap and Animate both honor it so the layout toggle
     // cannot resurrect the strip.
     private bool _stripHidden;
+    // Quake window: the top VerticalTitleBar (layout-toggle chevron +
+    // window title) is suppressed entirely. The wintty icon at the top of
+    // the vertical strip becomes the topmost element above the tabs. Layout
+    // switching still works via the keyboard chord.
+    private bool _verticalTitleBarSuppressed;
     private DispatcherTimer? _columnTimer;
 
     public LayoutCoordinator(
@@ -96,8 +101,16 @@ internal sealed class LayoutCoordinator
         _horizontalHost.Visibility = verticalTabs ? Visibility.Collapsed : Visibility.Visible;
         _horizontalHost.IsHitTestVisible = !verticalTabs;
 
-        _verticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
-        _verticalTitleBar.Opacity = verticalTabs ? 1 : 0;
+        if (_verticalTitleBarSuppressed)
+        {
+            _verticalTitleBar.Visibility = Visibility.Collapsed;
+            _verticalTitleBar.Opacity = 0;
+        }
+        else
+        {
+            _verticalTitleBar.Visibility = verticalTabs ? Visibility.Visible : Visibility.Collapsed;
+            _verticalTitleBar.Opacity = verticalTabs ? 1 : 0;
+        }
 
         // Reset any dangling translate offsets so future switches
         // start from origin. Safe to overwrite: Snap is only called
@@ -132,6 +145,12 @@ internal sealed class LayoutCoordinator
         Snap(verticalTabs);
     }
 
+    public void SuppressVerticalTitleBar(bool suppress, bool verticalTabs)
+    {
+        _verticalTitleBarSuppressed = suppress;
+        Snap(verticalTabs);
+    }
+
     /// <summary>
     /// Cross-fade + slide animation between horizontal and vertical
     /// layouts. Runs the chrome transforms (Opacity, RenderTransform)
@@ -154,7 +173,8 @@ internal sealed class LayoutCoordinator
 
         var targetColWidth = verticalTabs ? VerticalStripCollapsedWidth : 0;
 
-        _verticalTitleBar.Visibility = Visibility.Visible;
+        if (!_verticalTitleBarSuppressed)
+            _verticalTitleBar.Visibility = Visibility.Visible;
         _verticalHost.Visibility = Visibility.Visible;
         _horizontalHost.Visibility = Visibility.Visible;
 
@@ -181,8 +201,9 @@ internal sealed class LayoutCoordinator
         var sb = new Storyboard();
         sb.Children.Add(MakeDoubleAnim(incoming, "Opacity", 0, 1));
         sb.Children.Add(MakeDoubleAnim(outgoing, "Opacity", outgoing.Opacity, 0));
-        sb.Children.Add(MakeDoubleAnim(_verticalTitleBar, "Opacity",
-            verticalTabs ? 0 : 1, verticalTabs ? 1 : 0));
+        if (!_verticalTitleBarSuppressed)
+            sb.Children.Add(MakeDoubleAnim(_verticalTitleBar, "Opacity",
+                verticalTabs ? 0 : 1, verticalTabs ? 1 : 0));
 
         sb.Children.Add(MakeTransformAnim(incoming, "X", incomingTx.X, 0));
         sb.Children.Add(MakeTransformAnim(incoming, "Y", incomingTx.Y, 0));

--- a/windows/Ghostty/Shell/TitleBarCoordinator.cs
+++ b/windows/Ghostty/Shell/TitleBarCoordinator.cs
@@ -45,6 +45,12 @@ internal sealed class TitleBarCoordinator
     private TabModel? _boundTab;
     private LeafPane? _activeLeaf;
 
+    // Quake window: borderless, no OS caption buttons, so the reserved
+    // caption inset (vertical column + horizontal drag-region MinWidth) is
+    // dead space and the vertical-mode window title is noise. When set,
+    // SyncCaptionInset keeps the inset collapsed instead of re-expanding.
+    private bool _captionless;
+
     public TitleBarCoordinator(
         Window window,
         TabManager tabs,
@@ -95,6 +101,12 @@ internal sealed class TitleBarCoordinator
     /// </summary>
     public void SyncCaptionInset()
     {
+        if (_captionless)
+        {
+            _captionInset.Width = new GridLength(0);
+            return;
+        }
+
         try
         {
             var inset = _window.AppWindow.TitleBar.RightInset;
@@ -108,6 +120,21 @@ internal sealed class TitleBarCoordinator
             // RightInset can throw early during construction; leave
             // the XAML default in place.
         }
+    }
+
+    /// <summary>
+    /// Quake-only: collapse the caption-button inset (the OS buttons are
+    /// gone in borderless mode) and hide the vertical-mode title text for
+    /// a minimal look. Idempotent.
+    /// </summary>
+    public void SetCaptionless(bool value)
+    {
+        _captionless = value;
+        if (!value) return;
+        _captionInset.Width = new GridLength(0);
+        if (_horizontalTabHost.DragRegion is FrameworkElement dragRegion)
+            dragRegion.MinWidth = 0;
+        _verticalTitleText.Visibility = Visibility.Collapsed;
     }
 
     private void RebindVerticalTitle()


### PR DESCRIPTION
Completes the quake / drop-down terminal.

Config keys:
- quick-terminal-autohide (default true): hide when the window loses focus
- quick-terminal-animation-duration (default 0.2s, 0 disables): slide/fade
- quick-terminal-key (default ctrl+backquote): override the toggle hotkey

Window:
- borderless, no title bar or minimize/maximize/close buttons
- tab strip hidden when one tab is open, shown at two or more (horizontal and vertical)
- session pin to keep it open on focus loss
- vertical tabs show with no top bar; the app icon sits above the tabs
- height is resizable and remembered per user across restarts

The slide/fade runs on Microsoft.UI.Composition over the window content, so there
is no swap-chain resize. The QuickTerminalKeyChord parser is pure logic in
Ghostty.Core with unit tests. 1111 tests pass.