### PR TITLE
Keyboard shortcuts: enumerate-keybinds C ABI

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -385,6 +385,21 @@ typedef struct {
   ghostty_input_mods_e mods;
 } ghostty_input_trigger_s;
 
+// Maximum trigger steps in a single enumerated keybind (leader sequences).
+// Bindings longer than this are clamped with a logged warning. Keep in sync
+// with input.Binding.keybind_max_steps (Zig) and KeybindInterop.MaxSteps (C#).
+#define GHOSTTY_KEYBIND_MAX_STEPS 4
+
+// A single parsed keybind, flattened so a leader sequence (e.g. "ctrl+k>ctrl+s")
+// is one entry with multiple steps. Pointers are owned by the ghostty_config_t
+// and are valid until it is freed. Produced by ghostty_config_get_keybind.
+typedef struct {
+  ghostty_input_trigger_s steps[GHOSTTY_KEYBIND_MAX_STEPS];
+  uint32_t step_count;   // number of valid entries in steps (1 for a chord)
+  const char* action;    // null-terminated action string, e.g. "new_split:right"
+  uint32_t flags;        // bitfield of ghostty_binding_flags_e
+} ghostty_keybind_s;
+
 typedef struct {
   const char* action_key;
   const char* action;
@@ -1115,6 +1130,8 @@ GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
 GHOSTTY_API bool ghostty_config_key_is_binding(ghostty_config_t, ghostty_input_key_s);
 GHOSTTY_API uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
 GHOSTTY_API ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
+GHOSTTY_API uint32_t ghostty_config_keybinds_count(ghostty_config_t);
+GHOSTTY_API ghostty_keybind_s ghostty_config_get_keybind(ghostty_config_t, uint32_t);
 GHOSTTY_API ghostty_string_s ghostty_config_open_path(void);
 
 GHOSTTY_API ghostty_app_t ghostty_app_new(const ghostty_runtime_config_s*,

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -132,6 +132,16 @@ export fn ghostty_config_get_diagnostic(self: *Config, idx: u32) Diagnostic {
     return .{ .message = message.ptr };
 }
 
+export fn ghostty_config_keybinds_count(self: *Config) u32 {
+    return @intCast(self.keybindsCList().len);
+}
+
+export fn ghostty_config_get_keybind(self: *Config, idx: u32) inputpkg.Binding.Set.CEntry {
+    const list = self.keybindsCList();
+    if (idx >= list.len) return .{};
+    return list[idx];
+}
+
 export fn ghostty_config_open_path() String {
     const path = edit.openPath(state.alloc) catch |err| {
         log.err("error opening config in editor err={}", .{err});
@@ -242,6 +252,23 @@ test "ghostty_config_get: struct cval conversion" {
     try testing.expectEqual(@as(u8, 12), out.r);
     try testing.expectEqual(@as(u8, 34), out.g);
     try testing.expectEqual(@as(u8, 56), out.b);
+}
+
+test "ghostty_config_keybinds: count and get" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+    const count = ghostty_config_keybinds_count(&cfg);
+    try testing.expect(count > 0);
+
+    const kb = ghostty_config_get_keybind(&cfg, 0);
+    try testing.expect(kb.step_count >= 1);
+    try testing.expect(kb.action[0] != 0);
+
+    const oob = ghostty_config_get_keybind(&cfg, count);
+    try testing.expectEqual(@as(u32, 0), oob.step_count);
 }
 
 test "ghostty_config_trigger: default keybind" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3912,6 +3912,9 @@ pub fn deinit(self: *Config) void {
 
 /// Returns the flattened keybind list, building + caching it on first call.
 /// Slice + strings live in _arena (freed at deinit). Empty on alloc failure.
+/// The cache assumes a finalized, immutable config; it is not rebuilt if the
+/// keybind set changes after the first call (callers re-enumerate via a fresh
+/// config on reload, matching the cached-diagnostics lifetime model).
 pub fn keybindsCList(self: *Config) []const inputpkg.Binding.Set.CEntry {
     if (self._keybinds_c) |list| return list;
     const alloc = self._arena.?.allocator();

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3885,6 +3885,10 @@ _arena: ?ArenaAllocator = null,
 /// the configuration.
 _diagnostics: cli.DiagnosticList = .{},
 
+/// Lazily-built flattened keybind list for the enumerate-keybinds C ABI.
+/// Allocated in _arena, so freed by _arena.deinit (no explicit free).
+_keybinds_c: ?[]inputpkg.Binding.Set.CEntry = null,
+
 /// The conditional truths for the configuration. This is used to
 /// determine if a conditional configuration matches or not.
 _conditional_state: conditional.State = .{},
@@ -3904,6 +3908,19 @@ _replay_steps: std.ArrayListUnmanaged(Replay.Step) = .{},
 pub fn deinit(self: *Config) void {
     if (self._arena) |arena| arena.deinit();
     self.* = undefined;
+}
+
+/// Returns the flattened keybind list, building + caching it on first call.
+/// Slice + strings live in _arena (freed at deinit). Empty on alloc failure.
+pub fn keybindsCList(self: *Config) []const inputpkg.Binding.Set.CEntry {
+    if (self._keybinds_c) |list| return list;
+    const alloc = self._arena.?.allocator();
+    const list = self.keybind.set.cList(alloc) catch |err| {
+        log.warn("failed to build keybind C list: {}", .{err});
+        return &.{};
+    };
+    self._keybinds_c = list;
+    return list;
 }
 
 /// Load the configuration according to the default rules:

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -4961,3 +4961,28 @@ test "Set.cList: single chord" {
     try testing.expectEqual(@as(u32, 1), entries[0].step_count);
     try testing.expectEqualStrings("new_tab", std.mem.span(entries[0].action));
 }
+
+test "Set.cList: sequence and flags" {
+    const testing = std.testing;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var set: Set = .{};
+    try set.parseAndPut(alloc, "performable:alt+shift+equal=new_split:right");
+    try set.parseAndPut(alloc, "ctrl+k>ctrl+s=write_screen_file:paste");
+
+    const entries = try set.cList(alloc);
+    try testing.expectEqual(@as(usize, 2), entries.len);
+
+    var seq: ?Set.CEntry = null;
+    var perf: ?Set.CEntry = null;
+    for (entries) |e| {
+        if (e.step_count == 2) seq = e;
+        if (std.mem.eql(u8, std.mem.span(e.action), "new_split:right")) perf = e;
+    }
+    try testing.expect(seq != null);
+    try testing.expectEqual(@as(u32, 2), seq.?.step_count);
+    try testing.expect(perf != null);
+    try testing.expectEqual(@as(u32, 0b1001), perf.?.flags); // consumed(1) + performable(8)
+}

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -4,6 +4,7 @@ const Binding = @This();
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const log = std.log.scoped(.keybind);
 const assert = @import("../quirks.zig").inlineAssert;
 const build_config = @import("../build_config.zig");
 const uucode = @import("uucode");
@@ -2269,6 +2270,71 @@ pub const Set = struct {
             };
         }
     };
+
+    /// Maximum trigger steps in a flattened keybind (leader sequences).
+    /// Keep in sync with GHOSTTY_KEYBIND_MAX_STEPS (ghostty.h) and
+    /// KeybindInterop.MaxSteps (C#).
+    pub const keybind_max_steps = 4;
+
+    /// A flattened keybind for the C ABI. Sync with ghostty_keybind_s.
+    /// A leader sequence becomes one entry with step_count > 1.
+    pub const CEntry = extern struct {
+        steps: [keybind_max_steps]Trigger.C = @splat(.{}),
+        step_count: u32 = 0,
+        action: [*:0]const u8 = "",
+        flags: u32 = 0,
+    };
+
+    /// Flatten every binding (depth-first over the insertion-ordered map) into a
+    /// slice of CEntry allocated with `alloc`. Action strings are allocPrintZ'd
+    /// with `alloc`; the caller owns the returned slice and its strings.
+    pub fn cList(self: *const Set, alloc: Allocator) ![]CEntry {
+        var list: std.ArrayListUnmanaged(CEntry) = .{};
+        errdefer list.deinit(alloc);
+        var path: [keybind_max_steps]Trigger = undefined;
+        try cListWalk(self, alloc, &path, 0, &list);
+        return list.toOwnedSlice(alloc);
+    }
+
+    fn cListWalk(
+        set: *const Set,
+        alloc: Allocator,
+        path: *[keybind_max_steps]Trigger,
+        depth: usize,
+        list: *std.ArrayListUnmanaged(CEntry),
+    ) !void {
+        var it = set.bindings.iterator();
+        while (it.next()) |entry| {
+            if (depth < keybind_max_steps) path[depth] = entry.key_ptr.*;
+            switch (entry.value_ptr.*) {
+                .leader => |next| try cListWalk(next, alloc, path, depth + 1, list),
+                .leaf => |leaf| try cListEmit(alloc, path, depth, leaf.action, leaf.flags, list),
+                .leaf_chained => |chain| for (chain.actions.items) |action| {
+                    try cListEmit(alloc, path, depth, action, chain.flags, list);
+                },
+            }
+        }
+    }
+
+    fn cListEmit(
+        alloc: Allocator,
+        path: *const [keybind_max_steps]Trigger,
+        depth: usize,
+        action: Action,
+        flags: Flags,
+        list: *std.ArrayListUnmanaged(CEntry),
+    ) !void {
+        const count = @min(depth + 1, keybind_max_steps);
+        if (depth + 1 > keybind_max_steps) {
+            log.warn("keybind sequence exceeds {d} steps; clamping", .{keybind_max_steps});
+        }
+        var e: CEntry = .{};
+        for (0..count) |i| e.steps[i] = path[i].cval();
+        e.step_count = @intCast(count);
+        e.action = try std.fmt.allocPrintZ(alloc, "{f}", .{action});
+        e.flags = @intCast(flags.cval());
+        try list.append(alloc, e);
+    }
 
     /// A full key-value entry for the set.
     pub const Entry = HashMap.Entry;
@@ -4879,4 +4945,19 @@ test "set: formatEntries leaf_chained with text action" {
         \\
     ;
     try testing.expectEqualStrings(expected, output.written());
+}
+
+test "Set.cList: single chord" {
+    const testing = std.testing;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var set: Set = .{};
+    try set.parseAndPut(alloc, "ctrl+shift+t=new_tab");
+
+    const entries = try set.cList(alloc);
+    try testing.expectEqual(@as(usize, 1), entries.len);
+    try testing.expectEqual(@as(u32, 1), entries[0].step_count);
+    try testing.expectEqualStrings("new_tab", std.mem.span(entries[0].action));
 }

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -2331,7 +2331,7 @@ pub const Set = struct {
         var e: CEntry = .{};
         for (0..count) |i| e.steps[i] = path[i].cval();
         e.step_count = @intCast(count);
-        e.action = try std.fmt.allocPrintZ(alloc, "{f}", .{action});
+        e.action = (try std.fmt.allocPrintSentinel(alloc, "{f}", .{action}, 0)).ptr;
         e.flags = @intCast(flags.cval());
         try list.append(alloc, e);
     }

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -2309,6 +2309,8 @@ pub const Set = struct {
             switch (entry.value_ptr.*) {
                 .leader => |next| try cListWalk(next, alloc, path, depth + 1, list),
                 .leaf => |leaf| try cListEmit(alloc, path, depth, leaf.action, leaf.flags, list),
+                // A chained trigger emits one entry per action, all sharing the
+                // same trigger path and flags. Consumers see repeated triggers.
                 .leaf_chained => |chain| for (chain.actions.items) |action| {
                     try cListEmit(alloc, path, depth, action, chain.flags, list);
                 },
@@ -2324,6 +2326,9 @@ pub const Set = struct {
         flags: Flags,
         list: *std.ArrayListUnmanaged(CEntry),
     ) !void {
+        // Sequences deeper than the cap are truncated to the first
+        // keybind_max_steps triggers. Two such sequences sharing a prefix
+        // collapse to the same entry, so (steps, step_count) is not a unique key.
         const count = @min(depth + 1, keybind_max_steps);
         if (depth + 1 > keybind_max_steps) {
             log.warn("keybind sequence exceeds {d} steps; clamping", .{keybind_max_steps});

--- a/windows/Ghostty.Core/Input/EnumeratedKeybind.cs
+++ b/windows/Ghostty.Core/Input/EnumeratedKeybind.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Ghostty.Core.Interop;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>One physical trigger step (modifiers + key) of a keybind.</summary>
+public readonly record struct KeybindTrigger(int Tag, uint Key, uint Mods);
+
+/// <summary>
+/// A single parsed keybind enumerated from libghostty. A leader sequence
+/// (e.g. Ctrl+K Ctrl+S) carries more than one step.
+/// </summary>
+public sealed record EnumeratedKeybind(
+    IReadOnlyList<KeybindTrigger> Steps,
+    string Action,
+    GhosttyBindingFlags Flags);

--- a/windows/Ghostty.Core/Interop/KeybindInterop.cs
+++ b/windows/Ghostty.Core/Interop/KeybindInterop.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Ghostty.Core.Input;
+
+namespace Ghostty.Core.Interop;
+
+/// <summary>Bitfield mirror of ghostty_binding_flags_e.</summary>
+[Flags]
+public enum GhosttyBindingFlags : uint
+{
+    None = 0,
+    Consumed = 1 << 0,
+    All = 1 << 1,
+    Global = 1 << 2,
+    Performable = 1 << 3,
+}
+
+/// <summary>Blittable mirror of ghostty_input_trigger_s.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct GhosttyTriggerC
+{
+    public int Tag;   // 0=physical, 1=unicode, 2=catch_all
+    public uint Key;  // union: translated/physical key or unicode codepoint
+    public uint Mods; // modifier flags
+}
+
+/// <summary>Inline fixed buffer of GHOSTTY_KEYBIND_MAX_STEPS triggers.</summary>
+[InlineArray(KeybindInterop.MaxSteps)]
+public struct TriggerSteps
+{
+    private GhosttyTriggerC _element0;
+}
+
+/// <summary>Blittable mirror of ghostty_keybind_s.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct GhosttyKeybindC
+{
+    public TriggerSteps Steps;
+    public uint StepCount;
+    public IntPtr Action; // const char*, owned by config
+    public uint Flags;
+}
+
+public static class KeybindInterop
+{
+    /// <summary>Keep in sync with GHOSTTY_KEYBIND_MAX_STEPS and keybind_max_steps.</summary>
+    public const int MaxSteps = 4;
+
+    /// <summary>Maps a native keybind struct to the pure record (decodes the action string).</summary>
+    public static EnumeratedKeybind ToEnumerated(in GhosttyKeybindC c)
+    {
+        var count = (int)Math.Min(c.StepCount, (uint)MaxSteps);
+        var steps = new List<KeybindTrigger>(count);
+
+        // InlineArray indexing needs a writable ref, but `c` is an `in`
+        // parameter; copy the inline buffer to a local first so the
+        // indexer is happy.
+        var stepBuffer = c.Steps;
+        for (var i = 0; i < count; i++)
+        {
+            var t = stepBuffer[i];
+            steps.Add(new KeybindTrigger(t.Tag, t.Key, t.Mods));
+        }
+
+        var action = c.Action == IntPtr.Zero
+            ? string.Empty
+            : Marshal.PtrToStringUTF8(c.Action) ?? string.Empty;
+
+        return new EnumeratedKeybind(steps, action, (GhosttyBindingFlags)c.Flags);
+    }
+}

--- a/windows/Ghostty.Core/Interop/KeybindInterop.cs
+++ b/windows/Ghostty.Core/Interop/KeybindInterop.cs
@@ -54,9 +54,8 @@ public static class KeybindInterop
         var count = (int)Math.Min(c.StepCount, (uint)MaxSteps);
         var steps = new List<KeybindTrigger>(count);
 
-        // InlineArray indexing needs a writable ref, but `c` is an `in`
-        // parameter; copy the inline buffer to a local first so the
-        // indexer is happy.
+        // InlineArray's indexer requires a writable ref, which an `in`
+        // parameter forbids, so copy the (small, cold-path) buffer locally.
         var stepBuffer = c.Steps;
         for (var i = 0; i < count; i++)
         {

--- a/windows/Ghostty.Tests/Interop/KeybindInteropLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/KeybindInteropLayoutTests.cs
@@ -34,6 +34,9 @@ public class KeybindInteropLayoutTests
         Assert.Equal(48, (int)Marshal.OffsetOf<GhosttyKeybindC>(nameof(GhosttyKeybindC.StepCount)));
         Assert.Equal(56, (int)Marshal.OffsetOf<GhosttyKeybindC>(nameof(GhosttyKeybindC.Action)));
         Assert.Equal(64, (int)Marshal.OffsetOf<GhosttyKeybindC>(nameof(GhosttyKeybindC.Flags)));
+        // Whole-struct size (64 + flags u32 + 4 tail pad) catches a trailing
+        // field or padding change the per-field offsets alone would miss.
+        Assert.Equal(72, Marshal.SizeOf<GhosttyKeybindC>());
     }
 
     [Theory]

--- a/windows/Ghostty.Tests/Interop/KeybindInteropLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/KeybindInteropLayoutTests.cs
@@ -1,0 +1,48 @@
+using System.Runtime.InteropServices;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+public class KeybindInteropLayoutTests
+{
+    [Fact]
+    public void MaxSteps_MatchesAbiContract()
+    {
+        Assert.Equal(4, KeybindInterop.MaxSteps);
+    }
+
+    [Fact]
+    public void GhosttyTriggerC_HasExpectedLayout()
+    {
+        Assert.Equal(12, Marshal.SizeOf<GhosttyTriggerC>());
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyTriggerC>(nameof(GhosttyTriggerC.Tag)));
+        Assert.Equal(4, (int)Marshal.OffsetOf<GhosttyTriggerC>(nameof(GhosttyTriggerC.Key)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<GhosttyTriggerC>(nameof(GhosttyTriggerC.Mods)));
+    }
+
+    [Fact]
+    public void TriggerSteps_IsContiguousArrayOfTriggers()
+    {
+        Assert.Equal(12 * KeybindInterop.MaxSteps, Marshal.SizeOf<TriggerSteps>());
+    }
+
+    [Fact]
+    public void GhosttyKeybindC_HasExpectedLayout()
+    {
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyKeybindC>(nameof(GhosttyKeybindC.Steps)));
+        Assert.Equal(48, (int)Marshal.OffsetOf<GhosttyKeybindC>(nameof(GhosttyKeybindC.StepCount)));
+        Assert.Equal(56, (int)Marshal.OffsetOf<GhosttyKeybindC>(nameof(GhosttyKeybindC.Action)));
+        Assert.Equal(64, (int)Marshal.OffsetOf<GhosttyKeybindC>(nameof(GhosttyKeybindC.Flags)));
+    }
+
+    [Theory]
+    [InlineData(GhosttyBindingFlags.Consumed, 1u)]
+    [InlineData(GhosttyBindingFlags.All, 2u)]
+    [InlineData(GhosttyBindingFlags.Global, 4u)]
+    [InlineData(GhosttyBindingFlags.Performable, 8u)]
+    public void BindingFlags_MatchAbiValues(GhosttyBindingFlags flag, uint expected)
+    {
+        Assert.Equal(expected, (uint)flag);
+    }
+}

--- a/windows/Ghostty.Tests/Interop/KeybindMapperTests.cs
+++ b/windows/Ghostty.Tests/Interop/KeybindMapperTests.cs
@@ -46,4 +46,26 @@ public class KeybindMapperTests
         Assert.Equal(KeybindInterop.MaxSteps, result.Steps.Count);
         Assert.Equal(string.Empty, result.Action);
     }
+
+    [Fact]
+    public void ToEnumerated_PreservesMultiStepSequenceOrder()
+    {
+        var c = new GhosttyKeybindC { StepCount = 2, Action = IntPtr.Zero };
+        c.Steps[0] = new GhosttyTriggerC { Tag = 0, Key = 11, Mods = 1 };
+        c.Steps[1] = new GhosttyTriggerC { Tag = 0, Key = 22, Mods = 2 };
+
+        var result = KeybindInterop.ToEnumerated(c);
+
+        Assert.Equal(2, result.Steps.Count);
+        Assert.Equal(11u, result.Steps[0].Key);
+        Assert.Equal(22u, result.Steps[1].Key);
+    }
+
+    [Fact]
+    public void ToEnumerated_HandlesZeroSteps()
+    {
+        var c = new GhosttyKeybindC { StepCount = 0, Action = IntPtr.Zero };
+        var result = KeybindInterop.ToEnumerated(c);
+        Assert.Empty(result.Steps);
+    }
 }

--- a/windows/Ghostty.Tests/Interop/KeybindMapperTests.cs
+++ b/windows/Ghostty.Tests/Interop/KeybindMapperTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+public class KeybindMapperTests
+{
+    [Fact]
+    public void ToEnumerated_MapsStepsActionAndFlags()
+    {
+        var actionBytes = Encoding.UTF8.GetBytes("new_split:right\0");
+        var handle = GCHandle.Alloc(actionBytes, GCHandleType.Pinned);
+        try
+        {
+            var c = new GhosttyKeybindC
+            {
+                StepCount = 1,
+                Action = handle.AddrOfPinnedObject(),
+                Flags = (uint)(GhosttyBindingFlags.Consumed | GhosttyBindingFlags.Performable),
+            };
+            c.Steps[0] = new GhosttyTriggerC { Tag = 0, Key = 42, Mods = 5 };
+
+            var result = KeybindInterop.ToEnumerated(c);
+
+            Assert.Equal("new_split:right", result.Action);
+            Assert.Single(result.Steps);
+            Assert.Equal(42u, result.Steps[0].Key);
+            Assert.True(result.Flags.HasFlag(GhosttyBindingFlags.Performable));
+            Assert.True(result.Flags.HasFlag(GhosttyBindingFlags.Consumed));
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
+
+    [Fact]
+    public void ToEnumerated_ClampsStepCountToMax()
+    {
+        var c = new GhosttyKeybindC { StepCount = 99, Action = IntPtr.Zero };
+        var result = KeybindInterop.ToEnumerated(c);
+        Assert.Equal(KeybindInterop.MaxSteps, result.Steps.Count);
+        Assert.Equal(string.Empty, result.Action);
+    }
+}

--- a/windows/Ghostty/Interop/KeybindEnumerator.cs
+++ b/windows/Ghostty/Interop/KeybindEnumerator.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+
+namespace Ghostty.Interop;
+
+/// <summary>
+/// Reads the full parsed keybind set from a libghostty config via the
+/// count + indexed-getter C ABI and maps it to pure EnumeratedKeybind records.
+/// </summary>
+internal static class KeybindEnumerator
+{
+    public static IReadOnlyList<EnumeratedKeybind> Enumerate(GhosttyConfig config)
+    {
+        var count = NativeMethods.ConfigKeybindsCount(config);
+        var result = new List<EnumeratedKeybind>((int)count);
+        for (uint i = 0; i < count; i++)
+        {
+            var native = NativeMethods.ConfigGetKeybind(config, i);
+            result.Add(KeybindInterop.ToEnumerated(native));
+        }
+
+        return result;
+    }
+}

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -340,6 +340,14 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial GhosttyDiagnostic ConfigGetDiagnostic(GhosttyConfig config, uint index);
 
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_keybinds_count")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial uint ConfigKeybindsCount(GhosttyConfig config);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_get_keybind")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial GhosttyKeybindC ConfigGetKeybind(GhosttyConfig config, uint idx);
+
     [LibraryImport(Dll, EntryPoint = "ghostty_config_open_path")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial GhosttyString ConfigOpenPath();


### PR DESCRIPTION
Adds a forward-enumeration C ABI that lists every parsed keybind from a config: `ghostty_config_keybinds_count` + `ghostty_config_get_keybind`, returning trigger steps, action string, and flags. Mirrors the existing `ghostty_config_diagnostics_count` / `get_diagnostic` count + indexed-getter pair.

Why a new API: macOS and GTK only ever reverse-lookup a known action to its trigger (`ghostty_config_trigger`), driven by a hardcoded action list. That can't back a keybind editor or cheat sheet here, because the reverse map deliberately excludes performable and sequence binds (our Windows split defaults are performable, so they'd show blank), and it can't represent the real config (duplicate binds, unbind, arbitrary user triggers). GTK gets the full set by walking the Zig `Set` in-process; Windows is across P/Invoke, so it needs this.

C# side: blittable `GhosttyKeybindC` mirror in `Ghostty.Core/Interop` (InlineArray step buffer, no runtime marshalling), pure `EnumeratedKeybind` record, and a `KeybindEnumerator`. Struct size/offsets and flag values pinned by tests.

Part of the keyboard-shortcuts series (follows the engine-swap PR). No UI consumer yet: `KeybindEnumerator` is plumbing the read-only editor / keyboard-map / cheat-sheet will consume next. `source` (default vs user) is intentionally deferred.

Verified: Zig CApi test (count/get/out-of-range), C# layout + mapper tests, and an end-to-end run against the built dll enumerating 70 default binds with `new_split:right` and other performable splits correctly present.