### PR TITLE
feat(keybinds): visual keyboard map (inline editor)

### DIFF
--- a/windows/Ghostty.Core/Input/KeybindActionCatalog.cs
+++ b/windows/Ghostty.Core/Input/KeybindActionCatalog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Ghostty.Core.Input;
 
@@ -81,5 +82,31 @@ public static class KeybindActionCatalog
         }
 
         return new ActionDescription(hit.Category, friendly);
+    }
+
+    /// <summary>An action the user can assign from the keyboard map / picker.</summary>
+    public readonly record struct AssignableAction(string RawAction, string Category, string Friendly);
+
+    /// <summary>
+    /// Distinct assignable actions taken from the finalized bind set, described
+    /// and ordered (category, then friendly name). Using the enumerated actions
+    /// keeps every offered action a valid libghostty string with no new ABI.
+    /// </summary>
+    public static IReadOnlyList<AssignableAction> AllActions(IReadOnlyList<EnumeratedKeybind> binds)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var list = new List<AssignableAction>();
+        foreach (var kb in binds)
+        {
+            if (string.IsNullOrEmpty(kb.Action) || !seen.Add(kb.Action)) continue;
+            var d = Describe(kb.Action);
+            list.Add(new AssignableAction(kb.Action, d.Category, d.Friendly));
+        }
+
+        return list
+            .OrderBy(a => a.Category == "Other" ? 1 : 0)
+            .ThenBy(a => a.Category, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(a => a.Friendly, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 }

--- a/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
+++ b/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
@@ -45,6 +45,17 @@ public static class KeybindTriggerSyntax
     public static string Encode(EnumeratedKeybind kb)
         => string.Join(">", kb.Steps.Select(EncodeStep));
 
+    /// <summary>
+    /// Build a single-step trigger token from a canonical modifier mask and a
+    /// physical key ordinal (e.g. mask ctrl+shift, ordinal of key_t -> "ctrl+shift+key_t").
+    /// Reuses Encode so emission order/spelling stay identical to enumerated binds.
+    /// </summary>
+    public static string EncodePhysical(uint mods, int keyOrdinal)
+        => Encode(new EnumeratedKeybind(
+            new[] { new KeybindTrigger(TagPhysical, (uint)keyOrdinal, mods) },
+            string.Empty,
+            default));
+
     private static string EncodeStep(KeybindTrigger step)
     {
         var sb = new StringBuilder();

--- a/windows/Ghostty.Core/Input/KeyboardLayout.cs
+++ b/windows/Ghostty.Core/Input/KeyboardLayout.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// One key on the visual keyboard. <see cref="KeyName"/> is the input.Key enum
+/// name (empty for a spacer). <see cref="Ordinal"/> is its KeyNames ordinal (-1
+/// for non-bindable caps/spacers). <see cref="Units"/> is the key width in
+/// standard key units (1.0 = a letter key). Non-bindable cells (modifier caps,
+/// Fn, spacers) render but never light up — modifiers are chosen via the chips.
+/// </summary>
+public readonly record struct KeyCell(string KeyName, int Ordinal, string Label, double Units, bool Bindable);
+
+/// <summary>
+/// Static ANSI-104 physical layout in three blocks (main, nav cluster, numpad),
+/// each a list of rows. The visual map renders these; KeyboardMapModel decides
+/// which bindable cells light up for a chosen modifier combo. KeyboardLayoutTests
+/// pins ordinal validity and completeness.
+/// </summary>
+public static class KeyboardLayout
+{
+    private static KeyCell K(string name, double units = 1.0)
+        => new(name, KeyNames.OrdinalOf(name) ?? -1, LabelFor(name), units, Bindable: true);
+
+    private static KeyCell Cap(string name, string label, double units = 1.0)
+        => new(name, -1, label, units, Bindable: false);
+
+    private static KeyCell Gap(double units = 0.5) => new("", -1, "", units, Bindable: false);
+
+    private static string LabelFor(string name) => TriggerLabeler.LabelForName(name);
+
+    public static IReadOnlyList<IReadOnlyList<KeyCell>> Main { get; } = new[]
+    {
+        new[]
+        {
+            K("escape"), Gap(),
+            K("f1"), K("f2"), K("f3"), K("f4"), Gap(),
+            K("f5"), K("f6"), K("f7"), K("f8"), Gap(),
+            K("f9"), K("f10"), K("f11"), K("f12"),
+        },
+        new[]
+        {
+            K("backquote"), K("digit_1"), K("digit_2"), K("digit_3"), K("digit_4"), K("digit_5"),
+            K("digit_6"), K("digit_7"), K("digit_8"), K("digit_9"), K("digit_0"),
+            K("minus"), K("equal"), K("backspace", 2.0),
+        },
+        new[]
+        {
+            K("tab", 1.5), K("key_q"), K("key_w"), K("key_e"), K("key_r"), K("key_t"), K("key_y"),
+            K("key_u"), K("key_i"), K("key_o"), K("key_p"),
+            K("bracket_left"), K("bracket_right"), K("backslash", 1.5),
+        },
+        new[]
+        {
+            Cap("caps_lock", "Caps", 1.75), K("key_a"), K("key_s"), K("key_d"), K("key_f"), K("key_g"),
+            K("key_h"), K("key_j"), K("key_k"), K("key_l"), K("semicolon"), K("quote"),
+            K("enter", 2.25),
+        },
+        new[]
+        {
+            Cap("shift_left", "Shift", 2.25), K("key_z"), K("key_x"), K("key_c"), K("key_v"), K("key_b"),
+            K("key_n"), K("key_m"), K("comma"), K("period"), K("slash"),
+            Cap("shift_right", "Shift", 2.75),
+        },
+        new[]
+        {
+            Cap("control_left", "Ctrl", 1.25), Cap("meta_left", "Win", 1.25), Cap("alt_left", "Alt", 1.25),
+            K("space", 6.25),
+            Cap("alt_right", "Alt", 1.25), Cap("meta_right", "Win", 1.25),
+            K("context_menu", 1.25), Cap("control_right", "Ctrl", 1.25),
+        },
+    };
+
+    public static IReadOnlyList<IReadOnlyList<KeyCell>> Nav { get; } = new[]
+    {
+        new[] { K("insert"), K("home"), K("page_up") },
+        new[] { K("delete"), K("end"), K("page_down") },
+        new[] { Gap(), Gap(), Gap() },
+        new[] { Gap(), K("arrow_up"), Gap() },
+        new[] { K("arrow_left"), K("arrow_down"), K("arrow_right") },
+    };
+
+    public static IReadOnlyList<IReadOnlyList<KeyCell>> Numpad { get; } = new[]
+    {
+        new[] { Cap("num_lock", "Num", 1.0), K("numpad_divide"), K("numpad_multiply"), K("numpad_subtract") },
+        new[] { K("numpad_7"), K("numpad_8"), K("numpad_9"), K("numpad_add") },
+        new[] { K("numpad_4"), K("numpad_5"), K("numpad_6") },
+        new[] { K("numpad_1"), K("numpad_2"), K("numpad_3"), K("numpad_enter") },
+        new[] { K("numpad_0", 2.0), K("numpad_decimal") },
+    };
+}

--- a/windows/Ghostty.Core/Input/KeyboardMapModel.cs
+++ b/windows/Ghostty.Core/Input/KeyboardMapModel.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>State of one bound key on the current modifier layer.</summary>
+public sealed record KeyboardKeyState(
+    string KeyName,
+    bool IsBound,
+    string ActionLabel,
+    string RawAction,
+    KeybindSource Source,
+    KeybindConflict Conflict,
+    bool IsMultiStep,
+    EnumeratedKeybind Bind);
+
+/// <summary>
+/// Projects the finalized keybind set onto a single modifier layer: which
+/// physical keys are bound when exactly the given modifier combo is held, with
+/// the action label, source, conflict, and multi-step flag for each. Pure; the
+/// WinUI view renders the result and the page edits via the source Bind.
+/// </summary>
+public sealed class KeyboardMapModel
+{
+    private const uint Shift = 1u << 0, Ctrl = 1u << 1, Alt = 1u << 2, Super = 1u << 3;
+    private const uint ShiftR = 1u << 6, CtrlR = 1u << 7, AltR = 1u << 8, SuperR = 1u << 9;
+    private const int TagPhysical = 0;
+
+    public uint ModifierMask { get; }
+    private readonly Dictionary<string, KeyboardKeyState> _byKey;
+
+    private KeyboardMapModel(uint mask, Dictionary<string, KeyboardKeyState> byKey)
+    {
+        ModifierMask = mask;
+        _byKey = byKey;
+    }
+
+    /// <summary>State for a physical key on this layer, or null if unbound.</summary>
+    public KeyboardKeyState? ForKey(string keyName)
+        => _byKey.TryGetValue(keyName, out var s) ? s : null;
+
+    public static KeyboardMapModel Build(
+        IReadOnlyList<EnumeratedKeybind> binds,
+        IReadOnlyList<EnumeratedKeybind>? defaults,
+        uint modifierMask)
+    {
+        var defaultKeys = defaults is null ? null : KeybindSourceClassifier.BuildDefaultKeys(defaults);
+        var byKey = new Dictionary<string, KeyboardKeyState>();
+
+        foreach (var kb in binds)
+        {
+            if (kb.Steps.Count == 0) continue;
+            var first = kb.Steps[0];
+            if (first.Tag != TagPhysical) continue;
+            if (Canonical(first.Mods) != modifierMask) continue;
+            var name = KeyNames.NameOf((int)first.Key);
+            if (name is null) continue;
+
+            var source = defaultKeys is null
+                ? KeybindSource.Default
+                : KeybindSourceClassifier.Classify(kb, defaultKeys);
+
+            byKey[name] = new KeyboardKeyState(
+                name,
+                IsBound: true,
+                ActionLabel: KeybindActionCatalog.Describe(kb.Action).Friendly,
+                RawAction: kb.Action,
+                Source: source,
+                Conflict: KeybindConflictAnalyzer.Analyze(kb),
+                IsMultiStep: kb.Steps.Count > 1,
+                Bind: kb);
+        }
+
+        return new KeyboardMapModel(modifierMask, byKey);
+    }
+
+    private static uint Canonical(uint mods)
+    {
+        uint m = 0;
+        if ((mods & (Shift | ShiftR)) != 0) m |= Shift;
+        if ((mods & (Ctrl | CtrlR)) != 0) m |= Ctrl;
+        if ((mods & (Alt | AltR)) != 0) m |= Alt;
+        if ((mods & (Super | SuperR)) != 0) m |= Super;
+        return m;
+    }
+}

--- a/windows/Ghostty.Core/Input/KeyboardMapModel.cs
+++ b/windows/Ghostty.Core/Input/KeyboardMapModel.cs
@@ -75,6 +75,7 @@ public sealed class KeyboardMapModel
 
     private static uint Canonical(uint mods)
     {
+        // caps_lock(bit 4) / num_lock(bit 5) intentionally dropped — not modifier-layer bits.
         uint m = 0;
         if ((mods & (Shift | ShiftR)) != 0) m |= Shift;
         if ((mods & (Ctrl | CtrlR)) != 0) m |= Ctrl;

--- a/windows/Ghostty.Core/Input/TriggerLabeler.cs
+++ b/windows/Ghostty.Core/Input/TriggerLabeler.cs
@@ -74,7 +74,7 @@ public static class TriggerLabeler
         }
     }
 
-    private static string LabelForName(string name)
+    public static string LabelForName(string name)
     {
         if (Special.TryGetValue(name, out var s)) return s;
         if (name.StartsWith("key_", StringComparison.Ordinal)) return name[4..].ToUpperInvariant();

--- a/windows/Ghostty.Tests/Input/KeybindActionCatalogTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindActionCatalogTests.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
 using Xunit;
 
 namespace Ghostty.Tests.Input;
@@ -26,4 +28,25 @@ public class KeybindActionCatalogTests
         Assert.Equal("Other", entry.Category);
         Assert.Equal("some_future_action:99", entry.Friendly);
     }
+
+    [Fact]
+    public void AllActions_DedupesAndDescribes()
+    {
+        var binds = new[]
+        {
+            MakeBind("new_tab"),
+            MakeBind("new_tab"),          // dup
+            MakeBind("new_split:right"),
+            MakeBind("copy_to_clipboard"),
+        };
+        var actions = KeybindActionCatalog.AllActions(binds);
+
+        Assert.Equal(3, actions.Count);
+        Assert.Contains(actions, a => a.RawAction == "new_tab" && a.Friendly == "New Tab" && a.Category == "Tabs");
+        Assert.Contains(actions, a => a.RawAction == "new_split:right" && a.Friendly == "Split Right");
+    }
+
+    private static EnumeratedKeybind MakeBind(string action) =>
+        new(new[] { new KeybindTrigger(0, (uint)KeyNames.OrdinalOf("key_a")!.Value, 1u << 1) },
+            action, GhosttyBindingFlags.Consumed);
 }

