### PR TITLE
tabs: compact top bar, drop the layout-switch button, spin the icon on toggle

### DIFF
--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -57,8 +57,8 @@
             Col 0 mirrors StripColumn so the drag region starts after
             the tab strip, avoiding a Z-order fight with the chevron
             button inside VerticalTabHost. Col 1 is the draggable
-            area with the layout-switch button and window title.
-            Col 2 reserves room for the OS caption buttons.
+            area with the window title. Col 2 reserves room for the
+            OS caption buttons.
 
             No Background on the outer Grid so clicks in Col 0 pass
             through to the VerticalTabHost (chevron) below.
@@ -76,20 +76,6 @@
             <Grid x:Name="VerticalTitleDragRegion"
                   Grid.Column="1"
                   Background="Transparent">
-
-                <Button x:Name="VerticalSwitchButton"
-                        Width="32" Height="32"
-                        Padding="0"
-                        Margin="4,0,0,0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Center"
-                        Background="Transparent"
-                        BorderThickness="0"
-                        Click="OnVerticalSwitchButtonClick">
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
-                              Glyph="&#xE8A9;"
-                              FontSize="{StaticResource BodyTextBlockFontSize}"/>
-                </Button>
 
                 <TextBlock x:Name="VerticalTitleText"
                            VerticalAlignment="Center"

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -63,9 +63,13 @@
             No Background on the outer Grid so clicks in Col 0 pass
             through to the VerticalTabHost (chevron) below.
         -->
+        <!-- Height matches the horizontal TabView strip so the wintty
+             icon and the terminal top edge stay put when toggling
+             between the two layouts. Keep in sync with the slide
+             distance in LayoutCoordinator.Animate. -->
         <Grid x:Name="VerticalTitleBar"
               Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
-              Height="32"
+              Height="34"
               Visibility="Collapsed">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="TitleBarStripMirror" Width="0"/>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -462,7 +462,8 @@ public sealed partial class MainWindow : Window
             TitleBarStripMirror,
             (FrameworkElement)_horizontalTabHost.HostElement,
             _verticalTabHost,
-            VerticalTitleBar);
+            VerticalTitleBar,
+            _horizontalTabHost.IconBadge);
         _layout.Snap(_verticalTabsVisible);
 
         _titleBar = new TitleBarCoordinator(

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -399,9 +399,9 @@ public sealed partial class MainWindow : Window
         // Both tab hosts are inserted at the back of the Z-order so
         // the XAML-declared VerticalTitleBar stays on top in the Row 0
         // overlap region. Without this, the expanded vertical strip
-        // covers the layout-switch button in the title bar. The
-        // VerticalTitleBar's Background="Transparent" already enables
-        // hit-testing for its drag region and switch button.
+        // covers the title bar. The VerticalTitleBar's
+        // Background="Transparent" already enables hit-testing for its
+        // drag region.
         var hostElement = (FrameworkElement)_horizontalTabHost.HostElement;
         Grid.SetRow(hostElement, 0);
         Grid.SetColumn(hostElement, 0);
@@ -453,15 +453,6 @@ public sealed partial class MainWindow : Window
 
         // Apply initial cursor-color-derived pane border.
         UpdateCursorAccentColors();
-
-        // Tooltip chord label is sourced from KeyBindings.Default so
-        // the button description cannot drift from the accelerator.
-        var chord = KeyBindings.Default.Label(PaneAction.ToggleTabLayout);
-        ToolTipService.SetToolTip(
-            VerticalSwitchButton,
-            chord is null
-                ? "Switch to horizontal tabs"
-                : $"Switch to horizontal tabs ({chord})");
 
         _verticalTabsVisible = _configService.VerticalTabs;
         _tabHost = _verticalTabsVisible ? _verticalTabHost : _horizontalTabHost;
@@ -1028,9 +1019,6 @@ public sealed partial class MainWindow : Window
         foreach (var t in _tabManager.Tabs) t.PaneHost.DisposeAllLeaves();
         _host.Dispose();
     }
