### PR TITLE
feat(windows): MSYS2 UCRT64/MINGW64/CLANG64 environment profiles (#80)

### DIFF
--- a/windows/Ghostty.Core/Profiles/Probes/Msys2Probe.cs
+++ b/windows/Ghostty.Core/Profiles/Probes/Msys2Probe.cs
@@ -23,6 +23,15 @@ namespace Ghostty.Core.Profiles.Probes;
 /// job control" warnings. `--login -i` sources /etc/profile, which sets
 /// up the default MSYS environment (prompt, PATH, UTF-8 locale). winpty,
 /// NOT mintty: mintty is a GUI terminal that would open its own window.
+///
+/// Beyond the base MSYS environment we also surface MSYS2's modern
+/// toolchain subsystems (UCRT64, MINGW64, CLANG64) as their own profiles
+/// when their per-environment launcher (e.g. <c>ucrt64.exe</c>) is present
+/// in the install root. Each variant runs the same bash but selects the
+/// subsystem by setting <c>MSYSTEM</c> via coreutils <c>env</c> (which
+/// /etc/profile reads to wire up the right PATH), mirroring what
+/// <c>msys2_shell.cmd -ucrt64</c> does. Legacy 32-bit subsystems
+/// (mingw32/clang32) are intentionally not surfaced.
 /// </summary>
 internal sealed class Msys2Probe(IFileSystem fs) : IInstalledShellProbe
 {
@@ -30,6 +39,15 @@ internal sealed class Msys2Probe(IFileSystem fs) : IInstalledShellProbe
 
     // Ordered by preference: 64-bit default first, legacy 32-bit second.
     private static readonly string[] Roots = { @"C:\msys64", @"C:\msys32" };
+
+    // Modern toolchain subsystems, in display order. Each is detected by
+    // its root launcher "<key>.exe" and selected at runtime via MSYSTEM.
+    private static readonly (string Msystem, string Suffix)[] Subsystems =
+    {
+        ("UCRT64", "ucrt64"),
+        ("MINGW64", "mingw64"),
+        ("CLANG64", "clang64"),
+    };
 
     public Task<IReadOnlyList<DiscoveredProfile>> DiscoverAsync(CancellationToken ct)
     {
@@ -39,18 +57,41 @@ internal sealed class Msys2Probe(IFileSystem fs) : IInstalledShellProbe
             if (!fs.FileExists(bash)) continue;
 
             var winpty = Path.Combine(root, "usr", "bin", "winpty.exe");
-            var command = fs.FileExists(winpty)
-                ? $"{ProbeUtil.QuoteIfNeeded(winpty)} {ProbeUtil.QuoteIfNeeded(bash)} --login -i"
-                : $"{ProbeUtil.QuoteIfNeeded(bash)} --login -i";
+            var winptyPrefix = fs.FileExists(winpty)
+                ? ProbeUtil.QuoteIfNeeded(winpty) + " "
+                : "";
+            var bashSuffix = $"{ProbeUtil.QuoteIfNeeded(bash)} --login -i";
 
-            var profile = new DiscoveredProfile(
-                Id: "msys2",
-                Name: "MSYS2",
-                Command: command,
-                ProbeId: ProbeId,
-                Icon: new IconSpec.BundledKey("bash"));
+            var profiles = new List<DiscoveredProfile>
+            {
+                new(
+                    Id: "msys2",
+                    Name: "MSYS2",
+                    Command: $"{winptyPrefix}{bashSuffix}",
+                    ProbeId: ProbeId,
+                    Icon: new IconSpec.BundledKey("bash")),
+            };
 
-            return Task.FromResult<IReadOnlyList<DiscoveredProfile>>(new[] { profile });
+            // Subsystem variants require coreutils `env` to set MSYSTEM.
+            // It ships with the runtime alongside bash; guard defensively.
+            var env = Path.Combine(root, "usr", "bin", "env.exe");
+            if (fs.FileExists(env))
+            {
+                var envQuoted = ProbeUtil.QuoteIfNeeded(env);
+                foreach (var (msystem, suffix) in Subsystems)
+                {
+                    if (!fs.FileExists(Path.Combine(root, suffix + ".exe"))) continue;
+
+                    profiles.Add(new DiscoveredProfile(
+                        Id: $"msys2-{suffix}",
+                        Name: $"MSYS2 {msystem}",
+                        Command: $"{winptyPrefix}{envQuoted} MSYSTEM={msystem} {bashSuffix}",
+                        ProbeId: ProbeId,
+                        Icon: new IconSpec.BundledKey("bash")));
+                }
+            }
+
+            return Task.FromResult<IReadOnlyList<DiscoveredProfile>>(profiles);
         }
 
         return Task.FromResult<IReadOnlyList<DiscoveredProfile>>(System.Array.Empty<DiscoveredProfile>());

--- a/windows/Ghostty.Core/Profiles/Probes/Msys2Probe.cs
+++ b/windows/Ghostty.Core/Profiles/Probes/Msys2Probe.cs
@@ -42,6 +42,9 @@ internal sealed class Msys2Probe(IFileSystem fs) : IInstalledShellProbe
 
     // Modern toolchain subsystems, in display order. Each is detected by
     // its root launcher "<key>.exe" and selected at runtime via MSYSTEM.
+    // Msystem values must be argv-safe (no spaces/quotes): they are emitted
+    // unquoted into the command string as `MSYSTEM=<value>` and must survive
+    // libghostty's ArgIteratorGeneral as a single token.
     private static readonly (string Msystem, string Suffix)[] Subsystems =
     {
         ("UCRT64", "ucrt64"),

--- a/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
+++ b/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
@@ -63,4 +63,95 @@ public sealed class Msys2ProbeTests
         var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
         Assert.Contains("msys64", p.Command);
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_Ucrt64Present_EmitsVariantAfterBase()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys64\usr\bin\env.exe");
+        fs.AddFile(@"C:\msys64\ucrt64.exe");
+
+        var result = (await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None)).ToList();
+        Assert.Equal(2, result.Count);
+        Assert.Equal("msys2", result[0].Id);
+
+        var v = result[1];
+        Assert.Equal("msys2-ucrt64", v.Id);
+        Assert.Equal("MSYS2 UCRT64", v.Name);
+        Assert.Equal("msys2", v.ProbeId);
+        Assert.Contains("env.exe", v.Command);
+        Assert.Contains("MSYSTEM=UCRT64", v.Command);
+        Assert.Contains("bash.exe", v.Command);
+        Assert.Contains("--login", v.Command);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_AllSubsystems_EmitsAllOrdered()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys64\usr\bin\env.exe");
+        fs.AddFile(@"C:\msys64\ucrt64.exe");
+        fs.AddFile(@"C:\msys64\mingw64.exe");
+        fs.AddFile(@"C:\msys64\clang64.exe");
+
+        var ids = (await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None))
+            .Select(p => p.Id).ToList();
+        Assert.Equal(new[] { "msys2", "msys2-ucrt64", "msys2-mingw64", "msys2-clang64" }, ids);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_32BitSubsystems_AreIgnored()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys64\usr\bin\env.exe");
+        fs.AddFile(@"C:\msys64\mingw32.exe");
+        fs.AddFile(@"C:\msys64\clang32.exe");
+
+        var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
+        Assert.Equal("msys2", p.Id);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_VariantWithWinpty_PrependsWinptyBeforeEnv()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys64\usr\bin\winpty.exe");
+        fs.AddFile(@"C:\msys64\usr\bin\env.exe");
+        fs.AddFile(@"C:\msys64\ucrt64.exe");
+
+        var v = (await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None)).First(p => p.Id == "msys2-ucrt64");
+        Assert.Contains("winpty.exe", v.Command);
+        Assert.True(v.Command.IndexOf("winpty.exe") < v.Command.IndexOf("env.exe"),
+            "winpty must precede env in the command");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_VariantNoWinpty_StartsWithEnv()
+    {
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys64\usr\bin\env.exe");
+        fs.AddFile(@"C:\msys64\ucrt64.exe");
+
+        var v = (await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None)).First(p => p.Id == "msys2-ucrt64");
+        Assert.DoesNotContain("winpty", v.Command);
+        Assert.Contains("env.exe", v.Command);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_EnvMissing_EmitsBaseOnly()
+    {
+        // env.exe absent => cannot set MSYSTEM, so no variants even though
+        // a subsystem launcher is present.
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys64\ucrt64.exe");
+
+        var p = Assert.Single(await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None));
+        Assert.Equal("msys2", p.Id);
+    }
 }

