### PR TITLE
Keyboard shortcuts: unbind / reset + user-source

### DIFF
--- a/windows/Ghostty.Core/Config/ConfigFileParser.cs
+++ b/windows/Ghostty.Core/Config/ConfigFileParser.cs
@@ -72,6 +72,25 @@ public static class ConfigFileParser
     }
 
     /// <summary>
+    /// Returns the value (RHS of the first '=') of every uncommented line for
+    /// the given key, in file order. Mirrors <see cref="SetRepeatableValues"/>'s
+    /// view of which lines count for a key (uses <see cref="ConfigLine.Parse"/>).
+    /// </summary>
+    public static string[] GetRepeatableValues(string[] lines, string key)
+    {
+        var values = new List<string>();
+        foreach (var line in lines)
+        {
+            var parsed = ConfigLine.Parse(line);
+            if (parsed.IsComment || parsed.IsEmpty || parsed.Key != key)
+                continue;
+            values.Add((parsed.Value ?? string.Empty).TrimEnd());
+        }
+
+        return values.ToArray();
+    }
+
+    /// <summary>
     /// Replace all occurrences of a repeatable key with new values.
     /// Comments out existing lines and appends new ones.
     /// </summary>

--- a/windows/Ghostty.Core/Config/IConfigFileEditor.cs
+++ b/windows/Ghostty.Core/Config/IConfigFileEditor.cs
@@ -32,4 +32,7 @@ public interface IConfigFileEditor
     /// entries and appends new ones.
     /// </summary>
     void SetRepeatableValues(string key, string[] values);
+
+    /// <summary>Read all values for a repeatable key (e.g. "keybind"), in file order.</summary>
+    string[] GetRepeatableValues(string key);
 }

--- a/windows/Ghostty.Core/Input/KeybindCatalog.cs
+++ b/windows/Ghostty.Core/Input/KeybindCatalog.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace Ghostty.Core.Input;
 
 /// <summary>One displayed keybind row.</summary>
-public sealed record KeybindListItem(string Friendly, string RawAction, string Label, Interop.GhosttyBindingFlags Flags, KeybindConflict Conflict);
+public sealed record KeybindListItem(string Friendly, string RawAction, string Label, Interop.GhosttyBindingFlags Flags, KeybindConflict Conflict, KeybindSource Source);
 
 /// <summary>A category header row in the flattened list.</summary>
 public sealed record KeybindCategoryHeader(string Name);
@@ -23,15 +23,24 @@ public sealed class KeybindCatalog
 
     private KeybindCatalog(IReadOnlyList<KeybindCategory> categories) => Categories = categories;
 
-    public static KeybindCatalog Build(IReadOnlyList<EnumeratedKeybind> binds)
+    public static KeybindCatalog Build(
+        IReadOnlyList<EnumeratedKeybind> binds,
+        IReadOnlyList<EnumeratedKeybind>? defaults = null)
     {
+        var defaultKeys = defaults is null
+            ? null
+            : KeybindSourceClassifier.BuildDefaultKeys(defaults);
+
         var byCategory = new Dictionary<string, List<KeybindListItem>>(StringComparer.Ordinal);
         foreach (var kb in binds)
         {
             var desc = KeybindActionCatalog.Describe(kb.Action);
+            var source = defaultKeys is null
+                ? KeybindSource.Default
+                : KeybindSourceClassifier.Classify(kb, defaultKeys);
             var item = new KeybindListItem(
                 desc.Friendly, kb.Action, TriggerLabeler.Describe(kb), kb.Flags,
-                KeybindConflictAnalyzer.Analyze(kb));
+                KeybindConflictAnalyzer.Analyze(kb), source);
             if (!byCategory.TryGetValue(desc.Category, out var list))
                 byCategory[desc.Category] = list = new List<KeybindListItem>();
             list.Add(item);

--- a/windows/Ghostty.Core/Input/KeybindSource.cs
+++ b/windows/Ghostty.Core/Input/KeybindSource.cs
@@ -15,6 +15,10 @@ public enum KeybindSource
 /// </summary>
 public static class KeybindSourceClassifier
 {
+    // '|' cannot appear in an encoded trigger (mods/'+'/'>'/key-name) or in an
+    // action string, so distinct (trigger, action) pairs never collide.
+    private const char Separator = '|';
+
     public static KeybindSource Classify(EnumeratedKeybind kb, HashSet<string> defaultKeys)
         => defaultKeys.Contains(KeyOf(kb)) ? KeybindSource.Default : KeybindSource.User;
 
@@ -26,5 +30,5 @@ public static class KeybindSourceClassifier
     }
 
     private static string KeyOf(EnumeratedKeybind kb)
-        => KeybindTriggerSyntax.Encode(kb) + "" + kb.Action;
+        => KeybindTriggerSyntax.Encode(kb) + Separator + kb.Action;
 }

