### PR TITLE
quake: remove docked-edge frame band, lock resize to opposite edge

### DIFF
--- a/windows/Ghostty.Core/Hosting/QuickTerminalFrameGeometry.cs
+++ b/windows/Ghostty.Core/Hosting/QuickTerminalFrameGeometry.cs
@@ -1,0 +1,61 @@
+namespace Ghostty.Core.Hosting;
+
+/// <summary>
+/// The one edge of the quake window that may be resize-dragged: the edge
+/// opposite the docked edge. The docked edge (and the two perpendicular edges)
+/// sit flush against the monitor and stay fixed. <see cref="None"/> when the
+/// window is centered, where no edge is flush to the monitor.
+/// </summary>
+internal enum QuickTerminalResizeEdge
+{
+    None,
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+/// <summary>
+/// Pure-logic direction helpers for the quake window's non-client frame. The
+/// Win32 plumbing (the window-proc subclass and its WM_NCCALCSIZE /
+/// WM_NCHITTEST handling) lives in the app's <c>QuickTerminalFrame</c>; this
+/// holds the edge math so it can be unit-tested without a real window. All
+/// coordinates are physical screen pixels in the same space as the window rect.
+/// </summary>
+internal static class QuickTerminalFrameGeometry
+{
+    /// <summary>
+    /// The single resizable edge for a docked position: the one opposite the
+    /// dock. Center has no flush edge, so it is not edge-resized here.
+    /// </summary>
+    public static QuickTerminalResizeEdge ResizableEdge(QuickTerminalPosition position) =>
+        position switch
+        {
+            QuickTerminalPosition.Top => QuickTerminalResizeEdge.Bottom,
+            QuickTerminalPosition.Bottom => QuickTerminalResizeEdge.Top,
+            QuickTerminalPosition.Left => QuickTerminalResizeEdge.Right,
+            QuickTerminalPosition.Right => QuickTerminalResizeEdge.Left,
+            _ => QuickTerminalResizeEdge.None,
+        };
+
+    /// <summary>
+    /// The resize edge hit when the point (<paramref name="x"/>,
+    /// <paramref name="y"/>) falls within <paramref name="grip"/> pixels of the
+    /// resizable edge of the window rect [<paramref name="left"/>,
+    /// <paramref name="top"/>, <paramref name="right"/>, <paramref name="bottom"/>);
+    /// otherwise <see cref="QuickTerminalResizeEdge.None"/>. This answers
+    /// WM_NCHITTEST for the thin non-client strip kept on that edge.
+    /// </summary>
+    public static QuickTerminalResizeEdge HitTest(
+        QuickTerminalPosition position,
+        int left, int top, int right, int bottom,
+        int x, int y, int grip) =>
+        ResizableEdge(position) switch
+        {
+            QuickTerminalResizeEdge.Bottom => y >= bottom - grip ? QuickTerminalResizeEdge.Bottom : QuickTerminalResizeEdge.None,
+            QuickTerminalResizeEdge.Top => y <= top + grip ? QuickTerminalResizeEdge.Top : QuickTerminalResizeEdge.None,
+            QuickTerminalResizeEdge.Right => x >= right - grip ? QuickTerminalResizeEdge.Right : QuickTerminalResizeEdge.None,
+            QuickTerminalResizeEdge.Left => x <= left + grip ? QuickTerminalResizeEdge.Left : QuickTerminalResizeEdge.None,
+            _ => QuickTerminalResizeEdge.None,
+        };
+}

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -40,5 +40,6 @@ internal static class LogEvents
     internal static class Hosting
     {
         public const int HotKeyRegisterFailed = 1300;
+        public const int QuakeFrameSubclassFailed = 1301;
     }
 }