--- a/windows/Ghostty.Tests/Input/KeybindTriggerSyntaxTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindTriggerSyntaxTests.cs
@@ -56,4 +56,19 @@ public class KeybindTriggerSyntaxTests
             KeybindTriggerSyntax.Canonicalize("performable:ctrl+key_a"));
         Assert.Equal("ctrl+key_a", KeybindTriggerSyntax.Canonicalize("performable:ctrl+key_a"));
     }
+
+    [Fact]
+    public void EncodePhysical_BuildsTriggerTokenFromMaskAndOrdinal()
+    {
+        uint mask = (1u << 1) | (1u << 0); // ctrl + shift
+        var ord = KeyNames.OrdinalOf("key_t")!.Value;
+        Assert.Equal("ctrl+shift+key_t", KeybindTriggerSyntax.EncodePhysical(mask, ord));
+    }
+
+    [Fact]
+    public void EncodePhysical_NoMods_IsBareKey()
+    {
+        var ord = KeyNames.OrdinalOf("f11")!.Value;
+        Assert.Equal("f11", KeybindTriggerSyntax.EncodePhysical(0, ord));
+    }
 }

--- a/windows/Ghostty.Tests/Input/KeyboardLayoutTests.cs
+++ b/windows/Ghostty.Tests/Input/KeyboardLayoutTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeyboardLayoutTests
+{
+    private static IEnumerable<KeyCell> AllCells() =>
+        KeyboardLayout.Main.SelectMany(r => r)
+            .Concat(KeyboardLayout.Nav.SelectMany(r => r))
+            .Concat(KeyboardLayout.Numpad.SelectMany(r => r));
+
+    [Fact]
+    public void EveryBindableCellMapsToAValidOrdinal()
+    {
+        foreach (var cell in AllCells().Where(c => c.Bindable))
+        {
+            Assert.False(string.IsNullOrEmpty(cell.KeyName));
+            Assert.Equal(KeyNames.OrdinalOf(cell.KeyName), cell.Ordinal);
+            Assert.NotNull(KeyNames.NameOf(cell.Ordinal));
+        }
+    }
+
+    [Fact]
+    public void NoDuplicateBindableKeys()
+    {
+        var names = AllCells().Where(c => c.Bindable).Select(c => c.KeyName).ToList();
+        Assert.Equal(names.Count, names.Distinct().Count());
+    }
+
+    [Fact]
+    public void ModifierCapsAreNonBindable()
+    {
+        var mods = new[] { "control_left", "control_right", "shift_left", "shift_right",
+                           "alt_left", "alt_right", "meta_left", "meta_right" };
+        foreach (var cell in AllCells().Where(c => mods.Contains(c.KeyName)))
+            Assert.False(cell.Bindable);
+    }
+
+    [Fact]
+    public void IncludesCommonBindableKeys()
+    {
+        var bindable = AllCells().Where(c => c.Bindable).Select(c => c.KeyName).ToHashSet();
+        foreach (var n in new[] { "key_t", "key_a", "f1", "f12", "escape", "enter",
+                                  "arrow_up", "digit_1", "numpad_0", "bracket_left" })
+            Assert.Contains(n, bindable);
+    }
+}