--- a/windows/Ghostty.Core/Input/KeybindSource.cs
+++ b/windows/Ghostty.Core/Input/KeybindSource.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Input;
+
+public enum KeybindSource
+{
+    Default,
+    User,
+}
+
+/// <summary>
+/// Classifies each current binding as Default or User by diffing against a
+/// default-only enumeration. A binding is User when its (canonical trigger,
+/// action) pair is absent from the defaults (covers rebinds and user-added).
+/// </summary>
+public static class KeybindSourceClassifier
+{
+    public static KeybindSource Classify(EnumeratedKeybind kb, HashSet<string> defaultKeys)
+        => defaultKeys.Contains(KeyOf(kb)) ? KeybindSource.Default : KeybindSource.User;
+
+    public static HashSet<string> BuildDefaultKeys(IReadOnlyList<EnumeratedKeybind> defaults)
+    {
+        var set = new HashSet<string>();
+        foreach (var d in defaults) set.Add(KeyOf(d));
+        return set;
+    }
+
+    private static string KeyOf(EnumeratedKeybind kb)
+        => KeybindTriggerSyntax.Encode(kb) + "" + kb.Action;
+}

--- a/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
+++ b/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Encodes a keybind trigger to ghostty config syntax (e.g. "ctrl+shift+key_t")
+/// and canonicalizes a raw trigger token so equivalent spellings compare equal.
+/// ghostty's Trigger.parse matches a key token against the input.Key enum field
+/// name directly, so the KeyNames name round-trips as a physical key.
+/// </summary>
+public static class KeybindTriggerSyntax
+{
+    private const uint ModShift = 1u << 0;
+    private const uint ModCtrl = 1u << 1;
+    private const uint ModAlt = 1u << 2;
+    private const uint ModSuper = 1u << 3;
+    private const uint ModShiftRight = 1u << 6;
+    private const uint ModCtrlRight = 1u << 7;
+    private const uint ModAltRight = 1u << 8;
+    private const uint ModSuperRight = 1u << 9;
+
+    private const int TagPhysical = 0;
+    private const int TagUnicode = 1;
+    private const int TagCatchAll = 2;
+
+    // Fixed emission order. Maps a normalized mod token -> its rank.
+    private static readonly string[] ModOrder = { "ctrl", "shift", "alt", "super" };
+
+    private static readonly Dictionary<string, string> ModAliases = new(StringComparer.Ordinal)
+    {
+        ["ctrl"] = "ctrl", ["control"] = "ctrl",
+        ["shift"] = "shift",
+        ["alt"] = "alt", ["opt"] = "alt", ["option"] = "alt",
+        ["super"] = "super", ["cmd"] = "super", ["command"] = "super", ["win"] = "super",
+    };
+
+    public static string Encode(EnumeratedKeybind kb)
+        => string.Join(">", kb.Steps.Select(EncodeStep));
+
+    private static string EncodeStep(KeybindTrigger step)
+    {
+        var sb = new StringBuilder();
+        if ((step.Mods & (ModCtrl | ModCtrlRight)) != 0) sb.Append("ctrl+");
+        if ((step.Mods & (ModShift | ModShiftRight)) != 0) sb.Append("shift+");
+        if ((step.Mods & (ModAlt | ModAltRight)) != 0) sb.Append("alt+");
+        if ((step.Mods & (ModSuper | ModSuperRight)) != 0) sb.Append("super+");
+        sb.Append(KeyToken(step));
+        return sb.ToString();
+    }
+
+    private static string KeyToken(KeybindTrigger step) => step.Tag switch
+    {
+        TagUnicode => char.ConvertFromUtf32((int)step.Key),
+        TagCatchAll => "catch_all",
+        _ => KeyNames.NameOf((int)step.Key) ?? "unidentified",
+    };
+
+    /// <summary>Normalize a raw trigger token (possibly a sequence) for equality compare.</summary>
+    public static string Canonicalize(string token)
+        => string.Join(">", token.Split('>').Select(CanonicalizeStep));
+
+    private static string CanonicalizeStep(string step)
+    {
+        var mods = new List<string>();
+        string? key = null;
+        foreach (var raw in step.Split('+'))
+        {
+            var part = raw.Trim().ToLowerInvariant();
+            if (part.Length == 0) { key = "+"; continue; } // literal '+'
+            if (ModAliases.TryGetValue(part, out var mod)) mods.Add(mod);
+            else key = part; // last non-mod token wins
+        }
+
+        var ordered = ModOrder.Where(mods.Contains);
+        return key is null ? string.Join("+", ordered) : string.Join("+", ordered.Append(key));
+    }
+}

