### PR TITLE
settings: expose undo-timeout on the General page

### DIFF
--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml
@@ -30,6 +30,27 @@
                         Toggled="VerticalTabsToggle_Toggled" />
                 </ctrl:SettingsCard>
 
+                <ctrl:SettingsCard
+                    Header="Undo timeout (ms)"
+                    Description="How long a pane split, close, resize, or zoom can be undone (Ctrl+Shift+Z), in milliseconds. Set to 0 to disable undo. Ghostty default is 5000 (5 seconds)."
+                    ctrl:SettingsCard.ConfigKey="undo-timeout">
+                    <!-- Milliseconds (the config's native Duration granularity)
+                         so no value is lost in a seconds round-trip. Maximum
+                         mirrors ConfigService's int clamp (~24.8 days), so the
+                         box never clamps a value the config can represent.
+                         Value here is a placeholder; LoadValues sets the real one. -->
+                    <NumberBox
+                        x:Name="UndoTimeoutBox"
+                        Value="5000"
+                        Minimum="0"
+                        Maximum="2147483647"
+                        SmallChange="100"
+                        LargeChange="1000"
+                        SpinButtonPlacementMode="Compact"
+                        MinWidth="160"
+                        ValueChanged="UndoTimeout_ValueChanged" />
+                </ctrl:SettingsCard>
+
                 <ctrl:SettingsCard Header="Configuration"
                                    Description="Reload from disk or open the config file in your default editor.">
                     <StackPanel Orientation="Horizontal" Spacing="8">

--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
@@ -34,6 +34,10 @@ internal sealed partial class GeneralPage : Page
     {
         AutoReloadToggle.IsOn = _configService.AutoReloadEnabled;
         VerticalTabsToggle.IsOn = _configService.VerticalTabs;
+        // undo-timeout is a Duration stored as milliseconds; present it
+        // directly in ms (its native granularity) so a sub-second value is
+        // never lost to a seconds round-trip.
+        UndoTimeoutBox.Value = _configService.UndoTimeoutMs;
     }
 
     private void AutoReloadToggle_Toggled(object sender, RoutedEventArgs e)
@@ -57,6 +61,23 @@ internal sealed partial class GeneralPage : Page
         Ghostty.App.ConfigWriteScheduler?.Schedule(
             "vertical-tabs", on ? "true" : "false");
         VerticalTabsToggled?.Invoke(on);
+    }
+
+    private void UndoTimeout_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        if (_loading) return;
+        // A cleared/invalid NumberBox yields NaN; ignore it rather than
+        // casting NaN to 0 and silently writing "0ms" (which disables undo).
+        if (double.IsNaN(sender.Value)) return;
+
+        var ms = Math.Max(0, (int)Math.Round(sender.Value));
+        // Debounce through the scheduler rather than writing + Reload() on
+        // every spinner tick (a held spin button fires many ValueChanged in a
+        // row). The scheduler coalesces last-write-wins, try/catches the
+        // SetValue, and owns the post-write reload — mirroring the
+        // vertical-tabs toggle. "<n>ms" is a valid Duration unit; "0ms"
+        // round-trips to a disabled undo policy.
+        Ghostty.App.ConfigWriteScheduler?.Schedule("undo-timeout", ms + "ms");
     }
 
     private void ReloadButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## What

Completes the `undo-timeout` feature line (#480 wiring, #483 `0`=disable) by surfacing it in the **Settings UI** — General → App Behavior — so users can change the pane undo/redo window without hand-editing the config file.

## How

- **NumberBox in milliseconds.** The config `Duration` is stored in ms (`ConfigService.UndoTimeoutMs`), so presenting ms is lossless — no seconds rounding, no float round-trip. `Maximum` mirrors ConfigService's own `int` clamp (2147483647 ≈ 24.8 days) so opening Settings can never silently clamp/shrink a representable existing value. `0` is a first-class value (disable undo).
- **Debounced write via `ConfigWriteScheduler`.** Writes `"<n>ms"` through the scheduler (last-write-wins, `try/catch` around `SetValue`, owns the post-write reload) instead of a full config `Reload()` on every spinner tick — mirroring the existing vertical-tabs toggle. `"0ms"` round-trips to a disabled `UndoPolicy`.
- **NaN guard** on `ValueChanged`: a cleared NumberBox surfaces `NaN`; we ignore it rather than casting to `0` and silently writing `"0ms"` (which would disable undo).

Reads `UndoTimeoutMs` off `IConfigService` (added in #480); mirrors the `TerminalPage` scrollback-limit NumberBox pattern.

## Testing

- WinUI app builds clean (0 errors); full suite **1334 passed / 1 skipped**.
- Verified the round-trip against `src/config/Config.zig` `Duration.parseCLI`: a bare non-zero number is rejected, so the `ms` unit is always appended; `0` (with unit) parses to a zero duration → `UndoPolicy.Disabled`.
- Reviewed by two independent subagents (dotnet-windows + config-round-trip/UX). No Critical findings. Their two main recommendations are **applied**: switched seconds → **milliseconds** (eliminates sub-second/over-max lossiness) and switched immediate write+Reload → **ConfigWriteScheduler debounce** (which also makes the write exception-safe).

## Follow-up (out of scope)

Both reviewers noted the *immediate-write* sibling handlers (`AutoReloadToggle_Toggled`, `TerminalPage.OnValueChanged`) wrap `SuppressWatcher` without a `try/finally` — if `SetValue` throws, the watcher stays suppressed and auto-reload silently dies. This PR's handler avoids that (uses the scheduler); the pre-existing handlers are filed as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
