### PR TITLE
Keyboard shortcuts: read-only keybind editor

### DIFF
--- a/windows/Ghostty.Core/Input/KeyNames.cs
+++ b/windows/Ghostty.Core/Input/KeyNames.cs
@@ -1,0 +1,43 @@
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Ordinal -> name table mirroring ghostty's input.Key enum (enum(c_int)).
+/// The enumerate ABI returns the Key ordinal for physical triggers; this maps
+/// it back to the enum name, which TriggerLabeler turns into a display label.
+/// Keep in exact order with src/input/key.zig. KeyNamesTests pins the count
+/// and several ordinals to catch drift.
+/// </summary>
+public static class KeyNames
+{
+    private static readonly string[] Names =
+    {
+        "unidentified", "backquote", "backslash", "bracket_left", "bracket_right", "comma", "digit_0", "digit_1",
+        "digit_2", "digit_3", "digit_4", "digit_5", "digit_6", "digit_7", "digit_8", "digit_9",
+        "equal", "intl_backslash", "intl_ro", "intl_yen", "key_a", "key_b", "key_c", "key_d",
+        "key_e", "key_f", "key_g", "key_h", "key_i", "key_j", "key_k", "key_l",
+        "key_m", "key_n", "key_o", "key_p", "key_q", "key_r", "key_s", "key_t",
+        "key_u", "key_v", "key_w", "key_x", "key_y", "key_z", "minus", "period",
+        "quote", "semicolon", "slash", "alt_left", "alt_right", "backspace", "caps_lock", "context_menu",
+        "control_left", "control_right", "enter", "meta_left", "meta_right", "shift_left", "shift_right", "space",
+        "tab", "convert", "kana_mode", "non_convert", "delete", "end", "help", "home",
+        "insert", "page_down", "page_up", "arrow_down", "arrow_left", "arrow_right", "arrow_up", "num_lock",
+        "numpad_0", "numpad_1", "numpad_2", "numpad_3", "numpad_4", "numpad_5", "numpad_6", "numpad_7",
+        "numpad_8", "numpad_9", "numpad_add", "numpad_backspace", "numpad_clear", "numpad_clear_entry", "numpad_comma", "numpad_decimal",
+        "numpad_divide", "numpad_enter", "numpad_equal", "numpad_memory_add", "numpad_memory_clear", "numpad_memory_recall", "numpad_memory_store", "numpad_memory_subtract",
+        "numpad_multiply", "numpad_paren_left", "numpad_paren_right", "numpad_subtract", "numpad_separator", "numpad_up", "numpad_down", "numpad_right",
+        "numpad_left", "numpad_begin", "numpad_home", "numpad_end", "numpad_insert", "numpad_delete", "numpad_page_up", "numpad_page_down",
+        "escape", "f1", "f2", "f3", "f4", "f5", "f6", "f7",
+        "f8", "f9", "f10", "f11", "f12", "f13", "f14", "f15",
+        "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+        "f24", "f25", "fn_lock", "print_screen", "scroll_lock", "pause", "browser_back", "browser_favorites",
+        "browser_forward", "browser_home", "browser_refresh", "browser_search", "browser_stop", "eject", "launch_app_1", "launch_app_2",
+        "launch_mail", "media_play_pause", "media_select", "media_stop", "media_track_next", "media_track_previous", "power", "sleep",
+        "audio_volume_down", "audio_volume_mute", "audio_volume_up", "wake_up", "copy", "cut", "paste",
+    };
+
+    public static int Count => Names.Length;
+
+    /// <summary>Name for an ordinal, or null if out of range.</summary>
+    public static string? NameOf(int ordinal)
+        => ordinal >= 0 && ordinal < Names.Length ? Names[ordinal] : null;
+}

--- a/windows/Ghostty.Core/Input/KeyNames.cs
+++ b/windows/Ghostty.Core/Input/KeyNames.cs
@@ -29,7 +29,7 @@ public static class KeyNames
         "escape", "f1", "f2", "f3", "f4", "f5", "f6", "f7",
         "f8", "f9", "f10", "f11", "f12", "f13", "f14", "f15",
         "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
-        "f24", "f25", "fn_lock", "print_screen", "scroll_lock", "pause", "browser_back", "browser_favorites",
+        "f24", "f25", "fn", "fn_lock", "print_screen", "scroll_lock", "pause", "browser_back", "browser_favorites",
         "browser_forward", "browser_home", "browser_refresh", "browser_search", "browser_stop", "eject", "launch_app_1", "launch_app_2",
         "launch_mail", "media_play_pause", "media_select", "media_stop", "media_track_next", "media_track_previous", "power", "sleep",
         "audio_volume_down", "audio_volume_mute", "audio_volume_up", "wake_up", "copy", "cut", "paste",