--- a/windows/Ghostty.Core/Input/UserKeybindEditor.cs
+++ b/windows/Ghostty.Core/Input/UserKeybindEditor.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Pure transforms on the user config's repeatable `keybind` line list (the
+/// values, e.g. "ctrl+key_t=new_tab"). Defaults live compiled in libghostty,
+/// not the file, so these lines are only user customizations.
+/// </summary>
+public static class UserKeybindEditor
+{
+    /// <summary>Append "&lt;trigger&gt;=unbind" if not already present (idempotent).</summary>
+    public static string[] Unbind(IReadOnlyList<string> lines, EnumeratedKeybind binding)
+    {
+        var trigger = KeybindTriggerSyntax.Encode(binding);
+        var unbindLine = trigger + "=unbind";
+        var canonical = KeybindTriggerSyntax.Canonicalize(trigger);
+        var already = lines.Any(l =>
+            string.Equals(TriggerOf(l), canonical, StringComparison.Ordinal) &&
+            string.Equals(ActionOf(l), "unbind", StringComparison.Ordinal));
+        return already ? lines.ToArray() : lines.Append(unbindLine).ToArray();
+    }
+
+    /// <summary>Remove every user line whose trigger matches the binding's trigger.</summary>
+    public static string[] Reset(IReadOnlyList<string> lines, EnumeratedKeybind binding)
+    {
+        var canonical = KeybindTriggerSyntax.Canonicalize(KeybindTriggerSyntax.Encode(binding));
+        return lines.Where(l => !string.Equals(TriggerOf(l), canonical, StringComparison.Ordinal)).ToArray();
+    }
+
+    private static string TriggerOf(string line)
+    {
+        var eq = line.IndexOf('=');
+        var trigger = eq < 0 ? line : line[..eq];
+        return KeybindTriggerSyntax.Canonicalize(trigger.Trim());
+    }
+
+    private static string ActionOf(string line)
+    {
+        var eq = line.IndexOf('=');
+        return eq < 0 ? string.Empty : line[(eq + 1)..].Trim();
+    }
+}

--- a/windows/Ghostty.Core/Input/UserKeybindEditor.cs
+++ b/windows/Ghostty.Core/Input/UserKeybindEditor.cs
@@ -23,7 +23,14 @@ public static class UserKeybindEditor
         return already ? lines.ToArray() : lines.Append(unbindLine).ToArray();
     }
 