--- a/windows/Ghostty.Tests/Input/KeyboardMapModelTests.cs
+++ b/windows/Ghostty.Tests/Input/KeyboardMapModelTests.cs
@@ -78,4 +78,20 @@ public class KeyboardMapModelTests
         var model = KeyboardMapModel.Build(new[] { uni }, null, Ctrl);
         Assert.Null(model.ForKey("key_a"));
     }
+
+    [Fact]
+    public void BareKeyLayer_LightsUnmodifiedKeysOnly()
+    {
+        var binds = new[]
+        {
+            Bind("f11", 0, "toggle_fullscreen"),   // bare key -> layer 0
+            Bind("key_t", Ctrl, "new_tab"),        // modified -> must NOT leak onto layer 0
+        };
+        var model = KeyboardMapModel.Build(binds, defaults: null, modifierMask: 0);
+
+        var f11 = model.ForKey("f11");
+        Assert.NotNull(f11);
+        Assert.Equal("toggle_fullscreen", f11!.RawAction);
+        Assert.Null(model.ForKey("key_t"));        // modified bind absent from bare layer
+    }
 }

--- a/windows/Ghostty.Tests/Input/KeyboardMapModelTests.cs
+++ b/windows/Ghostty.Tests/Input/KeyboardMapModelTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeyboardMapModelTests
+{
+    private const uint Shift = 1u << 0, Ctrl = 1u << 1;
+
+    private static EnumeratedKeybind Bind(string keyName, uint mods, string action, int extraSteps = 0)
+    {
+        var steps = new List<KeybindTrigger>
+        {
+            new(0, (uint)KeyNames.OrdinalOf(keyName)!.Value, mods),
+        };
+        for (var i = 0; i < extraSteps; i++)
+            steps.Add(new KeybindTrigger(0, (uint)KeyNames.OrdinalOf("key_s")!.Value, 0));
+        return new EnumeratedKeybind(steps, action, GhosttyBindingFlags.Consumed);
+    }
+
+    [Fact]
+    public void LightsKeysOnSelectedLayerOnly()
+    {
+        var binds = new[]
+        {
+            Bind("key_t", Ctrl | Shift, "new_split:right"),
+            Bind("key_n", Ctrl, "new_tab"),
+        };
+        var model = KeyboardMapModel.Build(binds, defaults: null, modifierMask: Ctrl | Shift);
+
+        var t = model.ForKey("key_t");
+        Assert.NotNull(t);
+        Assert.True(t!.IsBound);
+        Assert.Equal("new_split:right", t.RawAction);
+        Assert.Equal("Split Right", t.ActionLabel);
+        Assert.Null(model.ForKey("key_n"));
+    }
+
+    [Fact]
+    public void CollapsesRightSideModifiers()
+    {
+        var binds = new[] { Bind("key_t", (1u << 7) | (1u << 6), "new_tab") };
+        var model = KeyboardMapModel.Build(binds, null, Ctrl | Shift);
+        Assert.NotNull(model.ForKey("key_t"));
+    }
+
+    [Fact]
+    public void MultiStepBindFlaggedAndKeyedToFirstStep()
+    {
+        var binds = new[] { Bind("key_k", Ctrl, "new_split:right", extraSteps: 1) };
+        var model = KeyboardMapModel.Build(binds, null, Ctrl);
+        var k = model.ForKey("key_k");
+        Assert.NotNull(k);
+        Assert.True(k!.IsMultiStep);
+    }
+
+    [Fact]
+    public void ClassifiesUserVsDefault()
+    {
+        var defaults = new[] { Bind("key_t", Ctrl, "new_tab") };
+        var binds = new[]
+        {
+            Bind("key_t", Ctrl, "new_tab"),
+            Bind("key_y", Ctrl, "new_window"),
+        };
+        var model = KeyboardMapModel.Build(binds, defaults, Ctrl);
+        Assert.Equal(KeybindSource.Default, model.ForKey("key_t")!.Source);
+        Assert.Equal(KeybindSource.User, model.ForKey("key_y")!.Source);
+    }
+
+    [Fact]
+    public void SkipsNonPhysicalSteps()
+    {
+        var uni = new EnumeratedKeybind(new[] { new KeybindTrigger(1, (uint)'a', Ctrl) },
+                                        "new_tab", GhosttyBindingFlags.Consumed);
+        var model = KeyboardMapModel.Build(new[] { uni }, null, Ctrl);
+        Assert.Null(model.ForKey("key_a"));
+    }
+}

