### PR TITLE
settings: guard SuppressWatcher with try/finally on immediate config writes

### DIFF
--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
@@ -44,8 +44,8 @@ internal sealed partial class GeneralPage : Page
     {
         if (_loading) return;
         _configService.SuppressWatcher(true);
-        _editor.SetValue("auto-reload-config", AutoReloadToggle.IsOn ? "true" : "false");
-        _configService.SuppressWatcher(false);
+        try { _editor.SetValue("auto-reload-config", AutoReloadToggle.IsOn ? "true" : "false"); }
+        finally { _configService.SuppressWatcher(false); }
         _configService.Reload();
     }
 

--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
@@ -247,9 +247,12 @@ internal sealed partial class RawEditorPage : Page
     private void SaveButton_Click(object sender, RoutedEventArgs e)
     {
         _configService.SuppressWatcher(true);
-        _editor.WriteRaw(GetEditorText());
-        _lastLoadedText = GetEditorText();
-        _configService.SuppressWatcher(false);
+        try
+        {
+            _editor.WriteRaw(GetEditorText());
+            _lastLoadedText = GetEditorText();
+        }
+        finally { _configService.SuppressWatcher(false); }
 
         var success = _configService.Reload();
         var count = _configService.DiagnosticsCount;

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
@@ -36,8 +36,8 @@ internal sealed partial class TerminalPage : Page
     {
         if (_loading) return;
         _configService.SuppressWatcher(true);
-        _editor.SetValue(key, value);
-        _configService.SuppressWatcher(false);
+        try { _editor.SetValue(key, value); }
+        finally { _configService.SuppressWatcher(false); }
         _configService.Reload();
     }
 


### PR DESCRIPTION
## Problem

The immediate config-write handlers in the Settings UI wrapped an editor write in `SuppressWatcher(true)` / `SuppressWatcher(false)` **without** a `try/finally`. If the write threw (file locked, IO error), the file-system watcher was left **permanently suppressed**, silently killing `auto-reload-config` for the rest of the session.

## Fix

Wrap each write in `try/finally` so `SuppressWatcher(false)` always runs, matching the existing idiom in `AppearancePage`/`ColorsPage`/`ProfilesPage`:

- **`GeneralPage.AutoReloadToggle_Toggled`** -- `auto-reload-config`
- **`TerminalPage.OnValueChanged`** -- `scrollback-limit`, `cursor-style`, `cursor-style-blink`, `mouse-hide-while-typing`
- **`RawEditorPage.SaveButton_Click`** -- raw write; `_lastLoadedText` moved inside the `try` so a failed write does not record a false "saved" baseline

`Reload()` stays after the `try/finally`, so a failed write restores the watcher and skips the reload (no reload of a half-written file).

`ConfigWriteScheduler`-based handlers (`vertical-tabs`, `undo-timeout`) were already safe and are left untouched.

## Verification

- `dotnet build windows/Ghostty/Ghostty.csproj -p:Platform=x64` -> 0 errors
- `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj -p:Platform=x64` -> 1334 passed, 0 failed, 1 skipped (pre-existing)

## Follow-up

Reviewed with the dotnet-windows-reviewer skill: no Critical findings. A pre-existing cross-cutting concern was noted -- these synchronous UI handlers do not catch IO failures, so a locked/unwritable config file fail-fasts the process. That affects all Settings pages equally and is filed as a separate task (extract a shared catch+log writer), kept out of this focused fix.

Generated with [Claude Code](https://claude.com/claude-code)