--- a/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
+++ b/windows/Ghostty.Tests/Profiles/Probes/Msys2ProbeTests.cs
@@ -130,7 +130,7 @@ public sealed class Msys2ProbeTests
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task Discover_VariantNoWinpty_StartsWithEnv()
+    public async System.Threading.Tasks.Task Discover_VariantNoWinpty_ExactCommand()
     {
         var fs = new FakeFileSystem();
         fs.AddFile(@"C:\msys64\usr\bin\bash.exe");
@@ -138,8 +138,26 @@ public sealed class Msys2ProbeTests
         fs.AddFile(@"C:\msys64\ucrt64.exe");
 
         var v = (await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None)).First(p => p.Id == "msys2-ucrt64");
-        Assert.DoesNotContain("winpty", v.Command);
-        Assert.Contains("env.exe", v.Command);
+        // Pin the exact token sequence + quoting: env precedes the unquoted
+        // MSYSTEM assignment precedes bash; no winpty when absent.
+        Assert.Equal(
+            @"C:\msys64\usr\bin\env.exe MSYSTEM=UCRT64 C:\msys64\usr\bin\bash.exe --login -i",
+            v.Command);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Discover_Msys32Root_EmitsVariant()
+    {
+        // Subsystem detection is root-relative; confirm it works under the
+        // legacy 32-bit fallback root too.
+        var fs = new FakeFileSystem();
+        fs.AddFile(@"C:\msys32\usr\bin\bash.exe");
+        fs.AddFile(@"C:\msys32\usr\bin\env.exe");
+        fs.AddFile(@"C:\msys32\ucrt64.exe");
+
+        var v = (await new Msys2Probe(fs).DiscoverAsync(CancellationToken.None)).First(p => p.Id == "msys2-ucrt64");
+        Assert.Contains(@"C:\msys32\usr\bin\env.exe", v.Command);
+        Assert.Contains("MSYSTEM=UCRT64", v.Command);
     }
 
     [Fact]


