### PR TITLE
feat(windows): full CMD shell integration via Clink (OSC 133 C/D) (#80)

### DIFF
--- a/src/shell-integration/cmd/README.md
+++ b/src/shell-integration/cmd/README.md
@@ -1,0 +1,26 @@
+# cmd.exe shell integration
+
+cmd.exe has no rc file or pre/post-exec hooks, so Ghostty's base
+integration sets the `PROMPT` environment variable to emit:
+
+- `OSC 133;A` / `OSC 133;B` — prompt start / input start
+- `OSC 9;9` — current working directory
+
+`PROMPT` cannot mark when a command *starts* or *finishes*. For those,
+`ghostty.lua` adds the remaining marks **when the user runs
+[Clink](https://chrisant996.github.io/clink/)**:
+
+- `OSC 133;C` — a command was submitted and is about to run
+- `OSC 133;D;<code>` — the command finished, with its exit code
+
+Ghostty loads `ghostty.lua` automatically by prepending this directory to
+`CLINK_PATH`; Clink autoloads `*.lua` from `CLINK_PATH` when it is injected
+into cmd. If Clink is not installed, the variable is simply ignored and you
+still get the `PROMPT`-based A/B/cwd marks.
+
+The script deliberately does **not** emit `133;A`/`133;B` — `PROMPT`
+already does, and doubling them would confuse the terminal. It therefore
+complements, rather than replaces, the `PROMPT`-based integration.
+
+Reading the previous command's exit code uses Clink's `cmd.get_errorlevel`
+setting, which is enabled by default.

--- a/src/shell-integration/cmd/ghostty.lua
+++ b/src/shell-integration/cmd/ghostty.lua
@@ -1,0 +1,72 @@
+-- Ghostty shell integration for cmd.exe, via Clink (https://chrisant996.github.io/clink/).
+--
+-- cmd.exe has no rc file or pre/post-exec hooks, so Ghostty's base
+-- integration sets the PROMPT env var to emit OSC 133;A (prompt start),
+-- OSC 133;B (prompt end) and OSC 9;9 (cwd). PROMPT cannot mark when a
+-- command starts or finishes. When the user runs Clink, this script adds
+-- exactly those missing marks:
+--
+--   OSC 133;C         command was submitted and is about to run
+--   OSC 133;D;<code>  the command finished, with its exit code
+--
+-- It deliberately does NOT emit 133;A/133;B: PROMPT already does, and
+-- doubling the prompt marks would confuse the terminal. So this script
+-- COMPLEMENTS the PROMPT-based integration rather than replacing it.
+--
+-- Ghostty loads this automatically by prepending its shell-integration
+-- "cmd" directory to CLINK_PATH; Clink autoloads *.lua from CLINK_PATH
+-- when it is injected into cmd. If Clink is not installed/injected, the
+-- env var is simply ignored. Nothing here runs without Clink.
+--
+-- Reading the previous command's exit code relies on Clink's
+-- `cmd.get_errorlevel` setting (enabled by default).
+
+local function osc(body)
+    -- BEL-terminated OSC. Clink scripts run inside cmd, so io.write goes
+    -- straight to the console Ghostty is reading.
+    io.write("\x1b]" .. body .. "\x07")
+end
+
+-- Emit functions are exposed on the returned module so they can be tested
+-- in isolation (e.g. via `clink lua`), where the session event API below
+-- is unavailable.
+local M = {}
+
+function M.mark_command_start()
+    osc("133;C")
+end
+
+function M.mark_command_end(code)
+    osc("133;D;" .. tostring(code))
+end
+
+-- Whether a real (non-blank) command was submitted since the last prompt.
+local ran_command = false
+
+-- Register with Clink's edit lifecycle. Guarded so the script can also be
+-- loaded outside an injected session (e.g. `clink lua`) without erroring;
+-- in that context the event functions don't exist and there's nothing to
+-- hook anyway.
+if clink and clink.onbeginedit and clink.onendedit then
+    -- Fires just before each prompt is drawn. If a command ran, report its
+    -- end + exit code now (before the next 133;A from PROMPT). Skipped on
+    -- the first prompt, where no command has run yet.
+    clink.onbeginedit(function()
+        if ran_command then
+            M.mark_command_end(os.geterrorlevel())
+            ran_command = false
+        end
+    end)
+
+    -- Fires when the user accepts the input line (Enter). Mark the command
+    -- start for non-blank lines only, so bare Enter doesn't emit spurious
+    -- C/D marks.
+    clink.onendedit(function(line)
+        if line and line:match("%S") then
+            M.mark_command_start()
+            ran_command = true
+        end
+    end)
+end
+
+return M

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -81,7 +81,7 @@ pub fn setup(
             env,
         ),
 
-        .cmd => try setupCmd(alloc_arena, command, env),
+        .cmd => try setupCmd(alloc_arena, command, resource_dir, env),
 
         .elvish, .fish => xdg: {
             if (!try setupXdgDataDirs(alloc_arena, resource_dir, env)) return null;
@@ -1064,13 +1064,22 @@ test "powershell: user-supplied args are left untouched" {
 /// Setup cmd.exe shell integration. cmd has no rc file or pre/post-exec
 /// hooks, but it re-expands the PROMPT env var on every prompt and supports
 /// `$e` (ESC) on Windows 10+. We wrap the prompt body in OSC 133;A / 133;B
-/// (prompt-start / input-start) and report cwd via OSC 9;9. No command
-/// start/end (C/D) marks are possible. Unlike the script-based shells, cmd
+/// (prompt-start / input-start) and report cwd via OSC 9;9. PROMPT cannot
+/// emit command start/end (C/D) marks. Unlike the script-based shells, cmd
 /// has no way to read GHOSTTY_SHELL_FEATURES at runtime, so these marks are
 /// always emitted (the gated features do not apply to cmd anyway).
+///
+/// For the missing C/D marks we additionally prepend our shell-integration
+/// "cmd" directory to CLINK_PATH. When the user runs Clink, it autoloads
+/// `ghostty.lua` from there and emits OSC 133;C / 133;D;<code> to complement
+/// the PROMPT-based A/B marks. CLINK_PATH is a native Windows path list
+/// (`;`-separated), so no POSIX path conversion is involved, and it is a
+/// harmless no-op when Clink is not installed. We skip it when the
+/// integration directory is missing (e.g. a build without resources).
 fn setupCmd(
     alloc_arena: Allocator,
     command: config.Command,
+    resource_dir: []const u8,
     env: *EnvMap,
 ) !?config.Command {
     // Preserve the user's prompt body if set, else cmd's default `$p$g`.
@@ -1082,6 +1091,35 @@ fn setupCmd(
         .{body},
     );
     try env.put("PROMPT", wrapped);
+
+    // Forward slashes are fine for Clink on Windows, matching the other
+    // setup functions' path style.
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const clink_dir = try std.fmt.bufPrint(
+        &path_buf,
+        "{s}/shell-integration/cmd",
+        .{resource_dir},
+    );
+    if (std.fs.openDirAbsolute(clink_dir, .{})) |dir_| {
+        var dir = dir_;
+        dir.close();
+        try env.put(
+            "CLINK_PATH",
+            try internal_os.prependEnv(
+                alloc_arena,
+                env.get("CLINK_PATH") orelse "",
+                clink_dir,
+            ),
+        );
+    } else |err| switch (err) {
+        // No integration dir is the expected case for a build without
+        // resources (e.g. lib-only): base PROMPT marks still apply and
+        // Clink users just won't get the C/D marks. Don't warn on every
+        // cmd launch for it; reserve warn for genuine failures.
+        error.FileNotFound => log.debug("cmd: no clink integration dir at {s}", .{clink_dir}),
+        else => log.warn("cmd: clink integration dir unavailable {s}: {}", .{ clink_dir, err }),
+    }
+
     return try command.clone(alloc_arena);
 }
 
@@ -1091,10 +1129,13 @@ test "cmd: PROMPT carries OSC 133 marks" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
+    var res: TmpResourcesDir = try .init(alloc, .cmd);
+    defer res.deinit();
+
     var env = EnvMap.init(alloc);
     defer env.deinit();
 
-    _ = try setupCmd(alloc, .{ .shell = "cmd.exe" }, &env);
+    _ = try setupCmd(alloc, .{ .shell = "cmd.exe" }, res.path, &env);
 
     const prompt = env.get("PROMPT") orelse return error.NoPrompt;
     try testing.expect(std.mem.indexOf(u8, prompt, "133;A") != null);
@@ -1108,17 +1149,84 @@ test "cmd: preserves existing PROMPT body" {
     defer arena.deinit();
     const alloc = arena.allocator();
 
+    var res: TmpResourcesDir = try .init(alloc, .cmd);
+    defer res.deinit();
+
     var env = EnvMap.init(alloc);
     defer env.deinit();
 
     try env.put("PROMPT", "$p$g$s");
 
-    _ = try setupCmd(alloc, .{ .shell = "cmd.exe" }, &env);
+    _ = try setupCmd(alloc, .{ .shell = "cmd.exe" }, res.path, &env);
 
     const prompt = env.get("PROMPT") orelse return error.NoPrompt;
     try testing.expect(std.mem.indexOf(u8, prompt, "$p$g$s") != null);
     try testing.expect(std.mem.indexOf(u8, prompt, "133;A") != null);
     try testing.expect(std.mem.indexOf(u8, prompt, "133;B") != null);
+}
+
+test "cmd: CLINK_PATH includes the shell-integration cmd dir" {
+    const testing = std.testing;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var res: TmpResourcesDir = try .init(alloc, .cmd);
+    defer res.deinit();
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+
+    _ = try setupCmd(alloc, .{ .shell = "cmd.exe" }, res.path, &env);
+
+    // Exact match: with no prior CLINK_PATH, ours is the sole entry.
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(
+        try std.fmt.bufPrint(&path_buf, "{s}/shell-integration/cmd", .{res.path}),
+        env.get("CLINK_PATH") orelse return error.NoClinkPath,
+    );
+}
+
+test "cmd: CLINK_PATH prepends ours and preserves existing entries" {
+    const testing = std.testing;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var res: TmpResourcesDir = try .init(alloc, .cmd);
+    defer res.deinit();
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+
+    try env.put("CLINK_PATH", "C:\\my\\scripts");
+
+    _ = try setupCmd(alloc, .{ .shell = "cmd.exe" }, res.path, &env);
+
+    const clink = env.get("CLINK_PATH") orelse return error.NoClinkPath;
+    // Windows path-list delimiter is ';'. Ours is prepended.
+    try testing.expect(std.mem.endsWith(u8, clink, "C:\\my\\scripts"));
+    try testing.expect(std.mem.indexOf(u8, clink, ";") != null);
+    try testing.expect(std.mem.indexOf(u8, clink, "shell-integration") != null);
+}
+
+test "cmd: CLINK_PATH is left unset when the cmd integration dir is absent" {
+    const testing = std.testing;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // A resources dir whose shell-integration has bash but no cmd/.
+    var res: TmpResourcesDir = try .init(alloc, .bash);
+    defer res.deinit();
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+
+    _ = try setupCmd(alloc, .{ .shell = "cmd.exe" }, res.path, &env);
+
+    try testing.expect(env.get("PROMPT") != null);
+    try testing.expect(env.get("CLINK_PATH") == null);
 }
 
 /// Setup the zsh automatic shell integration. This works by setting


### PR DESCRIPTION
Unit B of the #80 shell-compat tail. Brings cmd.exe to full OSC 133 prompt-marking parity for users who run [Clink](https://chrisant996.github.io/clink/).

## What
cmd's `PROMPT` can emit `OSC 133;A/B` (prompt start/end) + `OSC 9;9` (cwd) but **cannot** mark when a command starts or finishes. This adds the missing marks via Clink:

- **`src/shell-integration/cmd/ghostty.lua`** (new): emits `OSC 133;C` on command submit (`clink.onendedit`) and `OSC 133;D;<exit>` before the next prompt (`clink.onbeginedit` + `os.geterrorlevel`). It deliberately does **not** emit A/B — `PROMPT` already does — so it *complements*, never doubles, the prompt marks. Registration is guarded so the module also loads standalone (for testing).
- **`setupCmd`** gains a `resource_dir` param and prepends `<resource_dir>\shell-integration\cmd` to **`CLINK_PATH`** so an injected Clink autoloads the script. `CLINK_PATH` is a native-Windows `;`-separated list (no POSIX conversion). Harmless no-op when Clink isn't installed; skipped (debug-logged, not warned) when the integration dir is absent (e.g. a build without resources). `PROMPT` wrapping is unchanged.

The script ships automatically (`addInstallDirectory` copies the whole `shell-integration` tree; `.md` excluded). No build.zig change.

## Tests / verification
- Zig units: `CLINK_PATH` includes the cmd dir (exact-match), prepends+preserves existing entries, unset when the dir is absent, PROMPT marks intact. Full `zig build test -Dapp-runtime=none` green.
- **Headless (decisive):** `clink lua` capture confirms the script emits exactly `ESC]133;C BEL`, `ESC]133;D;0 BEL`, `ESC]133;D;1 BEL`; `clink info` confirms `CLINK_PATH` lands in Clink's script search paths.
- In-app: cmd spawns and Wintty is stable; the no-resources path is graceful (`shell integration disabled` → cmd still spawns).
- ghostty-reviewer: no blocking findings; applied its exact-match test + downgraded the absent-dir log `warn`→`debug`.

## Notes
Clink is **not** auto-installed; this only wires `CLINK_PATH` so Clink users get the C/D marks. Exit-code reads use Clink's default-on `cmd.get_errorlevel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)