### PR TITLE
fix(windows): repaint surfaces on config_change so live reloads take effect (#193 #244)

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -38,6 +38,7 @@ internal enum GhosttyActionTag
     MouseOverLink = 38,
     OpenConfig = 40,
     ReloadConfig = 47,
+    ConfigChange = 48,
     CloseWindow = 49,
     RingBell = 50,
     ProgressReport = 56,

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -25,6 +25,7 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.MouseShape, 36)]
     [InlineData((int)GhosttyActionTag.MouseVisibility, 37)]
     [InlineData((int)GhosttyActionTag.MouseOverLink, 38)]
+    [InlineData((int)GhosttyActionTag.ConfigChange, 48)]
     [InlineData((int)GhosttyActionTag.CloseWindow, 49)]
     [InlineData((int)GhosttyActionTag.RingBell, 50)]
     [InlineData((int)GhosttyActionTag.ProgressReport, 56)]

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -124,6 +124,22 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     internal IntPtr SurfaceHandle => _surface.Handle;
 
     /// <summary>
+    /// Schedule an immediate repaint of this surface. Used by the
+    /// <c>config_change</c> action handler so a live config/theme reload
+    /// presents a fresh frame: libghostty re-resolves default-colored cells,
+    /// cursor style, font metrics, etc. against the new config on the next
+    /// rebuild, but on Windows nothing otherwise forces that frame to be
+    /// drawn after a reload (issues #193, #244). Must be called on the UI
+    /// thread. No-op once the surface is gone so a reload racing teardown
+    /// can't draw into freed native state.
+    /// </summary>
+    internal void RequestRepaint()
+    {
+        if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return;
+        NativeMethods.SurfaceDraw(_surface);
+    }
+
+    /// <summary>
     /// Returns the pid of the shell process attached to this surface, or
     /// null when libghostty cannot report one (surface not yet created,
     /// already disposed, or the platform's pty layer is a stub). The

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -441,6 +441,16 @@ internal sealed class GhosttyHost : IDisposable
                             ReloadConfigRequested?.Invoke(this, EventArgs.Empty));
                         return 1;
 
+                    case GhosttyActionTag.ConfigChange:
+                        // App-level config_change fires once per reload after
+                        // libghostty has pushed the new config to every surface.
+                        // The per-surface config_change dispatches (handled in
+                        // the surface-target switch below) already force each
+                        // surface to repaint, so there is nothing extra to do at
+                        // the app level -- just acknowledge so libghostty stops
+                        // logging it as unhandled (issue #193).
+                        return 1;
+
                     case GhosttyActionTag.ToggleQuickTerminal:
                         // Routed to App rather than a per-window event because
                         // the quake window is a singleton owned by App; any
@@ -704,6 +714,23 @@ internal sealed class GhosttyHost : IDisposable
                     {
                         if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                             c.RaiseFirstRender();
+                    });
+                    return 1;
+                }
+
+                case GhosttyActionTag.ConfigChange:
+                {
+                    // A live config/theme reload pushed new config into this
+                    // surface. libghostty re-resolves default-colored cells,
+                    // cursor style, font metrics, etc. on the next rebuild, but
+                    // on Windows nothing otherwise forces that frame to be drawn
+                    // after a reload -- so existing terminal content stays stale
+                    // until the next keystroke. Force an immediate repaint so the
+                    // re-resolved frame is presented (issues #193, #244).
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                            c.RequestRepaint();
                     });
                     return 1;
                 }


### PR DESCRIPTION
## Problem

The `config_change` action (`ghostty_action_tag_e` = 48) was **missing** from `GhosttyActionTag`, so `GhosttyHost.OnAction` fell through to the default branch and returned `0` (unhandled) for every live config/theme reload.

libghostty already re-resolves default-colored cells, cursor style and font metrics into the renderer's buffers on reload (its renderer thread does a full rebuild). But on Windows nothing forced the swapchain to **present** that frame after a reload, so:

- **#193**: existing terminal text kept the old foreground — it only recolored when you typed (which dirties new rows).
- **#244**: runtime settings (cursor-style, font-size, …) appeared not to re-apply.

Both are the same root cause: the re-resolved frame was never presented.

## Fix (repaint-only)

- Add `ConfigChange = 48` to `GhosttyActionTag` and pin the ordinal in `GhosttyActionsLayoutTests`.
- Handle `ConfigChange` in `OnAction`:
  - **surface target** → force an immediate repaint via the new `TerminalControl.RequestRepaint()` (`ghostty_surface_draw`).
  - **app target** → acknowledge (the per-surface dispatches already cover every surface).
- `RequestRepaint()` is UI-thread-only and no-ops once the surface is disposed, so a reload racing teardown can't draw into freed native state (consistent with the #208 guards).

The embedded apprt already forwards `config_change` for both app and surface targets (`src/apprt/embedded.zig performAction`), so **no Zig change is needed**.

## Why no core (Zig) change

The original #193 hypothesis (cells cache resolved RGB at write time) does not hold in current code: `.none`-fg cells resolve at *render* time from the live terminal foreground, and `Termio.changeConfig` already forces a full rebuild. The verified A/B below confirms the rebuild produces correct colors — the only gap was the Windows present.

## Verification (live, DX12 build)

Isolated `XDG_CONFIG_HOME`, `auto-reload-config` file-watcher trigger, GDI screenshot + pixel histogram. Identical controlled scenario (window moved to a clear area, no focus/typing):

| | baseline | after reload | repaint called |
|---|---|---|---|
| **With fix** | red=955px | **red=0, green=955** | yes (per surface) |
| **Without fix** | red | **stays red, green=0** | no |

- `red→green` recolored only with the handler (same 955px swap = same cells re-resolved).
- `font-size 28→46` re-applied live (green text px 2299→6025) — covers #244.
- All **1352** C# tests pass; clean AOT build (no new warnings).

Closes #193, closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)