### PR TITLE
feat(windows): MSYS2 profile + Git Bash direct-spawn winpty wrap (#80 tail)

### DIFF
--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -187,6 +187,30 @@ pub fn identify(exe_path: []const u8) Kind {
     return kinds.get(lower) orelse .unknown;
 }
 
+/// Candidate winpty.exe locations relative to a Cygwin-family bash.exe.
+/// Two layouts cover Git for Windows and MSYS2:
+///   - same dir as bash:   <dir>\winpty.exe         (Git/MSYS2 usr\bin)
+///   - sibling usr\bin:    <parent>\usr\bin\winpty.exe  (Git bin\bash.exe)
+///
+/// Pure path math; existence is checked by the caller. Caller frees each
+/// returned slice. Surrounding quotes/whitespace are stripped so a config
+/// value like `"C:\Git\bin\bash.exe"` resolves correctly. We use the
+/// Windows-specific dirname and an explicit `\` separator (rather than
+/// std.fs.path.join/dirname, which follow the *host* OS) so the result is
+/// deterministic when these tests run on a non-Windows CI host.
+pub fn winptyCandidatePaths(
+    alloc: std.mem.Allocator,
+    bash_exe_path: []const u8,
+) std.mem.Allocator.Error![2][]const u8 {
+    const trimmed = std.mem.trim(u8, bash_exe_path, "\"' \t\r\n");
+    const dir = std.fs.path.dirnameWindows(trimmed) orelse ".";
+    const parent = std.fs.path.dirnameWindows(dir) orelse dir;
+    return .{
+        try std.fmt.allocPrint(alloc, "{s}\\winpty.exe", .{dir}),
+        try std.fmt.allocPrint(alloc, "{s}\\usr\\bin\\winpty.exe", .{parent}),
+    };
+}
+
 /// Returns true if the system ANSI codepage (`GetACP()`) is one of the
 /// legacy double-byte CJK codepages where forcing UTF-8 on a spawned
 /// shell would mojibake legacy `.bat` scripts whose script text is
@@ -367,6 +391,25 @@ test "utf8Preamble: prefix ends with shell-appropriate separator" {
 
     // none: empty.
     try testing.expectEqualStrings("", Preamble.none.prefix());
+}
+
+test "winptyCandidatePaths: git bin layout" {
+    const c = try winptyCandidatePaths(testing.allocator, "C:\\Program Files\\Git\\bin\\bash.exe");
+    defer for (c) |p| testing.allocator.free(p);
+    try testing.expectEqualStrings("C:\\Program Files\\Git\\bin\\winpty.exe", c[0]);
+    try testing.expectEqualStrings("C:\\Program Files\\Git\\usr\\bin\\winpty.exe", c[1]);
+}
+
+test "winptyCandidatePaths: msys2 usr/bin layout" {
+    const c = try winptyCandidatePaths(testing.allocator, "C:\\msys64\\usr\\bin\\bash.exe");
+    defer for (c) |p| testing.allocator.free(p);
+    try testing.expectEqualStrings("C:\\msys64\\usr\\bin\\winpty.exe", c[0]);
+}
+
+test "winptyCandidatePaths: strips surrounding quotes" {
+    const c = try winptyCandidatePaths(testing.allocator, "\"C:\\Git\\bin\\bash.exe\"");
+    defer for (c) |p| testing.allocator.free(p);
+    try testing.expectEqualStrings("C:\\Git\\bin\\winpty.exe", c[0]);
 }
 
 test "isCjkAnsiCodePage: links GetACP and agrees with the pure-logic helper" {

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -189,8 +189,10 @@ pub fn identify(exe_path: []const u8) Kind {
 
 /// Candidate winpty.exe locations relative to a Cygwin-family bash.exe.
 /// Two layouts cover Git for Windows and MSYS2:
-///   - same dir as bash:   <dir>\winpty.exe         (Git/MSYS2 usr\bin)
-///   - sibling usr\bin:    <parent>\usr\bin\winpty.exe  (Git bin\bash.exe)
+///   - same dir as bash:  <dir>\winpty.exe
+///       matches MSYS2 (usr\bin\bash.exe) and Git's usr\bin\bash.exe
+///   - parent's usr\bin:  <parent>\usr\bin\winpty.exe
+///       matches Git's bin\bash.exe (winpty lives one level up in usr\bin)
 ///
 /// Pure path math; existence is checked by the caller. Caller frees each
 /// returned slice. Surrounding quotes/whitespace are stripped so a config

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1913,19 +1913,21 @@ fn windowsShellNeedsCmdWrapping(s: []const u8) bool {
 /// ConPTY instead of emitting "cannot set terminal process group (-1):
 /// Inappropriate ioctl for device" + "no job control in this shell".
 ///
-/// This mirrors what the profile-discovery probes (GitBashProbe,
-/// Msys2Probe) already build into their command strings, so a manual
-/// `command = "C:\Program Files\Git\bin\bash.exe"` behaves like the
-/// discovered profile.
+/// This gives a manual `command = "C:\Program Files\Git\bin\bash.exe"`
+/// the same winpty/ConPTY job-control bridge that the profile-discovery
+/// probes (GitBashProbe, Msys2Probe) build into their command strings.
+/// (The probes additionally append `--login -i`; here the user owns
+/// their own flags, so we only prepend winpty.)
 ///
 /// Gated narrowly so we never wrap the wrong bash:
 ///   - args[0] must identify as bash (basename `bash`/`bash.exe`).
-///   - args[0] must be path-qualified (contain a separator). Bare `bash`
-///     is left alone: on a normal PATH it resolves to
-///     C:\Windows\System32\bash.exe (the WSL launcher, which must NOT be
-///     winpty-wrapped), and PATH-resolving here would duplicate
-///     Command.startWindows. A bare-`bash`-via-Git-on-PATH user keeps the
-///     pre-existing warnings (graceful degradation).
+///   - args[0] must be an absolute path. Bare `bash` is left alone: on a
+///     normal PATH it resolves to C:\Windows\System32\bash.exe (the WSL
+///     launcher, which must NOT be winpty-wrapped), and PATH-resolving
+///     here would duplicate Command.startWindows. A relative path is also
+///     left alone: it can't be validated by accessAbsolute below (which
+///     requires an absolute path). Both degrade gracefully to the
+///     pre-existing behavior.
 ///   - a winpty.exe must exist adjacent to the bash (see
 ///     windows_shell.winptyCandidatePaths). System32 has none, so WSL is
 ///     excluded; a discovered profile's args[0] is winpty (not bash), so
@@ -1941,10 +1943,14 @@ fn maybeWrapGitBashWithWinpty(
     if (args.len == 0) return args;
     if (internal_os.windows_shell.identify(args[0]) != .bash) return args;
 
-    // Path-qualified only (see doc comment).
-    if (std.mem.indexOfAny(u8, args[0], "\\/") == null) return args;
+    // Absolute path only (see doc comment): bare/relative bash is skipped,
+    // and an absolute path satisfies accessAbsolute's precondition below.
+    if (!std.fs.path.isAbsoluteWindows(std.mem.trim(u8, args[0], "\"' \t\r\n")))
+        return args;
 
-    const candidates = try internal_os.windows_shell.winptyCandidatePaths(alloc, args[0]);
+    // Best effort: an allocation failure here just skips the wrap rather
+    // than failing the spawn.
+    const candidates = internal_os.windows_shell.winptyCandidatePaths(alloc, args[0]) catch return args;
 
     const winpty: []const u8 = found: {
         for (candidates) |c| {
@@ -3679,4 +3685,58 @@ test "maybeInjectUtf8Preamble windows: -EncodedCommand with BOM + param() is ski
     const args: []const [:0]const u8 = &.{ "pwsh", "-EncodedCommand", b64 };
     const out = try maybeInjectUtf8Preamble(alloc, args, .always);
     try testing.expectEqualStrings(b64, out[2]);
+}
+
+test "maybeWrapGitBashWithWinpty windows: non-bash is left untouched" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const args: []const [:0]const u8 = &.{"C:\\Windows\\System32\\cmd.exe"};
+    const out = try maybeWrapGitBashWithWinpty(alloc, args);
+    try testing.expectEqual(args.ptr, out.ptr); // unchanged slice
+}
+
+test "maybeWrapGitBashWithWinpty windows: relative bash is skipped (no accessAbsolute panic)" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // A relative path-qualified bash passes the basename check but is not
+    // absolute; it must short-circuit BEFORE accessAbsolute (which asserts
+    // an absolute path) and return the args unchanged.
+    for ([_][:0]const u8{ "bin\\bash.exe", ".\\bash.exe", "bash.exe" }) |arg| {
+        const args: []const [:0]const u8 = &.{arg};
+        const out = try maybeWrapGitBashWithWinpty(alloc, args);
+        try testing.expectEqual(args.ptr, out.ptr);
+    }
+}
+
+test "maybeWrapGitBashWithWinpty windows: absolute bash with adjacent winpty is wrapped" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // Build a real bash.exe + adjacent winpty.exe under a tmp dir so the
+    // accessAbsolute existence check passes, then assert winpty is prepended.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "bash.exe", .data = "" });
+    try tmp.dir.writeFile(.{ .sub_path = "winpty.exe", .data = "" });
+    const real = try tmp.dir.realpathAlloc(alloc, ".");
+    const bash = try std.fmt.allocPrintSentinel(alloc, "{s}\\bash.exe", .{real}, 0);
+    const winpty = try std.fmt.allocPrint(alloc, "{s}\\winpty.exe", .{real});
+
+    const args: []const [:0]const u8 = &.{ bash, "--login" };
+    const out = try maybeWrapGitBashWithWinpty(alloc, args);
+    try testing.expectEqual(@as(usize, 3), out.len);
+    try testing.expectEqualStrings(winpty, out[0]);
+    try testing.expectEqualStrings(bash, out[1]);
+    try testing.expectEqualStrings("--login", out[2]);
 }

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1765,11 +1765,12 @@ fn execCommand(
         .direct => |_| direct: {
             const cloned = (try command.clone(alloc)).direct;
             if (comptime builtin.os.tag == .windows) {
-                break :direct try maybeInjectUtf8Preamble(
+                const with_preamble = try maybeInjectUtf8Preamble(
                     alloc,
                     cloned,
                     utf8_console,
                 );
+                break :direct try maybeWrapGitBashWithWinpty(alloc, with_preamble);
             }
             break :direct cloned;
         },
@@ -1830,11 +1831,12 @@ fn execCommand(
                     }
 
                     const direct_args = try args.toOwnedSlice(alloc);
-                    break :shell try maybeInjectUtf8Preamble(
+                    const with_preamble = try maybeInjectUtf8Preamble(
                         alloc,
                         direct_args,
                         utf8_console,
                     );
+                    break :shell try maybeWrapGitBashWithWinpty(alloc, with_preamble);
                 }
 
                 // Command contains cmd.exe metacharacters (or parsing
@@ -1904,6 +1906,58 @@ fn windowsShellNeedsCmdWrapping(s: []const u8) bool {
         else => {},
     };
     return false;
+}
+
+/// Prepend winpty to a manually-configured Git-for-Windows / MSYS2
+/// `bash.exe` so its job-control init sees a MinTTY-compatible PTY under
+/// ConPTY instead of emitting "cannot set terminal process group (-1):
+/// Inappropriate ioctl for device" + "no job control in this shell".
+///
+/// This mirrors what the profile-discovery probes (GitBashProbe,
+/// Msys2Probe) already build into their command strings, so a manual
+/// `command = "C:\Program Files\Git\bin\bash.exe"` behaves like the
+/// discovered profile.
+///
+/// Gated narrowly so we never wrap the wrong bash:
+///   - args[0] must identify as bash (basename `bash`/`bash.exe`).
+///   - args[0] must be path-qualified (contain a separator). Bare `bash`
+///     is left alone: on a normal PATH it resolves to
+///     C:\Windows\System32\bash.exe (the WSL launcher, which must NOT be
+///     winpty-wrapped), and PATH-resolving here would duplicate
+///     Command.startWindows. A bare-`bash`-via-Git-on-PATH user keeps the
+///     pre-existing warnings (graceful degradation).
+///   - a winpty.exe must exist adjacent to the bash (see
+///     windows_shell.winptyCandidatePaths). System32 has none, so WSL is
+///     excluded; a discovered profile's args[0] is winpty (not bash), so
+///     there is no double-wrap.
+///
+/// When no wrap applies the input `args` slice is returned unchanged.
+/// Both input and output are owned by the caller's arena.
+fn maybeWrapGitBashWithWinpty(
+    alloc: Allocator,
+    args: []const [:0]const u8,
+) Allocator.Error![]const [:0]const u8 {
+    if (comptime builtin.os.tag != .windows) return args;
+    if (args.len == 0) return args;
+    if (internal_os.windows_shell.identify(args[0]) != .bash) return args;
+
+    // Path-qualified only (see doc comment).
+    if (std.mem.indexOfAny(u8, args[0], "\\/") == null) return args;
+
+    const candidates = try internal_os.windows_shell.winptyCandidatePaths(alloc, args[0]);
+
+    const winpty: []const u8 = found: {
+        for (candidates) |c| {
+            std.fs.accessAbsolute(c, .{}) catch continue;
+            break :found c;
+        }
+        return args;
+    };
+
+    const out = try alloc.alloc([:0]const u8, args.len + 1);
+    out[0] = try alloc.dupeZ(u8, winpty);
+    @memcpy(out[1..], args);
+    return out;
 }
 
 /// Inject a shell-specific UTF-8 codepage setup into argv when the

--- a/windows/Ghostty.Core/Profiles/Probes/Msys2Probe.cs
+++ b/windows/Ghostty.Core/Profiles/Probes/Msys2Probe.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ghostty.Core.Profiles.Probes;
+
+/// <summary>
+/// Probes for an MSYS2 install at its canonical roots (C:\msys64, then
+/// the legacy 32-bit C:\msys32) and surfaces its bash as a profile.
+///
+/// Detection is path-based, not registry-based: MSYS2 has no documented
+/// stable registry key (no HKLM\SOFTWARE\MSYS2), and its uninstaller
+/// lives under enumerable Uninstall\* subkeys that IRegistryReader does
+/// not expose. The official installer and `winget install MSYS2.MSYS2`
+/// both target C:\msys64, so trusting the well-known path mirrors how
+/// CmdProbe / PowerShellProbe locate their shells.
+///
+/// MSYS2 shares Git for Windows' MSYS2/Cygwin bash runtime, so we reuse
+/// GitBashProbe's exact launch shape: wrap with usr\bin\winpty.exe when
+/// present so bash's job-control init sees a MinTTY-compatible PTY under
+/// ConPTY instead of emitting "cannot set terminal process group" + "no
+/// job control" warnings. `--login -i` sources /etc/profile, which sets
+/// up the default MSYS environment (prompt, PATH, UTF-8 locale). winpty,
+/// NOT mintty: mintty is a GUI terminal that would open its own window.
+/// </summary>
+internal sealed class Msys2Probe(IFileSystem fs) : IInstalledShellProbe
+{
+    public string ProbeId => "msys2";
+
+    // Ordered by preference: 64-bit default first, legacy 32-bit second.
+    private static readonly string[] Roots = { @"C:\msys64", @"C:\msys32" };
+
+    public Task<IReadOnlyList<DiscoveredProfile>> DiscoverAsync(CancellationToken ct)
+    {
+        foreach (var root in Roots)
+        {
+            var bash = Path.Combine(root, "usr", "bin", "bash.exe");
+            if (!fs.FileExists(bash)) continue;
+
+            var winpty = Path.Combine(root, "usr", "bin", "winpty.exe");
+            var command = fs.FileExists(winpty)
+                ? $"{ProbeUtil.QuoteIfNeeded(winpty)} {ProbeUtil.QuoteIfNeeded(bash)} --login -i"
+                : $"{ProbeUtil.QuoteIfNeeded(bash)} --login -i";
+
+            var profile = new DiscoveredProfile(
+                Id: "msys2",
+                Name: "MSYS2",
+                Command: command,
+                ProbeId: ProbeId,
+                Icon: new IconSpec.BundledKey("bash"));
+
+            return Task.FromResult<IReadOnlyList<DiscoveredProfile>>(new[] { profile });
+        }
+
+        return Task.FromResult<IReadOnlyList<DiscoveredProfile>>(System.Array.Empty<DiscoveredProfile>());
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
+++ b/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using System.Threading;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Profiles.Probes;
+using Ghostty.Tests.Profiles.Fakes;
+using Xunit;
+
+namespace Ghostty.Tests.Profiles.Probes;
+
+public sealed class Msys2ProbeTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_Msys64WithWinpty_ReturnsWrappedProfile()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys64\usr\bin\winpty.exe");
+
+        var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
+        Assert.Equal("msys2", p.Id);
+        Assert.Equal("MSYS2", p.Name);
+        Assert.Contains("winpty.exe", p.Command);
+        Assert.Contains("bash.exe", p.Command);
+        Assert.Contains("--login", p.Command);
+        Assert.Equal("msys2", p.ProbeId);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_Msys64NoWinpty_ReturnsBareBash()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+
+        var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
+        Assert.DoesNotContain("winpty", p.Command);
+        Assert.Contains("bash.exe", p.Command);
+        Assert.Contains("--login", p.Command);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_Msys32Fallback_ReturnsProfile()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys32\usr\bin\bash.exe");
+
+        var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
+        Assert.Contains(@"msys32", p.Command);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_NotInstalled_ReturnsEmpty()
+    {
+        Assert.Empty(await new Msys2Probe(new FakeFileSystem()).DiscoverAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_PrefersMsys64OverMsys32()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys32\usr\bin\bash.exe");
+
+        var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
+        Assert.Contains(@"msys64", p.Command);
+    }
+}

--- a/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
+++ b/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
@@ -44,7 +44,7 @@ public sealed class Msys2ProbeTests
         fs.AddFile(@"C:\msys32\usr\bin\bash.exe");
 
         var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
-        Assert.Contains(@"msys32", p.Command);
+        Assert.Contains("msys32", p.Command);
     }
 
     [Fact]
@@ -61,6 +61,6 @@ public sealed class Msys2ProbeTests
         fs.AddFile(@"C:\msys32\usr\bin\bash.exe");
 
         var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
-        Assert.Contains(@"msys64", p.Command);
+        Assert.Contains("msys64", p.Command);
     }
 }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -504,6 +504,7 @@ public partial class App : Application
             new Ghostty.Core.Profiles.Probes.PowerShellProbe(fileSystem, processRunner),
             new Ghostty.Core.Profiles.Probes.WslProbe(processRunner),
             new Ghostty.Core.Profiles.Probes.GitBashProbe(registryReader, fileSystem),
+            new Ghostty.Core.Profiles.Probes.Msys2Probe(fileSystem),
             new Ghostty.Core.Profiles.Probes.AzureCloudShellProbe(processRunner),
         };
 


### PR DESCRIPTION
Finishes the shell-compatibility tail of the rescoped #80. Two independent, focused items.

## 1. MSYS2 auto-discovered profile (`Msys2Probe.cs`)
- Path-based detection at `C:\msys64` then `C:\msys32` (MSYS2 has no stable registry key; `IRegistryReader` can't enumerate `Uninstall\*` anyway). Mirrors `CmdProbe`/`PowerShellProbe` trusting well-known paths.
- Launch mirrors the sibling `GitBashProbe` **exactly**: `winpty + bash --login -i`, with graceful bare-bash fallback when winpty is absent.
- **winpty, not mintty** (mintty is a GUI terminal — would pop its own window). Not `msys2_shell.cmd -defterm` either: it's a `.cmd` needing a `cmd /c` layer that triggers the known "Terminate batch job (Y/N)?" Ctrl-D bug under embedding terminals ([terminal#14663](https://github.com/microsoft/terminal/discussions/14663)).
- Reuses the bundled `bash` icon; no new `ShellKind`.

## 2. Git Bash direct-spawn winpty wrap (Zig)
A manual `command = "C:\Program Files\Git\bin\bash.exe"` bypassed the winpty wrap the discovered profile builds, so Cygwin bash emitted *"cannot set terminal process group (-1)"* + *"no job control"* under ConPTY. `maybeWrapGitBashWithWinpty` (in `Exec.zig`, alongside the existing `maybeInjectUtf8Preamble` transform) prepends an adjacent `winpty.exe`. Pure path math (`winptyCandidatePaths`) lives in `windows_shell.zig` and is unit-tested.

Gated narrowly: `args[0]` identifies as bash **and** is path-qualified **and** a `winpty.exe` exists adjacent (`<dir>\winpty.exe` or `<dir>\..\usr\bin\winpty.exe`). This excludes `System32\bash.exe` (WSL — no sibling winpty) and avoids double-wrapping discovered profiles (their `args[0]` is winpty). Bare `bash` is left alone (documented).

## Tests
- C#: 5 new `Msys2ProbeTests` + full suite (1356) green (x64).
- Zig: new `winptyCandidatePaths` tests + full `zig build test -Dapp-runtime=none` green (pinned 0.15.2).
- In-app verification (MSYS2 installed via winget): see PR thread.

## Out of scope (remaining on #80)
Clink, WSL-wrapper, MSYS2 environment-variant profiles (UCRT64/MINGW64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)