--- a/windows/Ghostty.Core/Input/KeybindActionCatalog.cs
+++ b/windows/Ghostty.Core/Input/KeybindActionCatalog.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>Category + human-friendly name resolved for a keybind action.</summary>
+public readonly record struct ActionDescription(string Category, string Friendly);
+
+/// <summary>
+/// Maps a keybind action string (e.g. "new_split:right") to a UI category and a
+/// friendly name. Matches on the verb before ':'. Unmapped actions fall back to
+/// the raw action under "Other". Covers the curated Windows default set; extend
+/// as needed.
+/// </summary>
+public static class KeybindActionCatalog
+{
+    // verb -> (category, friendly). For verbs whose argument matters (splits,
+    // goto_split, resize_split) the argument is appended in Describe.
+    private static readonly Dictionary<string, (string Category, string Friendly)> Verbs =
+        new(StringComparer.Ordinal)
+    {
+        ["new_split"] = ("Panes", "Split"),
+        ["goto_split"] = ("Panes", "Focus Split"),
+        ["resize_split"] = ("Panes", "Resize Split"),
+        ["equalize_splits"] = ("Panes", "Equalize Splits"),
+        ["toggle_split_zoom"] = ("Panes", "Toggle Split Zoom"),
+        ["new_tab"] = ("Tabs", "New Tab"),
+        ["close_tab"] = ("Tabs", "Close Tab"),
+        ["previous_tab"] = ("Tabs", "Previous Tab"),
+        ["next_tab"] = ("Tabs", "Next Tab"),
+        ["goto_tab"] = ("Tabs", "Go To Tab"),
+        ["move_tab"] = ("Tabs", "Move Tab"),
+        ["last_tab"] = ("Tabs", "Last Tab"),
+        ["scroll_page_up"] = ("Scroll", "Scroll Page Up"),
+        ["scroll_page_down"] = ("Scroll", "Scroll Page Down"),
+        ["scroll_to_top"] = ("Scroll", "Scroll To Top"),
+        ["scroll_to_bottom"] = ("Scroll", "Scroll To Bottom"),
+        ["jump_to_prompt"] = ("Scroll", "Jump To Prompt"),
+        ["copy_to_clipboard"] = ("Clipboard", "Copy"),
+        ["paste_from_clipboard"] = ("Clipboard", "Paste"),
+        ["paste_from_selection"] = ("Clipboard", "Paste Selection"),
+        ["select_all"] = ("Clipboard", "Select All"),
+        ["adjust_selection"] = ("Clipboard", "Adjust Selection"),
+        ["increase_font_size"] = ("Font", "Increase Font Size"),
+        ["decrease_font_size"] = ("Font", "Decrease Font Size"),
+        ["reset_font_size"] = ("Font", "Reset Font Size"),
+        ["toggle_fullscreen"] = ("Window", "Toggle Fullscreen"),
+        ["toggle_quick_terminal"] = ("Window", "Toggle Quick Terminal"),
+        ["toggle_command_palette"] = ("Window", "Command Palette"),
+        ["new_window"] = ("Window", "New Window"),
+        ["reload_config"] = ("App", "Reload Config"),
+        ["open_config"] = ("App", "Open Config"),
+        ["quit"] = ("App", "Quit"),
+        ["start_search"] = ("Search", "Find"),
+        ["write_screen_file"] = ("Terminal", "Write Screen To File"),
+    };
+
+    // Friendly suffix for directional/indexed arguments, where it reads well.
+    private static readonly Dictionary<string, string> ArgLabel = new(StringComparer.Ordinal)
+    {
+        ["right"] = "Right", ["left"] = "Left", ["up"] = "Up", ["down"] = "Down",
+    };
+
+    public static ActionDescription Describe(string action)
+    {
+        if (string.IsNullOrEmpty(action)) return new ActionDescription("Other", action ?? string.Empty);
+
+        var colon = action.IndexOf(':');
+        var verb = colon < 0 ? action : action[..colon];
+        var arg = colon < 0 ? null : action[(colon + 1)..];
+
+        if (!Verbs.TryGetValue(verb, out var hit))
+            return new ActionDescription("Other", action);
+
+        var friendly = hit.Friendly;
+        // Append a direction word for split/focus/resize so each row is distinct.
+        if (arg is not null && ArgLabel.TryGetValue(arg, out var dir)
+            && (verb == "new_split" || verb == "goto_split" || verb == "resize_split"))
+        {
+            friendly = $"{hit.Friendly} {dir}";
+        }
+
+        return new ActionDescription(hit.Category, friendly);
+    }
+}

