### PR TITLE
panes: honor undo-timeout config for undo/redo eviction window

### DIFF
--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -80,6 +80,17 @@ public interface IConfigService : IDisposable
     uint BackgroundColor { get; }
 
     /// <summary>
+    /// Eviction window for pane undo/redo, in milliseconds, read from the
+    /// libghostty <c>undo-timeout</c> <c>Duration</c> config. Defaults to
+    /// upstream Ghostty's 5s default when the key can't be read.
+    /// <c>PaneHost</c> converts this via
+    /// <see cref="Ghostty.Core.Panes.UndoTimeout.FromMilliseconds"/>, which
+    /// also handles the non-positive case (see its docs for the divergence
+    /// from upstream's <c>0 = disable</c> semantic).
+    /// </summary>
+    int UndoTimeoutMs { get; }
+
+    /// <summary>
     /// Re-read config from disk and apply it. Returns true on
     /// success, false if the reload failed (old config stays active).
     /// </summary>

--- a/windows/Ghostty.Core/Panes/UndoTimeout.cs
+++ b/windows/Ghostty.Core/Panes/UndoTimeout.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Ghostty.Core.Panes;
+
+/// <summary>
+/// Resolves the effective undo/redo eviction window for a
+/// <c>PaneHost</c> from the libghostty <c>undo-timeout</c> config value.
+/// Pure (no config handle, no WinUI) so the fallback/guard decision is
+/// unit-testable in Core; the actual native read lives in the WinUI
+/// <c>ConfigService</c>.
+/// </summary>
+public static class UndoTimeout
+{
+    /// <summary>
+    /// Compile-time default matching upstream Ghostty's <c>undo-timeout</c>
+    /// default value (5s, see <c>src/config/Config.zig</c>). Used when the
+    /// config value can't be read, or when it resolves to a non-positive
+    /// (degenerate) duration — see <see cref="FromMilliseconds"/>.
+    /// </summary>
+    public static readonly TimeSpan Default = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Convert a raw <c>undo-timeout</c> reading (milliseconds) into the
+    /// eviction window passed to <see cref="PaneHistory"/>.
+    ///
+    /// DIVERGENCE FROM UPSTREAM: Ghostty documents <c>undo-timeout = 0</c>
+    /// as "effectively disable undo operations" (and the knob is macOS-only
+    /// there). This Windows fork reuses the key for its own pane undo/redo
+    /// and intentionally treats a non-positive value as "unset", falling
+    /// back to <see cref="Default"/> instead of disabling. Rationale: a zero
+    /// eviction window would not cleanly disable undo here anyway — the
+    /// prune timer only ticks once a second, so synchronous undo would still
+    /// work briefly — so until pane undo grows a dedicated disable switch,
+    /// the predictable 5s default beats a half-disabled state. Read-failures
+    /// already arrive here as the caller's default (also 5s), so both
+    /// degenerate paths converge.
+    /// </summary>
+    public static TimeSpan FromMilliseconds(int milliseconds)
+        => milliseconds > 0 ? TimeSpan.FromMilliseconds(milliseconds) : Default;
+}

