### PR TITLE
config: suppress unknown-field diagnostic for agent-detect.* keys

### DIFF
--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -148,4 +148,27 @@ public static class WindowsOnlyKeys
         return key.Length > Prefix.Length
             && key.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Returns true when <paramref name="key"/> is an agent-detector key
+    /// of the shape <c>agent-detect.&lt;name&gt;</c>. These are a
+    /// Windows-fork-only feature (custom tab-icon process detectors) read
+    /// entirely on the C# side from the raw config file; libghostty has no
+    /// such field and flags each line as an "unknown field". Suppressing
+    /// them here keeps that diagnostic out of the settings UI notice list.
+    /// Like <see cref="IsInternalKey"/> and <see cref="IsProfileSubkey"/>,
+    /// these are absorbed silently rather than surfaced via
+    /// <c>WindowsOnlyKeysUsed</c>, since the keys are per-detector
+    /// repeatable and would otherwise flood the list one entry per row.
+    /// </summary>
+    public static bool IsAgentDetectKey(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        const string Prefix = "agent-detect.";
+        // Need the full prefix plus at least one character of <name>;
+        // bare "agent-detect." or "agent-detect" alone shouldn't match.
+        return key.Length > Prefix.Length
+            && key.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -153,13 +153,12 @@ public static class WindowsOnlyKeys
     /// Returns true when <paramref name="key"/> is an agent-detector key
     /// of the shape <c>agent-detect.&lt;name&gt;</c>. These are a
     /// Windows-fork-only feature (custom tab-icon process detectors) read
-    /// entirely on the C# side from the raw config file; libghostty has no
-    /// such field and flags each line as an "unknown field". Suppressing
-    /// them here keeps that diagnostic out of the settings UI notice list.
-    /// Like <see cref="IsInternalKey"/> and <see cref="IsProfileSubkey"/>,
-    /// these are absorbed silently rather than surfaced via
-    /// <c>WindowsOnlyKeysUsed</c>, since the keys are per-detector
-    /// repeatable and would otherwise flood the list one entry per row.
+    /// directly from the raw config file by the Pro tab-icon layer and are
+    /// not surfaced as Windows-only public config; suppressing them here
+    /// keeps libghostty's "unknown field" diagnostic out of the settings
+    /// UI notice list, exactly like <see cref="IsInternalKey"/>. The
+    /// matcher mirrors that reader's prefix test, so a name that itself
+    /// contains dots (<c>agent-detect.my.bot</c>) still matches.
     /// </summary>
     public static bool IsAgentDetectKey(string key)
     {

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -141,6 +141,7 @@ public class WindowsOnlyKeysTests
     [InlineData("agent-detect.mybot", true)]
     [InlineData("agent-detect.claude", true)]
     [InlineData("agent-detect.a", true)]                // minimal valid (single char name)
+    [InlineData("agent-detect.my.bot", true)]           // dotted name: reader takes key[prefix..] verbatim
     [InlineData("AGENT-DETECT.MYBOT", true)]            // case-insensitive prefix
     [InlineData("agent-detect.", false)]                // bare prefix, no name
     [InlineData("agent-detect", false)]                 // exact scalar

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -136,4 +136,37 @@ public class WindowsOnlyKeysTests
     {
         Assert.Equal(expected, Ghostty.Core.Config.WindowsOnlyKeys.IsInternalKey(key));
     }
+
+    [Theory]
+    [InlineData("agent-detect.mybot", true)]
+    [InlineData("agent-detect.claude", true)]
+    [InlineData("agent-detect.a", true)]                // minimal valid (single char name)
+    [InlineData("AGENT-DETECT.MYBOT", true)]            // case-insensitive prefix
+    [InlineData("agent-detect.", false)]                // bare prefix, no name
+    [InlineData("agent-detect", false)]                 // exact scalar
+    [InlineData("agent-detectish", false)]              // prefix-without-dot, different key
+    [InlineData("profile.x.agent-detect", false)]       // different namespace
+    [InlineData("background-style", false)]             // unrelated public key
+    public void IsAgentDetectKey_Expected(string key, bool expected)
+    {
+        Assert.Equal(expected, Ghostty.Core.Config.WindowsOnlyKeys.IsAgentDetectKey(key));
+    }
+
+    [Fact]
+    public void AgentDetectDiagnostic_ExtractsKey_AndClassifiesForSilentSuppression()
+    {
+        // A saved agent detector (agent-detect.mybot = process=mybot) is an
+        // unknown field to libghostty's parser, which emits this diagnostic.
+        // The filter must recognize the extracted key as an agent-detect key
+        // so ConfigService can suppress it -- and it must NOT be a first-class
+        // Windows-only key (those surface via WindowsOnlyKeysUsed; agent
+        // detectors are per-row repeatable and stay silent like internal.*).
+        const string message =
+            "C:\\Users\\alex\\AppData\\Roaming\\com.mitchellh.ghostty\\config:5:agent-detect.mybot: unknown field";
+
+        Assert.True(WindowsOnlyKeys.TryExtractUnknownFieldKey(message, out var key));
+        Assert.Equal("agent-detect.mybot", key);
+        Assert.True(WindowsOnlyKeys.IsAgentDetectKey(key));
+        Assert.False(WindowsOnlyKeys.Contains(key));
+    }
 }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -452,10 +452,10 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
                 {
                     // agent-detect.<name> keys are custom tab-icon
                     // process detectors read directly from the raw
-                    // config file (Pro TabIconsConfig); they're
-                    // per-detector repeatable, so we suppress silently
-                    // rather than flood WindowsOnlyKeysUsed one entry
-                    // per detector.
+                    // config file (Pro TabIconsConfig); like internal.*
+                    // they aren't public Windows-only config, so we
+                    // suppress the diagnostic silently rather than
+                    // surface it.
                     continue;
                 }
                 if (WindowsOnlyKeys.Contains(key))

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -448,6 +448,16 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
                     // them via WindowsOnlyKeysUsed either.
                     continue;
                 }