--- a/windows/Ghostty/Settings/AssignActionDialog.xaml
+++ b/windows/Ghostty/Settings/AssignActionDialog.xaml
@@ -1,0 +1,26 @@
+<ContentDialog
+    x:Class="Ghostty.Settings.AssignActionDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Assign action"
+    PrimaryButtonText="Assign"
+    CloseButtonText="Cancel"
+    IsPrimaryButtonEnabled="False"
+    DefaultButton="Primary">
+    <Grid RowDefinitions="Auto,*" Width="360" Height="420">
+        <AutoSuggestBox x:Name="FilterBox" PlaceholderText="Search actions..."
+                        QueryIcon="Find" TextChanged="FilterBox_TextChanged" Margin="0,0,0,8" />
+        <ListView x:Name="ActionList" Grid.Row="1" SelectionMode="Single"
+                  SelectionChanged="ActionList_SelectionChanged">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Padding="4,6">
+                        <TextBlock x:Name="FriendlyText" />
+                        <TextBlock x:Name="CategoryText" FontSize="11"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </Grid>
+</ContentDialog>

--- a/windows/Ghostty/Settings/AssignActionDialog.xaml.cs
+++ b/windows/Ghostty/Settings/AssignActionDialog.xaml.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Input;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Settings;
+
+internal sealed partial class AssignActionDialog : ContentDialog
+{
+    private readonly IReadOnlyList<KeybindActionCatalog.AssignableAction> _all;
+
+    /// <summary>Chosen raw action string, or null if cancelled.</summary>
+    public string? SelectedAction { get; private set; }
+
+    public AssignActionDialog(IReadOnlyList<EnumeratedKeybind> binds, string? preselectRawAction = null)
+    {
+        _all = KeybindActionCatalog.AllActions(binds);
+        InitializeComponent();
+        ActionList.ContainerContentChanging += OnContainerContentChanging;
+        Apply(null);
+
+        if (preselectRawAction is not null)
+        {
+            var match = _all.FirstOrDefault(a => a.RawAction == preselectRawAction);
+            if (match.RawAction is not null)
+            {
+                ActionList.SelectedItem = match;
+                ActionList.ScrollIntoView(match);
+            }
+        }
+    }
+
+    private void Apply(string? query)
+    {
+        var items = string.IsNullOrWhiteSpace(query)
+            ? _all
+            : _all.Where(a => a.Friendly.Contains(query, StringComparison.OrdinalIgnoreCase)
+                           || a.RawAction.Contains(query, StringComparison.OrdinalIgnoreCase)
+                           || a.Category.Contains(query, StringComparison.OrdinalIgnoreCase)).ToList();
+        ActionList.ItemsSource = items;
+    }
+
+    private void OnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.InRecycleQueue) return;
+        if (args.Item is KeybindActionCatalog.AssignableAction a
+            && args.ItemContainer.ContentTemplateRoot is StackPanel panel)
+        {
+            if (panel.FindName("FriendlyText") is TextBlock f) f.Text = a.Friendly;
+            if (panel.FindName("CategoryText") is TextBlock c) c.Text = a.Category;
+        }
+    }
+
+    private void FilterBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+        Apply(FilterBox.Text);
+    }
+
+    private void ActionList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        SelectedAction = ActionList.SelectedItem is KeybindActionCatalog.AssignableAction a ? a.RawAction : null;
+        IsPrimaryButtonEnabled = SelectedAction is not null;
+    }
+}