--- a/windows/Ghostty.Tests/Panes/UndoTimeoutTests.cs
+++ b/windows/Ghostty.Tests/Panes/UndoTimeoutTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Ghostty.Core.Panes;
+using Xunit;
+
+namespace Ghostty.Tests.Panes;
+
+public sealed class UndoTimeoutTests
+{
+    [Fact]
+    public void Default_MatchesUpstreamFiveSeconds()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(5), UndoTimeout.Default);
+    }
+
+    [Theory]
+    [InlineData(5000)]  // the upstream default, read back verbatim
+    [InlineData(1)]     // smallest honored value
+    [InlineData(30000)] // a user-raised window
+    public void FromMilliseconds_PositiveValue_HonoredVerbatim(int ms)
+    {
+        Assert.Equal(TimeSpan.FromMilliseconds(ms), UndoTimeout.FromMilliseconds(ms));
+    }
+
+    [Theory]
+    [InlineData(0)]            // upstream's "disable" sentinel; this fork falls back instead
+    [InlineData(-1)]
+    [InlineData(int.MinValue)] // a wrapped native value can't slip through > 0
+    public void FromMilliseconds_NonPositive_FallsBackToDefault(int ms)
+    {
+        // Intentional divergence from upstream's 0 = disable: a non-positive
+        // window is treated as "unset" and resolves to the 5s default rather
+        // than a half-disabled state. See UndoTimeout.FromMilliseconds docs.
+        Assert.Equal(UndoTimeout.Default, UndoTimeout.FromMilliseconds(ms));
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -366,7 +366,7 @@ public sealed partial class MainWindow : Window
             loggerFactory.CreateLogger<ThemePreviewService>());
         _themePreview.ListThemesRequested += OnListThemesRequested;
 
-        _factory = new PaneHostFactory(_host);
+        _factory = new PaneHostFactory(_host, configService);
         _tabManager = new TabManager(
             snapshot => _factory.Create(snapshot),
             seed: seedTab);

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -110,8 +110,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
 
     // Undo/redo of structural pane ops. Per-PaneHost (per-tab). Snapshots
     // are captured before each op; closed leaves are retained alive here
-    // until their entry is evicted (~5s), so undo resurrects the shell.
-    private const double UndoTimeoutSeconds = 5.0;
+    // until their entry is evicted (default ~5s, configurable via the
+    // libghostty `undo-timeout` config), so undo resurrects the shell.
     private readonly TimeProvider _time = TimeProvider.System;
     private readonly Core.Panes.PaneHistory _history;
     // Set while Undo()/Redo() restore state, so the capture helper does
@@ -210,12 +210,20 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// <see cref="TerminalControl.Snapshot"/> before the control loads.</param>
     /// <param name="initialSnapshot">Profile snapshot for the first leaf,
     /// or null for cold-start / legacy paths.</param>