-    /// <summary>Remove every user line whose trigger matches the binding's trigger.</summary>
+    /// <summary>
+    /// Remove every user line whose (whole) trigger matches the binding's trigger,
+    /// reverting that trigger fully to its compiled default. This is intentionally
+    /// trigger-only (not trigger+action like Unbind): "reset this trigger" drops all
+    /// of the user's customizations of it, which is correct under last-wins where only
+    /// one user line for a trigger is ever active. A sequence line that merely shares
+    /// the first step has a different whole-trigger canonical form and is NOT removed.
+    /// </summary>
     public static string[] Reset(IReadOnlyList<string> lines, EnumeratedKeybind binding)
     {
         var canonical = KeybindTriggerSyntax.Canonicalize(KeybindTriggerSyntax.Encode(binding));

--- a/windows/Ghostty.Tests/Config/ConfigFileParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigFileParserTests.cs
@@ -68,3 +68,21 @@ public class ConfigFileParserTests
         Assert.Equal(-1, ConfigFileParser.FindLastUncommented(lines, "font-size"));
     }
 }
+
+public class ConfigFileParserGetRepeatableTests
+{
+    [Fact]
+    public void GetRepeatableValues_ReturnsUncommentedValuesForKey()
+    {
+        var lines = new[]
+        {
+            "# comment",
+            "keybind = ctrl+key_t=new_tab",
+            "font-size = 12",
+            "keybind=ctrl+key_w=close_tab",
+            "# keybind = ctrl+key_x=ignore",
+        };
+        var values = ConfigFileParser.GetRepeatableValues(lines, "keybind");
+        Assert.Equal(new[] { "ctrl+key_t=new_tab", "ctrl+key_w=close_tab" }, values);
+    }
+}

--- a/windows/Ghostty.Tests/Config/ConfigWriteSchedulerTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigWriteSchedulerTests.cs
@@ -31,6 +31,7 @@ public class ConfigWriteSchedulerTests
         public void RemoveValue(string key) => Removes.Add(key);
         public void WriteRaw(string content) { }
         public void SetRepeatableValues(string key, string[] values) { }
+        public string[] GetRepeatableValues(string key) => System.Array.Empty<string>();
     }
 
     [Fact]
@@ -148,6 +149,7 @@ public class ConfigWriteSchedulerTests
         public void RemoveValue(string key) { }
         public void WriteRaw(string content) { }
         public void SetRepeatableValues(string key, string[] values) { }
+        public string[] GetRepeatableValues(string key) => System.Array.Empty<string>();
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindCatalogTests.cs
@@ -104,4 +104,29 @@ public class KeybindCatalogTests
         var rows = KeybindCatalog.Build(Sample()).Filter(null, conflictsOnly: false);
         Assert.Equal(3, rows.OfType<KeybindListItem>().Count());
     }
+
+    [Fact]
+    public void Build_NoDefaults_AllSourceDefault()
+    {
+        var cat = KeybindCatalog.Build(Sample());
+        Assert.All(cat.Categories.SelectMany(c => c.Items), i => Assert.Equal(KeybindSource.Default, i.Source));
+    }
+
+    [Fact]
+    public void Build_WithDefaults_ClassifiesUserVsDefault()
+    {
+        var current = new System.Collections.Generic.List<EnumeratedKeybind>
+        {
+            Kb("new_tab", 39, 1u << 1),       // Ctrl+key_t  -> matches a default below
+            Kb("new_window", 22, 1u << 1),    // Ctrl+key_c  -> NOT in defaults => User
+        };
+        var defaults = new System.Collections.Generic.List<EnumeratedKeybind>
+        {
+            Kb("new_tab", 39, 1u << 1),
+        };
+        var cat = KeybindCatalog.Build(current, defaults);
+        var items = cat.Categories.SelectMany(c => c.Items).ToList();
+        Assert.Equal(KeybindSource.Default, items.Single(i => i.RawAction == "new_tab").Source);
+        Assert.Equal(KeybindSource.User, items.Single(i => i.RawAction == "new_window").Source);
+    }
 }

