### PR TITLE
fix(windows): re-subscribe AppearancePage to config changes on every show

### DIFF
--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -122,11 +122,25 @@ internal sealed partial class AppearancePage : Page
 
         // Re-seed the gradient editor when the config file changes on disk.
         // The editor's own writes set _loading/SuppressWatcher, so this only
-        // fires for genuine external edits.
-        _configService.ConfigChanged += OnConfigChanged;
-        Unloaded += (_, _) => _configService.ConfigChanged -= OnConfigChanged;
+        // fires for genuine external edits. Subscribe in Loaded rather than the
+        // ctor: SettingsWindow caches and reuses page instances, so the ctor
+        // runs once while Loaded/Unloaded fire on every navigation. A ctor-time
+        // subscription paired with an Unloaded unsubscribe would be dropped the
+        // first time the user navigates away and never restored on return.
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
 
         LoadFontsAsync();
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _configService.ConfigChanged += OnConfigChanged;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _configService.ConfigChanged -= OnConfigChanged;
     }
 
     private void SelectWindowTheme(string theme)


### PR DESCRIPTION
AppearancePage subscribed to `IConfigService.ConfigChanged` in its constructor but unsubscribed in `Unloaded`. SettingsWindow caches and reuses page instances, so the ctor runs once while `Loaded`/`Unloaded` fire on every navigation. The first time the user navigated away from Appearance, `Unloaded` dropped the subscription, and it was never restored on return. The page then silently stopped re-seeding its gradient editor when the config changed on disk.

Move the subscription into a `Loaded` handler, keeping the `Unloaded` unsubscribe, so the pairing holds across unlimited cache re-shows. This matches the existing `ColorsPage` and `RawEditorPage` pattern. The ctor already seeds initial state inline, so nothing needs duplicating into `Loaded`.

Pre-existing latent bug spotted during the keybindings read-only editor work and kept out of that PR's scope.

Verified with `dotnet build windows/Ghostty/Ghostty.csproj -p:Platform=x64` (0 errors).
