### PR TITLE
feat(keybinds): keyboard shortcuts cheat sheet + markdown export

### DIFF
--- a/windows/Ghostty.Core/Input/KeybindMarkdownExporter.cs
+++ b/windows/Ghostty.Core/Input/KeybindMarkdownExporter.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Renders a KeybindCatalog as a Markdown cheat sheet: a title, then a
+/// "## Category" section per category with an Action/Shortcut table. Pure;
+/// the WinUI cheat-sheet dialog calls this for copy-to-clipboard / save.
+/// </summary>
+public static class KeybindMarkdownExporter
+{
+    public const string Title = "# Keyboard Shortcuts";
+
+    public static string Export(KeybindCatalog catalog) => Export(catalog.Categories);
+
+    public static string Export(IReadOnlyList<KeybindCategory> categories)
+    {
+        var sb = new StringBuilder();
+        sb.Append(Title).Append('\n');
+        foreach (var category in categories)
+        {
+            sb.Append('\n').Append("## ").Append(category.Name).Append('\n').Append('\n');
+            sb.Append("| Action | Shortcut |").Append('\n');
+            sb.Append("| --- | --- |").Append('\n');
+            foreach (var item in category.Items)
+                sb.Append("| ").Append(Escape(item.Friendly))
+                  .Append(" | ").Append(Escape(item.Label)).Append(" |").Append('\n');
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Escape(string s) => s.Replace("|", "\\|");
+}

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -86,4 +86,8 @@ public enum PaneAction
     // App-level singleton rather than the active leaf because the
     // quake window may not even be open when the action fires.
     ToggleQuickTerminal = 48,
+
+    // Open the read-only keyboard-shortcuts cheat sheet. Routed via event to
+    // MainWindow, which shows the cheat sheet dialog (needs an XamlRoot/HWND).
+    ShowKeybindCheatsheet = 49,
 }

--- a/windows/Ghostty.Tests/Input/KeybindMarkdownExporterTests.cs
+++ b/windows/Ghostty.Tests/Input/KeybindMarkdownExporterTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class KeybindMarkdownExporterTests
+{
+    private static KeybindListItem Item(string friendly, string label) =>
+        new(friendly, friendly, label, default, default, KeybindSource.Default);
+
+    private static KeybindCategory Cat(string name, params KeybindListItem[] items) =>
+        new(name, items);
+
+    [Fact]
+    public void Export_RendersTitleHeadingsAndTable()
+    {
+        var cats = new[]
+        {
+            Cat("Tabs", Item("New Tab", "Ctrl+Shift+T"), Item("Close Tab", "Ctrl+Shift+W")),
+            Cat("Clipboard", Item("Copy", "Ctrl+Shift+C")),
+        };
+        var md = KeybindMarkdownExporter.Export(cats);
+
+        Assert.StartsWith("# Keyboard Shortcuts", md);
+        Assert.Contains("## Tabs", md);
+        Assert.Contains("## Clipboard", md);
+        Assert.Contains("| Action | Shortcut |", md);
+        Assert.Contains("| --- | --- |", md);
+        Assert.Contains("| New Tab | Ctrl+Shift+T |", md);
+        Assert.Contains("| Copy | Ctrl+Shift+C |", md);
+    }
+
+    [Fact]
+    public void Export_EscapesPipes()
+    {
+        var cats = new[] { Cat("Other", Item("Weird | Action", "Ctrl+|")) };
+        var md = KeybindMarkdownExporter.Export(cats);
+        Assert.Contains(@"| Weird \| Action | Ctrl+\| |", md);
+    }
+
+    [Fact]
+    public void Export_EmptyCatalog_IsTitleOnly()
+    {
+        var md = KeybindMarkdownExporter.Export(new List<KeybindCategory>());
+        Assert.Equal("# Keyboard Shortcuts\n", md);
+    }
+
+    [Fact]
+    public void Export_FromBuiltCatalog_Works()
+    {
+        var binds = new[]
+        {
+            new EnumeratedKeybind(
+                new[] { new KeybindTrigger(0, (uint)KeyNames.OrdinalOf("key_t")!.Value, (1u << 1) | (1u << 0)) },
+                "new_tab", GhosttyBindingFlags.Consumed),
+        };
+        var catalog = KeybindCatalog.Build(binds);
+        var md = KeybindMarkdownExporter.Export(catalog);
+        Assert.Contains("## Tabs", md);
+        Assert.Contains("| New Tab | Ctrl+Shift+T |", md);
+    }
+}

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -56,6 +56,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.ToggleVerticalTabsPinned, "Toggle Vertical Tabs Pinned", "Pin or unpin the vertical tab sidebar", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.ToggleTabLayout, "Toggle Tab Layout", "Switch between horizontal and vertical tab layout", CommandCategory.Tab, "\uE8AB");
         AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal);
