### PR TITLE
settings: catch IO failures on immediate config writes via shared SettingsConfigWriter

### DIFF
--- a/windows/Ghostty.Core/Config/SettingsConfigWriter.cs
+++ b/windows/Ghostty.Core/Config/SettingsConfigWriter.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using Ghostty.Core.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Outcome of a <see cref="SettingsConfigWriter.Write"/> call.
+/// <see cref="WriteSucceeded"/> is false when the editor mutation threw a
+/// disk error (the file is unchanged or only partially written);
+/// <see cref="Reloaded"/> is the result of the post-write
+/// <see cref="IConfigService.Reload"/>; <see cref="Error"/> carries the
+/// caught exception so a page with a status affordance can surface it.
+/// <para>
+/// <see cref="Reloaded"/> is independent of <see cref="WriteSucceeded"/>:
+/// the reload runs even after a caught write failure, so a true
+/// <see cref="Reloaded"/> means "the runtime re-read the file", not "the
+/// write took effect". Callers that care whether the change landed must
+/// check <see cref="WriteSucceeded"/> first.
+/// </para>
+/// </summary>
+public readonly record struct SettingsWriteResult(
+    bool WriteSucceeded,
+    bool Reloaded,
+    Exception? Error);
+
+/// <summary>
+/// Shared helper for the Settings pages' synchronous "immediate write"
+/// handlers (toggles, sliders, color pickers, raw save). Each page used
+/// to inline the same idiom:
+/// <code>
+/// SuppressWatcher(true);
+/// try { editor.SetValue(...); }
+/// finally { SuppressWatcher(false); }
+/// Reload();
+/// </code>
+/// which leaves an <see cref="IOException"/> / <see cref="UnauthorizedAccessException"/>
+/// (file locked, disk full, permission denied) to propagate unhandled out
+/// of the WinUI routed-event handler into <c>Application.UnhandledException</c>,
+/// fail-fasting the whole process. This helper keeps the watcher-balancing
+/// and reload behavior but catches those disk errors, logs them, and
+/// reports the outcome so the page can keep running (and optionally show a
+/// message). It is the synchronous sibling of
+/// <see cref="ConfigWriteScheduler"/>, which already owns this discipline
+/// for debounced writes.
+/// </summary>
+public sealed partial class SettingsConfigWriter
+{
+    private readonly IConfigService _configService;
+    private readonly ILogger<SettingsConfigWriter> _logger;
+
+    public SettingsConfigWriter(
+        IConfigService configService,
+        ILogger<SettingsConfigWriter> logger)
+    {
+        ArgumentNullException.ThrowIfNull(configService);
+        ArgumentNullException.ThrowIfNull(logger);
+        _configService = configService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Run <paramref name="edit"/> (the editor mutation) with the file
+    /// watcher suppressed, catching disk failures, then reload. The
+    /// watcher flag is always balanced via <c>finally</c>, even when the
+    /// edit throws.
+    /// </summary>
+    /// <param name="edit">The editor mutation (SetValue / RemoveValue /
+    /// WriteRaw / SetRepeatableValues, or a conditional combination).</param>
+    /// <param name="context">Optional human-readable label for what is
+    /// being written (typically the config key) so a caught failure names
+    /// the affected setting in the log. The <see cref="IOException"/>
+    /// usually carries the file path but not which setting failed.</param>
+    /// <remarks>
+    /// Only <see cref="IOException"/> and <see cref="UnauthorizedAccessException"/>
+    /// are caught -- the realistic disk-write failures. Any other exception
+    /// is a programming error and is left to propagate rather than be
+    /// silently swallowed; the watcher flag is still reset on the way out.
+    /// The reload runs after a caught write failure too, so the live runtime
+    /// resyncs to whatever actually made it to disk (mirroring
+    /// <see cref="ConfigWriteScheduler"/>, which signals a reload even after
+    /// a failed batch item).
+    /// </remarks>
+    public SettingsWriteResult Write(Action edit, string? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(edit);
+
+        Exception? error = null;
+        _configService.SuppressWatcher(true);
+        try
+        {
+            edit();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            error = ex;
+            LogWriteFailed(ex, context ?? "(unspecified)");
+        }
+        finally
+        {
+            _configService.SuppressWatcher(false);
+        }
+
+        var reloaded = _configService.Reload();
+        return new SettingsWriteResult(error is null, reloaded, error);
+    }
+
+    [LoggerMessage(EventId = LogEvents.Config.SettingsWriteErr,
+                   Level = LogLevel.Warning,
+                   Message = "[SettingsConfigWriter] config write failed for {Context}")]
+    private partial void LogWriteFailed(Exception ex, string context);
+}

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -15,6 +15,7 @@ internal static class LogEvents
         public const int WriteSchedulerErr = 1001;
         public const int TimerDisposeSlow  = 1002;
         public const int SeedFailed        = 1003;
+        public const int SettingsWriteErr  = 1004;
     }
 
     // 1100-1199: Frecency / command history