--- a/windows/Ghostty.Tests/Input/KeybindTriggerSyntaxTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindTriggerSyntaxTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeybindTriggerSyntaxTests
+{
+    private static EnumeratedKeybind Kb(params KeybindTrigger[] steps)
+        => new(steps, "noop", GhosttyBindingFlags.Consumed);
+
+    [Fact]
+    public void Encode_PhysicalChord_UsesKeyEnumNameAndFixedModOrder()
+    {
+        // super+alt+shift+ctrl input must normalize to ctrl+shift+alt+super; key_t physical = ord 39.
+        var s = KeybindTriggerSyntax.Encode(Kb(new KeybindTrigger(0, 39, 1u | 2u | 4u | 8u)));
+        Assert.Equal("ctrl+shift+alt+super+key_t", s);
+    }
+
+    [Fact]
+    public void Encode_Unicode_UsesChar()
+    {
+        var s = KeybindTriggerSyntax.Encode(Kb(new KeybindTrigger(1, '=', 1u << 2)));
+        Assert.Equal("alt+=", s);
+    }
+
+    [Fact]
+    public void Encode_Sequence_JoinedWithGreaterThan()
+    {
+        var s = KeybindTriggerSyntax.Encode(Kb(
+            new KeybindTrigger(0, 30, 1u << 1),   // ctrl+key_k
+            new KeybindTrigger(0, 38, 1u << 1))); // ctrl+key_s
+        Assert.Equal("ctrl+key_k>ctrl+key_s", s);
+    }
+
+    [Theory]
+    [InlineData("ctrl+shift+key_t", "ctrl+shift+key_t")]
+    [InlineData("shift+ctrl+key_t", "ctrl+shift+key_t")]   // mod order normalized
+    [InlineData("CTRL+Shift+key_t", "ctrl+shift+key_t")]   // case normalized
+    [InlineData("control+key_a", "ctrl+key_a")]            // alias control->ctrl
+    [InlineData("cmd+key_a", "super+key_a")]               // alias cmd->super
+    [InlineData("ctrl+key_k>ctrl+key_s", "ctrl+key_k>ctrl+key_s")] // sequence
+    public void Canonicalize_NormalizesModsAndAliases(string input, string expected)
+    {
+        Assert.Equal(expected, KeybindTriggerSyntax.Canonicalize(input));
+    }
+}

--- a/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
+++ b/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
@@ -1,0 +1,42 @@
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class UserKeybindEditorTests
+{
+    private static EnumeratedKeybind Kb(uint key, uint mods)
+        => new(new[] { new KeybindTrigger(0, key, mods) }, "noop", GhosttyBindingFlags.Consumed);
+
+    [Fact]
+    public void Unbind_AppendsUnbindLine()
+    {
+        var result = UserKeybindEditor.Unbind(new[] { "ctrl+key_a=new_tab" }, Kb(39, 1u << 1)); // ctrl+key_t
+        Assert.Equal(new[] { "ctrl+key_a=new_tab", "ctrl+key_t=unbind" }, result);
+    }
+
+    [Fact]
+    public void Unbind_Idempotent()
+    {
+        var once = UserKeybindEditor.Unbind(System.Array.Empty<string>(), Kb(39, 1u << 1));
+        var twice = UserKeybindEditor.Unbind(once, Kb(39, 1u << 1));
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void Reset_RemovesMatchingTrigger_RegardlessOfSpelling()
+    {
+        // user lines spell it shift+ctrl; reset target is ctrl+shift+key_t.
+        var lines = new[] { "shift+ctrl+key_t=new_window", "ctrl+key_a=new_tab" };
+        var result = UserKeybindEditor.Reset(lines, Kb(39, 1u << 1 | 1u << 0));
+        Assert.Equal(new[] { "ctrl+key_a=new_tab" }, result);
+    }
+
+    [Fact]
+    public void Reset_RemovesUnbindLineToo()
+    {
+        var lines = new[] { "ctrl+key_t=unbind" };
+        Assert.Empty(UserKeybindEditor.Reset(lines, Kb(39, 1u << 1)));
+    }
+}

--- a/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
+++ b/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
@@ -39,4 +39,23 @@ public class UserKeybindEditorTests
         var lines = new[] { "ctrl+key_t=unbind" };
         Assert.Empty(UserKeybindEditor.Reset(lines, Kb(39, 1u << 1)));
     }
