### PR TITLE
panes: apply unzoom focus chrome without waiting on the compositor

### DIFF
--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -676,6 +676,15 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             // A ratio change while zoomed (EqualizeSplits) only touched
             // the model; sync the live Grids now that they are shown.
             ApplyAllRatios();
+            // Force a synchronous measure+arrange so the just-respliced leaf
+            // has valid layout slots (and a measured size) before we position
+            // the chrome below. Without it the leaf is unmeasured here and the
+            // border/dim only settle on a coalesced layout pass up to ~750ms
+            // later -- the visible unzoom delay. (The unpark Translation
+            // itself commits lazily on the idle compositor, but
+            // PositionOverlayOverLeaf reads layout slots, not that transform,
+            // so the chrome no longer waits on the compositor.)
+            UpdateLayout();
             _highlightOverlay.Visibility = Visibility.Visible;
             UpdateHighlightPosition();
             DispatcherQueue.TryEnqueue(() => _activeLeaf.Terminal().Focus(FocusState.Programmatic));
@@ -965,17 +974,34 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             rect.Visibility = Visibility.Collapsed;
             return;
         }
-        Rect bounds;
-        try
+        // Position from the LAYOUT-slot chain rather than TransformToVisual.
+        // TransformToVisual reflects the render-thread transform, which the
+        // (idle) compositor does not commit until ~750ms after an unzoom
+        // unparks the tree -- stranding this chrome at the parked offset (the
+        // "borders/dimming apply late" delay). Layout slots are resolved
+        // synchronously by the arrange pass, so the rect tracks the pane's
+        // true position immediately. The only transform a pane ever carries is
+        // the zoom park, and the chrome is hidden while parked, so ignoring
+        // transforms here is correct. In steady state this exactly matches
+        // TransformToVisual.
+        //
+        // INVARIANT: every element from the leaf up to the host Grid -- the
+        // leaf root (TerminalControl), each split Grid and _treeRoot built by
+        // BuildVisual, and the host Grid -- must keep Margin=0 and Stretch
+        // alignment, so each arrange slot equals the rendered rect and the
+        // summed offsets equal the position relative to PaneHost. Adding a
+        // Margin/Padding, a non-Stretch alignment, or a (non-park)
+        // RenderTransform to any of them would offset this chrome; keep panes
+        // wrapper-free at the build site (BuildVisual).
+        double bx = 0, by = 0;
+        for (FrameworkElement? fe = ctl; fe is not null && !ReferenceEquals(fe, this);
+             fe = VisualTreeHelper.GetParent(fe) as FrameworkElement)
         {
-            var transform = ctl.TransformToVisual(this);
-            bounds = transform.TransformBounds(new Rect(0, 0, ctl.ActualWidth, ctl.ActualHeight));
+            var slot = Microsoft.UI.Xaml.Controls.Primitives.LayoutInformation.GetLayoutSlot(fe);
+            bx += slot.X;
+            by += slot.Y;
         }
-        catch
-        {
-            rect.Visibility = Visibility.Collapsed;
-            return;
-        }
+        var bounds = new Rect(bx, by, ctl.ActualWidth, ctl.ActualHeight);
         // For the stroked active border, inset by half the stroke
         // thickness so the 1.5px stroke draws entirely INSIDE the
         // leaf bounds. For dim fills, use the full rect.


### PR DESCRIPTION
## Problem

After un-zooming a split pane (`Ctrl+Shift+Enter`), the **focused-pane border and the dimming of inactive panes appeared ~0.5s late** — the panes themselves were instantly correct, but the highlight chrome snapped into place after a visible delay.

## Root cause

Zoom parks the whole pane tree off-screen via a Composition `Translation` on an ancestor (`ParkTree`) and floats the active leaf full-size. On unzoom, `ParkTree(false)` resets `Translation = 0` **instantly**, but the compositor is idle (panes are static, no frame is scheduled) and does **not commit** that change for ~750ms.

`PositionOverlayOverLeaf` positioned the chrome with `TransformToVisual`, which reflects the **render-thread-committed** transform — so for ~750ms it returned the stale *parked* offset (e.g. `y=640`) and the border/dim rects were placed off-screen until an unrelated layout pass flushed it.

Verified by instrumentation — at the unzoom instant:

```
[uhp] ACTIVE ok layout=0,0 1240x320  xform=0,640   <- layout correct, transform stale
... ~750ms later ...
[uhp] ACTIVE ok layout=0,0 1240x320  xform=0,0      <- transform finally catches up
```

In steady state and on every other code path, `layout` and `xform` are identical.

## Fix (`PaneHost.cs` only)

1. **Position the chrome from the layout-slot chain** (`LayoutInformation.GetLayoutSlot` summed up the visual tree) instead of `TransformToVisual`. Layout slots are resolved synchronously by the arrange pass and are transform-independent, so the rect tracks the pane's true position immediately with no compositor dependency. The only transform a pane carries is the zoom park, and the chrome is hidden while parked, so ignoring transforms is correct.
2. **`UpdateLayout()` during unzoom** so the re-spliced leaf has valid slots (and a measured size) before the chrome is positioned — otherwise it waits for a coalesced layout pass up to ~750ms out.

The change documents the load-bearing invariant the slot sum relies on (every leaf→host-Grid element keeps `Margin=0` + Stretch).

## Review

Reviewed by two adversarial subagents — **no Critical**. Both confirmed the slot sum is provably equal to `TransformToVisual` for every tree shape this code builds (zero-margin/Stretch chain), DPI/scaling is clean, the forced `UpdateLayout()` has no re-entrancy/recursion hazard, and dropping the old `try/catch` is safe (the loop can't throw). The one Recommended — make the zero-margin invariant a greppable contract — is applied as an in-code `INVARIANT:` note.

## Testing

Live on the Pro build: split top/bottom → zoom the top pane → unzoom → the focused border + inactive-pane dimming now apply **instantly** (confirmed by the author). Steady-state positioning is unchanged (slot sum == transform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