### PR DESCRIPTION
Unit A of the #80 shell-compat tail. Surfaces MSYS2's modern toolchain environments as their own auto-discovered profiles.

## What
Extends `Msys2Probe`: alongside the base **MSYS2** profile, emit one profile per modern subsystem (**UCRT64 / MINGW64 / CLANG64**) whose root launcher (`ucrt64.exe` etc.) exists. Each selects its environment via coreutils `env`:

```
[<winpty>] <root>\usr\bin\env.exe MSYSTEM=UCRT64 <root>\usr\bin\bash.exe --login -i
```

- Detection is file-based (`<root>\<subsys>.exe`), so it works with the existing `FakeFileSystem`.
- Legacy 32-bit subsystems (mingw32/clang32) intentionally skipped (YAGNI).
- Variants require coreutils `env.exe` (guarded → base-only if absent).
- Base profile unchanged (backward-compatible). Mirrors what `msys2_shell.cmd -ucrt64` does and WT's per-subsystem fragment.

## Tests / verification
- 12 `Msys2ProbeTests` (base-only, per-subsystem, all-ordered, 32-bit-ignored, winpty ordering, env-missing→base-only, exact-command token/quoting lock, msys32-root). Full C# suite **1363 / 0**.
- Live: `env MSYSTEM=UCRT64 bash --login` → `MSYSTEM=UCRT64`, PATH leads `/ucrt64/bin`.
- In-app: UCRT64 variant spawns the full **winpty → winpty-agent → env → bash** chain (verified via libghostty spawn-log + process tree).
- dotnet-windows-reviewer: no blocking findings; applied its recommended exact-command assertion + invariant comment + msys32-root test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)