-
-    private void OnVerticalSwitchButtonClick(object sender, RoutedEventArgs e)
-        => _router.RequestToggleTabLayout();
 
     private void AddPaneHost(TabModel tab)
     {

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -45,6 +45,11 @@ internal sealed class LayoutCoordinator
     private readonly VerticalTabHost _verticalTabHost;
     private readonly FrameworkElement _verticalHost;
     private readonly Grid _verticalTitleBar;
+    // The wintty icon in each layout. Only the incoming one is spun on a
+    // switch (see Animate), so the icon looks like the surrounding chrome
+    // is shoving it into its new home.
+    private readonly FrameworkElement _horizontalIcon;
+    private readonly FrameworkElement _verticalIcon;
 
     private bool _switching;
     // When true (quake window with a single tab), the strip + vertical
@@ -64,7 +69,8 @@ internal sealed class LayoutCoordinator
         ColumnDefinition titleBarStripMirror,
         FrameworkElement horizontalHost,
         VerticalTabHost verticalTabHost,
-        Grid verticalTitleBar)
+        Grid verticalTitleBar,
+        FrameworkElement horizontalIcon)
     {
         _stripColumn = stripColumn;
         _titleBarStripMirror = titleBarStripMirror;
@@ -72,6 +78,8 @@ internal sealed class LayoutCoordinator
         _verticalTabHost = verticalTabHost;
         _verticalHost = verticalTabHost;
         _verticalTitleBar = verticalTitleBar;
+        _horizontalIcon = horizontalIcon;
+        _verticalIcon = verticalTabHost.IconBadge;
 
         // The chevron toggle inside VerticalTabHost asks the outer
         // shell to widen the strip column. Forward through the same
@@ -217,6 +225,26 @@ internal sealed class LayoutCoordinator
         sb.Children.Add(MakeTransformAnim(outgoing, "X", outgoingTx.X, outgoingOffset.X));
         sb.Children.Add(MakeTransformAnim(outgoing, "Y", outgoingTx.Y, outgoingOffset.Y));
 
+        // Spin + pop the wintty icon while keeping it pinned in place.
+        // Each icon counter-translates its own host's slide, so it stays
+        // glued to the same anchor point while the strip/title-bar chrome
+        // slides around it -- the icon reads as a fixed pivot the layout
+        // rotates about, not something that flies in with the rest.
+        //
+        // Both icons spin the same way so the cross-fade between them
+        // (one per layout, sitting at the same spot) looks like a single
+        // steady, turning ghost. Direction follows the chrome sweep:
+        // going vertical (top bar -> left rail) is counter-clockwise,
+        // going horizontal (left rail -> top bar) clockwise. One full
+        // turn lands it upright.
+        var spin = verticalTabs ? -360.0 : 360.0;
+        var incomingIcon = verticalTabs ? _verticalIcon : _horizontalIcon;
+        var outgoingIcon = verticalTabs ? _horizontalIcon : _verticalIcon;
+        SpinIconInPlace(sb, incomingIcon, spin,
+            -incomingOffset.X, -incomingOffset.Y, 0, 0);
+        SpinIconInPlace(sb, outgoingIcon, spin,
+            0, 0, -outgoingOffset.X, -outgoingOffset.Y);
+
         // Snap the strip column width immediately. The crossfade
         // hides the jump; see the Animate summary for rationale.
         _stripColumn.Width = new GridLength(targetColWidth);
@@ -225,6 +253,10 @@ internal sealed class LayoutCoordinator
 
         sb.Completed += (_, _) =>
         {
+            // 360 lands upright, but reset to 0 so the next spin starts
+            // from a clean angle rather than accumulating.
+            ResetIconTransform(incomingIcon);
+            ResetIconTransform(outgoingIcon);
             Snap(verticalTabs);
             _switching = false;
             onCompleted?.Invoke();
@@ -274,6 +306,122 @@ internal sealed class LayoutCoordinator
         var nt = new TranslateTransform();
         fe.RenderTransform = nt;
         return nt;
+    }
+
+    // Spin + pop one icon while holding it at a fixed anchor. The
+    // translate runs from/to the negative of the host's slide so it
+    // exactly cancels it (same easing + duration as the host slide),
+    // leaving only the in-place rotate and scale visible.
+    private static void SpinIconInPlace(
+        Storyboard sb, FrameworkElement? icon, double spin,
+        double fromX, double fromY, double toX, double toY)
+    {
+        if (icon is null) return;
+        var (scale, rotate, translate) = EnsureIconTransform(icon);
+        rotate.Angle = 0;
+        scale.ScaleX = 1;
+        scale.ScaleY = 1;
+        translate.X = fromX;
+        translate.Y = fromY;
+        sb.Children.Add(MakeRotateAnim(rotate, 0, spin));
+        sb.Children.Add(MakePopAnim(scale, "ScaleX"));
+        sb.Children.Add(MakePopAnim(scale, "ScaleY"));
+        sb.Children.Add(MakeIconTranslateAnim(translate, "X", fromX, toX));
+        sb.Children.Add(MakeIconTranslateAnim(translate, "Y", fromY, toY));
+    }
+
+    // Give the icon a Scale+Rotate+Translate group: scale and rotate
+    // pivot on its centre (RenderTransformOrigin), the translate (applied
+    // last, so it stays axis-aligned) cancels the host slide.
+    private static (ScaleTransform Scale, RotateTransform Rotate, TranslateTransform Translate) EnsureIconTransform(FrameworkElement fe)
+    {
+        if (fe.RenderTransform is TransformGroup g
+            && g.Children.Count == 3
+            && g.Children[0] is ScaleTransform existingScale
+            && g.Children[1] is RotateTransform existingRotate
+            && g.Children[2] is TranslateTransform existingTranslate)
+            return (existingScale, existingRotate, existingTranslate);
+
+        var scale = new ScaleTransform();
+        var rotate = new RotateTransform();
+        var translate = new TranslateTransform();
+        var group = new TransformGroup();
+        group.Children.Add(scale);
+        group.Children.Add(rotate);
+        group.Children.Add(translate);
+        fe.RenderTransform = group;
+        fe.RenderTransformOrigin = new Windows.Foundation.Point(0.5, 0.5);
+        return (scale, rotate, translate);
+    }
+
+    private static void ResetIconTransform(FrameworkElement? fe)
+    {
+        if (fe is null) return;
+        var (scale, rotate, translate) = EnsureIconTransform(fe);
+        rotate.Angle = 0;
+        scale.ScaleX = 1;
+        scale.ScaleY = 1;
+        translate.X = 0;
+        translate.Y = 0;
+    }
+
+    private static DoubleAnimation MakeIconTranslateAnim(TranslateTransform target, string axis, double from, double to)
+    {
+        // Match the host slide's easing + duration so the cancellation
+        // holds at every frame, not just the endpoints.
+        var anim = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
+            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(anim, target);
+        Storyboard.SetTargetProperty(anim, axis);
+        return anim;
+    }
+
+    private static DoubleAnimation MakeRotateAnim(RotateTransform target, double from, double to)
+    {
+        // A touch of back-ease overshoot at the end sells the "shoved
+        // and settling" feel rather than a mechanical stop.
+        var anim = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
+            EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = 0.25 },
+        };
+        Storyboard.SetTarget(anim, target);
+        Storyboard.SetTargetProperty(anim, "Angle");
+        return anim;
+    }
+
+    // Dip the icon's scale mid-spin then spring back past 1.0, so it
+    // pops as it lands.
+    private static DoubleAnimationUsingKeyFrames MakePopAnim(ScaleTransform target, string axis)
+    {
+        var anim = new DoubleAnimationUsingKeyFrames();
+        anim.KeyFrames.Add(new EasingDoubleKeyFrame
+        {
+            KeyTime = KeyTime.FromTimeSpan(TimeSpan.Zero),
+            Value = 1.0,
+        });
+        anim.KeyFrames.Add(new EasingDoubleKeyFrame
+        {
+            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(SwitchDurationMs * 0.45)),
+            Value = 0.78,
+            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+        });
+        anim.KeyFrames.Add(new EasingDoubleKeyFrame
+        {
+            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(SwitchDurationMs)),
+            Value = 1.0,
+            EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = 0.6 },
+        });
+        Storyboard.SetTarget(anim, target);
+        Storyboard.SetTargetProperty(anim, axis);
+        return anim;
     }
 
     private static DoubleAnimation MakeDoubleAnim(DependencyObject target, string path, double from, double to)

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -39,6 +39,14 @@ internal sealed class LayoutCoordinator
     // MainWindow.xaml.
     private const double VerticalTitleBarHeight = 34;
 