+
+    [Fact]
+    public void Reset_RemovesAllSameTriggerLines_ButKeepsSequencesAndOtherTriggers()
+    {
+        // ctrl+key_t bound twice (last-wins keeps one active); a sequence that only
+        // shares the first step; and an unrelated trigger. Reset of ctrl+key_t drops
+        // both ctrl+key_t lines, keeps the sequence and the other trigger.
+        var lines = new[]
+        {
+            "ctrl+key_t=new_tab",
+            "ctrl+key_t=new_window",
+            "ctrl+key_t>key_x=new_window", // sequence: different whole-trigger
+            "ctrl+key_a=copy_to_clipboard",
+        };
+        var result = UserKeybindEditor.Reset(lines, Kb(39, 1u << 1)); // ctrl+key_t
+        Assert.Equal(
+            new[] { "ctrl+key_t>key_x=new_window", "ctrl+key_a=copy_to_clipboard" },
+            result);
+    }
 }

--- a/windows/Ghostty.Tests/Logging/ConfigWriteSchedulerLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/ConfigWriteSchedulerLoggingTests.cs
@@ -39,6 +39,7 @@ public class ConfigWriteSchedulerLoggingTests
         public void RemoveValue(string key) { }
         public void WriteRaw(string content) { }
         public void SetRepeatableValues(string key, string[] values) { }
+        public string[] GetRepeatableValues(string key) => System.Array.Empty<string>();
     }
 
     private sealed class ManualTimer : ISchedulerTimer

--- a/windows/Ghostty.Tests/Settings/TempFileEditor.cs
+++ b/windows/Ghostty.Tests/Settings/TempFileEditor.cs
@@ -48,6 +48,9 @@ internal sealed class TempFileEditor : IConfigFileEditor
         Write(updated);
     }
 
+    public string[] GetRepeatableValues(string key)
+        => ConfigFileParser.GetRepeatableValues(ReadLines(), key);
+
     private string[] ReadLines()
         => File.Exists(FilePath) ? File.ReadAllLines(FilePath) : Array.Empty<string>();
 

--- a/windows/Ghostty/Services/ConfigFileEditor.cs
+++ b/windows/Ghostty/Services/ConfigFileEditor.cs
@@ -67,6 +67,12 @@ internal sealed class ConfigFileEditor : IConfigFileEditor
         }
     }
 
+    public string[] GetRepeatableValues(string key)
+    {
+        lock (_lock)
+            return ConfigFileParser.GetRepeatableValues(ReadLines(), key);
+    }
+
     private string[] ReadLines()
     {
         return File.Exists(FilePath) ? File.ReadAllLines(FilePath) : Array.Empty<string>();

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -380,6 +380,26 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         return true;
     }
 
