### PR TITLE
fix(config): empty value defers to theme instead of compile default (#228)

### DIFF
--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -513,6 +513,8 @@ pub fn isEmptyScalarReset(comptime T: type, arg: []const u8) bool {
             // value, so they are intentionally left alone.
             if (@typeInfo(field.type) == .optional) return false;
 
+            // Optionals already returned above, so field.type is the
+            // unwrapped type that parseIntoField's empty-value branch keys on.
             const fieldInfo = @typeInfo(field.type);
             const canHaveDecls = fieldInfo == .@"struct" or
                 fieldInfo == .@"union" or
@@ -981,6 +983,7 @@ test "isEmptyScalarReset" {
 
     const S = struct {
         foo: u8 = 5,
+        nodefault: u8,
         bar: ?u8 = null,
         list: struct {
             const Self = @This();
@@ -989,6 +992,7 @@ test "isEmptyScalarReset" {
                 self.* = .{};
             }
         } = .{},
+        vd: void = {},
         _hidden: u8 = 0,
     };
 
@@ -998,11 +1002,17 @@ test "isEmptyScalarReset" {
     // Non-empty value is not a reset.
     try testing.expect(!isEmptyScalarReset(S, "--foo=3"));
 
+    // A non-optional field without a compile-time default has no reset path.
+    try testing.expect(!isEmptyScalarReset(S, "--nodefault="));
+
     // Optional fields reset to null and are intentionally excluded.
     try testing.expect(!isEmptyScalarReset(S, "--bar="));
 
     // init-clearing list types are excluded.
     try testing.expect(!isEmptyScalarReset(S, "--list="));
+
+    // void fields carry no value and are skipped.
+    try testing.expect(!isEmptyScalarReset(S, "--vd="));
 
     // Missing value (no "=") is not a reset.
     try testing.expect(!isEmptyScalarReset(S, "--foo"));

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -471,6 +471,67 @@ pub fn parseIntoField(
     return error.InvalidField;
 }
 
+/// Returns true if applying `arg` (in `--key=value` form) would reset a
+/// non-optional scalar field of `T` to its compile-time default purely
+/// because the value is the empty string.
+///
+/// This mirrors the empty-value branch of `parseIntoField`: only fields that
+/// take the `default_value_ptr` reset path qualify. Optional fields (which
+/// reset to `null`, their natural "unset") and `init`-clearing list types
+/// (e.g. font-family) are excluded so their existing semantics are preserved.
+///
+/// Callers use this to let an empty value defer to a lower configuration layer
+/// (such as a theme) instead of clobbering it with the compile-time default.
+/// See Config.loadTheme for the motivating case.
+pub fn isEmptyScalarReset(comptime T: type, arg: []const u8) bool {
+    const info = @typeInfo(T);
+    if (info != .@"struct") return false;
+
+    // Args from the CLI and from the file LineIterator both arrive in
+    // "--key=value" form. Anything else can't be an empty reset.
+    if (!mem.startsWith(u8, arg, "--")) return false;
+
+    var key: []const u8 = arg[2..];
+    const value: ?[]const u8 = value: {
+        if (mem.indexOf(u8, key, "=")) |idx| {
+            defer key = key[0..idx];
+            break :value key[idx + 1 ..];
+        }
+
+        break :value null;
+    };
+
+    // Only a present-but-empty value is a reset. A missing value (no "=")
+    // is "value required", not a reset.
+    const v = value orelse return false;
+    if (v.len != 0) return false;
+
+    inline for (info.@"struct".fields) |field| {
+        if (comptime field.type == void) continue;
+        if (field.name[0] != '_' and mem.eql(u8, field.name, key)) {
+            // Optional fields reset to null, which is their correct "unset"
+            // value, so they are intentionally left alone.
+            if (@typeInfo(field.type) == .optional) return false;
+
+            const fieldInfo = @typeInfo(field.type);
+            const canHaveDecls = fieldInfo == .@"struct" or
+                fieldInfo == .@"union" or
+                fieldInfo == .@"enum";
+
+            // init-clearing types keep their documented "empty means clear"
+            // semantics rather than deferring.
+            if (canHaveDecls and @hasDecl(field.type, "init")) return false;
+
+            // Only fields with a compile-time default actually take the reset
+            // path; without one the empty value falls through to normal
+            // parsing (typically an error), which is not a reset.
+            return field.default_value_ptr != null;
+        }
+    }
+
+    return false;
+}
+
 pub fn parseTaggedUnion(comptime T: type, alloc: Allocator, v: []const u8) !T {
     const info = @typeInfo(T).@"union";
     assert(@typeInfo(info.tag_type.?) == .@"enum");
@@ -913,6 +974,45 @@ test "parseIntoField: ignore underscore-prefixed fields" {
         parseIntoField(@TypeOf(data), alloc, &data, "_a", "42"),
     );
     try testing.expectEqualStrings("12", data._a);
+}
+
+test "isEmptyScalarReset" {
+    const testing = std.testing;
+
+    const S = struct {
+        foo: u8 = 5,
+        bar: ?u8 = null,
+        list: struct {
+            const Self = @This();
+            v: []const u8 = "",
+            pub fn init(self: *Self, _: Allocator) !void {
+                self.* = .{};
+            }
+        } = .{},
+        _hidden: u8 = 0,
+    };
+
+    // Non-optional scalar with empty value is a reset.
+    try testing.expect(isEmptyScalarReset(S, "--foo="));
+
+    // Non-empty value is not a reset.
+    try testing.expect(!isEmptyScalarReset(S, "--foo=3"));
+
+    // Optional fields reset to null and are intentionally excluded.
+    try testing.expect(!isEmptyScalarReset(S, "--bar="));
+
+    // init-clearing list types are excluded.
+    try testing.expect(!isEmptyScalarReset(S, "--list="));
+
+    // Missing value (no "=") is not a reset.
+    try testing.expect(!isEmptyScalarReset(S, "--foo"));
+
+    // Underscore-prefixed fields are not addressable.
+    try testing.expect(!isEmptyScalarReset(S, "--_hidden="));
+
+    // Unknown field and non "--" forms are not resets.
+    try testing.expect(!isEmptyScalarReset(S, "--nope="));
+    try testing.expect(!isEmptyScalarReset(S, "foo="));
 }
 
 test "parseIntoField: struct with init func" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -11580,3 +11580,46 @@ test "issue 228: empty foreground with no theme stays compile-time default" {
         .b = 0xFF,
     }, cfg.foreground);
 }
+
+test "issue 228: empty foreground via real config file defers to theme" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Exercise the real file-loading path (loadFile -> LineIterator) the app
+    // uses, rather than synthesizing CLI args. The user config sets a theme
+    // and an empty `foreground =`, which must defer to the theme color.
+    var td = try internal_os.TempDir.init();
+    defer td.deinit();
+    var buf: [4096]u8 = undefined;
+    {
+        var file = try td.dir.createFile("theme_with_colors", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.writeAll(@embedFile("testdata/theme_with_colors"));
+        try writer.end();
+    }
+    var theme_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const theme_path = try td.dir.realpath("theme_with_colors", &theme_buf);
+
+    {
+        var file = try td.dir.createFile("config", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.print("theme = {s}\n", .{theme_path});
+        try writer.interface.writeAll("foreground =\n");
+        try writer.end();
+    }
+    var cfg_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cfg_path = try td.dir.realpath("config", &cfg_buf);
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+    try cfg.loadFile(alloc, cfg_path);
+    try cfg.finalize();
+
+    try testing.expectEqual(Color{
+        .r = 0xAA,
+        .g = 0xBB,
+        .b = 0xCC,
+    }, cfg.foreground);
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4576,8 +4576,11 @@ fn loadTheme(self: *Config, theme: Theme) !void {
     }
 
     // Replay our previous inputs so that we can override values
-    // from the theme.
+    // from the theme. Empty scalar resets (`key =`) are skipped here so they
+    // defer to the theme rather than resetting to the compile-time default;
+    // this only applies to the theme overlay, not the initial load.
     var slice_it = Replay.iterator(self._replay_steps.items, &new_config);
+    slice_it.skip_empty_resets = true;
     try new_config.loadIter(alloc_gpa, &slice_it);
 
     // Success, swap our new config in and free the old.
@@ -5268,6 +5271,12 @@ const Replay = struct {
         slice: []const Replay.Step,
         idx: usize = 0,
 
+        /// When set, replay steps that would reset a non-optional scalar
+        /// field to its compile-time default via an empty value are skipped.
+        /// This lets `key =` defer to a lower configuration layer (the theme)
+        /// instead of clobbering it. See loadTheme.
+        skip_empty_resets: bool = false,
+
         pub fn next(self: *Self) ?[]const u8 {
             while (true) {
                 if (self.idx >= self.slice.len) return null;
@@ -5304,10 +5313,18 @@ const Replay = struct {
                             }
                         }
 
+                        if (self.skip_empty_resets and
+                            cli.args.isEmptyScalarReset(Config, v.arg)) continue;
+
                         return v.arg;
                     },
 
-                    .arg => |arg| return arg,
+                    .arg => |arg| {
+                        if (self.skip_empty_resets and
+                            cli.args.isEmptyScalarReset(Config, arg)) continue;
+
+                        return arg;
+                    },
                     .@"-e" => return "-e",
                 }
             }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -11307,3 +11307,259 @@ test "compatibility: window new-window" {
         );
     }
 }
+
+// Issue #228: an empty config value (e.g. "foreground =") for a non-optional
+// field should defer to the active theme, not reset to the compile-time
+// default. Config loading is `defaults -> theme -> user-config replay`; the
+// fix skips re-applying empty scalar resets during the theme overlay replay so
+// the theme value survives. Optional fields (reset to null) and list/clear
+// fields keep their existing semantics.
+
+test "issue 228: empty foreground after theme defers to theme value" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const alloc_arena = arena.allocator();
+
+    var td = try internal_os.TempDir.init();
+    defer td.deinit();
+    var buf: [4096]u8 = undefined;
+    {
+        var file = try td.dir.createFile("theme_with_colors", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.writeAll(@embedFile("testdata/theme_with_colors"));
+        try writer.end();
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try td.dir.realpath("theme_with_colors", &path_buf);
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    // User config: set the theme, then write "foreground =" (empty value).
+    // The empty value must defer to the theme's foreground (#AABBCC) rather
+    // than resetting to the compile-time default (#FFFFFF).
+    var it: TestIterator = .{ .data = &.{
+        try std.fmt.allocPrint(alloc_arena, "--theme={s}", .{path}),
+        "--foreground=",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(Color{
+        .r = 0xAA,
+        .g = 0xBB,
+        .b = 0xCC,
+    }, cfg.foreground);
+}
+
+test "issue 228: empty selection-background after theme resets optional to null" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const alloc_arena = arena.allocator();
+
+    var td = try internal_os.TempDir.init();
+    defer td.deinit();
+    var buf: [4096]u8 = undefined;
+    {
+        var file = try td.dir.createFile("theme_with_colors", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.writeAll(@embedFile("testdata/theme_with_colors"));
+        try writer.end();
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try td.dir.realpath("theme_with_colors", &path_buf);
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    // Optional fields use null as their "unset" sentinel, so an empty value
+    // resetting to null is the correct existing behavior and is out of scope
+    // for the #228 fix. This documents that the fix does NOT change them.
+    var it: TestIterator = .{ .data = &.{
+        try std.fmt.allocPrint(alloc_arena, "--theme={s}", .{path}),
+        "--selection-background=",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(@as(?TerminalColor, null), cfg.@"selection-background");
+}
+
+test "issue 228: empty cursor-color after theme resets optional to null" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const alloc_arena = arena.allocator();
+
+    var td = try internal_os.TempDir.init();
+    defer td.deinit();
+    var buf: [4096]u8 = undefined;
+    {
+        var file = try td.dir.createFile("theme_with_colors", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.writeAll(@embedFile("testdata/theme_with_colors"));
+        try writer.end();
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try td.dir.realpath("theme_with_colors", &path_buf);
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    // Same as selection-background: optional, so null is correct and unchanged.
+    var it: TestIterator = .{ .data = &.{
+        try std.fmt.allocPrint(alloc_arena, "--theme={s}", .{path}),
+        "--cursor-color=",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(@as(?TerminalColor, null), cfg.@"cursor-color");
+}
+
+test "issue 228: empty palette after theme defers to theme palette" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const alloc_arena = arena.allocator();
+
+    var td = try internal_os.TempDir.init();
+    defer td.deinit();
+    var buf: [4096]u8 = undefined;
+    {
+        var file = try td.dir.createFile("theme_with_colors", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.writeAll(@embedFile("testdata/theme_with_colors"));
+        try writer.end();
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try td.dir.realpath("theme_with_colors", &path_buf);
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    // Palette is a non-optional struct without an `init` clear decl, so an
+    // empty "palette =" takes the compile-time-default reset path just like a
+    // scalar. With the #228 fix it therefore defers to the theme's palette
+    // (index 0 = #ABCDEF) instead of discarding the theme.
+    var it: TestIterator = .{ .data = &.{
+        try std.fmt.allocPrint(alloc_arena, "--theme={s}", .{path}),
+        "--palette=",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(
+        terminal.color.RGB{ .r = 0xAB, .g = 0xCD, .b = 0xEF },
+        cfg.palette.value[0],
+    );
+    try testing.expect(cfg.palette.mask.isSet(0));
+}
+
+test "issue 228: theme foreground preserved when no empty foreground written" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const alloc_arena = arena.allocator();
+
+    var td = try internal_os.TempDir.init();
+    defer td.deinit();
+    var buf: [4096]u8 = undefined;
+    {
+        var file = try td.dir.createFile("theme_with_colors", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.writeAll(@embedFile("testdata/theme_with_colors"));
+        try writer.end();
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try td.dir.realpath("theme_with_colors", &path_buf);
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    // Control: with no "foreground =" line the theme's foreground is preserved.
+    var it: TestIterator = .{ .data = &.{
+        try std.fmt.allocPrint(alloc_arena, "--theme={s}", .{path}),
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(Color{
+        .r = 0xAA,
+        .g = 0xBB,
+        .b = 0xCC,
+    }, cfg.foreground);
+}
+
+test "issue 228: non-empty foreground still overrides theme" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var arena = ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const alloc_arena = arena.allocator();
+
+    var td = try internal_os.TempDir.init();
+    defer td.deinit();
+    var buf: [4096]u8 = undefined;
+    {
+        var file = try td.dir.createFile("theme_with_colors", .{});
+        defer file.close();
+        var writer = file.writer(&buf);
+        try writer.interface.writeAll(@embedFile("testdata/theme_with_colors"));
+        try writer.end();
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try td.dir.realpath("theme_with_colors", &path_buf);
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    // A real (non-empty) user value must still win over the theme.
+    var it: TestIterator = .{ .data = &.{
+        try std.fmt.allocPrint(alloc_arena, "--theme={s}", .{path}),
+        "--foreground=#123456",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(Color{
+        .r = 0x12,
+        .g = 0x34,
+        .b = 0x56,
+    }, cfg.foreground);
+}
+
+test "issue 228: empty foreground with no theme stays compile-time default" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+
+    // With no theme there is no lower layer to defer to, so an empty value
+    // keeps the compile-time default (#FFFFFF). This guards against the skip
+    // logic leaking into the non-theme path.
+    var it: TestIterator = .{ .data = &.{
+        "--foreground=",
+    } };
+    try cfg.loadIter(alloc, &it);
+    try cfg.finalize();
+
+    try testing.expectEqual(Color{
+        .r = 0xFF,
+        .g = 0xFF,
+        .b = 0xFF,
+    }, cfg.foreground);
+}

--- a/src/config/testdata/theme_with_colors
+++ b/src/config/testdata/theme_with_colors
@@ -1,0 +1,6 @@
+# Theme that sets various color fields for empty-value override testing
+foreground = #AABBCC
+background = #112233
+selection-background = #445566
+cursor-color = #778899
+palette = 0=#ABCDEF


### PR DESCRIPTION
## Summary

Fixes #228. Writing `foreground =` (a key with an **empty value**) reset the field to its compile-time default (white `#FFFFFF`) instead of deferring to the active theme.

Config loading is `defaults → theme → user-config replay`. During `loadTheme()` the user config is replayed on top of the theme, so the empty value's reset-to-default clobbered the theme color.

## Approach

Distinguish an explicitly-empty value for a **non-optional scalar** field from a real override, and skip re-applying it **only during the theme overlay replay** so it defers to the theme. The initial (non-theme) load is unchanged; with no theme there is no lower layer, so the field keeps its compile-time default as before.

Out of scope by design (existing semantics preserved):
- **Optional fields** (`cursor-color`, `selection-background`) reset to `null`, their natural "unset" value.
- **`init`-clearing list types** keep their documented "empty means clear".

`palette` is a non-optional struct **without** an `init` decl, so it took the same compile-time-default reset path as a scalar — under this fix it now defers to the theme's palette too, which is the more intuitive behavior (clearing your palette override with a theme active yields the theme's palette, not hardcoded ANSI).

## Changes

- **`src/cli/args.zig`** — `isEmptyScalarReset(comptime T, arg)` detector that mirrors `parseIntoField`'s empty-value branch (single source of truth for what counts as a reset). + focused unit test.
- **`src/config/Config.zig`** — opt-in `skip_empty_resets` flag on `Replay.Iterator`, enabled only for the `loadTheme` overlay replay.
- **Tests** — re-landed the fixture + 5 tests stranded in dangling commit `5fd9cfe5e` (assertions set to fixed behavior), plus guards for non-empty override and the no-theme path.

## Behavior matrix

| Config (with theme that sets the field) | Before | After |
|---|---|---|
| `foreground =` (empty) | white `#FFFFFF` | theme value ✅ |
| `foreground = #123456` | `#123456` | `#123456` (unchanged) |
| `palette =` (empty) | default ANSI | theme palette ✅ |
| `cursor-color =` / `selection-background =` (optional) | `null` | `null` (unchanged) |
| `foreground =` with **no theme** | compile default | compile default (unchanged) |

## Notes

- Shared core Zig — keep clean as a candidate to propose to mainline.
- Tested with pinned zig `0.15.2`: `zig build test -Dapp-runtime=none` (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)