### PR TITLE
Keyboard shortcuts: chord capture + assign

### DIFF
--- a/windows/Ghostty.Core/Input/ChordEncoder.cs
+++ b/windows/Ghostty.Core/Input/ChordEncoder.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Maps a Windows VirtualKey (numeric) + modifier state to a physical ghostty
+/// KeybindTrigger for chord capture. US-ANSI layout; returns null for unmapped
+/// or modifier-only keys (capture rejects those). Plain ints so Ghostty.Core
+/// stays free of WinRT types.
+/// </summary>
+public static class ChordEncoder
+{
+    private const uint ModShift = 1u << 0;
+    private const uint ModCtrl = 1u << 1;
+    private const uint ModAlt = 1u << 2;
+    private const uint ModSuper = 1u << 3;
+
+    // VirtualKey numeric -> input.Key enum name. US-ANSI.
+    private static readonly Dictionary<int, string> VkToName = BuildVkToName();
+
+    public static KeybindTrigger? TryEncode(int virtualKey, bool ctrl, bool shift, bool alt, bool win)
+    {
+        if (!VkToName.TryGetValue(virtualKey, out var name)) return null;
+        var ordinal = KeyNames.OrdinalOf(name);
+        if (ordinal is null) return null;
+
+        uint mods = 0;
+        if (ctrl) mods |= ModCtrl;
+        if (shift) mods |= ModShift;
+        if (alt) mods |= ModAlt;
+        if (win) mods |= ModSuper;
+
+        return new KeybindTrigger(0, (uint)ordinal.Value, mods);
+    }
+
+    private static Dictionary<int, string> BuildVkToName()
+    {
+        var m = new Dictionary<int, string>();
+
+        // Letters A-Z (VK 0x41-0x5A) -> key_a..key_z
+        for (var vk = 0x41; vk <= 0x5A; vk++)
+            m[vk] = "key_" + (char)('a' + (vk - 0x41));
+
+        // Top-row digits 0-9 (VK 0x30-0x39) -> digit_0..digit_9
+        for (var vk = 0x30; vk <= 0x39; vk++)
+            m[vk] = "digit_" + (char)('0' + (vk - 0x30));
+
+        // Numpad 0-9 (VK 0x60-0x69) -> numpad_0..numpad_9
+        for (var vk = 0x60; vk <= 0x69; vk++)
+            m[vk] = "numpad_" + (char)('0' + (vk - 0x60));
+
+        // Function keys F1-F24 (VK 0x70-0x87) -> f1..f24
+        for (var i = 1; i <= 24; i++)
+            m[0x70 + (i - 1)] = "f" + i;
+
+        // Named keys
+        m[0x0D] = "enter";
+        m[0x09] = "tab";
+        m[0x20] = "space";
+        m[0x1B] = "escape";
+        m[0x08] = "backspace";
+        m[0x2E] = "delete";
+        m[0x2D] = "insert";
+        m[0x24] = "home";
+        m[0x23] = "end";
+        m[0x21] = "page_up";
+        m[0x22] = "page_down";
+        m[0x26] = "arrow_up";
+        m[0x28] = "arrow_down";
+        m[0x25] = "arrow_left";
+        m[0x27] = "arrow_right";
+
+        // OEM punctuation (US-ANSI)
+        m[0xC0] = "backquote";     // `
+        m[0xBD] = "minus";         // -
+        m[0xBB] = "equal";         // =
+        m[0xBA] = "semicolon";     // ;
+        m[0xBF] = "slash";         // /
+        m[0xDB] = "bracket_left";  // [
+        m[0xDD] = "bracket_right"; // ]
+        m[0xDC] = "backslash";     // \
+        m[0xDE] = "quote";         // '
+        m[0xBC] = "comma";         // ,
+        m[0xBE] = "period";        // .
+
+        return m;
+    }
+}

--- a/windows/Ghostty.Core/Input/KeyNames.cs
+++ b/windows/Ghostty.Core/Input/KeyNames.cs
@@ -37,7 +37,20 @@ public static class KeyNames
 
     public static int Count => Names.Length;
 
