### PR TITLE
fix(windows): stop window-theme switch-then-close crash (#208)

### DIFF
--- a/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
+++ b/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
@@ -205,4 +205,23 @@ public sealed class ThemeResolutionTests
         Assert.True(ThemeResolution.ResolveIsDark(
             "ghostty", BlackBg, ThemeFallbackStyle.Palette, isSystemDark: false));
     }
+
+    [Fact]
+    public void SystemAndAuto_AreNotRedundant_DivergeOnDarkBgLightOs()
+    {
+        // Issue #208 claimed "system" and "auto" are redundant. They are
+        // not: "system" follows the OS dark-mode flag, while "auto" (the
+        // Palette fallback) follows the terminal background luminance.
+        // With a dark background on a light OS they MUST disagree — this
+        // pins the two values as genuinely distinct so neither is
+        // "simplified away" later.
+        var system = ThemeResolution.ResolveIsDark(
+            "system", BlackBg, ThemeFallbackStyle.Palette, isSystemDark: false);
+        var auto = ThemeResolution.ResolveIsDark(
+            "auto", BlackBg, ThemeFallbackStyle.Palette, isSystemDark: false);
+
+        Assert.False(system); // OS is light → light frame
+        Assert.True(auto);    // background is dark → dark frame
+        Assert.NotEqual(system, auto);
+    }
 }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -789,6 +789,14 @@ public partial class App : Application
         {
             try
             {
+                // Stop config reloads FIRST, before anything below frees the
+                // libghostty app or the DX12 renderer. A debounced reload
+                // from a last-moment config change (e.g. a window-theme
+                // switch right before close) would otherwise run
+                // AppUpdateConfig on freed state and crash the process with
+                // a native access violation (issue #208 switch-then-close).
+                _configService.BeginShutdown();
+
                 // Stop the process tracker before any tab teardown could
                 // race its Timer callback. Dispose unsubscribes the
                 // Changed handler in addition to cancelling the timer,

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -967,6 +967,21 @@ public sealed partial class MainWindow : Window
         _isClosed = true;
         _themeManager.Dispose();
 
+        // If this is the last regular window the app is exiting: the
+        // bootstrap libghostty app and the DX12 renderer are about to be
+        // freed (here via _host.Dispose below, and in
+        // App.OnAnyWindowClosedInternal via the bootstrap host). Stop config
+        // reloads NOW, before any of that, so a debounced reload from a
+        // last-moment window-theme switch can't run AppUpdateConfig into
+        // freed surfaces/app (issue #208). OnClosedAsync runs before
+        // OnAnyWindowClosedInternal, so suppressing here closes the window
+        // that the later call would miss. The last-window guard keeps
+        // auto-reload working for other windows in a multi-window session;
+        // App.OnAnyWindowClosedInternal still calls BeginShutdown as the
+        // definitive backstop (it is idempotent).
+        if (!IsQuickTerminal && Ghostty.App.WindowsByRoot.Count <= 1)
+            _configService.BeginShutdown();
+
         // Detach from process-global event sources before we tear
         // down the dispatcher-bound state below. The ConfigService
         // outlives individual MainWindows, so a lingering subscription

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -370,7 +370,7 @@ public sealed partial class MainWindow : Window
         // ExtendsContentIntoTitleBar is true).
         _themeManager = new WindowThemeManager(configService, DispatcherQueue);
         ApplyTheme();
-        _themeManager.ThemeChanged += _ => ApplyTheme();
+        _themeManager.ThemeChanged += OnWindowThemeChanged;
 
         _shellTheme = new ShellThemeService(configService);
         _shellTheme.ThemeChanged += OnShellThemeChanged;
@@ -1725,6 +1725,14 @@ public sealed partial class MainWindow : Window
     /// theme (caption buttons, tab hosts, title text) and refreshes
     /// the single RootGrid.Background source of truth.
     /// </summary>
+    /// <summary>
+    /// WindowThemeManager.ThemeChanged handler. Named (not an anonymous
+    /// lambda) so it reads consistently with the other config-driven
+    /// handlers; ApplyTheme is itself _isClosed-gated and the manager nulls
+    /// the event on dispose, so no teardown guard is needed here.
+    /// </summary>
+    private void OnWindowThemeChanged(bool isDark) => ApplyTheme();
+
     private void OnShellThemeChanged()
     {
         // Same teardown race as ApplyTheme: ShellThemeService routes its

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -624,15 +624,7 @@ public sealed partial class MainWindow : Window
         //   - ApplyRootGridBackground: RootGrid.Background
         // Keeping these disjoint prevents any step from piggybacking
         // on another's side effects (the original cause of # 239).
-        _configService.ConfigChanged += _ =>
-        {
-            ApplyBackdropStyle();
-            UpdateAcrylicTuning();
-            ApplyGradientTint();
-            UpdateCursorAccentColors();
-            ApplyShellTheme();
-            ApplyRootGridBackground();
-        };
+        _configService.ConfigChanged += OnConfigReloadedChrome;
 
         // Re-evaluate the gradient and other power-gated effects whenever
         // low-power mode toggles. MainWindow runs on the UI thread so we
@@ -985,6 +977,8 @@ public sealed partial class MainWindow : Window
         Ghostty.Settings.Pages.GeneralPage.VerticalTabsToggled
             -= OnVerticalTabsToggledFromSettings;
         _configService.ConfigChanged -= OnConfigReloaded;
+        _configService.ConfigChanged -= OnConfigReloadedChrome;
+        _shellTheme.ThemeChanged -= OnShellThemeChanged;
         if (Ghostty.App.PowerStateMonitor is { } powerMonitor)
         {
             powerMonitor.LowPowerChanged -= OnLowPowerChanged;
@@ -1718,6 +1712,33 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void OnShellThemeChanged()
     {
+        // Same teardown race as ApplyTheme: ShellThemeService routes its
+        // ConfigChanged through the dispatcher, so a window-theme switch
+        // immediately followed by close can queue this against a dead
+        // XamlRoot / AppWindow.TitleBar (issue #208). OnClosedAsync also
+        // unsubscribes this handler; the gate covers the in-flight call.
+        if (_isClosed) return;
+        ApplyShellTheme();
+        ApplyRootGridBackground();
+    }
+
+    /// <summary>
+    /// ConfigService.ConfigChanged handler that re-applies window chrome
+    /// (backdrop, acrylic, gradient, accent colors, shell theme, root
+    /// background) after a live config reload. Each call owns exactly one
+    /// disjoint piece of chrome state (see ctor note / issue # 239).
+    /// </summary>
+    private void OnConfigReloadedChrome(IConfigService _)
+    {
+        // ConfigService outlives the window and dispatches ConfigChanged,
+        // so a switch-then-close can queue this against dying XAML /
+        // AppWindow. Gated by _isClosed and unsubscribed in OnClosedAsync
+        // (which also stops the per-window handler leak). Issue #208.
+        if (_isClosed) return;
+        ApplyBackdropStyle();
+        UpdateAcrylicTuning();
+        ApplyGradientTint();
+        UpdateCursorAccentColors();
         ApplyShellTheme();
         ApplyRootGridBackground();
     }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -118,6 +118,11 @@ public sealed partial class MainWindow : Window
     private readonly ShellThemeService _shellTheme;
     private readonly ThemePreviewService _themePreview;
 
+    // Set at the top of OnClosedAsync. Theme callbacks route through the
+    // dispatcher, so a switch-then-close can leave an ApplyTheme queued to
+    // run mid-teardown; this gate makes it a no-op (issue #208).
+    private bool _isClosed;
+
     // Tracks the currently applied backdrop style so we can skip
     // redundant SystemBackdrop swaps on config reload.
     private string _currentBackdropStyle = "";
@@ -960,6 +965,16 @@ public sealed partial class MainWindow : Window
 
     private async void OnClosedAsync(object sender, WindowEventArgs args)
     {
+        // Stop theme application before any teardown or await.
+        // WindowThemeManager routes ConfigChanged/ColorValuesChanged
+        // through the dispatcher, so a switch-then-close can leave an
+        // ApplyTheme queued to run mid-teardown against a dead XamlRoot/HWND
+        // (issue #208). Set the gate and dispose the manager synchronously,
+        // before the first await below, so no theme callback fires after
+        // teardown begins.
+        _isClosed = true;
+        _themeManager.Dispose();
+
         // Detach from process-global event sources before we tear
         // down the dispatcher-bound state below. The ConfigService
         // outlives individual MainWindows, so a lingering subscription
@@ -1040,7 +1055,8 @@ public sealed partial class MainWindow : Window
         _gradientVisual = null;
         _slideAnimator?.Dispose();
         _taskbar.Dispose();
-        _themeManager.Dispose();
+        // _themeManager was disposed at the top of this method, before the
+        // first await, so no theme callback can fire mid-teardown (#208).
 
         // Surface lifetime is decoupled from Loaded/Unloaded
         // (see TerminalControl.DisposeSurface), so we have to
@@ -1297,6 +1313,15 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void ApplyTheme()
     {
+        // A ConfigChanged / ColorValuesChanged callback may already be
+        // queued on the dispatcher when the window starts closing. By then
+        // XamlRoot is null and the HWND is dying (see the RegisteredRoot
+        // capture in the ctor), so touching RequestedTheme/DWM throws. We
+        // cannot gate on XamlRoot == null — it is also null during the
+        // ctor's first ApplyTheme(), which must still apply the initial
+        // theme — so _isClosed is the startup-safe teardown signal (#208).
+        if (_isClosed) return;
+
         if (Content is FrameworkElement root)
             root.RequestedTheme = _themeManager.ElementTheme;
         _themeManager.ApplyToWindow(this);

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -360,12 +360,19 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     {
         // No reloads once teardown has begun: the libghostty app (and the
         // DX12 renderer it drives) may already be freed, so AppUpdateConfig
-        // would dereference freed state and crash natively. This is the
-        // switch-then-close use-after-free in issue #208.
+        // would dereference freed state and crash natively (issue #208,
+        // switch-then-close use-after-free). The actual safety guarantee is
+        // that BeginShutdown runs to completion on the UI thread before
+        // AppFree, and Reload (also UI thread) re-checks this flag below
+        // just before the native call -- so a reload enqueued before
+        // shutdown but pumped after it is fenced off. The flag, not the
+        // timer cancellation, is what closes the race.
         if (_shuttingDown) return false;
 
         // Don't reload before the app is created -- the initial config
-        // is the one passed to ghostty_app_new and must stay alive.
+        // is the one passed to ghostty_app_new and must stay alive. Note
+        // this does NOT cover the post-AppFree case: nothing zeroes _app on
+        // teardown, so _shuttingDown is the only guard against the freed app.
         if (_app.Handle == IntPtr.Zero) return false;
 
         GhosttyConfig newConfig;
@@ -387,6 +394,18 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // own config swap doesn't trigger a redundant file-change reload.
         var wasSuppressed = _suppressWatcher;
         _suppressWatcher = true;
+
+        // Final fence right before the native call: if teardown began while
+        // we were building newConfig, bail rather than push into a freed
+        // app. Keeps the freed-pointer guard local to AppUpdateConfig so a
+        // future refactor (await mid-method, AppFree off the UI thread)
+        // can't silently reopen the #208 race. Free the config we created.
+        if (_shuttingDown)
+        {
+            NativeMethods.ConfigFree(newConfig);
+            _suppressWatcher = wasSuppressed;
+            return false;
+        }
 
         NativeMethods.AppUpdateConfig(_app, newConfig);
 
@@ -1163,6 +1182,10 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         if (_suppressWatcher || _shuttingDown) return;
         lock (_timerLock)
         {
+            // Re-check under the lock: BeginShutdown may have run between the
+            // unguarded check above and here, and we must not re-arm a
+            // debounce timer after shutdown disposed it (issue #208).
+            if (_shuttingDown) return;
             _debounceTimer?.Dispose();
             _debounceTimer = new Timer(_ =>
             {

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -34,6 +34,14 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     private readonly DispatcherQueue _dispatcher;
     private volatile bool _suppressWatcher;
 
+    // Set by BeginShutdown when the app is tearing down so a queued or
+    // debounced reload can't call into a libghostty app that is about to
+    // be (or has been) freed. volatile because the watcher / debounce-timer
+    // callbacks read it from the thread pool. Issue #208: a window-theme
+    // switch immediately followed by close left a debounced Reload to run
+    // AppUpdateConfig on the freed app -> native access violation.
+    private volatile bool _shuttingDown;
+
     public event Action<IConfigService>? ConfigChanged;
     public string ConfigFilePath { get; }
     public bool AutoReloadEnabled { get; private set; }
@@ -350,6 +358,12 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
     public bool Reload()
     {
+        // No reloads once teardown has begun: the libghostty app (and the
+        // DX12 renderer it drives) may already be freed, so AppUpdateConfig
+        // would dereference freed state and crash natively. This is the
+        // switch-then-close use-after-free in issue #208.
+        if (_shuttingDown) return false;
+
         // Don't reload before the app is created -- the initial config
         // is the one passed to ghostty_app_new and must stay alive.
         if (_app.Handle == IntPtr.Zero) return false;
@@ -1146,7 +1160,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
     private void OnFileChanged(object? sender, FileSystemEventArgs e)
     {
-        if (_suppressWatcher) return;
+        if (_suppressWatcher || _shuttingDown) return;
         lock (_timerLock)
         {
             _debounceTimer?.Dispose();
@@ -1157,13 +1171,28 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         }
     }
 
-    public void Dispose()
+    /// <summary>
+    /// Stop applying config reloads ahead of app teardown. After this,
+    /// queued or debounced <see cref="Reload"/> calls no-op instead of
+    /// calling <c>AppUpdateConfig</c> on a libghostty app that is about to
+    /// be (or has been) freed by the bootstrap host's AppFree. Called from
+    /// <c>App.OnAnyWindowClosedInternal</c> before that teardown. Idempotent;
+    /// safe to call before <see cref="Dispose"/>. Issue #208.
+    /// </summary>
+    public void BeginShutdown()
     {
+        _shuttingDown = true;
         StopWatcher();
         lock (_timerLock)
         {
             _debounceTimer?.Dispose();
+            _debounceTimer = null;
         }
+    }
+
+    public void Dispose()
+    {
+        BeginShutdown();
         if (_config.Handle != IntPtr.Zero)
             NativeMethods.ConfigFree(_config);
     }

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -95,8 +95,10 @@ internal sealed class WindowThemeManager : IDisposable
                                       or ObjectDisposedException)
         {
             // The window was torn down between a queued theme update and
-            // its dispatch, so its HWND is already gone. Mirrors the
-            // teardown-race guard in MainWindow.OnLowPowerChanged (#208).
+            // its dispatch, so GetWindowHandle hits a closed/disposed Window
+            // (RO_E_CLOSED COMException / ObjectDisposedException). Same
+            // teardown-race class as MainWindow.OnLowPowerChanged, though the
+            // exact exception set differs by call site (#208).
             return;
         }
 

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Ghostty.Core.Config;
 using Ghostty.Core.Windows;
 using Microsoft.UI.Dispatching;
@@ -30,6 +31,10 @@ internal sealed class WindowThemeManager : IDisposable
     // System theme tracking for "system" mode (and any non-explicit
     // mode when the fallback is System).
     private readonly Windows.UI.ViewManagement.UISettings _uiSettings;
+
+    // Set in Dispose so a callback already queued on the dispatcher before
+    // teardown becomes inert instead of touching a dying window (issue #208).
+    private bool _isDisposed;
 
     /// <summary>
     /// Fired on the UI thread whenever the resolved theme changes.
@@ -63,6 +68,9 @@ internal sealed class WindowThemeManager : IDisposable
 
     public void Dispose()
     {
+        if (_isDisposed) return;
+        _isDisposed = true;
+
         _configService.ConfigChanged -= OnConfigChanged;
         _uiSettings.ColorValuesChanged -= OnSystemThemeChanged;
 
@@ -77,7 +85,23 @@ internal sealed class WindowThemeManager : IDisposable
     /// </summary>
     public unsafe void ApplyToWindow(Window window)
     {
-        var hwnd = new HWND(WindowNative.GetWindowHandle(window));
+        HWND hwnd;
+        try
+        {
+            hwnd = new HWND(WindowNative.GetWindowHandle(window));
+        }
+        catch (Exception ex) when (ex is COMException
+                                      or InvalidOperationException
+                                      or ObjectDisposedException)
+        {
+            // The window was torn down between a queued theme update and
+            // its dispatch, so its HWND is already gone. Mirrors the
+            // teardown-race guard in MainWindow.OnLowPowerChanged (#208).
+            return;
+        }
+
+        if (hwnd == HWND.Null) return;
+
         BOOL useDarkMode = IsDarkMode;
         PInvoke.DwmSetWindowAttribute(
             hwnd,
@@ -107,6 +131,10 @@ internal sealed class WindowThemeManager : IDisposable
 
     private void ResolveAndNotifyIfChanged()
     {
+        // A switch-then-close can leave this queued on the dispatcher; once
+        // disposed there are no subscribers and the window is gone (#208).
+        if (_isDisposed) return;
+
         var previous = IsDarkMode;
         Resolve();
         if (IsDarkMode != previous)


### PR DESCRIPTION
## Summary

Fixes the crash in #208 — switching `window-theme` at runtime and then closing the window crashed the app. Also lands the `system`/`auto` scope correction and teardown hardening.

> **Diagnosis correction:** the ticket attributed the crash to `MainWindow.ApplyTheme()` throwing on a null `XamlRoot`. Empirical debugging (cdb + exit-code differential) showed that's **not** the crash. Pure runtime switching doesn't crash (survives 10+ switches); the crash is **switch-then-close**, and it's a **native access violation in `ghostty.dll`**, not a managed exception (`crash.log` never grew).

## Root cause (verified with cdb)

A runtime `window-theme` change writes the config file → `ConfigService`'s `FileSystemWatcher` debounces 300 ms → `_dispatcher.TryEnqueue(() => Reload())` → `Reload()` calls `AppUpdateConfig(_app, …)` into libghostty. Closing the window right after frees the libghostty app/renderer (`MainWindow.OnClosedAsync → _host.Dispose`; `App.OnAnyWindowClosedInternal → _bootstrapHost.Dispose → AppFree`) while a debounced `Reload` is still queued → the reload dereferences freed state → **0xC0000005**. cdb caught it at `ghostty!ghostty_app_open_config+0xd6` reading a freed pointer (`ds:…=????`), alongside D3D12 `OBJECT_DELETED_WHILE_STILL_IN_USE` teardown errors.

## Fix

**Primary (the crash):** stop config reloads before teardown frees libghostty/renderer.
- `ConfigService.BeginShutdown()` — sets a `volatile _shuttingDown`, stops the watcher, cancels the debounce timer. `Reload()`/`OnFileChanged()` no-op once set; `Reload()` also re-checks the flag immediately before `AppUpdateConfig` (freeing the new config on the suppressed path).
- Called at the **earliest** teardown point: top of `MainWindow.OnClosedAsync` when this is the last regular window (multi-window-safe — auto-reload keeps working for other windows), with `App.OnAnyWindowClosedInternal` as the idempotent backstop.

**Hardening (defense-in-depth, from review):** `_isClosed` gate on `ApplyTheme`/`OnShellThemeChanged`/`OnConfigReloadedChrome`, early `_themeManager` dispose, and unsubscribing the previously-anonymous `ConfigChanged` chrome lambda (also fixes a per-window handler leak). `WindowThemeManager.ApplyToWindow` try/catches a dying HWND.

**Scope correction:** the ticket called `system`/`auto` redundant. They are not — `system` follows the OS dark-mode flag, `auto` follows terminal-background luminance. Both kept; `SystemAndAuto_AreNotRedundant_DivergeOnDarkBgLightOs` pins it.

## Verification (empirical, on Windows)

Driven via config-file edits (the exact `ConfigChanged` dispatch path) with process exit-code capture across the dangerous switch→close timing window:

| switch-then-close | Before fix | After fix |
|---|---|---|
| `0xC0000005` native AV (config-reload UAF) | ~50% (3/6) | **0** (0 in 280+ trials) |
| `0x80000003` assert | observed | **0** |
| `0xC000027B` stowed exception | (rarer teardown race) | **0 in 220 consecutive** trials |
| plain close (control) | clean | clean (0/45) |
| live runtime switches still apply | — | yes, no auto-reload regression |

The earlier-suppression refinement (last-window `BeginShutdown` before any teardown) drove the residual teardown crashes below reproducibility — switch-then-close went from ~50% crashing to **0 across 220 consecutive trials**. `dotnet test windows/Ghostty.Tests -p:Platform=x64` → **1335 passed, 1 skipped**. App builds clean (x64).

A temporary in-app minidump capture (vectored exception handler) was used during investigation to confirm the residual was unreproducible after the fix; it has been removed and is not in the diff.

> The dispatcher/window/native-teardown race has no automated coverage — `Ghostty.Tests` is plain `net10.0` and excludes WinUI + native libghostty by design — so it's verified by reproduction.

## Review

Reviewed across 3 subagent passes using the `dotnet-windows-reviewer` skill (WinUI lifecycle → concurrency/lifecycle adversarial → the ConfigService/App teardown fix). All findings addressed (the sibling-path leak, the earlier-suppression gap, the `Reload` self-protecting re-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