--- a/windows/Ghostty/Settings/KeyboardMapView.xaml
+++ b/windows/Ghostty/Settings/KeyboardMapView.xaml
@@ -1,0 +1,24 @@
+<UserControl
+    x:Class="Ghostty.Settings.KeyboardMapView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Spacing="12">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+            <ToggleButton x:Name="CtrlChip" Content="Ctrl" Click="Chip_Click" />
+            <ToggleButton x:Name="ShiftChip" Content="Shift" Click="Chip_Click" />
+            <ToggleButton x:Name="AltChip" Content="Alt" Click="Chip_Click" />
+            <ToggleButton x:Name="WinChip" Content="Win" Click="Chip_Click" />
+            <TextBlock x:Name="HintText" VerticalAlignment="Center" Margin="12,0,0,0"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       Text="Pick a modifier combo, then click a key to assign or edit." />
+        </StackPanel>
+        <ScrollViewer HorizontalScrollMode="Auto" HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollMode="Disabled">
+            <StackPanel Orientation="Horizontal" Spacing="20" VerticalAlignment="Top">
+                <StackPanel x:Name="MainBlock" Spacing="4" />
+                <StackPanel x:Name="NavBlock" Spacing="4" />
+                <StackPanel x:Name="NumpadBlock" Spacing="4" />
+            </StackPanel>
+        </ScrollViewer>
+    </StackPanel>
+</UserControl>

--- a/windows/Ghostty/Settings/KeyboardMapView.xaml.cs
+++ b/windows/Ghostty/Settings/KeyboardMapView.xaml.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Ghostty.Settings;
+
+/// <summary>Args for a click on a physical key cell of the keyboard map.</summary>
+internal sealed class KeyboardKeyClickedEventArgs : EventArgs
+{
+    public required KeyCell Cell { get; init; }
+    public required KeyboardKeyState? State { get; init; }
+    public required FrameworkElement Anchor { get; init; }
+}
+
+internal sealed partial class KeyboardMapView : UserControl
+{
+    private const double UnitWidth = 34;
+    private const double KeyHeight = 34;
+    private const uint Shift = 1u << 0, Ctrl = 1u << 1, Alt = 1u << 2, Super = 1u << 3;
+
+    private KeyboardMapModel? _model;
+    private readonly Dictionary<string, Button> _keyButtons = new();
+
+    public event EventHandler? ModifierChanged;
+    public event EventHandler<KeyboardKeyClickedEventArgs>? KeyClicked;
+
+    public KeyboardMapView()
+    {
+        InitializeComponent();
+        BuildBlock(MainBlock, KeyboardLayout.Main);
+        BuildBlock(NavBlock, KeyboardLayout.Nav);
+        BuildBlock(NumpadBlock, KeyboardLayout.Numpad);
+    }
+
+    public uint ModifierMask
+    {
+        get
+        {
+            uint m = 0;
+            if (CtrlChip.IsChecked == true) m |= Ctrl;
+            if (ShiftChip.IsChecked == true) m |= Shift;
+            if (AltChip.IsChecked == true) m |= Alt;
+            if (WinChip.IsChecked == true) m |= Super;
+            return m;
+        }
+    }
+
+    private void BuildBlock(StackPanel block, IReadOnlyList<IReadOnlyList<KeyCell>> rows)
+    {
+        foreach (var row in rows)
+        {
+            var rowPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
+            foreach (var cell in row)
+            {
+                if (string.IsNullOrEmpty(cell.KeyName) && !cell.Bindable)
+                {
+                    rowPanel.Children.Add(new Border { Width = cell.Units * UnitWidth, Height = KeyHeight });
+                    continue;
+                }
+
+                var btn = new Button
+                {
+                    Width = cell.Units * UnitWidth,
+                    Height = KeyHeight,
+                    Padding = new Thickness(2),
+                    FontSize = 11,
+                    Content = cell.Label,
+                    Tag = cell,
+                    IsEnabled = cell.Bindable,
+                };
+                if (cell.Bindable)
+                {
+                    btn.Click += Key_Click;
+                    _keyButtons[cell.KeyName] = btn;
+                }
+                rowPanel.Children.Add(btn);
+            }
+            block.Children.Add(rowPanel);
+        }
+    }
+
+    /// <summary>Repaint every key for the given layer model.</summary>
+    public void Apply(KeyboardMapModel model)
+    {
+        _model = model;
+        foreach (var (name, btn) in _keyButtons)
+        {
+            var state = model.ForKey(name);
+            if (state is null)
+            {
+                btn.ClearValue(Control.BackgroundProperty);
+                btn.ClearValue(Control.ForegroundProperty);
+                btn.ClearValue(Control.BorderBrushProperty);
+                btn.ClearValue(Control.BorderThicknessProperty);
+                var cell0 = (KeyCell)btn.Tag;
+                btn.Content = cell0.Label;
+                ToolTipService.SetToolTip(btn, null);
+                continue;
+            }
+
+            btn.Background = new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xB3, 0x47));
+            btn.Foreground = new SolidColorBrush(Colors.Black);
+            if (state.Source == KeybindSource.User)
+            {
+                btn.BorderBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0xD6, 0x5A, 0x2E));
+                btn.BorderThickness = new Thickness(2);
+            }
+            else
+            {
+                btn.ClearValue(Control.BorderBrushProperty);
+                btn.ClearValue(Control.BorderThicknessProperty);
+            }
+
+            var mark = state.IsMultiStep ? " ⋯" : (state.Conflict.HasConflict ? " ⚠" : "");
+            btn.Content = state.ActionLabel + mark;
+            ToolTipService.SetToolTip(btn,
+                state.ActionLabel + (state.Conflict.HasConflict ? "\n" + state.Conflict.Message : ""));
+        }
+    }
+
+    private void Chip_Click(object sender, RoutedEventArgs e) => ModifierChanged?.Invoke(this, EventArgs.Empty);
+
+    private void Key_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn || btn.Tag is not KeyCell cell) return;
+        KeyClicked?.Invoke(this, new KeyboardKeyClickedEventArgs
+        {
+            Cell = cell,
+            State = _model?.ForKey(cell.KeyName),
+            Anchor = btn,
+        });
+    }
+}

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
@@ -2,7 +2,8 @@
     x:Class="Ghostty.Settings.Pages.KeybindingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Ghostty.Settings.Pages">