+    private static readonly System.Collections.Generic.Dictionary<string, int> Ordinals = BuildOrdinals();
+
+    private static System.Collections.Generic.Dictionary<string, int> BuildOrdinals()
+    {
+        var map = new System.Collections.Generic.Dictionary<string, int>(Names.Length, System.StringComparer.Ordinal);
+        for (var i = 0; i < Names.Length; i++) map[Names[i]] = i;
+        return map;
+    }
+
     /// <summary>Name for an ordinal, or null if out of range.</summary>
     public static string? NameOf(int ordinal)
         => ordinal >= 0 && ordinal < Names.Length ? Names[ordinal] : null;
+
+    /// <summary>Ordinal for an input.Key name, or null if unknown. Inverse of NameOf.</summary>
+    public static int? OrdinalOf(string name)
+        => Ordinals.TryGetValue(name, out var ordinal) ? ordinal : null;
 }

--- a/windows/Ghostty.Core/Input/KeybindConflicts.cs
+++ b/windows/Ghostty.Core/Input/KeybindConflicts.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>Assign-time conflict lookups over the current (finalized) bind set.</summary>
+public static class KeybindConflicts
+{
+    /// <summary>The existing binding whose trigger matches triggerToken, or null.</summary>
+    public static EnumeratedKeybind? FindByTrigger(IReadOnlyList<EnumeratedKeybind> binds, string triggerToken)
+    {
+        var canonical = KeybindTriggerSyntax.Canonicalize(triggerToken);
+        return binds.FirstOrDefault(b =>
+            string.Equals(KeybindTriggerSyntax.Canonicalize(KeybindTriggerSyntax.Encode(b)), canonical,
+                System.StringComparison.Ordinal));
+    }
+}

--- a/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
+++ b/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
@@ -37,6 +37,11 @@ public static class KeybindTriggerSyntax
         ["super"] = "super", ["cmd"] = "super", ["command"] = "super", ["win"] = "super",
     };
 
+    // ghostty keybind values may carry chained leading flag prefixes before the
+    // trigger (e.g. "global:unconsumed:ctrl+a=..."). They are not modifiers or keys,
+    // so strip them before parsing or they get mistaken for a key/mod token.
+    private static readonly string[] FlagPrefixes = { "all:", "global:", "unconsumed:", "performable:" };
+
     public static string Encode(EnumeratedKeybind kb)
         => string.Join(">", kb.Steps.Select(EncodeStep));
 
@@ -60,7 +65,31 @@ public static class KeybindTriggerSyntax
 
     /// <summary>Normalize a raw trigger token (possibly a sequence) for equality compare.</summary>
     public static string Canonicalize(string token)
-        => string.Join(">", token.Split('>').Select(CanonicalizeStep));
+    {
+        token = StripFlags(token);
+        return string.Join(">", token.Split('>').Select(CanonicalizeStep));
+    }
+
+    /// <summary>Strip chained leading flag prefixes (all:/global:/unconsumed:/performable:).</summary>
+    private static string StripFlags(string token)
+    {
+        var t = token.TrimStart();
+        bool stripped = true;
+        while (stripped)
+        {
+            stripped = false;
+            foreach (var f in FlagPrefixes)
+            {
+                if (t.StartsWith(f, StringComparison.OrdinalIgnoreCase))
+                {
+                    t = t[f.Length..].TrimStart();
+                    stripped = true;
+                    break;
+                }
+            }
+        }
+        return t;
+    }
 
     private static string CanonicalizeStep(string step)
     {

--- a/windows/Ghostty.Core/Input/UserKeybindEditor.cs
+++ b/windows/Ghostty.Core/Input/UserKeybindEditor.cs
@@ -37,6 +37,18 @@ public static class UserKeybindEditor
         return lines.Where(l => !string.Equals(TriggerOf(l), canonical, StringComparison.Ordinal)).ToArray();
     }
 