+        AddPaneCommand(commands, PaneAction.ShowKeybindCheatsheet, "Keyboard Shortcuts", "Show the keyboard shortcuts cheat sheet", CommandCategory.Terminal, "");
 
         // Binding-action-backed commands
         AddBindingCommand(commands, "reset", "Reset Terminal", "Reset the terminal to a clean state", CommandCategory.Terminal, "\uE777");

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -141,6 +141,10 @@ internal sealed class KeyBindings
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Number7, PaneAction.OpenProfile7),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Number8, PaneAction.OpenProfile8),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Number9, PaneAction.OpenProfile9),
+
+        // Ctrl+Shift+/ ("Ctrl+?") opens the keyboard-shortcuts cheat sheet.
+        // VK 191 = VK_OEM_2 ('/') on US-ANSI.
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, (VirtualKey)191, PaneAction.ShowKeybindCheatsheet),
     });
 
     /// <summary>

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -99,6 +99,12 @@ internal sealed class PaneActionRouter
     /// </summary>
     public event EventHandler? QuickTerminalToggleRequested;
 
+    /// <summary>
+    /// Raised when the cheat-sheet chord or palette entry fires. MainWindow
+    /// listens and shows the keyboard-shortcuts cheat sheet dialog.
+    /// </summary>
+    public event EventHandler? ShowKeybindCheatsheetRequested;
+
     public void Invoke(PaneAction action)
     {
         // Event-only actions that don't need pane/tab state — handle
@@ -122,6 +128,9 @@ internal sealed class PaneActionRouter
                 return;
             case PaneAction.ToggleQuickTerminal:
                 QuickTerminalToggleRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ShowKeybindCheatsheet:
+                ShowKeybindCheatsheetRequested?.Invoke(this, EventArgs.Empty);
                 return;
 
             // Scrollback jumps are dispatched as libghostty binding

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -66,5 +66,7 @@ internal static class LogEvents
     {
         public const int ConfigOpenFailed   = 2600;
         public const int KeybindWriteFailed = 2601;
+        public const int CheatSheetShowFailed = 2602;
+        public const int CheatSheetExportFailed = 2603;
     }
 }

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -39,6 +39,9 @@ namespace Ghostty.Logging;
 ///     refactor than this slot is worth.
 ///   - <see cref="KeybindingsPage"/>: same XAML-page constraint as
 ///     <see cref="GeneralPage"/>; logs keybind config write failures.
+///   - <see cref="CheatSheet"/>: read-only keybind cheat-sheet
+///     <c>ContentDialog</c>, constructed directly (no DI-enabled
+///     <c>Frame</c>); logs show / export failures.
 ///
 /// Tests should use <see cref="Install"/> which returns an
 /// <see cref="IDisposable"/> scope that restores the pre-install
@@ -62,6 +65,7 @@ internal static class StaticLoggers
     private static ILogger<Ghostty.Settings.WindowState>? _windowState;
     private static ILogger<Ghostty.Settings.Pages.GeneralPage>? _generalPage;
     private static ILogger<Ghostty.Settings.Pages.KeybindingsPage>? _keybindingsPage;
+    private static ILogger<Ghostty.Settings.CheatSheetDialog>? _cheatSheet;
     private static ILogger<App>? _app;
 
     internal static ILogger<Ghostty.Services.ConfigService> ConfigService
@@ -74,6 +78,8 @@ internal static class StaticLoggers
         => _generalPage ?? NullLogger<Ghostty.Settings.Pages.GeneralPage>.Instance;
     internal static ILogger<Ghostty.Settings.Pages.KeybindingsPage> KeybindingsPage
         => _keybindingsPage ?? NullLogger<Ghostty.Settings.Pages.KeybindingsPage>.Instance;
+    internal static ILogger<Ghostty.Settings.CheatSheetDialog> CheatSheet
+        => _cheatSheet ?? NullLogger<Ghostty.Settings.CheatSheetDialog>.Instance;
     internal static ILogger<App> App
         => _app ?? NullLogger<App>.Instance;
 