+    // Feel constants for the icon spin/pop, tuned by eye. The spin is one
+    // full turn; the pop dips the scale partway through and springs back
+    // past 1.0 as it lands.
+    private const double IconSpinOvershoot = 0.25; // BackEase amplitude on the rotation settle
+    private const double IconPopMidpoint = 0.45;   // fraction of the switch where the scale dip bottoms out
+    private const double IconPopDipScale = 0.78;   // smallest scale at the dip
+    private const double IconPopOvershoot = 0.6;   // BackEase amplitude springing the scale back past 1.0
+
     private readonly ColumnDefinition _stripColumn;
     private readonly ColumnDefinition _titleBarStripMirror;
     private readonly FrameworkElement _horizontalHost;
@@ -126,13 +134,18 @@ internal sealed class LayoutCoordinator
             _verticalTitleBar.Opacity = verticalTabs ? 1 : 0;
         }
 
-        // Reset any dangling translate offsets so future switches
-        // start from origin. Safe to overwrite: Snap is only called
-        // when no transform animation is in flight.
+        // Reset any dangling transform offsets so future switches start
+        // from origin. Snap is the single end-state authority, so it
+        // also returns the spun icons to identity -- without this, a
+        // switch interrupted by SetStripHidden / SuppressVerticalTitleBar
+        // (which call Snap directly) could leave an icon rotated or
+        // scaled once the strip is shown again.
         GetOrCreateTranslate(_verticalHost).X = 0;
         GetOrCreateTranslate(_verticalHost).Y = 0;
         GetOrCreateTranslate(_horizontalHost).X = 0;
         GetOrCreateTranslate(_horizontalHost).Y = 0;