+    /// <summary>
+    /// Bind <paramref name="action"/> to <paramref name="triggerToken"/>: drop any
+    /// user line already at that trigger (override / last-wins) and append the new
+    /// line. The action's other triggers are left intact (add/override, not move).
+    /// </summary>
+    public static string[] Assign(IReadOnlyList<string> lines, string triggerToken, string action)
+    {
+        var canonical = KeybindTriggerSyntax.Canonicalize(triggerToken);
+        var kept = lines.Where(l => !string.Equals(TriggerOf(l), canonical, System.StringComparison.Ordinal));
+        return kept.Append($"{triggerToken}={action}").ToArray();
+    }
+
     private static string TriggerOf(string line)
     {
         var eq = line.IndexOf('=');

--- a/windows/Ghostty.Tests/Input/ChordEncoderTests.cs
+++ b/windows/Ghostty.Tests/Input/ChordEncoderTests.cs
@@ -1,4 +1,5 @@
 using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
 using Xunit;
 
 namespace Ghostty.Tests.Input;
@@ -20,7 +21,7 @@ public class ChordEncoderTests
         Assert.Equal((uint)KeyNames.OrdinalOf("key_t")!, t.Value.Key);
         Assert.Equal(ModCtrl | ModShift, t.Value.Mods);
         // round-trips to ghostty syntax + a friendly label
-        var kb = new EnumeratedKeybind(new[] { t.Value }, "x", Interop.GhosttyBindingFlags.Consumed);
+        var kb = new EnumeratedKeybind(new[] { t.Value }, "x", GhosttyBindingFlags.Consumed);
         Assert.Equal("ctrl+shift+key_t", KeybindTriggerSyntax.Encode(kb));
         Assert.Equal("Ctrl+Shift+T", TriggerLabeler.Describe(kb));
     }

--- a/windows/Ghostty.Tests/Input/ChordEncoderTests.cs
+++ b/windows/Ghostty.Tests/Input/ChordEncoderTests.cs
@@ -1,0 +1,59 @@
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class ChordEncoderTests
+{
+    private const uint ModShift = 1u << 0;
+    private const uint ModCtrl = 1u << 1;
+    private const uint ModAlt = 1u << 2;
+    private const uint ModSuper = 1u << 3;
+
+    [Fact]
+    public void Letter_WithCtrlShift_EncodesPhysicalKeyAndMods()
+    {
+        // VK 'T' = 0x54.
+        var t = ChordEncoder.TryEncode(0x54, ctrl: true, shift: true, alt: false, win: false);
+        Assert.NotNull(t);
+        Assert.Equal(0, t!.Value.Tag);                 // physical
+        Assert.Equal((uint)KeyNames.OrdinalOf("key_t")!, t.Value.Key);
+        Assert.Equal(ModCtrl | ModShift, t.Value.Mods);
+        // round-trips to ghostty syntax + a friendly label
+        var kb = new EnumeratedKeybind(new[] { t.Value }, "x", Interop.GhosttyBindingFlags.Consumed);
+        Assert.Equal("ctrl+shift+key_t", KeybindTriggerSyntax.Encode(kb));
+        Assert.Equal("Ctrl+Shift+T", TriggerLabeler.Describe(kb));
+    }
+
+    [Theory]
+    [InlineData(0x70, "f1")]      // VK_F1
+    [InlineData(0x26, "arrow_up")]// VK_UP
+    [InlineData(0xC0, "backquote")] // VK_OEM_3
+    [InlineData(0xBD, "minus")]   // VK_OEM_MINUS
+    [InlineData(0x0D, "enter")]   // VK_RETURN
+    [InlineData(0x30, "digit_0")] // VK '0'
+    public void MapsNamedAndOemKeys(int vk, string expectedName)
+    {
+        var t = ChordEncoder.TryEncode(vk, ctrl: false, shift: false, alt: false, win: false);
+        Assert.NotNull(t);
+        Assert.Equal((uint)KeyNames.OrdinalOf(expectedName)!, t!.Value.Key);
+    }
+
+    [Theory]
+    [InlineData(0x10)] // VK_SHIFT (modifier-only)
+    [InlineData(0x11)] // VK_CONTROL
+    [InlineData(0x12)] // VK_MENU
+    [InlineData(0x5B)] // VK_LWIN
+    [InlineData(0x07)] // undefined/unmapped
+    public void ModifierOnlyOrUnmapped_ReturnsNull(int vk)
+    {
+        Assert.Null(ChordEncoder.TryEncode(vk, ctrl: true, shift: false, alt: false, win: false));
+    }
+
+    [Fact]
+    public void Win_MapsToSuper()
+    {
+        var t = ChordEncoder.TryEncode(0x54, ctrl: false, shift: false, alt: false, win: true);
+        Assert.Equal(ModSuper, t!.Value.Mods);
+    }
+}