--- a/windows/Ghostty.Core/Input/KeybindCatalog.cs
+++ b/windows/Ghostty.Core/Input/KeybindCatalog.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>One displayed keybind row.</summary>
+public sealed record KeybindListItem(string Friendly, string RawAction, string Label, Interop.GhosttyBindingFlags Flags);
+
+/// <summary>A category header row in the flattened list.</summary>
+public sealed record KeybindCategoryHeader(string Name);
+
+/// <summary>A category with its ordered items.</summary>
+public sealed record KeybindCategory(string Name, IReadOnlyList<KeybindListItem> Items);
+
+/// <summary>
+/// Turns an enumerated keybind list into ordered, category-grouped, searchable
+/// rows for the read-only editor. Pure; the WinUI page renders the result.
+/// </summary>
+public sealed class KeybindCatalog
+{
+    public IReadOnlyList<KeybindCategory> Categories { get; }
+
+    private KeybindCatalog(IReadOnlyList<KeybindCategory> categories) => Categories = categories;
+
+    public static KeybindCatalog Build(IReadOnlyList<EnumeratedKeybind> binds)
+    {
+        var byCategory = new Dictionary<string, List<KeybindListItem>>(StringComparer.Ordinal);
+        foreach (var kb in binds)
+        {
+            var desc = KeybindActionCatalog.Describe(kb.Action);
+            var item = new KeybindListItem(desc.Friendly, kb.Action, TriggerLabeler.Describe(kb), kb.Flags);
+            if (!byCategory.TryGetValue(desc.Category, out var list))
+                byCategory[desc.Category] = list = new List<KeybindListItem>();
+            list.Add(item);
+        }
+
+        var categories = byCategory
+            .Select(kv => new KeybindCategory(
+                kv.Key,
+                kv.Value.OrderBy(i => i.Friendly, StringComparer.OrdinalIgnoreCase).ToList()))
+            .OrderBy(c => c.Name == "Other" ? 1 : 0)            // "Other" last
+            .ThenBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new KeybindCatalog(categories);
+    }
+
+    /// <summary>Header + item rows for a flat ListView (all categories).</summary>
+    public IReadOnlyList<object> Flatten() => FlattenFrom(Categories);
+
+    /// <summary>Filtered header + item rows; empty groups are dropped.</summary>
+    public IReadOnlyList<object> Filter(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return Flatten();
+        var q = query.Trim();
+        var filtered = Categories
+            .Select(c => new KeybindCategory(
+                c.Name,
+                c.Items.Where(i => Matches(i, q)).ToList()))
+            .Where(c => c.Items.Count > 0)
+            .ToList();
+        return FlattenFrom(filtered);
+    }
+
+    private static bool Matches(KeybindListItem i, string q)
+        => i.Friendly.Contains(q, StringComparison.OrdinalIgnoreCase)
+        || i.RawAction.Contains(q, StringComparison.OrdinalIgnoreCase)
+        || i.Label.Contains(q, StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<object> FlattenFrom(IReadOnlyList<KeybindCategory> categories)
+    {
+        var rows = new List<object>();
+        foreach (var c in categories)
+        {
+            rows.Add(new KeybindCategoryHeader(c.Name));
+            rows.AddRange(c.Items);
+        }
+
+        return rows;
+    }
+}

--- a/windows/Ghostty.Core/Input/TriggerLabeler.cs
+++ b/windows/Ghostty.Core/Input/TriggerLabeler.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Renders an EnumeratedKeybind's trigger to a display label like "Ctrl+Shift+T".
+/// US-ANSI / current-layout labels; layout-awareness is deferred (cheat sheet).
+/// </summary>
+public static class TriggerLabeler
+{
+    // ghostty_input_mods_e bits (authoritative, include/ghostty.h).
+    private const uint ModShift = 1u << 0;
+    private const uint ModCtrl = 1u << 1;
+    private const uint ModAlt = 1u << 2;
+    private const uint ModSuper = 1u << 3;
+    private const uint ModShiftRight = 1u << 6;
+    private const uint ModCtrlRight = 1u << 7;
+    private const uint ModAltRight = 1u << 8;
+    private const uint ModSuperRight = 1u << 9;
+
+    private const int TagPhysical = 0;
+    private const int TagUnicode = 1;
+    private const int TagCatchAll = 2;
+
+    private static readonly Dictionary<string, string> Special = new(StringComparer.Ordinal)
+    {
+        ["backquote"] = "`", ["backslash"] = "\\", ["bracket_left"] = "[", ["bracket_right"] = "]",
+        ["comma"] = ",", ["equal"] = "=", ["minus"] = "-", ["period"] = ".", ["quote"] = "'",
+        ["semicolon"] = ";", ["slash"] = "/",
+        ["space"] = "Space", ["enter"] = "Enter", ["tab"] = "Tab", ["escape"] = "Esc",
+        ["delete"] = "Delete", ["backspace"] = "Backspace", ["insert"] = "Insert",
+        ["home"] = "Home", ["end"] = "End", ["page_up"] = "Page Up", ["page_down"] = "Page Down",
+        ["caps_lock"] = "Caps Lock", ["print_screen"] = "Print Screen", ["scroll_lock"] = "Scroll Lock",
+        ["pause"] = "Pause", ["context_menu"] = "Menu",
+        ["arrow_up"] = "Up", ["arrow_down"] = "Down", ["arrow_left"] = "Left", ["arrow_right"] = "Right",
+    };
+
+    public static string Describe(EnumeratedKeybind kb)
+    {
+        if (kb.Steps.Count == 0) return string.Empty;
+        var sb = new StringBuilder();
+        for (var i = 0; i < kb.Steps.Count; i++)
+        {
+            if (i > 0) sb.Append(' ');
+            AppendStep(sb, kb.Steps[i]);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendStep(StringBuilder sb, KeybindTrigger step)
+    {
+        if ((step.Mods & (ModCtrl | ModCtrlRight)) != 0) sb.Append("Ctrl+");
+        if ((step.Mods & (ModShift | ModShiftRight)) != 0) sb.Append("Shift+");
+        if ((step.Mods & (ModAlt | ModAltRight)) != 0) sb.Append("Alt+");
+        if ((step.Mods & (ModSuper | ModSuperRight)) != 0) sb.Append("Win+");
+        sb.Append(KeyLabel(step));
+    }
+
+    private static string KeyLabel(KeybindTrigger step)
+    {
+        switch (step.Tag)
+        {
+            case TagCatchAll:
+                return "Any";
+            case TagUnicode:
+                return char.ConvertFromUtf32((int)step.Key);
+            case TagPhysical:
+            default:
+                var name = KeyNames.NameOf((int)step.Key);
+                return name is null ? "?" : LabelForName(name);
+        }
+    }
+
+    private static string LabelForName(string name)
+    {
+        if (Special.TryGetValue(name, out var s)) return s;
+        if (name.StartsWith("key_", StringComparison.Ordinal)) return name[4..].ToUpperInvariant();
+        if (name.StartsWith("digit_", StringComparison.Ordinal)) return name[6..];
+        if (name.Length >= 1 && name[0] == 'f' && int.TryParse(name.AsSpan(1), out _)) return name.ToUpperInvariant();
+        if (name.StartsWith("numpad_", StringComparison.Ordinal)) return "Num " + TitleCase(name[7..]);
+        return TitleCase(name);
+    }
+
+    private static string TitleCase(string snake)
+    {
+        var parts = snake.Split('_', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < parts.Length; i++)
+            parts[i] = char.ToUpperInvariant(parts[i][0]) + parts[i][1..];
+        return string.Join(' ', parts);
+    }
+}

--- a/windows/Ghostty.Tests/Input/KeyNamesTests.cs
+++ b/windows/Ghostty.Tests/Input/KeyNamesTests.cs
@@ -8,7 +8,10 @@ public class KeyNamesTests
     [Fact]
     public void Table_HasExpectedCount()
     {
-        Assert.Equal(175, KeyNames.Count);
+        // Mirrors input.Key (enum c_int) in src/input/key.zig: 176 members as of
+        // windows@11976dcda, including the @"fn" keyword member at ordinal 146.
+        // If Zig adds/removes a key this fails -> re-extract the table.
+        Assert.Equal(176, KeyNames.Count);
     }
 
     [Theory]
@@ -17,7 +20,8 @@ public class KeyNamesTests
     [InlineData(58, "enter")]
     [InlineData(78, "arrow_up")]
     [InlineData(121, "f1")]
-    [InlineData(174, "paste")]
+    [InlineData(146, "fn")]
+    [InlineData(175, "paste")]
     public void Ordinal_MapsToName(int ordinal, string expected)
     {
         Assert.Equal(expected, KeyNames.NameOf(ordinal));
@@ -25,7 +29,7 @@ public class KeyNamesTests
 
     [Theory]
     [InlineData(-1)]
-    [InlineData(175)]
+    [InlineData(176)]
     [InlineData(99999)]
     public void OutOfRange_ReturnsNull(int ordinal)
     {

--- a/windows/Ghostty.Tests/Input/KeyNamesTests.cs
+++ b/windows/Ghostty.Tests/Input/KeyNamesTests.cs
@@ -1,0 +1,34 @@
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeyNamesTests
+{
+    [Fact]
+    public void Table_HasExpectedCount()
+    {
+        Assert.Equal(175, KeyNames.Count);
+    }
+
+    [Theory]
+    [InlineData(0, "unidentified")]
+    [InlineData(20, "key_a")]
+    [InlineData(58, "enter")]
+    [InlineData(78, "arrow_up")]
+    [InlineData(121, "f1")]
+    [InlineData(174, "paste")]
+    public void Ordinal_MapsToName(int ordinal, string expected)
+    {
+        Assert.Equal(expected, KeyNames.NameOf(ordinal));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(175)]
+    [InlineData(99999)]
+    public void OutOfRange_ReturnsNull(int ordinal)
+    {
+        Assert.Null(KeyNames.NameOf(ordinal));
+    }
+}

--- a/windows/Ghostty.Tests/Input/KeybindActionCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindActionCatalogTests.cs
@@ -1,0 +1,29 @@
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeybindActionCatalogTests
+{
+    [Theory]
+    [InlineData("new_split:right", "Panes", "Split Right")]
+    [InlineData("goto_split:left", "Panes", "Focus Split Left")]
+    [InlineData("new_tab", "Tabs", "New Tab")]
+    [InlineData("copy_to_clipboard:mixed", "Clipboard", "Copy")]
+    [InlineData("increase_font_size:1", "Font", "Increase Font Size")]
+    [InlineData("toggle_fullscreen", "Window", "Toggle Fullscreen")]
+    public void KnownActions_MapToCategoryAndFriendly(string action, string category, string friendly)
+    {
+        var entry = KeybindActionCatalog.Describe(action);
+        Assert.Equal(category, entry.Category);
+        Assert.Equal(friendly, entry.Friendly);
+    }
+
+    [Fact]
+    public void UnknownAction_FallsBackToOtherWithRawName()
+    {
+        var entry = KeybindActionCatalog.Describe("some_future_action:99");
+        Assert.Equal("Other", entry.Category);
+        Assert.Equal("some_future_action:99", entry.Friendly);
+    }
+}

--- a/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeybindCatalogTests
+{
+    private static EnumeratedKeybind Kb(string action, int key, uint mods)
+        => new(new[] { new KeybindTrigger(0, key, mods) }, action, GhosttyBindingFlags.Consumed);
+
+    private static List<EnumeratedKeybind> Sample() => new()
+    {
+        Kb("new_tab", 39, 1u | 2u),          // Tabs / Ctrl+Shift+T
+        Kb("new_split:right", 16, 1u | 4u),  // Panes / equal(16) Shift+Alt -> "Alt+Shift+="? mods Shift|Alt
+        Kb("copy_to_clipboard:mixed", 22, 1u | 2u), // Clipboard / key_c(22)
+    };
+
+    [Fact]
+    public void Build_GroupsByCategory_SortedWithOtherLast()
+    {
+        var cat = KeybindCatalog.Build(Sample());
+        var names = cat.Categories.Select(c => c.Name).ToList();
+        // Alphabetical, but "Other" (if present) sorts last. Here: Clipboard, Panes, Tabs.
+        Assert.Equal(new[] { "Clipboard", "Panes", "Tabs" }, names);
+    }
+
+    [Fact]
+    public void Build_PopulatesItemFields()
+    {
+        var cat = KeybindCatalog.Build(Sample());
+        var tabs = cat.Categories.Single(c => c.Name == "Tabs");
+        var item = tabs.Items.Single();
+        Assert.Equal("New Tab", item.Friendly);
+        Assert.Equal("new_tab", item.RawAction);
+        Assert.Equal("Ctrl+Shift+T", item.Label);
+    }
+
+    [Fact]
+    public void Flatten_EmitsHeaderThenItems()
+    {
+        var rows = KeybindCatalog.Build(Sample()).Flatten();
+        Assert.IsType<KeybindCategoryHeader>(rows[0]);
+        Assert.Equal("Clipboard", ((KeybindCategoryHeader)rows[0]).Name);
+        Assert.IsType<KeybindListItem>(rows[1]);
+    }
+
+    [Fact]
+    public void Search_FiltersByFriendlyRawOrLabel_AndDropsEmptyGroups()
+    {
+        var rows = KeybindCatalog.Build(Sample()).Filter("copy");
+        var headers = rows.OfType<KeybindCategoryHeader>().Select(h => h.Name).ToList();
+        Assert.Equal(new[] { "Clipboard" }, headers);
+        Assert.Single(rows.OfType<KeybindListItem>());
+    }
+
+    [Fact]
+    public void Search_Empty_ReturnsAll()
+    {
+        var rows = KeybindCatalog.Build(Sample()).Filter("   ");
+        Assert.Equal(3, rows.OfType<KeybindListItem>().Count());
+    }
+}

--- a/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
@@ -8,7 +8,7 @@ namespace Ghostty.Tests.Input;
 
 public class KeybindCatalogTests
 {
-    private static EnumeratedKeybind Kb(string action, int key, uint mods)
+    private static EnumeratedKeybind Kb(string action, uint key, uint mods)
         => new(new[] { new KeybindTrigger(0, key, mods) }, action, GhosttyBindingFlags.Consumed);
 
     private static List<EnumeratedKeybind> Sample() => new()

--- a/windows/Ghostty.Tests/Input/TriggerLabelerTests.cs
+++ b/windows/Ghostty.Tests/Input/TriggerLabelerTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class TriggerLabelerTests
+{
+    private static EnumeratedKeybind Kb(params KeybindTrigger[] steps)
+        => new(steps, "noop", GhosttyBindingFlags.Consumed);
+
+    [Fact]
+    public void PhysicalChord_DecodesModsAndKey()
+    {
+        var kb = Kb(new KeybindTrigger(0, 39, 1u | 2u));
+        Assert.Equal("Ctrl+Shift+T", TriggerLabeler.Describe(kb));
+    }
+
+    [Fact]
+    public void ModOrder_IsCtrlShiftAltWin()
+    {
+        var kb = Kb(new KeybindTrigger(0, 20, 1u | 2u | 4u | 8u));
+        Assert.Equal("Ctrl+Shift+Alt+Win+A", TriggerLabeler.Describe(kb));
+    }
+
+    [Fact]
+    public void NamedAndArrowKeys_GetFriendlyLabels()
+    {
+        Assert.Equal("Enter", TriggerLabeler.Describe(Kb(new KeybindTrigger(0, 58, 0))));
+        Assert.Equal("Alt+Up", TriggerLabeler.Describe(Kb(new KeybindTrigger(0, 78, 4u))));
+        Assert.Equal("F11", TriggerLabeler.Describe(Kb(new KeybindTrigger(0, 131, 0))));
+        Assert.Equal("Ctrl+`", TriggerLabeler.Describe(Kb(new KeybindTrigger(0, 1, 2u))));
+    }
+
+    [Fact]
+    public void UnicodeTrigger_UsesCodepointChar()
+    {
+        var kb = Kb(new KeybindTrigger(1, 0x3D, 4u));
+        Assert.Equal("Alt+=", TriggerLabeler.Describe(kb));
+    }
+
+    [Fact]
+    public void CatchAll_RendersAny()
+    {
+        var kb = Kb(new KeybindTrigger(2, 0, 0));
+        Assert.Equal("Any", TriggerLabeler.Describe(kb));
+    }
+
+    [Fact]
+    public void Sequence_JoinsStepsWithSpace()
+    {
+        var kb = Kb(new KeybindTrigger(0, 30, 2u), new KeybindTrigger(0, 38, 2u));
+        Assert.Equal("Ctrl+K Ctrl+S", TriggerLabeler.Describe(kb));
+    }
+
+    [Fact]
+    public void NoSteps_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, TriggerLabeler.Describe(new EnumeratedKeybind(new List<KeybindTrigger>(), "x", GhosttyBindingFlags.None)));
+    }
+}

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
@@ -1,7 +1,32 @@
 <Page
     x:Class="Ghostty.Settings.Pages.KeybindingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Ghostty.Settings.Pages">
+
+    <Page.Resources>
+        <DataTemplate x:Key="KeybindHeaderTemplate">
+            <TextBlock x:Name="HeaderText"
+                       Style="{StaticResource BodyStrongTextBlockStyle}"
+                       Margin="0,12,0,4" />
+        </DataTemplate>
+        <DataTemplate x:Key="KeybindEntryTemplate">
+            <Grid ColumnDefinitions="*,Auto" Padding="8,4">
+                <TextBlock x:Name="FriendlyText" VerticalAlignment="Center" />
+                <Border Grid.Column="1"
+                        Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                        CornerRadius="4" Padding="8,2">
+                    <TextBlock x:Name="LabelText"
+                               FontFamily="Cascadia Code, Consolas, monospace"
+                               VerticalAlignment="Center" />
+                </Border>
+            </Grid>
+        </DataTemplate>
+        <local:KeybindRowTemplateSelector
+            x:Key="RowSelector"
+            HeaderTemplate="{StaticResource KeybindHeaderTemplate}"
+            EntryTemplate="{StaticResource KeybindEntryTemplate}" />
+    </Page.Resources>
 
     <Grid Padding="24" RowDefinitions="Auto,Auto,*">
         <TextBlock Text="Keybindings" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
@@ -9,27 +34,14 @@
         <AutoSuggestBox
             x:Name="SearchBox"
             Grid.Row="1"
-            PlaceholderText="Search by action or key combo..."
+            PlaceholderText="Search by action or key..."
             QueryIcon="Find"
             TextChanged="SearchBox_TextChanged"
             Margin="0,0,0,16" />
 
-        <ListView x:Name="BindingsList" Grid.Row="2" SelectionMode="None">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <!-- Properties set from ContainerContentChanging
-                         (AOT-safe, avoids reflection-based {Binding}). -->
-                    <Grid ColumnDefinitions="*,200,80" Padding="4">
-                        <TextBlock x:Name="ActionText" VerticalAlignment="Center" />
-                        <TextBlock x:Name="KeyComboText" Grid.Column="1"
-                                   FontFamily="Cascadia Code, Consolas, monospace"
-                                   VerticalAlignment="Center" />
-                        <TextBlock x:Name="SourceText" Grid.Column="2"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   VerticalAlignment="Center" />
-                    </Grid>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <ListView x:Name="BindingsList"
+                  Grid.Row="2"
+                  SelectionMode="None"
+                  ItemTemplateSelector="{StaticResource RowSelector}" />
     </Grid>
 </Page>

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -1,41 +1,82 @@
-using Ghostty.Core.Config;
+using System;
+using Ghostty.Core.Input;
+using Ghostty.Interop;
+using Ghostty.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Ghostty.Settings.Pages;
 
+/// <summary>Picks header vs entry template by row type (AOT-safe, no reflection).</summary>
+internal sealed class KeybindRowTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? HeaderTemplate { get; set; }
+    public DataTemplate? EntryTemplate { get; set; }
+
+    protected override DataTemplate? SelectTemplateCore(object item)
+        => item is KeybindCategoryHeader ? HeaderTemplate : EntryTemplate;
+
+    protected override DataTemplate? SelectTemplateCore(object item, DependencyObject container)
+        => SelectTemplateCore(item);
+}
+
 internal sealed partial class KeybindingsPage : Page
 {
-    private readonly IKeyBindingsProvider _keybindings;
+    // Concrete ConfigService is used (not IConfigService) because the
+    // libghostty config handle (ConfigHandle) the enumerate ABI needs is
+    // only exposed on the concrete type; the interface only carries
+    // ConfigChanged.
+    private readonly ConfigService _configService;
+    private KeybindCatalog _catalog;
 
-    public KeybindingsPage(IKeyBindingsProvider keybindings)
+    public KeybindingsPage(ConfigService configService)
     {
-        _keybindings = keybindings;
+        _configService = configService;
         InitializeComponent();
-        BindingsList.ItemsSource = _keybindings.All;
-        // AOT-safe: populate TextBlocks from code-behind instead of
-        // {Binding} which relies on reflection that NativeAOT trims.
+
+        _catalog = KeybindCatalog.Build(Array.Empty<EnumeratedKeybind>());
         BindingsList.ContainerContentChanging += OnContainerContentChanging;
+        Rebuild();
+
+        _configService.ConfigChanged += OnConfigChanged;
+        Unloaded += OnUnloaded;
     }
 
-    private static void OnContainerContentChanging(
-        ListViewBase sender, ContainerContentChangingEventArgs args)
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+        => _configService.ConfigChanged -= OnConfigChanged;
+
+    private void OnConfigChanged(Ghostty.Core.Config.IConfigService _)
+    {
+        if (DispatcherQueue.HasThreadAccess) Rebuild();
+        else DispatcherQueue.TryEnqueue(Rebuild);
+    }
+
+    private void Rebuild()
+    {
+        var binds = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
+        _catalog = KeybindCatalog.Build(binds);
+        BindingsList.ItemsSource = _catalog.Flatten();
+    }
+
+    private void OnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
         if (args.InRecycleQueue) return;
-        if (args.ItemContainer.ContentTemplateRoot is not Grid grid) return;
-        if (args.Item is not BindingEntry entry) return;
-
-        if (grid.FindName("ActionText") is TextBlock action)
-            action.Text = entry.Action;
-        if (grid.FindName("KeyComboText") is TextBlock combo)
-            combo.Text = entry.KeyCombo;
-        if (grid.FindName("SourceText") is TextBlock source)
-            source.Text = entry.Source;
+        var root = args.ItemContainer.ContentTemplateRoot;
+        switch (args.Item)
+        {
+            case KeybindCategoryHeader header when root is TextBlock headerText:
+                headerText.Text = header.Name;
+                break;
+            case KeybindListItem item when root is Grid grid:
+                if (grid.FindName("FriendlyText") is TextBlock f) f.Text = item.Friendly;
+                if (grid.FindName("LabelText") is TextBlock l) l.Text = item.Label;
+                break;
+        }
     }
 
     private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
     {
         if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
-        BindingsList.ItemsSource = _keybindings.Search(sender.Text);
+        BindingsList.ItemsSource = _catalog.Filter(sender.Text);
     }
 }

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -36,10 +36,19 @@ internal sealed partial class KeybindingsPage : Page
 
         _catalog = KeybindCatalog.Build(Array.Empty<EnumeratedKeybind>());
         BindingsList.ContainerContentChanging += OnContainerContentChanging;
-        Rebuild();
 
-        _configService.ConfigChanged += OnConfigChanged;
+        // Subscribe in Loaded (not the ctor): SettingsWindow caches pages and
+        // reuses the instance, so the ctor runs once but Loaded/Unloaded fire on
+        // every navigation. Pairing here keeps the subscription correct across
+        // re-shows (matches ColorsPage / RawEditorPage).
+        Loaded += OnLoaded;
         Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _configService.ConfigChanged += OnConfigChanged;
+        Rebuild(); // refresh in case the config changed while detached
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -233,7 +233,10 @@ internal sealed partial class SettingsWindow : Window
                     _editor),
                 "colors" => new Pages.ColorsPage(_configService, _editor, _theme),
                 "terminal" => new Pages.TerminalPage(_configService, _editor),
-                "keybindings" => new Pages.KeybindingsPage(_keybindings),
+                // The keybindings page reads the libghostty config handle via
+                // the enumerate ABI, which only the concrete ConfigService
+                // exposes. The injected instance is always a ConfigService.
+                "keybindings" => new Pages.KeybindingsPage((ConfigService)_configService),
                 "advanced" => new Pages.AdvancedPage(_configService, _editor),
                 "raw" => new Pages.RawEditorPage(_configService, _editor),
                 _ => null,


### PR DESCRIPTION
Rewires the Settings "Keybindings" page to list every parsed keybind from the enumerate ABI: category-grouped, friendly-named, with resolved key labels ("Ctrl+Shift+T"), searchable. Read-only.

Before this, the page only labeled the ~12 Windows-only residual chords; the ~58 standard binds showed blank after the engine swap. Now all ~70 appear.

Pure Ghostty.Core logic (TDD): TriggerLabeler (Mods bitfield + input.Key ordinal -> label, unicode/catch-all, sequence join, with a Key-enum drift pin), KeybindActionCatalog (action -> category + friendly name, raw fallback), KeybindCatalog (grouped + searchable rows). The WinUI page renders a flat header+entry ListView via a code DataTemplateSelector + ContainerContentChanging (AOT-safe, no {Binding}) and refreshes on config reload.

Part of the keyboard-shortcuts series. The visual keyboard map and editing/conflicts are later PRs. No new C ABI, no Zig changes.

Self-review caught two bugs, both fixed: a missing input.Key member (the @"fn" keyword key at ordinal 146) that shifted later key labels, and ConfigChanged subscription moved to Loaded/Unloaded so the cached Settings page keeps updating across re-shows.