+    xmlns:local="using:Ghostty.Settings.Pages"
+    xmlns:settings="using:Ghostty.Settings">
 
     <Page.Resources>
         <DataTemplate x:Key="KeybindHeaderTemplate">
@@ -58,24 +59,26 @@
     <Grid Padding="24" RowDefinitions="Auto,Auto,*">
         <TextBlock Text="Keybindings" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
 
-        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,16">
-            <AutoSuggestBox
-                x:Name="SearchBox"
-                PlaceholderText="Search by action or key..."
-                QueryIcon="Find"
-                TextChanged="SearchBox_TextChanged" />
-            <ToggleButton
-                x:Name="ConflictsToggle"
-                Grid.Column="1"
-                Content="Conflicts"
-                Margin="8,0,0,0"
-                Checked="ConflictsToggle_Toggled"
-                Unchecked="ConflictsToggle_Toggled" />
+        <SelectorBar x:Name="ViewBar" Grid.Row="0" HorizontalAlignment="Right"
+                     SelectionChanged="ViewBar_SelectionChanged">
+            <SelectorBarItem x:Name="ListBarItem" Text="List" IsSelected="True" />
+            <SelectorBarItem x:Name="KeyboardBarItem" Text="Keyboard" />
+        </SelectorBar>
+
+        <Grid x:Name="ListPanel" Grid.Row="1" Grid.RowSpan="2" RowDefinitions="Auto,*">
+            <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,16">
+                <AutoSuggestBox x:Name="SearchBox" PlaceholderText="Search by action or key..."
+                                QueryIcon="Find" TextChanged="SearchBox_TextChanged" />
+                <ToggleButton x:Name="ConflictsToggle" Grid.Column="1" Content="Conflicts"
+                              Margin="8,0,0,0" Checked="ConflictsToggle_Toggled"
+                              Unchecked="ConflictsToggle_Toggled" />
+            </Grid>
+            <ListView x:Name="BindingsList" Grid.Row="1" SelectionMode="None"
+                      ItemTemplateSelector="{StaticResource RowSelector}" />
         </Grid>
 
-        <ListView x:Name="BindingsList"
-                  Grid.Row="2"
-                  SelectionMode="None"
-                  ItemTemplateSelector="{StaticResource RowSelector}" />
+        <ScrollViewer x:Name="KeyboardPanel" Grid.Row="1" Grid.RowSpan="2" Visibility="Collapsed">
+            <settings:KeyboardMapView x:Name="Map" Margin="0,8,0,0" />
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Ghostty.Core.Input;
 using Ghostty.Interop;
 using Ghostty.Logging;
@@ -33,6 +35,8 @@ internal sealed partial class KeybindingsPage : Page
     private readonly ConfigService _configService;
     private readonly Ghostty.Core.Config.IConfigFileEditor _editor;
     private KeybindCatalog _catalog;
+    private IReadOnlyList<EnumeratedKeybind> _binds = Array.Empty<EnumeratedKeybind>();
+    private IReadOnlyList<EnumeratedKeybind> _defaults = Array.Empty<EnumeratedKeybind>();
 
     // The row whose context menu is currently open. WinUI doesn't reliably
     // populate MenuFlyout.Target for a ContextFlyout, so we capture the
@@ -49,6 +53,9 @@ internal sealed partial class KeybindingsPage : Page
 
         _catalog = KeybindCatalog.Build(Array.Empty<EnumeratedKeybind>());
         BindingsList.ContainerContentChanging += OnContainerContentChanging;
+
+        Map.ModifierChanged += (_, _) => ApplyMap();
+        Map.KeyClicked += Map_KeyClicked;
 
         // Subscribe in Loaded (not the ctor): SettingsWindow caches pages and
         // reuses the instance, so the ctor runs once but Loaded/Unloaded fire on
@@ -75,11 +82,15 @@ internal sealed partial class KeybindingsPage : Page
 
     private void Rebuild()
     {
-        var binds = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
-        var defaults = _configService.EnumerateDefaultKeybinds();
-        _catalog = KeybindCatalog.Build(binds, defaults);
+        _binds = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
+        _defaults = _configService.EnumerateDefaultKeybinds();
+        _catalog = KeybindCatalog.Build(_binds, _defaults);
         ApplyFilter();
+        if (KeyboardPanel.Visibility == Visibility.Visible) ApplyMap();
     }
+
+    private void ApplyMap()
+        => Map.Apply(KeyboardMapModel.Build(_binds, _defaults, Map.ModifierMask));
 
     private void OnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
@@ -206,6 +217,86 @@ internal sealed partial class KeybindingsPage : Page
 
     private void ApplyFilter()
         => BindingsList.ItemsSource = _catalog.Filter(SearchBox.Text, ConflictsToggle.IsChecked == true);