@@ -84,6 +90,7 @@ internal static class StaticLoggers
         _windowState = factory.CreateLogger<Ghostty.Settings.WindowState>();
         _generalPage = factory.CreateLogger<Ghostty.Settings.Pages.GeneralPage>();
         _keybindingsPage = factory.CreateLogger<Ghostty.Settings.Pages.KeybindingsPage>();
+        _cheatSheet = factory.CreateLogger<Ghostty.Settings.CheatSheetDialog>();
         _app = factory.CreateLogger<App>();
     }
 
@@ -95,7 +102,7 @@ internal static class StaticLoggers
     }
 
     private static Snapshot CaptureSnapshot() => new(
-        _configService, _windowStateMigration, _windowState, _generalPage, _keybindingsPage, _app);
+        _configService, _windowStateMigration, _windowState, _generalPage, _keybindingsPage, _cheatSheet, _app);
 
     private readonly record struct Snapshot(
         ILogger<Ghostty.Services.ConfigService>? ConfigService,
@@ -103,6 +110,7 @@ internal static class StaticLoggers
         ILogger<Ghostty.Settings.WindowState>? WindowState,
         ILogger<Ghostty.Settings.Pages.GeneralPage>? GeneralPage,
         ILogger<Ghostty.Settings.Pages.KeybindingsPage>? KeybindingsPage,
+        ILogger<Ghostty.Settings.CheatSheetDialog>? CheatSheet,
         ILogger<App>? App);
 
     private sealed class Scope : IDisposable
@@ -117,7 +125,21 @@ internal static class StaticLoggers
             _windowState = _prior.WindowState;
             _generalPage = _prior.GeneralPage;
             _keybindingsPage = _prior.KeybindingsPage;
+            _cheatSheet = _prior.CheatSheet;
             _app = _prior.App;
         }
     }
+}
+
+internal static partial class CheatSheetLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SettingsUi.CheatSheetShowFailed,
+                   Level = LogLevel.Warning, Message = "Failed to show keybind cheat sheet")]
+    internal static partial void LogCheatSheetShowFailed(
+        this ILogger<Ghostty.Settings.CheatSheetDialog> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SettingsUi.CheatSheetExportFailed,
+                   Level = LogLevel.Warning, Message = "Failed to export keybind cheat sheet")]
+    internal static partial void LogCheatSheetExportFailed(
+        this ILogger<Ghostty.Settings.CheatSheetDialog> logger, System.Exception ex);
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1273,6 +1273,12 @@ public sealed partial class MainWindow : Window
         // hotkey, so any MainWindow can be the chord source.
         _router.QuickTerminalToggleRequested += (_, _) =>
             ((App)Application.Current).ToggleQuickTerminal();
+
+        _router.ShowKeybindCheatsheetRequested += (_, _) =>
+            _ = Ghostty.Settings.CheatSheetLauncher.ShowAsync(
+                _configService,
+                Content?.XamlRoot,
+                WinRT.Interop.WindowNative.GetWindowHandle(this));
     }
 
     /// <summary>

--- a/windows/Ghostty/Settings/CheatSheetDialog.xaml
+++ b/windows/Ghostty/Settings/CheatSheetDialog.xaml
@@ -1,0 +1,37 @@
+<ContentDialog
+    x:Class="Ghostty.Settings.CheatSheetDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Ghostty.Settings"
+    Title="Keyboard Shortcuts"
+    CloseButtonText="Close"
+    DefaultButton="Close">
+    <ContentDialog.Resources>
+        <DataTemplate x:Key="CheatHeaderTemplate">
+            <TextBlock x:Name="HeaderText" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,12,0,4" />
+        </DataTemplate>
+        <DataTemplate x:Key="CheatEntryTemplate">
+            <Grid ColumnDefinitions="*,Auto" Padding="4,4">
+                <TextBlock x:Name="FriendlyText" VerticalAlignment="Center" />
+                <Border Grid.Column="1" Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                        CornerRadius="4" Padding="8,2">
+                    <TextBlock x:Name="LabelText" FontFamily="Cascadia Code, Consolas, monospace" />
+                </Border>
+            </Grid>
+        </DataTemplate>
+        <local:CheatRowTemplateSelector x:Key="CheatRowSelector"
+            HeaderTemplate="{StaticResource CheatHeaderTemplate}"
+            EntryTemplate="{StaticResource CheatEntryTemplate}" />
+    </ContentDialog.Resources>
+
+    <Grid RowDefinitions="Auto,*,Auto" Width="460" Height="520">
+        <AutoSuggestBox x:Name="SearchBox" PlaceholderText="Search shortcuts..."
+                        QueryIcon="Find" TextChanged="SearchBox_TextChanged" Margin="0,0,0,8" />
+        <ListView x:Name="RowsList" Grid.Row="1" SelectionMode="None"
+                  ItemTemplateSelector="{StaticResource CheatRowSelector}" />
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+            <Button x:Name="CopyButton" Content="Copy as Markdown" Click="CopyButton_Click" />
+            <Button x:Name="SaveButton" Content="Save..." Click="SaveButton_Click" />
+        </StackPanel>
+    </Grid>
+</ContentDialog>