--- a/windows/Ghostty.Tests/Hosting/QuickTerminalFrameGeometryTests.cs
+++ b/windows/Ghostty.Tests/Hosting/QuickTerminalFrameGeometryTests.cs
@@ -1,0 +1,104 @@
+using Ghostty.Core.Hosting;
+using Xunit;
+
+namespace Ghostty.Tests.Hosting;
+
+// Pure-logic coverage for the quake window's resize-edge direction math.
+// Reference window rect is 1000 wide x 400 tall at the origin; grip is 8px.
+public class QuickTerminalFrameGeometryTests
+{
+    private const int Left = 0, Top = 0, Right = 1000, Bottom = 400, Grip = 8;
+
+    // ---- ResizableEdge: the edge opposite the dock ------------------------
+    // One Fact rather than a Theory because the enum types are internal and
+    // cannot appear as parameters of a public xUnit test method (CS0051).
+
+    [Fact]
+    public void ResizableEdge_Is_Opposite_The_Dock()
+    {
+        Assert.Equal(QuickTerminalResizeEdge.Bottom, QuickTerminalFrameGeometry.ResizableEdge(QuickTerminalPosition.Top));
+        Assert.Equal(QuickTerminalResizeEdge.Top, QuickTerminalFrameGeometry.ResizableEdge(QuickTerminalPosition.Bottom));
+        Assert.Equal(QuickTerminalResizeEdge.Right, QuickTerminalFrameGeometry.ResizableEdge(QuickTerminalPosition.Left));
+        Assert.Equal(QuickTerminalResizeEdge.Left, QuickTerminalFrameGeometry.ResizableEdge(QuickTerminalPosition.Right));
+        Assert.Equal(QuickTerminalResizeEdge.None, QuickTerminalFrameGeometry.ResizableEdge(QuickTerminalPosition.Center));
+    }
+
+    // ---- HitTest: only the resizable-edge strip reports a grip ------------
+
+    [Fact]
+    public void Top_Dock_Resizes_From_Bottom_Strip_Only()
+    {
+        // Inside the bottom grip strip [Bottom-Grip, Bottom].
+        Assert.Equal(
+            QuickTerminalResizeEdge.Bottom,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Top, Left, Top, Right, Bottom, 500, Bottom - 1, Grip));
+        // Just above the strip -> client (no resize).
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Top, Left, Top, Right, Bottom, 500, Bottom - Grip - 1, Grip));
+        // The docked (top) edge is NOT resizable.
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Top, Left, Top, Right, Bottom, 500, Top, Grip));
+    }
+
+    [Fact]
+    public void Bottom_Dock_Resizes_From_Top_Strip_Only()
+    {
+        Assert.Equal(
+            QuickTerminalResizeEdge.Top,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Bottom, Left, Top, Right, Bottom, 500, Top + 1, Grip));
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Bottom, Left, Top, Right, Bottom, 500, Top + Grip + 1, Grip));
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Bottom, Left, Top, Right, Bottom, 500, Bottom, Grip));
+    }
+
+    [Fact]
+    public void Left_Dock_Resizes_From_Right_Strip_Only()
+    {
+        Assert.Equal(
+            QuickTerminalResizeEdge.Right,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Left, Left, Top, Right, Bottom, Right - 1, 200, Grip));
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Left, Left, Top, Right, Bottom, Right - Grip - 1, 200, Grip));
+    }
+
+    [Fact]
+    public void Right_Dock_Resizes_From_Left_Strip_Only()
+    {
+        Assert.Equal(
+            QuickTerminalResizeEdge.Left,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Right, Left, Top, Right, Bottom, Left + 1, 200, Grip));
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Right, Left, Top, Right, Bottom, Left + Grip + 1, 200, Grip));
+    }
+
+    [Fact]
+    public void Center_Never_Reports_A_Grip()
+    {
+        // No flush edge -> no custom resize strip anywhere.
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Center, Left, Top, Right, Bottom, 500, Bottom - 1, Grip));
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Center, Left, Top, Right, Bottom, Left, Top, Grip));
+    }
+
+    [Fact]
+    public void HitTest_Honors_A_Non_Origin_Window_Rect()
+    {
+        // Window at (200, 100)-(1200, 500): bottom strip is y in [492, 500].
+        Assert.Equal(
+            QuickTerminalResizeEdge.Bottom,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Top, 200, 100, 1200, 500, 700, 495, Grip));
+        Assert.Equal(
+            QuickTerminalResizeEdge.None,
+            QuickTerminalFrameGeometry.HitTest(QuickTerminalPosition.Top, 200, 100, 1200, 500, 700, 490, Grip));
+    }
+}

--- a/windows/Ghostty/Hosting/QuickTerminalFrame.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalFrame.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using Windows.Win32.Foundation;
+using Ghostty.Core.Hosting;
 
 namespace Ghostty.Hosting;
 
