### PR TITLE
panes: show a cols x rows pill while resizing a pane

### DIFF
--- a/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayMode.cs
+++ b/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayMode.cs
@@ -1,0 +1,38 @@
+namespace Ghostty.Core.ResizeOverlay;
+
+/// <summary>
+/// When the resize overlay (the cols x rows pill shown while a pane is
+/// resized) is allowed to appear. Mirrors the libghostty `resize-overlay`
+/// config key (always / never / after-first).
+/// </summary>
+public enum ResizeOverlayMode
+{
+    /// <summary>Show on every grid-size change.</summary>
+    Always,
+
+    /// <summary>Never show.</summary>
+    Never,
+
+    /// <summary>
+    /// Do not show on the initial layout, only on subsequent changes.
+    /// This is the libghostty default and avoids flashing the overlay
+    /// when a pane first appears.
+    /// </summary>
+    AfterFirst,
+}
+
+public static class ResizeOverlayModeExtensions
+{
+    /// <summary>
+    /// Parse a libghostty-formatted enum tag. Unknown or null falls back
+    /// to <see cref="ResizeOverlayMode.AfterFirst"/> (the upstream
+    /// default), matching the resilient-to-config-typos philosophy.
+    /// </summary>
+    public static ResizeOverlayMode Parse(string? raw) => raw switch
+    {
+        "always" => ResizeOverlayMode.Always,
+        "never" => ResizeOverlayMode.Never,
+        "after-first" => ResizeOverlayMode.AfterFirst,
+        _ => ResizeOverlayMode.AfterFirst,
+    };
+}

--- a/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayPosition.cs
+++ b/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayPosition.cs
@@ -1,0 +1,36 @@
+namespace Ghostty.Core.ResizeOverlay;
+
+/// <summary>
+/// Where the resize overlay pill sits inside the pane. Mirrors the
+/// libghostty `resize-overlay-position` config key.
+/// </summary>
+public enum ResizeOverlayPosition
+{
+    Center,
+    TopLeft,
+    TopCenter,
+    TopRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+}
+
+public static class ResizeOverlayPositionExtensions
+{
+    /// <summary>
+    /// Parse a libghostty-formatted enum tag. Unknown or null falls back
+    /// to <see cref="ResizeOverlayPosition.Center"/> (the upstream
+    /// default).
+    /// </summary>
+    public static ResizeOverlayPosition Parse(string? raw) => raw switch
+    {
+        "center" => ResizeOverlayPosition.Center,
+        "top-left" => ResizeOverlayPosition.TopLeft,
+        "top-center" => ResizeOverlayPosition.TopCenter,
+        "top-right" => ResizeOverlayPosition.TopRight,
+        "bottom-left" => ResizeOverlayPosition.BottomLeft,
+        "bottom-center" => ResizeOverlayPosition.BottomCenter,
+        "bottom-right" => ResizeOverlayPosition.BottomRight,
+        _ => ResizeOverlayPosition.Center,
+    };
+}

