### PR TITLE
feat(windows): MSYS2 fish shell integration via -C source (#80) (#494)

### DIFF
--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -1545,10 +1545,12 @@ test "zsh: missing resources" {
 /// On Windows, fish is always MSYS2/Cygwin (there is no native Windows fish
 /// build), and its $__fish_vendor_confdirs is a fixed set that ignores the
 /// runtime XDG_DATA_DIRS — so the vendor conf is never auto-loaded there.
-/// We deliver it explicitly with `-C 'source <file>'`. `-C` (--init-command)
-/// runs after fish reads its config and vendor dirs but before interactive
-/// input, so sourcing the file registers its `--on-event fish_prompt`
-/// handler normally — the same end state as Linux's auto-load.
+/// We deliver it explicitly by appending `-C "source $GHOSTTY_SHELL_INTEGRATION_XDG_DIR/.../ghostty-shell-integration.fish"`
+/// (see the inline comment below for why the path is referenced via the env
+/// var rather than embedded). `-C` (--init-command) runs after fish reads its
+/// configuration but before interactive input, so sourcing the file registers
+/// its `--on-event fish_prompt` handler normally — the same end state as
+/// Linux's auto-load.
 fn setupFish(
     alloc: Allocator,
     command: config.Command,

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -83,12 +83,17 @@ pub fn setup(
 
         .cmd => try setupCmd(alloc_arena, command, resource_dir, env),
 
-        .elvish, .fish => |s| xdg: {
-            // fish under Windows is always MSYS2/Cygwin (no native build), so
-            // it needs POSIX-form paths; elvish has a native Windows build and
-            // keeps the Windows path conventions.
-            const cygwin = s == .fish;
-            if (!try setupXdgDataDirs(alloc_arena, resource_dir, env, cygwin)) return null;
+        .fish => try setupFish(
+            alloc_arena,
+            command,
+            resource_dir,
+            env,
+        ),
+
+        .elvish => xdg: {
+            // elvish has a native Windows build and keeps the Windows path
+            // conventions (cygwin = false).
+            if (!try setupXdgDataDirs(alloc_arena, resource_dir, env, false)) return null;
             break :xdg try command.clone(alloc_arena);
         },
     } orelse return null;
@@ -1527,6 +1532,124 @@ test "zsh: missing resources" {
     defer env.deinit();
 
     try testing.expect(try setupZsh(alloc, .{ .shell = "zsh" }, resources_dir, &env) == null);
+    try testing.expectEqual(0, env.count());
+}
+
+/// Setup automatic shell integration for fish.
+///
+/// On every platform we export the shell-integration dir via XDG_DATA_DIRS
+/// (Linux fish derives $__fish_vendor_confdirs from it, and the integration
+/// script's own ghostty_restore_xdg_data_dir cleanup needs
+/// GHOSTTY_SHELL_INTEGRATION_XDG_DIR + XDG_DATA_DIRS).
+///
+/// On Windows, fish is always MSYS2/Cygwin (there is no native Windows fish
+/// build), and its $__fish_vendor_confdirs is a fixed set that ignores the
+/// runtime XDG_DATA_DIRS — so the vendor conf is never auto-loaded there.
+/// We deliver it explicitly with `-C 'source <file>'`. `-C` (--init-command)
+/// runs after fish reads its config and vendor dirs but before interactive
+/// input, so sourcing the file registers its `--on-event fish_prompt`
+/// handler normally — the same end state as Linux's auto-load.
+fn setupFish(
+    alloc: Allocator,
+    command: config.Command,
+    resource_dir: []const u8,
+    env: *EnvMap,
+) !?config.Command {
+    if (!try setupXdgDataDirs(alloc, resource_dir, env, true)) return null;
+
+    if (comptime builtin.os.tag == .windows) {
+        // POSIX path to the vendor conf file for the Cygwin/MSYS2 fish.
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const integ_file = try std.fmt.bufPrint(
+            &path_buf,
+            "{s}/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish",
+            .{resource_dir},
+        );
+        const posix_file = try winToCygwinPath(alloc, integ_file);
+
+        var stack_fallback = std.heap.stackFallback(4096, alloc);
+        var cmd = internal_os.shell.ShellCommandBuilder.init(stack_fallback.get());
+        defer cmd.deinit();
+
+        // Preserve the original command line.
+        var iter = try command.argIterator(alloc);
+        defer iter.deinit();
+        while (iter.next()) |arg| try cmd.appendArg(arg);
+
+        // Append `-C "source '<posix-file>'"`. The outer double quotes make
+        // ArgIteratorGeneral (single_quotes = false) re-parse the value as one
+        // argument; the inner single quotes protect spaces for fish. POSIX
+        // paths contain no `"` or `\`, so no further escaping is needed.
+        try cmd.appendArg("-C");
+        try cmd.appendArg(try std.fmt.allocPrint(
+            alloc,
+            "\"source '{s}'\"",
+            .{posix_file},
+        ));
+
+        return .{ .shell = try alloc.dupeZ(u8, try cmd.toOwnedSlice()) };
+    }
+
+    // Non-Windows: the XDG export above is sufficient (Linux/macOS fish).
+    return try command.clone(alloc);
+}
+
+test "fish" {
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var res: TmpResourcesDir = try .init(testing.allocator, .fish);
+    defer res.deinit();
+
+    var env = EnvMap.init(testing.allocator);
+    defer env.deinit();
+
+    const command = try setupFish(alloc, .{ .shell = "fish -i" }, res.path, &env);
+
+    // The XDG dir is exported on every platform; the integration script's own
+    // ghostty_restore_xdg_data_dir cleanup relies on it.
+    try testing.expect(env.get("GHOSTTY_SHELL_INTEGRATION_XDG_DIR") != null);
+
+    if (comptime builtin.os.tag == .windows) {
+        // Windows fish is always MSYS2/Cygwin, whose $__fish_vendor_confdirs
+        // ignores runtime XDG_DATA_DIRS, so the vendor conf is delivered
+        // explicitly via `-C 'source <posix-file>'`.
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const integ_file = try std.fmt.bufPrint(
+            &path_buf,
+            "{s}/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish",
+            .{res.path},
+        );
+        const expected = try std.fmt.allocPrint(
+            alloc,
+            "fish -i -C \"source '{s}'\"",
+            .{try winToCygwinPath(alloc, integ_file)},
+        );
+        try testing.expectEqualStrings(expected, command.?.shell);
+    } else {
+        // Other platforms: command unchanged; the XDG export does the work.
+        try testing.expectEqualStrings("fish -i", command.?.shell);
+    }
+}
+
+test "fish: missing resources" {
+    const testing = std.testing;
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const resources_dir = try tmp_dir.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(resources_dir);
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+
+    try testing.expect(try setupFish(alloc, .{ .shell = "fish" }, resources_dir, &env) == null);
     try testing.expectEqual(0, env.count());
 }
 

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -1558,15 +1558,6 @@ fn setupFish(
     if (!try setupXdgDataDirs(alloc, resource_dir, env, true)) return null;
 
     if (comptime builtin.os.tag == .windows) {
-        // POSIX path to the vendor conf file for the Cygwin/MSYS2 fish.
-        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const integ_file = try std.fmt.bufPrint(
-            &path_buf,
-            "{s}/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish",
-            .{resource_dir},
-        );
-        const posix_file = try winToCygwinPath(alloc, integ_file);
-
         var stack_fallback = std.heap.stackFallback(4096, alloc);
         var cmd = internal_os.shell.ShellCommandBuilder.init(stack_fallback.get());
         defer cmd.deinit();
@@ -1576,16 +1567,28 @@ fn setupFish(
         defer iter.deinit();
         while (iter.next()) |arg| try cmd.appendArg(arg);
 
-        // Append `-C "source '<posix-file>'"`. The outer double quotes make
-        // ArgIteratorGeneral (single_quotes = false) re-parse the value as one
-        // argument; the inner single quotes protect spaces for fish. POSIX
-        // paths contain no `"` or `\`, so no further escaping is needed.
+        // Append `-C "source $GHOSTTY_SHELL_INTEGRATION_XDG_DIR/.../ghostty-shell-integration.fish"`.
+        // The outer double quotes make ArgIteratorGeneral (single_quotes =
+        // false) re-parse the value as a single argument.
+        //
+        // We reference the vendor conf through the
+        // GHOSTTY_SHELL_INTEGRATION_XDG_DIR env var (set above by
+        // setupXdgDataDirs, in POSIX form) instead of embedding the literal
+        // path, for two reasons:
+        //   1. The spawned `.shell` command line then carries no filesystem
+        //      path. Embedding one risks cmd.exe metacharacters (`( )` from
+        //      `Program Files (x86)`, `%`, `!`) tripping
+        //      windowsShellNeedsCmdWrapping in Exec.zig, which would route the
+        //      whole command through `cmd.exe /C` — making cmd.exe (not fish)
+        //      the spawned process. `$VAR` is expanded by fish at runtime, not
+        //      on the spawn-side command line, so no path metacharacter ever
+        //      reaches that check.
+        //   2. fish does not word-split variable expansions, so a path with
+        //      spaces resolves as a single token natively.
         try cmd.appendArg("-C");
-        try cmd.appendArg(try std.fmt.allocPrint(
-            alloc,
-            "\"source '{s}'\"",
-            .{posix_file},
-        ));
+        try cmd.appendArg(
+            "\"source $GHOSTTY_SHELL_INTEGRATION_XDG_DIR/fish/vendor_conf.d/ghostty-shell-integration.fish\"",
+        );
 
         return .{ .shell = try alloc.dupeZ(u8, try cmd.toOwnedSlice()) };
     }
@@ -1615,19 +1618,18 @@ test "fish" {
     if (comptime builtin.os.tag == .windows) {
         // Windows fish is always MSYS2/Cygwin, whose $__fish_vendor_confdirs
         // ignores runtime XDG_DATA_DIRS, so the vendor conf is delivered
-        // explicitly via `-C 'source <posix-file>'`.
-        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const integ_file = try std.fmt.bufPrint(
-            &path_buf,
-            "{s}/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish",
-            .{res.path},
+        // explicitly via `-C source`. The path is referenced through the
+        // GHOSTTY_SHELL_INTEGRATION_XDG_DIR env var rather than embedded, so
+        // the command line carries no filesystem path that could trip the
+        // cmd.exe metacharacter check in Exec.zig (e.g. `Program Files (x86)`).
+        try testing.expectEqualStrings(
+            "fish -i -C \"source $GHOSTTY_SHELL_INTEGRATION_XDG_DIR/fish/vendor_conf.d/ghostty-shell-integration.fish\"",
+            command.?.shell,
         );
-        const expected = try std.fmt.allocPrint(
-            alloc,
-            "fish -i -C \"source '{s}'\"",
-            .{try winToCygwinPath(alloc, integ_file)},
-        );
-        try testing.expectEqualStrings(expected, command.?.shell);
+        // Regression guard: no resource path is embedded in the command, so
+        // a metacharacter in the install path can never reach windowsShell-
+        // NeedsCmdWrapping (which would force a cmd.exe wrapper).
+        try testing.expect(std.mem.indexOfScalar(u8, command.?.shell, '(') == null);
     } else {
         // Other platforms: command unchanged; the XDG export does the work.
         try testing.expectEqualStrings("fish -i", command.?.shell);


### PR DESCRIPTION
## Summary

MSYS2/Cygwin **fish** on Windows now auto-loads Ghostty's shell integration (OSC 133 marks, title, cursor). This is the fish half of #494 (child of #80); bash & zsh already shipped in #493.

**Why fish needed special handling:** Linux fish derives `$__fish_vendor_confdirs` from the runtime `XDG_DATA_DIRS`, so prepending our `shell-integration` dir is enough. MSYS2 fish's `$__fish_vendor_confdirs` is a **fixed set** that ignores `XDG_DATA_DIRS`, so `fish/vendor_conf.d/ghostty-shell-integration.fish` was never auto-loaded.

**What changed (`src/termio/shell_integration.zig` only):** split fish out of the shared `.elvish, .fish` arm into a dedicated `setupFish`. It keeps today's `setupXdgDataDirs` export (Linux fish + the integration's own cleanup rely on `GHOSTTY_SHELL_INTEGRATION_XDG_DIR`) and, **Windows-only**, appends:

```
-C "source $GHOSTTY_SHELL_INTEGRATION_XDG_DIR/fish/vendor_conf.d/ghostty-shell-integration.fish"
```

`-C` (`--init-command`) runs after fish reads its config/vendor dirs, so the `--on-event fish_prompt` handler registers normally — same end state as Linux's auto-load. **Non-Windows behavior is byte-for-byte unchanged** (elvish stays in the shared XDG arm, `cygwin=false`).

**Why reference the path via the env var instead of embedding it:** the spawned `.shell` command line carries no filesystem path, so a resources path containing cmd.exe metacharacters (`( )` from `Program Files (x86)`, `%`, `!`) can't trip `windowsShellNeedsCmdWrapping` in `Exec.zig` and route the spawn through `cmd.exe /C` (which would make cmd.exe — not fish — the spawned process). fish expands `$VAR` at runtime and does not word-split it, so spaces in the path resolve natively. (This was a real bug caught in review and fixed at the root cause.)

## Test Plan

- [x] Zig unit tests (`zig build test -Dapp-runtime=none`, pinned scoop 0.15.2): new `test "fish"` (Windows asserts the `-C "source $GHOSTTY_SHELL_INTEGRATION_XDG_DIR/..."` form + no `(` in command; non-Windows asserts the command is unchanged) and `test "fish: missing resources"` (null + empty env). Existing `force shell` / `detectShell` / all `bash:`/`zsh:` tests stay green. **Full suite: pass.**
- [x] In-app (real MSYS2 fish 4.7.1 in the GUI): launched Wintty with `command = fish.exe -i` + `GHOSTTY_RESOURCES_DIR=<src>`. Spawn-log: `shell integration automatically injected shell=.fish` + `started subcommand path=C:\msys64\usr\bin\fish.exe` (**direct path, not cmd.exe** — confirms the env-var fix). A temp probe in the vendor conf confirmed it was **sourced via `-C`**, `$GHOSTTY_SHELL_INTEGRATION_XDG_DIR` expanded to the correct POSIX path, and `interactive=yes` (handler registers).
- [x] Regression (in-app): pwsh and MSYS2 bash still spawn correctly with this build (log-confirmed `path=powershell.exe`; bash winpty chain confirmed). cmd/zsh/elvish setup paths untouched.
- [x] Reviewed with the ghostty-reviewer subagent; the one IMPORTANT finding (cmd.exe-metacharacter path embedding) was fixed at the root cause.

Closes the fish half of #494. WSL reach remains (tracked in #494). Part of #80.