@@ -23,8 +26,10 @@ namespace Ghostty.Hosting;
 /// can no longer be hit-tested for resize. The strip stays uncovered, which is
 /// why native OS resize (and its cursor) still works there.
 ///
-/// Win32 surface is hand-written (matching <see cref="WindowsGlobalHotKey"/>)
-/// because the SUBCLASSPROC is passed as a raw function pointer via
+/// The edge-direction math lives in <see cref="QuickTerminalFrameGeometry"/>
+/// (pure, unit-tested); this file is only the Win32 plumbing. Win32 surface is
+/// hand-written (matching <see cref="WindowsGlobalHotKey"/>) because the
+/// SUBCLASSPROC is passed as a raw function pointer via
 /// Marshal.GetFunctionPointerForDelegate, which the source-generated CsWin32
 /// signatures do not model.
 /// </summary>
@@ -57,24 +62,33 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     private static readonly UIntPtr SubclassId = (UIntPtr)0x5157; // 'QW'
 
     private readonly IntPtr _hwnd;
-    private readonly Func<Ghostty.Core.Hosting.QuickTerminalPosition> _position;
+    private readonly Func<QuickTerminalPosition> _position;
+    private readonly ILogger<QuickTerminalFrame>? _logger;
 
     // Held for the subclass's lifetime: the GC must not collect the delegate
-    // while Windows holds its function pointer.
+    // while Windows holds its function pointer. GetFunctionPointerForDelegate
+    // returns the same thunk for this instance, so the ctor and Dispose pass an
+    // identical pointer to Set/RemoveWindowSubclass.
     private readonly SubclassProcDelegate _proc;
+
+    // Resize-border depth in physical pixels. Computed once: the sizing border
+    // is square on standard themes, so a single value covers both axes
+    // (SM_CYSIZEFRAME + SM_CXPADDEDBORDER == the per-edge frame thickness). Read
+    // at construction-time DPI; a few px off after a cross-monitor DPI change is
+    // immaterial for an 8px grab strip, so it is deliberately not recomputed.
     private readonly int _grip;
     private bool _installed;
 
     public QuickTerminalFrame(
         IntPtr hwnd,
-        Func<Ghostty.Core.Hosting.QuickTerminalPosition> position)
+        Func<QuickTerminalPosition> position,
+        ILogger<QuickTerminalFrame>? logger)
     {
         ArgumentNullException.ThrowIfNull(position);
         _hwnd = hwnd;
         _position = position;
+        _logger = logger;
         _proc = WndProc;
-        // Resize-grip depth = the sizing border Windows would have drawn, so the
-        // grab zone matches what the user expects from a normal window edge.
         _grip = Math.Max(1, GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER));
 
         _installed = SetWindowSubclass(
@@ -86,52 +100,59 @@ internal sealed partial class QuickTerminalFrame : IDisposable
             SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0, 0,
                 SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
         }