+        ResetIconTransform(_horizontalIcon);
+        ResetIconTransform(_verticalIcon);
 
         if (_stripHidden)
         {
@@ -229,7 +242,9 @@ internal sealed class LayoutCoordinator
         // Each icon counter-translates its own host's slide, so it stays
         // glued to the same anchor point while the strip/title-bar chrome
         // slides around it -- the icon reads as a fixed pivot the layout
-        // rotates about, not something that flies in with the rest.
+        // rotates about, not something that flies in with the rest. This
+        // only cancels because the icon is a child of its host: the two
+        // translates compose, so equal-and-opposite nets to zero.
         //
         // Both icons spin the same way so the cross-fade between them
         // (one per layout, sitting at the same spot) looks like a single
@@ -253,10 +268,9 @@ internal sealed class LayoutCoordinator
 
         sb.Completed += (_, _) =>
         {
-            // 360 lands upright, but reset to 0 so the next spin starts
-            // from a clean angle rather than accumulating.
-            ResetIconTransform(incomingIcon);
-            ResetIconTransform(outgoingIcon);
+            // Snap returns the icons to identity (360 lands them upright
+            // anyway; this just stops the angle accumulating across
+            // switches) along with the rest of the end state.
             Snap(verticalTabs);
             _switching = false;
             onCompleted?.Invoke();
@@ -326,8 +340,11 @@ internal sealed class LayoutCoordinator
         sb.Children.Add(MakeRotateAnim(rotate, 0, spin));
         sb.Children.Add(MakePopAnim(scale, "ScaleX"));
         sb.Children.Add(MakePopAnim(scale, "ScaleY"));
-        sb.Children.Add(MakeIconTranslateAnim(translate, "X", fromX, toX));
-        sb.Children.Add(MakeIconTranslateAnim(translate, "Y", fromY, toY));
+        // Same easing + duration helper as the host slide, so the
+        // counter-translate cancels it frame for frame, not just at the
+        // endpoints.
+        sb.Children.Add(MakeDoubleAnim(translate, "X", fromX, toX));
+        sb.Children.Add(MakeDoubleAnim(translate, "Y", fromY, toY));
     }
 
     // Give the icon a Scale+Rotate+Translate group: scale and rotate
@@ -365,22 +382,6 @@ internal sealed class LayoutCoordinator
         translate.Y = 0;
     }
 