--- a/windows/Ghostty.Tests/Input/ChordEncoderTests.cs
+++ b/windows/Ghostty.Tests/Input/ChordEncoderTests.cs
@@ -33,6 +33,8 @@ public class ChordEncoderTests
     [InlineData(0xBD, "minus")]   // VK_OEM_MINUS
     [InlineData(0x0D, "enter")]   // VK_RETURN
     [InlineData(0x30, "digit_0")] // VK '0'
+    [InlineData(0x60, "numpad_0")]// VK_NUMPAD0
+    [InlineData(0x69, "numpad_9")]// VK_NUMPAD9
     public void MapsNamedAndOemKeys(int vk, string expectedName)
     {
         var t = ChordEncoder.TryEncode(vk, ctrl: false, shift: false, alt: false, win: false);

--- a/windows/Ghostty.Tests/Input/KeyNamesTests.cs
+++ b/windows/Ghostty.Tests/Input/KeyNamesTests.cs
@@ -35,4 +35,21 @@ public class KeyNamesTests
     {
         Assert.Null(KeyNames.NameOf(ordinal));
     }
+
+    [Theory]
+    [InlineData("key_t", 39)]
+    [InlineData("backquote", 1)]
+    [InlineData("arrow_up", 78)]
+    [InlineData("f11", 131)]
+    public void OrdinalOf_IsInverseOfNameOf(string name, int expected)
+    {
+        Assert.Equal(expected, KeyNames.OrdinalOf(name));
+        Assert.Equal(name, KeyNames.NameOf(expected));
+    }
+
+    [Fact]
+    public void OrdinalOf_UnknownName_ReturnsNull()
+    {
+        Assert.Null(KeyNames.OrdinalOf("not_a_key"));
+    }
 }

--- a/windows/Ghostty.Tests/Input/KeybindConflictsTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindConflictsTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeybindConflictsTests
+{
+    private static EnumeratedKeybind Kb(string action, uint key, uint mods)
+        => new(new[] { new KeybindTrigger(0, key, mods) }, action, GhosttyBindingFlags.Consumed);
+
+    [Fact]
+    public void FindByTrigger_ReturnsExistingBindingAtChord()
+    {
+        var binds = new List<EnumeratedKeybind>
+        {
+            Kb("new_tab", 39, 1u << 1),   // ctrl+key_t
+            Kb("copy_to_clipboard:mixed", 22, 1u << 1),
+        };
+        var hit = KeybindConflicts.FindByTrigger(binds, "ctrl+key_t");
+        Assert.NotNull(hit);
+        Assert.Equal("new_tab", hit!.Action);
+    }
+
+    [Fact]
+    public void FindByTrigger_NoMatch_ReturnsNull()
+    {
+        var binds = new List<EnumeratedKeybind> { Kb("new_tab", 39, 1u << 1) };
+        Assert.Null(KeybindConflicts.FindByTrigger(binds, "ctrl+key_w"));
+    }
+}

--- a/windows/Ghostty.Tests/Input/KeybindTriggerSyntaxTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindTriggerSyntaxTests.cs
@@ -41,8 +41,19 @@ public class KeybindTriggerSyntaxTests
     [InlineData("control+key_a", "ctrl+key_a")]            // alias control->ctrl
     [InlineData("cmd+key_a", "super+key_a")]               // alias cmd->super
     [InlineData("ctrl+key_k>ctrl+key_s", "ctrl+key_k>ctrl+key_s")] // sequence
+    [InlineData("performable:ctrl+key_a", "ctrl+key_a")]            // flag prefix stripped
+    [InlineData("global:unconsumed:shift+ctrl+key_t", "ctrl+shift+key_t")] // chained flags stripped
     public void Canonicalize_NormalizesModsAndAliases(string input, string expected)
     {
         Assert.Equal(expected, KeybindTriggerSyntax.Canonicalize(input));
+    }
+
+    [Fact]
+    public void Canonicalize_FlagPrefixedTrigger_EqualsUnflagged()
+    {
+        Assert.Equal(
+            KeybindTriggerSyntax.Canonicalize("ctrl+key_a"),
+            KeybindTriggerSyntax.Canonicalize("performable:ctrl+key_a"));
+        Assert.Equal("ctrl+key_a", KeybindTriggerSyntax.Canonicalize("performable:ctrl+key_a"));
     }
 }