--- a/windows/Ghostty/Settings/CheatSheetDialog.xaml.cs
+++ b/windows/Ghostty/Settings/CheatSheetDialog.xaml.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Input;
+using Ghostty.Logging;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using WinClipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
+
+namespace Ghostty.Settings;
+
+/// <summary>Picks header vs entry template by row type (AOT-safe, no reflection).</summary>
+internal sealed class CheatRowTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? HeaderTemplate { get; set; }
+    public DataTemplate? EntryTemplate { get; set; }
+
+    protected override DataTemplate? SelectTemplateCore(object item)
+        => item is KeybindCategoryHeader ? HeaderTemplate : EntryTemplate;
+
+    protected override DataTemplate? SelectTemplateCore(object item, DependencyObject container)
+        => SelectTemplateCore(item);
+}
+
+internal sealed partial class CheatSheetDialog : ContentDialog
+{
+    private readonly KeybindCatalog _catalog;
+    private readonly IntPtr _ownerHwnd;
+
+    public CheatSheetDialog(KeybindCatalog catalog, IntPtr ownerHwnd)
+    {
+        _catalog = catalog;
+        _ownerHwnd = ownerHwnd;
+        InitializeComponent();
+        RowsList.ContainerContentChanging += OnContainerContentChanging;
+        ApplyFilter();
+    }
+
+    private void ApplyFilter() => RowsList.ItemsSource = _catalog.Filter(SearchBox.Text);
+
+    private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+        ApplyFilter();
+    }
+
+    private void OnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.InRecycleQueue) return;
+        var root = args.ItemContainer.ContentTemplateRoot;
+        switch (args.Item)
+        {
+            case KeybindCategoryHeader header when root is TextBlock headerText:
+                headerText.Text = header.Name;
+                break;
+            case KeybindListItem item when root is Grid grid:
+                if (grid.FindName("FriendlyText") is TextBlock f) f.Text = item.Friendly;
+                if (grid.FindName("LabelText") is TextBlock l) l.Text = item.Label;
+                break;
+        }
+    }
+
+    private void CopyButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var package = new DataPackage();
+            package.SetText(KeybindMarkdownExporter.Export(_catalog));
+            WinClipboard.SetContent(package);
+        }
+        catch (Exception ex)
+        {
+            StaticLoggers.CheatSheet.LogCheatSheetExportFailed(ex);
+        }
+    }
+
+    private async void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var picker = new FileSavePicker { SuggestedFileName = "keybindings" };
+            picker.FileTypeChoices.Add("Markdown", new List<string> { ".md" });
+            WinRT.Interop.InitializeWithWindow.Initialize(picker, _ownerHwnd);
+            var file = await picker.PickSaveFileAsync();
+            if (file is null) return;
+            await FileIO.WriteTextAsync(file, KeybindMarkdownExporter.Export(_catalog));
+        }
+        catch (Exception ex)
+        {
+            StaticLoggers.CheatSheet.LogCheatSheetExportFailed(ex);
+        }
+    }
+}

--- a/windows/Ghostty/Settings/CheatSheetLauncher.cs
+++ b/windows/Ghostty/Settings/CheatSheetLauncher.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using Ghostty.Core.Input;
+using Ghostty.Interop;
+using Ghostty.Logging;
+using Ghostty.Services;
+using Microsoft.UI.Xaml;
+
+namespace Ghostty.Settings;
+
+/// <summary>
+/// Single entry point for the keyboard-shortcuts cheat sheet. Enumerates the
+/// current binds, builds the catalog, and shows the dialog. Holds the only
+/// re-entrancy guard (WinUI allows one ContentDialog at a time; a second
+/// ShowAsync would throw on the caller's fire-and-forget stack).
+/// </summary>
+internal static class CheatSheetLauncher
+{
+    private static bool _open;
+
+    public static async Task ShowAsync(ConfigService configService, XamlRoot? root, IntPtr ownerHwnd)
+    {
+        if (_open || root is null) return;
+        _open = true;
+        try
+        {
+            var binds = KeybindEnumerator.Enumerate(configService.ConfigHandle);
+            var defaults = configService.EnumerateDefaultKeybinds();
+            var catalog = KeybindCatalog.Build(binds, defaults);
+            var dialog = new CheatSheetDialog(catalog, ownerHwnd) { XamlRoot = root };
+            await dialog.ShowAsync();
+        }
+        catch (Exception ex)
+        {
+            StaticLoggers.CheatSheet.LogCheatSheetShowFailed(ex);
+        }
+        finally
+        {
+            _open = false;
+        }
+    }
+}

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml
@@ -59,11 +59,13 @@
     <Grid Padding="24" RowDefinitions="Auto,Auto,*">
         <TextBlock Text="Keybindings" Style="{StaticResource TitleTextBlockStyle}" Margin="0,0,0,16" />
 