-    private static DoubleAnimation MakeIconTranslateAnim(TranslateTransform target, string axis, double from, double to)
-    {
-        // Match the host slide's easing + duration so the cancellation
-        // holds at every frame, not just the endpoints.
-        var anim = new DoubleAnimation
-        {
-            From = from,
-            To = to,
-            Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
-            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
-        };
-        Storyboard.SetTarget(anim, target);
-        Storyboard.SetTargetProperty(anim, axis);
-        return anim;
-    }
-
     private static DoubleAnimation MakeRotateAnim(RotateTransform target, double from, double to)
     {
         // A touch of back-ease overshoot at the end sells the "shoved
@@ -390,7 +391,7 @@ internal sealed class LayoutCoordinator
             From = from,
             To = to,
             Duration = new Duration(TimeSpan.FromMilliseconds(SwitchDurationMs)),
-            EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = 0.25 },
+            EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = IconSpinOvershoot },
         };
         Storyboard.SetTarget(anim, target);
         Storyboard.SetTargetProperty(anim, "Angle");
@@ -409,15 +410,15 @@ internal sealed class LayoutCoordinator
         });
         anim.KeyFrames.Add(new EasingDoubleKeyFrame
         {
-            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(SwitchDurationMs * 0.45)),
-            Value = 0.78,
+            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(SwitchDurationMs * IconPopMidpoint)),
+            Value = IconPopDipScale,
             EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
         });
         anim.KeyFrames.Add(new EasingDoubleKeyFrame
         {
             KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(SwitchDurationMs)),
             Value = 1.0,
-            EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = 0.6 },
+            EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = IconPopOvershoot },
         });
         Storyboard.SetTarget(anim, target);
         Storyboard.SetTargetProperty(anim, axis);

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -33,6 +33,12 @@ internal sealed class LayoutCoordinator
     public const double VerticalStripCollapsedWidth = 40;
     public const int SwitchDurationMs = 220;
 
+    // Vertical-mode title bar height. The horizontal host slides this
+    // far vertically during the cross-fade so the swap feels like the
+    // strip lifting away. Must match VerticalTitleBar.Height in
+    // MainWindow.xaml.
+    private const double VerticalTitleBarHeight = 34;
+
     private readonly ColumnDefinition _stripColumn;
     private readonly ColumnDefinition _titleBarStripMirror;
     private readonly FrameworkElement _horizontalHost;
@@ -182,9 +188,9 @@ internal sealed class LayoutCoordinator
         var outgoing = verticalTabs ? _horizontalHost : _verticalHost;
         var incomingOffset = verticalTabs
             ? new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0)
-            : new Windows.Foundation.Point(0, -32);
+            : new Windows.Foundation.Point(0, -VerticalTitleBarHeight);
         var outgoingOffset = verticalTabs