--- a/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
+++ b/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
@@ -60,6 +60,15 @@ public class UserKeybindEditorTests
     }
 
     [Fact]
+    public void Reset_RemovesFlagPrefixedUserLine()
+    {
+        // user line carries a performable: flag prefix; reset of ctrl+key_t must still match.
+        var lines = new[] { "performable:ctrl+key_t=new_split:right", "ctrl+key_a=new_tab" };
+        var result = UserKeybindEditor.Reset(lines, Kb(39, 1u << 1)); // ctrl+key_t
+        Assert.Equal(new[] { "ctrl+key_a=new_tab" }, result);
+    }
+
+    [Fact]
     public void Assign_AppendsTriggerActionAndOverridesSameTrigger()
     {
         var lines = new[] { "ctrl+key_t=old_action", "ctrl+key_a=copy_to_clipboard" };

--- a/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
+++ b/windows/Ghostty.Tests/Input/UserKeybindEditorTests.cs
@@ -58,4 +58,13 @@ public class UserKeybindEditorTests
             new[] { "ctrl+key_t>key_x=new_window", "ctrl+key_a=copy_to_clipboard" },
             result);
     }
+
+    [Fact]
+    public void Assign_AppendsTriggerActionAndOverridesSameTrigger()
+    {
+        var lines = new[] { "ctrl+key_t=old_action", "ctrl+key_a=copy_to_clipboard" };
+        var result = UserKeybindEditor.Assign(lines, "ctrl+key_t", "new_tab");
+        // existing ctrl+key_t line dropped (override), new appended, other kept
+        Assert.Equal(new[] { "ctrl+key_a=copy_to_clipboard", "ctrl+key_t=new_tab" }, result);
+    }
 }

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -64,6 +64,7 @@ internal static class LogEvents
     // 2600-2699: Settings UI
     internal static class SettingsUi
     {
-        public const int ConfigOpenFailed = 2600;
+        public const int ConfigOpenFailed   = 2600;
+        public const int KeybindWriteFailed = 2601;
     }
 }

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -37,6 +37,8 @@ namespace Ghostty.Logging;
 ///     WinUI 3 Frame via a parameterless ctor; ctor injection
 ///     requires a DI-enabled <c>Frame</c> which is a larger
 ///     refactor than this slot is worth.
+///   - <see cref="KeybindingsPage"/>: same XAML-page constraint as
+///     <see cref="GeneralPage"/>; logs keybind config write failures.
 ///
 /// Tests should use <see cref="Install"/> which returns an
 /// <see cref="IDisposable"/> scope that restores the pre-install
@@ -59,6 +61,7 @@ internal static class StaticLoggers
     private static ILogger? _windowStateMigration;
     private static ILogger<Ghostty.Settings.WindowState>? _windowState;
     private static ILogger<Ghostty.Settings.Pages.GeneralPage>? _generalPage;
+    private static ILogger<Ghostty.Settings.Pages.KeybindingsPage>? _keybindingsPage;
     private static ILogger<App>? _app;
 
     internal static ILogger<Ghostty.Services.ConfigService> ConfigService
@@ -69,6 +72,8 @@ internal static class StaticLoggers
         => _windowState ?? NullLogger<Ghostty.Settings.WindowState>.Instance;
     internal static ILogger<Ghostty.Settings.Pages.GeneralPage> GeneralPage
         => _generalPage ?? NullLogger<Ghostty.Settings.Pages.GeneralPage>.Instance;
+    internal static ILogger<Ghostty.Settings.Pages.KeybindingsPage> KeybindingsPage
+        => _keybindingsPage ?? NullLogger<Ghostty.Settings.Pages.KeybindingsPage>.Instance;
     internal static ILogger<App> App
         => _app ?? NullLogger<App>.Instance;
 
@@ -78,6 +83,7 @@ internal static class StaticLoggers
         _windowStateMigration = factory.CreateLogger(WindowStateMigrationCategory);
         _windowState = factory.CreateLogger<Ghostty.Settings.WindowState>();
         _generalPage = factory.CreateLogger<Ghostty.Settings.Pages.GeneralPage>();