--- a/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayState.cs
+++ b/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayState.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Ghostty.Core.ResizeOverlay;
+
+/// <summary>
+/// Observable state for the resize overlay: the transient pill that shows
+/// the terminal grid dimensions (e.g. "80 x 24") while a pane is being
+/// resized. Pure logic with no WinUI references; the ResizeOverlayControl
+/// owns an instance and binds its TextBlock to <see cref="SizeText"/>,
+/// while the per-pane controller calls <see cref="ShouldPulse"/> from the
+/// surface size-changed handler.
+///
+/// The decision of whether a given size change should make the pill appear
+/// lives here so it can be unit-tested. Time-based guards (the startup
+/// settle grace and the focus-bounce window) stay in the view because they
+/// depend on wall-clock instants the view already tracks.
+/// </summary>
+public sealed class ResizeOverlayState : INotifyPropertyChanged
+{
+    private int _columns;
+    private int _rows;
+    private bool _hasBaseline;
+
+    /// <summary>
+    /// Which <see cref="ResizeOverlayMode"/> governs visibility. Set by
+    /// the view from the current config before each <see cref="ShouldPulse"/>
+    /// call so hot-reloaded config is honored without a subscription.
+    /// </summary>
+    public ResizeOverlayMode Mode { get; set; } = ResizeOverlayMode.AfterFirst;
+
+    /// <summary>Most recently observed grid column count.</summary>
+    public int Columns
+    {
+        get => _columns;
+        private set
+        {
+            if (_columns == value) return;
+            _columns = value;
+            Notify(nameof(Columns));
+            Notify(nameof(SizeText));
+        }
+    }
+
+    /// <summary>Most recently observed grid row count.</summary>
+    public int Rows
+    {
+        get => _rows;
+        private set
+        {
+            if (_rows == value) return;
+            _rows = value;
+            Notify(nameof(Rows));
+            Notify(nameof(SizeText));
+        }
+    }
+
+    // U+00D7 MULTIPLICATION SIGN, the separator macOS Ghostty uses between
+    // columns and rows. Built from its code point so this source stays ASCII.
+    private const char Separator = (char)0x00D7;
+
+    /// <summary>
+    /// Display string for the pill, e.g. "80 x 24" (using U+00D7
+    /// MULTIPLICATION SIGN as the separator, matching macOS Ghostty).
+    /// </summary>
+    public string SizeText => string.Format(
+        CultureInfo.InvariantCulture,
+        "{0} {1} {2}",
+        _columns,
+        Separator,
+        _rows);
+
+    /// <summary>
+    /// Record a new grid size and decide whether the pill should appear
+    /// for this change. Always updates <see cref="Columns"/> /
+    /// <see cref="Rows"/> (so the text tracks the latest value), then
+    /// returns:
+    /// <list type="bullet">
+    /// <item><c>false</c> if the grid did not actually change.</item>
+    /// <item><c>false</c> when <see cref="Mode"/> is
+    /// <see cref="ResizeOverlayMode.Never"/>.</item>
+    /// <item><c>false</c> for the first observed size when
+    /// <see cref="Mode"/> is <see cref="ResizeOverlayMode.AfterFirst"/>.</item>
+    /// <item><c>true</c> otherwise.</item>
+    /// </list>
+    /// </summary>
+    public bool ShouldPulse(ushort cols, ushort rows)
+    {
+        var unchanged = _hasBaseline && cols == _columns && rows == _rows;
+        var isFirst = !_hasBaseline;
+
+        Columns = cols;
+        Rows = rows;
+        _hasBaseline = true;
+
+        if (unchanged) return false;
+
+        // No catch-all arm: each mode is handled explicitly so a future
+        // ResizeOverlayMode addition surfaces here rather than silently
+        // falling through to a default.
+        if (Mode == ResizeOverlayMode.Never) return false;
+        if (Mode == ResizeOverlayMode.Always) return true;
+        return !isFirst; // AfterFirst
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged
+    {
+        add => _pc += value;
+        remove => _pc -= value;
+    }
+
+    private PropertyChangedEventHandler? _pc;
+
+    private void Notify(string name) =>
+        _pc?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/windows/Ghostty.Tests/ResizeOverlay/ResizeOverlayEnumTests.cs
+++ b/windows/Ghostty.Tests/ResizeOverlay/ResizeOverlayEnumTests.cs
@@ -1,0 +1,47 @@
+using Ghostty.Core.ResizeOverlay;
+using Xunit;
+
+namespace Ghostty.Tests.ResizeOverlay;
+
+public class ResizeOverlayEnumTests
+{
+    [Theory]
+    [InlineData("always", ResizeOverlayMode.Always)]
+    [InlineData("never", ResizeOverlayMode.Never)]
+    [InlineData("after-first", ResizeOverlayMode.AfterFirst)]
+    public void Mode_parses_known_tags(string raw, ResizeOverlayMode expected)
+    {
+        Assert.Equal(expected, ResizeOverlayModeExtensions.Parse(raw));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("bogus")]
+    public void Mode_falls_back_to_after_first(string? raw)
+    {
+        Assert.Equal(ResizeOverlayMode.AfterFirst, ResizeOverlayModeExtensions.Parse(raw));
+    }
+
+    [Theory]
+    [InlineData("center", ResizeOverlayPosition.Center)]
+    [InlineData("top-left", ResizeOverlayPosition.TopLeft)]
+    [InlineData("top-center", ResizeOverlayPosition.TopCenter)]
+    [InlineData("top-right", ResizeOverlayPosition.TopRight)]
+    [InlineData("bottom-left", ResizeOverlayPosition.BottomLeft)]
+    [InlineData("bottom-center", ResizeOverlayPosition.BottomCenter)]
+    [InlineData("bottom-right", ResizeOverlayPosition.BottomRight)]
+    public void Position_parses_known_tags(string raw, ResizeOverlayPosition expected)
+    {
+        Assert.Equal(expected, ResizeOverlayPositionExtensions.Parse(raw));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("bogus")]
+    public void Position_falls_back_to_center(string? raw)
+    {
+        Assert.Equal(ResizeOverlayPosition.Center, ResizeOverlayPositionExtensions.Parse(raw));
+    }
+}

--- a/windows/Ghostty.Tests/ResizeOverlay/ResizeOverlayStateTests.cs
+++ b/windows/Ghostty.Tests/ResizeOverlay/ResizeOverlayStateTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Ghostty.Core.ResizeOverlay;
+using Xunit;
+
+namespace Ghostty.Tests.ResizeOverlay;
+
+public class ResizeOverlayStateTests
+{
+    [Fact]
+    public void Default_state_is_zero_and_after_first()
+    {
+        var state = new ResizeOverlayState();
+
+        Assert.Equal(0, state.Columns);
+        Assert.Equal(0, state.Rows);
+        Assert.Equal(ResizeOverlayMode.AfterFirst, state.Mode);
+    }
+
+    [Fact]
+    public void SizeText_formats_columns_by_rows()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+
+        state.ShouldPulse(80, 24);
+
+        // U+00D7 MULTIPLICATION SIGN, built from its code point so the source stays ASCII.
+        Assert.Equal("80 " + (char)0x00D7 + " 24", state.SizeText);
+    }
+
+    [Fact]
+    public void ShouldPulse_updates_columns_and_rows()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+
+        state.ShouldPulse(120, 40);
+
+        Assert.Equal(120, state.Columns);
+        Assert.Equal(40, state.Rows);
+    }
+
+    [Fact]
+    public void Never_mode_never_pulses()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Never };
+
+        Assert.False(state.ShouldPulse(80, 24));
+        Assert.False(state.ShouldPulse(100, 30));
+    }
+
+    [Fact]
+    public void Always_mode_pulses_on_first_size()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+
+        Assert.True(state.ShouldPulse(80, 24));
+    }
+
+    [Fact]
+    public void AfterFirst_suppresses_initial_layout_then_pulses()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.AfterFirst };
+
+        Assert.False(state.ShouldPulse(80, 24));   // baseline
+        Assert.True(state.ShouldPulse(100, 30));   // a real resize
+    }
+
+    [Fact]
+    public void Identical_grid_does_not_repulse()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+
+        Assert.True(state.ShouldPulse(80, 24));
+        Assert.False(state.ShouldPulse(80, 24));  // unchanged grid
+        Assert.True(state.ShouldPulse(80, 25));   // changed again
+    }
+
+    [Fact]
+    public void ShouldPulse_raises_PropertyChanged_for_columns_rows_sizetext()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+        var raised = Subscribe(state);
+
+        state.ShouldPulse(80, 24);
+
+        Assert.Contains(nameof(ResizeOverlayState.Columns), raised);
+        Assert.Contains(nameof(ResizeOverlayState.Rows), raised);
+        Assert.Contains(nameof(ResizeOverlayState.SizeText), raised);
+    }
+
+    private static List<string?> Subscribe(ResizeOverlayState state)
+    {
+        var raised = new List<string?>();
+        ((INotifyPropertyChanged)state).PropertyChanged +=
+            (_, e) => raised.Add(e.PropertyName);
+        return raised;
+    }
+}