+    /// <summary>
+    /// Enumerate the compiled default keybinds only (no user config files),
+    /// for the default-vs-user source diff in the keybindings settings page.
+    /// Deliberately skips <c>ConfigLoadDefaultFiles</c> so the user's file
+    /// doesn't taint the baseline. The throwaway config is freed immediately.
+    /// </summary>
+    public IReadOnlyList<Ghostty.Core.Input.EnumeratedKeybind> EnumerateDefaultKeybinds()
+    {
+        var def = NativeMethods.ConfigNew();
+        try
+        {
+            NativeMethods.ConfigFinalize(def);
+            return KeybindEnumerator.Enumerate(def);
+        }
+        finally
+        {
+            NativeMethods.ConfigFree(def);
+        }
+    }
+
     public string GetDiagnostic(int index)
     {
         if (index < 0 || index >= _diagnosticMessages.Count) return string.Empty;

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
@@ -11,7 +11,13 @@
                        Margin="0,12,0,4" />
         </DataTemplate>
         <DataTemplate x:Key="KeybindEntryTemplate">
-            <Grid ColumnDefinitions="*,Auto,Auto" Padding="8,4">
+            <Grid ColumnDefinitions="*,Auto,Auto,Auto" Padding="8,4">
+                <Grid.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem x:Name="UnbindItem" Text="Unbind" Click="UnbindItem_Click" />
+                        <MenuFlyoutItem x:Name="ResetItem" Text="Reset to default" Click="ResetItem_Click" />
+                    </MenuFlyout>
+                </Grid.ContextFlyout>
                 <TextBlock x:Name="FriendlyText" VerticalAlignment="Center" />
                 <FontIcon x:Name="ConflictIcon"
                           Grid.Column="1"
@@ -22,7 +28,17 @@
                           Margin="0,0,8,0"
                           VerticalAlignment="Center"
                           Visibility="Collapsed" />
-                <Border Grid.Column="2"
+                <Border x:Name="UserTag"
+                        Grid.Column="2"
+                        Background="{ThemeResource SubtleFillColorTertiaryBrush}"
+                        CornerRadius="4" Padding="6,1"
+                        Margin="0,0,8,0"
+                        VerticalAlignment="Center"
+                        Visibility="Collapsed">
+                    <TextBlock Text="User" FontSize="11"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                </Border>
+                <Border Grid.Column="3"
                         Background="{ThemeResource SubtleFillColorSecondaryBrush}"
                         CornerRadius="4" Padding="8,2">
                     <TextBlock x:Name="LabelText"

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Linq;
 using Ghostty.Core.Input;
 using Ghostty.Interop;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 
 namespace Ghostty.Settings.Pages;
 
@@ -27,11 +29,20 @@ internal sealed partial class KeybindingsPage : Page
     // only exposed on the concrete type; the interface only carries
     // ConfigChanged.
     private readonly ConfigService _configService;
+    private readonly Ghostty.Core.Config.IConfigFileEditor _editor;
     private KeybindCatalog _catalog;
 
-    public KeybindingsPage(ConfigService configService)
+    // The row whose context menu is currently open. WinUI doesn't reliably
+    // populate MenuFlyout.Target for a ContextFlyout, so we capture the
+    // right-tapped row's item here (the row Grid's Tag) instead of walking
+    // the flyout's target chain. Each container's RightTapped handler reads
+    // grid.Tag, which OnContainerContentChanging refreshes on every realize.
+    private KeybindListItem? _contextRowItem;
+
+    public KeybindingsPage(ConfigService configService, Ghostty.Core.Config.IConfigFileEditor editor)
     {
         _configService = configService;
+        _editor = editor;
         InitializeComponent();
 
         _catalog = KeybindCatalog.Build(Array.Empty<EnumeratedKeybind>());
@@ -63,7 +74,8 @@ internal sealed partial class KeybindingsPage : Page
     private void Rebuild()
     {
         var binds = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
-        _catalog = KeybindCatalog.Build(binds);
+        var defaults = _configService.EnumerateDefaultKeybinds();
+        _catalog = KeybindCatalog.Build(binds, defaults);
         ApplyFilter();
     }
 
@@ -92,8 +104,55 @@ internal sealed partial class KeybindingsPage : Page
                         ToolTipService.SetToolTip(icon, null);
                     }
                 }
