### PR TITLE
termio: drop dead write-tagging pipeline after ConPTY-only transport

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2837,7 +2837,7 @@ pub fn keyCallback(
         errdefer write_req.deinit();
         self.queueIo(switch (write_req) {
             .small => |v| .{ .write_small = .{ .data = v.data, .len = v.len } },
-            .stable => |v| .{ .write_stable = .{ .data = v } },
+            .stable => |v| .{ .write_stable = v },
             .alloc => |v| .{ .write_alloc = .{ .alloc = v.alloc, .data = v.data } },
         }, .unlocked);
     } else {
@@ -3188,7 +3188,7 @@ fn endKeySequence(
         .flush => for (self.keyboard.sequence_queued.items) |write_req| {
             self.queueIo(switch (write_req) {
                 .small => |v| .{ .write_small = .{ .data = v.data, .len = v.len } },
-                .stable => |v| .{ .write_stable = .{ .data = v } },
+                .stable => |v| .{ .write_stable = v },
                 .alloc => |v| .{ .write_alloc = .{ .alloc = v.alloc, .data = v.data } },
             }, .unlocked);
         },
@@ -3581,7 +3581,7 @@ pub fn scrollCallback(
                     };
                 };
                 for (0..y.magnitude()) |_| {
-                    self.queueIo(.{ .write_stable = .{ .data = seq } }, .locked);
+                    self.queueIo(.{ .write_stable = seq }, .locked);
                 }
             }
 
@@ -4276,13 +4276,13 @@ fn maybePromptClick(self: *Surface) !bool {
             const move = screen.promptClickMove(click_pin);
             for (0..move.left) |_| {
                 self.queueIo(
-                    .{ .write_stable = .{ .data = left_arrow } },
+                    .{ .write_stable = left_arrow },
                     .locked,
                 );
             }
             for (0..move.right) |_| {
                 self.queueIo(
-                    .{ .write_stable = .{ .data = right_arrow } },
+                    .{ .write_stable = right_arrow },
                     .locked,
                 );
             }
@@ -4901,9 +4901,9 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             };
 
             if (normal) {
-                self.queueIo(.{ .write_stable = .{ .data = ck.normal } }, .unlocked);
+                self.queueIo(.{ .write_stable = ck.normal }, .unlocked);
             } else {
-                self.queueIo(.{ .write_stable = .{ .data = ck.application } }, .unlocked);
+                self.queueIo(.{ .write_stable = ck.application }, .unlocked);
             }
         },
 

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -45,7 +45,9 @@ pub const Mode = enum { conpty };
 /// Arguments to `Pty.open`.
 pub const Options = struct {
     size: winsize,
-    /// Windows-only. Ignored on POSIX.
+    /// Transport mode. ConPTY is the only transport today, so this field
+    /// has a single value and is ignored on every platform; retained for
+    /// cross-platform call-shape parity (see `Mode`).
     mode: Mode = .conpty,
 };
 
@@ -374,7 +376,6 @@ const WindowsPty = struct {
     /// pair is created in `open`.
     pseudo_console: ?windows.exp.HPCON,
     size: winsize,
-    mode: Mode,
 
     /// Build a UTF-16 path string for `<exe-dir>\conpty.dll`. Returns
     /// null if the executable path can't be queried, has no parent
@@ -549,7 +550,6 @@ const WindowsPty = struct {
         try windows.SetHandleInformation(pty.out_pipe_pty, windows.HANDLE_FLAG_INHERIT, 0);
 
         pty.size = size;
-        pty.mode = opts.mode;
         pty.pseudo_console = null;
 
         // ConPTY is the sole Windows transport. Create the pseudoconsole
@@ -680,5 +680,4 @@ test "WindowsPty: conpty mode populates pseudo_console" {
     });
     defer pty.deinit();
     try std.testing.expect(pty.pseudo_console != null);
-    try std.testing.expectEqual(Mode.conpty, pty.mode);
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -189,9 +189,6 @@ pub fn threadEnter(
         .read_thread_pipe = pipe[1],
         .read_thread_fd = pty_fds.read,
         .termios_timer = termios_timer,
-        .shell_kind = if (comptime builtin.os.tag == .windows)
-            self.subprocess.resolved_shell_kind
-        else {},
     } };
 
     // On Windows, spawn a dedicated thread that blocks on WaitForSingleObject
