### PR TITLE
feat(windows): OSC 7 cwd reporting + path translation for WSL (#80) (#494)

### DIFF
--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -29,6 +29,7 @@ pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");
 pub const windows_shell = @import("windows_shell.zig");
+pub const wsl_path = @import("wsl_path.zig");
 pub const macos = @import("macos.zig");
 pub const shell = @import("shell.zig");
 pub const uri = @import("uri.zig");
@@ -75,6 +76,7 @@ test {
     _ = uri;
     _ = shell;
     _ = windows_shell;
+    _ = wsl_path;
 
     if (comptime builtin.os.tag == .linux) {
         _ = kernel_info;

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -480,6 +480,35 @@ pub fn wslDistro(argv: []const []const u8) ?[]const u8 {
     return ""; // wsl with no explicit distro -> default
 }
 
+/// Launch context describing a WSL surface, derived from its spawn argv.
+pub const WslContext = struct {
+    /// Real WSL distribution name (e.g. "Ubuntu-24.04"), or null when this is a
+    /// WSL surface whose distro name is unknown (a bare `wsl.exe` default-distro
+    /// session — resolving its real name from the registry is a deferred follow-up).
+    distro: ?[]const u8 = null,
+
+    /// Detect WSL launch context from the spawn argv. Returns null for non-WSL
+    /// (or non-Windows) surfaces. When `distro` is present it is duped from
+    /// `alloc` and the owner must free it.
+    pub fn fromArgs(
+        alloc: std.mem.Allocator,
+        args: []const [:0]const u8,
+    ) ?WslContext {
+        if (comptime builtin.os.tag != .windows) return null;
+        if (args.len == 0 or !isWslExe(args[0])) return null;
+
+        // wslDistro takes []const []const u8; build a thin non-sentinel view.
+        const view = alloc.alloc([]const u8, args.len) catch return null;
+        defer alloc.free(view);
+        for (args, 0..) |a, i| view[i] = a;
+
+        const distro = wslDistro(view) orelse return null;
+        if (distro.len == 0) return .{ .distro = null }; // default distro, name deferred
+        const owned = alloc.dupe(u8, distro) catch return .{ .distro = null };
+        return .{ .distro = owned };
+    }
+};
+
 test "wslDistro: detects distro and default, ignores non-WSL" {
     {
         const argv = [_][]const u8{ "wsl.exe", "-d", "Ubuntu" };
@@ -519,4 +548,39 @@ test "wslDistro: detects distro and default, ignores non-WSL" {
         const argv = [_][]const u8{};
         try testing.expect(wslDistro(&argv) == null);
     }
+}
+
+test "WslContext.fromArgs: explicit distro" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    const args = [_][:0]const u8{ "wsl.exe", "-d", "Ubuntu-24.04" };
+    const ctx = WslContext.fromArgs(alloc, &args).?;
+    defer if (ctx.distro) |d| alloc.free(d);
+    try std.testing.expectEqualStrings("Ubuntu-24.04", ctx.distro.?);
+}
+
+test "WslContext.fromArgs: =-joined distro" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    const args = [_][:0]const u8{ "wsl.exe", "-d=Ubuntu" };
+    const ctx = WslContext.fromArgs(alloc, &args).?;
+    defer if (ctx.distro) |d| alloc.free(d);
+    try std.testing.expectEqualStrings("Ubuntu", ctx.distro.?);
+}
+
+test "WslContext.fromArgs: bare wsl is WSL with unknown distro" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    const args = [_][:0]const u8{"wsl.exe"};
+    const ctx = WslContext.fromArgs(alloc, &args).?;
+    try std.testing.expect(ctx.distro == null);
+}
+
+test "WslContext.fromArgs: non-WSL and empty are null" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    const pwsh = [_][:0]const u8{ "pwsh.exe", "-NoLogo" };
+    try std.testing.expect(WslContext.fromArgs(alloc, &pwsh) == null);
+    const empty = [_][:0]const u8{};
+    try std.testing.expect(WslContext.fromArgs(alloc, &empty) == null);
 }

