### PR TITLE
glslang: rename CL env var so cl.exe stops eating its own path

### DIFF
--- a/pkg/glslang/build_msvc.bat
+++ b/pkg/glslang/build_msvc.bat
@@ -147,10 +147,8 @@ for %%f in (
 )
 
 echo Compiling with MSVC...
-REM Quote %CLEXE%: the expanded path contains "Program Files" (with a space) on
-REM stock Windows, so an unquoted invocation has cmd parse 'C:\Program' as the
-REM command and the rest as args. Breaks on windows-latest runners and any
-REM default VS install.
+REM Quote %CLEXE%: the path has a space (see above), so unquoted cmd would parse
+REM 'C:\Program' as the command and the rest as args.
 "%CLEXE%" %CFLAGS% %FILES%
 
 if errorlevel 1 (

--- a/pkg/glslang/build_msvc.bat
+++ b/pkg/glslang/build_msvc.bat
@@ -73,7 +73,11 @@ if not defined GLSLANG_SRC (
 
 echo Using glslang source: %GLSLANG_SRC%
 
-set CL=!MSVC_DIR!\bin\Hostx64\x64\cl.exe
+REM Do NOT name this variable CL: cl.exe treats the CL environment variable as
+REM an extra command line and prepends its contents to its own args. Our path
+REM contains "Program Files" (a space), so cl.exe would split it into phantom
+REM source files ('C:\Program', 'Files\Microsoft', ...) and emit D9024/D9027.
+set CLEXE=!MSVC_DIR!\bin\Hostx64\x64\cl.exe
 set LIB=!MSVC_DIR!\lib\x64;%WINSDK_LIB%\um\x64;%WINSDK_LIB%\ucrt\x64
 REM Include paths must mirror what build.zig wires up for the zig-driven build:
 REM   - MSVC + Windows SDK for libc/libc++
@@ -143,11 +147,11 @@ for %%f in (
 )
 
 echo Compiling with MSVC...
-REM Quote %CL%: the expanded path contains "Program Files" (with a space) on
+REM Quote %CLEXE%: the expanded path contains "Program Files" (with a space) on
 REM stock Windows, so an unquoted invocation has cmd parse 'C:\Program' as the
 REM command and the rest as args. Breaks on windows-latest runners and any
 REM default VS install.
-"%CL%" %CFLAGS% %FILES%
+"%CLEXE%" %CFLAGS% %FILES%
 
 if errorlevel 1 (
     echo ERROR: Compilation failed


### PR DESCRIPTION
The MSVC build script for glslang set a variable named `CL` to hold the cl.exe path. `CL` is a reserved cl.exe environment variable: cl.exe prepends its contents to the command line at startup. Since the path contains "Program Files" (with a space), cl.exe split it into phantom source files and emitted `D9024`/`D9027` warnings on every default Visual Studio install.

Renamed the variable to `CLEXE`. The invocation was already quoted, so this was not a quoting bug.

Repro before fix: `zig build -Dapp-runtime=none` on Windows with VS installed under a path with spaces:

```
cl : Command line warning D9024 : unrecognized source file type 'C:\Program', object file assumed
cl : Command line warning D9027 : source file 'C:\Program' ignored
```

After: `zig build -Dapp-runtime=none` compiles glslang with no warnings and links glslang.lib successfully.