### PR TITLE
terminal: fix integer overflow when unzooming a split pane

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -1059,7 +1059,11 @@ fn resizeCols(
         break :cursor .{
             .tracked_pin = c.pin orelse try self.trackPin(p),
             .untrack = c.pin == null,
-            .remaining_rows = self.rows - c.y - 1,
+            // In the `.lt` path the row resize already ran, so `self.rows` may
+            // be smaller than the old-active-area `c.y` (e.g. unzoom shrinks
+            // cols and rows together). Saturate: a cursor at/below the new
+            // bottom has zero rows beneath it, as the consumer below assumes.
+            .remaining_rows = self.rows -| c.y -| 1,
             .wrapped_rows = wrapped,
         };
     } else null;
@@ -10203,6 +10207,47 @@ test "PageList resize (no reflow) less rows cursor on bottom" {
         } }, pt);
     }
 }
+
+test "PageList resize reflow shrink cols and rows with cursor below new active area" {
+    // Regression: shrinking BOTH cols and rows at once (what unzooming a
+    // pane does) takes the reflow `.lt` path, which applies the row shrink
+    // *before* resizeCols. resizeCols then reads the pre-shrink cursor y,
+    // which can be >= the new (smaller) rows. The `remaining_rows` math
+    // must not underflow in that case.
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var s = try init(alloc, 10, 10, 1000);
+    defer s.deinit();
+
+    // A pin at the bottom of the active area mirrors the cursor pin that
+    // Screen.resize passes through. The pin is required to hit the bug:
+    // without it, resizeCols re-resolves the cursor via active coordinates
+    // and clamps, masking the underflow.
+    const p = try s.trackPin(s.pin(.{ .active = .{ .x = 0, .y = 9 } }).?);
+    defer s.untrackPin(p);
+
+    // cols 10 -> 5 forces the reflow `.lt` path; rows 10 -> 5 shrinks the
+    // active area so the cursor's old y (9) exceeds the new rows (5).
+    try s.resize(.{
+        .cols = 5,
+        .rows = 5,
+        .reflow = true,
+        .cursor = .{ .x = 0, .y = 9, .pin = p },
+    });
+
+    try testing.expectEqual(@as(size.CellCountInt, 5), s.cols);
+    try testing.expectEqual(@as(size.CellCountInt, 5), s.rows);
+
+    // The preserved cursor must stay inside the new active area (remaining
+    // rows below it saturates to zero, so it sits on the bottom row) and the
+    // active-area invariant must hold.
+    const cursor_pt = s.pointFromPin(.active, p.*);
+    try testing.expect(cursor_pt != null);
+    try testing.expect(cursor_pt.?.active.y < s.rows);
+    try testing.expect(s.totalRows() >= s.rows);
+}
+
 test "PageList resize (no reflow) less rows cursor in scrollback" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
## What

Unzooming a split pane could panic libghostty with an integer overflow and crash the whole app. The faulting line is in `PageList.resizeCols`:

```zig
.remaining_rows = self.rows - c.y - 1,
```

When a resize shrinks both columns and rows at once (unzoom goes from full-window back to the small split slot), `resize` takes the cols-shrink path that applies the row shrink first, reducing `self.rows`. `resizeCols` then uses the cursor `y` captured from the larger pre-resize active area, so `c.y` can be `>= self.rows` and the unsigned subtraction underflows. The panic fires on the termio (IO) thread: `Termio.resize` -> `Screen.resize` -> `PageList.resize` -> `resizeCols`.

It looks intermittent because it only triggers when the cursor sits below the new (smaller) row count at unzoom time. It reproduces reliably by toggling zoom rapidly on a maximized multi-pane window.

## Fix

Use saturating subtraction (`self.rows -| c.y -| 1`). A cursor at or below the new bottom has no rows beneath it, so 0 is correct. This matches the saturating math the consumer further down `resizeCols` already uses.

## Verification

- New regression test shrinks cols and rows together with the cursor below the new active area; panics before, passes after.
- Full terminal test suite passes.
- Manually hammered `toggle_split_zoom` 600+ times on a maximized 3-pane window with no crash (previously crashed within tens of toggles).