--- a/src/os/wsl_path.zig
+++ b/src/os/wsl_path.zig
@@ -126,3 +126,46 @@ test "wsl_path: non-absolute or empty is invalid" {
         posixToWindows(std.testing.allocator, "relative/path", "Ubuntu"),
     );
 }
+
+// Exercises the exact OSC 7 parse -> path-extract -> translate chain that
+// stream_handler.reportPwd runs, for both shell-emitted URL forms. This guards
+// the one seam the unit tests above don't reach (URL parsing + fish escaping).
+test "wsl_path: OSC 7 URL forms extract and translate (reportPwd seam)" {
+    const builtin = @import("builtin");
+    const uri = @import("uri.zig");
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    const Case = struct { url: []const u8, distro: ?[]const u8, want: []const u8 };
+    const cases = [_]Case{
+        // bash/zsh: \e]7;kitty-shell-cwd://<host><PWD>\a (raw, unescaped path)
+        .{
+            .url = "kitty-shell-cwd://wsl/home/alex",
+            .distro = "Ubuntu-24.04",
+            .want = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\alex",
+        },
+        .{
+            .url = "kitty-shell-cwd://wsl/mnt/c/Users/alex",
+            .distro = "Ubuntu",
+            .want = "C:\\Users\\alex",
+        },
+        // fish: \e]7;file://<host><url-escaped PWD>\a (percent-decoded path)
+        .{
+            .url = "file://wsl/home/alex%20space",
+            .distro = "Ubuntu",
+            .want = "\\\\wsl.localhost\\Ubuntu\\home\\alex space",
+        },
+    };
+
+    for (cases) |c| {
+        const u = try uri.parse(c.url, .{
+            .mac_address = comptime builtin.os.tag != .macos,
+            .raw_path = std.mem.startsWith(u8, c.url, "kitty-shell-cwd://"),
+        });
+        const path = try u.path.toRawMaybeAlloc(aa);
+        const got = try posixToWindows(aa, path, c.distro);
+        try std.testing.expectEqualStrings(c.want, got);
+    }
+}

--- a/src/os/wsl_path.zig
+++ b/src/os/wsl_path.zig
@@ -61,6 +61,11 @@ fn mountDrive(path: []const u8) ?Mount {
 }
 
 /// Append `s` (a `/`-separated POSIX remainder) translating `/` -> `\`.
