### PR TITLE
resize-overlay: drive pill visibility from observable state

### DIFF
--- a/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayState.cs
+++ b/windows/Ghostty.Core/ResizeOverlay/ResizeOverlayState.cs
@@ -70,6 +70,27 @@ public sealed class ResizeOverlayState : INotifyPropertyChanged
         Separator,
         _rows);
 
+    private bool _isVisible;
+
+    /// <summary>
+    /// Whether the pill should currently be shown. Driven by
+    /// <see cref="NotifyResize"/> (set true when a resize qualifies) and
+    /// <see cref="Hide"/> (the auto-hide timer elapsing). The view binds the
+    /// pill's visibility to this property instead of toggling it imperatively,
+    /// which keeps the show/hide decision here where it can be unit-tested and
+    /// is immune to view lifecycle quirks (reparenting on split / rebuild).
+    /// </summary>
+    public bool IsVisible
+    {
+        get => _isVisible;
+        private set
+        {
+            if (_isVisible == value) return;
+            _isVisible = value;
+            Notify(nameof(IsVisible));
+        }
+    }
+
     /// <summary>
     /// Record a new grid size and decide whether the pill should appear
     /// for this change. Always updates <see cref="Columns"/> /
@@ -102,6 +123,31 @@ public sealed class ResizeOverlayState : INotifyPropertyChanged
         if (Mode == ResizeOverlayMode.Always) return true;
         return !isFirst; // AfterFirst
     }
+
+    /// <summary>
+    /// Record a resize. Always updates the tracked grid size (so
+    /// <see cref="SizeText"/> stays current), then shows the pill when the
+    /// change should pulse (per <see cref="Mode"/> and the first-layout / dedup
+    /// rules in <see cref="ShouldPulse"/>) and the view allows it. Returns true
+    /// when the pill was (re)shown so the caller can (re)start its auto-hide
+    /// timer.
+    ///
+    /// A resize that does not qualify (suppressed by <paramref name="allowShow"/>,
+    /// mode, or an unchanged grid) never hides an already-visible pill -- only
+    /// <see cref="Hide"/> does that. This matters because a drag delivers many
+    /// size events, some duplicate, and the pill must stay up until the resize
+    /// settles.
+    /// </summary>
+    public bool NotifyResize(ushort cols, ushort rows, bool allowShow)
+    {
+        var pulse = ShouldPulse(cols, rows);
+        if (!allowShow || !pulse) return false;
+        IsVisible = true;
+        return true;
+    }
+
+    /// <summary>Hide the pill. Called when the auto-hide interval elapses.</summary>
+    public void Hide() => IsVisible = false;
 
     public event PropertyChangedEventHandler? PropertyChanged
     {

--- a/windows/Ghostty.Tests/ResizeOverlay/ResizeOverlayStateTests.cs
+++ b/windows/Ghostty.Tests/ResizeOverlay/ResizeOverlayStateTests.cs
@@ -88,6 +88,121 @@ public class ResizeOverlayStateTests
         Assert.Contains(nameof(ResizeOverlayState.SizeText), raised);
     }
 
