### PR TITLE
panes: undo/redo for split/close/equalize/resize/zoom (#166)

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -90,4 +90,10 @@ public enum PaneAction
     // Open the read-only keyboard-shortcuts cheat sheet. Routed via event to
     // MainWindow, which shows the cheat sheet dialog (needs an XamlRoot/HWND).
     ShowKeybindCheatsheet = 49,
+
+    // Pane undo/redo (#166). Apprt-only: libghostty has no Windows undo
+    // implementation, so these are matched in KeyBindings.WindowsOnly and
+    // dispatched to PaneHost.Undo/Redo. Time-bounded (~5s) snapshot stack.
+    Undo = 50,
+    Redo = 51,
 }

--- a/windows/Ghostty.Core/Panes/PaneHistory.cs
+++ b/windows/Ghostty.Core/Panes/PaneHistory.cs
@@ -76,5 +76,51 @@ internal sealed class PaneHistory
         return entry.Snapshot;
     }
 
-    // Eviction added in Task 4.
+    /// <summary>
+    /// Drop entries (from either stack) whose age exceeds the timeout.
+    /// Returns the leaves that were referenced ONLY by evicted entries
+    /// (candidates for surface disposal). The caller must still exclude
+    /// any leaf present in the live tree before tearing it down.
+    /// </summary>
+    public IReadOnlyList<LeafPane> Prune(DateTimeOffset now)
+    {
+        var evicted = new List<Entry>();
+        RemoveExpired(_undo, now, evicted);
+        RemoveExpired(_redo, now, evicted);
+        if (evicted.Count == 0) return Array.Empty<LeafPane>();
+        return OrphansOf(evicted);
+    }
+
+    /// <summary>Drop everything; return every leaf any entry referenced.</summary>
+    public IReadOnlyList<LeafPane> Clear()
+    {
+        var all = _undo.Concat(_redo).ToList();
+        _undo.Clear();
+        _redo.Clear();
+        if (all.Count == 0) return Array.Empty<LeafPane>();
+        return LeavesOf(all).Distinct().ToList();
+    }
+
+    private void RemoveExpired(List<Entry> stack, DateTimeOffset now, List<Entry> evicted)
+    {
+        for (var i = stack.Count - 1; i >= 0; i--)
+        {
+            if (now - stack[i].Stamp < _timeout) continue;
+            evicted.Add(stack[i]);
+            stack.RemoveAt(i);
+        }
+    }
+
+    // Leaves in evicted entries that no surviving entry still references.
+    private IReadOnlyList<LeafPane> OrphansOf(List<Entry> evicted)
+    {
+        var survivors = LeavesOf(_undo.Concat(_redo)).ToHashSet();
+        return LeavesOf(evicted)
+            .Where(l => !survivors.Contains(l))
+            .Distinct()
+            .ToList();
+    }
+
+    private static IEnumerable<LeafPane> LeavesOf(IEnumerable<Entry> entries)
+        => entries.SelectMany(e => PaneTree.Leaves(e.Snapshot.Root));
 }

--- a/windows/Ghostty.Core/Panes/PaneHistory.cs
+++ b/windows/Ghostty.Core/Panes/PaneHistory.cs
@@ -22,6 +22,11 @@ internal sealed class PaneHistory
 {
     private readonly record struct Entry(PaneSnapshot Snapshot, DateTimeOffset Stamp);
 
+    // Only consecutive resizes WITHIN this window coalesce, so a held-chord
+    // burst collapses to one undo step while two deliberate, seconds-apart
+    // resizes stay independently undoable.
+    private static readonly TimeSpan ResizeCoalesceWindow = TimeSpan.FromMilliseconds(750);
+
     private readonly TimeProvider _time;
     private readonly TimeSpan _timeout;
     private readonly List<Entry> _undo = new(); // top == last
@@ -36,23 +41,40 @@ internal sealed class PaneHistory
     public bool CanUndo => _undo.Count > 0;
     public bool CanRedo => _redo.Count > 0;
 
-    /// <summary>Record the pre-op state. Clears redo. Coalesces a
-    /// resize that immediately follows another resize.</summary>
-    public void Push(PaneSnapshot pre)
+    /// <summary>
+    /// Record the pre-op state and clear the redo stack (a new op
+    /// invalidates redo). Consecutive resizes within
+    /// <see cref="ResizeCoalesceWindow"/> coalesce into the earliest
+    /// pre-burst snapshot.
+    ///
+    /// Returns the leaves orphaned by clearing redo: a redo entry can be
+    /// the SOLE reference keeping a closed/split-away pane's surface alive
+    /// (e.g. Split then Undo leaves the new pane reachable only via redo).
+    /// Dropping it here without disposal would leak the libghostty surface
+    /// and its shell forever, so the caller must tear those leaves down
+    /// (excluding any still in the live tree).
+    /// </summary>
+    public IReadOnlyList<LeafPane> Push(PaneSnapshot pre)
     {
+        var now = _time.GetUtcNow();
+        var clearedRedo = _redo.Count > 0 ? new List<Entry>(_redo) : null;
+
         if (pre.Kind == PaneOpKind.Resize
             && _undo.Count > 0
-            && _undo[^1].Snapshot.Kind == PaneOpKind.Resize)
+            && _undo[^1].Snapshot.Kind == PaneOpKind.Resize
+            && now - _undo[^1].Stamp < ResizeCoalesceWindow)
         {
             // Keep the earlier (pre-burst) snapshot; just refresh its
             // timestamp so the whole burst expires from the last nudge.
-            _undo[^1] = _undo[^1] with { Stamp = _time.GetUtcNow() };
-            _redo.Clear();
-            return;
+            _undo[^1] = _undo[^1] with { Stamp = now };
+        }
+        else
+        {
+            _undo.Add(new Entry(pre, now));
         }
 
-        _undo.Add(new Entry(pre, _time.GetUtcNow()));
         _redo.Clear();
+        return clearedRedo is null ? Array.Empty<LeafPane>() : OrphansOf(clearedRedo);
     }
 
     /// <summary>Pop the last undo entry; push <paramref name="current"/>