+///
+/// A literal backslash in a Linux path (legal but exotic, e.g. `/home/a\b`) is
+/// passed through verbatim and so reads as a Windows path separator in the
+/// result. We accept this: such paths are vanishingly rare and the only
+/// consequence is a slightly-wrong title/cwd, never a crash.
 fn appendBackslashed(
     alloc: Allocator,
     buf: *std.ArrayListUnmanaged(u8),

--- a/src/os/wsl_path.zig
+++ b/src/os/wsl_path.zig
@@ -1,0 +1,128 @@
+//! Translate POSIX paths reported by WSL shells (via OSC 7) into Windows paths.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const Error = error{ UnknownDistro, InvalidPath } || Allocator.Error;
+
+/// Translate a POSIX path reported by a WSL shell into the equivalent Windows path.
+///
+///   /mnt/<d>[/rest]  -> <D>:\rest                          (drive-letter form)
+///   /<rest>          -> \\wsl.localhost\<distro>\<rest>     (UNC form)
+///
+/// `distro` is the real WSL distribution name (e.g. "Ubuntu-24.04"). Pass null for a
+/// default-distro session whose name is unknown: a `/mnt/*` path still translates, but a
+/// non-`/mnt` path yields error.UnknownDistro (caller leaves pwd unset). Caller owns the
+/// returned slice.
+pub fn posixToWindows(
+    alloc: Allocator,
+    posix_path: []const u8,
+    distro: ?[]const u8,
+) Error![]u8 {
+    // Only absolute POSIX paths are translatable.
+    if (posix_path.len == 0 or posix_path[0] != '/') return error.InvalidPath;
+
+    // /mnt/<drive>[/rest] -> drive-letter form (needs no distro).
+    if (mountDrive(posix_path)) |m| {
+        var buf: std.ArrayListUnmanaged(u8) = .{};
+        errdefer buf.deinit(alloc);
+        try buf.append(alloc, std.ascii.toUpper(m.drive));
+        try buf.appendSlice(alloc, ":\\");
+        try appendBackslashed(alloc, &buf, m.rest);
+        return buf.toOwnedSlice(alloc);
+    }
+
+    // Everything else lives inside the distro filesystem -> UNC form.
+    const name = distro orelse return error.UnknownDistro;
+
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    errdefer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "\\\\wsl.localhost\\");
+    try buf.appendSlice(alloc, name);
+    try buf.append(alloc, '\\');
+    // posix_path starts with '/'; strip it, backslash the remainder.
+    try appendBackslashed(alloc, &buf, posix_path[1..]);
+    return buf.toOwnedSlice(alloc);
+}
+
+const Mount = struct { drive: u8, rest: []const u8 };
+
+/// Match `/mnt/<drive>(/...)?` where `<drive>` is a single ASCII letter.
+/// `rest` has no leading slash and may be empty.
+fn mountDrive(path: []const u8) ?Mount {
+    const prefix = "/mnt/";
+    if (!std.mem.startsWith(u8, path, prefix)) return null;
+    const after = path[prefix.len..];
+    if (after.len == 0) return null;
+    const drive = after[0];
+    if (!std.ascii.isAlphabetic(drive)) return null;
+    if (after.len == 1) return .{ .drive = drive, .rest = "" };
+    if (after[1] != '/') return null; // e.g. /mnt/wsl -> not a drive
+    return .{ .drive = drive, .rest = after[2..] };
+}
+
+/// Append `s` (a `/`-separated POSIX remainder) translating `/` -> `\`.
+fn appendBackslashed(
+    alloc: Allocator,
+    buf: *std.ArrayListUnmanaged(u8),
+    s: []const u8,
+) Allocator.Error!void {
+    for (s) |c| try buf.append(alloc, if (c == '/') '\\' else c);
+}
+
+fn expectTranslate(
+    expected: []const u8,
+    posix_path: []const u8,
+    distro: ?[]const u8,
+) !void {
+    const got = try posixToWindows(std.testing.allocator, posix_path, distro);
+    defer std.testing.allocator.free(got);
+    try std.testing.expectEqualStrings(expected, got);
+}
+
+test "wsl_path: /mnt drive forms" {
+    try expectTranslate("C:\\Users\\alex", "/mnt/c/Users/alex", "Ubuntu");
+    try expectTranslate("C:\\", "/mnt/c", "Ubuntu");
+    try expectTranslate("C:\\", "/mnt/c/", "Ubuntu");
+    try expectTranslate("D:\\work\\repo", "/mnt/d/work/repo", null); // no distro needed
+    // Uppercase drive letter regardless of POSIX casing.
+    try expectTranslate("C:\\src", "/mnt/c/src", "Ubuntu");
+}
+
+test "wsl_path: UNC distro forms" {
+    try expectTranslate(
+        "\\\\wsl.localhost\\Ubuntu-24.04\\home\\alex",
+        "/home/alex",
+        "Ubuntu-24.04",
+    );
+    try expectTranslate("\\\\wsl.localhost\\Debian\\", "/", "Debian");
+    // /mnt/wsl is NOT a drive (second segment isn't a single letter) -> UNC.
+    try expectTranslate(
+        "\\\\wsl.localhost\\Ubuntu\\mnt\\wsl\\foo",
+        "/mnt/wsl/foo",
+        "Ubuntu",
+    );
+    // Distro name with dots survives verbatim.
+    try expectTranslate(
+        "\\\\wsl.localhost\\Ubuntu-22.04\\opt\\x",
+        "/opt/x",
+        "Ubuntu-22.04",
+    );
+}
+
+test "wsl_path: unknown distro on non-/mnt path errors" {
+    try std.testing.expectError(
+        error.UnknownDistro,
+        posixToWindows(std.testing.allocator, "/home/alex", null),
+    );
+}
+
+test "wsl_path: non-absolute or empty is invalid" {
+    try std.testing.expectError(
+        error.InvalidPath,
+        posixToWindows(std.testing.allocator, "", "Ubuntu"),
+    );
+    try std.testing.expectError(
+        error.InvalidPath,
+        posixToWindows(std.testing.allocator, "relative/path", "Ubuntu"),
+    );
+}

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -272,10 +272,20 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
     var backend = opts.backend;
     backend.initTerminal(&term);
 
