### PR TITLE
fix(windows): element-theme batch — caption buttons, palette, tabs, ScrollViewer, picker resize (#235 #236 #342 #160 #219)

### DIFF
--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -911,8 +911,9 @@ pub const Surface = struct {
         // renderer never presents the intermediate alt-screen reflow frame
         // before the feature clears and redraws. Mode 2026 is begun BEFORE
         // sizeCallback so the reflow happens under the hold, and ended only
-        // after the feature has redrawn — yielding a single clean present.
-        // ?2026l is emitted on every exit path so the hold can't get stuck. (#219)
+        // after the feature has redrawn, yielding a single clean present.
+        // ?2026l is emitted on every exit path of this (non-re-entrant)
+        // call so the hold is always released. (#219)
         if (comptime builtin.os.tag == .windows) {
             if (self.resize_redirect) |redirect| {
                 self.core_surface.writeVt("\x1b[?2026h");

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -905,19 +905,34 @@ pub const Surface = struct {
             .height = height,
         };
 
-        // Call the primary callback.
+        // When an in-process feature owns the screen (Windows-only
+        // resize_redirect, e.g. the inline theme picker), wrap the
+        // reflow + redraw in a synchronized update (DEC mode 2026) so the
+        // renderer never presents the intermediate alt-screen reflow frame
+        // before the feature clears and redraws. Mode 2026 is begun BEFORE
+        // sizeCallback so the reflow happens under the hold, and ended only
+        // after the feature has redrawn — yielding a single clean present.
+        // ?2026l is emitted on every exit path so the hold can't get stuck. (#219)
+        if (comptime builtin.os.tag == .windows) {
+            if (self.resize_redirect) |redirect| {
+                self.core_surface.writeVt("\x1b[?2026h");
+                self.core_surface.sizeCallback(self.size) catch |err| {
+                    log.err("error in size callback err={}", .{err});
+                    self.core_surface.writeVt("\x1b[?2026l");
+                    return;
+                };
+                const grid = self.core_surface.size.grid();
+                redirect.callback(redirect.userdata, @intCast(grid.columns), @intCast(grid.rows));
+                self.core_surface.writeVt("\x1b[?2026l");
+                return;
+            }
+        }
+
+        // Default path: no in-process feature owns the screen.
         self.core_surface.sizeCallback(self.size) catch |err| {
             log.err("error in size callback err={}", .{err});
             return;
         };
-
-        // Notify in-process features after the grid has been recalculated.
-        if (comptime builtin.os.tag == .windows) {
-            if (self.resize_redirect) |redirect| {
-                const grid = self.core_surface.size.grid();
-                redirect.callback(redirect.userdata, @intCast(grid.columns), @intCast(grid.rows));
-            }
-        }
     }
 
     pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) void {

--- a/src/cli/inline_theme_picker.zig
+++ b/src/cli/inline_theme_picker.zig
@@ -553,6 +553,9 @@ pub const InlineThemePicker = struct {
             config.deinit();
             return null;
         };
+        // `config` is moved into the cache; do NOT deinit it here. The
+        // cache (and deinit) own it now. The only deinit of a successfully
+        // loaded config happens on the next miss or in InlineThemePicker.deinit.
         self.cached_config = config;
         self.cached_config_idx = theme_idx;
         return &self.cached_config.?;

--- a/src/cli/inline_theme_picker.zig
+++ b/src/cli/inline_theme_picker.zig
@@ -78,8 +78,6 @@ pub fn discoverThemes(arena: Allocator) ![]ThemeEntry {
 /// the write callback (no Vaxis).
 pub const InlineThemePicker = struct {
     allocator: Allocator,
-    /// Arena for per-frame allocations, reset each draw call.
-    frame_arena: std.heap.ArenaAllocator,
     /// Arena that owns the theme name/path strings. Freed on deinit.
     theme_arena: ?std.heap.ArenaAllocator,
     themes: []ThemeEntry,
@@ -102,6 +100,13 @@ pub const InlineThemePicker = struct {
     // Track previous theme index for change detection
     prev_theme_idx: ?usize,
 
+    // Cached parsed config for the previewed theme, so a resize storm
+    // (selection unchanged) doesn't re-read + re-parse the theme file
+    // from disk on every frame. Keyed by the absolute theme index. Owned
+    // by the picker's allocator; freed on invalidation and in deinit. (#219)
+    cached_config: ?Config,
+    cached_config_idx: ?usize,
+
     const Mode = enum { normal, search, help };
 
     // Layout constants
@@ -122,7 +127,6 @@ pub const InlineThemePicker = struct {
         const self = try allocator.create(InlineThemePicker);
         self.* = .{
             .allocator = allocator,
-            .frame_arena = std.heap.ArenaAllocator.init(allocator),
             .theme_arena = theme_arena,
             .themes = themes,
             .filtered = try .initCapacity(allocator, themes.len),
@@ -139,6 +143,8 @@ pub const InlineThemePicker = struct {
             .write_ud = write_ud,
             .theme_cb = theme_cb,
             .prev_theme_idx = null,
+            .cached_config = null,
+            .cached_config_idx = null,
         };
 
         // Initialize filtered list with all themes
@@ -151,7 +157,7 @@ pub const InlineThemePicker = struct {
 
     pub fn deinit(self: *InlineThemePicker) void {
         const allocator = self.allocator;
-        self.frame_arena.deinit();
+        if (self.cached_config) |*c| c.deinit();
         self.filtered.deinit(allocator);
         self.search_buf.deinit(allocator);
         if (self.theme_arena) |*arena| arena.deinit();
@@ -440,17 +446,14 @@ pub const InlineThemePicker = struct {
         if (self.should_quit) return;
         self.cols = cols;
         self.rows = rows;
-        // Clear immediately to avoid showing stale content from the
-        // alt screen reflow during the resize.
-        self.write("\x1b[2J\x1b[H");
+        // draw() already clears the screen as its first action; a second
+        // clear here only adds a frame of flicker. The synchronized-update
+        // wrap in apprt updateSize hides the reflow frame instead. (#219)
         self.draw();
     }
 
     /// Render the current state via VT escape sequences.
     pub fn draw(self: *InlineThemePicker) void {
-        _ = self.frame_arena.reset(.retain_capacity);
-        const alloc = self.frame_arena.allocator();
-
         // Clear screen and home cursor
         self.write("\x1b[2J\x1b[H");
 
@@ -473,7 +476,7 @@ pub const InlineThemePicker = struct {
         self.drawThemeList();
 
         // Draw the preview panel (right side)
-        self.drawPreview(alloc);
+        self.drawPreview();
 
         // Draw overlays based on mode
         switch (self.mode) {
@@ -530,7 +533,32 @@ pub const InlineThemePicker = struct {
         }
     }
 
-    fn drawPreview(self: *InlineThemePicker, alloc: Allocator) void {
+    /// Return the parsed config for the given absolute theme index,
+    /// loading + caching it on a miss. Owned by self.allocator (NOT the
+    /// frame arena) so it survives across draws. Returns null if the
+    /// theme file can't be opened/parsed. (#219)
+    fn previewConfig(self: *InlineThemePicker, theme_idx: usize) ?*Config {
+        if (self.cached_config_idx) |idx| {
+            if (idx == theme_idx) {
+                if (self.cached_config) |*c| return c;
+            }
+        }
+        // Miss: drop the stale entry, load fresh.
+        if (self.cached_config) |*c| c.deinit();
+        self.cached_config = null;
+        self.cached_config_idx = null;
+
+        var config = Config.default(self.allocator) catch return null;
+        config.loadFile(config._arena.?.allocator(), self.themes[theme_idx].path) catch {
+            config.deinit();
+            return null;
+        };
+        self.cached_config = config;
+        self.cached_config_idx = theme_idx;
+        return &self.cached_config.?;
+    }
+
+    fn drawPreview(self: *InlineThemePicker) void {
         const x_off = list_width;
         if (x_off >= self.cols) return;
         const width = self.cols - x_off;
@@ -546,12 +574,11 @@ pub const InlineThemePicker = struct {
             return;
         }
 
-        const theme = self.themes[self.filtered.items[self.current]];
+        const theme_idx = self.filtered.items[self.current];
+        const theme = self.themes[theme_idx];
 
-        // Load theme config to get colors
-        var config = Config.default(alloc) catch return;
-        defer config.deinit();
-        config.loadFile(config._arena.?.allocator(), theme.path) catch {
+        // Load (cached) theme config to get colors.
+        const config_ptr = self.previewConfig(theme_idx) orelse {
             // Show error
             const center_row = self.rows / 2;
             self.moveTo(center_row, x_off + 2);
@@ -560,6 +587,7 @@ pub const InlineThemePicker = struct {
             self.print("Unable to open {s}", .{theme.name});
             return;
         };
+        const config = config_ptr.*;
 
         // Set the terminal's default fg/bg via OSC 10/11 so the
         // entire terminal background matches the theme, not just

--- a/windows/Ghostty.Core/Windows/AncestorScrollViewerScope.cs
+++ b/windows/Ghostty.Core/Windows/AncestorScrollViewerScope.cs
@@ -1,0 +1,24 @@
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// Decides which ScrollViewers a nearest-first ancestor walk should
+/// neuter (IsTabStop=false) to kill the click-focus storm (#159) without
+/// breaking legitimate descendant ScrollViewers (#160).
+///
+/// The walk visits the element's parent first (index 0) and farther
+/// ancestors at larger indices. The app content root (Window.Content)
+/// appears at <c>rootIndex</c>. The parasitic framework-injected
+/// ScrollViewer is an ancestor of the app root (index ≥ rootIndex);
+/// legitimate ScrollViewers (settings panes, tab strips) are descendants
+/// of the app root (index &lt; rootIndex). When the app root is not found
+/// (<c>rootIndex &lt; 0</c>) the original single-pane behaviour is kept:
+/// every ScrollViewer is in scope.
+///
+/// Pure (no WinUI) so it stays unit-testable in Ghostty.Core; the WinUI
+/// walk in TerminalControl supplies the indices.
+/// </summary>
+public static class AncestorScrollViewerScope
+{
+    public static bool InScope(int index, int rootIndex) =>
+        rootIndex < 0 || index >= rootIndex;
+}

--- a/windows/Ghostty.Core/Windows/ThemeResolution.cs
+++ b/windows/Ghostty.Core/Windows/ThemeResolution.cs
@@ -4,9 +4,9 @@ namespace Ghostty.Core.Windows;
 /// How the resolver interprets <c>window-theme</c> values that are not
 /// explicitly <c>light</c>, <c>dark</c>, or <c>system</c> (i.e.
 /// <c>auto</c>, <c>ghostty</c>, and unknown values). The terminal
-/// chrome uses Palette so it tracks the active colour palette; the
-/// Settings and command-palette surfaces use System so they feel
-/// OS-native regardless of the terminal's colours.
+/// chrome and the command palette use Palette so they track the active
+/// colour palette and match each other (#236); the Settings surface uses
+/// System so it feels OS-native regardless of the terminal's colours.
 /// </summary>
 public enum ThemeFallbackStyle
 {

--- a/windows/Ghostty.Core/Windows/ThemeResolution.cs
+++ b/windows/Ghostty.Core/Windows/ThemeResolution.cs
@@ -84,4 +84,14 @@ public static class ThemeResolution
         var luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0;
         return luminance < 0.5;
     }
+
+    /// <summary>
+    /// Whether a light (white) foreground reads better than a dark
+    /// (black) one over the given backdrop. Thin intent-revealing alias
+    /// over <see cref="IsBackgroundDark"/> so caption-button and tab-text
+    /// call sites read as "pick a readable foreground for this backdrop"
+    /// while the luminance math stays in one place. (#235, #342)
+    /// </summary>
+    public static bool PreferLightForeground(uint backgroundColor) =>
+        IsBackgroundDark(backgroundColor);
 }

--- a/windows/Ghostty.Tests/Windows/AncestorScrollViewerScopeTests.cs
+++ b/windows/Ghostty.Tests/Windows/AncestorScrollViewerScopeTests.cs
@@ -1,0 +1,38 @@
+using Ghostty.Core.Windows;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+public sealed class AncestorScrollViewerScopeTests
+{
+    // The walk is nearest-first: index 0 is the element's immediate
+    // parent, larger indices are farther ancestors. The app content
+    // root (Window.Content) sits high in the chain; the parasitic
+    // framework ScrollViewer is its ancestor (index >= rootIndex).
+    // Legitimate ScrollViewers (settings, tab strips) are descendants
+    // of the app root (index < rootIndex) and must be left alone.
+
+    [Fact]
+    public void AppRootMissing_NeutersEverything()
+    {
+        // rootIndex < 0 means the app root was not seen in the walk;
+        // preserve the original single-pane behaviour (neuter all).
+        Assert.True(AncestorScrollViewerScope.InScope(index: 0, rootIndex: -1));
+        Assert.True(AncestorScrollViewerScope.InScope(index: 5, rootIndex: -1));
+    }
+
+    [Fact]
+    public void BelowAppRoot_IsLegitimate_NotInScope()
+    {
+        // Indices before the app root are descendants of it = legitimate.
+        Assert.False(AncestorScrollViewerScope.InScope(index: 0, rootIndex: 3));
+        Assert.False(AncestorScrollViewerScope.InScope(index: 2, rootIndex: 3));
+    }
+
+    [Fact]
+    public void AtOrAboveAppRoot_IsParasitic_InScope()
+    {
+        Assert.True(AncestorScrollViewerScope.InScope(index: 3, rootIndex: 3));
+        Assert.True(AncestorScrollViewerScope.InScope(index: 4, rootIndex: 3));
+    }
+}

--- a/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
+++ b/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
@@ -224,4 +224,22 @@ public sealed class ThemeResolutionTests
         Assert.True(auto);    // background is dark → dark frame
         Assert.NotEqual(system, auto);
     }
+
+    // ── PreferLightForeground: readable caption/label foreground ─────────
+
+    [Fact]
+    public void PreferLightForeground_DarkBackground_PrefersLight() =>
+        Assert.True(ThemeResolution.PreferLightForeground(0x000000));
+
+    [Fact]
+    public void PreferLightForeground_LightBackground_PrefersDark() =>
+        Assert.False(ThemeResolution.PreferLightForeground(0xFFFFFF));
+
+    [Fact]
+    public void PreferLightForeground_MatchesIsBackgroundDark()
+    {
+        // Intent alias: PreferLightForeground is exactly IsBackgroundDark.
+        foreach (uint c in new uint[] { 0x000000, 0xFFFFFF, 0x808080, 0x7F7F7F, 0x00FF00, 0x0000FF })
+            Assert.Equal(ThemeResolution.IsBackgroundDark(c), ThemeResolution.PreferLightForeground(c));
+    }
 }

--- a/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
+++ b/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
@@ -181,10 +181,12 @@ public sealed class ThemeResolutionTests
     [Fact]
     public void Regression_DarkPaletteOnLightOs_SystemFallback_IsLight()
     {
-        // The bug this PR fixes: command palette was rendering dark
-        // because it tracked the terminal palette luminance directly.
-        // Under the new System fallback, a dark terminal background on
-        // a light OS must resolve to light.
+        // Pure-function contract for the System fallback: a dark terminal
+        // background on a light OS resolves to LIGHT (the fallback ignores
+        // the palette and tracks the OS). SettingsWindow still uses System
+        // fallback. NOTE: the command palette no longer uses System
+        // fallback — as of #236 it uses Palette fallback to match the
+        // window chrome (see Regression_DarkPaletteOnLightOs_PaletteFallback_IsDark).
         Assert.False(ThemeResolution.ResolveIsDark(
             "ghostty", BlackBg, ThemeFallbackStyle.System, isSystemDark: false));
     }

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -39,12 +39,12 @@ internal sealed partial class CommandPaletteControl : UserControl
     // theme flipped otherwise.
     private string _backgroundSetting = string.Empty;
 
-    // Config+OS-driven theme resolver. The palette uses System fallback
-    // (same as SettingsWindow) so it feels OS-native regardless of the
-    // terminal's palette: a dark palette on a light OS leaves the
-    // palette light, matching every other system UI surface. Created
-    // in Configure() and disposed on Unloaded. Null until Configure
-    // runs, which happens once during MainWindow init.
+    // Config+OS-driven theme resolver. The palette uses Palette fallback
+    // (same as MainWindow) so it matches the window chrome: window-theme=
+    // ghostty + a dark terminal renders a dark window AND a dark palette,
+    // instead of the palette tracking the OS theme and mismatching the
+    // chrome (#236). Created in Configure() and disposed on Unloaded.
+    // Null until Configure runs, which happens once during MainWindow init.
     private WindowThemeManager? _themeManager;
 
     public CommandPaletteControl()
@@ -64,10 +64,11 @@ internal sealed partial class CommandPaletteControl : UserControl
 
     /// <summary>
     /// Wires theme resolution to the live config + OS theme. Matches
-    /// the SettingsWindow pattern: explicit <c>window-theme</c> wins,
+    /// the MainWindow chrome: explicit <c>window-theme</c> wins,
     /// "system" follows the OS, and any other value (auto/ghostty)
-    /// falls back to the OS too — the palette is a system-native
-    /// surface, not a palette-coloured one.
+    /// falls back to the terminal background luminance — so the palette
+    /// renders in the same light/dark variant as the window it floats
+    /// over (#236).
     ///
     /// Idempotent re-wiring is supported: a subsequent call tears
     /// down the previous subscription before creating a new one. In
@@ -84,7 +85,7 @@ internal sealed partial class CommandPaletteControl : UserControl
         }
 
         _themeManager = new WindowThemeManager(
-            configService, DispatcherQueue, ThemeFallbackStyle.System);
+            configService, DispatcherQueue, ThemeFallbackStyle.Palette);
         _themeManager.ThemeChanged += OnThemeChanged;
         ApplyTheme();
     }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Ghostty.Core.Input;
 using Ghostty.Core.ResizeOverlay;
+using Ghostty.Core.Windows;
 using Ghostty.Core.Search;
 using Ghostty.Hosting;
 using Ghostty.Input;
@@ -424,7 +425,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
                 node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
                 if (node is null) break;
                 if (node is ScrollViewer sv &&
-                    Ghostty.Core.Windows.AncestorScrollViewerScope.InScope(i, rootIndex))
+                    AncestorScrollViewerScope.InScope(i, rootIndex))
                 {
                     sv.IsTabStop = false;
                 }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -388,11 +388,48 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void DisableAncestorScrollViewerTabStop()
     {
-        DependencyObject? node = this;
-        while (node is not null)
+        // Only the framework-injected ScrollViewer ABOVE the app content
+        // root is parasitic; legitimate ScrollViewers (settings panes,
+        // tab strips) are descendants of the app root and must keep their
+        // tab stop so Tab navigation through them works (#160). Walk
+        // nearest-first, find the app content root, and neuter only
+        // ScrollViewers at or above it. If the root isn't reachable,
+        // fall back to the original neuter-all behaviour.
+        var appRoot = XamlRoot?.Content as DependencyObject;
+
+        // First pass: record the index of the app content root.
+        int rootIndex = -1;
         {
-            node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
-            if (node is ScrollViewer sv) sv.IsTabStop = false;
+            int i = 0;
+            DependencyObject? node = this;
+            while (node is not null)
+            {
+                node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+                if (node is null) break;
+                if (appRoot is not null && ReferenceEquals(node, appRoot))
+                {
+                    rootIndex = i;
+                    break;
+                }
+                i++;
+            }
+        }
+
+        // Second pass: neuter only the in-scope ScrollViewers.
+        {
+            int i = 0;
+            DependencyObject? node = this;
+            while (node is not null)
+            {
+                node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+                if (node is null) break;
+                if (node is ScrollViewer sv &&
+                    Ghostty.Core.Windows.AncestorScrollViewerScope.InScope(i, rootIndex))
+                {
+                    sv.IsTabStop = false;
+                }
+                i++;
+            }
         }
     }
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using Ghostty.Interop;
 using Ghostty.Input;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Shell;
+using Ghostty.Core.Windows;
 using Ghostty.Services;
 using Ghostty.Logging;
 using Ghostty.Panes;
@@ -1338,16 +1339,24 @@ public sealed partial class MainWindow : Window
         // Caption button colors must be set explicitly when
         // ExtendsContentIntoTitleBar is true, otherwise WinUI 3
         // fills them with the system accent color.
-        var fg = _themeManager.IsDarkMode
+        //
+        // Contrast against the backdrop the buttons actually sit on (the
+        // terminal background, blended through Mica/acrylic), NOT the
+        // abstract element theme. window-theme=dark forces IsDarkMode=true
+        // even over a light terminal palette, which painted white buttons
+        // onto a near-white chrome → invisible (#235). Luminance of the
+        // terminal background tracks what the user sees behind the buttons.
+        bool backdropDark = ThemeResolution.PreferLightForeground(_configService.BackgroundColor);
+        var fg = backdropDark
             ? Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0xFF, 0x00, 0x00, 0x00);
-        var fgInactive = _themeManager.IsDarkMode
+        var fgInactive = backdropDark
             ? Windows.UI.Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0x66, 0x00, 0x00, 0x00);
-        var hoverBg = _themeManager.IsDarkMode
+        var hoverBg = backdropDark
             ? Windows.UI.Color.FromArgb(0x33, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0x33, 0x00, 0x00, 0x00);
-        var pressedBg = _themeManager.IsDarkMode
+        var pressedBg = backdropDark
             ? Windows.UI.Color.FromArgb(0x22, 0xFF, 0xFF, 0xFF)
             : Windows.UI.Color.FromArgb(0x22, 0x00, 0x00, 0x00);
 

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using Ghostty.Core.Windows;
 using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
 
@@ -86,7 +87,13 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // If the shell theme is already active, paint the new tab's
         // title in the cached active-text brush so tabs opened after
         // ApplyShellTheme match the ones that were present at the time.
-        if (_shellActiveTextBrush is not null)
+        // A tab opened while a shell theme is active starts inactive
+        // (the new tab becomes active via TabAdded→SelectActive, which
+        // then promotes it). Default to the inactive brush so it never
+        // flashes the active-on-inactive-bg invisible state (#342).
+        if (_shellInactiveTextBrush is not null)
+            headerText.Foreground = _shellInactiveTextBrush;
+        else if (_shellActiveTextBrush is not null)
             headerText.Foreground = _shellActiveTextBrush;
         var headerBar = new ProgressBar
         {
@@ -203,6 +210,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 ApplyTabColor(headerPanel, model.Color, isSelected);
             }
         }
+
+        // Active/inactive foreground must follow selection too, else the
+        // newly-deselected tab keeps the active brush and goes invisible
+        // against its inactive background (#342).
+        RecolorTabText();
 
         if (ReferenceEquals(TabViewControl.SelectedItem, item)) return;
         _suppressSelectionEvent = true;
@@ -419,12 +431,39 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // resolved to the TabViewItem DataContext (the TabModel), so
         // every tab rendered its type name "Ghostty.Core.Tabs.TabModel"
         // instead of the title.
+        //
+        // Inactive tabs sit on the near-bg tab-bar background, not the
+        // accent background, so the active brush gives them zero contrast
+        // (#342). Pick a luminance-readable foreground over the tab-bar
+        // background and mute it to ~70% so inactive reads as inactive.
         _shellActiveTextBrush = activeTextBrush;
-        foreach (var tb in _headerTextByModel.Values)
-            tb.Foreground = activeTextBrush;
+        uint tabBgPacked = (uint)((theme.TabBarBackground.R << 16)
+            | (theme.TabBarBackground.G << 8)
+            | theme.TabBarBackground.B);
+        var inactiveColor = ThemeResolution.PreferLightForeground(tabBgPacked)
+            ? Windows.UI.Color.FromArgb(0xB3, 0xFF, 0xFF, 0xFF)  // white @ ~70%
+            : Windows.UI.Color.FromArgb(0xB3, 0x00, 0x00, 0x00); // black @ ~70%
+        _shellInactiveTextBrush = new SolidColorBrush(inactiveColor);
+        RecolorTabText();
     }
 
     private SolidColorBrush? _shellActiveTextBrush;
+    private SolidColorBrush? _shellInactiveTextBrush;
+
+    // Recolor every tab title to its active/inactive shell-theme brush.
+    // No-op unless a shell theme is active (brushes non-null). The active
+    // brush is calibrated against the accent background; the inactive
+    // brush is a muted, luminance-readable foreground over the near-bg
+    // tab-bar background — without this, inactive titles inherited the
+    // active brush and vanished (#342).
+    private void RecolorTabText()
+    {
+        if (_shellActiveTextBrush is null || _shellInactiveTextBrush is null) return;
+        foreach (var (model, tb) in _headerTextByModel)
+            tb.Foreground = ReferenceEquals(model, _manager.ActiveTab)
+                ? _shellActiveTextBrush
+                : _shellInactiveTextBrush;
+    }
 
     private ElementTheme _cachedTheme = ElementTheme.Default;
 
@@ -438,6 +477,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         TabViewControl.Resources.Remove("TabViewBackground");
         TabViewControl.Resources.Remove("TabViewItemHeaderBackgroundSelected");
         _shellActiveTextBrush = null;
+        _shellInactiveTextBrush = null;
 
         // Revert each tab title's Foreground to its inherited theme
         // brush so the default WinUI text color returns.

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -90,11 +90,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // A tab opened while a shell theme is active starts inactive
         // (the new tab becomes active via TabAdded→SelectActive, which
         // then promotes it). Default to the inactive brush so it never
-        // flashes the active-on-inactive-bg invisible state (#342).
+        // flashes the active-on-inactive-bg invisible state (#342). The
+        // active/inactive brushes are a coupled pair (both set in
+        // ApplyShellTheme, both nulled in ClearShellTheme), so a non-null
+        // inactive brush is sufficient to know a shell theme is active.
         if (_shellInactiveTextBrush is not null)
             headerText.Foreground = _shellInactiveTextBrush;
-        else if (_shellActiveTextBrush is not null)
-            headerText.Foreground = _shellActiveTextBrush;
         var headerBar = new ProgressBar
         {
             Height = 2,


### PR DESCRIPTION
## Summary

Batch fix for five Windows-fork theme / element-theme bugs. Verified each root cause against the code before fixing.

| Issue | Fix |
|---|---|
| **#235** caption buttons invisible (dark window-theme + light terminal) | Caption foreground now contrasts the **backdrop** (terminal bg luminance), not the abstract `IsDarkMode`. |
| **#342** inactive tab titles invisible after shell-theme apply | Active tab keeps the active brush; inactive tabs get a luminance-readable muted brush vs the tab-bar bg, re-applied on selection/add. |
| **#236** command palette ignores window element theme | Palette `WindowThemeManager` fallback `System → Palette` so it matches the window chrome. |
| **#160** ancestor ScrollViewer walk neuters legitimate ScrollViewers | Walk now scopes `IsTabStop=false` to ScrollViewers **above the app content root** (the parasitic framework one). |
| **#219** inline theme picker resize jank/flash | Windows-only: wrap the resize in synchronized output (DEC 2026) so no intermediate reflow frame presents; drop the picker double-clear; cache the per-theme config parse. |

## Root-cause grouping

- **#235 + #342 share one root cause** — a foreground chosen without regard to the actual background behind it. Both reuse the new `ThemeResolution.PreferLightForeground` (alias over the existing BT.709 `IsBackgroundDark`).
- **#236 / #160 / #219 are independent.**

## ⚠️ Intentional reversal (read before reviewing #236)

PR #330 **deliberately** put the command palette on `System` fallback (OS-native) and added a regression test pinning it. #236 is the newer authoritative ask: the palette must match the **window chrome**, not the OS. They conflict only when OS theme ≠ resolved window theme (e.g. `window-theme=ghostty` + dark terminal on a light OS). This PR sides with #236 and flips the fallback. No mechanical test breaks (the regression test asserts the pure `ResolveIsDark` function, which is unchanged); its now-misleading comment was corrected to note the palette no longer uses `System` fallback. `SettingsWindow` still uses `System` fallback.

## #219 scope note

Conservative, in-PR: Windows-only (`embedded.zig`) + picker-only (`inline_theme_picker.zig`). **No** cross-platform `src/Surface.zig` edits (avoids renderer regression + daily-rebase conflict risk). The flash elimination relies on the DX12 renderer honoring synchronized-output across a swapchain-resize present — validated by app-test; the double-clear removal and parse cache reduce jank regardless.

## Testing

- New unit tests: `PreferLightForeground` (3), `AncestorScrollViewerScope.InScope` (3).
- Full C# suite: **1351 passed, 0 failed, 1 skipped**.
- `zig build test -Dapp-runtime=none`: pass.
- App-tested each of the five visually (see PR comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