+        _keybindingsPage = factory.CreateLogger<Ghostty.Settings.Pages.KeybindingsPage>();
         _app = factory.CreateLogger<App>();
     }
 
@@ -89,13 +95,14 @@ internal static class StaticLoggers
     }
 
     private static Snapshot CaptureSnapshot() => new(
-        _configService, _windowStateMigration, _windowState, _generalPage, _app);
+        _configService, _windowStateMigration, _windowState, _generalPage, _keybindingsPage, _app);
 
     private readonly record struct Snapshot(
         ILogger<Ghostty.Services.ConfigService>? ConfigService,
         ILogger? WindowStateMigration,
         ILogger<Ghostty.Settings.WindowState>? WindowState,
         ILogger<Ghostty.Settings.Pages.GeneralPage>? GeneralPage,
+        ILogger<Ghostty.Settings.Pages.KeybindingsPage>? KeybindingsPage,
         ILogger<App>? App);
 
     private sealed class Scope : IDisposable
@@ -109,6 +116,7 @@ internal static class StaticLoggers
             _windowStateMigration = _prior.WindowStateMigration;
             _windowState = _prior.WindowState;
             _generalPage = _prior.GeneralPage;
+            _keybindingsPage = _prior.KeybindingsPage;
             _app = _prior.App;
         }
     }

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
@@ -14,6 +14,8 @@
             <Grid ColumnDefinitions="*,Auto,Auto,Auto" Padding="8,4">
                 <Grid.ContextFlyout>
                     <MenuFlyout>
+                        <MenuFlyoutItem x:Name="RebindItem" Text="Rebind..." Click="RebindItem_Click" />
+                        <MenuFlyoutSeparator />
                         <MenuFlyoutItem x:Name="UnbindItem" Text="Unbind" Click="UnbindItem_Click" />
                         <MenuFlyoutItem x:Name="ResetItem" Text="Reset to default" Click="ResetItem_Click" />
                     </MenuFlyout>

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -137,6 +137,27 @@ internal sealed partial class KeybindingsPage : Page
         ApplyUserEdit(item, UserKeybindEditor.Reset);
     }
 
+    private async void RebindItem_Click(object sender, RoutedEventArgs e)
+    {
+        if (_contextRowItem is not { } item) return;
+
+        // Pass the live finalized bind set so the dialog can warn about
+        // assign-time conflicts against what is actually in effect.
+        var current = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
+        var dialog = new Ghostty.Settings.RebindDialog(current, item.RawAction, item.Friendly)
+        {
+            XamlRoot = XamlRoot,
+        };
+        var result = await dialog.ShowAsync();
+        if (result != ContentDialogResult.Primary || dialog.CapturedTrigger is not { } token) return;
+
+        // Add/override: write the new trigger=action line (dropping any user
+        // line already at that chord). The action's other triggers stay intact.
+        var updated = UserKeybindEditor.Assign(_editor.GetRepeatableValues("keybind"), token, item.RawAction);
+        _editor.SetRepeatableValues("keybind", updated);
+        _configService.Reload(); // raises ConfigChanged -> Rebuild
+    }
+
     private void ApplyUserEdit(
         KeybindListItem item,
         Func<string[], EnumeratedKeybind, string[]> op)

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -2,7 +2,9 @@ using System;
 using System.Linq;
 using Ghostty.Core.Input;
 using Ghostty.Interop;
+using Ghostty.Logging;
 using Ghostty.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -153,9 +155,8 @@ internal sealed partial class KeybindingsPage : Page
 
         // Add/override: write the new trigger=action line (dropping any user
         // line already at that chord). The action's other triggers stay intact.