--- a/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
+++ b/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Ghostty.Core.Config;
+using Ghostty.Core.Profiles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public class SettingsConfigWriterTests
+{
+    [Fact]
+    public void Write_runs_edit_then_reloads_and_reports_success()
+    {
+        var svc = new FakeConfigService { ReloadResult = true };
+        var writer = new SettingsConfigWriter(svc, NullLogger<SettingsConfigWriter>.Instance);
+
+        var edited = false;
+        var result = writer.Write(() => edited = true);
+
+        Assert.True(edited);
+        Assert.True(result.WriteSucceeded);
+        Assert.True(result.Reloaded);
+        Assert.Null(result.Error);
+        Assert.Equal(1, svc.ReloadCount);
+    }
+
+    [Fact]
+    public void Write_brackets_edit_with_suppress_true_then_false()
+    {
+        var svc = new FakeConfigService();
+        var writer = new SettingsConfigWriter(svc, NullLogger<SettingsConfigWriter>.Instance);
+
+        writer.Write(() => svc.SuppressLog.Add("edit"));
+
+        // Watcher is suppressed before the edit runs and resumed after.
+        Assert.Equal(new[] { "true", "edit", "false" }, svc.SuppressLog);
+    }
+
+    [Fact]
+    public void Write_returns_reload_result_when_reload_fails()
+    {
+        var svc = new FakeConfigService { ReloadResult = false };
+        var writer = new SettingsConfigWriter(svc, NullLogger<SettingsConfigWriter>.Instance);
+
+        var result = writer.Write(() => { });
+
+        Assert.True(result.WriteSucceeded);
+        Assert.False(result.Reloaded);
+    }
+
+    [Fact]
+    public void Write_swallows_IOException_and_still_resets_watcher_and_reloads()
+    {
+        var svc = new FakeConfigService { ReloadResult = true };
+        var writer = new SettingsConfigWriter(svc, NullLogger<SettingsConfigWriter>.Instance);
+        var boom = new IOException("disk full");
+
+        var result = writer.Write(() => throw boom);
+
+        Assert.False(result.WriteSucceeded);
+        Assert.Same(boom, result.Error);
+        // Watcher must be balanced even on failure, and the reload still runs
+        // so the runtime resyncs to whatever actually landed on disk.
+        Assert.Equal(new[] { "true", "false" }, svc.SuppressLog);
+        Assert.Equal(1, svc.ReloadCount);
+    }
+
+    [Fact]
+    public void Write_swallows_UnauthorizedAccessException()
+    {
+        var svc = new FakeConfigService();
+        var writer = new SettingsConfigWriter(svc, NullLogger<SettingsConfigWriter>.Instance);
+        var boom = new UnauthorizedAccessException("denied");
+
+        var result = writer.Write(() => throw boom);
+
+        Assert.False(result.WriteSucceeded);
+        Assert.Same(boom, result.Error);
+    }
+
+    [Fact]
+    public void Write_does_not_swallow_unexpected_exceptions_but_still_resets_watcher()
+    {
+        var svc = new FakeConfigService();
+        var writer = new SettingsConfigWriter(svc, NullLogger<SettingsConfigWriter>.Instance);
+
+        // A programming error (not a disk failure) must propagate so it isn't
+        // silently masked -- but the watcher flag must still be balanced.
+        Assert.Throws<InvalidOperationException>(
+            () => writer.Write(() => throw new InvalidOperationException("bug")));
+
+        Assert.Equal(new[] { "true", "false" }, svc.SuppressLog);
+        Assert.Equal(0, svc.ReloadCount); // reload is skipped when the edit faults unexpectedly
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_arguments()
+    {
+        var svc = new FakeConfigService();
+        Assert.Throws<ArgumentNullException>(
+            () => new SettingsConfigWriter(null!, NullLogger<SettingsConfigWriter>.Instance));
+        Assert.Throws<ArgumentNullException>(
+            () => new SettingsConfigWriter(svc, null!));
+    }
+
+    [Fact]
+    public void Write_rejects_null_edit()
+    {
+        var svc = new FakeConfigService();
+        var writer = new SettingsConfigWriter(svc, NullLogger<SettingsConfigWriter>.Instance);
+        Assert.Throws<ArgumentNullException>(() => writer.Write(null!));
+    }
+
+    private sealed class FakeConfigService : IConfigService
+    {
+        public List<string> SuppressLog { get; } = new();
+        public int ReloadCount { get; private set; }
+        public bool ReloadResult { get; set; } = true;
+
+        public void SuppressWatcher(bool suppress) => SuppressLog.Add(suppress ? "true" : "false");
+        public bool Reload() { ReloadCount++; return ReloadResult; }
+
+        // --- Unused members (the writer only touches SuppressWatcher/Reload) ---
+        public event Action<IConfigService>? ConfigChanged { add { } remove { } }
+        public string ConfigFilePath => string.Empty;
+        public bool AutoReloadEnabled => false;
+        public bool SettingsUiEnabled => false;
+        public double BackgroundOpacity => 1.0;
+        public bool VerticalTabs => false;
+        public bool CommandPaletteGroupCommands => false;
+        public string CommandPaletteBackground => "acrylic";
+        public string LogLevel => "info";
+        public string LogFilter => string.Empty;
+        public string WindowTheme => "auto";
+        public uint BackgroundColor => 0;
+        public int UndoTimeoutMs => 5000;
+        public int DiagnosticsCount => 0;
+        public string GetDiagnostic(int index) => string.Empty;
+        public IReadOnlyList<string> WindowsOnlyKeysUsed => Array.Empty<string>();
+        public IReadOnlyDictionary<string, ProfileDef> ParsedProfiles =>
+            new Dictionary<string, ProfileDef>();
+        public IReadOnlyList<string> ProfileOrder => Array.Empty<string>();
+        public string? DefaultProfileId => null;
+        public IReadOnlySet<string> HiddenProfileIds => new HashSet<string>();
+        public IReadOnlyList<string> ProfileWarnings => Array.Empty<string>();
+        public void Dispose() { }
+    }
+}

--- a/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghostty.Core.Config;
+using Ghostty.Core.Logging;
+using Ghostty.Core.Logging.Testing;
+using Ghostty.Core.Profiles;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghostty.Tests.Logging;
+
+public class SettingsConfigWriterLoggingTests
+{
+    [Fact]
+    public void Write_EditThatThrowsIOException_EmitsWarningWithSettingsWriteErrEventId()
+    {
+        var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var writer = new SettingsConfigWriter(
+            new NoopConfigService(),
+            factory.CreateLogger<SettingsConfigWriter>());
+
+        writer.Write(() => throw new System.IO.IOException("injected"));
+
+        var warnings = capture.Entries.Where(e => e.Level == LogLevel.Warning).ToArray();
+        Assert.Contains(warnings, e => e.EventId.Id == LogEvents.Config.SettingsWriteErr);
+    }
+
+    [Fact]
+    public void Write_WithContext_RendersContextInWarningMessage()
+    {
+        var capture = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(capture));
+
+        var writer = new SettingsConfigWriter(
+            new NoopConfigService(),
+            factory.CreateLogger<SettingsConfigWriter>());
+
+        writer.Write(() => throw new System.IO.IOException("injected"), "background-opacity");
+
+        var warning = capture.Entries.Single(
+            e => e.Level == LogLevel.Warning && e.EventId.Id == LogEvents.Config.SettingsWriteErr);
+        Assert.Contains("background-opacity", warning.Message);
+    }
+
+    // Minimal IConfigService stand-in: the writer only calls
+    // SuppressWatcher and Reload, so everything else is a default no-op.
+    private sealed class NoopConfigService : IConfigService
+    {
+        public void SuppressWatcher(bool suppress) { }
+        public bool Reload() => true;
+
+        public event Action<IConfigService>? ConfigChanged { add { } remove { } }
+        public string ConfigFilePath => string.Empty;
+        public bool AutoReloadEnabled => false;
+        public bool SettingsUiEnabled => false;
+        public double BackgroundOpacity => 1.0;
+        public bool VerticalTabs => false;
+        public bool CommandPaletteGroupCommands => false;
+        public string CommandPaletteBackground => "acrylic";
+        public string LogLevel => "info";
+        public string LogFilter => string.Empty;
+        public string WindowTheme => "auto";
+        public uint BackgroundColor => 0;
+        public int UndoTimeoutMs => 5000;
+        public int DiagnosticsCount => 0;
+        public string GetDiagnostic(int index) => string.Empty;
+        public IReadOnlyList<string> WindowsOnlyKeysUsed => Array.Empty<string>();
+        public IReadOnlyDictionary<string, ProfileDef> ParsedProfiles =>
+            new Dictionary<string, ProfileDef>();
+        public IReadOnlyList<string> ProfileOrder => Array.Empty<string>();
+        public string? DefaultProfileId => null;
+        public IReadOnlySet<string> HiddenProfileIds => new HashSet<string>();
+        public IReadOnlyList<string> ProfileWarnings => Array.Empty<string>();
+        public void Dispose() { }
+    }
+}

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -42,6 +42,10 @@ namespace Ghostty.Logging;
 ///   - <see cref="CheatSheet"/>: read-only keybind cheat-sheet
 ///     <c>ContentDialog</c>, constructed directly (no DI-enabled
 ///     <c>Frame</c>); logs show / export failures.
