### PR TITLE
feat(windows): provision xterm-ghostty terminfo for WSL sessions (#80) (#494)

### DIFF
--- a/src/cli/ssh.zig
+++ b/src/cli/ssh.zig
@@ -6,7 +6,7 @@ const diagnostics = @import("diagnostics.zig");
 const Action = @import("ghostty.zig").Action;
 const DiskCache = @import("ssh_cache.zig").DiskCache;
 const internal_os = @import("../os/main.zig");
-const ghostty_terminfo = @import("../terminfo/main.zig").ghostty;
+const terminfo_install = @import("../terminfo/install.zig");
 
 const log = std.log.scoped(.ssh);
 
@@ -443,11 +443,6 @@ fn installRemoteTerminfo(
     opts: *const Options,
     stderr: *std.Io.Writer,
 ) !void {
-    var buf: std.Io.Writer.Allocating = .init(alloc);
-    defer buf.deinit();
-    try ghostty_terminfo.encode(&buf.writer);
-    const terminfo = buf.written();
-
     // ControlPath is in TMPDIR with a short, random basename. ssh uses
     // ControlPath as the bind address for a Unix domain socket; macOS
     // limits sockaddr_un.sun_path to ~104 bytes, so keeping the path
@@ -459,27 +454,12 @@ fn installRemoteTerminfo(
         .{control_path},
     );
 
-    // Under --verbose, let remote stderr through (the `tic` step is
-    // the most common failure source) and inherit ssh's stderr so it
-    // reaches the user's terminal. Other steps stay quiet either way.
-    const remote_script = if (opts.verbose)
-        \\infocmp xterm-ghostty >/dev/null 2>&1 && exit 0
-        \\command -v tic >/dev/null 2>&1 || exit 1
-        \\mkdir -p ~/.terminfo 2>/dev/null && tic -x - && exit 0
-        \\exit 1
-    else
-        \\infocmp xterm-ghostty >/dev/null 2>&1 && exit 0
-        \\command -v tic >/dev/null 2>&1 || exit 1
-        \\mkdir -p ~/.terminfo 2>/dev/null && tic -x - 2>/dev/null && exit 0
-        \\exit 1
-    ;
-
-    // Set up an SSH ControlMaster scoped to this single install:
-    //   - ControlMaster=yes makes our client also act as the master,
-    //     so `infocmp | ssh tic` runs over a single connection.
-    //   - ControlPersist=no tears the master down when our client
-    //     exits; no socket lingers on the remote side.
-    const argv = try std.mem.concat(alloc, []const u8, &.{
+    // The ssh launcher prefix: an SSH ControlMaster scoped to this single
+    // install (ControlMaster=yes makes our client also act as the master so
+    // the install runs over a single connection; ControlPersist=no tears it
+    // down when we exit). terminfo_install.install appends the install script
+    // and pipes the encoded terminfo to the remote's stdin.
+    const prefix = try std.mem.concat(alloc, []const u8, &.{
         &.{opts.ssh},
         &.{
             "-o", "ControlMaster=yes",
@@ -487,31 +467,10 @@ fn installRemoteTerminfo(
             "-o", control_path_opt,
         },
         opts._ssh_args.items,
-        &.{remote_script},
     });
-    verbosePrint(opts, stderr, "exec: {f}", .{Joined{ .items = argv }});
+    verbosePrint(opts, stderr, "exec: {f} <terminfo-install>", .{Joined{ .items = prefix }});
 
-    var child: std.process.Child = .init(argv, alloc);
-    child.stdin_behavior = .Pipe;
-    child.stdout_behavior = .Ignore;
-    child.stderr_behavior = if (opts.verbose) .Inherit else .Ignore;
-
-    child.spawn() catch |err| {
-        log.warn("terminfo install spawn failed: {}", .{err});
-        return error.InstallFailed;
-    };
-
-    if (child.stdin) |stdin| {
-        stdin.writeAll(terminfo) catch {};
-        stdin.close();
-        child.stdin = null;
-    }
-
-    const term = child.wait() catch |err| {
-        log.warn("terminfo install wait failed: {}", .{err});
-        return error.InstallFailed;
-    };
-    checkExit(term, "terminfo install") catch return error.InstallFailed;
+    terminfo_install.install(alloc, prefix, opts.verbose) catch return error.InstallFailed;
 }
 
 /// Returns `128 + signum` for signal-killed children, matching shell convention.

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -443,3 +443,62 @@ test "isCjkAnsiCodePageFor: non-CJK codepages return false" {
     try std.testing.expect(!isCjkAnsiCodePageFor(1255)); // Hebrew (single-byte)
     try std.testing.expect(!isCjkAnsiCodePageFor(1258)); // Vietnamese (single-byte)
 }
+
+/// If `argv` invokes the WSL launcher (`wsl`/`wsl.exe`, case-insensitive,
+/// any path), return the target distro from `-d <distro>` /
+/// `--distribution <distro>`, or `""` for the default distro. Returns null
+/// for non-WSL commands. Pure; safe to call on any platform.
+pub fn wslDistro(argv: []const []const u8) ?[]const u8 {
+    if (argv.len == 0) return null;
+    const exe = std.fs.path.basename(argv[0]);
+    const name = if (std.ascii.endsWithIgnoreCase(exe, ".exe"))
+        exe[0 .. exe.len - 4]
+    else
+        exe;
+    if (!std.ascii.eqlIgnoreCase("wsl", name)) return null;
+
+    var i: usize = 1;
+    while (i < argv.len) : (i += 1) {
+        const a = argv[i];
+        if (std.mem.eql(u8, a, "-d") or std.mem.eql(u8, a, "--distribution")) {
+            if (i + 1 < argv.len) return argv[i + 1];
+            return "";
+        }
+        // `--` ends WSL options; everything after is the in-distro command.
+        if (std.mem.eql(u8, a, "--")) break;
+    }
+    return ""; // wsl with no explicit distro -> default
+}
+
+test "wslDistro: detects distro and default, ignores non-WSL" {
+    {
+        const argv = [_][]const u8{ "wsl.exe", "-d", "Ubuntu" };
+        try testing.expectEqualStrings("Ubuntu", wslDistro(&argv).?);
+    }
+    {
+        const argv = [_][]const u8{ "C:\\Windows\\System32\\wsl.exe", "--distribution", "Ubuntu-24.04" };
+        try testing.expectEqualStrings("Ubuntu-24.04", wslDistro(&argv).?);
+    }
+    {
+        // bare wsl: default distro -> empty-string sentinel.
+        const argv = [_][]const u8{"wsl.exe"};
+        try testing.expectEqualStrings("", wslDistro(&argv).?);
+    }
+    {
+        // `--` ends WSL options; no -d before it -> default.
+        const argv = [_][]const u8{ "wsl.exe", "--", "htop" };
+        try testing.expectEqualStrings("", wslDistro(&argv).?);
+    }
+    {
+        const argv = [_][]const u8{ "pwsh.exe", "-NoLogo" };
+        try testing.expect(wslDistro(&argv) == null);
+    }
+    {
+        const argv = [_][]const u8{ "C:\\msys64\\usr\\bin\\bash.exe", "-i" };
+        try testing.expect(wslDistro(&argv) == null);
+    }
+    {
+        const argv = [_][]const u8{};
+        try testing.expect(wslDistro(&argv) == null);
+    }
+}

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -444,18 +444,23 @@ test "isCjkAnsiCodePageFor: non-CJK codepages return false" {
     try std.testing.expect(!isCjkAnsiCodePageFor(1258)); // Vietnamese (single-byte)
 }
 
-/// If `argv` invokes the WSL launcher (`wsl`/`wsl.exe`, case-insensitive,
-/// any path), return the target distro from `-d <distro>` /
-/// `--distribution <distro>`, or `""` for the default distro. Returns null
-/// for non-WSL commands. Pure; safe to call on any platform.
-pub fn wslDistro(argv: []const []const u8) ?[]const u8 {
-    if (argv.len == 0) return null;
-    const exe = std.fs.path.basename(argv[0]);
+/// True if `arg0` is the WSL launcher (`wsl`/`wsl.exe`, case-insensitive,
+/// any path). Cheap pre-check so callers can skip work for non-WSL commands.
+pub fn isWslExe(arg0: []const u8) bool {
+    const exe = std.fs.path.basename(arg0);
     const name = if (std.ascii.endsWithIgnoreCase(exe, ".exe"))
         exe[0 .. exe.len - 4]
     else
         exe;
-    if (!std.ascii.eqlIgnoreCase("wsl", name)) return null;
+    return std.ascii.eqlIgnoreCase("wsl", name);
+}
+
+/// If `argv` invokes the WSL launcher, return the target distro from
+/// `-d <distro>` / `--distribution <distro>` (and the `=`-joined forms), or
+/// `""` for the default distro. Returns null for non-WSL commands. Pure; safe
+/// to call on any platform.
+pub fn wslDistro(argv: []const []const u8) ?[]const u8 {
+    if (argv.len == 0 or !isWslExe(argv[0])) return null;
 
     var i: usize = 1;
     while (i < argv.len) : (i += 1) {
@@ -464,6 +469,11 @@ pub fn wslDistro(argv: []const []const u8) ?[]const u8 {
             if (i + 1 < argv.len) return argv[i + 1];
             return "";
         }
+        // `=`-joined forms. WSL profiles emit the space-separated form, but a
+        // hand-written command may use these; recognize them so we don't
+        // mis-target the default distro.
+        if (std.mem.startsWith(u8, a, "-d=")) return a["-d=".len..];
+        if (std.mem.startsWith(u8, a, "--distribution=")) return a["--distribution=".len..];
         // `--` ends WSL options; everything after is the in-distro command.
         if (std.mem.eql(u8, a, "--")) break;
     }
@@ -478,6 +488,14 @@ test "wslDistro: detects distro and default, ignores non-WSL" {
     {
         const argv = [_][]const u8{ "C:\\Windows\\System32\\wsl.exe", "--distribution", "Ubuntu-24.04" };
         try testing.expectEqualStrings("Ubuntu-24.04", wslDistro(&argv).?);
+    }
+    {
+        const argv = [_][]const u8{ "wsl.exe", "--distribution=Debian" };
+        try testing.expectEqualStrings("Debian", wslDistro(&argv).?);
+    }
+    {
+        const argv = [_][]const u8{ "wsl.exe", "-d=Arch" };
+        try testing.expectEqualStrings("Arch", wslDistro(&argv).?);
     }
     {
         // bare wsl: default distro -> empty-string sentinel.

--- a/src/terminfo/install.zig
+++ b/src/terminfo/install.zig
@@ -1,0 +1,93 @@
+//! Install Ghostty's terminfo onto a target reached via a launcher command
+//! (ssh remote, WSL distro, ...). The terminfo source is compiled into the
+//! binary and encoded at runtime, then piped to the target's stdin where an
+//! idempotent script compiles it with `tic`. Shared by `cli/ssh.zig` and the
+//! Windows WSL spawn path in `termio/Exec.zig`.
+
+const std = @import("std");
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
+const ghostty_terminfo = @import("main.zig").ghostty;
+
+const log = std.log.scoped(.terminfo_install);
+
+pub const Error = error{InstallFailed} || Allocator.Error;
+
+/// The idempotent remote install script, read by the target shell. The
+/// terminfo source arrives on stdin. The script: skips when the entry already
+/// exists, bails (exit 1) when `tic` is unavailable, otherwise compiles the
+/// source into the user's terminfo database. The `verbose` variant lets the
+/// remote `tic` stderr through.
+pub fn scriptFor(verbose: bool) []const u8 {
+    return if (verbose)
+        \\infocmp xterm-ghostty >/dev/null 2>&1 && exit 0
+        \\command -v tic >/dev/null 2>&1 || exit 1
+        \\mkdir -p ~/.terminfo 2>/dev/null && tic -x - && exit 0
+        \\exit 1
+    else
+        \\infocmp xterm-ghostty >/dev/null 2>&1 && exit 0
+        \\command -v tic >/dev/null 2>&1 || exit 1
+        \\mkdir -p ~/.terminfo 2>/dev/null && tic -x - 2>/dev/null && exit 0
+        \\exit 1
+    ;
+}
+
+/// Install Ghostty's terminfo onto a target reached via `launcher_prefix`,
+/// e.g. `["ssh", ..., dest]` or `["wsl.exe", "-d", distro, "--", "sh", "-c"]`.
+/// The encoded terminfo source is piped to the target's stdin; the script
+/// appended after `launcher_prefix` compiles it with `tic`.
+pub fn install(
+    alloc: Allocator,
+    launcher_prefix: []const []const u8,
+    verbose: bool,
+) Error!void {
+    var buf: std.Io.Writer.Allocating = .init(alloc);
+    defer buf.deinit();
+    // The only failure for an Allocating writer is OOM, surfaced as
+    // WriteFailed; fold it into our explicit error set.
+    ghostty_terminfo.encode(&buf.writer) catch return error.InstallFailed;
+    const terminfo = buf.written();
+
+    const argv = try std.mem.concat(alloc, []const u8, &.{
+        launcher_prefix,
+        &.{scriptFor(verbose)},
+    });
+    defer alloc.free(argv);
+
+    var child: std.process.Child = .init(argv, alloc);
+    child.stdin_behavior = .Pipe;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = if (verbose) .Inherit else .Ignore;
+
+    child.spawn() catch |err| {
+        log.warn("terminfo install spawn failed: {}", .{err});
+        return error.InstallFailed;
+    };
+    if (child.stdin) |stdin| {
+        stdin.writeAll(terminfo) catch {};
+        stdin.close();
+        child.stdin = null;
+    }
+    const term = child.wait() catch |err| {
+        log.warn("terminfo install wait failed: {}", .{err});
+        return error.InstallFailed;
+    };
+    switch (term) {
+        .Exited => |rc| if (rc != 0) return error.InstallFailed,
+        else => return error.InstallFailed,
+    }
+}
+
+test "install: script is idempotent and encodes ghostty terminfo" {
+    const alloc = testing.allocator;
+
+    const script = scriptFor(false);
+    try testing.expect(std.mem.indexOf(u8, script, "infocmp xterm-ghostty") != null);
+    try testing.expect(std.mem.indexOf(u8, script, "tic -x -") != null);
+    try testing.expect(std.mem.indexOf(u8, script, "command -v tic") != null);
+
+    var buf: std.Io.Writer.Allocating = .init(alloc);
+    defer buf.deinit();
+    try ghostty_terminfo.encode(&buf.writer);
+    try testing.expect(std.mem.indexOf(u8, buf.written(), "xterm-ghostty") != null);
+}

--- a/src/terminfo/main.zig
+++ b/src/terminfo/main.zig
@@ -7,6 +7,7 @@
 
 pub const ghostty = @import("ghostty.zig").ghostty;
 pub const Source = @import("Source.zig");
+pub const install = @import("install.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -18,6 +18,8 @@ const fastmem = @import("../fastmem.zig");
 const internal_os = @import("../os/main.zig");
 const renderer = @import("../renderer.zig");
 const shell_integration = @import("shell_integration.zig");
+const terminfo_install = @import("../terminfo/install.zig");
+const DiskCache = @import("../cli/ssh-cache/DiskCache.zig");
 const terminal = @import("../terminal/main.zig");
 const termio = @import("../termio.zig");
 const Command = @import("../Command.zig");
@@ -994,6 +996,15 @@ const Subprocess = struct {
     } {
         assert(self.pty == null and self.process == null);
 
+        // Windows: provision Ghostty's xterm-ghostty terminfo into a target
+        // WSL distro before we spawn the shell, so the first session resolves
+        // it. Best-effort and self-gating to `wsl` commands; never fails the
+        // spawn. Runs here (the IO-thread spawn site) rather than at argv-build
+        // time, which is on the UI thread.
+        if (comptime builtin.os.tag == .windows) {
+            maybeProvisionWslTerminfo(alloc, self.args);
+        }
+
         // This function is funny because on POSIX systems it can
         // fail in the forked process. This is flipped to true if
         // we're in an error state in the forked process (child
@@ -1933,6 +1944,173 @@ fn windowsShellNeedsCmdWrapping(s: []const u8) bool {
 ///     excluded; a discovered profile's args[0] is winpty (not bash), so
 ///     there is no double-wrap.
 ///
+/// Build the WSL launcher prefix that runs the terminfo-install script in the
+/// target distro: `wsl.exe [-d <distro>] -- sh -c`. terminfo_install.install
+/// appends the script as the final arg.
+fn wslTerminfoLauncherPrefix(
+    alloc: Allocator,
+    distro: []const u8,
+) Allocator.Error![]const []const u8 {
+    if (distro.len == 0) {
+        return try alloc.dupe([]const u8, &.{ "wsl.exe", "--", "sh", "-c" });
+    }
+    return try alloc.dupe([]const u8, &.{ "wsl.exe", "-d", distro, "--", "sh", "-c" });
+}
+
+/// Turn a WSL distro name into a single hostname label that always passes
+/// `DiskCache.isValidCacheKey` (which validates keys as RFC-1123 hostnames).
+/// Keeps `[A-Za-z0-9]`, collapses every other run to a single `-`, never
+/// produces a leading/trailing `-`, caps the label at 63 bytes, and falls back
+/// to `"wsl"` if nothing valid remains. A non-readable but bulletproof hash
+/// would also work; a readable slug keeps the cache file inspectable.
+fn wslDistroSlug(buf: []u8, name: []const u8) []const u8 {
+    const max_label = 63;
+    var n: usize = 0;
+    var prev_dash = false;
+    for (name) |c| {
+        if (n >= buf.len or n >= max_label) break;
+        switch (c) {
+            'A'...'Z', 'a'...'z', '0'...'9' => {
+                buf[n] = c;
+                n += 1;
+                prev_dash = false;
+            },
+            // Collapse runs of non-alnum to one `-`, and never lead with one.
+            else => if (!prev_dash and n > 0) {
+                buf[n] = '-';
+                n += 1;
+                prev_dash = true;
+            },
+        }
+    }
+    // Strip a trailing `-` (a label may not end with one).
+    while (n > 0 and buf[n - 1] == '-') n -= 1;
+    if (n == 0) {
+        const fallback = "wsl";
+        @memcpy(buf[0..fallback.len], fallback);
+        return buf[0..fallback.len];
+    }
+    return buf[0..n];
+}
+
+/// Windows-only: if `argv` launches WSL, ensure Ghostty's `xterm-ghostty`
+/// terminfo is installed in the target distro before the shell spawns, so the
+/// first session resolves it. Installs the real terminfo the same way the
+/// `ssh-terminfo` feature provisions remote hosts (pipe the encoded source to
+/// `tic` over the launcher). Cached per distro so steady-state launches skip
+/// the extra `wsl` spawn. Side-effecting and entirely best-effort: any failure
+/// degrades to a warning, and the install script itself skips when terminfo is
+/// already present and bails without `tic`. Never affects the spawned argv.
+fn maybeProvisionWslTerminfo(
+    alloc: Allocator,
+    argv: []const [:0]const u8,
+) void {
+    if (comptime builtin.os.tag != .windows) return;
+
+    // Cheap gate first: most spawns are not WSL, so avoid the view alloc below.
+    if (argv.len == 0 or !internal_os.windows_shell.isWslExe(argv[0])) return;
+
+    // wslDistro takes []const []const u8; build a thin non-sentinel view.
+    const view = alloc.alloc([]const u8, argv.len) catch return;
+    defer alloc.free(view);
+    for (argv, 0..) |a, i| view[i] = a;
+
+    const distro = internal_os.windows_shell.wslDistro(view) orelse return;
+
+    // The default distro (empty) is keyed "default". A real distro literally
+    // named "default" would share that marker, which is harmless (both want
+    // the same terminfo).
+    var slug_buf: [256]u8 = undefined;
+    const key = wslDistroSlug(&slug_buf, if (distro.len == 0) "default" else distro);
+
+    // Per-distro cache (reuses the ssh terminfo DiskCache mechanism, separate
+    // file). Optional: any lookup failure just means we run the (idempotent,
+    // self-skipping) install script.
+    const cache: ?DiskCache = cache: {
+        const state_dir = internal_os.xdg.state(
+            alloc,
+            .{ .subdir = "ghostty" },
+        ) catch break :cache null;
+        defer alloc.free(state_dir);
+        const path = std.fs.path.join(
+            alloc,
+            &.{ state_dir, "wsl_terminfo_cache" },
+        ) catch break :cache null;
+        break :cache .{ .path = path };
+    };
+    defer if (cache) |c| alloc.free(c.path);
+
+    if (cache) |c| {
+        if (c.contains(alloc, key) catch false) return;
+    }
+
+    const prefix = wslTerminfoLauncherPrefix(alloc, distro) catch return;
+    defer alloc.free(prefix);
+    terminfo_install.install(alloc, prefix, false) catch |err| {
+        log.warn("wsl terminfo install failed (distro={s}): {}", .{ key, err });
+        return;
+    };
+
+    // Best-effort record; a write failure just re-runs the self-skipping
+    // script next launch.
+    if (cache) |c| c.add(alloc, key, std.time.timestamp()) catch {};
+}
+
+test "wslTerminfoLauncherPrefix builds wsl sh -c prefix" {
+    const testing = std.testing;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const prefix = try wslTerminfoLauncherPrefix(alloc, "Ubuntu");
+    try testing.expectEqual(@as(usize, 6), prefix.len);
+    try testing.expectEqualStrings("wsl.exe", prefix[0]);
+    try testing.expectEqualStrings("-d", prefix[1]);
+    try testing.expectEqualStrings("Ubuntu", prefix[2]);
+    try testing.expectEqualStrings("--", prefix[3]);
+    try testing.expectEqualStrings("sh", prefix[4]);
+    try testing.expectEqualStrings("-c", prefix[5]);
+
+    // Default distro (empty) omits -d.
+    const prefix_def = try wslTerminfoLauncherPrefix(alloc, "");
+    try testing.expectEqual(@as(usize, 4), prefix_def.len);
+    try testing.expectEqualStrings("wsl.exe", prefix_def[0]);
+    try testing.expectEqualStrings("--", prefix_def[1]);
+    try testing.expectEqualStrings("sh", prefix_def[2]);
+    try testing.expectEqualStrings("-c", prefix_def[3]);
+}
+
+test "wslDistroSlug always yields a valid DiskCache key" {
+    const testing = std.testing;
+    var buf: [256]u8 = undefined;
+
+    // Adversarial names that previously slugged to invalid hostname keys
+    // (leading/trailing '-', empty labels, over-long) and silently disabled
+    // the cache. All must now pass DiskCache.isValidCacheKey.
+    const names = [_][]const u8{
+        "Ubuntu",
+        "Ubuntu-24.04",
+        "Ubuntu 22.04 LTS",
+        "default",
+        "Ubuntu ", // trailing space -> would have been "Ubuntu-"
+        " -weird- ", // leading/trailing junk
+        "My_Distro_",
+        "....", // all non-alnum
+        "" ++ ("x" ** 100), // over-long label
+        "",
+    };
+    inline for (names) |name| {
+        const slug = wslDistroSlug(&buf, name);
+        try testing.expect(DiskCache.isValidCacheKey(slug));
+    }
+
+    // Concrete spot-checks.
+    try testing.expectEqualStrings("Ubuntu-24-04", wslDistroSlug(&buf, "Ubuntu-24.04"));
+    try testing.expectEqualStrings("Ubuntu", wslDistroSlug(&buf, "Ubuntu "));
+    try testing.expectEqualStrings("wsl", wslDistroSlug(&buf, "...."));
+    try testing.expect(wslDistroSlug(&buf, "" ++ ("x" ** 100)).len == 63);
+}
+
 /// When no wrap applies the input `args` slice is returned unchanged.
 /// Both input and output are owned by the caller's arena.
 fn maybeWrapGitBashWithWinpty(


### PR DESCRIPTION
## Summary

WSL sessions launched by Wintty now get Ghostty's real **`xterm-ghostty` terminfo** installed in the distro, so apps stop hitting "unknown terminal type" / broken keys & colors. This is slice **2a** of the WSL reach (#494, child of #80); OSC 133 integration (2b) and OSC 7 cwd translation (2c) stay deferred.

**Why:** WSL profiles run `wsl.exe -d <distro>` and `TERM=xterm-ghostty`, but the xterm-ghostty terminfo entry doesn't exist in the distro, and the Windows build ships no compiled terminfo DB. Rather than ship a fake `xterm-256color` alias (which would lie about capabilities — the reason Ghostty ships its own terminfo), this **reuses Ghostty's existing `ssh-terminfo` machinery**: the terminfo source is compiled into libghostty, encoded at runtime, and piped to `tic` on the target.

**What changed (all Zig):**
- `src/terminfo/install.zig` (new) — `install(alloc, launcher_prefix, verbose)` extracted from `ssh.zig`'s `installRemoteTerminfo`: encode the source → spawn `<launcher> <idempotent script>` with the source on stdin. `src/cli/ssh.zig` now builds its ControlMaster prefix and calls the shared helper (behavior-preserving; net −50 lines there).
- `src/os/windows_shell.zig` — pure `isWslExe` / `wslDistro(argv)` (parses `-d`/`--distribution`, incl. `=`-joined; `""` = default distro).
- `src/termio/Exec.zig` — `maybeProvisionWslTerminfo`, run at the **IO-thread spawn site** (`Subprocess.start`, not the UI-thread `execCommand`) for `wsl.exe` commands: build a `wsl.exe [-d <distro>] -- sh -c` launcher, check a per-distro `DiskCache` (reused, separate `wsl_terminfo_cache` file, slugged distro key), and `install`. **Best-effort:** every failure path degrades to `log.warn` + proceed; the install script self-skips when terminfo is present and bails without `tic`. Never affects the spawned argv. Self-gates to `wsl` so all other shells are untouched.

## Test Plan

- [x] Zig unit tests (pinned scoop 0.15.2, `zig build test -Dapp-runtime=none`): `install:` (script + encode), `wslDistro` (detection incl. `=`-forms / default / non-WSL), `wslDistroSlug` (asserts `DiskCache.isValidCacheKey` for adversarial distro names), `wslTerminfoLauncherPrefix`; ssh refactor parity. **Full suite: pass.**
- [x] In-app (real WSL Ubuntu-24.04): cleared `~/.terminfo/x/xterm-ghostty` + cache, launched a `wsl.exe -d Ubuntu-24.04` profile → `infocmp xterm-ghostty` now resolves (`/home/<user>/.terminfo/x/xterm-ghostty`), and `…\Local\ghostty\wsl_terminfo_cache` records `Ubuntu-24-04|<ts>|xterm-ghostty` (valid slugged key).
- [x] Mechanism spiked end-to-end: `printf '<src>' | wsl.exe -d Ubuntu-24.04 -- sh -c '<install script>'` installs and `infocmp` confirms.
- [x] Regression: non-WSL spawns (pwsh/cmd/bash/zsh/fish) hit the `isWslExe` early-return → untouched. ssh `+ssh` terminfo install preserved (shared helper, parity-tested).
- [x] Reviewed with the ghostty-reviewer subagent; all findings fixed (the ship-blocker: slug now guarantees a valid `DiskCache` key so the cache isn't silently disabled for odd distro names).

Closes slice 2a of #494. Part of #80.