--- a/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml
+++ b/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    ResizeOverlayControl: the transient "cols x rows" pill shown over a
+    pane while it is being resized (window resize, split-divider drag,
+    keyboard split resize, font-size change). Mirrors macOS Ghostty's
+    SurfaceResizeOverlay.
+
+    The UserControl fills the pane (Stretch) and aligns the inner Border
+    per the resolved resize-overlay-position; the parent toggles nothing,
+    the control flips its own Visibility and runs its own auto-hide timer.
+
+    IsHitTestVisible=False so the pill never steals pointer events from the
+    SwapChainPanel underneath - a terminal app running mouse=a keeps seeing
+    every mouse move through the pill's footprint.
+-->
+<UserControl
+    x:Class="Ghostty.Controls.ResizeOverlay.ResizeOverlayControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    mc:Ignorable="d"
+    HorizontalAlignment="Stretch"
+    VerticalAlignment="Stretch"
+    IsHitTestVisible="False">
+
+    <Border x:Name="Pill"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Margin="8"
+            Padding="12,6"
+            Background="{ThemeResource LayerFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource ControlElevationBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="{ThemeResource ControlCornerRadius}">
+        <TextBlock x:Name="SizeLabel"
+                   FontSize="14"
+                   Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                   Text="{x:Bind State.SizeText, Mode=OneWay}" />
+    </Border>
+</UserControl>