+///   - <see cref="SettingsConfigWriter"/>: shared Core helper
+///     constructed by the XAML Settings pages (same no-DI-Frame
+///     constraint as <see cref="GeneralPage"/>); logs config-file
+///     write failures from immediate-write handlers.
 ///
 /// Tests should use <see cref="Install"/> which returns an
 /// <see cref="IDisposable"/> scope that restores the pre-install
@@ -66,6 +70,7 @@ internal static class StaticLoggers
     private static ILogger<Ghostty.Settings.Pages.GeneralPage>? _generalPage;
     private static ILogger<Ghostty.Settings.Pages.KeybindingsPage>? _keybindingsPage;
     private static ILogger<Ghostty.Settings.CheatSheetDialog>? _cheatSheet;
+    private static ILogger<Ghostty.Core.Config.SettingsConfigWriter>? _settingsConfigWriter;
     private static ILogger<App>? _app;
 
     internal static ILogger<Ghostty.Services.ConfigService> ConfigService
@@ -80,6 +85,8 @@ internal static class StaticLoggers
         => _keybindingsPage ?? NullLogger<Ghostty.Settings.Pages.KeybindingsPage>.Instance;
     internal static ILogger<Ghostty.Settings.CheatSheetDialog> CheatSheet
         => _cheatSheet ?? NullLogger<Ghostty.Settings.CheatSheetDialog>.Instance;
