### PR TITLE
fix(palette): execute '>' command-mode actions (#255)

### DIFF
--- a/windows/Ghostty.Core/Commands/ActionAutoCompleter.cs
+++ b/windows/Ghostty.Core/Commands/ActionAutoCompleter.cs
@@ -23,7 +23,7 @@ internal sealed class ActionAutoCompleter
         {
             var matches = _sortedNames
                 .Where(n => n.StartsWith(input, StringComparison.OrdinalIgnoreCase))
-                .Select(n => new AutocompleteSuggestion(n, _actions[n].Description))
+                .Select(n => new AutocompleteSuggestion(n, _actions[n].Description, n))
                 .ToList();
 
             var ghost = matches.Count > 0 ? matches[0].Name[input.Length..] : null;
@@ -41,7 +41,7 @@ internal sealed class ActionAutoCompleter
 
         var paramMatches = schema.Parameters
             .Where(p => p.StartsWith(paramPart, StringComparison.OrdinalIgnoreCase))
-            .Select(p => new AutocompleteSuggestion(p, $"{schema.Name}:{p}"))
+            .Select(p => new AutocompleteSuggestion(p, $"{schema.Name}:{p}", $"{schema.Name}:{p}"))
             .ToList();
 
         var paramGhost = paramMatches.Count > 0 ? paramMatches[0].Name[paramPart.Length..] : null;
@@ -76,7 +76,7 @@ internal sealed record ActionSchema
     public required bool RequiresParameter { get; init; }
 }
 
-internal sealed record AutocompleteSuggestion(string Name, string Description);
+internal sealed record AutocompleteSuggestion(string Name, string Description, string ActionKey);
 
 internal sealed record AutocompleteResult(
     IReadOnlyList<AutocompleteSuggestion> Suggestions,

--- a/windows/Ghostty.Tests/Commands/ActionAutoCompleterTests.cs
+++ b/windows/Ghostty.Tests/Commands/ActionAutoCompleterTests.cs
@@ -175,4 +175,14 @@ public class ActionAutoCompleterTests
         Assert.NotEmpty(result.Suggestions);
         Assert.All(result.Suggestions, s => Assert.StartsWith("goto_tab:", s.ActionKey));
     }
+
+    [Fact]
+    public void Complete_ColonUnknownParam_ReturnsNoSuggestions()
+    {
+        // A known action with an unmatched parameter must yield no suggestions,
+        // so no dangling ActionKey can be dispatched.
+        var c = CreateCompleter();
+        var result = c.Complete("new_split:zzz");
+        Assert.Empty(result.Suggestions);
+    }
 }

--- a/windows/Ghostty.Tests/Commands/ActionAutoCompleterTests.cs
+++ b/windows/Ghostty.Tests/Commands/ActionAutoCompleterTests.cs
@@ -138,4 +138,41 @@ public class ActionAutoCompleterTests
         var c = CreateCompleter();
         Assert.False(c.IsValid("does_not_exist"));
     }
+
+    [Fact]
+    public void Complete_NoParamAction_ActionKeyIsActionName()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("reset");
+        Assert.Single(result.Suggestions);
+        Assert.Equal("reset", result.Suggestions[0].ActionKey);
+    }
+
+    [Fact]
+    public void Complete_Prefix_ActionKeyEqualsName()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("new");
+        Assert.All(result.Suggestions, s => Assert.Equal(s.Name, s.ActionKey));
+    }
+
+    [Fact]
+    public void Complete_ColonParam_ActionKeyIsFullActionColonParam()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("new_split:r");
+        Assert.Single(result.Suggestions);
+        // Name is just the parameter; ActionKey is the dispatchable full string.
+        Assert.Equal("right", result.Suggestions[0].Name);
+        Assert.Equal("new_split:right", result.Suggestions[0].ActionKey);
+    }
+
+    [Fact]
+    public void Complete_ColonAllParams_ActionKeyPrefixedWithAction()
+    {
+        var c = CreateCompleter();
+        var result = c.Complete("goto_tab:");
+        Assert.NotEmpty(result.Suggestions);
+        Assert.All(result.Suggestions, s => Assert.StartsWith("goto_tab:", s.ActionKey));
+    }
 }

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -242,7 +242,11 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
                 var actionKey = s.ActionKey;
                 return new CommandItem
                 {
-                    Id = $"cmdline:{s.Name}",
+                    // Key frecency off the resolved action, not s.Name: for a
+                    // parameterized action s.Name is only the parameter (e.g.
+                    // "1"), so distinct actions sharing a param value would
+                    // otherwise collide in the frecency store.
+                    Id = $"cmdline:{actionKey}",
                     Title = s.Name,
                     Description = s.Description,
                     ActionKey = actionKey,

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -24,6 +24,7 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
     private readonly FrecencyStore _frecency;
     private readonly ActionAutoCompleter? _autoCompleter;
     private readonly bool _groupByCategory;
+    private readonly Action<string>? _commandLineDispatch;
     private List<CommandItem> _allCommands = [];
 
     public bool IsOpen
@@ -92,12 +93,14 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
         IReadOnlyList<ICommandSource> sources,
         FrecencyStore frecency,
         ActionAutoCompleter? autoCompleter,
-        bool groupByCategory = false)
+        bool groupByCategory = false,
+        Action<string>? commandLineDispatch = null)
     {
         _sources = sources;
         _frecency = frecency;
         _autoCompleter = autoCompleter;
         _groupByCategory = groupByCategory;
+        _commandLineDispatch = commandLineDispatch;
     }
 
     public void Open()