--- a/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml.cs
+++ b/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml.cs
@@ -1,0 +1,122 @@
+using System;
+using Ghostty.Core.ResizeOverlay;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Controls.ResizeOverlay;
+
+/// <summary>
+/// The transient grid-dimension pill ("80 x 24") shown over a pane while
+/// it is resized. Mirrors macOS Ghostty's SurfaceResizeOverlay.
+///
+/// The control owns its <see cref="ResizeOverlayState"/> and a one-shot
+/// auto-hide timer. The per-pane <see cref="TerminalControl"/> feeds it
+/// resize events via <see cref="NotifyResize"/>, passing the current
+/// config values (read fresh each time so hot-reload is honored) and an
+/// <c>allowShow</c> flag that folds in the time-based guards the view-side
+/// owner tracks (startup settle grace, focus-bounce window).
+/// </summary>
+public sealed partial class ResizeOverlayControl : UserControl
+{
+    private readonly DispatcherQueueTimer _hideTimer;
+
+    public ResizeOverlayControl()
+    {
+        State = new ResizeOverlayState();
+        InitializeComponent();
+
+        // DispatcherQueueTimer fires on the UI thread, so the Tick handler
+        // can touch Visibility with no marshalling. Non-repeating: each
+        // pulse restarts it, so it only fires once the resizing settles.
+        _hideTimer = DispatcherQueue.CreateTimer();
+        _hideTimer.IsRepeating = false;
+        _hideTimer.Tick += OnHideTick;
+
+        // Drop the Tick handler when the control leaves the tree so a
+        // reparented or torn-down pane does not accumulate handler links
+        // on the dispatcher's timer list.
+        Unloaded += OnControlUnloaded;
+    }
+
+    /// <summary>
+    /// Observable state bound by the XAML. The control owns the instance;
+    /// <see cref="NotifyResize"/> mutates it as resize events arrive.
+    /// </summary>
+    public ResizeOverlayState State { get; }
+
+    /// <summary>
+    /// Record a resize and, when warranted, flash the pill. Always updates
+    /// the displayed size; only makes the pill visible when
+    /// <paramref name="allowShow"/> is true and the
+    /// <see cref="ResizeOverlayState"/> decides this change should pulse
+    /// (per <paramref name="mode"/> and first-layout / dedup rules).
+    /// </summary>
+    /// <param name="cols">Current grid column count.</param>
+    /// <param name="rows">Current grid row count.</param>
+    /// <param name="mode">The resolved resize-overlay mode.</param>
+    /// <param name="position">Where the pill should sit in the pane.</param>
+    /// <param name="durationMs">How long the pill stays visible.</param>
+    /// <param name="allowShow">
+    /// False suppresses the visual pulse (e.g. during the startup settle or
+    /// just after a focus change) while still letting the state track the
+    /// latest size and baseline.
+    /// </param>
+    public void NotifyResize(
+        ushort cols,
+        ushort rows,
+        ResizeOverlayMode mode,
+        ResizeOverlayPosition position,
+        int durationMs,
+        bool allowShow)
+    {
+        State.Mode = mode;
+        var pulse = State.ShouldPulse(cols, rows);
+        if (!allowShow || !pulse) return;
+
+        ApplyPosition(position);
+
+        // Clamp to a sane floor: a zero/negative duration would make the
+        // timer never fire, leaving the pill stuck on screen.
+        _hideTimer.Interval = TimeSpan.FromMilliseconds(Math.Max(1, durationMs));
+        Visibility = Visibility.Visible;
+        _hideTimer.Stop();
+        _hideTimer.Start();
+    }
+
+    private void OnHideTick(DispatcherQueueTimer sender, object args)
+    {
+        sender.Stop();
+        Visibility = Visibility.Collapsed;
+    }
+
+    private void ApplyPosition(ResizeOverlayPosition position)
+    {
+        Pill.HorizontalAlignment = position switch
+        {
+            ResizeOverlayPosition.TopLeft or
+            ResizeOverlayPosition.BottomLeft => HorizontalAlignment.Left,
+            ResizeOverlayPosition.TopRight or
+            ResizeOverlayPosition.BottomRight => HorizontalAlignment.Right,
+            _ => HorizontalAlignment.Center,
+        };
+
+        Pill.VerticalAlignment = position switch
+        {
+            ResizeOverlayPosition.TopLeft or
+            ResizeOverlayPosition.TopCenter or
+            ResizeOverlayPosition.TopRight => VerticalAlignment.Top,
+            ResizeOverlayPosition.BottomLeft or
+            ResizeOverlayPosition.BottomCenter or
+            ResizeOverlayPosition.BottomRight => VerticalAlignment.Bottom,
+            _ => VerticalAlignment.Center,
+        };
+    }
+
+    private void OnControlUnloaded(object sender, RoutedEventArgs e)
+    {
+        _hideTimer.Stop();
+        _hideTimer.Tick -= OnHideTick;
+        Unloaded -= OnControlUnloaded;
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -24,6 +24,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:search="using:Ghostty.Controls.Search"
+    xmlns:resize="using:Ghostty.Controls.ResizeOverlay"
     IsTabStop="True"
     TabNavigation="Cycle"
     HorizontalAlignment="Stretch"
@@ -149,5 +150,15 @@
             Margin="0,8,8,0"
             Visibility="Collapsed"
             Closed="OnSearchClosed" />
+
+        <!--
+            Transient cols x rows pill shown while the pane is resized.
+            Fills the cell and self-positions per resize-overlay-position;
+            starts Collapsed and flips its own Visibility. Last child so it
+            layers above the SwapChainPanel and the other overlays.
+        -->
+        <resize:ResizeOverlayControl
+            x:Name="ResizeOverlay"
+            Visibility="Collapsed" />
     </Grid>
 </UserControl>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Ghostty.Core.Input;
+using Ghostty.Core.ResizeOverlay;
 using Ghostty.Core.Search;
 using Ghostty.Hosting;
 using Ghostty.Input;
@@ -398,6 +399,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
             _surface,
             (uint)Math.Max(1, w * sx),
             (uint)Math.Max(1, h * sy));
+
+        // Start the resize-overlay startup grace from this first settled
+        // layout (and again after any reparent that re-arms this handler),
+        // so the initial layout passes do not flash the cols x rows pill.
+        ArmResizeOverlayGrace();
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -414,6 +420,12 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // sure it does not fire spuriously after the panel detaches.
         // OnLoaded re-subscribes when the control re-enters a tree.
         Panel.LayoutUpdated -= OnFirstLayoutUpdated;
+
+        // Stop the grace timer so its Tick cannot flip _resizeOverlayReady
+        // while the control is detached. The timer (and its single Tick
+        // subscription) is kept for reuse when the control re-enters a tree;
+        // ArmResizeOverlayGrace restarts it.
+        _resizeOverlayGraceTimer?.Stop();
     }
 
     /// <summary>