+    internal static ILogger<Ghostty.Core.Config.SettingsConfigWriter> SettingsConfigWriter
+        => _settingsConfigWriter ?? NullLogger<Ghostty.Core.Config.SettingsConfigWriter>.Instance;
     internal static ILogger<App> App
         => _app ?? NullLogger<App>.Instance;
 
@@ -91,6 +98,7 @@ internal static class StaticLoggers
         _generalPage = factory.CreateLogger<Ghostty.Settings.Pages.GeneralPage>();
         _keybindingsPage = factory.CreateLogger<Ghostty.Settings.Pages.KeybindingsPage>();
         _cheatSheet = factory.CreateLogger<Ghostty.Settings.CheatSheetDialog>();
+        _settingsConfigWriter = factory.CreateLogger<Ghostty.Core.Config.SettingsConfigWriter>();
         _app = factory.CreateLogger<App>();
     }
 
@@ -102,7 +110,8 @@ internal static class StaticLoggers
     }
 
     private static Snapshot CaptureSnapshot() => new(
-        _configService, _windowStateMigration, _windowState, _generalPage, _keybindingsPage, _cheatSheet, _app);
+        _configService, _windowStateMigration, _windowState, _generalPage, _keybindingsPage,
+        _cheatSheet, _settingsConfigWriter, _app);
 
     private readonly record struct Snapshot(
         ILogger<Ghostty.Services.ConfigService>? ConfigService,
@@ -111,6 +120,7 @@ internal static class StaticLoggers
         ILogger<Ghostty.Settings.Pages.GeneralPage>? GeneralPage,
         ILogger<Ghostty.Settings.Pages.KeybindingsPage>? KeybindingsPage,
         ILogger<Ghostty.Settings.CheatSheetDialog>? CheatSheet,
+        ILogger<Ghostty.Core.Config.SettingsConfigWriter>? SettingsConfigWriter,
         ILogger<App>? App);
 
     private sealed class Scope : IDisposable