--- a/windows/Ghostty.Core/Panes/PaneHistory.cs
+++ b/windows/Ghostty.Core/Panes/PaneHistory.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ghostty.Core.Panes;
+
+/// <summary>
+/// Bounded undo/redo history of <see cref="PaneSnapshot"/>s for one
+/// <c>PaneHost</c>. Pure and host-free: time comes from an injected
+/// <see cref="TimeProvider"/> so eviction is deterministic in tests.
+///
+/// Snapshots are captured BEFORE a mutation. Undo swaps the current
+/// state onto the redo stack and returns the previous snapshot; redo is
+/// the mirror. A new push clears redo. Consecutive resize ops coalesce
+/// so a burst of divider nudges collapses to one undo step.
+///
+/// The history never disposes surfaces. <see cref="Prune"/>/<see cref="Clear"/>
+/// return leaves no longer referenced by any remaining entry; the host
+/// intersects that with the live tree before tearing surfaces down.
+/// </summary>
+internal sealed class PaneHistory
+{
+    private readonly record struct Entry(PaneSnapshot Snapshot, DateTimeOffset Stamp);
+
+    private readonly TimeProvider _time;
+    private readonly TimeSpan _timeout;
+    private readonly List<Entry> _undo = new(); // top == last
+    private readonly List<Entry> _redo = new();
+
+    public PaneHistory(TimeProvider time, TimeSpan timeout)
+    {
+        _time = time;
+        _timeout = timeout;
+    }
+
+    public bool CanUndo => _undo.Count > 0;
+    public bool CanRedo => _redo.Count > 0;
+
+    /// <summary>Record the pre-op state. Clears redo. Coalesces a
+    /// resize that immediately follows another resize.</summary>
+    public void Push(PaneSnapshot pre)
+    {
+        if (pre.Kind == PaneOpKind.Resize
+            && _undo.Count > 0
+            && _undo[^1].Snapshot.Kind == PaneOpKind.Resize)
+        {
+            // Keep the earlier (pre-burst) snapshot; just refresh its
+            // timestamp so the whole burst expires from the last nudge.
+            _undo[^1] = _undo[^1] with { Stamp = _time.GetUtcNow() };
+            _redo.Clear();
+            return;
+        }
+
+        _undo.Add(new Entry(pre, _time.GetUtcNow()));
+        _redo.Clear();
+    }
+
+    /// <summary>Pop the last undo entry; push <paramref name="current"/>
+    /// onto redo. Returns null when there is nothing to undo.</summary>
+    public PaneSnapshot? Undo(PaneSnapshot current)
+    {
+        if (_undo.Count == 0) return null;
+        var entry = _undo[^1];
+        _undo.RemoveAt(_undo.Count - 1);
+        _redo.Add(new Entry(current, _time.GetUtcNow()));
+        return entry.Snapshot;
+    }
+
+    /// <summary>Mirror of <see cref="Undo"/>.</summary>
+    public PaneSnapshot? Redo(PaneSnapshot current)
+    {
+        if (_redo.Count == 0) return null;
+        var entry = _redo[^1];
+        _redo.RemoveAt(_redo.Count - 1);
+        _undo.Add(new Entry(current, _time.GetUtcNow()));
+        return entry.Snapshot;
+    }
+
+    // Eviction added in Task 4.
+}

--- a/windows/Ghostty.Core/Panes/PaneSnapshot.cs
+++ b/windows/Ghostty.Core/Panes/PaneSnapshot.cs
@@ -1,0 +1,20 @@
+namespace Ghostty.Core.Panes;
+
+/// <summary>
+/// Which structural operation a <see cref="PaneSnapshot"/> precedes.
+/// Used by <see cref="PaneHistory"/> to coalesce resize bursts; the
+/// other kinds are recorded one entry per op.
+/// </summary>
+internal enum PaneOpKind { Split, Close, Equalize, Resize, Zoom }
+
+/// <summary>
+/// Immutable capture of the pane-tree model taken BEFORE an undoable
+/// operation mutates it. <see cref="Root"/> is a structural clone (see
+/// <see cref="PaneTree.Clone"/>) whose leaf identities match the live
+/// tree, so restoring it rebuilds the same TerminalControls.
+/// </summary>
+internal sealed record PaneSnapshot(
+    PaneNode Root,
+    LeafPane Active,
+    LeafPane? Zoomed,
+    PaneOpKind Kind);

--- a/windows/Ghostty.Core/Panes/PaneTree.cs
+++ b/windows/Ghostty.Core/Panes/PaneTree.cs
@@ -38,6 +38,28 @@ internal static class PaneTree
     }
 
     /// <summary>