+    // --- Declarative visibility (IsVisible / NotifyResize / Hide) ----------
+
+    [Fact]
+    public void IsVisible_defaults_false()
+    {
+        Assert.False(new ResizeOverlayState().IsVisible);
+    }
+
+    [Fact]
+    public void NotifyResize_shows_and_returns_true_on_a_real_resize()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+
+        var shown = state.NotifyResize(80, 24, allowShow: true);
+
+        Assert.True(shown);
+        Assert.True(state.IsVisible);
+        Assert.Equal("80 " + (char)0x00D7 + " 24", state.SizeText);
+    }
+
+    [Fact]
+    public void NotifyResize_tracks_size_but_stays_hidden_when_not_allowed()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+
+        var shown = state.NotifyResize(100, 30, allowShow: false);
+
+        Assert.False(shown);
+        Assert.False(state.IsVisible);
+        // Size still tracked so the label is correct the next time it shows.
+        Assert.Equal(100, state.Columns);
+        Assert.Equal(30, state.Rows);
+    }
+
+    [Fact]
+    public void NotifyResize_does_not_show_when_grid_is_unchanged()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+
+        Assert.True(state.NotifyResize(80, 24, allowShow: true));
+        state.Hide();
+
+        Assert.False(state.NotifyResize(80, 24, allowShow: true));
+        Assert.False(state.IsVisible);
+    }
+
+    [Fact]
+    public void NotifyResize_never_mode_never_shows()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Never };
+
+        Assert.False(state.NotifyResize(80, 24, allowShow: true));
+        Assert.False(state.IsVisible);
+    }
+
+    [Fact]
+    public void NotifyResize_after_first_suppresses_initial_then_shows()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.AfterFirst };
+
+        Assert.False(state.NotifyResize(80, 24, allowShow: true)); // baseline
+        Assert.False(state.IsVisible);
+        Assert.True(state.NotifyResize(100, 30, allowShow: true));  // real resize
+        Assert.True(state.IsVisible);
+    }
+
+    [Fact]
+    public void Hide_clears_IsVisible()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+        state.NotifyResize(80, 24, allowShow: true);
+
+        state.Hide();
+
+        Assert.False(state.IsVisible);
+    }
+
+    [Fact]
+    public void NotifyResize_with_unchanged_grid_does_not_hide_a_visible_pill()
+    {
+        // A duplicate size event (common during a drag) must not flip the pill
+        // off; only Hide (the auto-hide timer) clears it.
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+        state.NotifyResize(80, 24, allowShow: true);
+
+        var shown = state.NotifyResize(80, 24, allowShow: true);
+
+        Assert.False(shown);          // nothing new to pulse
+        Assert.True(state.IsVisible); // but still visible until Hide
+    }
+
+    [Fact]
+    public void NotifyResize_raises_PropertyChanged_for_IsVisible()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+        var raised = Subscribe(state);
+
+        state.NotifyResize(80, 24, allowShow: true);
+
+        Assert.Contains(nameof(ResizeOverlayState.IsVisible), raised);
+    }
+
+    [Fact]
+    public void Hide_raises_PropertyChanged_for_IsVisible_only_when_changing()
+    {
+        var state = new ResizeOverlayState { Mode = ResizeOverlayMode.Always };
+        state.NotifyResize(80, 24, allowShow: true);
+        var raised = Subscribe(state);
+
+        state.Hide();
+        state.Hide(); // idempotent: no second notification
+
+        Assert.Single(raised, nameof(ResizeOverlayState.IsVisible));
+    }
+
     private static List<string?> Subscribe(ResizeOverlayState state)
     {
         var raised = new List<string?>();

--- a/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml
+++ b/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml
@@ -6,8 +6,9 @@
     SurfaceResizeOverlay.
 
     The UserControl fills the pane (Stretch) and aligns the inner Border
-    per the resolved resize-overlay-position; the parent toggles nothing,
-    the control flips its own Visibility and runs its own auto-hide timer.
+    per the resolved resize-overlay-position. The pill's Visibility is bound
+    (OneWay) to ResizeOverlayState.IsVisible; the control's only imperative
+    job is the wall-clock auto-hide timer, which flips that state off.
 
     IsHitTestVisible=False so the pill never steals pointer events from the
     SwapChainPanel underneath - a terminal app running mouse=a keeps seeing
@@ -27,6 +28,7 @@
     <Border x:Name="Pill"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
+            Visibility="{x:Bind ToVisibility(State.IsVisible), Mode=OneWay}"
             Margin="8"
             Padding="12,6"
             Background="{ThemeResource LayerFillColorDefaultBrush}"

--- a/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml.cs
+++ b/windows/Ghostty/Controls/ResizeOverlay/ResizeOverlayControl.xaml.cs
@@ -27,7 +27,7 @@ public sealed partial class ResizeOverlayControl : UserControl
         InitializeComponent();
 
         // DispatcherQueueTimer fires on the UI thread, so the Tick handler
-        // can touch Visibility with no marshalling. Non-repeating: each
+        // can update the bound state with no marshalling. Non-repeating: each
         // pulse restarts it, so it only fires once the resizing settles.
         //
         // The timer and its Tick handler live for the lifetime of the
@@ -80,15 +80,17 @@ public sealed partial class ResizeOverlayControl : UserControl
         bool allowShow)
     {
         State.Mode = mode;
-        var pulse = State.ShouldPulse(cols, rows);
-        if (!allowShow || !pulse) return;
+
+        // The state owns the show/hide decision and flips IsVisible, which the
+        // pill's Visibility is bound to. We only handle the view concerns:
+        // position and the wall-clock auto-hide timer.
+        if (!State.NotifyResize(cols, rows, allowShow)) return;
 
         ApplyPosition(position);
 
         // Clamp to a sane floor: a zero/negative duration would make the
         // timer never fire, leaving the pill stuck on screen.
         _hideTimer.Interval = TimeSpan.FromMilliseconds(Math.Max(1, durationMs));
-        Visibility = Visibility.Visible;
         _hideTimer.Stop();
         _hideTimer.Start();
     }