@@ -126,6 +136,7 @@ internal static class StaticLoggers
             _generalPage = _prior.GeneralPage;
             _keybindingsPage = _prior.KeybindingsPage;
             _cheatSheet = _prior.CheatSheet;
+            _settingsConfigWriter = _prior.SettingsConfigWriter;
             _app = _prior.App;
         }
     }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -72,6 +72,13 @@ public sealed partial class MainWindow : Window
     // so anything in this window that needs to mutate the config file
     // goes through App.ConfigFileEditor rather than building its own.
     private readonly IConfigFileEditor _configEditor;
+    // Synchronous immediate-write helper for the window's own config
+    // mutations (e.g. the opacity-adjust keybindings). Catches disk
+    // failures and keeps the watcher flag balanced so an IOException
+    // can't fail-fast the process or leave the watcher suppressed --
+    // the same guarantee the Settings pages get. Debounced writes
+    // (e.g. vertical-tabs) still go through App.ConfigWriteScheduler.
+    private readonly SettingsConfigWriter _configWriter;
     // Narrower than holding ILoggerFactory: AcrylicBackdrop is rebuilt
     // per backdrop-style change in ApplyBackdropStyle(), and that is
     // the ONLY reason this window needed a way to mint loggers after
@@ -259,6 +266,8 @@ public sealed partial class MainWindow : Window
             ?? throw new InvalidOperationException(
                 "MainWindow: App.ConfigFileEditor is null. " +
                 "App.OnLaunched must initialize it before constructing a window.");
+        _configWriter = new SettingsConfigWriter(
+            _configService, StaticLoggers.SettingsConfigWriter);
         _newAcrylicLogger = loggerFactory.CreateLogger<AcrylicBackdrop>;
         _logger = loggerFactory.CreateLogger<MainWindow>();
 
@@ -2101,10 +2110,9 @@ public sealed partial class MainWindow : Window
         // Skip the write+reload round-trip when nothing changed.
         if (Math.Abs(next - current) < 0.001) return;
 
-        _configService.SuppressWatcher(true);
-        _configEditor.SetValue("background-opacity", next.ToString("F2"));
-        _configService.SuppressWatcher(false);
-        _configService.Reload();
+        _configWriter.Write(
+            () => _configEditor.SetValue("background-opacity", next.ToString("F2")),
+            "background-opacity");
     }
 
     private void ToggleCommandPalette()

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -6,6 +6,7 @@ using Ghostty.Controls.Settings;
 using Ghostty.Core.Config;
 using Ghostty.Core.DirectWrite;
 using Ghostty.Core.Settings;
