### PR TITLE
Keyboard shortcuts: terminal-shadow conflict warnings

### DIFF
--- a/windows/Ghostty.Core/Input/KeybindCatalog.cs
+++ b/windows/Ghostty.Core/Input/KeybindCatalog.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace Ghostty.Core.Input;
 
 /// <summary>One displayed keybind row.</summary>
-public sealed record KeybindListItem(string Friendly, string RawAction, string Label, Interop.GhosttyBindingFlags Flags);
+public sealed record KeybindListItem(string Friendly, string RawAction, string Label, Interop.GhosttyBindingFlags Flags, KeybindConflict Conflict);
 
 /// <summary>A category header row in the flattened list.</summary>
 public sealed record KeybindCategoryHeader(string Name);
@@ -29,7 +29,9 @@ public sealed class KeybindCatalog
         foreach (var kb in binds)
         {
             var desc = KeybindActionCatalog.Describe(kb.Action);
-            var item = new KeybindListItem(desc.Friendly, kb.Action, TriggerLabeler.Describe(kb), kb.Flags);
+            var item = new KeybindListItem(
+                desc.Friendly, kb.Action, TriggerLabeler.Describe(kb), kb.Flags,
+                KeybindConflictAnalyzer.Analyze(kb));
             if (!byCategory.TryGetValue(desc.Category, out var list))
                 byCategory[desc.Category] = list = new List<KeybindListItem>();
             list.Add(item);
@@ -49,15 +51,19 @@ public sealed class KeybindCatalog
     /// <summary>Header + item rows for a flat ListView (all categories).</summary>
     public IReadOnlyList<object> Flatten() => FlattenFrom(Categories);
 
-    /// <summary>Filtered header + item rows; empty groups are dropped.</summary>
-    public IReadOnlyList<object> Filter(string? query)
+    /// <summary>Filtered header + item rows; empty groups dropped. Optional conflicts-only.</summary>
+    public IReadOnlyList<object> Filter(string? query, bool conflictsOnly = false)
     {
-        if (string.IsNullOrWhiteSpace(query)) return Flatten();
-        var q = query.Trim();
+        var hasQuery = !string.IsNullOrWhiteSpace(query);
+        if (!hasQuery && !conflictsOnly) return Flatten();
+
+        var q = query?.Trim() ?? string.Empty;
         var filtered = Categories
             .Select(c => new KeybindCategory(
                 c.Name,
-                c.Items.Where(i => Matches(i, q)).ToList()))
+                c.Items.Where(i =>
+                    (!hasQuery || Matches(i, q)) &&
+                    (!conflictsOnly || i.Conflict.HasConflict)).ToList()))
             .Where(c => c.Items.Count > 0)
             .ToList();
         return FlattenFrom(filtered);

