### PR TITLE
search: keep keystrokes in the search box from reaching the terminal

### DIFF
--- a/windows/Ghostty.Tests.Windows/Search/SearchBarSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Search/SearchBarSmokeTests.cs
@@ -53,4 +53,32 @@ public class SearchBarSmokeTests
     public void SearchTotalAndSelected_FromLibghostty_FlowToCounterText()
     {
     }
+
+    // Smoke spec for keyboard-focus isolation while the search bar is open.
+    //
+    // The search bar's controls are children of TerminalControl's visual
+    // tree, so their KeyDown / CharacterReceived routed events bubble to
+    // the TerminalControl handlers that forward input to libghostty.
+    // Without a guard, every character typed into the needle also reaches
+    // the shell. TerminalControl.OnKeyDown / OnKeyUp / OnCharacterReceived
+    // gate on SearchBarControl.ContainsFocus (live focus anywhere in the
+    // bar, not the bar's open state) so the leak is closed without killing
+    // terminal typing when the bar is left visible and the user clicks back
+    // into the surface.
+    //
+    // To validate by hand once the binary lands:
+    //
+    // 1. Open wintty on a pwsh pane.
+    // 2. Press Ctrl+Shift+F, then type "hello". The text appears ONLY in
+    //    the search needle; nothing is echoed at the shell prompt.
+    // 3. Press Esc. Focus returns to the terminal; type "echo hi" and
+    //    confirm it reaches the shell normally.
+    // 4. Press Ctrl+Shift+F again, then click back into the terminal
+    //    surface while the bar stays visible. Typing now reaches the shell
+    //    (the needle no longer holds focus), confirming the gate keys off
+    //    focus rather than the bar's open state.
+    [Fact(Skip = "Manual smoke; key forwarding needs a live MainWindow + libghostty surface.")]
+    public void SearchNeedleFocused_KeystrokesDoNotLeakToShell_ButReachShellWhenSurfaceFocused()
+    {
+    }
 }

--- a/windows/Ghostty/Controls/Search/SearchBarControl.xaml.cs
+++ b/windows/Ghostty/Controls/Search/SearchBarControl.xaml.cs
@@ -106,6 +106,38 @@ public sealed partial class SearchBarControl : UserControl
         NeedleBox.SelectAll();
     }
 
+    /// <summary>
+    /// True while keyboard focus is anywhere inside the search bar (the
+    /// needle box or the prev/next/close buttons). The parent reads this
+    /// to gate terminal key forwarding: the bar is a child of
+    /// TerminalControl's visual tree, so its KeyDown and CharacterReceived
+    /// events bubble up to the TerminalControl handlers that forward input
+    /// to libghostty. Without this gate, keystrokes (and characters, while
+    /// the needle is focused) would also reach the shell.
+    ///
+    /// Tracking live focus rather than the bar's open state is deliberate:
+    /// the bar can stay visible after the user clicks back into the
+    /// terminal surface, and in that case typing must keep flowing to the
+    /// shell. Containment (not just the needle) matters because focusing a
+    /// nav button would otherwise re-open the same leak for keys the button
+    /// does not consume.
+    /// </summary>
+    public bool ContainsFocus
+    {
+        get
+        {
+            // XamlRoot is null until the control is loaded; no focus to own.
+            if (XamlRoot is null) return false;
+            var node = FocusManager.GetFocusedElement(XamlRoot) as DependencyObject;
+            while (node is not null)
+            {
+                if (ReferenceEquals(node, this)) return true;
+                node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+            }
+            return false;
+        }
+    }
+
     // ── Event handlers ────────────────────────────────────────────────
 
     private void OnNeedleTextChanged(object _, TextChangedEventArgs __)

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -953,6 +953,14 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     {
         if (CommandPaletteIsOpen) return;
 
+        // Suppress forwarding while the in-pane search bar owns keyboard
+        // focus: its controls are children of this visual tree, so their
+        // KeyDown bubbles up here and would otherwise also run in the
+        // shell. Gate on live focus rather than the bar's open state so
+        // typing keeps reaching the terminal when the bar is left visible
+        // after the user clicks back into the surface.
+        if (SearchBar.ContainsFocus) return;
+
         // Stamp the shared host so VerticalTabHost's hover-expand
         // suppression knows the user is mid-typing and holds back
         // the sidebar pop-open. Unconditional: we want every key
@@ -986,6 +994,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnKeyUp(object sender, KeyRoutedEventArgs e)
     {
+        // Mirror OnKeyDown: while the search bar owns focus, swallow the
+        // key-up too so libghostty never sees a release for a press it
+        // never received.
+        if (SearchBar.ContainsFocus) return;
+
         // Same short-circuit so the matching key-up never reaches
         // libghostty either. Without this, libghostty would see a
         // stray release for a press it never saw. Assumes every bound
@@ -1083,6 +1096,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     private void OnCharacterReceived(UIElement sender, CharacterReceivedRoutedEventArgs e)
     {
         if (_surface.Handle == IntPtr.Zero) return;
+
+        // WM_CHAR from the focused search bar bubbles up here too. Drop it
+        // so typed characters edit the needle only and never reach
+        // libghostty as terminal text. See the matching guard in OnKeyDown.
+        if (SearchBar.ContainsFocus) return;
 
         // If the matching OnKeyDown short-circuited a bound chord, drop
         // the WM_CHAR that follows. WinUI 3 raises CharacterReceived


### PR DESCRIPTION
While the in-pane scrollback search bar is open, typing in the needle box also leaked the same keystrokes to the terminal: characters appeared in the search field and were sent to the shell at the same time.

The search bar's controls live inside TerminalControl's visual tree, so their bubbling KeyDown and CharacterReceived events reach the TerminalControl handlers that forward input to libghostty. There was a guard for the command palette but none for the search bar.

This gates OnKeyDown, OnKeyUp and OnCharacterReceived on whether focus is inside the search bar (new SearchBarControl.ContainsFocus), alongside the existing command-palette guard. Keying off live focus rather than the bar's open state keeps terminal typing working when the bar is left visible after clicking back into the surface; Esc still closes the bar and returns focus to the terminal. Checking containment rather than just the needle also covers the prev/next/close buttons.

Verified on the running app over pwsh: with the bar open, typing edits only the needle; after Esc, typing reaches the shell again.