@@ -482,6 +494,86 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     {
         if (_surface.Handle == IntPtr.Zero) return;
         PushSurfaceSize();
+        UpdateResizeOverlay();
+    }
+
+    // Resize overlay -----------------------------------------------------
+    //
+    // The cols x rows pill mirrors macOS's SurfaceResizeOverlay. The Core
+    // ResizeOverlayState decides whether a given size change should pulse
+    // (mode + first-layout + dedup); the two time-based guards live here
+    // because they depend on wall-clock instants this control already sees.
+
+    // Roughly half a second of grace after the surface first sizes, during
+    // which the initial layout settle (often several passes) must not flash
+    // the overlay. Matches macOS's `ready` delay.
+    private static readonly TimeSpan ResizeOverlayStartupGrace =
+        TimeSpan.FromMilliseconds(500);
+
+    // Suppress the overlay for this long after the pane gains focus, so a
+    // focus-driven relayout does not flash it. Matches macOS's focusInstant
+    // guard.
+    private static readonly TimeSpan ResizeOverlayFocusGuard =
+        TimeSpan.FromMilliseconds(500);
+
+    private bool _resizeOverlayReady;
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _resizeOverlayGraceTimer;
+    // Monotonic (TickCount64) so an NTP/DST wall-clock jump cannot widen or
+    // collapse the focus guard. 0 means "never focused yet".
+    private long _lastFocusGainedTick;
+
+    private void ArmResizeOverlayGrace()
+    {
+        // The first settled layout (and each reparent that re-arms this) opens
+        // the grace window; once it elapses, real user resizes may pulse the
+        // overlay. Reuse one one-shot timer so re-arming just restarts it
+        // instead of leaking a fresh timer + closure each reparent.
+        _resizeOverlayReady = false;
+        if (_resizeOverlayGraceTimer is null)
+        {
+            _resizeOverlayGraceTimer = DispatcherQueue.CreateTimer();
+            _resizeOverlayGraceTimer.Interval = ResizeOverlayStartupGrace;
+            _resizeOverlayGraceTimer.IsRepeating = false;
+            _resizeOverlayGraceTimer.Tick += OnResizeOverlayGraceTick;
+        }
+        _resizeOverlayGraceTimer.Stop();
+        _resizeOverlayGraceTimer.Start();
+    }
+
+    private void OnResizeOverlayGraceTick(
+        Microsoft.UI.Dispatching.DispatcherQueueTimer sender, object args)
+    {
+        sender.Stop();
+        _resizeOverlayReady = true;
+    }
+
+    private void UpdateResizeOverlay()
+    {
+        var cfg = App.ConfigService;
+        if (cfg is null) return;
+
+        // Read config fresh each pulse so hot-reload is honored with no
+        // subscription to unwind on teardown.
+        var mode = cfg.ResizeOverlayMode;
+
+        // SurfaceSetSize (called above via PushSurfaceSize) recalculates the
+        // grid synchronously on this thread, so this read already reflects the
+        // new cols/rows; only the GPU buffer resize is deferred.
+        var size = NativeMethods.SurfaceSize(_surface);
+
+        var withinFocusGuard =
+            _lastFocusGainedTick != 0 &&
+            Environment.TickCount64 - _lastFocusGainedTick
+                < ResizeOverlayFocusGuard.TotalMilliseconds;
+        var allowShow = _resizeOverlayReady && !withinFocusGuard;
+
+        ResizeOverlay.NotifyResize(
+            size.Columns,
+            size.Rows,
+            mode,
+            cfg.ResizeOverlayPosition,
+            cfg.ResizeOverlayDurationMs,
+            allowShow);
     }
 
     private void PushSurfaceSize()