+    /// Deep-clone the structure of <paramref name="root"/>: every
+    /// <see cref="SplitPane"/> becomes a NEW node copying orientation and
+    /// ratio, but every <see cref="LeafPane"/> is returned by the SAME
+    /// reference. Used to snapshot the tree for undo/redo without aliasing
+    /// the live tree's mutable split nodes, while keeping leaf identity so
+    /// the visual rebuild reuses the live TerminalControl/surface.
+    /// </summary>
+    public static PaneNode Clone(PaneNode root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        return root switch
+        {
+            SplitPane s => new SplitPane(
+                s.Orientation,
+                Clone(s.Child1),
+                Clone(s.Child2),
+                s.Ratio),
+            _ => root, // LeafPane: shared by reference
+        };
+    }
+
+    /// <summary>
     /// Return the leftmost (Child1-first) leaf reachable from
     /// <paramref name="root"/>. Used to pick the focus target after a
     /// pane closes.

--- a/windows/Ghostty.Tests/PaneHistoryTests.cs
+++ b/windows/Ghostty.Tests/PaneHistoryTests.cs
@@ -90,4 +90,81 @@ public sealed class PaneHistoryTests
         h.Undo(Snap(PaneOpKind.Resize));
         Assert.True(h.CanUndo); // resize entry consumed, split remains
     }
+
+    [Fact]
+    public void Prune_RemovesEntriesOlderThanTimeout()
+    {
+        var time = new FakeTimeProvider();
+        var h = New(time, timeoutSeconds: 5);
+        h.Push(Snap(PaneOpKind.Split));
+
+        time.Now = time.Now.AddSeconds(6); // past the 5s window
+        h.Prune(time.Now);
+
+        Assert.False(h.CanUndo);
+    }
+
+    [Fact]
+    public void Prune_KeepsFreshEntries()
+    {
+        var time = new FakeTimeProvider();
+        var h = New(time, timeoutSeconds: 5);
+        h.Push(Snap(PaneOpKind.Split));
+
+        time.Now = time.Now.AddSeconds(2);
+        h.Prune(time.Now);
+
+        Assert.True(h.CanUndo);
+    }
+
+    [Fact]
+    public void Prune_ReturnsLeavesUniqueToEvictedEntries()
+    {
+        var time = new FakeTimeProvider();
+        var h = New(time, timeoutSeconds: 5);
+
+        // A close snapshot whose tree still references the closed leaf.
+        var closed = new LeafPane();
+        var snap = new PaneSnapshot(closed, closed, null, PaneOpKind.Close);
+        h.Push(snap);
+
+        time.Now = time.Now.AddSeconds(6);
+        var orphans = h.Prune(time.Now);
+
+        Assert.Contains(closed, orphans);
+    }
+
+    [Fact]
+    public void Prune_DoesNotReturnLeavesStillReferencedByOtherEntries()
+    {
+        var time = new FakeTimeProvider();
+        var h = New(time, timeoutSeconds: 5);
+
+        var shared = new LeafPane();
+        h.Push(new PaneSnapshot(shared, shared, null, PaneOpKind.Close)); // entry A (old)
+        time.Now = time.Now.AddSeconds(3);
+        h.Push(new PaneSnapshot(shared, shared, null, PaneOpKind.Equalize)); // entry B (newer)
+
+        time.Now = time.Now.AddSeconds(3); // A is 6s old, B is 3s old
+        var orphans = h.Prune(time.Now);
+
+        Assert.DoesNotContain(shared, orphans); // still referenced by B
+    }
+
+    [Fact]
+    public void Clear_ReturnsAllReferencedLeaves()
+    {
+        var h = New();
+        var a = new LeafPane();
+        var b = new LeafPane();
+        h.Push(new PaneSnapshot(a, a, null, PaneOpKind.Close));
+        h.Push(new PaneSnapshot(b, b, null, PaneOpKind.Close));
+
+        var all = h.Clear();
+
+        Assert.Contains(a, all);
+        Assert.Contains(b, all);
+        Assert.False(h.CanUndo);
+        Assert.False(h.CanRedo);
+    }
 }

--- a/windows/Ghostty.Tests/PaneHistoryTests.cs
+++ b/windows/Ghostty.Tests/PaneHistoryTests.cs
@@ -92,6 +92,49 @@ public sealed class PaneHistoryTests
     }
 
     [Fact]