-        var updated = UserKeybindEditor.Assign(_editor.GetRepeatableValues("keybind"), token, item.RawAction);
-        _editor.SetRepeatableValues("keybind", updated);
-        _configService.Reload(); // raises ConfigChanged -> Rebuild
+        TryWriteKeybinds(current =>
+            UserKeybindEditor.Assign(current, token, item.RawAction));
     }
 
     private void ApplyUserEdit(
@@ -166,14 +167,33 @@ internal sealed partial class KeybindingsPage : Page
         // steps the editor needs. Re-find the live EnumeratedKeybind by
         // matching its action + the same label the row was built from.
         var binds = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
-        var match = binds.FirstOrDefault(b =>
-            b.Action == item.RawAction && TriggerLabeler.Describe(b) == item.Label);
-        if (match is null) return;
+        if (binds.FirstOrDefault(b =>
+                b.Action == item.RawAction && TriggerLabeler.Describe(b) == item.Label)
+            is not { } match) return;
 
-        var current = _editor.GetRepeatableValues("keybind");
-        var updated = op(current, match);
-        _editor.SetRepeatableValues("keybind", updated);
-        _configService.Reload(); // raises ConfigChanged -> Rebuild
+        TryWriteKeybinds(current => op(current, match));
+    }
+
+    /// <summary>
+    /// Read the user's keybind lines, apply <paramref name="transform"/>, write
+    /// them back, and reload. The read/write/reload touch disk, so the whole
+    /// sequence is guarded: an IOException/UnauthorizedAccessException here would
+    /// otherwise fail-fast the process (this runs from an async-void handler).
+    /// On failure the edit is logged and dropped, leaving the file unchanged.
+    /// </summary>
+    private void TryWriteKeybinds(Func<string[], string[]> transform)
+    {
+        try
+        {
+            var current = _editor.GetRepeatableValues("keybind");
+            var updated = transform(current);
+            _editor.SetRepeatableValues("keybind", updated);
+            _configService.Reload(); // raises ConfigChanged -> Rebuild
+        }
+        catch (System.Exception ex)
+        {
+            StaticLoggers.KeybindingsPage.LogKeybindWriteFailed(ex);
+        }
     }
 
     private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
@@ -186,4 +206,13 @@ internal sealed partial class KeybindingsPage : Page
 
     private void ApplyFilter()
         => BindingsList.ItemsSource = _catalog.Filter(SearchBox.Text, ConflictsToggle.IsChecked == true);