@@ -528,7 +620,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private bool _focused;
 
-    private void OnGotFocus(object sender, RoutedEventArgs e) => SetFocusState(true);
+    private void OnGotFocus(object sender, RoutedEventArgs e)
+    {
+        // Stamp the focus instant so a focus-driven relayout in the next
+        // ~500 ms does not flash the resize overlay (matches macOS).
+        _lastFocusGainedTick = Environment.TickCount64;
+        SetFocusState(true);
+    }
 
     private void OnLostFocus(object sender, RoutedEventArgs e) => SetFocusState(false);
 

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -110,6 +110,30 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
             GetString("quick-terminal-screen", "main"));
 
     /// <summary>
+    /// When the resize overlay (the cols x rows pill shown while a pane
+    /// is resized) is allowed to appear. Default `after-first` matches
+    /// upstream Ghostty.
+    /// </summary>
+    public Ghostty.Core.ResizeOverlay.ResizeOverlayMode ResizeOverlayMode =>
+        Ghostty.Core.ResizeOverlay.ResizeOverlayModeExtensions.Parse(
+            GetString("resize-overlay", "after-first"));
+
+    /// <summary>
+    /// Where the resize overlay pill sits inside the pane. Default
+    /// `center` matches upstream Ghostty.
+    /// </summary>
+    public Ghostty.Core.ResizeOverlay.ResizeOverlayPosition ResizeOverlayPosition =>
+        Ghostty.Core.ResizeOverlay.ResizeOverlayPositionExtensions.Parse(
+            GetString("resize-overlay-position", "center"));
+
+    /// <summary>
+    /// How long the resize overlay stays visible after the last size
+    /// change, in milliseconds. Default 750 matches upstream Ghostty.
+    /// </summary>
+    public int ResizeOverlayDurationMs =>
+        GetDurationMs("resize-overlay-duration", 750);
+
+    /// <summary>
     /// Size of the quake window on each axis. Either axis can be
     /// null in which case the resolver uses sensible defaults
     /// (50% primary, 100% secondary).
