### PR TITLE
resize-overlay: keep the size pill auto-hiding across pane reparents

### DIFF
--- a/windows/Ghostty.Tests.Windows/ResizeOverlay/ResizeOverlaySmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/ResizeOverlay/ResizeOverlaySmokeTests.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace Ghostty.Tests.Windows.ResizeOverlay;
+
+public class ResizeOverlaySmokeTests
+{
+    // Manual smoke spec for the per-pane resize pill auto-hide.
+    //
+    // ResizeOverlayState behaviour (dedup, mode gating, SizeText) is
+    // covered exhaustively by ResizeOverlayStateTests in Ghostty.Tests
+    // (pure-logic xUnit, no host). The piece this spec guards lives in
+    // ResizeOverlayControl and cannot be automated: it needs a real
+    // DispatcherQueue (for the one-shot hide timer to tick) and a live
+    // visual tree that reparents on split -- the same MainWindow +
+    // dispatcher blocker that keeps SearchBarSmokeTests and the split
+    // button / profile chord specs un-automated.
+    //
+    // REGRESSION (fixed): ResizeOverlayControl used to drop its hide
+    // timer's Tick handler on Unloaded. WinUI 3 raises Unloaded on every
+    // reparent (each split / rebuild), not only on teardown, so after the
+    // first split every pre-existing pane's pill lost its auto-hide: the
+    // restarted timer fired into a detached delegate and the pill stayed
+    // stuck on screen. Only the newest, never-reparented pane still hid.
+    // The fix keeps the timer + Tick handler wired for the control's whole
+    // lifetime (the cycle is self-contained and GC-collected together).
+    //
+    // To validate by hand once the binary lands:
+    //
+    // 1. Open wintty (single pane). Drag the window border. A "cols x rows"
+    //    pill appears and auto-hides ~750ms after the drag settles.
+    // 2. Split into three or more panes (e.g. Ctrl+Shift+E then
+    //    Ctrl+Shift+O) so the pre-existing panes reparent at least once.
+    // 3. Drag the window border so ALL panes resize at once. Every pane's
+    //    pill appears.
+    // 4. Stop dragging and wait ~1 second WITHOUT touching the window.
+    //    EVERY pane's pill must disappear -- not just one. Before the fix,
+    //    one pill (the most recently created pane) hid and the rest stayed
+    //    stuck visible.
+    [Fact(Skip = "Manual smoke; hide timer needs a live DispatcherQueue and reparenting visual tree. Pure-logic coverage is in Ghostty.Tests.ResizeOverlay.ResizeOverlayStateTests.")]
+    public void AllPanePills_AutoHideAfterResize_IncludingReparentedPanes()
+    {
+    }
+}

--- a/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml.cs
+++ b/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml.cs
@@ -29,14 +29,23 @@ public sealed partial class ResizeOverlayControl : UserControl
         // DispatcherQueueTimer fires on the UI thread, so the Tick handler
         // can touch Visibility with no marshalling. Non-repeating: each
         // pulse restarts it, so it only fires once the resizing settles.
+        //
+        // The timer and its Tick handler live for the lifetime of the
+        // control on purpose: we do NOT unwire them on Unloaded. WinUI 3
+        // raises Unloaded whenever the visual tree reparents a pane (every
+        // split / rebuild), not only on real teardown -- the same gotcha
+        // TerminalControl.OnUnloaded documents. Dropping the handler there
+        // permanently broke auto-hide for every pre-existing pane after a
+        // split: the restarted timer would fire into a detached delegate
+        // and the pill stayed stuck on screen. Keeping the wiring is safe:
+        // control -> timer -> Tick -> control is a self-contained cycle the
+        // GC collects together, a stopped non-repeating timer is not
+        // retained by the dispatcher, and a hide still pending when a pane
+        // is truly closed simply ticks once (harmlessly setting Visibility
+        // on the dead control) and releases.
         _hideTimer = DispatcherQueue.CreateTimer();
         _hideTimer.IsRepeating = false;
         _hideTimer.Tick += OnHideTick;
-
-        // Drop the Tick handler when the control leaves the tree so a
-        // reparented or torn-down pane does not accumulate handler links
-        // on the dispatcher's timer list.
-        Unloaded += OnControlUnloaded;
     }
 
     /// <summary>
@@ -111,12 +120,5 @@ public sealed partial class ResizeOverlayControl : UserControl
             ResizeOverlayPosition.BottomRight => VerticalAlignment.Bottom,
             _ => VerticalAlignment.Center,
         };
-    }
-
-    private void OnControlUnloaded(object sender, RoutedEventArgs e)
-    {
-        _hideTimer.Stop();
-        _hideTimer.Tick -= OnHideTick;
-        Unloaded -= OnControlUnloaded;
     }
 }


### PR DESCRIPTION
## What

Fixes the resize-overlay pill (the transient `cols x rows` indicator) staying stuck on screen for every pane except the most recently created one.

The pill hides itself on a one-shot `DispatcherQueueTimer`. The control dropped that timer's `Tick` handler on `Unloaded`. WinUI raises `Unloaded` on every reparent (each split or rebuild), not only on teardown, so after the first split every pre-existing pane lost its auto-hide: the restarted timer fired into a detached delegate and the pill stayed visible. Only the newest, never-reparented pane still hid. This is the same WinUI lifecycle gotcha that `TerminalControl.OnUnloaded` already documents.

## How

Keep the timer and its `Tick` handler wired for the control's whole lifetime. The cycle is self-contained and collected with the control, a stopped non-repeating timer is not retained by the dispatcher, and a hide still pending when a pane closes simply ticks once and releases.

macOS handles this declaratively (`SurfaceResizeOverlay` computes visibility from `lastSize == geoSize` and auto-hides via `.task(id: geoSize)`), which is structurally immune to this class of bug. This change keeps the existing imperative model but makes it reparent-safe; a follow-up could move Windows to the declarative pattern.

## Test

Adds a manual smoke spec documenting the reparent regression and the hand-validation steps (the auto-hide needs a live DispatcherQueue + reparenting visual tree, the same harness blocker as the other `*SmokeTests`). `ResizeOverlayState` pure logic stays covered by `ResizeOverlayStateTests`.