### PR TITLE
panes: hide command-palette Undo/Redo when the stack is empty

### DIFF
--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -10,16 +10,22 @@ internal sealed class BuiltInCommandSource : ICommandSource
     private readonly Func<PaneAction, Action<CommandItem>> _paneActionFactory;
     private readonly Func<string, Action<CommandItem>> _bindingActionFactory;
     private readonly Action<int>? _opacityAction;
+    private readonly Func<bool>? _canUndo;
+    private readonly Func<bool>? _canRedo;
     private List<CommandItem>? _cache;
 
     public BuiltInCommandSource(
         Func<PaneAction, Action<CommandItem>> paneActionFactory,
         Func<string, Action<CommandItem>> bindingActionFactory,
-        Action<int>? opacityAction = null)
+        Action<int>? opacityAction = null,
+        Func<bool>? canUndo = null,
+        Func<bool>? canRedo = null)
     {
         _paneActionFactory = paneActionFactory;
         _bindingActionFactory = bindingActionFactory;
         _opacityAction = opacityAction;
+        _canUndo = canUndo;
+        _canRedo = canRedo;
     }
 
     public IReadOnlyList<CommandItem> GetCommands()
@@ -57,8 +63,15 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.ToggleTabLayout, "Toggle Tab Layout", "Switch between horizontal and vertical tab layout", CommandCategory.Tab, "\uE8AB");
         AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal);
         AddPaneCommand(commands, PaneAction.ShowKeybindCheatsheet, "Keyboard Shortcuts", "Show the keyboard shortcuts cheat sheet", CommandCategory.Terminal, "");
-        AddPaneCommand(commands, PaneAction.Undo, "Undo", "Undo the last pane split, close, resize, equalize, or zoom", CommandCategory.Pane);
-        AddPaneCommand(commands, PaneAction.Redo, "Redo", "Redo the last undone pane operation", CommandCategory.Pane);
+        // Undo/Redo are omitted when their stack is empty so the palette
+        // never offers a dead no-op. The palette rebuilds this list on every
+        // open (CommandPaletteViewModel.Open -> Refresh + GetCommands), so a
+        // build-time check reflects the active pane's current history; a null
+        // predicate (no host wired) keeps the legacy always-shown behavior.
+        if (_canUndo?.Invoke() ?? true)
+            AddPaneCommand(commands, PaneAction.Undo, "Undo", "Undo the last pane split, close, resize, equalize, or zoom", CommandCategory.Pane);
+        if (_canRedo?.Invoke() ?? true)
+            AddPaneCommand(commands, PaneAction.Redo, "Redo", "Redo the last undone pane operation", CommandCategory.Pane);
 
         // Binding-action-backed commands
         AddBindingCommand(commands, "reset", "Reset Terminal", "Reset the terminal to a clean state", CommandCategory.Terminal, "\uE777");

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -102,16 +102,26 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
 
     public void Open()
     {
-        foreach (var source in _sources)
-            source.Refresh();
-
-        _allCommands = _sources.SelectMany(s => s.GetCommands()).ToList();
+        RebuildCommands();
 
         IsOpen = true;
         SearchText = "";
         IsPinned = false;
         Mode = PaletteMode.Search;
         ApplyFilter();
+    }
+
+    // Refresh every source and re-collect the command list. Sources can
+    // emit context-dependent commands (e.g. BuiltInCommandSource omits
+    // Undo/Redo when the active pane's stack is empty), so this must run
+    // any time the list could have gone stale -- on open AND after a
+    // command executes while the palette stays pinned open.
+    private void RebuildCommands()
+    {
+        foreach (var source in _sources)
+            source.Refresh();
+
+        _allCommands = _sources.SelectMany(s => s.GetCommands()).ToList();
     }
 
     public void Close()
@@ -139,6 +149,12 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
 
         if (IsPinned)
         {
+            // Rebuild so context commands (e.g. Undo/Redo visibility) don't
+            // freeze at their open-time state while the palette stays pinned.
+            // Pane actions dispatch on a later tick, so a history op fired
+            // from here is reflected on the next execute/reopen, not this one
+            // -- acceptable for a cosmetic availability hint.
+            RebuildCommands();
             SearchText = "";
             ApplyFilter();
         }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2164,7 +2164,9 @@ public sealed partial class MainWindow : Window
         var builtIn = new BuiltInCommandSource(
             paneActionFactory: action => _ => DispatcherQueue.TryEnqueue(() => _router.Invoke(action)),
             bindingActionFactory: actionKey => _ => DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)),