+
+    private void ViewBar_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
+    {
+        var keyboard = sender.SelectedItem == KeyboardBarItem;
+        KeyboardPanel.Visibility = keyboard ? Visibility.Visible : Visibility.Collapsed;
+        ListPanel.Visibility = keyboard ? Visibility.Collapsed : Visibility.Visible;
+        if (keyboard) ApplyMap();
+    }
+
+    private async void Map_KeyClicked(object? sender, Ghostty.Settings.KeyboardKeyClickedEventArgs e)
+    {
+        var mask = Map.ModifierMask;
+
+        // Chords aren't representable on a single key, so route a multi-step
+        // binding to the full capture dialog instead of the inline picker.
+        if (e.State is { IsMultiStep: true } ms)
+        {
+            await RebindActionAsync(ms.RawAction, ms.ActionLabel);
+            return;
+        }
+
+        // Dark key (nothing bound on this layer): pick an action and assign it
+        // to this physical trigger.
+        if (e.State is null)
+        {
+            var action = await PickActionAsync(preselect: null);
+            if (action is null) return;
+            var token = KeybindTriggerSyntax.EncodePhysical(mask, e.Cell.Ordinal);
+            TryWriteKeybinds(cur => UserKeybindEditor.Assign(cur, token, action));
+            return;
+        }
+
+        // Lit key (single-step): offer reassign / unbind / reset.
+        ShowKeyFlyout(e.Anchor, e.Cell, mask, e.State);
+    }
+
+    private void ShowKeyFlyout(FrameworkElement anchor, KeyCell cell, uint mask, KeyboardKeyState state)
+    {
+        var flyout = new MenuFlyout();
+        flyout.Items.Add(new MenuFlyoutItem { Text = state.ActionLabel, IsEnabled = false });
+        flyout.Items.Add(new MenuFlyoutSeparator());
+
+        var reassign = new MenuFlyoutItem { Text = "Reassign..." };
+        reassign.Click += async (_, _) =>
+        {
+            var action = await PickActionAsync(preselect: state.RawAction);
+            if (action is null) return;
+            var token = KeybindTriggerSyntax.EncodePhysical(mask, cell.Ordinal);
+            TryWriteKeybinds(cur => UserKeybindEditor.Assign(cur, token, action));
+        };
+        flyout.Items.Add(reassign);
+
+        var unbind = new MenuFlyoutItem { Text = "Unbind" };
+        unbind.Click += (_, _) => TryWriteKeybinds(cur => UserKeybindEditor.Unbind(cur, state.Bind));
+        flyout.Items.Add(unbind);
+
+        if (state.Source == KeybindSource.User)
+        {
+            var reset = new MenuFlyoutItem { Text = "Reset to default" };
+            reset.Click += (_, _) => TryWriteKeybinds(cur => UserKeybindEditor.Reset(cur, state.Bind));
+            flyout.Items.Add(reset);
+        }
+
+        flyout.ShowAt(anchor);
+    }
+
+    private async Task<string?> PickActionAsync(string? preselect)
+    {
+        var dialog = new Ghostty.Settings.AssignActionDialog(_binds, preselect) { XamlRoot = XamlRoot };
+        var result = await dialog.ShowAsync();
+        return result == ContentDialogResult.Primary ? dialog.SelectedAction : null;
+    }
+
+    private async Task RebindActionAsync(string rawAction, string friendly)
+    {
+        var dialog = new Ghostty.Settings.RebindDialog(_binds, rawAction, friendly) { XamlRoot = XamlRoot };
+        var dr = await dialog.ShowAsync();
+        if (dr != ContentDialogResult.Primary || dialog.CapturedTrigger is not { } token) return;
+        TryWriteKeybinds(cur => UserKeybindEditor.Assign(cur, token, rawAction));
+    }
 }
 
 internal static partial class KeybindingsPageLogExtensions

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -45,6 +45,10 @@ internal sealed partial class KeybindingsPage : Page
     // grid.Tag, which OnContainerContentChanging refreshes on every realize.
     private KeybindListItem? _contextRowItem;
 