+        else
+        {
+            // Degrade rather than throw: the window stays usable, it just keeps
+            // its default sizing border (and the dark band). SetWindowSubclass
+            // does not set a useful last error, so the warning stands alone.
+            _logger?.LogQuakeFrameSubclassFailed();
+        }
     }
 
     public void Dispose()
     {
-        if (_installed)
-        {
-            RemoveWindowSubclass(_hwnd, Marshal.GetFunctionPointerForDelegate(_proc), SubclassId);
-            _installed = false;
-        }
+        if (!_installed) return;
+        // Best-effort: comctl32 also removes the subclass automatically on
+        // WM_NCDESTROY, so if the HWND is already gone (teardown ordering) this
+        // is a benign no-op. Either way no further message reaches _proc after
+        // this, so the delegate is safe to collect once this instance is.
+        RemoveWindowSubclass(_hwnd, Marshal.GetFunctionPointerForDelegate(_proc), SubclassId);
+        _installed = false;
     }
 
     private IntPtr WndProc(
         IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, UIntPtr id, UIntPtr data)
     {
-        var pos = _position();
+        var edge = QuickTerminalFrameGeometry.ResizableEdge(_position());
 
-        // Center docking has no edge flush against the monitor, so there is no
-        // band to hide: keep the normal resizable frame on every edge.
-        if (pos != Ghostty.Core.Hosting.QuickTerminalPosition.Center)
+        // None == Center docking: no edge is flush to the monitor, so leave the
+        // normal resizable frame on every edge (there is no band to hide).
+        if (edge != QuickTerminalResizeEdge.None)
         {
             switch (msg)
             {
                 // wParam == TRUE: lParam points at NCCALCSIZE_PARAMS whose first
                 // RECT (rgrc[0], at offset 0) is the proposed window rect and
                 // becomes the client rect on return. Pull the client out to every
-                // edge EXCEPT the one opposite the dock, where a thin non-client
-                // strip is kept. That strip is the only thing Windows can draw a
-                // resize border on (and hit-test for the drag); removing the
-                // frame on the other three edges drops the dark sizing band,
-                // including the prominent one at the docked edge.
+                // edge except the resizable one, where a thin non-client strip is
+                // kept so Windows still draws a sizing border there. Maximize is
+                // disabled on this window, so no work-area clamp is needed.
                 case WM_NCCALCSIZE when wParam != IntPtr.Zero:
                 {
                     var rc = Marshal.PtrToStructure<RECT>(lParam);
-                    switch (pos)
+                    switch (edge)
                     {
-                        case Ghostty.Core.Hosting.QuickTerminalPosition.Top: rc.bottom -= _grip; break;
-                        case Ghostty.Core.Hosting.QuickTerminalPosition.Bottom: rc.top += _grip; break;
-                        case Ghostty.Core.Hosting.QuickTerminalPosition.Left: rc.right -= _grip; break;
-                        case Ghostty.Core.Hosting.QuickTerminalPosition.Right: rc.left += _grip; break;
+                        case QuickTerminalResizeEdge.Bottom: rc.bottom -= _grip; break;
+                        case QuickTerminalResizeEdge.Top: rc.top += _grip; break;
+                        case QuickTerminalResizeEdge.Left: rc.left += _grip; break;
+                        case QuickTerminalResizeEdge.Right: rc.right -= _grip; break;
                     }
                     Marshal.StructureToPtr(rc, lParam, false);
                     return IntPtr.Zero;
                 }
 
                 case WM_NCHITTEST:
-                    return (IntPtr)HitTest(lParam, pos);
+                    return (IntPtr)HitTest(lParam);
             }
         }
 
@@ -139,12 +160,11 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     }
 
     /// <summary>
-    /// Report a resize grip on the edge opposite the docked edge -- the only
-    /// edge left non-client by WM_NCCALCSIZE, so it is the only one the cursor
-    /// can reach here (XAML's content HWND covers the client edges). Anything
-    /// else is client.
+    /// Map the cursor position to a resize hit-code for the kept strip, or
+    /// HTCLIENT everywhere else. The strip is the only non-client area left, so
+    /// it is the only place the cursor reaches this proc.
     /// </summary>
-    private int HitTest(IntPtr lParam, Ghostty.Core.Hosting.QuickTerminalPosition pos)
+    private int HitTest(IntPtr lParam)
     {
         if (!GetWindowRect(_hwnd, out var r))
             return HTCLIENT;
@@ -154,27 +174,15 @@ internal sealed partial class QuickTerminalFrame : IDisposable
         int x = unchecked((short)(lp & 0xFFFF));
         int y = unchecked((short)((lp >> 16) & 0xFFFF));
 
-        return pos switch
+        return QuickTerminalFrameGeometry.HitTest(
+            _position(), r.left, r.top, r.right, r.bottom, x, y, _grip) switch
         {
-            Ghostty.Core.Hosting.QuickTerminalPosition.Top =>
-                y >= r.bottom - _grip ? HTBOTTOM : HTCLIENT,
-            Ghostty.Core.Hosting.QuickTerminalPosition.Bottom =>
-                y <= r.top + _grip ? HTTOP : HTCLIENT,
-            Ghostty.Core.Hosting.QuickTerminalPosition.Left =>
-                x >= r.right - _grip ? HTRIGHT : HTCLIENT,
-            Ghostty.Core.Hosting.QuickTerminalPosition.Right =>
-                x <= r.left + _grip ? HTLEFT : HTCLIENT,
+            QuickTerminalResizeEdge.Bottom => HTBOTTOM,
+            QuickTerminalResizeEdge.Top => HTTOP,
+            QuickTerminalResizeEdge.Left => HTLEFT,
+            QuickTerminalResizeEdge.Right => HTRIGHT,
             _ => HTCLIENT,
         };
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct RECT
-    {
-        public int left;
-        public int top;
-        public int right;
-        public int bottom;
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Winapi)]
@@ -211,4 +219,14 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool SetWindowPos(
         IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+}