-            ? new Windows.Foundation.Point(0, -32)
+            ? new Windows.Foundation.Point(0, -VerticalTitleBarHeight)
             : new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0);
 
         incoming.IsHitTestVisible = true;

--- a/windows/Ghostty/Tabs/TabHost.xaml
+++ b/windows/Ghostty/Tabs/TabHost.xaml
@@ -43,8 +43,15 @@
          reparenting the SwapChainPanels. This UserControl now renders
          only the tab strip chrome. -->
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Top">
+        <!-- Trim the default 8px top gap above the tab strip
+             (TabViewHeaderPadding) so the strip is not taller than it
+             needs to be. The vertical-mode title bar height and the
+             strip-header icon margin are matched to the resulting
+             height so the icon and terminal top do not jump when the
+             layout toggles. -->
         <controls:TabView
             x:Name="TabViewControl"
+            Padding="0,2,0,0"
             HorizontalAlignment="Stretch"
             CanReorderTabs="True"
             CanDragTabs="True"

--- a/windows/Ghostty/Tabs/TabHost.xaml
+++ b/windows/Ghostty/Tabs/TabHost.xaml
@@ -62,7 +62,7 @@
             SelectionChanged="OnSelectionChanged"
             TabDragCompleted="OnTabDragCompleted">
             <controls:TabView.TabStripHeader>
-                <branding:AppIconBadge />
+                <branding:AppIconBadge x:Name="IconBadgeHost" />
             </controls:TabView.TabStripHeader>
             <!--
                 TabStripFooter is a two-cell row. Cell 0 holds the

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -39,6 +39,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
     public FrameworkElement HostElement => this;
 
     /// <summary>
+    /// The wintty icon shown at the start of the tab strip. Exposed so
+    /// the layout switch can spin it independently of the strip chrome.
+    /// </summary>
+    public FrameworkElement IconBadge => IconBadgeHost;
+
+    /// <summary>
     /// The Grid that sits in the TabView's TabStripFooter and
     /// reserves room for the OS caption buttons. <see cref="MainWindow"/>
     /// passes this to <c>Window.SetTitleBar</c> so clicks on the

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml
@@ -25,11 +25,14 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
+        <!-- Top margin centers the icon at the same Y as the horizontal
+             TabView's strip header so it does not jump when the layout
+             toggles. -->
         <branding:AppIconBadge
             Grid.Row="0"
             Grid.Column="0"
             HorizontalAlignment="Left"
-            Margin="4,4,0,4"/>
+            Margin="4,3,0,4"/>
 
         <ContentPresenter x:Name="StripHost"
                           Grid.Row="1"

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml
@@ -29,6 +29,7 @@
              TabView's strip header so it does not jump when the layout
              toggles. -->
         <branding:AppIconBadge
+            x:Name="IconBadgeHost"
             Grid.Row="0"
             Grid.Column="0"
             HorizontalAlignment="Left"

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -37,6 +37,12 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     private readonly VerticalTabStrip _strip;
     private readonly ColumnDragHandle _dragHandle;
 
+    /// <summary>
+    /// The wintty icon pinned at the top of the vertical strip. Exposed
+    /// so the layout switch can spin it independently of the chrome.
+    /// </summary>
+    public FrameworkElement IconBadge => IconBadgeHost;
+
     // TODO(config): vertical-tabs-width (int px, default 220)
     private const double ExpandedWidth = 220;
     // TODO(config): vertical-tabs-pinned (bool, default false)


### PR DESCRIPTION
Three small changes to the tab strip and the vertical-tabs title bar.

- Remove the layout-switch button from the vertical-mode title bar. The keyboard chord and the command palette entry already toggle the layout, so it was redundant chrome.
- Trim the 8px gap above the horizontal tab strip and size the vertical-mode title bar to match. The wintty icon and the terminal top edge now sit at the same place in both layouts, so nothing shifts when toggling.
- Spin the wintty icon in place when switching layouts: it stays pinned to its anchor and does one full turn with a scale pop, turning the way the chrome sweeps.