+    /// <param name="undoTimeout">Eviction window for the undo/redo history.
+    /// Read from the libghostty <c>undo-timeout</c> config at construction
+    /// by <see cref="Ghostty.Tabs.PaneHostFactory"/>; null falls back to
+    /// <see cref="Core.Panes.UndoTimeout.Default"/> (5s). The window is
+    /// captured once here, so a config reload only affects PaneHosts created
+    /// afterward (new tabs) — existing tabs keep their construction-time
+    /// value since <see cref="Core.Panes.PaneHistory"/> holds it immutably.</param>
     public PaneHost(GhosttyHost host, Func<ProfileSnapshot?, TerminalControl> terminalFactory,
-        ProfileSnapshot? initialSnapshot = null)
+        ProfileSnapshot? initialSnapshot = null, TimeSpan? undoTimeout = null)
     {
         _host = host;
         _terminalFactory = terminalFactory;
-        _history = new Core.Panes.PaneHistory(_time, TimeSpan.FromSeconds(UndoTimeoutSeconds));
+        _history = new Core.Panes.PaneHistory(
+            _time, undoTimeout ?? Core.Panes.UndoTimeout.Default);
 
         _activeBorderRect = new Rectangle
         {

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -134,6 +134,17 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         GetDurationMs("resize-overlay-duration", 750);
 
     /// <summary>
+    /// Eviction window for pane undo/redo, in milliseconds. Read live from
+    /// the libghostty <c>undo-timeout</c> <c>Duration</c> config handle (not
+    /// the file cache, which can be stale outside ReadFlags). Falls back to
+    /// <see cref="Ghostty.Core.Panes.UndoTimeout.Default"/> (upstream
+    /// Ghostty's 5s default) when the key isn't set, keeping a single source
+    /// of truth for the default with the Core helper.
+    /// </summary>
+    public int UndoTimeoutMs =>
+        GetDurationMs("undo-timeout", (int)Ghostty.Core.Panes.UndoTimeout.Default.TotalMilliseconds);
+
+    /// <summary>
     /// Size of the quake window on each axis. Either axis can be
     /// null in which case the resolver uses sensible defaults
     /// (50% primary, 100% secondary).

--- a/windows/Ghostty/Tabs/PaneHostFactory.cs
+++ b/windows/Ghostty/Tabs/PaneHostFactory.cs
@@ -1,4 +1,5 @@
 using Ghostty.Controls;
+using Ghostty.Core.Config;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Profiles;
 using Ghostty.Hosting;
@@ -19,12 +20,21 @@ namespace Ghostty.Tabs;
 internal sealed class PaneHostFactory
 {
     private readonly GhosttyHost _host;
+    private readonly IConfigService _config;
 
-    public PaneHostFactory(GhosttyHost host) { _host = host; }
+    public PaneHostFactory(GhosttyHost host, IConfigService config)
+    {
+        _host = host;
+        _config = config;
+    }
 
     public IPaneHost Create(ProfileSnapshot? snapshot = null) =>
         new PaneHost(
             _host,
             terminalFactory: snap => new TerminalControl { Snapshot = snap },
-            initialSnapshot: snapshot);
+            initialSnapshot: snapshot,
+            // Read the undo-timeout live per tab so a config reload takes
+            // effect on newly created tabs. Resolved through the pure Core
+            // helper so a degenerate (<=0) value falls back to the 5s default.
+            undoTimeout: UndoTimeout.FromMilliseconds(_config.UndoTimeoutMs));
 }


### PR DESCRIPTION
@
## What

Pane undo/redo (PR #166) hardcoded the eviction window at a `5.0`s constant (`UndoTimeoutSeconds` in `PaneHost`), ignoring upstream Ghostty's `undo-timeout` config (default 5s, `Duration`-typed, `src/config/Config.zig`). This wires the real config value through so user config is honored.

## How

- **`ConfigService.UndoTimeoutMs`** reads `undo-timeout` via the existing `GetDurationMs` `Duration` getter — the **live config handle**, not the `_configFileCache` path (whose readers `IsConfiguredInFile`/`GetRawFileValue` return the fallback outside `ReadFlags`). Defaults to `5000` on read failure. Mirrors the sibling `ResizeOverlayDurationMs`.
- **New pure Core helper `UndoTimeout`** (`Ghostty.Core/Panes/UndoTimeout.cs`): `Default` (5s) + `FromMilliseconds(int)`. A non-positive (degenerate) value falls back to `Default` rather than a broken-undo state — the prune timer only ticks once a second, so a zero/negative window isn't a meaningful "disable" knob. This is the deliberate guard decision, documented and tested.
- **`PaneHostFactory`** takes `IConfigService` (ctor injection) and reads the value **live per tab**, so a config reload takes effect on newly created tabs. Passes the resolved `TimeSpan` to the `PaneHost` ctor.
- **`PaneHost`** ctor gains an optional `TimeSpan? undoTimeout` (null → `UndoTimeout.Default`). `PaneHistory` holds the window immutably, so existing tabs keep their construction-time value — a config reload only affects tabs opened afterward (documented on the ctor).

## Testing

- `UndoTimeoutTests` (Core, 7 cases): default-is-5s, positive values honored verbatim, non-positive → default.
- Full suite: **1328 passed / 1 skipped**.
- WinUI app (`Ghostty.csproj`) builds clean (0 errors) against an ABI-compatible native `ghostty.dll` — this PR is C#-only and touches no Zig ABI.
- Self-reviewed with the dotnet-windows-reviewer skill: no critical/recommended findings.

## Notes for reviewer

The `≤0 → Default` guard slightly diverges from "honor the raw value verbatim." It's intentional given the 1s prune cadence; flagging it so it isn't misread as an accidental clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@