+                if (WindowsOnlyKeys.IsAgentDetectKey(key))
+                {
+                    // agent-detect.<name> keys are custom tab-icon
+                    // process detectors read directly from the raw
+                    // config file (Pro TabIconsConfig); they're
+                    // per-detector repeatable, so we suppress silently
+                    // rather than flood WindowsOnlyKeysUsed one entry
+                    // per detector.
+                    continue;
+                }
                 if (WindowsOnlyKeys.Contains(key))
                 {
                     if (_windowsOnlyKeysSeen.Add(key))


### PR DESCRIPTION
## What

`agent-detect.<name>` config keys are a Windows-fork-only feature: they define custom tab-icon process detectors and are read entirely on the C# side (Pro `TabIconsConfig.Read()` enumerates the config-file cache). The native config parser has no `agent-detect` field, so it flags every `agent-detect.<name>` line as an "unknown field", and each saved detector surfaced a spurious error in the settings UI notice list.

This adds `WindowsOnlyKeys.IsAgentDetectKey(key)` (shape `agent-detect.<name>`, non-empty name) and wires it into `ConfigService.CacheDiagnostics()` alongside the existing `internal.*` and `profile.*` subkey suppressors. The detector diagnostics are suppressed silently rather than surfaced via `WindowsOnlyKeysUsed`, because the keys are per-detector repeatable and would otherwise flood the notice list one entry per detector — same reasoning as `internal.*` / `profile.*`.

This mirrors the existing `internal.*` suppression (#350) line for line.

## Why

A config with `agent-detect.mybot = process=mybot` previously produced a misleading "unknown field" warning even though the key works as designed. After this change it produces no diagnostic.

## Tests

- `IsAgentDetectKey_Expected` theory covering the same boundary rows as `IsInternalKey_Expected` (bare prefix, scalar, no-dot, wrong namespace, case-insensitivity).
- A chain test asserting a realistic `…:agent-detect.mybot: unknown field` diagnostic extracts to `agent-detect.mybot`, classifies as an agent-detect key, and is not in the first-class Windows-only set (so it is suppressed).
- Full `Ghostty.Tests` suite: 1322 passed, 1 skipped, 0 failed.