--- a/windows/Ghostty.Core/Input/KeybindConflict.cs
+++ b/windows/Ghostty.Core/Input/KeybindConflict.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Interop;
+
+namespace Ghostty.Core.Input;
+
+public enum ConflictKind
+{
+    None,
+    TerminalShadow,
+}
+
+/// <summary>A soft-conflict classification for a keybind.</summary>
+public readonly record struct KeybindConflict(ConflictKind Kind, string Message)
+{
+    public static readonly KeybindConflict None = new(ConflictKind.None, string.Empty);
+
+    public bool HasConflict => Kind != ConflictKind.None;
+}
+
+/// <summary>
+/// Read-only soft-conflict detection over the finalized keybind set. Flags a
+/// binding whose trigger shadows a common terminal control code. Hard conflicts
+/// (duplicate trigger / sequence-prefix) are pre-resolved by libghostty's
+/// finalize and are handled at assign-time in the editing PR, not here.
+/// </summary>
+public static class KeybindConflictAnalyzer
+{
+    private const uint ModShift = 1u << 0;
+    private const uint ModCtrl = 1u << 1;
+    private const uint ModAlt = 1u << 2;
+    private const uint ModSuper = 1u << 3;
+    private const uint ModShiftRight = 1u << 6;
+    private const uint ModCtrlRight = 1u << 7;
+    private const uint ModAltRight = 1u << 8;
+    private const uint ModSuperRight = 1u << 9;
+
+    private const uint CtrlMask = ModCtrl | ModCtrlRight;
+    private const uint OtherMask =
+        ModShift | ModShiftRight | ModAlt | ModAltRight | ModSuper | ModSuperRight;
+
+    private const int TagPhysical = 0;
+    private const int TagUnicode = 1;
+
+    // Plain Ctrl+<letter> control codes worth warning about.
+    private static readonly Dictionary<char, string> Shadows = new()
+    {
+        ['c'] = "Shadows Ctrl+C (interrupt signal)",
+        ['d'] = "Shadows Ctrl+D (end of input)",
+        ['z'] = "Shadows Ctrl+Z (suspend)",
+        ['l'] = "Shadows Ctrl+L (clear screen)",
+        ['s'] = "Shadows Ctrl+S (flow-control stop)",
+        ['q'] = "Shadows Ctrl+Q (flow-control resume)",
+        ['\\'] = "Shadows Ctrl+\\ (quit signal)",
+    };
+
+    public static KeybindConflict Analyze(EnumeratedKeybind kb)
+    {
+        if (kb.Steps.Count != 1) return KeybindConflict.None;
+        if (!kb.Flags.HasFlag(GhosttyBindingFlags.Consumed)) return KeybindConflict.None;
+
+        var step = kb.Steps[0];
+        if ((step.Mods & CtrlMask) == 0) return KeybindConflict.None;       // needs Ctrl
+        if ((step.Mods & OtherMask) != 0) return KeybindConflict.None;      // Ctrl only
+
+        var ch = ControlChar(step);
+        if (ch is char c && Shadows.TryGetValue(c, out var message))
+            return new KeybindConflict(ConflictKind.TerminalShadow, message);
+
+        return KeybindConflict.None;
+    }
+
+    private static char? ControlChar(KeybindTrigger step)
+    {
+        switch (step.Tag)
+        {
+            case TagUnicode:
+                return char.ToLowerInvariant((char)step.Key);
+            case TagPhysical:
+                var name = KeyNames.NameOf((int)step.Key);
+                if (name is null) return null;
+                if (name.Length == 5 && name.StartsWith("key_", StringComparison.Ordinal))
+                    return name[4]; // "key_c" -> 'c'
+                if (name == "backslash") return '\\';
+                return null;
+            default:
+                return null;
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
@@ -62,4 +62,46 @@ public class KeybindCatalogTests
         var rows = KeybindCatalog.Build(Sample()).Filter("   ");
         Assert.Equal(3, rows.OfType<KeybindListItem>().Count());
     }
+
+    [Fact]
+    public void Build_AttachesTerminalShadowConflict()
+    {
+        // key_c = 22, Ctrl only -> shadow. (Action text is arbitrary here.)
+        var binds = new System.Collections.Generic.List<EnumeratedKeybind>
+        {
+            Kb("copy_to_clipboard:mixed", 22, 1u << 1), // Ctrl+C
+        };
+        var cat = KeybindCatalog.Build(binds);
+        var item = cat.Categories.SelectMany(c => c.Items).Single();
+        Assert.Equal(ConflictKind.TerminalShadow, item.Conflict.Kind);
+    }
+
+    [Fact]
+    public void Build_NoConflictForNormalChord()
+    {
+        var cat = KeybindCatalog.Build(Sample());
+        Assert.All(cat.Categories.SelectMany(c => c.Items),
+            i => Assert.Equal(ConflictKind.None, i.Conflict.Kind));
+    }
+
+    [Fact]
+    public void Filter_ConflictsOnly_KeepsOnlyConflicting()
+    {
+        var binds = new System.Collections.Generic.List<EnumeratedKeybind>
+        {
+            Kb("new_tab", 39, 1u << 1),                 // Ctrl+T  (no shadow)
+            Kb("copy_to_clipboard:mixed", 22, 1u << 1), // Ctrl+C  (shadow)
+        };
+        var rows = KeybindCatalog.Build(binds).Filter(null, conflictsOnly: true);
+        var items = rows.OfType<KeybindListItem>().ToList();
+        Assert.Single(items);
+        Assert.Equal("copy_to_clipboard:mixed", items[0].RawAction);
+    }
+
+    [Fact]
+    public void Filter_ConflictsOnly_False_ReturnsAll()
+    {
+        var rows = KeybindCatalog.Build(Sample()).Filter(null, conflictsOnly: false);
+        Assert.Equal(3, rows.OfType<KeybindListItem>().Count());
+    }
 }

--- a/windows/Ghostty.Tests/Input/KeybindConflictAnalyzerTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindConflictAnalyzerTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeybindConflictAnalyzerTests
+{
+    private const uint Ctrl = 1u << 1;
+    private const uint Shift = 1u << 0;
+    private const uint Alt = 1u << 2;
+
+    private static EnumeratedKeybind Kb(uint key, uint mods, int tag = 0,
+        GhosttyBindingFlags flags = GhosttyBindingFlags.Consumed, int steps = 1)
+    {
+        var list = new List<KeybindTrigger>();
+        for (var i = 0; i < steps; i++) list.Add(new KeybindTrigger(tag, key, mods));
+        return new EnumeratedKeybind(list, "noop", flags);
+    }
+
+    [Fact]
+    public void PlainCtrlC_Physical_IsTerminalShadow()
+    {
+        // key_c ordinal = 22 in input.Key.
+        var c = KeybindConflictAnalyzer.Analyze(Kb(22, Ctrl));
+        Assert.Equal(ConflictKind.TerminalShadow, c.Kind);
+        Assert.Contains("Ctrl+C", c.Message);
+    }
+
+    [Fact]
+    public void CtrlBackslash_Physical_IsShadow()
+    {
+        // backslash ordinal = 2.
+        Assert.Equal(ConflictKind.TerminalShadow, KeybindConflictAnalyzer.Analyze(Kb(2, Ctrl)).Kind);
+    }
+
+    [Fact]
+    public void CtrlC_Unicode_IsShadow()
+    {
+        // tag 1 unicode, codepoint 'c'.
+        Assert.Equal(ConflictKind.TerminalShadow, KeybindConflictAnalyzer.Analyze(Kb('c', Ctrl, tag: 1)).Kind);
+    }
+
+    [Fact]
+    public void CtrlShiftC_IsNotShadow()
+    {
+        Assert.Equal(ConflictKind.None, KeybindConflictAnalyzer.Analyze(Kb(22, Ctrl | Shift)).Kind);
+    }
+
+    [Fact]
+    public void AltC_IsNotShadow()
+    {
+        Assert.Equal(ConflictKind.None, KeybindConflictAnalyzer.Analyze(Kb(22, Alt)).Kind);
+    }
+
+    [Fact]
+    public void CtrlT_NonControlLetter_IsNotShadow()
+    {
+        // key_t = 39.
+        Assert.Equal(ConflictKind.None, KeybindConflictAnalyzer.Analyze(Kb(39, Ctrl)).Kind);
+    }
+
+    [Fact]
+    public void NonConsumed_IsNotShadow()
+    {
+        Assert.Equal(ConflictKind.None,
+            KeybindConflictAnalyzer.Analyze(Kb(22, Ctrl, flags: GhosttyBindingFlags.Performable)).Kind);
+    }
+
+    [Fact]
+    public void Sequence_IsNotShadow()
+    {
+        Assert.Equal(ConflictKind.None, KeybindConflictAnalyzer.Analyze(Kb(22, Ctrl, steps: 2)).Kind);
+    }
+
+    [Fact]
+    public void None_HasNoConflictFlag()
+    {
+        Assert.False(KeybindConflictAnalyzer.Analyze(Kb(39, Ctrl)).HasConflict);
+        Assert.True(KeybindConflictAnalyzer.Analyze(Kb(22, Ctrl)).HasConflict);
+    }
+}

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
@@ -11,9 +11,18 @@
                        Margin="0,12,0,4" />
         </DataTemplate>
         <DataTemplate x:Key="KeybindEntryTemplate">
-            <Grid ColumnDefinitions="*,Auto" Padding="8,4">
+            <Grid ColumnDefinitions="*,Auto,Auto" Padding="8,4">
                 <TextBlock x:Name="FriendlyText" VerticalAlignment="Center" />
-                <Border Grid.Column="1"
+                <FontIcon x:Name="ConflictIcon"
+                          Grid.Column="1"
+                          Glyph="&#xE7BA;"
+                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                          Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                          FontSize="14"
+                          Margin="0,0,8,0"
+                          VerticalAlignment="Center"
+                          Visibility="Collapsed" />
+                <Border Grid.Column="2"
                         Background="{ThemeResource SubtleFillColorSecondaryBrush}"
                         CornerRadius="4" Padding="8,2">
                     <TextBlock x:Name="LabelText"
@@ -31,13 +40,20 @@
     <Grid Padding="24" RowDefinitions="Auto,Auto,*">
         <TextBlock Text="Keybindings" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
 
-        <AutoSuggestBox
-            x:Name="SearchBox"
-            Grid.Row="1"
-            PlaceholderText="Search by action or key..."
-            QueryIcon="Find"
-            TextChanged="SearchBox_TextChanged"
-            Margin="0,0,0,16" />
+        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,16">
+            <AutoSuggestBox
+                x:Name="SearchBox"
+                PlaceholderText="Search by action or key..."
+                QueryIcon="Find"
+                TextChanged="SearchBox_TextChanged" />
+            <ToggleButton
+                x:Name="ConflictsToggle"
+                Grid.Column="1"
+                Content="Conflicts"
+                Margin="8,0,0,0"
+                Checked="ConflictsToggle_Toggled"
+                Unchecked="ConflictsToggle_Toggled" />
+        </Grid>
 
         <ListView x:Name="BindingsList"
                   Grid.Row="2"

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -64,7 +64,7 @@ internal sealed partial class KeybindingsPage : Page
     {
         var binds = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
         _catalog = KeybindCatalog.Build(binds);
-        BindingsList.ItemsSource = _catalog.Flatten();
+        ApplyFilter();
     }
 
     private void OnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
@@ -79,6 +79,19 @@ internal sealed partial class KeybindingsPage : Page
             case KeybindListItem item when root is Grid grid:
                 if (grid.FindName("FriendlyText") is TextBlock f) f.Text = item.Friendly;
                 if (grid.FindName("LabelText") is TextBlock l) l.Text = item.Label;
+                if (grid.FindName("ConflictIcon") is FontIcon icon)
+                {
+                    if (item.Conflict.HasConflict)
+                    {
+                        icon.Visibility = Visibility.Visible;
+                        ToolTipService.SetToolTip(icon, item.Conflict.Message);
+                    }
+                    else
+                    {
+                        icon.Visibility = Visibility.Collapsed;
+                        ToolTipService.SetToolTip(icon, null);
+                    }
+                }
                 break;
         }
     }