+    // Derive WSL launch context (for OSC 7 path translation). Returns null on
+    // non-Windows and for non-WSL surfaces.
+    const wsl_ctx = internal_os.windows_shell.WslContext.fromArgs(
+        alloc,
+        switch (backend) {
+            .exec => |*exec| exec.subprocess.args,
+        },
+    );
+
     // Create our stream handler. This points to memory in self so it
     // isn't safe to use until self.* is set.
     const handler: StreamHandler = .{
         .alloc = alloc,
+        .wsl = wsl_ctx,
         .termio_mailbox = &self.mailbox,
         .surface_mailbox = opts.surface_mailbox,
         .renderer_state = opts.renderer_state,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -273,13 +273,18 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
     backend.initTerminal(&term);
 
     // Derive WSL launch context (for OSC 7 path translation). Returns null on
-    // non-Windows and for non-WSL surfaces.
+    // non-Windows and for non-WSL surfaces. Note: keys on argv[0] being the
+    // (unwrapped) wsl.exe; if WSL spawns are ever shell-wrapped this silently
+    // disables WSL OSC 7 translation (falls back to the historical no-op).
     const wsl_ctx = internal_os.windows_shell.WslContext.fromArgs(
         alloc,
         switch (backend) {
             .exec => |*exec| exec.subprocess.args,
         },
     );
+    // Until ownership transfers to the StreamHandler (via terminal_stream
+    // below), we own the duped distro string; free it if init fails first.
+    errdefer if (wsl_ctx) |w| if (w.distro) |d| alloc.free(d);
 
     // Create our stream handler. This points to memory in self so it
     // isn't safe to use until self.* is set.

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1206,11 +1206,6 @@ pub const StreamHandler = struct {
             return;
         }
 
-        if (builtin.os.tag == .windows) {
-            log.warn("reportPwd unimplemented on windows", .{});
-            return;
-        }
-
         // Attempt to parse this file-style URI using options appropriate
         // for this OSC 7 context (e.g. kitty-shell-cwd expects the full,
         // unencoded path).
@@ -1229,32 +1224,43 @@ pub const StreamHandler = struct {
             return;
         }
 
-        var host_buffer: [std.Uri.host_name_max]u8 = undefined;
-        const host = uri.getHost(&host_buffer) catch |err| switch (err) {
-            error.UriMissingHost => {
-                log.warn("OSC 7 uri must contain a hostname: {}", .{err});
+        if (comptime builtin.os.tag == .windows) {
+            // WSL-only: non-WSL Windows surfaces keep the historical no-op.
+            // A WSL surface means we spawned wsl.exe ourselves, so the host is
+            // as local as it gets — skip the isLocal check (same trust basis
+            // ghostty applies to its own ssh sessions).
+            if (self.wsl == null) {
+                log.warn("OSC 7 ignored: non-WSL windows surface", .{});
                 return;
-            },
-            error.UriHostTooLong => {
-                log.warn("failed to get full hostname for OSC 7 validation: {}", .{err});
-                return;
-            },
-        };
+            }
+        } else {
+            var host_buffer: [std.Uri.host_name_max]u8 = undefined;
+            const host = uri.getHost(&host_buffer) catch |err| switch (err) {
+                error.UriMissingHost => {
+                    log.warn("OSC 7 uri must contain a hostname: {}", .{err});
+                    return;
+                },
+                error.UriHostTooLong => {
+                    log.warn("failed to get full hostname for OSC 7 validation: {}", .{err});
+                    return;
+                },
+            };
 
-        // OSC 7 is a little sketchy because anyone can send any value from
-        // any host (such an SSH session). The best practice terminals follow
-        // is to valid the hostname to be local.
-        const host_valid = internal_os.hostname.isLocal(host) catch |err| switch (err) {
-            error.PermissionDenied,
-            error.Unexpected,
-            => {
-                log.warn("failed to get hostname for OSC 7 validation: {}", .{err});
+            // OSC 7 is a little sketchy because anyone can send any value from
+            // any host (such an SSH session). The best practice terminals follow
+            // is to valid the hostname to be local.
+            const host_valid = internal_os.hostname.isLocal(host) catch |err| switch (err) {
+                error.PermissionDenied,
+                error.Unexpected,
+                => {
+                    log.warn("failed to get hostname for OSC 7 validation: {}", .{err});
+                    return;
+                },
+            };
+            if (!host_valid) {
+                log.warn("OSC 7 host ({s}) must be local", .{host});
                 return;
-            },
-        };
-        if (!host_valid) {
-            log.warn("OSC 7 host ({s}) must be local", .{host});
-            return;
+            }
         }
 
         // We need the raw path, which might require unescaping. We try to
@@ -1264,12 +1270,28 @@ pub const StreamHandler = struct {
         defer arena_alloc.deinit();
         const path = try uri.path.toRawMaybeAlloc(stack_alloc.get());
 
-        log.debug("terminal pwd: {s}", .{path});
-        try self.terminal.setPwd(path);
+        // On Windows the path comes from a WSL shell as a POSIX path; translate
+        // it to its Windows form so the title and inherited cwd are usable.
+        // `reported` shares `path`'s stack-fallback arena, and setPwd/WriteReq
+        // copy synchronously, so the lifetime matches the untranslated path.
+        const reported = if (comptime builtin.os.tag == .windows)
+            internal_os.wsl_path.posixToWindows(
+                stack_alloc.get(),
+                path,
+                self.wsl.?.distro,
+            ) catch |err| {
+                log.warn("OSC 7 WSL path translation failed: {}", .{err});
+                return;
+            }
+        else
+            path;
+
+        log.debug("terminal pwd: {s}", .{reported});
+        try self.terminal.setPwd(reported);
 
         // Report it to the surface. If creating our write request fails
         // then we just ignore it.
-        if (apprt.surface.Message.WriteReq.init(self.alloc, path)) |req| {
+        if (apprt.surface.Message.WriteReq.init(self.alloc, reported)) |req| {
             self.surfaceMessageWriter(.{ .pwd_change = req });
         } else |err| {
             log.warn("error notifying surface of pwd change err={}", .{err});
@@ -1277,7 +1299,7 @@ pub const StreamHandler = struct {
 
         // If we haven't seen a title, use our pwd as the title.
         if (!self.seen_title) {
-            try self.windowTitle(path);
+            try self.windowTitle(reported);
             self.seen_title = false;
         }
     }

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -58,6 +58,10 @@ pub const StreamHandler = struct {
     /// whoever owns StreamHandler.
     enquiry_response: []const u8,
 
+    /// WSL launch context for OSC 7 path translation. null for non-WSL (and
+    /// non-Windows) surfaces. Owns `distro` (freed in deinit).
+    wsl: ?internal_os.windows_shell.WslContext = null,
+
     /// The color reporting format for OSC requests.
     osc_color_report_format: configpkg.Config.OSCColorReportFormat,
 
@@ -105,6 +109,7 @@ pub const StreamHandler = struct {
         self.apc.deinit();
         self.dcs.deinit();
         self.multipart_iterm2.deinit(self.alloc);
+        if (self.wsl) |w| if (w.distro) |d| self.alloc.free(d);
         if (comptime tmux_enabled) tmux: {
             const viewer = self.tmux_viewer orelse break :tmux;
             viewer.deinit();


### PR DESCRIPTION
## What

Makes **OSC 7 working-directory reporting work for WSL sessions** on Windows. Previously `reportPwd` was a hard no-op on Windows (`reportPwd unimplemented on windows`), so OSC 7 was unwired for every shell. This PR implements it for WSL surfaces and translates the reported POSIX path into its Windows form:

- `/mnt/<d>/rest` -> `<D>:\rest` (drive form)
- any other absolute `/p` -> `\wsl.localhost\<distro>\p` (UNC form, real distro name)

This lights up the **receiver** side of cwd reporting (surface pwd -> title / new-surface `working_directory`). The **transmitter** (auto-injecting shell integration into WSL so the shell emits OSC 7) is the deferred #494 slice 2b; this PR handles the signal whenever it arrives (manual emit, a TUI, or once 2b lands).

Part of #80 / #494. Scope: **WSL only**, all Zig.

## How

1. **`src/os/wsl_path.zig`** (new) - pure `posixToWindows(alloc, path, distro)` translator. `error.UnknownDistro` for a non-`/mnt` path when the default distro's name is unknown.
2. **`src/os/windows_shell.zig`** - `WslContext.fromArgs(args)` reuses the existing `isWslExe`/`wslDistro`: explicit `-d X` -> duped distro name; bare `wsl.exe` -> WSL-with-unknown-distro; non-WSL -> null.
3. **`src/termio/stream_handler.zig`** - `reportPwd` Windows branch now reuses the existing URI parse (both `kitty-shell-cwd://` raw and fish's url-escaped `file://`), replaces the `isLocal` host check with WSL-context trust (we spawned `wsl.exe` ourselves), translates, then `setPwd` / `pwd_change` / title. Non-WSL Windows surfaces keep the previous no-op.
4. **`src/termio/Termio.zig`** - derives the `WslContext` from the exec backend argv at init.

## Translation must be in Zig

The pwd has two consumers: the title (`pwd_change` -> C#) **and** new-tab/split cwd inheritance (`core_surface.pwd()` -> `working_directory`, pure Zig). Translating in C# would fix only the title and still hand a POSIX path to `CreateProcess`. Translating once at `setPwd` fixes both.

## Tests

- **Translator** - exhaustive: drive forms, UNC forms, `/mnt/c` root, trailing slashes, distro names with dots, `error.UnknownDistro`, non-absolute/empty.
- **`WslContext.fromArgs`** - explicit `-d`, `=`-joined, bare `wsl`, non-WSL, empty.
- **OSC 7 seam test** - runs `reportPwd`'s exact parse->extract->translate chain on both shell-emitted URL forms (including fish url-decoding), guarding the one seam the other unit tests don't reach.
- Full Zig suite green (`zig build test -Dapp-runtime=none`, pinned 0.15.2).

## In-app verification

Confirmed on a real Wintty build with the swapped dll: it loads/runs (ABI-compatible), a `WSL: Ubuntu-24.04` tab spawns with argv `wsl.exe -d Ubuntu-24.04` (the exact `fromArgs` input), and `reportPwd` processes the WSL OSC 7 without crashing. A crash seen when injecting this dll into the *downstream* "pro" build was isolated (clean dev-build repro) to an ABI mismatch, not a defect here.

## Deferred (follow-ups)

- Default-distro registry name resolution (bare `wsl.exe`, non-`/mnt` paths) - needs Zig registry FFI; the `WslContext.distro: ?[]const u8` shape already accommodates it.
- MSYS2/Cygwin translators (same plumbing, different path conventions).
- #494 slice 2b (OSC 133 / shell-integration injection into WSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
