### PR TITLE
panes: keep the splitter divider visible after unzoom

### DIFF
--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -1059,6 +1059,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             splitter.HorizontalAlignment = HorizontalAlignment.Right;
             splitter.VerticalAlignment = VerticalAlignment.Stretch;
             splitter.Width = 1;
+            // Keep the splitter above the panes regardless of later child
+            // order. Operations that re-add a leaf via Children.Add -- unzoom
+            // (ToggleSplitZoom) splicing the floated leaf back, and an in-place
+            // Split of a cell-0 leaf -- would otherwise append the leaf on top
+            // of this splitter, occluding the 1px divider line and stealing its
+            // drag hit-testing. A high z-index pins it on top by intent, not by
+            // add-order luck.
+            Canvas.SetZIndex(splitter, 1);
             grid.Children.Add(splitter);
         }
         else
@@ -1083,6 +1091,9 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             splitter.VerticalAlignment = VerticalAlignment.Bottom;
             splitter.HorizontalAlignment = HorizontalAlignment.Stretch;
             splitter.Height = 1;
+            // Pin above the panes so a later Children.Add (unzoom / cell-0
+            // split) can't occlude the divider. See the vertical case above.
+            Canvas.SetZIndex(splitter, 1);
             grid.Children.Add(splitter);
         }
 


### PR DESCRIPTION
## Problem

Zoom a split pane (`Ctrl+Shift+Enter`), then unzoom — the splitter **divider
line** of that pane's grid is gone (and the divider is no longer draggable). It
bites when you zoom a left/top (cell-0) pane.

## Root cause

`BuildVisual` adds each `Splitter` to its grid **last**, so the 1px divider
renders on top of the panes only by child order. Unzoom (`ToggleSplitZoom`)
splices the floated leaf back via `_zoomRestoreParent.Children.Add(leafCtl)`,
which **appends the leaf above the splitter** — occluding the divider line and
stealing its pointer hit-testing. (The same occlusion latently affects an
in-place `Split` of a cell-0 leaf.)

## Fix

Pin each splitter above its panes with `Canvas.SetZIndex(splitter, 1)`, so a
later `Children.Add` can't occlude it — on top by intent, not add-order luck.
Restores both the divider line and its drag. +11 lines, `PaneHost.cs` only.

## Verification

Live on the Pro build (where the per-pane glow made it easy to hit): split,
zoom a left pane, unzoom → divider restored and draggable. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