@@ -230,14 +233,22 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
         var result = _autoCompleter.Complete(input);
 
         FilteredCommands = result.Suggestions
-            .Select(s => new CommandItem
+            .Select(s =>
             {
-                Id = $"cmdline:{s.Name}",
-                Title = s.Name,
-                Description = s.Description,
-                ActionKey = s.Name,
-                Category = CommandCategory.Custom,
-                Execute = _ => { },
+                // Capture the resolved full action string (e.g.
+                // "increase_font_size:1", not just the parameter "1") so the
+                // command-mode entry dispatches the same way regular binding
+                // commands do via BuiltInCommandSource.
+                var actionKey = s.ActionKey;
+                return new CommandItem
+                {
+                    Id = $"cmdline:{s.Name}",
+                    Title = s.Name,
+                    Description = s.Description,
+                    ActionKey = actionKey,
+                    Category = CommandCategory.Custom,
+                    Execute = _ => _commandLineDispatch?.Invoke(actionKey),
+                };
             })
             .ToList();
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2216,7 +2216,12 @@ public sealed partial class MainWindow : Window
             sources,
             frecency,
             autoCompleter,
-            groupByCategory: _configService.CommandPaletteGroupCommands);
+            groupByCategory: _configService.CommandPaletteGroupCommands,
+            // Route '>' command-mode actions through the same libghostty
+            // binding-action path BuiltInCommandSource uses, deferred to the
+            // next tick so the palette closes before the action runs.
+            commandLineDispatch: actionKey =>
+                DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)));
     }
 
     private void ExecuteBindingAction(string actionKey)


### PR DESCRIPTION
## Summary

Fixes #255 — in the command palette, `>` command-mode actions did not execute.

Selecting a `>` action (or pressing Enter on one) did nothing because the
command-line `CommandItem` was built with an empty `Execute` stub:

```csharp
Execute = _ => { },   // <-- the bug
```

The dispatch infrastructure already existed and is used by regular (non-`>`)
palette commands via `BuiltInCommandSource` → `bindingActionFactory` →
`MainWindow.ExecuteBindingAction` → `NativeMethods.SurfaceBindingAction`. This PR
routes `>` actions through that same path.

## Changes

1. **`ActionAutoCompleter` (Ghostty.Core)** — add a resolved `ActionKey` to
   `AutocompleteSuggestion`. For parameterized actions the colon-branch `Name` is
   only the parameter (`"1"`), while the dispatchable string is the full
   `action:param` (`"increase_font_size:1"`). The autocompleter is the only
   component that knows the colon context, so it resolves the full key.
2. **`CommandPaletteViewModel` (Ghostty app)** — add an `Action<string>?
   commandLineDispatch` constructor parameter (mirroring `bindingActionFactory`'s
   inner shape) and wire the command-mode `Execute` lambda to dispatch the
   resolved `ActionKey`.
3. **`MainWindow`** — supply the delegate:
   `actionKey => DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey))`,
   deferred to the next tick so the palette closes before the action runs.

## Testing

- **Unit (TDD, Ghostty.Core):** 4 new `ActionAutoCompleter` tests asserting the
  resolved `ActionKey` for no-param, prefix, colon-param, and colon-all-params
  cases. Full suite: **1325 passed / 1 skipped**.
- **VM note:** `Ghostty.Tests` deliberately does not reference the WinUI app
  project, so `CommandPaletteViewModel` glue is covered by manual verification on
  Windows (codebase convention). The bug-risk logic (param resolution) lives in
  Core and is fully unit-tested.
- **Manual (Windows):** build & run, open palette, type `>`, execute param-less
  and parameterized actions; confirm regular palette commands still work.

## AOT safety

Plain delegates and records; no reflection or `{Binding}`. AOT-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
