### PR TITLE
fix(command-palette): render OEM keys as symbols in shortcut subtitles

### DIFF
--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -501,14 +501,10 @@ internal sealed partial class CommandPaletteControl : UserControl
         if (kb.Modifiers.HasFlag(VirtualKeyModifiers.Shift))   parts.Add("Shift");
         if (kb.Modifiers.HasFlag(VirtualKeyModifiers.Windows)) parts.Add("Win");
 
-        // Convert VirtualKey to a display name.
-        var key = kb.Key.ToString();
-
-        // Trim "Number" prefix from digit keys (VirtualKey.Number0 → "0")
-        if (key.StartsWith("Number", StringComparison.Ordinal))
-            key = key["Number".Length..];
-
-        parts.Add(key);
+        // Render the key via the shared OEM-aware table so punctuation keys
+        // (VK 188 → ",", 191 → "/") and digits (Number1 → "1") show their
+        // symbol instead of the raw VirtualKey name or numeric code.
+        parts.Add(Input.KeyBindings.KeyDisplayName(kb.Key));
         return string.Join("+", parts);
     }
 }

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -151,8 +151,10 @@ internal sealed class KeyBindings
     /// Human-readable name for a <see cref="VirtualKey"/>. Named enum
     /// members use ToString(); OEM keys that have no named member fall
     /// back to a lookup table so tooltips show "," instead of "188".
+    /// Also reused by the command palette's shortcut subtitles so chord
+    /// text is rendered from one OEM-aware table.
     /// </summary>
-    private static string KeyDisplayName(VirtualKey key) => (int)key switch
+    internal static string KeyDisplayName(VirtualKey key) => (int)key switch
     {
         // Top-row digits Number0..Number9 (VirtualKey values 0x30..0x39).
         // Default ToString() prints "Number1"; we want "1" for chord labels.


### PR DESCRIPTION
## Problem

The command palette renders keyboard-shortcut subtitles via `CommandPaletteControl.FormatKeyBinding`, which used `kb.Key.ToString()`. The `VirtualKey` enum has no named member for OEM-punctuation keys, so `ToString()` returned the raw numeric code instead of the symbol:

- **Toggle Tab Layout** (Ctrl+Shift+`,` = VK 188) showed `Ctrl+Shift+188`
- **Keyboard Shortcuts** cheat sheet (Ctrl+Shift+`/` = VK 191) showed `Ctrl+Shift+191`

## Fix

A correct, OEM-aware display table already existed: `KeyBindings.KeyDisplayName` (used by the tooltip `Label(...)` path). It maps `188 → ","`, `191 → "/"`, the rest of the OEM punctuation, and `Number0..9 → 0..9`.

- Promoted `KeyDisplayName` from `private` to `internal static` so the palette control (same assembly) can reuse it.
- Rewired `FormatKeyBinding` to call it, dropping the now-redundant inline `"Number"`-prefix trim (the shared table already handles digits).

Now the two affected entries render as **Ctrl+Shift+,** and **Ctrl+Shift+/**.

### Why not the Core `TriggerLabeler`/`KeyNames`?

Those operate on libghostty `input.Key` ordinals (`EnumeratedKeybind`), not WinUI `VirtualKey`. Using them here would require a `VirtualKey → input.Key` translation that doesn't exist on this path. `KeyBindings.KeyDisplayName` is the direct fit and keeps the OEM mapping in one place.

## Testing

`Ghostty.Tests` references only `Ghostty.Core`/`Ghostty.Bench`, not the WinUI app project where this logic lives, so it isn't reachable from the test project. Verified by building: `dotnet build Ghostty/Ghostty.csproj -p:Platform=x64` → **Build succeeded, 0 errors**.

Pure C# display fix, no ABI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)