+}
+
+internal static partial class KeybindingsPageLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SettingsUi.KeybindWriteFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to write keybind config")]
+    internal static partial void LogKeybindWriteFailed(
+        this ILogger<KeybindingsPage> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Settings/RebindDialog.xaml
+++ b/windows/Ghostty/Settings/RebindDialog.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentDialog
+    x:Class="Ghostty.Settings.RebindDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Assign shortcut"
+    PrimaryButtonText="Assign"
+    CloseButtonText="Cancel"
+    DefaultButton="Primary"
+    IsPrimaryButtonEnabled="False">
+    <StackPanel Spacing="12" MinWidth="320">
+        <TextBlock x:Name="ActionText" Style="{StaticResource BodyStrongTextBlockStyle}" />
+        <Border x:Name="CaptureBox"
+                BorderBrush="{ThemeResource TextControlBorderBrush}"
+                BorderThickness="2" CornerRadius="6" Padding="16,12"
+                IsTabStop="True">
+            <TextBlock x:Name="PreviewText" Text="Press a shortcut..."
+                       HorizontalAlignment="Center"
+                       FontFamily="Cascadia Code, Consolas, monospace" />
+        </Border>
+        <InfoBar x:Name="ConflictBar" IsOpen="False" Severity="Warning" IsClosable="False" />
+    </StackPanel>
+</ContentDialog>

--- a/windows/Ghostty/Settings/RebindDialog.xaml.cs
+++ b/windows/Ghostty/Settings/RebindDialog.xaml.cs
@@ -73,6 +73,7 @@ internal sealed partial class RebindDialog : ContentDialog
         var existing = KeybindConflicts.FindByTrigger(_current, CapturedTrigger);
         if (existing is not null && existing.Action != _action)
         {
+            ConflictBar.Title = "Already bound";
             ConflictBar.Message =
                 $"Already bound to {KeybindActionCatalog.Describe(existing.Action).Friendly}. Assign will override it.";
             ConflictBar.IsOpen = true;

--- a/windows/Ghostty/Settings/RebindDialog.xaml.cs
+++ b/windows/Ghostty/Settings/RebindDialog.xaml.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+
+namespace Ghostty.Settings;
+
+/// <summary>
+/// Captures a single keyboard chord and previews it, warning when the chord is
+/// already bound. The chosen ghostty trigger token is exposed via
+/// <see cref="CapturedTrigger"/>; the caller writes it on Primary.
+/// </summary>
+internal sealed partial class RebindDialog : ContentDialog
+{
+    private readonly IReadOnlyList<EnumeratedKeybind> _current;
+    private readonly string _action;
+
+    /// <summary>The encoded ghostty trigger token chosen, or null if none/invalid.</summary>
+    public string? CapturedTrigger { get; private set; }
+
+    public RebindDialog(
+        IReadOnlyList<EnumeratedKeybind> current,
+        string action,
+        string actionFriendly)
+    {
+        _current = current;
+        _action = action;
+        InitializeComponent();
+        ActionText.Text = $"Shortcut for: {actionFriendly}";
+
+        // Capture on the dialog's tunneling PreviewKeyDown rather than the
+        // Border's KeyDown. The ContentDialog activates its default (Assign)
+        // button from a key handler on itself; because PreviewKeyDown tunnels
+        // root->leaf, the dialog sees the key before the focused Border would,
+        // so marking it Handled here is what actually stops Enter/Space/Tab
+        // from triggering the primary button. That lets the user capture
+        // ctrl+enter, ctrl+space, etc. as real chords without closing.
+        PreviewKeyDown += OnPreviewKeyDown;
+        Loaded += (_, _) => CaptureBox.Focus(FocusState.Programmatic);
+    }
+
+    private void OnPreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        // Only intercept while the capture box owns focus; otherwise let the
+        // dialog behave normally (e.g. Esc/Enter on the buttons themselves).
+        if (CaptureBox.FocusState == FocusState.Unfocused) return;
+
+        e.Handled = true; // don't let Tab/Enter/Space leak to dialog buttons
+
+        var trigger = ChordEncoder.TryEncode(
+            (int)e.Key,
+            IsDown(VirtualKey.Control), IsDown(VirtualKey.Shift),
+            IsDown(VirtualKey.Menu),
+            IsDown(VirtualKey.LeftWindows) || IsDown(VirtualKey.RightWindows));
+
+        if (trigger is null)
+        {
+            CapturedTrigger = null;
+            IsPrimaryButtonEnabled = false;
+            PreviewText.Text = "Unsupported key - press another";
+            ConflictBar.IsOpen = false;
+            return;
+        }
+
+        var kb = new EnumeratedKeybind(new[] { trigger.Value }, _action, GhosttyBindingFlags.Consumed);
+        CapturedTrigger = KeybindTriggerSyntax.Encode(kb);
+        PreviewText.Text = TriggerLabeler.Describe(kb);
+        IsPrimaryButtonEnabled = true;
+
+        var existing = KeybindConflicts.FindByTrigger(_current, CapturedTrigger);
+        if (existing is not null && existing.Action != _action)
+        {
+            ConflictBar.Message =
+                $"Already bound to {KeybindActionCatalog.Describe(existing.Action).Friendly}. Assign will override it.";
+            ConflictBar.IsOpen = true;
+        }
+        else
+        {
+            ConflictBar.IsOpen = false;
+        }
+    }
+
+    // Reads live modifier state the same way as
+    // TerminalControl.CurrentChordModifiers (Microsoft.UI.Input source +
+    // Windows.UI.Core key states); extended here to cover the Windows key.
+    private static bool IsDown(VirtualKey key)
+        => (Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(key)
+            & Windows.UI.Core.CoreVirtualKeyStates.Down) != 0;
+}


### PR DESCRIPTION
Adds "Rebind..." to the Keybindings row context menu: a dialog that captures a single chord, previews it live ("Ctrl+Shift+J"), warns if the chord is already bound to another action, and writes the user config (binding the action to the new chord; the old trigger is left intact).

Pure Ghostty.Core (TDD): ChordEncoder maps a Windows VirtualKey + modifiers to a physical ghostty trigger (US-ANSI table; rejects unmapped / modifier-only keys so we never write an invalid line), KeyNames.OrdinalOf reverse lookup, UserKeybindEditor.Assign (override at the chord), KeybindConflicts.FindByTrigger. The dialog captures on the ContentDialog PreviewKeyDown (so Enter as a chord works without closing) and reuses the existing GetKeyStateForCurrentThread modifier-read.

Completes the capture half of the editor. Single chord only; sequence capture and layout-aware (physical-scancode) capture are deferred. No new C ABI, no Zig changes.