+
+internal static partial class QuickTerminalFrameLogExtensions
+{
+    // Warning, not Error: a failed subclass just means the quake window keeps
+    // its default sizing border. The window still works.
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Hosting.QuakeFrameSubclassFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[QuickTerminalFrame] SetWindowSubclass failed; quake window keeps its default sizing border")]
+    internal static partial void LogQuakeFrameSubclassFailed(this ILogger<QuickTerminalFrame> logger);
 }

--- a/windows/Ghostty/Hosting/QuickTerminalFrame.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalFrame.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Hosting;
+
+/// <summary>
+/// Tames the borderless quake window's non-client frame by subclassing its
+/// window procedure. A resizable (WS_THICKFRAME) borderless window still gets
+/// an ~8px sizing border on every edge, which Windows paints as a dark band at
+/// the docked edge and exposes as a resize grip there -- neither wanted on an
+/// edge that sits flush against the monitor.
+///
+/// Two messages are intercepted:
+///  - WM_NCCALCSIZE: the client area is pulled out to every edge EXCEPT the one
+///    opposite the dock, where a thin non-client strip is kept. The frame (and
+///    its dark band) is gone on the docked edge and the two perpendicular edges;
+///    the kept strip is the only place Windows still draws a sizing border.
+///  - WM_NCHITTEST: that one strip reports a resize grip; everything else is
+///    client. So only the edge opposite the dock is drag-resizable.
+///
+/// Keeping the strip non-client matters: WinUI hosts the XAML content in a
+/// child HWND that covers the whole client area, so an edge made fully client
+/// can no longer be hit-tested for resize. The strip stays uncovered, which is
+/// why native OS resize (and its cursor) still works there.
+///
+/// Win32 surface is hand-written (matching <see cref="WindowsGlobalHotKey"/>)
+/// because the SUBCLASSPROC is passed as a raw function pointer via
+/// Marshal.GetFunctionPointerForDelegate, which the source-generated CsWin32
+/// signatures do not model.
+/// </summary>
+internal sealed partial class QuickTerminalFrame : IDisposable
+{
+    private const uint WM_NCCALCSIZE = 0x0083;
+    private const uint WM_NCHITTEST = 0x0084;
+
+    // WM_NCHITTEST return codes.
+    private const int HTCLIENT = 1;
+    private const int HTLEFT = 10;
+    private const int HTRIGHT = 11;
+    private const int HTTOP = 12;
+    private const int HTBOTTOM = 15;
+
+    // GetSystemMetrics indices for the sizing border thickness.
+    private const int SM_CYSIZEFRAME = 33;
+    private const int SM_CXPADDEDBORDER = 92;
+
+    // SetWindowPos flags to force a one-time WM_NCCALCSIZE recompute so the
+    // frame is dropped immediately rather than on the next natural resize.
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOZORDER = 0x0004;
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const uint SWP_FRAMECHANGED = 0x0020;
+
+    // Arbitrary non-zero id distinguishing this subclass from any other on
+    // the same window.
+    private static readonly UIntPtr SubclassId = (UIntPtr)0x5157; // 'QW'
+
+    private readonly IntPtr _hwnd;
+    private readonly Func<Ghostty.Core.Hosting.QuickTerminalPosition> _position;
+
+    // Held for the subclass's lifetime: the GC must not collect the delegate
+    // while Windows holds its function pointer.
+    private readonly SubclassProcDelegate _proc;
+    private readonly int _grip;
+    private bool _installed;
+
+    public QuickTerminalFrame(
+        IntPtr hwnd,
+        Func<Ghostty.Core.Hosting.QuickTerminalPosition> position)
+    {
+        ArgumentNullException.ThrowIfNull(position);
+        _hwnd = hwnd;
+        _position = position;
+        _proc = WndProc;
+        // Resize-grip depth = the sizing border Windows would have drawn, so the
+        // grab zone matches what the user expects from a normal window edge.
+        _grip = Math.Max(1, GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER));
+
+        _installed = SetWindowSubclass(
+            _hwnd, Marshal.GetFunctionPointerForDelegate(_proc), SubclassId, UIntPtr.Zero);
+        if (_installed)
+        {
+            // Force the frame to recompute now so WM_NCCALCSIZE drops the band
+            // before the first show instead of waiting for a resize.
+            SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0, 0,
+                SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_installed)
+        {
+            RemoveWindowSubclass(_hwnd, Marshal.GetFunctionPointerForDelegate(_proc), SubclassId);
+            _installed = false;
+        }
+    }
+
+    private IntPtr WndProc(
+        IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, UIntPtr id, UIntPtr data)
+    {
+        var pos = _position();
+
+        // Center docking has no edge flush against the monitor, so there is no
+        // band to hide: keep the normal resizable frame on every edge.
+        if (pos != Ghostty.Core.Hosting.QuickTerminalPosition.Center)
+        {
+            switch (msg)
+            {
+                // wParam == TRUE: lParam points at NCCALCSIZE_PARAMS whose first
+                // RECT (rgrc[0], at offset 0) is the proposed window rect and
+                // becomes the client rect on return. Pull the client out to every
+                // edge EXCEPT the one opposite the dock, where a thin non-client
+                // strip is kept. That strip is the only thing Windows can draw a
+                // resize border on (and hit-test for the drag); removing the
+                // frame on the other three edges drops the dark sizing band,
+                // including the prominent one at the docked edge.
+                case WM_NCCALCSIZE when wParam != IntPtr.Zero:
+                {
+                    var rc = Marshal.PtrToStructure<RECT>(lParam);
+                    switch (pos)
+                    {
+                        case Ghostty.Core.Hosting.QuickTerminalPosition.Top: rc.bottom -= _grip; break;
+                        case Ghostty.Core.Hosting.QuickTerminalPosition.Bottom: rc.top += _grip; break;
+                        case Ghostty.Core.Hosting.QuickTerminalPosition.Left: rc.right -= _grip; break;
+                        case Ghostty.Core.Hosting.QuickTerminalPosition.Right: rc.left += _grip; break;
+                    }
+                    Marshal.StructureToPtr(rc, lParam, false);
+                    return IntPtr.Zero;
+                }
+
+                case WM_NCHITTEST:
+                    return (IntPtr)HitTest(lParam, pos);
+            }
+        }
+
+        return DefSubclassProc(hWnd, msg, wParam, lParam);
+    }
+
+    /// <summary>
+    /// Report a resize grip on the edge opposite the docked edge -- the only
+    /// edge left non-client by WM_NCCALCSIZE, so it is the only one the cursor
+    /// can reach here (XAML's content HWND covers the client edges). Anything
+    /// else is client.
+    /// </summary>
+    private int HitTest(IntPtr lParam, Ghostty.Core.Hosting.QuickTerminalPosition pos)
+    {
+        if (!GetWindowRect(_hwnd, out var r))
+            return HTCLIENT;
+
+        // lParam packs signed screen coords: x in the low word, y in the high.
+        long lp = lParam.ToInt64();
+        int x = unchecked((short)(lp & 0xFFFF));
+        int y = unchecked((short)((lp >> 16) & 0xFFFF));
+
+        return pos switch
+        {
+            Ghostty.Core.Hosting.QuickTerminalPosition.Top =>
+                y >= r.bottom - _grip ? HTBOTTOM : HTCLIENT,
+            Ghostty.Core.Hosting.QuickTerminalPosition.Bottom =>
+                y <= r.top + _grip ? HTTOP : HTCLIENT,
+            Ghostty.Core.Hosting.QuickTerminalPosition.Left =>
+                x >= r.right - _grip ? HTRIGHT : HTCLIENT,
+            Ghostty.Core.Hosting.QuickTerminalPosition.Right =>
+                x <= r.left + _grip ? HTLEFT : HTCLIENT,
+            _ => HTCLIENT,
+        };
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int left;
+        public int top;
+        public int right;
+        public int bottom;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate IntPtr SubclassProcDelegate(
+        IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, UIntPtr uIdSubclass, UIntPtr dwRefData);
+
+    [LibraryImport("comctl32.dll", EntryPoint = "SetWindowSubclass")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetWindowSubclass(
+        IntPtr hWnd, IntPtr pfnSubclass, UIntPtr uIdSubclass, UIntPtr dwRefData);
+
+    [LibraryImport("comctl32.dll", EntryPoint = "RemoveWindowSubclass")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool RemoveWindowSubclass(
+        IntPtr hWnd, IntPtr pfnSubclass, UIntPtr uIdSubclass);
+
+    [LibraryImport("comctl32.dll", EntryPoint = "DefSubclassProc")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial IntPtr DefSubclassProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowRect", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [LibraryImport("user32.dll", EntryPoint = "GetSystemMetrics")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int GetSystemMetrics(int nIndex);
+
+    [LibraryImport("user32.dll", EntryPoint = "SetWindowPos", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetWindowPos(
+        IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -952,6 +952,10 @@ public sealed partial class MainWindow : Window
 
         if (IsQuickTerminal)
         {
+            // Remove the window-proc subclass before the HWND is torn down.
+            _quakeFrame?.Dispose();
+            _quakeFrame = null;
+
             // Persist only the session-resized height, via read-modify-write
             // so we never clobber the regular window placement other windows
             // save. The quake window's X/Y/Width are config-driven
@@ -1778,6 +1782,14 @@ public sealed partial class MainWindow : Window
             presenter.IsMaximizable = false;
         }
 
+        // IsResizable leaves a WS_THICKFRAME sizing border that Windows paints
+        // as a dark band at the docked edge and exposes as a resize grip there.
+        // Subclass the window proc to drop that non-client frame (no band) and
+        // allow drag-resize only on the edge opposite the dock.
+        _quakeFrame = new Ghostty.Hosting.QuickTerminalFrame(
+            WindowNative.GetWindowHandle(this),
+            () => _configService.QuickTerminalPosition);
+
         // Borderless quake has no OS caption buttons; collapse the dead inset
         // and drop the vertical-mode title text.
         _titleBar.SetCaptionless(true);
@@ -1888,6 +1900,12 @@ public sealed partial class MainWindow : Window
     // window, so the AppWindow.Changed size-capture below ignores our own
     // resize and only records genuine user drags.
     private bool _movingQuake;
+
+    // Window-proc subclass that drops the borderless quake window's non-client
+    // sizing border (the dark band) and confines drag-resize to the edge
+    // opposite the dock. Null on regular windows; lives for the quake window's
+    // lifetime and is disposed on close.
+    private Ghostty.Hosting.QuickTerminalFrame? _quakeFrame;
 
     /// <summary>
     /// Position the window per <c>quick-terminal-position</c>,

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1771,9 +1771,9 @@ public sealed partial class MainWindow : Window
 
         // Borderless: a quake terminal is positioned by config and toggled by
         // the global hotkey, so it needs no title bar, border, caption buttons,
-        // or min/max. IsResizable=true keeps the (unpainted) resize frame so
-        // the user can drag the bottom edge to change height; the docked
-        // top/side edges sit at the monitor bounds and stay fixed.
+        // or min/max. IsResizable=true keeps a sizing frame so the window can be
+        // resize-dragged; QuickTerminalFrame (below) reshapes that frame to drop
+        // the docked-edge band and confine resize to the edge opposite the dock.
         if (AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
         {
             presenter.SetBorderAndTitleBar(hasBorder: false, hasTitleBar: false);
@@ -1788,7 +1788,8 @@ public sealed partial class MainWindow : Window
         // allow drag-resize only on the edge opposite the dock.
         _quakeFrame = new Ghostty.Hosting.QuickTerminalFrame(
             WindowNative.GetWindowHandle(this),
-            () => _configService.QuickTerminalPosition);
+            () => _configService.QuickTerminalPosition,
+            App.LoggerFactory?.CreateLogger<Ghostty.Hosting.QuickTerminalFrame>());
 
         // Borderless quake has no OS caption buttons; collapse the dead inset
         // and drop the vertical-mode title text.


### PR DESCRIPTION
The borderless quick terminal showed a dark strip at the docked edge and could be resize-dragged from that edge. Both came from the WS_THICKFRAME sizing border that IsResizable leaves on the window.

QuickTerminalFrame subclasses the window proc: WM_NCCALCSIZE drops the frame on the docked edge and the two sides (removing the band), while a thin non-client strip stays on the edge opposite the dock so WM_NCHITTEST keeps native resize and its cursor there. The strip has to stay because WinUI hosts content in a child HWND that covers the client area, so a fully frame-less edge can no longer be hit-tested for resize.

Tested on a top-docked window: band gone, resizes from the bottom edge, top edge no longer resizable, and the band stays gone across resizes.