### PR TITLE
search: live match counter while typing (needle binding update trigger)

### DIFF
--- a/windows/Ghostty.Core/Search/SearchState.cs
+++ b/windows/Ghostty.Core/Search/SearchState.cs
@@ -43,6 +43,14 @@ public sealed class SearchState : INotifyPropertyChanged
     }
 
     /// <summary>Current search query. Empty cancels the active search.</summary>
+    /// <remarks>
+    /// Must stay a verbatim passthrough (only null-coalescing): the
+    /// SearchBar needle TextBox binds here TwoWay with
+    /// UpdateSourceTrigger=PropertyChanged, so any transform (trim,
+    /// case-fold, normalize) would write a different string back into the
+    /// focused box mid-edit and corrupt the caret. The Ordinal dedupe below
+    /// is also what keeps the libghostty needle echo from looping.
+    /// </remarks>
     public string Needle
     {
         get => _needle;

--- a/windows/Ghostty/Controls/Search/SearchBarControl.xaml
+++ b/windows/Ghostty/Controls/Search/SearchBarControl.xaml
@@ -34,15 +34,20 @@
             <!--
                 Needle box. Two-way bound to State.Needle so external
                 resets (e.g. Reset()) flow back into the TextBox without
-                code-behind plumbing. Enter / Shift+Enter / Esc are
-                handled in code-behind via KeyDown.
+                code-behind plumbing. UpdateSourceTrigger=PropertyChanged is
+                REQUIRED: TextBox.Text two-way bindings update the source only
+                on LostFocus by default, but State.CounterText short-circuits
+                to blank while the needle is empty, so without per-keystroke
+                source updates the match counter stays blank until the box
+                loses focus. Enter / Shift+Enter / Esc are handled in
+                code-behind via KeyDown.
             -->
             <TextBox x:Name="NeedleBox"
                      Grid.Column="0"
                      PlaceholderText="Search scrollback"
                      AcceptsReturn="False"
                      VerticalAlignment="Center"
-                     Text="{x:Bind State.Needle, Mode=TwoWay}"
+                     Text="{x:Bind State.Needle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      TextChanged="OnNeedleTextChanged"
                      KeyDown="OnNeedleKeyDown"/>
 


### PR DESCRIPTION
## Problem

In-pane scrollback search (Ctrl+Shift+F): the **"N of M" match counter stayed blank while typing** — it only appeared after the pane lost focus. Clearing the box also left a stale `of -1`.

## Root cause

The counter binds to `SearchState.CounterText`, which short-circuits to `""` while `Needle` is empty. The needle `TextBox` is `TwoWay`-bound to `State.Needle`, but **`TextBox.Text` two-way bindings update the source only on `LostFocus` by default** — so `State.Needle` stayed empty during typing and `CounterText` was blank until focus left (which flushed the binding *and* triggered a repaint, masking the real cause). The search itself worked because the debounce handler reads `NeedleBox.Text` directly, not `State.Needle`.

Confirmed by runtime logging: with 244 matches reported, `State.CounterText` was `''` because `State.Needle` was `''`.

## Fix (1 attribute)

`Text="{x:Bind State.Needle, Mode=TwoWay}"` → `... UpdateSourceTrigger=PropertyChanged}"` so the needle syncs per keystroke. The counter now updates live, and clearing the box no longer shows `of -1` (an empty needle short-circuits before the `Total=-1` "no active search" sentinel is formatted).

Also adds a `<remarks>` guard on `SearchState.Needle` documenting that it must remain a verbatim passthrough — the per-keystroke two-way write-back would corrupt the caret if the setter ever transformed the text.

## Review

Two subagents (WinUI correctness + adversarial) — **no Critical**. Both confirmed: idiomatic fix, AOT-safe (compile-time markup attribute, no reflection), and **no caret-jump/feedback loop** because the `Needle` setter is a verbatim passthrough with an Ordinal dedupe (which also no-ops the libghostty needle echo). Debounce cadence and search-trigger count are unchanged. IME/CJK, paste, and select-all-then-type all verified safe.

## Testing

Live on the Pro build: Ctrl+Shift+F → typing shows the counter updating live (`3 of 12`), Enter navigates with a live position, normal typing (no caret jump), and deleting the query clears the counter cleanly. Confirmed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