@@ -86,6 +99,11 @@ internal sealed partial class KeybindingsPage : Page
     private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
     {
         if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
-        BindingsList.ItemsSource = _catalog.Filter(sender.Text);
+        ApplyFilter();
     }
+
+    private void ConflictsToggle_Toggled(object sender, RoutedEventArgs e) => ApplyFilter();
+
+    private void ApplyFilter()
+        => BindingsList.ItemsSource = _catalog.Filter(SearchBox.Text, ConflictsToggle.IsChecked == true);
 }


### PR DESCRIPTION
Flags keybinds whose trigger shadows a common terminal control code (plain Ctrl + C/D/Z/L/S/Q/\) with an amber warning badge + a Conflicts filter toggle in the Keybindings settings list.

The enumerate ABI returns the finalized keybind set (last-wins already applied), so hard/duplicate conflicts aren't visible read-only here by design - they're handled at assign-time in the editing PR. This PR detects the soft class, which is computable from the finalized set.

Pure Ghostty.Core analyzer (TDD): single-step trigger, Ctrl-only mods, control-code key, and consumed -> a per-letter warning ("Shadows Ctrl+C (interrupt signal)"). KeybindCatalog attaches it per item; the page shows the badge (recycle-safe) + a Conflicts-only filter.

Part of the keyboard-shortcuts series. With today's mostly-Ctrl+Shift defaults few/zero rows trip; the detector + UI lights up once user binds plain-Ctrl chords. No new C ABI, no Zig changes.