+    public void Push_ResizesFarApartInTime_NotCoalesced()
+    {
+        var time = new FakeTimeProvider();
+        var h = New(time);
+        h.Push(Snap(PaneOpKind.Resize));
+        time.Now = time.Now.AddSeconds(2); // beyond the coalesce window
+        h.Push(Snap(PaneOpKind.Resize));
+
+        h.Undo(Snap(PaneOpKind.Resize));
+        Assert.True(h.CanUndo); // two distinct gestures -> two undo steps
+    }
+
+    [Fact]
+    public void Push_ReturnsLeavesOrphanedByClearedRedo()
+    {
+        var h = New();
+        var a = new LeafPane();
+        var b = new LeafPane();
+
+        // Pre-split state references only A.
+        h.Push(new PaneSnapshot(a, a, null, PaneOpKind.Split));
+        // Undo pushes the post-split tree (A + B) onto redo; B is now
+        // reachable ONLY from the redo entry.
+        h.Undo(new PaneSnapshot(new SplitPane(PaneOrientation.Vertical, a, b), a, null, PaneOpKind.Split));
+
+        // A new op clears redo and must report B as orphaned (its surface
+        // would otherwise leak), but NOT A (still referenced by the new
+        // undo entry).
+        var orphans = h.Push(new PaneSnapshot(a, a, null, PaneOpKind.Close));
+
+        Assert.Contains(b, orphans);
+        Assert.DoesNotContain(a, orphans);
+    }
+
+    [Fact]
+    public void Push_NoRedoToClear_ReturnsEmpty()
+    {
+        var h = New();
+        var orphans = h.Push(Snap(PaneOpKind.Split));
+        Assert.Empty(orphans);
+    }
+
+    [Fact]
     public void Prune_RemovesEntriesOlderThanTimeout()
     {
         var time = new FakeTimeProvider();

--- a/windows/Ghostty.Tests/PaneHistoryTests.cs
+++ b/windows/Ghostty.Tests/PaneHistoryTests.cs
@@ -1,0 +1,93 @@
+using System;
+using Ghostty.Core.Panes;
+using Xunit;
+
+namespace Ghostty.Tests;
+
+public sealed class PaneHistoryTests
+{
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        public DateTimeOffset Now = DateTimeOffset.UnixEpoch;
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private static PaneSnapshot Snap(PaneOpKind kind, LeafPane? active = null)
+        => new(new LeafPane(), active ?? new LeafPane(), null, kind);
+
+    private static PaneHistory New(FakeTimeProvider? time = null, double timeoutSeconds = 5)
+        => new(time ?? new FakeTimeProvider(), TimeSpan.FromSeconds(timeoutSeconds));
+
+    [Fact]
+    public void Push_ThenUndo_ReturnsPushedSnapshot()
+    {
+        var h = New();
+        var pre = Snap(PaneOpKind.Split);
+        h.Push(pre);
+
+        Assert.True(h.CanUndo);
+        var current = Snap(PaneOpKind.Split);
+        var restored = h.Undo(current);
+        Assert.Same(pre, restored);
+        Assert.False(h.CanUndo);
+        Assert.True(h.CanRedo);
+    }
+
+    [Fact]
+    public void Undo_Empty_ReturnsNull()
+    {
+        var h = New();
+        Assert.Null(h.Undo(Snap(PaneOpKind.Split)));
+    }
+
+    [Fact]
+    public void Redo_AfterUndo_ReturnsTheStateThatWasCurrentAtUndo()
+    {
+        var h = New();
+        h.Push(Snap(PaneOpKind.Split));
+        var atUndo = Snap(PaneOpKind.Split);
+        h.Undo(atUndo);
+
+        var atRedo = Snap(PaneOpKind.Split);
+        var restored = h.Redo(atRedo);
+        Assert.Same(atUndo, restored); // redo restores what was live when we undid
+        Assert.True(h.CanUndo);
+        Assert.False(h.CanRedo);
+    }
+
+    [Fact]
+    public void Push_ClearsRedoStack()
+    {
+        var h = New();
+        h.Push(Snap(PaneOpKind.Split));
+        h.Undo(Snap(PaneOpKind.Split));
+        Assert.True(h.CanRedo);
+
+        h.Push(Snap(PaneOpKind.Close));
+        Assert.False(h.CanRedo); // a new op invalidates redo
+    }
+
+    [Fact]
+    public void Push_CoalescesConsecutiveResizes()
+    {
+        var h = New();
+        h.Push(Snap(PaneOpKind.Resize)); // captures pre-burst ratios
+        h.Push(Snap(PaneOpKind.Resize)); // coalesced away
+        h.Push(Snap(PaneOpKind.Resize)); // coalesced away
+
+        h.Undo(Snap(PaneOpKind.Resize));
+        Assert.False(h.CanUndo); // single undo step back to pre-burst
+    }
+
+    [Fact]
+    public void Push_ResizeAfterNonResize_NotCoalesced()
+    {
+        var h = New();
+        h.Push(Snap(PaneOpKind.Split));
+        h.Push(Snap(PaneOpKind.Resize));
+        h.Push(Snap(PaneOpKind.Resize)); // coalesced into the prior resize
+
+        h.Undo(Snap(PaneOpKind.Resize));
+        Assert.True(h.CanUndo); // resize entry consumed, split remains
+    }
+}

--- a/windows/Ghostty.Tests/PaneTreeCloneTests.cs
+++ b/windows/Ghostty.Tests/PaneTreeCloneTests.cs
@@ -1,0 +1,58 @@
+using Ghostty.Core.Panes;
+using Xunit;
+
+namespace Ghostty.Tests;
+
+public sealed class PaneTreeCloneTests
+{
+    [Fact]
+    public void Clone_SingleLeaf_ReturnsSameLeafReference()
+    {
+        var leaf = new LeafPane();
+        var clone = PaneTree.Clone(leaf);
+        Assert.Same(leaf, clone); // leaf identities are preserved
+    }
+
+    [Fact]
+    public void Clone_Split_NewSplitNodeButSharedLeaves()
+    {
+        var l = new LeafPane();
+        var r = new LeafPane();
+        var root = new SplitPane(PaneOrientation.Vertical, l, r, ratio: 0.3);
+
+        var clone = (SplitPane)PaneTree.Clone(root);
+
+        Assert.NotSame(root, clone);                 // structural node is new
+        Assert.Equal(PaneOrientation.Vertical, clone.Orientation);
+        Assert.Equal(0.3, clone.Ratio);
+        Assert.Same(l, clone.Child1);                // leaves shared
+        Assert.Same(r, clone.Child2);
+    }
+
+    [Fact]
+    public void Clone_IsDeep_NestedSplitsAreNewNodes()
+    {
+        var a = new LeafPane();
+        var b = new LeafPane();
+        var c = new LeafPane();
+        var inner = new SplitPane(PaneOrientation.Horizontal, b, c, ratio: 0.7);
+        var root = new SplitPane(PaneOrientation.Vertical, a, inner, ratio: 0.4);
+
+        var clone = (SplitPane)PaneTree.Clone(root);
+        var clonedInner = (SplitPane)clone.Child2;
+
+        Assert.NotSame(inner, clonedInner);
+        Assert.Equal(0.7, clonedInner.Ratio);
+        Assert.Same(b, clonedInner.Child1);
+        Assert.Same(c, clonedInner.Child2);
+    }
+
+    [Fact]
+    public void Clone_MutatingCloneRatio_DoesNotAffectOriginal()
+    {
+        var root = new SplitPane(PaneOrientation.Vertical, new LeafPane(), new LeafPane(), ratio: 0.5);
+        var clone = (SplitPane)PaneTree.Clone(root);
+        clone.Ratio = 0.9;
+        Assert.Equal(0.5, root.Ratio); // independence
+    }
+}

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -57,6 +57,8 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.ToggleTabLayout, "Toggle Tab Layout", "Switch between horizontal and vertical tab layout", CommandCategory.Tab, "\uE8AB");
         AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal);
         AddPaneCommand(commands, PaneAction.ShowKeybindCheatsheet, "Keyboard Shortcuts", "Show the keyboard shortcuts cheat sheet", CommandCategory.Terminal, "");