-            opacityAction: direction => DispatcherQueue.TryEnqueue(() => AdjustOpacity(direction)));
+            opacityAction: direction => DispatcherQueue.TryEnqueue(() => AdjustOpacity(direction)),
+            canUndo: () => (_tabManager.ActiveTab?.PaneHost as Panes.PaneHost)?.CanUndo ?? false,
+            canRedo: () => (_tabManager.ActiveTab?.PaneHost as Panes.PaneHost)?.CanRedo ?? false);
 
         var jump = new JumpCommandSource(
             _tabManager,

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -796,6 +796,15 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         }
     }
 
+    /// <summary>True when there is at least one undoable op on the stack.
+    /// Lets the command palette omit a dead "Undo" entry. Mirrors the
+    /// concrete-only surfacing of <see cref="Undo"/> (the router casts to
+    /// <see cref="PaneHost"/> rather than going through IPaneHost).</summary>
+    public bool CanUndo => _history.CanUndo;
+
+    /// <summary>Mirror of <see cref="CanUndo"/> for the redo stack.</summary>
+    public bool CanRedo => _history.CanRedo;
+
     /// <summary>
     /// Restore the model to the state before the most recent undoable
     /// op. No-op if the history is empty. Resurrects a soft-closed pane's


### PR DESCRIPTION
## What

The command palette listed **Undo** and **Redo** pane commands unconditionally (added in [#478](https://github.com/deblasis/wintty/pull/478) / #166), so **Redo** appeared even with an empty redo stack. Executing on an empty stack was already a safe no-op (`PaneHost.RestoreFrom(null)` early-returns) — this was purely a UX nit: a dead palette entry.

This change omits each entry when its stack is empty.

## How

- **`PaneHost.CanUndo` / `CanRedo`** — passthroughs to the already-tested `PaneHistory.CanUndo`/`CanRedo`. Surfaced on the concrete `PaneHost` (not `IPaneHost`), mirroring how `Undo()`/`Redo()` are already exposed — `PaneActionRouter` casts to the concrete type rather than going through the interface, so no test-fake churn.
- **`BuiltInCommandSource`** gains optional `canUndo`/`canRedo` predicates and skips adding each entry when its predicate returns `false`. A **null** predicate keeps the legacy always-shown behavior, so the type stays host-free for any future test.
- **`MainWindow`** wires the predicates to the active tab's `PaneHost`.

### Why a build-time check is sufficient (no per-item enabled state)

The palette rebuilds its command list on **every open** (`CommandPaletteViewModel.Open` → `Refresh()` + `GetCommands()`), so a build-time check always reflects the active pane's current history. `CanUndo` reads the same live undo stack that `Undo()` pops, so the two agree exactly.

### Hide vs. disable

`CommandItem` has no `IsEnabled`/`CanExecute` field and the palette has no disabled-row visual. Adding both for a greyed-out entry would be real plumbing for a cosmetic gain — the kind of trade-off this task was scoped to avoid. Omission is the clean fit given the rebuild-on-open invariant.

## Testing

- `dotnet build windows/Ghostty/Ghostty.csproj /p:Platform=x64` — **succeeded** (0 errors).
- No new tests: `PaneHistory.CanUndo`/`CanRedo` semantics are already covered by `PaneHistoryTests`; the `PaneHost` passthrough is a WinUI type not unit-testable without runtime infra; and `BuiltInCommandSource` has no existing unit coverage (adding it would require new `InternalsVisibleTo` + an app-assembly test reference — significant plumbing for a cosmetic gain).

## Self-review

Reviewed with the `dotnet-windows-reviewer` skill: no critical/recommended issues. Verified UI-thread safety of the predicates (`_history` is UI-thread-only; predicates fire inside the UI-thread palette open) and the `as`-cast-with-null-coalesce choice (a palette-build predicate must never throw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)