@@ -96,8 +98,21 @@ public sealed partial class ResizeOverlayControl : UserControl
     private void OnHideTick(DispatcherQueueTimer sender, object args)
     {
         sender.Stop();
-        Visibility = Visibility.Collapsed;
+        State.Hide();
     }
+
+    /// <summary>
+    /// x:Bind helper that maps the observable
+    /// <see cref="ResizeOverlayState.IsVisible"/> flag to a XAML
+    /// <see cref="Visibility"/>. The conversion lives here, in the view layer,
+    /// so the Core state stays free of any WinUI types.
+    ///
+    /// Instance, not static: x:Bind function codegen emits
+    /// <c>this.ToVisibility(...)</c>, so a static method fails to compile
+    /// (CS0176). Do not "tidy" it to static.
+    /// </summary>
+    private Visibility ToVisibility(bool visible) =>
+        visible ? Visibility.Visible : Visibility.Collapsed;
 
     private void ApplyPosition(ResizeOverlayPosition position)
     {

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -153,12 +153,13 @@
 
         <!--
             Transient cols x rows pill shown while the pane is resized.
-            Fills the cell and self-positions per resize-overlay-position;
-            starts Collapsed and flips its own Visibility. Last child so it
-            layers above the SwapChainPanel and the other overlays.
+            Fills the cell and self-positions per resize-overlay-position.
+            The control stays visible (hit-test-false); its inner pill binds
+            its own Visibility to ResizeOverlayState.IsVisible and starts
+            hidden. Last child so it layers above the SwapChainPanel and the
+            other overlays.
         -->
         <resize:ResizeOverlayControl
-            x:Name="ResizeOverlay"
-            Visibility="Collapsed" />
+            x:Name="ResizeOverlay" />
     </Grid>
 </UserControl>


### PR DESCRIPTION
Closes #464.

## What

Refactors the resize pill from imperative code-behind visibility to a declarative, state-driven model, mirroring macOS `SurfaceResizeOverlay` (which computes visibility from state rather than toggling it). This is the follow-up tracked in #464 after #463 made the imperative model reparent-safe.

## How

- `ResizeOverlayState` (Ghostty.Core, pure logic) gains an observable `IsVisible` flag plus `NotifyResize(cols, rows, allowShow)` and `Hide()`. `NotifyResize` tracks the size and sets `IsVisible` when the change qualifies (mode + first-layout + dedup, via the existing `ShouldPulse`) and the view allows it. A non-qualifying or duplicate event never hides a visible pill (a drag delivers many duplicate sizes); only `Hide` (the auto-hide timer) clears it.
- The pill's `Visibility` now binds OneWay to `State.IsVisible` through an `x:Bind` function (`ToVisibility`), so the conversion lives in the view layer and Core stays free of WinUI types. The control no longer writes `Visibility` directly.
- The wall-clock guards (startup grace, focus bounce) stay in the view as `allowShow`, matching the existing Core/view split and macOS's own `ready`/`focusInstant` placement.

## Why it's more robust

The visibility decision is now a property of state, so a re-show follows automatically from a state change rather than a remembered imperative toggle. It's also unit-testable in Core with no live `DispatcherQueue`.

## Acceptance (from #464)

- [x] pill visibility is driven by bound state, not direct `Visibility =` writes in code-behind
- [x] existing behavior preserved: startup grace, focus-guard, never/always/after_first modes, per-pane independence, auto-hide after duration
- [x] reparent (split/rebuild) cannot leave any pane's pill stuck visible (the timer survives reparent per #463, and visibility is bound state)

## Test

Adds 10 `ResizeOverlayState` tests (show / suppress-when-not-allowed / dedup / never / after-first / hide / duplicate-while-visible / PropertyChanged). 18/18 pass. WinUI app builds clean (AOT-safe `x:Bind` function). The manual smoke spec from #463 still applies.