+        AddPaneCommand(commands, PaneAction.Undo, "Undo", "Undo the last pane split, close, resize, equalize, or zoom", CommandCategory.Pane);
+        AddPaneCommand(commands, PaneAction.Redo, "Redo", "Redo the last undone pane operation", CommandCategory.Pane);
 
         // Binding-action-backed commands
         AddBindingCommand(commands, "reset", "Reset Terminal", "Reset the terminal to a clean state", CommandCategory.Terminal, "\uE777");

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -145,6 +145,12 @@ internal sealed class KeyBindings
         // Ctrl+Shift+/ ("Ctrl+?") opens the keyboard-shortcuts cheat sheet.
         // VK 191 = VK_OEM_2 ('/') on US-ANSI.
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, (VirtualKey)191, PaneAction.ShowKeybindCheatsheet),
+
+        // Pane undo/redo. Ctrl+Z is SIGTSTP in the shell and Ctrl+Y is
+        // readline yank, so undo/redo use the shift-chords. Apprt-matched
+        // because libghostty has no Windows undo implementation.
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Z, PaneAction.Undo),
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Y, PaneAction.Redo),
     });
 
     /// <summary>

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -183,6 +183,8 @@ internal sealed class PaneActionRouter
             case PaneAction.ResizeSplitDown:   concrete.ResizeSplit(ResizeDirection.Down); break;
             case PaneAction.ResizeSplitLeft:   concrete.ResizeSplit(ResizeDirection.Left); break;
             case PaneAction.ResizeSplitRight:  concrete.ResizeSplit(ResizeDirection.Right); break;
