### PR TITLE
resize-overlay: keep the size pill showing across pane reparents

### DIFF
--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -433,11 +433,22 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // OnLoaded re-subscribes when the control re-enters a tree.
         Panel.LayoutUpdated -= OnFirstLayoutUpdated;
 
-        // Stop the grace timer so its Tick cannot flip _resizeOverlayReady
-        // while the control is detached. The timer (and its single Tick
-        // subscription) is kept for reuse when the control re-enters a tree;
-        // ArmResizeOverlayGrace restarts it.
-        _resizeOverlayGraceTimer?.Stop();
+        // Deliberately do NOT stop the resize-overlay grace timer here. WinUI 3
+        // raises Unloaded on every reparent (split / rebuild), not just on real
+        // teardown, and the matching Loaded does not guarantee a fresh settled-
+        // layout pass -- so the one-shot OnFirstLayoutUpdated may never re-fire
+        // to re-arm the grace. Stopping a grace armed just before this reparent
+        // would latch _resizeOverlayReady false forever, so the pane would never
+        // pulse the resize pill again and only the never-reparented active pane
+        // would show it during a multi-pane resize. Letting the armed grace run
+        // to completion guarantees readiness recovers across reparents (a tick
+        // landing while detached only sets the flag true, which is harmless).
+        //
+        // Re-arming in OnLoaded instead is wrong: ArmResizeOverlayGrace resets
+        // _resizeOverlayReady to false and restarts the window on every
+        // reparent, re-blanking the pill on each split. This mirrors
+        // ResizeOverlayControl._hideTimer (PR #463), which likewise keeps its
+        // non-repeating timer wired across Unloaded for the same reparent reason.
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

During a multi-pane resize (splitter drag or window resize), the transient
`cols x rows` resize pill appeared on **only the active pane** — every other
pane stayed blank. It should appear on every pane whose grid changes (and still
auto-hide).

## Root cause

`_resizeOverlayReady` latches `false` on reparented panes.

`OnFirstLayoutUpdated` arms the 500 ms startup grace (`ready = false`). A split
then reparents the existing pane, which raises `Unloaded` — and `OnUnloaded`
**stopped the grace timer**. The one-shot `OnFirstLayoutUpdated` is not
guaranteed to fire again after the matching `Loaded` (its re-fire depends on a
post-attach settled-layout pass that may not occur), so the timer never
restarts and `_resizeOverlayReady` stays `false` forever. With
`allowShow = _resizeOverlayReady && !withinFocusGuard` false, the pane never
pulses again. Only the never-reparented active pane stays ready — hence "only
the active pane shows the pill".

## Fix

Do **not** stop the grace timer in `OnUnloaded`. Letting an armed grace run to
completion guarantees `_resizeOverlayReady` recovers across reparents. A tick
that lands while the control is detached merely sets the flag `true`, which is
harmless: a detached control receives no `SizeChanged` events, and a later
reparent re-arms the grace via `OnFirstLayoutUpdated`.

One line removed (the `_resizeOverlayGraceTimer?.Stop()`), comment updated.

## Verification

Reproduced and fixed live with a per-pane lifecycle log + screenshots in a
downstream build whose per-pane startup animation adds enough layout churn to
reliably suppress the post-reparent `OnFirstLayoutUpdated` re-fire (latent
otherwise):

- Before: 4-pane layout, window resize -> only the active pane's pill; the
  three reparented panes logged `ready=false` / `vis=false`.
- After: all four panes pulse (`vis=true`), **0 panes stuck `ready=false`**.
- Auto-hide unaffected: all pills gone ~2 s after the resize (no stuck pills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