-        <SelectorBar x:Name="ViewBar" Grid.Row="0" HorizontalAlignment="Right"
-                     SelectionChanged="ViewBar_SelectionChanged">
-            <SelectorBarItem x:Name="ListBarItem" Text="List" IsSelected="True" />
-            <SelectorBarItem x:Name="KeyboardBarItem" Text="Keyboard" />
-        </SelectorBar>
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right" VerticalAlignment="Center">
+            <SelectorBar x:Name="ViewBar" SelectionChanged="ViewBar_SelectionChanged">
+                <SelectorBarItem x:Name="ListBarItem" Text="List" IsSelected="True" />
+                <SelectorBarItem x:Name="KeyboardBarItem" Text="Keyboard" />
+            </SelectorBar>
+            <Button x:Name="CheatSheetButton" Content="Cheat sheet" Click="CheatSheetButton_Click" />
+        </StackPanel>
 
         <Grid x:Name="ListPanel" Grid.Row="1" Grid.RowSpan="2" RowDefinitions="Auto,*">
             <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,16">

--- a/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/KeybindingsPage.xaml.cs
@@ -224,6 +224,16 @@ internal sealed partial class KeybindingsPage : Page
         if (keyboard) ApplyMap();
     }
 
+    private void CheatSheetButton_Click(object sender, RoutedEventArgs e)
+        => _ = Ghostty.Settings.CheatSheetLauncher.ShowAsync(
+            _configService, XamlRoot, GetActiveWindowHandle());
+
+    // The Settings window is the foreground window when its own button is
+    // clicked, so the foreground HWND is the owner the dialog's FileSavePicker
+    // needs. GetForegroundWindow is already in NativeMethods.txt.
+    private static IntPtr GetActiveWindowHandle()
+        => Windows.Win32.PInvoke.GetForegroundWindow();
+
     private async void Map_KeyClicked(object? sender, Ghostty.Settings.KeyboardKeyClickedEventArgs e)
     {
         var mask = Map.ModifierMask;


### PR DESCRIPTION
Adds a read-only "Keyboard Shortcuts" cheat sheet (grouped, searchable) with Markdown export. Completes the keyboard-shortcuts editor stack (engine swap → enumerate ABI → list → visual map → conflicts → unbind/reset → chord capture → this).

## What's new
- A cheat-sheet ContentDialog rendered from the existing `KeybindCatalog` (category headers + Action/Shortcut rows, searchable).
- **Copy as Markdown** (clipboard) and **Save…** (`.md` file) export.
- Opened three ways: the command palette ("Keyboard Shortcuts"), a **Cheat sheet** button on the Keybindings settings page, and a default chord **Ctrl+Shift+/**.

## Implementation
- Core (pure, unit-tested): `KeybindMarkdownExporter` renders the catalog to Markdown (per-category tables, pipe escaping). 4 tests.
- WinUI (AOT-safe, no `{Binding}`): `CheatSheetDialog` (imperative row population) + `CheatSheetLauncher` (single entry point with one re-entrancy guard). Clipboard/file IO and the dialog show are exception-guarded and logged via a new `CheatSheet` logger.
- Wiring: new `PaneAction.ShowKeybindCheatsheet` + `PaneActionRouter` event → MainWindow handler; the palette and the chord share that router path, the Settings button calls the launcher directly. No new Zig/ABI.

## Notes
- Like the existing list/keyboard views, the cheat sheet lists libghostty-enumerated binds; Windows-only binds (profiles, quake, the cheat-sheet chord itself) are not listed — documented limitation, not a regression.
- Full suite 1340 passing; app builds clean.