+using Ghostty.Logging;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -17,6 +18,7 @@ internal sealed partial class AppearancePage : Page
 {
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
+    private readonly SettingsConfigWriter _writer;
     private readonly SearchableList _fontList;
     private bool _loading = true;
     // Counts Reload() invocations we initiated ourselves. Each one will
@@ -30,6 +32,7 @@ internal sealed partial class AppearancePage : Page
     {
         _configService = configService;
         _editor = editor;
+        _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
         _fontList = new SearchableList(FontFamilySearch, chosen => OnValueChanged("font-family", chosen));
         OpacitySlider.Value = configService.BackgroundOpacity;
@@ -218,10 +221,7 @@ internal sealed partial class AppearancePage : Page
     private void OnValueChanged(string key, string value)
     {
         if (_loading) return;
-        _configService.SuppressWatcher(true);
-        try { _editor.SetValue(key, value); }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        _writer.Write(() => _editor.SetValue(key, value), key);
     }
 
     private void FontSize_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
@@ -272,10 +272,7 @@ internal sealed partial class AppearancePage : Page
     private void TintColor_Reset(object sender, RoutedEventArgs e)
     {
         if (_loading) return;
-        _configService.SuppressWatcher(true);
-        try { _editor.RemoveValue("background-tint-color"); }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        _writer.Write(() => _editor.RemoveValue("background-tint-color"), "background-tint-color");
 
         _loading = true;
         try { TintColorPicker.Color = ""; }
@@ -318,10 +315,8 @@ internal sealed partial class AppearancePage : Page
 
         if (!enabled)
         {
-            _configService.SuppressWatcher(true);
-            try { _editor.RemoveValue("background-gradient-point"); }
-            finally { _configService.SuppressWatcher(false); }
-            _configService.Reload();
+            _writer.Write(
+                () => _editor.RemoveValue("background-gradient-point"), "background-gradient-point");
             GradientEditor.SetPoints(System.Array.Empty<GradientPointModel>());
         }
         else if (GradientEditor.Points.Count == 0)
@@ -339,20 +334,21 @@ internal sealed partial class AppearancePage : Page
     private void WriteAllPoints()
     {
         if (_loading) return;
-        // Reload() fires ConfigChanged synchronously; OnConfigChanged
-        // decrements _expectingOwnReloads and skips the re-seed so an
-        // in-progress picker flyout isn't torn down. Inner try/finally
-        // on SuppressWatcher keeps the watcher flag balanced if
-        // SetRepeatableValues throws.
+        // The writer reloads after the (watcher-suppressed, IO-guarded)
+        // write; that reload re-enters OnConfigChanged via the dispatcher,
+        // where _expectingOwnReloads is decremented to skip the re-seed so
+        // an in-progress picker flyout isn't torn down. The increment must
+        // happen after the synchronous reload returns but before the
+        // dispatched echo runs -- which is exactly here.
         var values = GradientEditor.Points
             .Select(p => string.Create(
                 System.Globalization.CultureInfo.InvariantCulture,
                 $"{p.X:0.###},{p.Y:0.###},#{p.Color.R:X2}{p.Color.G:X2}{p.Color.B:X2},{p.Radius:0.###}"))
             .ToArray();
-        _configService.SuppressWatcher(true);
-        try { _editor.SetRepeatableValues("background-gradient-point", values); }
-        finally { _configService.SuppressWatcher(false); }
-        if (_configService.Reload())
+        var result = _writer.Write(
+            () => _editor.SetRepeatableValues("background-gradient-point", values),
+            "background-gradient-point");
+        if (result.Reloaded)
         {
             _expectingOwnReloads++;
         }

--- a/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ColorsPage.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using Ghostty.Controls.Settings;
 using Ghostty.Core.Config;
 using Ghostty.Core.Settings;
+using Ghostty.Logging;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -12,6 +13,7 @@ internal sealed partial class ColorsPage : Page
 {
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
+    private readonly SettingsConfigWriter _writer;
     private readonly SearchableList _themeList;
     private readonly SearchableList _lightThemeList;
     private readonly SearchableList _darkThemeList;
@@ -21,6 +23,7 @@ internal sealed partial class ColorsPage : Page
     {
         _configService = configService;
         _editor = editor;
+        _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
 
         _themeList = new SearchableList(ThemeSearch, chosen => OnThemeChosen(chosen));
@@ -155,10 +158,7 @@ internal sealed partial class ColorsPage : Page
     private void OnValueChanged(string key, string value)
     {
         if (_loading) return;
-        _configService.SuppressWatcher(true);
-        try { _editor.SetValue(key, value); }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        _writer.Write(() => _editor.SetValue(key, value), key);
     }
 
     private void Foreground_ColorChanged(object? sender, string hex)
@@ -215,10 +215,7 @@ internal sealed partial class ColorsPage : Page
     private void ResetColorOverride(string key, ColorPickerControl picker, Button resetButton)
     {
         if (_loading) return;
-        _configService.SuppressWatcher(true);
-        try { _editor.RemoveValue(key); }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        _writer.Write(() => _editor.RemoveValue(key), key);
 
         _loading = true;
         try { picker.Color = ""; }

--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml.cs
@@ -11,6 +11,7 @@ internal sealed partial class GeneralPage : Page
 {
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
+    private readonly SettingsConfigWriter _writer;
     private bool _loading = true;
 
     /// <summary>
@@ -25,6 +26,7 @@ internal sealed partial class GeneralPage : Page
     {
         _configService = configService;
         _editor = editor;
+        _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
         LoadValues();
         _loading = false;
@@ -43,10 +45,9 @@ internal sealed partial class GeneralPage : Page
     private void AutoReloadToggle_Toggled(object sender, RoutedEventArgs e)
     {
         if (_loading) return;
-        _configService.SuppressWatcher(true);
-        try { _editor.SetValue("auto-reload-config", AutoReloadToggle.IsOn ? "true" : "false"); }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        _writer.Write(() => _editor.SetValue(
+            "auto-reload-config", AutoReloadToggle.IsOn ? "true" : "false"),
+            "auto-reload-config");
     }
 
     private void VerticalTabsToggle_Toggled(object sender, RoutedEventArgs e)

--- a/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/ProfilesPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Ghostty.Controls.Settings;
 using Ghostty.Core.Config;
 using Ghostty.Core.Profiles;
+using Ghostty.Logging;
 using Ghostty.Settings;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -23,6 +24,7 @@ internal sealed partial class ProfilesPage : Page
     private readonly IProfileRegistry _registry;
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
+    private readonly SettingsConfigWriter _writer;
 
     // Per-id row cache so a Rebind triggered by a background event
     // (e.g. discovery completion) updates existing SettingsCard instances
@@ -48,6 +50,7 @@ internal sealed partial class ProfilesPage : Page
         _registry = registry;
         _configService = configService;
         _editor = editor;
+        _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
 
         // Subscribe at Loaded / unsubscribe at Unloaded so a cached
@@ -271,14 +274,11 @@ internal sealed partial class ProfilesPage : Page
         // defaults to false, so a stray "false" line is just noise that
         // also confuses the warnings filter for hidden-only blocks.
         var key = ProfileHiddenKey.For(id);
-        _configService.SuppressWatcher(true);
-        try
+        _writer.Write(() =>
         {
             if (toggle.IsOn) _editor.SetValue(key, "true");
             else _editor.RemoveValue(key);
-        }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        }, key);
     }
 
     private void OnProfileIconChanged(object? sender, IconSpec? newSpec)
@@ -304,14 +304,11 @@ internal sealed partial class ProfilesPage : Page
             _ => null,
         };
 
-        _configService.SuppressWatcher(true);
-        try
+        _writer.Write(() =>
         {
             if (value is null) _editor.RemoveValue(key);
             else _editor.SetValue(key, value);
-        }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        }, key);
     }
 
     private void OnTracksForegroundToggled(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -332,13 +329,10 @@ internal sealed partial class ProfilesPage : Page
         // to true removes the override instead of writing an explicit
         // "true" line and cluttering the config file.
         var key = $"profile.{id}.tab-icon-tracks-foreground";
-        _configService.SuppressWatcher(true);
-        try
+        _writer.Write(() =>
         {
             if (toggle.IsOn) _editor.RemoveValue(key);
             else _editor.SetValue(key, "false");
-        }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        }, key);
     }
 }

--- a/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/RawEditorPage.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Ghostty.Core.Config;
+using Ghostty.Logging;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -17,6 +18,7 @@ internal sealed partial class RawEditorPage : Page
 {
     private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
+    private readonly SettingsConfigWriter _writer;
     private readonly ObservableCollection<string> _diagnostics = new();
     private int _lastDiagnosticCount = -1;
 
@@ -53,6 +55,7 @@ internal sealed partial class RawEditorPage : Page
     {
         _configService = configService;
         _editor = editor;
+        _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
 
         // Theme flips while the page is live must force a recompute of
@@ -246,17 +249,24 @@ internal sealed partial class RawEditorPage : Page
 
     private void SaveButton_Click(object sender, RoutedEventArgs e)
     {
-        _configService.SuppressWatcher(true);
-        try
+        // _lastLoadedText is updated inside the edit so it only advances
+        // if WriteRaw actually succeeded; on a disk failure it stays at the
+        // prior on-disk content, keeping RefreshFromDiskIfPristine honest.
+        var result = _writer.Write(() =>
         {
             _editor.WriteRaw(GetEditorText());
             _lastLoadedText = GetEditorText();
-        }
-        finally { _configService.SuppressWatcher(false); }
+        }, "raw editor save");
 
-        var success = _configService.Reload();
+        if (!result.WriteSucceeded)
+        {
+            // The save never hit disk; tell the user instead of fail-fasting.
+            StatusText.Text = $"Save failed: {result.Error?.Message}";
+            return;
+        }
+
         var count = _configService.DiagnosticsCount;
-        StatusText.Text = success
+        StatusText.Text = result.Reloaded
             ? $"Saved and reloaded ({count} diagnostic{(count == 1 ? "" : "s")})"
             : "Reload failed -- check diagnostics";
     }

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
@@ -1,4 +1,5 @@
 using Ghostty.Core.Config;
+using Ghostty.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -6,14 +7,14 @@ namespace Ghostty.Settings.Pages;
 
 internal sealed partial class TerminalPage : Page
 {
-    private readonly IConfigService _configService;
     private readonly IConfigFileEditor _editor;
+    private readonly SettingsConfigWriter _writer;
     private bool _loading = true;
 
     public TerminalPage(IConfigService configService, IConfigFileEditor editor)
     {
-        _configService = configService;
         _editor = editor;
+        _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
         CursorStyleBox.ItemsSource = new[] { "block", "bar", "underline" };
 
@@ -35,10 +36,7 @@ internal sealed partial class TerminalPage : Page
     private void OnValueChanged(string key, string value)
     {
         if (_loading) return;
-        _configService.SuppressWatcher(true);
-        try { _editor.SetValue(key, value); }
-        finally { _configService.SuppressWatcher(false); }
-        _configService.Reload();
+        _writer.Write(() => _editor.SetValue(key, value), key);
     }
 
     private void Scrollback_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)


### PR DESCRIPTION
## What

Settings-page immediate-write handlers (toggles, sliders, color pickers, raw save) persisted config with a `SuppressWatcher → try/finally → Reload` idiom that **did not catch IO failures**. An `IOException`/`UnauthorizedAccessException` (file locked, disk full, permission denied) propagated unhandled out of the WinUI routed-event handler into `Application.UnhandledException`, **fail-fasting the whole process**.

## Fix

Extract a shared `SettingsConfigWriter` (`Ghostty.Core.Config`) — the synchronous sibling of `ConfigWriteScheduler`:

- suppresses the watcher, runs the editor mutation in a `try/catch` that catches **only** the realistic disk failures (`IOException`/`UnauthorizedAccessException`), logged via `[LoggerMessage]` (`LogEvents.Config.SettingsWriteErr`);
- always resets the watcher in `finally`, then reloads;
- returns `SettingsWriteResult(WriteSucceeded, Reloaded, Error)`;
- any **other** exception still propagates, so genuine bugs aren't masked;
- optional `context` arg names the failing setting in the log.

Rewired through it: all six Settings pages (Appearance/Colors/Profiles/General/Terminal/RawEditor) and `MainWindow.AdjustOpacity`. `RawEditorPage` surfaces failures via its existing `StatusText` affordance.

## Extra find (subagent review)

`MainWindow.AdjustOpacity` (the opacity-adjust keybindings) had **no `try/finally` at all** — a failed write would both fail-fast *and* leave the watcher stuck suppressed for the rest of the session. Now routed through the helper.

## Tests / verification

- New `SettingsConfigWriter` unit tests (success, reload-failure, both swallowed disk exceptions, unexpected-exception-propagates-but-watcher-balanced, null guards, suppress ordering) + logging-contract tests (event id + `{Context}` rendering).
- `dotnet build windows/Ghostty/Ghostty.csproj -p:Platform=x64` → 0 errors.
- `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj -p:Platform=x64` → **1344 passed, 1 skipped** (pre-existing skip), incl. `LogEventsUniquenessTests`.
- Reviewed by two parallel review subagents (dotnet-windows patterns + adversarial correctness); no Critical findings, the one actionable item (MainWindow) fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)