@@ -483,13 +480,8 @@ pub fn queueWrite(
     td: *termio.Termio.ThreadData,
     data: []const u8,
     linefeed: bool,
-    kind: termio.Message.WriteKind,
 ) !void {
     _ = self;
-    // ConPTY is the sole Windows transport now, so VT responses always
-    // reach a real console handle and never need suppression. The
-    // write classification is therefore unused on the write path.
-    _ = kind;
     const exec = &td.backend.exec;
 
     // If our process is exited then we don't send any more writes.
@@ -625,13 +617,6 @@ pub const ThreadData = struct {
     /// to prevent unnecessary locking of expensive mutexes.
     termios_mode: ptypkg.TerminalMode = .{},
 
-    /// Resolved Windows shell identity for the running child. Captured
-    /// from `Subprocess.start` for diagnostics and any future per-shell
-    /// quirk gating. `null` on Windows when classification did not match
-    /// a known shell. Not meaningful on POSIX.
-    shell_kind: if (builtin.os.tag == .windows) ?internal_os.windows_shell.Kind else void =
-        if (builtin.os.tag == .windows) null else {},
-
     pub fn deinit(self: *ThreadData, alloc: Allocator) void {
         posix.close(self.read_thread_pipe);
 
@@ -697,15 +682,6 @@ const Subprocess = struct {
         configpkg.Config.Utf8Console
     else
         void = if (builtin.os.tag == .windows) .auto else {},
-
-    /// Resolved shell identity set by `start`. `null` until `start`
-    /// runs OR if classification did not match a known shell. Read by
-    /// `Exec.threadEnter` to populate `Exec.ThreadData.shell_kind`.
-    /// Windows-only.
-    resolved_shell_kind: if (builtin.os.tag == .windows)
-        ?internal_os.windows_shell.Kind
-    else
-        void = if (builtin.os.tag == .windows) null else {},
 
     rt_pre_exec_info: Command.RtPreExecInfo,
     rt_post_fork_info: Command.RtPostForkInfo,
@@ -1026,16 +1002,6 @@ const Subprocess = struct {
 
         // ConPTY is the sole Windows transport; POSIX ignores opts.mode.
         const mode: ptypkg.Mode = .conpty;
-
-        // Cache the resolved shell identity so the termio thread can read
-        // it from Exec.ThreadData without re-running classification (and
-        // without holding the renderer lock). args[0] is the shell
-        // executable path (bare basename or full path), never a joined
-        // command line; windows_shell.identify does not split tokens on
-        // spaces.
-        if (comptime builtin.os.tag == .windows) {
-            self.resolved_shell_kind = internal_os.windows_shell.identify(self.args[0]);
-        }
 
         // Create our pty
         var pty = try Pty.open(.{

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -358,7 +358,7 @@ pub fn threadEnter(
 
     // If we have inputs, then queue them all up.
     for (inputs orelse &.{}) |input| switch (input) {
-        .string => |v| self.queueWrite(data, v, false, .input) catch |err| {
+        .string => |v| self.queueWrite(data, v, false) catch |err| {
             log.warn("failed to queue input string err={}", .{err});
             return error.InputFailed;
         },
@@ -372,7 +372,6 @@ pub fn threadEnter(
                 return error.InputFailed;
             },
             false,
-            .input,
         ) catch |err| {
             log.warn("failed to queue input file err={}", .{err});
             return error.InputFailed;
@@ -409,21 +408,13 @@ pub fn queueMessage(
 /// mailbox messages instead.
 ///
 /// If you're not using termio.Thread, this is not threadsafe.
-///
-/// `kind` classifies the write (see `termio.Message.WriteKind`). The
-/// classification is currently advisory — no backend acts on it today
-/// (it once drove response suppression under the raw-pipe transport,
-/// which no longer exists). Pass `.input` for user-driven writes
-/// (keystrokes, paste, focus events, scripted inputs) and `.response`
-/// for parser-driven replies to child queries.
 pub inline fn queueWrite(
     self: *Termio,
     td: *ThreadData,
     data: []const u8,
     linefeed: bool,
-    kind: termio.Message.WriteKind,
 ) !void {
-    try self.backend.queueWrite(self.alloc, td, data, linefeed, kind);
+    try self.backend.queueWrite(self.alloc, td, data, linefeed);
 }
 
 /// Update the configuration.
@@ -537,7 +528,7 @@ fn sizeReportLocked(self: *Termio, td: *ThreadData, style: termio.Message.SizeRe
         report_size,
     );
 
-    try self.queueWrite(td, writer.buffered(), false, .response);
+    try self.queueWrite(td, writer.buffered(), false);
 }
 
 /// Reset the synchronized output mode. This is usually called by timer
@@ -601,8 +592,7 @@ pub fn clearScreen(self: *Termio, td: *ThreadData, history: bool) !void {
     }
 
     // If we reached here it means we're at a prompt, so we send a form-feed.
-    // This is user-driven (the user invoked clear-screen) so it's `.input`.
-    try self.queueWrite(td, &[_]u8{0x0C}, false, .input);
+    try self.queueWrite(td, &[_]u8{0x0C}, false);
 }
 
 /// Scroll the viewport
@@ -640,9 +630,7 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
             log.err("error encoding focus event err={}", .{err});
             return;
         };
-        // Focus events are triggered by user/window-manager focus changes,
-        // not by a child VT query, so they're classified as `.input`.
-        try self.queueWrite(td, writer.buffered(), false, .input);
+        try self.queueWrite(td, writer.buffered(), false);
     }
 
     // We always notify our backend of focus changes.
@@ -728,7 +716,7 @@ pub fn colorSchemeReportLocked(self: *Termio, td: *ThreadData, force: bool) !voi
         .light => "\x1B[?997;2n",
         .dark => "\x1B[?997;1n",
     };
-    try self.queueWrite(td, output, false, .response);
+    try self.queueWrite(td, output, false);
 }
 
 /// ThreadData is the data created and stored in the termio thread

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -337,13 +337,11 @@ fn drainMailbox(
                 data,
                 v.data[0..v.len],
                 self.flags.linefeed_mode,
-                v.kind,
             ),
             .write_stable => |v| try io.queueWrite(
                 data,
-                v.data,
+                v,
                 self.flags.linefeed_mode,
-                v.kind,
             ),
             .write_alloc => |v| {
                 defer v.alloc.free(v.data);
@@ -351,7 +349,6 @@ fn drainMailbox(
                     data,
                     v.data,
                     self.flags.linefeed_mode,
-                    v.kind,
                 );
             },
         }

--- a/src/termio/backend.zig
+++ b/src/termio/backend.zig
@@ -79,10 +79,9 @@ pub const Backend = union(Kind) {
         td: *termio.Termio.ThreadData,
         data: []const u8,
         linefeed: bool,
-        kind: termio.Message.WriteKind,
     ) !void {
         switch (self.*) {
-            .exec => |*exec| try exec.queueWrite(alloc, td, data, linefeed, kind),
+            .exec => |*exec| try exec.queueWrite(alloc, td, data, linefeed),
         }
     }
 

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -16,45 +16,6 @@ pub const Message = union(enum) {
     /// in the future.
     pub const WriteReq = MessageData(u8, 38);
 
-    /// Classification of a pty write so the termio thread can decide
-    /// whether to deliver it to the child. Historically used on Windows
-    /// to suppress VT response bytes under the raw-pipe transport; with
-    /// ConPTY as the sole Windows transport, responses always reach a
-    /// real console handle, so the classification is currently advisory.
-    ///
-    /// The default is `.input` so writes that aren't explicitly tagged
-    /// (keystrokes, paste, mouse events, focus events, anything user-
-    /// driven) pass through unchanged.
-    pub const WriteKind = enum {
-        /// User-driven write: keystrokes, paste, mouse events, focus
-        /// events, anything that should always reach the child.
-        input,
-        /// Reply to a parser-driven query from the child (cursor
-        /// position, device attributes, color queries, etc.).
-        response,
-    };
-
-    /// Wrappers around the three `WriteReq` variants that carry an
-    /// extra `kind` tag (see `WriteKind`). Field names match
-    /// `WriteReq.Small`/`WriteReq.Alloc` so call sites that don't care
-    /// about `kind` keep working unchanged via the default.
-    pub const WriteSmallReq = struct {
-        data: WriteReq.Small.Array = undefined,
-        len: WriteReq.Small.Len = 0,
-        kind: WriteKind = .input,
-    };
-
-    pub const WriteStableReq = struct {
-        data: []const u8,
-        kind: WriteKind = .input,
-    };
-
-    pub const WriteAllocReq = struct {
-        alloc: Allocator,
-        data: []u8,
-        kind: WriteKind = .input,
-    };
-
     /// Request a color scheme report is sent to the pty.
     color_scheme_report: struct {
         /// Force write the current color scheme
@@ -113,26 +74,22 @@ pub const Message = union(enum) {
     focused: bool,
 
     /// Write where the data fits in the union.
-    write_small: WriteSmallReq,
+    write_small: WriteReq.Small,
 
     /// Write where the data pointer is stable.
-    write_stable: WriteStableReq,
+    write_stable: WriteReq.Stable,
 
     /// Write where the data is allocated and must be freed.
-    write_alloc: WriteAllocReq,
+    write_alloc: WriteReq.Alloc,
 
     /// Return a write request for the given data. This will use
     /// write_small if it fits or write_alloc otherwise. This should NOT
     /// be used for stable pointers which can be manually set to write_stable.
-    ///
-    /// The resulting message is tagged as `.input`. Callers that want to
-    /// tag the write as a parser-driven response should set
-    /// `.kind = .response` on the resulting variant before sending.
     pub fn writeReq(alloc: Allocator, data: anytype) !Message {
         return switch (try WriteReq.init(alloc, data)) {
             .stable => unreachable,
-            .small => |v| Message{ .write_small = .{ .data = v.data, .len = v.len } },
-            .alloc => |v| Message{ .write_alloc = .{ .alloc = v.alloc, .data = v.data } },
+            .small => |v| Message{ .write_small = v },
+            .alloc => |v| Message{ .write_alloc = v },
         };
     }
 
@@ -146,11 +103,6 @@ test {
 
 test {
     // Ensure we don't grow our IO message size without explicitly wanting to.
-    // Layout on 64-bit:
-    //   - payload max = WriteAllocReq = Allocator(16) + []u8(16) + WriteKind(1)
-    //     padded to 40 bytes
-    //   - union tag = 1 byte, padded to 8 for natural alignment
-    //   => total = 48 bytes
     const testing = std.testing;
-    try testing.expectEqual(@as(usize, 48), @sizeOf(Message));
+    try testing.expectEqual(@as(usize, 40), @sizeOf(Message));
 }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -155,21 +155,6 @@ pub const StreamHandler = struct {
         self.termio_messaged = true;
     }
 
-    /// Mutate a `Message` produced by `Message.writeReq` so its write
-    /// variant is tagged as a parser-driven response. The tag is
-    /// currently advisory: no backend acts on it today (it was once
-    /// used to suppress responses under the raw-pipe transport, which
-    /// no longer exists). Kept for diagnostics and future per-shell
-    /// quirk gating (see `WriteKind`).
-    inline fn tagResponse(msg: *termio.Message) void {
-        switch (msg.*) {
-            .write_small => |*v| v.kind = .response,
-            .write_stable => |*v| v.kind = .response,
-            .write_alloc => |*v| v.kind = .response,
-            else => unreachable, // Message.writeReq only returns write variants
-        }
-    }
-
     /// Send a renderer message and unlock the renderer state mutex
     /// if necessary to ensure we don't deadlock.
     ///
@@ -490,11 +475,10 @@ pub const StreamHandler = struct {
                         .command => |command| {
                             assert(command.len > 0);
                             assert(command[command.len - 1] == '\n');
-                            var msg = try termio.Message.writeReq(
+                            const msg = try termio.Message.writeReq(
                                 self.alloc,
                                 command,
                             );
-                            tagResponse(&msg);
                             self.messageWriter(msg);
                         },
 
@@ -509,10 +493,7 @@ pub const StreamHandler = struct {
                 const map = comptime terminfo.ghostty.xtgettcapMap();
                 while (gettcap.next()) |key| {
                     const response = map.get(key) orelse continue;
-                    self.messageWriter(.{ .write_stable = .{
-                        .data = response,
-                        .kind = .response,
-                    } });
+                    self.messageWriter(.{ .write_stable = response });
                 }
             },
 
@@ -583,8 +564,7 @@ pub const StreamHandler = struct {
 
                 // Write the response prefix into the buffer
                 _ = try std.fmt.bufPrint(response[0..prefix_len], prefix_fmt, .{@intFromBool(valid)});
-                var msg = try termio.Message.writeReq(self.alloc, response[0..stream.pos]);
-                tagResponse(&msg);
+                const msg = try termio.Message.writeReq(self.alloc, response[0..stream.pos]);
                 self.messageWriter(msg);
             },
 
@@ -633,8 +613,7 @@ pub const StreamHandler = struct {
                     const final = writer.buffered();
                     if (final.len > 2) {
                         log.debug("kitty graphics response: {x}", .{final});
-                        var msg = try termio.Message.writeReq(self.alloc, final);
-                        tagResponse(&msg);
+                        const msg = try termio.Message.writeReq(self.alloc, final);
                         self.messageWriter(msg);
                     }
                 }
@@ -707,7 +686,6 @@ pub const StreamHandler = struct {
         self.messageWriter(.{ .write_small = .{
             .data = data,
             .len = @intCast(writer.buffered().len),
-            .kind = .response,
         } });
     }
 
@@ -902,20 +880,14 @@ pub const StreamHandler = struct {
                 //  4 = Sixel graphics
                 // 22 = Color text
                 // 52 = Clipboard access
-                .write_stable = .{
-                    .data = if (self.clipboard_write != .deny)
-                        "\x1B[?62;4;22;52c"
-                    else
-                        "\x1B[?62;4;22c",
-                    .kind = .response,
-                },
+                .write_stable = if (self.clipboard_write != .deny)
+                    "\x1B[?62;4;22;52c"
+                else
+                    "\x1B[?62;4;22c",
             }),
 
             .secondary => self.messageWriter(.{
-                .write_stable = .{
-                    .data = "\x1B[>1;10;0c",
-                    .kind = .response,
-                },
+                .write_stable = "\x1B[>1;10;0c",
             }),
 
             else => log.warn("unimplemented device attributes req: {}", .{req}),
@@ -927,10 +899,7 @@ pub const StreamHandler = struct {
         req: terminal.device_status.Request,
     ) !void {
         switch (req) {
-            .operating_status => self.messageWriter(.{ .write_stable = .{
-                .data = "\x1B[0n",
-                .kind = .response,
-            } }),
+            .operating_status => self.messageWriter(.{ .write_stable = "\x1B[0n" }),
 
             .cursor_position => {
                 const pos: struct {
@@ -954,7 +923,7 @@ pub const StreamHandler = struct {
                 // here -- see #367 for the investigation. Note that the
                 // mode 2048 in-band size report (`size_report.zig`) ends
                 // in `t`, not `R`, and may precede this one.
-                var msg: termio.Message = .{ .write_small = .{ .kind = .response } };
+                var msg: termio.Message = .{ .write_small = .{} };
                 const resp = try std.fmt.bufPrint(&msg.write_small.data, "\x1B[{};{}R", .{
                     pos.y + 1,
                     pos.x + 1,
@@ -1031,8 +1000,7 @@ pub const StreamHandler = struct {
 
     pub fn enquiry(self: *StreamHandler) !void {
         log.debug("sending enquiry response={s}", .{self.enquiry_response});
-        var msg = try termio.Message.writeReq(self.alloc, self.enquiry_response);
-        tagResponse(&msg);
+        const msg = try termio.Message.writeReq(self.alloc, self.enquiry_response);
         self.messageWriter(msg);
     }
 
@@ -1068,7 +1036,6 @@ pub const StreamHandler = struct {
             .write_small = .{
                 .data = data,
                 .len = @intCast(resp.len),
-                .kind = .response,
             },
         });
     }
@@ -1086,8 +1053,7 @@ pub const StreamHandler = struct {
                 build_config.version_string,
             },
         );
-        var msg = try termio.Message.writeReq(self.alloc, resp);
-        tagResponse(&msg);
+        const msg = try termio.Message.writeReq(self.alloc, resp);
         self.messageWriter(msg);
     }
 
@@ -1535,8 +1501,7 @@ pub const StreamHandler = struct {
         if (response.items.len > 0) {
             // If any of the operations were reports, finalize the report
             // string and send it to the terminal.
-            var msg = try termio.Message.writeReq(self.alloc, response.items);
-            tagResponse(&msg);
+            const msg = try termio.Message.writeReq(self.alloc, response.items);
             self.messageWriter(msg);
         }
     }
@@ -1655,7 +1620,6 @@ pub const StreamHandler = struct {
                 .write_alloc = .{
                     .alloc = self.alloc,
                     .data = try stream.toOwnedSlice(),
-                    .kind = .response,
                 },
             });
         }


### PR DESCRIPTION
## What

Follow-up cleanup after #474 made ConPTY the sole Windows transport. With the raw-pipe bypass gone, VT responses always reach a real console handle and never need suppression, so the `WriteKind`/`.response` write-tagging pipeline had no remaining consumer. This removes the dead infrastructure.

## Per-field decisions

| Item | Decision | Why |
|---|---|---|
| `WriteKind` enum + `tagResponse` + `kind` plumbing | **Remove** | 100% fork divergence on hot cross-platform files maintained in the base ghostty tree; removing it reverts them toward that tree and reduces daily-rebase conflicts. Per-shell gating, if ever needed, belongs in Windows-only code, not threaded through shared signatures. |
| `Exec` `shell_kind` / `resolved_shell_kind` | **Remove** | Write-only once the bypass went away; Windows-only; re-derivable via `windows_shell.identify(args[0])`. |
| `WindowsPty.mode` stored field | **Remove** | Write-only; removing it matches the POSIX `Pty`, which never stored it. |
| `Mode` enum + `Options.mode` | **Keep** | Single-variant, but retained for cross-platform call-shape parity (comment refreshed to stay truthful). |

## Files

- `message.zig` / `Thread.zig` / `backend.zig`: reverted to the base ghostty tree (their only divergence was the `kind` plumbing).
- `Termio.zig`, `Exec.zig`, `stream_handler.zig`, `Surface.zig`: dropped the `kind` parameter, `tagResponse`, and every `.kind = .response` tag; `write_stable` returns to a bare slice.
- `pty.zig`: removed the write-only `WindowsPty.mode` field + its test assertion.

Net: 8 files, +38 / -173.

## Test

`zig build test -Dapp-runtime=none` on Windows (zig 0.15.2): **3085 passed, 55 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)