+    // Guards against opening a second ContentDialog (WinUI allows only one at a
+    // time; a concurrent ShowAsync throws on the async-void stack -> crash).
+    private bool _dialogOpen;
+
     public KeybindingsPage(ConfigService configService, Ghostty.Core.Config.IConfigFileEditor editor)
     {
         _configService = configService;
@@ -54,6 +58,9 @@ internal sealed partial class KeybindingsPage : Page
         _catalog = KeybindCatalog.Build(Array.Empty<EnumeratedKeybind>());
         BindingsList.ContainerContentChanging += OnContainerContentChanging;
 
+        // Map is a page-owned child control (its lifetime == the page's), so these
+        // ctor subscriptions need no Unloaded pairing — unlike ConfigChanged on the
+        // external _configService.
         Map.ModifierChanged += (_, _) => ApplyMap();
         Map.KeyClicked += Map_KeyClicked;
 
@@ -153,21 +160,11 @@ internal sealed partial class KeybindingsPage : Page
     private async void RebindItem_Click(object sender, RoutedEventArgs e)
     {
         if (_contextRowItem is not { } item) return;
-
-        // Pass the live finalized bind set so the dialog can warn about
-        // assign-time conflicts against what is actually in effect.
-        var current = KeybindEnumerator.Enumerate(_configService.ConfigHandle);
-        var dialog = new Ghostty.Settings.RebindDialog(current, item.RawAction, item.Friendly)
-        {
-            XamlRoot = XamlRoot,
-        };
-        var result = await dialog.ShowAsync();
-        if (result != ContentDialogResult.Primary || dialog.CapturedTrigger is not { } token) return;
+        if (await ShowRebindDialogAsync(item.RawAction, item.Friendly) is not { } token) return;
 
         // Add/override: write the new trigger=action line (dropping any user
         // line already at that chord). The action's other triggers stay intact.
-        TryWriteKeybinds(current =>
-            UserKeybindEditor.Assign(current, token, item.RawAction));
+        TryWriteKeybinds(cur => UserKeybindEditor.Assign(cur, token, item.RawAction));
     }
 
     private void ApplyUserEdit(
@@ -221,6 +218,7 @@ internal sealed partial class KeybindingsPage : Page
     private void ViewBar_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
     {
         var keyboard = sender.SelectedItem == KeyboardBarItem;
+        // ListPanel and KeyboardPanel deliberately overlap (both Row 1, RowSpan 2); exactly one is Visible.
         KeyboardPanel.Visibility = keyboard ? Visibility.Visible : Visibility.Collapsed;
         ListPanel.Visibility = keyboard ? Visibility.Collapsed : Visibility.Visible;
         if (keyboard) ApplyMap();
@@ -259,7 +257,7 @@ internal sealed partial class KeybindingsPage : Page
         flyout.Items.Add(new MenuFlyoutItem { Text = state.ActionLabel, IsEnabled = false });
         flyout.Items.Add(new MenuFlyoutSeparator());
 
-        var reassign = new MenuFlyoutItem { Text = "Reassign..." };
+        var reassign = new MenuFlyoutItem { Text = "Rebind..." };
         reassign.Click += async (_, _) =>
         {
             var action = await PickActionAsync(preselect: state.RawAction);
@@ -285,16 +283,35 @@ internal sealed partial class KeybindingsPage : Page
 
     private async Task<string?> PickActionAsync(string? preselect)
     {
-        var dialog = new Ghostty.Settings.AssignActionDialog(_binds, preselect) { XamlRoot = XamlRoot };
-        var result = await dialog.ShowAsync();
-        return result == ContentDialogResult.Primary ? dialog.SelectedAction : null;
+        if (_dialogOpen || XamlRoot is null) return null;
+        _dialogOpen = true;
+        try
+        {
+            var dialog = new Ghostty.Settings.AssignActionDialog(_binds, preselect) { XamlRoot = XamlRoot };
+            var result = await dialog.ShowAsync();
+            return result == ContentDialogResult.Primary ? dialog.SelectedAction : null;
+        }
+        finally { _dialogOpen = false; }
+    }
+
+    // Single guarded entry point for the Rebind capture dialog. Returns the
+    // captured trigger token, or null if cancelled / a dialog is already open.
+    private async Task<string?> ShowRebindDialogAsync(string rawAction, string friendly)
+    {
+        if (_dialogOpen || XamlRoot is null) return null;
+        _dialogOpen = true;
+        try
+        {
+            var dialog = new Ghostty.Settings.RebindDialog(_binds, rawAction, friendly) { XamlRoot = XamlRoot };
+            var result = await dialog.ShowAsync();
+            return result == ContentDialogResult.Primary ? dialog.CapturedTrigger : null;
+        }
+        finally { _dialogOpen = false; }
     }
 
     private async Task RebindActionAsync(string rawAction, string friendly)
     {
-        var dialog = new Ghostty.Settings.RebindDialog(_binds, rawAction, friendly) { XamlRoot = XamlRoot };
-        var dr = await dialog.ShowAsync();
-        if (dr != ContentDialogResult.Primary || dialog.CapturedTrigger is not { } token) return;
+        if (await ShowRebindDialogAsync(rawAction, friendly) is not { } token) return;
         TryWriteKeybinds(cur => UserKeybindEditor.Assign(cur, token, rawAction));
     }
 }

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -257,16 +257,20 @@ internal sealed partial class KeybindingsPage : Page
         flyout.Items.Add(new MenuFlyoutItem { Text = state.ActionLabel, IsEnabled = false });
         flyout.Items.Add(new MenuFlyoutSeparator());
 
-        var reassign = new MenuFlyoutItem { Text = "Rebind..." };
-        reassign.Click += async (_, _) =>
+        var changeAction = new MenuFlyoutItem { Text = "Change action..." };
+        changeAction.Click += async (_, _) =>
         {
             var action = await PickActionAsync(preselect: state.RawAction);
             if (action is null) return;
             var token = KeybindTriggerSyntax.EncodePhysical(mask, cell.Ordinal);
             TryWriteKeybinds(cur => UserKeybindEditor.Assign(cur, token, action));
         };
-        flyout.Items.Add(reassign);
+        flyout.Items.Add(changeAction);
 
+        // Unbind/Reset act on the EnumeratedKeybind captured at paint time. The map
+        // is rebuilt on every ConfigChanged, so state.Bind is only stale if the config
+        // changes while this flyout is open — a narrow window, and TryWriteKeybinds is
+        // exception-guarded so a stale bind degrades to a no-op rather than a crash.
         var unbind = new MenuFlyoutItem { Text = "Unbind" };
         unbind.Click += (_, _) => TryWriteKeybinds(cur => UserKeybindEditor.Unbind(cur, state.Bind));
         flyout.Items.Add(unbind);


### PR DESCRIPTION
Adds a second view to the Keybindings settings page: an on-screen ANSI-104 keyboard that shows which physical keys are bound at a selected modifier combination, and lets you assign, change, and unbind bindings directly from the keyboard.

## What's new
- "List | Keyboard" switch at the top of the Keybindings page.
- Ctrl / Shift / Alt / Win chips pick the modifier layer; the keyboard repaints to show that layer's bindings (one binding per key).
- Click an empty key to assign an action from a searchable, category-grouped picker.
- Click a bound key for a flyout: change action, unbind, or reset to default.
- User overrides get an accent border; terminal-shadow conflicts get a caution mark; leader/sequence binds are marked and route to the existing chord-capture dialog.
- All editing flows through the existing config write path (guarded against IO failure).

## Implementation
- Core logic is pure and unit-tested in `Ghostty.Core/Input`: `KeyboardLayout` (ANSI-104 table), `KeyboardMapModel` (projects the finalized bind set onto one modifier layer, collapsing right-side modifier bits), `KeybindTriggerSyntax.EncodePhysical` (mask + ordinal -> trigger token), and `KeybindActionCatalog.AllActions` (assignable actions taken from the enumerated set, so every offered action is a valid string with no new ABI).
- WinUI is thin and AOT-safe (no `{Binding}`; imperative population): `KeyboardMapView`, `AssignActionDialog`, and the page wiring. A single re-entrancy guard covers all dialog open sites.
- ~30 new tests; full suite 1325 passing, app builds clean.

Stacked on the keybindings editor (engine swap through chord capture).