+                if (grid.FindName("UserTag") is FrameworkElement tag)
+                    tag.Visibility = item.Source == KeybindSource.User
+                        ? Visibility.Visible
+                        : Visibility.Collapsed;
+
+                // Stash the item on the container so the context-menu handlers
+                // can resolve the right-clicked row. Containers are recycled,
+                // so refresh the Tag every realize. RightTapped is wired with
+                // -=/+= so the recycled container never accumulates handlers.
+                grid.Tag = item;
+                grid.RightTapped -= Row_RightTapped;
+                grid.RightTapped += Row_RightTapped;
                 break;
         }
+    }
+
+    private void Row_RightTapped(object sender, RightTappedRoutedEventArgs e)
+        => _contextRowItem = (sender as FrameworkElement)?.Tag as KeybindListItem;
+
+    private void UnbindItem_Click(object sender, RoutedEventArgs e)
+    {
+        if (_contextRowItem is not { } item) return;
+        ApplyUserEdit(item, UserKeybindEditor.Unbind);
+    }
+
+    private void ResetItem_Click(object sender, RoutedEventArgs e)
+    {
+        // Reset only makes sense for a user customization; a pure default row
+        // has nothing in the file to remove.
+        if (_contextRowItem is not { } item || item.Source != KeybindSource.User) return;
+        ApplyUserEdit(item, UserKeybindEditor.Reset);
+    }
+
+    private void ApplyUserEdit(
+        KeybindListItem item,
+        Func<string[], EnumeratedKeybind, string[]> op)
+    {
+        // The list item carries only the friendly label, not the trigger
+        // steps the editor needs. Re-find the live EnumeratedKeybind by
+        // matching its action + the same label the row was built from.
+        var binds = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
+        var match = binds.FirstOrDefault(b =>
+            b.Action == item.RawAction && TriggerLabeler.Describe(b) == item.Label);
+        if (match is null) return;
+
+        var current = _editor.GetRepeatableValues("keybind");
+        var updated = op(current, match);
+        _editor.SetRepeatableValues("keybind", updated);
+        _configService.Reload(); // raises ConfigChanged -> Rebuild
     }
 
     private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)

--- a/windows/Ghostty/Settings/SettingsWindow.xaml.cs
+++ b/windows/Ghostty/Settings/SettingsWindow.xaml.cs
@@ -236,7 +236,7 @@ internal sealed partial class SettingsWindow : Window
                 // The keybindings page reads the libghostty config handle via
                 // the enumerate ABI, which only the concrete ConfigService
                 // exposes. The injected instance is always a ConfigService.
-                "keybindings" => new Pages.KeybindingsPage((ConfigService)_configService),
+                "keybindings" => new Pages.KeybindingsPage((ConfigService)_configService, _editor),
                 "advanced" => new Pages.AdvancedPage(_configService, _editor),
                 "raw" => new Pages.RawEditorPage(_configService, _editor),
                 _ => null,


### PR DESCRIPTION
First editing slice for the Keybindings settings page.

Marks each keybind Default vs User by enumerating a default-only libghostty config (ConfigNew+Finalize, no user files) and diffing against the current set. Adds a right-click context menu per row: Unbind (appends `<trigger>=unbind` to the user config) and Reset-to-default (removes the user's keybind line so the compiled default returns). Writes via IConfigFileEditor + reload.

Pure Ghostty.Core (TDD): KeybindTriggerSyntax (encode a binding to round-trippable ghostty syntax via the input.Key enum names + canonicalize raw tokens), KeybindSourceClassifier (default-vs-user diff), UserKeybindEditor (unbind/reset over the keybind line list). A "User" tag marks customized rows.

Reset is intentionally trigger-only (removes all the user's customizations of that trigger, correct under last-wins), distinct from Unbind's trigger+action match - documented + tested.

Part of the keyboard-shortcuts series; chord capture + Assign/Rebind + assign-time conflicts are the next PR. No new C ABI, no Zig changes.