+            case PaneAction.Undo:            concrete.Undo(); break;
+            case PaneAction.Redo:            concrete.Redo(); break;
 
             // Tabs
             case PaneAction.NewTab: _tabs.NewTab(); break;

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -693,7 +693,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public void EqualizeSplits()
     {
-        CaptureForUndo(Core.Panes.PaneOpKind.Equalize);
+        // Only record undo when there is a split to equalize; on a single
+        // leaf Equalize is a no-op, so capturing would push a useless entry
+        // (and needlessly clear redo).
+        if (_root is SplitPane) CaptureForUndo(Core.Panes.PaneOpKind.Equalize);
         PaneTree.Equalize(_root);
         // When zoomed, only update the model - unzoom re-applies every
         // ratio to the live tree when the user toggles back.
@@ -997,7 +1000,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // still collapses a held-chord burst into one undo step.
         var pre = _restoring ? null : Snapshot(Core.Panes.PaneOpKind.Resize);
         if (!PaneTree.ResizeSplit(_root, _activeLeaf, direction, ResizeSplitDelta)) return;
-        if (pre is not null) _history.Push(pre);
+        if (pre is not null) DisposeOrphans(_history.Push(pre));
         // Ratio-only change: apply in place (see EqualizeSplits) rather
         // than Rebuild(), which ghosts dividers on deep trees.
         ApplyAllRatios();
@@ -1152,21 +1155,37 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         => new(Core.Panes.PaneTree.Clone(_root), _activeLeaf, _zoomedLeaf, kind);
 
     // Record the pre-op state for undo. No-op while restoring (so Undo's
-    // own re-zoom/rebuild does not push history).
+    // own re-zoom/rebuild does not push history). Pushing clears the redo
+    // stack, which can orphan a pane whose surface is still alive (its
+    // only reference was a redo entry); tear those down so the shell does
+    // not leak.
     private void CaptureForUndo(Core.Panes.PaneOpKind kind)
     {
         if (_restoring) return;
-        _history.Push(Snapshot(kind));
+        DisposeOrphans(_history.Push(Snapshot(kind)));
     }
 
     // Drop expired entries and dispose any leaf they orphaned that is no
     // longer in the live tree. Runs on the UI thread (timer marshals).
     private void PruneHistory()
     {
-        var candidates = _history.Prune(_time.GetUtcNow());
-        if (candidates.Count == 0) return;
+        // A prune may already be queued on the dispatcher when the host
+        // tears down (DisposeAllLeaves disposes the timer + clears history).
+        // It is harmless post-Clear, but bail explicitly so a future change
+        // to Prune/Clear semantics can't turn this into a use-after-teardown.
+        if (_allLeavesClosed) return;
+        DisposeOrphans(_history.Prune(_time.GetUtcNow()));
+    }
+
+    // Tear down the libghostty surface of each orphaned leaf that is not
+    // still in the live tree. Shared by the capture (redo-clear orphans),
+    // prune (time-eviction orphans), and teardown paths so the
+    // "never dispose a leaf still on screen" guard lives in one place.
+    private void DisposeOrphans(IReadOnlyList<LeafPane> orphans)
+    {
+        if (orphans.Count == 0) return;
         var live = Core.Panes.PaneTree.Leaves(_root).ToHashSet();
-        foreach (var leaf in candidates)
+        foreach (var leaf in orphans)
         {
             if (live.Contains(leaf)) continue; // still on screen — keep alive
             TeardownLeaf(leaf);

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -108,6 +108,17 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     // has already been disposed leaf-by-leaf in CloseLeaf.
     private bool _allLeavesClosed;
 
+    // Undo/redo of structural pane ops. Per-PaneHost (per-tab). Snapshots
+    // are captured before each op; closed leaves are retained alive here
+    // until their entry is evicted (~5s), so undo resurrects the shell.
+    private const double UndoTimeoutSeconds = 5.0;
+    private readonly TimeProvider _time = TimeProvider.System;
+    private readonly Core.Panes.PaneHistory _history;
+    // Set while Undo()/Redo() restore state, so the capture helper does
+    // not record the restore itself as a new undoable op.
+    private bool _restoring;
+    private System.Threading.ITimer? _pruneTimer;
+
     /// <summary>
     /// Raised when the active leaf changes (initially and on every focus
     /// change between leaves). Subscribers receive the new active leaf.
@@ -204,6 +215,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     {
         _host = host;
         _terminalFactory = terminalFactory;
+        _history = new Core.Panes.PaneHistory(_time, TimeSpan.FromSeconds(UndoTimeoutSeconds));
 
         _activeBorderRect = new Rectangle
         {
@@ -286,6 +298,13 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         {
             BindActiveLeafProgress();
             LeafFocused?.Invoke(this, _activeLeaf);
+            // Evict expired undo entries ~once a second; dispose any shell
+            // that is no longer reachable from the live tree or history.
+            _pruneTimer ??= _time.CreateTimer(
+                _ => DispatcherQueue.TryEnqueue(PruneHistory),
+                null,
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(1));
         };
         // Rebind progress whenever the active leaf changes later.
         LeafFocused += (_, _) => BindActiveLeafProgress();
@@ -308,6 +327,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public void Split(PaneOrientation orientation, ProfileSnapshot? snapshot)
     {
+        // Capture BEFORE the implicit unzoom below so undo restores the
+        // pre-split zoom state too.
+        CaptureForUndo(Core.Panes.PaneOpKind.Split);
+
         // Unzoom before splitting so the new sub-Grid is inserted into
         // the full tree, not into the zoomed single-leaf visual.
         if (_zoomedLeaf is not null)
@@ -393,7 +416,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public void CloseActive()
     {
-        CloseLeaf(_activeLeaf);
+        CloseLeaf(_activeLeaf, undoable: true);
     }
 
     /// <summary>
@@ -446,6 +469,18 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             }
         }
 
+        // Tear down any shell still retained ONLY by the undo history
+        // (soft-closed panes that were never evicted). Stop the timer
+        // first so no prune races this teardown. Guard on the live tree
+        // so we never double-dispose a leaf the walk above already freed.
+        _pruneTimer?.Dispose();
+        _pruneTimer = null;
+        var liveLeaves = Core.Panes.PaneTree.Leaves(_root).ToHashSet();
+        foreach (var leaf in _history.Clear())
+        {
+            if (!liveLeaves.Contains(leaf)) TeardownLeaf(leaf);
+        }
+
         // Event-nulling intentionally runs unconditionally: the gate
         // above only controls whether we re-walk the tree, not whether
         // this PaneHost is going away. Both code paths (tree-collapsed
@@ -461,21 +496,42 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// <see cref="ActiveLeaf"/>) and by <see cref="TerminalControl.CloseRequested"/>
     /// from libghostty's close-surface callback.
     /// </summary>
-    public void CloseLeaf(LeafPane leaf)
+    public void CloseLeaf(LeafPane leaf) => CloseLeaf(leaf, undoable: false);
+
+    /// <param name="undoable">When true and at least one pane survives,
+    /// the close is recorded for undo and the leaf's surface is NOT torn
+    /// down — it lingers (running) until the undo entry is evicted, so
+    /// undo can resurrect the live shell. Shell-initiated closes pass
+    /// false (a dead shell is not worth resurrecting).</param>
+    public void CloseLeaf(LeafPane leaf, bool undoable)
     {
+        // A retained (already soft-closed) leaf is no longer in the live
+        // tree; if its lingering shell exits and fires CloseRequested,
+        // ignore it — eviction will dispose it.
+        if (!Core.Panes.PaneTree.Leaves(_root).Contains(leaf)) return;
+
         // Which leaf (if any) was zoomed before this close. Used at the
         // end to keep an unrelated background close (e.g. a pane's shell
         // exiting on its own) from yanking the user out of zoom.
         var zoomedBefore = _zoomedLeaf;
 
-        // Detach the terminal from focus tracking BEFORE we drop it.
-        leaf.Terminal().GotFocus -= OnTerminalGotFocus;
-
-        // Tear down the libghostty surface for the leaf being removed.
-        // The surface lifetime is decoupled from OnLoaded/OnUnloaded
-        // (see TerminalControl.DisposeSurface comment), so we have to
-        // do it explicitly here.
-        leaf.Terminal().DisposeSurface();
+        // Decide undoability now: only meaningful if a pane survives.
+        // PaneTree.Close is a pure model op (no visual side effects), so
+        // computing it up front to drive the teardown decision is safe.
+        var newRoot = PaneTree.Close(_root, leaf);
+        var softClose = undoable && newRoot is not null;
+        if (softClose)
+        {
+            // Snapshot the tree WITH the leaf still present (and its shell
+            // alive) so undo can resurrect it. The history entry retains
+            // the leaf; teardown is deferred to eviction.
+            CaptureForUndo(Core.Panes.PaneOpKind.Close);
+        }
+        else
+        {
+            // Hard close: free the shell now (last pane, or shell-exit).
+            TeardownLeaf(leaf);
+        }
 
         // Capture the leaf's visual parent BEFORE detaching. This is
         // the Grid that visualizes the PaneTree split about to collapse;
@@ -486,13 +542,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
 
         // Detach the closed terminal from its visual parent Grid so the
         // old split Grid does not hold a reference that keeps the WinUI
-        // compositor rendering a ghost DXGI swap chain surface. Without
-        // this, the disposed TerminalControl stays in the old Grid's
-        // Children and can remain visually rendered even after the Grid
-        // itself is removed from the host.
+        // compositor rendering a ghost DXGI swap chain surface. A
+        // soft-closed leaf must leave the visual tree too; its surface
+        // keeps compositing into nothing until restored or evicted.
         DetachFromParent(leaf.Terminal());
 
-        var newRoot = PaneTree.Close(_root, leaf);
         if (newRoot is null)
         {
             // Last leaf - flag the host so DisposeAllLeaves on window
@@ -550,6 +604,21 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             _activeLeaf = zoomedBefore;
             ToggleSplitZoom();
         }
+    }
+
+    /// <summary>
+    /// Final teardown of a leaf: unsubscribe its TerminalControl from
+    /// focus/close tracking and free its libghostty surface. Idempotent
+    /// (DisposeSurface is). Split out so an undoable (soft) close can
+    /// DEFER this until the undo entry is evicted, keeping the shell
+    /// alive so undo can resurrect it.
+    /// </summary>
+    private void TeardownLeaf(LeafPane leaf)
+    {
+        var t = leaf.Terminal();
+        t.GotFocus -= OnTerminalGotFocus;
+        t.CloseRequested -= OnTerminalCloseRequested;
+        t.DisposeSurface();
     }
 
     /// <summary>
@@ -624,6 +693,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public void EqualizeSplits()
     {
+        CaptureForUndo(Core.Panes.PaneOpKind.Equalize);
         PaneTree.Equalize(_root);
         // When zoomed, only update the model - unzoom re-applies every
         // ratio to the live tree when the user toggles back.
@@ -648,6 +718,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         if (PaneCount <= 1) return;
 
         if (Content is not Grid hostGrid) return;
+
+        // Record the pre-toggle zoom state. No-op while restoring so the
+        // re-zoom that RestoreFrom performs is not itself recorded.
+        CaptureForUndo(Core.Panes.PaneOpKind.Zoom);
 
         if (_zoomedLeaf is not null)
         {
@@ -716,6 +790,49 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             _restoreZoomIcon.Glyph = RestoreZoomGlyphRest;
             _restoreZoomButton.Visibility = Visibility.Visible;
             DispatcherQueue.TryEnqueue(() => leafCtl.Focus(FocusState.Programmatic));
+        }
+    }
+
+    /// <summary>
+    /// Restore the model to the state before the most recent undoable
+    /// op. No-op if the history is empty. Resurrects a soft-closed pane's
+    /// live shell. Mirrors upstream's time-bounded undo.
+    /// </summary>
+    public void Undo() => RestoreFrom(_history.Undo(Snapshot(Core.Panes.PaneOpKind.Split)));
+
+    /// <summary>Re-apply the most recently undone op.</summary>
+    public void Redo() => RestoreFrom(_history.Redo(Snapshot(Core.Panes.PaneOpKind.Split)));
+
+    // Common restore path for Undo/Redo. The OpKind on the snapshot we
+    // hand the history is irrelevant (it is only used for coalescing on
+    // Push), so Split is passed as a harmless placeholder above.
+    private void RestoreFrom(Core.Panes.PaneSnapshot? snapshot)
+    {
+        if (snapshot is null) return;
+
+        _restoring = true;
+        try
+        {
+            _root = snapshot.Root;
+            _activeLeaf = snapshot.Active;
+            _zoomedLeaf = null;        // Rebuild() clears zoom; re-enter below
+            Rebuild();                 // full visual rebuild from the restored tree
+
+            if (snapshot.Zoomed is not null
+                && Core.Panes.PaneTree.Leaves(_root).Contains(snapshot.Zoomed))
+            {
+                _activeLeaf = snapshot.Zoomed;
+                ToggleSplitZoom();     // re-enter zoom via the existing enter-path
+            }
+
+            UpdateHighlightPosition();
+            LeafFocused?.Invoke(this, _activeLeaf);
+            var target = _activeLeaf;
+            DispatcherQueue.TryEnqueue(() => target.Terminal().Focus(FocusState.Programmatic));
+        }
+        finally
+        {
+            _restoring = false;
         }
     }
 
@@ -873,7 +990,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         if (_zoomedLeaf is not null) return;
         if (PaneTree.Leaves(_root).Take(2).Count() <= 1) return;
 
+        // Snapshot the pre-resize ratios (clone is independent of the live
+        // tree) but only RECORD it if the resize actually moves a divider,
+        // so a no-op resize (no matching-orientation ancestor) adds no
+        // undo entry. Push goes through PaneHistory directly so coalescing
+        // still collapses a held-chord burst into one undo step.
+        var pre = _restoring ? null : Snapshot(Core.Panes.PaneOpKind.Resize);
         if (!PaneTree.ResizeSplit(_root, _activeLeaf, direction, ResizeSplitDelta)) return;
+        if (pre is not null) _history.Push(pre);
         // Ratio-only change: apply in place (see EqualizeSplits) rather
         // than Rebuild(), which ghosts dividers on deep trees.
         ApplyAllRatios();
@@ -1019,6 +1143,34 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         var leaf = PaneTree.Leaves(_root).FirstOrDefault(l => ReferenceEquals(l.Terminal(), tc));
         if (leaf is null) return;
         CloseLeaf(leaf);
+    }
+
+    // Build a snapshot of the CURRENT model. Root is a structural clone
+    // (shared leaf identities) so later in-place ratio edits cannot
+    // corrupt it. Caller supplies the op kind.
+    private Core.Panes.PaneSnapshot Snapshot(Core.Panes.PaneOpKind kind)
+        => new(Core.Panes.PaneTree.Clone(_root), _activeLeaf, _zoomedLeaf, kind);
+
+    // Record the pre-op state for undo. No-op while restoring (so Undo's
+    // own re-zoom/rebuild does not push history).
+    private void CaptureForUndo(Core.Panes.PaneOpKind kind)
+    {
+        if (_restoring) return;
+        _history.Push(Snapshot(kind));
+    }
+
+    // Drop expired entries and dispose any leaf they orphaned that is no
+    // longer in the live tree. Runs on the UI thread (timer marshals).
+    private void PruneHistory()
+    {
+        var candidates = _history.Prune(_time.GetUtcNow());
+        if (candidates.Count == 0) return;
+        var live = Core.Panes.PaneTree.Leaves(_root).ToHashSet();
+        foreach (var leaf in candidates)
+        {
+            if (live.Contains(leaf)) continue; // still on screen — keep alive
+            TeardownLeaf(leaf);
+        }
     }
 
     private void Rebuild()


### PR DESCRIPTION
@
Closes the remaining gap on #166 (rescoped to undo/redo only — split/equalize/resize/zoom/goto already shipped).

## What

Time-bounded undo/redo of structural pane operations, mirroring upstream Ghosttys `undo`/`redo` semantics, adapted to the Windows surface lifecycle.

- **Undoable ops:** split, close, equalize, resize, zoom.
- **Live-shell parity:** an undoable close is a *soft close* — the pane leaves the model/visual but its libghostty surface (running shell) is **retained** by the history, so undo within the window resurrects the *same* shell. Surface teardown is deferred to eviction.
- **Eviction:** entries older than ~5s are pruned (mirrors upstream `undo-timeout` default); a leafs surface is disposed only when reachable from neither the live tree nor any history entry.
- **Keybinds:** `Ctrl+Shift+Z` = undo, `Ctrl+Shift+Y` = redo (`Ctrl+Z` is SIGTSTP in the shell, so its not free). Also exposed in the command palette.

## How

- `PaneTree.Clone` — structural deep clone with **shared `LeafPane` identities** (new `SplitPane` nodes copy ratio/orientation). Cloned structure cant be corrupted by later in-place ratio edits; shared identities let the visual rebuild reuse the live `TerminalControl`/surface.
- `PaneSnapshot` / `PaneHistory` (pure, `TimeProvider`-injected, fully unit-tested) — undo/redo stacks, resize-burst coalescing, time eviction, orphan-leaf collection.
- `PaneHost` — captures a snapshot before each op, soft-closes, restores via full `Rebuild()` (re-entering zoom + focus), and runs a `TimeProvider` prune timer (marshaled to the UI thread). `DisposeAllLeaves` drains history-retained shells on tab teardown.

## Tests

- 15 new Core unit tests (`PaneTreeCloneTests`, `PaneHistoryTests`): clone identity/independence, push/undo/redo, redo invalidation, resize coalescing, time eviction, orphan collection, clear. Full suite: **1318 passed, 1 skipped, 0 failed**.
- Interactive verification (live-shell undo-close, 5s timeout, deep-tree undo/redo, regression sweep) — see PR comments.

## Design note

On Windows, `CloseLeaf` previously disposed the surface immediately (unlike macOS where the `SurfaceView` survives in the retained tree). The soft-close + retention-by-reachability model is what makes live-shell undo possible here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@