@@ -662,6 +686,34 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
                 (IntPtr)keyPtr,
                 (UIntPtr)keyBytes.Length);
             return found ? result : defaultValue;
+        }
+    }
+
+    /// <summary>
+    /// Read a libghostty <c>Duration</c>-typed config value in
+    /// milliseconds. <c>Duration.cval()</c> returns a Zig <c>usize</c>, so
+    /// the output buffer must be pointer-width (<see cref="nuint"/>) -
+    /// using a 4-byte <c>uint</c> would let ghostty_config_get write past
+    /// the buffer on 64-bit. The value is already milliseconds (cval calls
+    /// asMilliseconds), so no conversion is needed here.
+    /// </summary>
+    private unsafe int GetDurationMs(string key, int defaultValue)
+    {
+        nuint result = 0;
+        var keyBytes = System.Text.Encoding.UTF8.GetBytes(key);
+        fixed (byte* keyPtr = keyBytes)
+        {
+            var found = NativeMethods.ConfigGet(
+                _config,
+                (IntPtr)(&result),
+                (IntPtr)keyPtr,
+                (UIntPtr)keyBytes.Length);
+            // Clamp rather than truncate: asMilliseconds is a c_uint that can
+            // exceed int.MaxValue (~24.8 days), and a raw (int) cast would wrap
+            // to a negative the timer logic would then floor to ~nothing.
+            return found
+                ? (int)Math.Min(result, (nuint)int.MaxValue)
+                : defaultValue;
         }
     }
 


### PR DESCRIPTION
Adds the resize overlay from macOS Ghostty to the Windows app: a small pill showing the terminal grid size (cols x rows) appears over a pane while it is resized, then auto-hides.

It shows for any size change of a pane: window resize, split-divider drag, keyboard split resize, and font-size change.

Honors the existing libghostty config keys:
- resize-overlay: never / always / after-first (default after-first)
- resize-overlay-position: center and the four corners / top-center / bottom-center (default center)
- resize-overlay-duration: how long it stays up before fading (default 750ms)

The show/hide decision is a pure type in Ghostty.Core (ResizeOverlayState) with unit tests covering the mode, first-layout, and dedup rules. The time-based guards (a short startup grace and a focus-change guard, both matching macOS) live in the control. Unlike macOS, which dedups on pixel size, this dedups on the grid so an unchanged readout never re-flashes during a drag.