### PR TITLE
renderer: emit first_render on first painted frame

### DIFF
--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -30,6 +30,14 @@ preedit: ?Preedit = null,
 /// need about the mouse.
 mouse: Mouse = .{},
 
+/// Set (under `mutex`) by the IO/parser thread once the terminal has
+/// printed its first cell of content. The renderer latches this in
+/// `updateFrame` and emits the one-shot `.first_render` surface message
+/// after the first frame that actually paints that content, so consumers
+/// learn when a surface comes alive on screen rather than when the parser
+/// first saw a printable byte. Set once and never reset.
+first_content: bool = false,
+
 pub const Mouse = struct {
     /// The point on the viewport where the mouse currently is. We use
     /// viewport points to avoid the complexity of mapping the mouse to

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -152,6 +152,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// cells for the draw call.
         cells_rebuilt: bool = false,
 
+        /// Latched copy of `renderer.State.first_content`, captured under
+        /// the render state mutex in `updateFrame`. Lets `drawFrame` tell
+        /// whether the terminal has produced content without re-taking the
+        /// mutex. Named distinctly from the `State` flag so the call sites
+        /// read as a render-thread-local snapshot, not the shared source.
+        first_content_latched: bool = false,
+
+        /// Set once we have pushed the one-shot `.first_render` surface
+        /// message, so it is emitted at most once per surface. We emit it
+        /// only after a frame that actually paints content is presented.
+        first_render_sent: bool = false,
+
         /// The current GPU uniform values.
         uniforms: shaderpkg.Uniforms,
 
@@ -1253,6 +1265,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 preedit: ?renderer.State.Preedit,
                 scrollbar: terminal.Scrollbar,
                 overlay_features: []const Overlay.Feature,
+                first_content: bool,
             };
 
             // Update all our data as tightly as possible within the mutex.
@@ -1386,8 +1399,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .preedit = preedit,
                     .scrollbar = scrollbar,
                     .overlay_features = overlay_features,
+                    .first_content = state.first_content,
                 };
             };
+
+            // Latch whether the terminal has produced its first content yet.
+            // `drawFrame` reads this to emit the one-shot first-render signal
+            // only after that content has actually been painted and presented.
+            self.first_content_latched = critical.first_content;
 
             // Outside the critical area we can update our links to contain
             // our regex results.
@@ -1564,6 +1583,26 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 if (self.surface_mailbox.push(.{
                     .scrollbar = self.scrollbar,
                 }, .instant) > 0) self.scrollbar_dirty = false;
+            };
+
+            // Capture whether the cells were rebuilt this frame before the
+            // draw path resets the flag below, so the first-render emit can
+            // tell that this frame actually paints terminal content.
+            const cells_rebuilt = self.cells_rebuilt;
+
+            // Set on the real draw path below, once we've committed to
+            // presenting a frame that paints the surface's first content.
+            // Read by the deferred first-render emit after that frame is
+            // presented (this defer runs after `frame_ctx.complete` below
+            // because it is registered earlier). We use the same instant
+            // push path as the scrollbar above; if the mailbox is momentarily
+            // full we leave it un-sent and retry on the next frame that
+            // rebuilds cells (cursor blink alone drives that), so the signal
+            // is delayed at worst, never dropped.
+            var first_content_painted = false;
+            defer if (first_content_painted and !self.first_render_sent) {
+                if (self.surface_mailbox.push(.first_render, .instant) > 0)
+                    self.first_render_sent = true;
             };
 
             // Let our graphics API do any bookkeeping, etc.
@@ -1890,6 +1929,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     });
                 }
             }
+
+            // We have finished encoding a frame that is about to be presented
+            // (the deferred `frame_ctx.complete` runs at scope exit). If it
+            // rebuilt the surface's first content, arm the one-shot first-render
+            // emit; the deferred push above then fires it after the present.
+            // Gating on `cells_rebuilt` keeps us from firing on frames drawn for
+            // a resize, animation, or forced sync that paint no new content.
+            if (cells_rebuilt and self.first_content_latched) first_content_painted = true;
         }
 
         // Callback from the graphics API when a frame is completed.

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -32,9 +32,11 @@ pub const StreamHandler = struct {
     /// Mailbox for the surface.
     surface_mailbox: apprt.surface.Mailbox,
 
-    /// Set once we have emitted the first_render signal for this surface,
-    /// so we emit it at most once. Surface-scoped: never reset.
-    first_render_sent: bool = false,
+    /// Set once we have flagged the render state that this surface has
+    /// produced its first cell of content, so we flag it at most once.
+    /// The renderer emits the actual `.first_render` signal after that
+    /// content is painted. Surface-scoped: never reset.
+    first_content_flagged: bool = false,
 
     /// The shared render state
     renderer_state: *renderer.State,
@@ -230,9 +232,16 @@ pub const StreamHandler = struct {
             .print => {
                 @branchHint(.likely);
                 try self.terminal.print(value.cp);
-                if (!self.first_render_sent) {
-                    self.first_render_sent = true;
-                    self.surfaceMessageWriter(.first_render);
+                if (!self.first_content_flagged) {
+                    self.first_content_flagged = true;
+                    // We hold `renderer_state.mutex` for the duration of
+                    // action dispatch (see `surfaceMessageWriter`), so we can
+                    // flag the shared render state directly. The renderer then
+                    // emits the one-shot `.first_render` signal once this
+                    // content is actually painted, rather than us emitting it
+                    // here on first parse (which can race ahead of the paint
+                    // when several surfaces start at once).
+                    self.renderer_state.first_content = true;
                 }
             },
             .print_repeat => try self.terminal.printRepeat(value),


### PR DESCRIPTION
The first_render signal fired from the parse thread on the first printable byte, before the renderer painted that pane. With one pane the gap is a frame and invisible, but opening several pwsh splits at once lets the render thread lag and reorder, so an older pane's signal fired several frames before its cells were drawn.

Move the trigger to the paint side: the first-print one-shot now flags the shared render state (first_content), updateFrame latches it, and drawFrame emits first_render once, after the first presented frame that actually rebuilt content for the surface. The apprt action, mailbox message, C ABI, and C# are unchanged.

No new unit test: the emit now depends on a presented GPU frame (drawFrame has no test harness), and the parse-side flag is a trivial one-shot already exercised by the parser tests.