### PR TITLE
feat(windows): MSYS2/Cygwin OSC 7 path translation (#494)

### DIFF
--- a/src/os/main.zig
+++ b/src/os/main.zig
@@ -29,7 +29,7 @@ pub const passwd = @import("passwd.zig");
 pub const xdg = @import("xdg.zig");
 pub const windows = @import("windows.zig");
 pub const windows_shell = @import("windows_shell.zig");
-pub const wsl_path = @import("wsl_path.zig");
+pub const posix_path = @import("posix_path.zig");
 pub const macos = @import("macos.zig");
 pub const shell = @import("shell.zig");
 pub const uri = @import("uri.zig");
@@ -76,7 +76,7 @@ test {
     _ = uri;
     _ = shell;
     _ = windows_shell;
-    _ = wsl_path;
+    _ = posix_path;
 
     if (comptime builtin.os.tag == .linux) {
         _ = kernel_info;

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -60,6 +60,9 @@ pub fn rootedToWindows(
     // otherwise be mis-read as a root-relative `/cygdrive` directory).
     if (driveAfter(posix_path, "/cygdrive/")) |m| return driveForm(alloc, m);
     // MSYS2/Git default automount: a single-letter top-level segment is a drive.
+    // This shadows a hypothetical single-letter root-relative directory (e.g. a
+    // literal `/c` dir), but stock MSYS2/Git/Cygwin layouts have none, so the
+    // automount reading is correct in practice.
     if (driveAfter(posix_path, "/")) |m| return driveForm(alloc, m);
 
     // Everything else lives under the install root.
@@ -134,7 +137,7 @@ fn expectRooted(
     try std.testing.expectEqualStrings(expected, got);
 }
 
-test "wsl_path: /mnt drive forms" {
+test "posix_path: wsl /mnt drive forms" {
     try expectTranslate("C:\\Users\\alex", "/mnt/c/Users/alex", "Ubuntu");
     try expectTranslate("C:\\", "/mnt/c", "Ubuntu");
     try expectTranslate("C:\\", "/mnt/c/", "Ubuntu");
@@ -143,7 +146,7 @@ test "wsl_path: /mnt drive forms" {
     try expectTranslate("C:\\src", "/mnt/c/src", "Ubuntu");
 }
 
-test "wsl_path: UNC distro forms" {
+test "posix_path: wsl UNC distro forms" {
     try expectTranslate(
         "\\\\wsl.localhost\\Ubuntu-24.04\\home\\alex",
         "/home/alex",
@@ -164,14 +167,14 @@ test "wsl_path: UNC distro forms" {
     );
 }
 
-test "wsl_path: unknown distro on non-/mnt path errors" {
+test "posix_path: wsl unknown distro on non-/mnt path errors" {
     try std.testing.expectError(
         error.UnknownDistro,
         wslToWindows(std.testing.allocator, "/home/alex", null),
     );
 }
 
-test "wsl_path: non-absolute or empty is invalid" {
+test "posix_path: wsl non-absolute or empty is invalid" {
     try std.testing.expectError(
         error.InvalidPath,
         wslToWindows(std.testing.allocator, "", "Ubuntu"),
@@ -185,7 +188,7 @@ test "wsl_path: non-absolute or empty is invalid" {
 // Exercises the exact OSC 7 parse -> path-extract -> translate chain that
 // stream_handler.reportPwd runs, for both shell-emitted URL forms. This guards
 // the one seam the unit tests above don't reach (URL parsing + fish escaping).
-test "wsl_path: OSC 7 URL forms extract and translate (reportPwd seam)" {
+test "posix_path: OSC 7 URL forms extract and translate (reportPwd seam)" {
     const builtin = @import("builtin");
     const uri = @import("uri.zig");
 

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -1,8 +1,9 @@
-//! Translate POSIX paths reported by WSL shells (via OSC 7) into Windows paths.
+//! Translate POSIX paths reported by Windows POSIX-emulation shells (WSL,
+//! MSYS2/MinGW/Git-Bash, Cygwin) via OSC 7 into the equivalent Windows paths.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-pub const Error = error{ UnknownDistro, InvalidPath } || Allocator.Error;
+pub const Error = error{ UnknownDistro, UnknownRoot, InvalidPath } || Allocator.Error;
 
 /// Translate a POSIX path reported by a WSL shell into the equivalent Windows path.
 ///
@@ -13,7 +14,7 @@ pub const Error = error{ UnknownDistro, InvalidPath } || Allocator.Error;
 /// default-distro session whose name is unknown: a `/mnt/*` path still translates, but a
 /// non-`/mnt` path yields error.UnknownDistro (caller leaves pwd unset). Caller owns the
 /// returned slice.
-pub fn posixToWindows(
+pub fn wslToWindows(
     alloc: Allocator,
     posix_path: []const u8,
     distro: ?[]const u8,
@@ -22,14 +23,7 @@ pub fn posixToWindows(
     if (posix_path.len == 0 or posix_path[0] != '/') return error.InvalidPath;
 
     // /mnt/<drive>[/rest] -> drive-letter form (needs no distro).
-    if (mountDrive(posix_path)) |m| {
-        var buf: std.ArrayListUnmanaged(u8) = .{};
-        errdefer buf.deinit(alloc);
-        try buf.append(alloc, std.ascii.toUpper(m.drive));
-        try buf.appendSlice(alloc, ":\\");
-        try appendBackslashed(alloc, &buf, m.rest);
-        return buf.toOwnedSlice(alloc);
-    }
+    if (driveAfter(posix_path, "/mnt/")) |m| return driveForm(alloc, m);
 
     // Everything else lives inside the distro filesystem -> UNC form.
     const name = distro orelse return error.UnknownDistro;
@@ -44,20 +38,66 @@ pub fn posixToWindows(
     return buf.toOwnedSlice(alloc);
 }
 
+/// Translate a POSIX path reported by a MSYS2/MinGW/Git-Bash or Cygwin shell
+/// into the equivalent Windows path.
+///
+///   /cygdrive/<d>[/rest]  -> <D>:\rest          (Cygwin drive mount)
+///   /<d>[/rest]           -> <D>:\rest          (MSYS2/Git default automount)
+///   /<rest>               -> <install_root>\<rest>
+///
+/// `install_root` is an already-Windows path with no trailing separator
+/// (e.g. "C:\msys64"). Pass null when it could not be derived: drive-form paths
+/// still translate, but a root-relative path yields error.UnknownRoot (caller
+/// leaves pwd unset). Caller owns the returned slice.
+pub fn rootedToWindows(
+    alloc: Allocator,
+    posix_path: []const u8,
+    install_root: ?[]const u8,
+) Error![]u8 {
+    if (posix_path.len == 0 or posix_path[0] != '/') return error.InvalidPath;
+
+    // Cygwin's distinctive mount prefix (checked first — it is longer and would
+    // otherwise be mis-read as a root-relative `/cygdrive` directory).
+    if (driveAfter(posix_path, "/cygdrive/")) |m| return driveForm(alloc, m);
+    // MSYS2/Git default automount: a single-letter top-level segment is a drive.
+    if (driveAfter(posix_path, "/")) |m| return driveForm(alloc, m);
+
+    // Everything else lives under the install root.
+    const root = install_root orelse return error.UnknownRoot;
+
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    errdefer buf.deinit(alloc);
+    try buf.appendSlice(alloc, root);
+    try buf.append(alloc, '\\');
+    try appendBackslashed(alloc, &buf, posix_path[1..]);
+    return buf.toOwnedSlice(alloc);
+}
+
 const Mount = struct { drive: u8, rest: []const u8 };
 
-/// Match `/mnt/<drive>(/...)?` where `<drive>` is a single ASCII letter.
-/// `rest` has no leading slash and may be empty.
-fn mountDrive(path: []const u8) ?Mount {
-    const prefix = "/mnt/";
+/// Match `<prefix><drive>(/...)?` where `<drive>` is a single ASCII letter and
+/// the char after it is `/` or end-of-string. `rest` has no leading slash and
+/// may be empty. Returns null when the segment after `<prefix>` is not a bare
+/// single-letter drive (e.g. `/mnt/wsl`, `/usr`, `/cygdriveX`).
+fn driveAfter(path: []const u8, prefix: []const u8) ?Mount {
     if (!std.mem.startsWith(u8, path, prefix)) return null;
     const after = path[prefix.len..];
     if (after.len == 0) return null;
     const drive = after[0];
     if (!std.ascii.isAlphabetic(drive)) return null;
     if (after.len == 1) return .{ .drive = drive, .rest = "" };
-    if (after[1] != '/') return null; // e.g. /mnt/wsl -> not a drive
+    if (after[1] != '/') return null;
     return .{ .drive = drive, .rest = after[2..] };
+}
+
+/// Build the drive-letter form `<D>:\<backslashed rest>` from a matched mount.
+fn driveForm(alloc: Allocator, m: Mount) Error![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    errdefer buf.deinit(alloc);
+    try buf.append(alloc, std.ascii.toUpper(m.drive));
+    try buf.appendSlice(alloc, ":\\");
+    try appendBackslashed(alloc, &buf, m.rest);
+    return buf.toOwnedSlice(alloc);
 }
 
 /// Append `s` (a `/`-separated POSIX remainder) translating `/` -> `\`.
@@ -79,7 +119,17 @@ fn expectTranslate(
     posix_path: []const u8,
     distro: ?[]const u8,
 ) !void {
-    const got = try posixToWindows(std.testing.allocator, posix_path, distro);
+    const got = try wslToWindows(std.testing.allocator, posix_path, distro);
+    defer std.testing.allocator.free(got);
+    try std.testing.expectEqualStrings(expected, got);
+}
+
+fn expectRooted(
+    expected: []const u8,
+    posix_path: []const u8,
+    root: ?[]const u8,
+) !void {
+    const got = try rootedToWindows(std.testing.allocator, posix_path, root);
     defer std.testing.allocator.free(got);
     try std.testing.expectEqualStrings(expected, got);
 }
@@ -117,18 +167,18 @@ test "wsl_path: UNC distro forms" {
 test "wsl_path: unknown distro on non-/mnt path errors" {
     try std.testing.expectError(
         error.UnknownDistro,
-        posixToWindows(std.testing.allocator, "/home/alex", null),
+        wslToWindows(std.testing.allocator, "/home/alex", null),
     );
 }
 
 test "wsl_path: non-absolute or empty is invalid" {
     try std.testing.expectError(
         error.InvalidPath,
-        posixToWindows(std.testing.allocator, "", "Ubuntu"),
+        wslToWindows(std.testing.allocator, "", "Ubuntu"),
     );
     try std.testing.expectError(
         error.InvalidPath,
-        posixToWindows(std.testing.allocator, "relative/path", "Ubuntu"),
+        wslToWindows(std.testing.allocator, "relative/path", "Ubuntu"),
     );
 }
 
@@ -170,7 +220,58 @@ test "wsl_path: OSC 7 URL forms extract and translate (reportPwd seam)" {
             .raw_path = std.mem.startsWith(u8, c.url, "kitty-shell-cwd://"),
         });
         const path = try u.path.toRawMaybeAlloc(aa);
-        const got = try posixToWindows(aa, path, c.distro);
+        const got = try wslToWindows(aa, path, c.distro);
         try std.testing.expectEqualStrings(c.want, got);
     }
+
+    // Rooted (MSYS2/Cygwin) form through the same parse chain.
+    {
+        const u = try uri.parse("kitty-shell-cwd://msys/c/Users/alex", .{
+            .mac_address = comptime builtin.os.tag != .macos,
+            .raw_path = true,
+        });
+        const path = try u.path.toRawMaybeAlloc(aa);
+        const got = try rootedToWindows(aa, path, "C:\\msys64");
+        try std.testing.expectEqualStrings("C:\\Users\\alex", got);
+    }
+}
+
+test "posix_path: rooted drive forms (MSYS2 /c and Cygwin /cygdrive)" {
+    // MSYS2/Git default automount: /<d>/...
+    try expectRooted("C:\\Users\\alex", "/c/Users/alex", "C:\\msys64");
+    try expectRooted("C:\\", "/c", "C:\\msys64");
+    try expectRooted("C:\\", "/c/", "C:\\msys64");
+    // Cygwin: /cygdrive/<d>/...
+    try expectRooted("D:\\work\\repo", "/cygdrive/d/work/repo", "C:\\cygwin64");
+    try expectRooted("D:\\", "/cygdrive/d", "C:\\cygwin64");
+    // Drive form needs no root.
+    try expectRooted("E:\\x", "/e/x", null);
+    try expectRooted("E:\\x", "/cygdrive/e/x", null);
+}
+
+test "posix_path: rooted root-relative forms map under install_root" {
+    try expectRooted("C:\\msys64\\home\\alex", "/home/alex", "C:\\msys64");
+    try expectRooted("C:\\msys64\\usr\\bin", "/usr/bin", "C:\\msys64");
+    try expectRooted("C:\\msys64\\", "/", "C:\\msys64");
+    try expectRooted("C:\\cygwin64\\etc", "/etc", "C:\\cygwin64");
+    // 'cygdriveX' is NOT the Cygwin mount prefix -> root-relative.
+    try expectRooted("C:\\msys64\\cygdriveX", "/cygdriveX", "C:\\msys64");
+}
+
+test "posix_path: rooted unknown root on root-relative path errors" {
+    try std.testing.expectError(
+        error.UnknownRoot,
+        rootedToWindows(std.testing.allocator, "/home/alex", null),
+    );
+}
+
+test "posix_path: rooted non-absolute or empty is invalid" {
+    try std.testing.expectError(
+        error.InvalidPath,
+        rootedToWindows(std.testing.allocator, "", "C:\\msys64"),
+    );
+    try std.testing.expectError(
+        error.InvalidPath,
+        rootedToWindows(std.testing.allocator, "rel/path", "C:\\msys64"),
+    );
 }

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -240,8 +240,12 @@ pub fn installRootFromExe(alloc: std.mem.Allocator, arg0: []const u8) ?[]u8 {
         (std.fs.path.dirnameWindows(up1) orelse return null)
     else
         up1;
-    if (root.len == 0) return null;
-    return alloc.dupe(u8, root) catch null;
+    // A drive-root install (`C:\bin\bash.exe`) leaves a trailing separator
+    // (`C:\`); strip it so the result honors rootedToWindows's "no trailing
+    // separator" contract (otherwise root-relative paths get a doubled `\`).
+    const normalized = std.mem.trimRight(u8, root, "\\/");
+    if (normalized.len == 0) return null;
+    return alloc.dupe(u8, normalized) catch null;
 }
 
 /// Returns true if the system ANSI codepage (`GetACP()`) is one of the
@@ -653,6 +657,8 @@ pub fn osc7ContextFromArgs(
 ) ?Osc7Context {
     if (comptime builtin.os.tag != .windows) return null;
     if (args.len == 0) return null;
+    // wsl.exe is handled here and is not a rooted kind, so it can never reach
+    // the rooted gate below (keep that true if isRootedPosixShell changes).
     if (WslContext.fromArgs(alloc, args)) |w| return .{ .wsl = w };
     if (isRootedPosixShell(identify(args[0]))) {
         return .{ .rooted = .{ .install_root = installRootFromExe(alloc, args[0]) } };
@@ -841,6 +847,15 @@ test "installRootFromExe: unknown layout or bare name -> null" {
     try testing.expect(installRootFromExe(alloc, "bash.exe") == null);
     try testing.expect(installRootFromExe(alloc, "C:\\Windows\\System32\\bash.exe") == null);
     try testing.expect(installRootFromExe(alloc, "C:\\tools\\bash.exe") == null);
+}
+
+test "installRootFromExe: drive-root install strips trailing separator" {
+    const alloc = testing.allocator;
+    // <drive>\bin\bash.exe would yield root "C:\" -> normalized to "C:" so
+    // rootedToWindows doesn't produce a doubled separator.
+    const r = installRootFromExe(alloc, "C:\\bin\\bash.exe").?;
+    defer alloc.free(r);
+    try testing.expectEqualStrings("C:", r);
 }
 
 test "isRootedPosixShell: bash/zsh/fish only" {

--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -214,6 +214,36 @@ pub fn winptyCandidatePaths(
     };
 }
 
+/// True for the POSIX-emulation shells (MSYS2/Git-Bash/Cygwin) that report
+/// `/`-rooted POSIX cwd paths via OSC 7. Excludes nu/elvish/xonsh, whose native
+/// Windows builds report `C:\...` already (translating those would corrupt a
+/// correct path).
+fn isRootedPosixShell(kind: Kind) bool {
+    return switch (kind) {
+        .bash, .zsh, .fish => true,
+        else => false,
+    };
+}
+
+/// Derive the install root from a POSIX-shell exe path by stripping the known
+/// layout suffix: `<root>\usr\bin\<sh>.exe` (MSYS2, Git's usr layout) or
+/// `<root>\bin\<sh>.exe` (Git, Cygwin). Owned dupe; null if neither layout
+/// matches (the caller then no-ops root-relative paths rather than guessing).
+/// Pure Windows path math (dirnameWindows/basenameWindows) so it is
+/// deterministic when these tests run on a non-Windows CI host.
+pub fn installRootFromExe(alloc: std.mem.Allocator, arg0: []const u8) ?[]u8 {
+    const trimmed = std.mem.trim(u8, arg0, "\"' \t\r\n");
+    const bin = std.fs.path.dirnameWindows(trimmed) orelse return null;
+    if (!std.ascii.eqlIgnoreCase(std.fs.path.basenameWindows(bin), "bin")) return null;
+    const up1 = std.fs.path.dirnameWindows(bin) orelse return null;
+    const root = if (std.ascii.eqlIgnoreCase(std.fs.path.basenameWindows(up1), "usr"))
+        (std.fs.path.dirnameWindows(up1) orelse return null)
+    else
+        up1;
+    if (root.len == 0) return null;
+    return alloc.dupe(u8, root) catch null;
+}
+
 /// Returns true if the system ANSI codepage (`GetACP()`) is one of the
 /// legacy double-byte CJK codepages where forcing UTF-8 on a spawned
 /// shell would mojibake legacy `.bat` scripts whose script text is
@@ -600,6 +630,36 @@ pub const WslContext = struct {
     }
 };
 
+/// OSC 7 context for a MSYS2/Git-Bash/Cygwin surface: the install root used to
+/// resolve root-relative POSIX paths. null when it could not be derived from
+/// argv[0] (root-relative paths then no-op; drive-form paths still translate).
+pub const RootedContext = struct { install_root: ?[]const u8 = null };
+
+/// What a Windows POSIX-emulation surface needs to translate OSC 7 paths: a WSL
+/// distro (UNC form) or a MSYS2/Cygwin install root (rooted form).
+pub const Osc7Context = union(enum) {
+    wsl: WslContext,
+    rooted: RootedContext,
+};
+
+/// Detect the OSC 7 path-translation context from a spawn argv. Pure and
+/// deterministic (the wsl arm's default-distro registry resolution happens
+/// later, in Termio). Returns null for non-Windows, non-POSIX shells
+/// (cmd/pwsh/nu/...), and empty argv. When present, owned strings inside must
+/// be freed by the caller (Termio errdefer + StreamHandler.deinit).
+pub fn osc7ContextFromArgs(
+    alloc: std.mem.Allocator,
+    args: []const [:0]const u8,
+) ?Osc7Context {
+    if (comptime builtin.os.tag != .windows) return null;
+    if (args.len == 0) return null;
+    if (WslContext.fromArgs(alloc, args)) |w| return .{ .wsl = w };
+    if (isRootedPosixShell(identify(args[0]))) {
+        return .{ .rooted = .{ .install_root = installRootFromExe(alloc, args[0]) } };
+    }
+    return null;
+}
+
 test "wslDistro: detects distro and default, ignores non-WSL" {
     {
         const argv = [_][]const u8{ "wsl.exe", "-d", "Ubuntu" };
@@ -739,7 +799,7 @@ test "defaultDistroName: links, never crashes, returns null-or-nonempty" {
 test "integration: resolved default distro feeds OSC 7 UNC translation" {
     if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
     const alloc = testing.allocator;
-    const wsl_path = @import("wsl_path.zig");
+    const posix_path = @import("posix_path.zig");
 
     // No default distro on this host (e.g. CI without WSL) -> nothing to prove.
     const distro = defaultDistroName(alloc) orelse return;
@@ -748,9 +808,86 @@ test "integration: resolved default distro feeds OSC 7 UNC translation" {
     // The gap this slice closes: an in-distro path (which yielded
     // error.UnknownDistro for a bare-wsl surface before resolution) must now
     // translate to the UNC form using the resolved name.
-    const win = try wsl_path.posixToWindows(alloc, "/home/alex", distro);
+    const win = try posix_path.wslToWindows(alloc, "/home/alex", distro);
     defer alloc.free(win);
     try testing.expect(std.mem.startsWith(u8, win, "\\\\wsl.localhost\\"));
     try testing.expect(std.mem.indexOf(u8, win, distro) != null);
     try testing.expect(std.mem.endsWith(u8, win, "\\home\\alex"));
+}
+
+test "installRootFromExe: MSYS2 usr\\bin layout" {
+    const alloc = testing.allocator;
+    const r = installRootFromExe(alloc, "C:\\msys64\\usr\\bin\\bash.exe").?;
+    defer alloc.free(r);
+    try testing.expectEqualStrings("C:\\msys64", r);
+}
+
+test "installRootFromExe: Git/Cygwin bin layout" {
+    const alloc = testing.allocator;
+    {
+        const r = installRootFromExe(alloc, "C:\\Program Files\\Git\\bin\\bash.exe").?;
+        defer alloc.free(r);
+        try testing.expectEqualStrings("C:\\Program Files\\Git", r);
+    }
+    {
+        const r = installRootFromExe(alloc, "C:\\cygwin64\\bin\\zsh.exe").?;
+        defer alloc.free(r);
+        try testing.expectEqualStrings("C:\\cygwin64", r);
+    }
+}
+
+test "installRootFromExe: unknown layout or bare name -> null" {
+    const alloc = testing.allocator;
+    try testing.expect(installRootFromExe(alloc, "bash.exe") == null);
+    try testing.expect(installRootFromExe(alloc, "C:\\Windows\\System32\\bash.exe") == null);
+    try testing.expect(installRootFromExe(alloc, "C:\\tools\\bash.exe") == null);
+}
+
+test "isRootedPosixShell: bash/zsh/fish only" {
+    try testing.expect(isRootedPosixShell(.bash));
+    try testing.expect(isRootedPosixShell(.zsh));
+    try testing.expect(isRootedPosixShell(.fish));
+    try testing.expect(!isRootedPosixShell(.nu));
+    try testing.expect(!isRootedPosixShell(.pwsh));
+    try testing.expect(!isRootedPosixShell(.wsl));
+    try testing.expect(!isRootedPosixShell(.unknown));
+}
+
+test "osc7ContextFromArgs: wsl arm" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = testing.allocator;
+    const args = [_][:0]const u8{ "wsl.exe", "-d", "Ubuntu" };
+    const ctx = osc7ContextFromArgs(alloc, &args).?;
+    defer switch (ctx) {
+        .wsl => |w| if (w.distro) |d| alloc.free(d),
+        .rooted => |r| if (r.install_root) |s| alloc.free(s),
+    };
+    try testing.expect(ctx == .wsl);
+    try testing.expectEqualStrings("Ubuntu", ctx.wsl.distro.?);
+}
+
+test "osc7ContextFromArgs: rooted arm (MSYS2 bash)" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = testing.allocator;
+    const args = [_][:0]const u8{ "C:\\msys64\\usr\\bin\\bash.exe", "-i" };
+    const ctx = osc7ContextFromArgs(alloc, &args).?;
+    defer switch (ctx) {
+        .wsl => |w| if (w.distro) |d| alloc.free(d),
+        .rooted => |r| if (r.install_root) |s| alloc.free(s),
+    };
+    try testing.expect(ctx == .rooted);
+    try testing.expectEqualStrings("C:\\msys64", ctx.rooted.install_root.?);
+}
+
+test "osc7ContextFromArgs: non-posix shells -> null" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = testing.allocator;
+    const pwsh = [_][:0]const u8{ "pwsh.exe", "-NoLogo" };
+    try testing.expect(osc7ContextFromArgs(alloc, &pwsh) == null);
+    const cmd = [_][:0]const u8{"cmd.exe"};
+    try testing.expect(osc7ContextFromArgs(alloc, &cmd) == null);
+    const nu = [_][:0]const u8{ "C:\\msys64\\usr\\bin\\nu.exe", "-i" };
+    try testing.expect(osc7ContextFromArgs(alloc, &nu) == null);
+    const empty = [_][:0]const u8{};
+    try testing.expect(osc7ContextFromArgs(alloc, &empty) == null);
 }

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -272,32 +272,38 @@ pub fn init(self: *Termio, alloc: Allocator, opts: termio.Options) !void {
     var backend = opts.backend;
     backend.initTerminal(&term);
 
-    // Derive WSL launch context (for OSC 7 path translation). Returns null on
-    // non-Windows and for non-WSL surfaces. Note: keys on argv[0] being the
-    // (unwrapped) wsl.exe; if WSL spawns are ever shell-wrapped this silently
-    // disables WSL OSC 7 translation (falls back to the historical no-op).
-    var wsl_ctx = internal_os.windows_shell.WslContext.fromArgs(
+    // Derive the OSC 7 path-translation context (WSL UNC, or MSYS2/Git/Cygwin
+    // install root). Returns null on non-Windows and for non-POSIX surfaces.
+    // Keys on argv[0]; a shell-wrapped spawn silently disables translation
+    // (falls back to the historical no-op).
+    var osc7 = internal_os.windows_shell.osc7ContextFromArgs(
         alloc,
         switch (backend) {
             .exec => |*exec| exec.subprocess.args,
         },
     );
-    // Bare `wsl.exe` (no -d) leaves the distro name unknown; resolve the
-    // default distro's real name from the registry so in-distro OSC 7 paths
-    // (e.g. /home/<user>) translate to \\wsl.localhost\<distro>\... rather than
-    // being dropped. Best-effort: null on any failure (then /mnt still works).
-    if (wsl_ctx) |*w| {
-        if (w.distro == null) w.distro = internal_os.windows_shell.defaultDistroName(alloc);
-    }
+    // Bare `wsl.exe` (no -d) leaves the distro name unknown; resolve the default
+    // distro's real name from the registry so in-distro OSC 7 paths (e.g.
+    // /home/<user>) translate to \\wsl.localhost\<distro>\... rather than being
+    // dropped. Best-effort: null on failure (then /mnt still works).
+    if (osc7) |*c| switch (c.*) {
+        .wsl => |*w| if (w.distro == null) {
+            w.distro = internal_os.windows_shell.defaultDistroName(alloc);
+        },
+        .rooted => {},
+    };
     // Until ownership transfers to the StreamHandler (via terminal_stream
-    // below), we own the duped distro string; free it if init fails first.
-    errdefer if (wsl_ctx) |w| if (w.distro) |d| alloc.free(d);
+    // below), we own the duped string; free it if init fails first.
+    errdefer if (osc7) |c| switch (c) {
+        .wsl => |w| if (w.distro) |d| alloc.free(d),
+        .rooted => |r| if (r.install_root) |s| alloc.free(s),
+    };
 
     // Create our stream handler. This points to memory in self so it
     // isn't safe to use until self.* is set.
     const handler: StreamHandler = .{
         .alloc = alloc,
-        .wsl = wsl_ctx,
+        .osc7 = osc7,
         .termio_mailbox = &self.mailbox,
         .surface_mailbox = opts.surface_mailbox,
         .renderer_state = opts.renderer_state,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -58,9 +58,10 @@ pub const StreamHandler = struct {
     /// whoever owns StreamHandler.
     enquiry_response: []const u8,
 
-    /// WSL launch context for OSC 7 path translation. null for non-WSL (and
-    /// non-Windows) surfaces. Owns `distro` (freed in deinit).
-    wsl: ?internal_os.windows_shell.WslContext = null,
+    /// OSC 7 path-translation context (WSL UNC, or MSYS2/Git/Cygwin install
+    /// root). null for non-POSIX (and non-Windows) surfaces. Owns the duped
+    /// distro/install_root string (freed in deinit).
+    osc7: ?internal_os.windows_shell.Osc7Context = null,
 
     /// The color reporting format for OSC requests.
     osc_color_report_format: configpkg.Config.OSCColorReportFormat,
@@ -109,7 +110,10 @@ pub const StreamHandler = struct {
         self.apc.deinit();
         self.dcs.deinit();
         self.multipart_iterm2.deinit(self.alloc);
-        if (self.wsl) |w| if (w.distro) |d| self.alloc.free(d);
+        if (self.osc7) |c| switch (c) {
+            .wsl => |w| if (w.distro) |d| self.alloc.free(d),
+            .rooted => |r| if (r.install_root) |s| self.alloc.free(s),
+        };
         if (comptime tmux_enabled) tmux: {
             const viewer = self.tmux_viewer orelse break :tmux;
             viewer.deinit();
@@ -1225,12 +1229,13 @@ pub const StreamHandler = struct {
         }
 
         if (comptime builtin.os.tag == .windows) {
-            // WSL-only: non-WSL Windows surfaces keep the historical no-op.
-            // A WSL surface means we spawned wsl.exe ourselves, so the host is
-            // as local as it gets — skip the isLocal check (same trust basis
-            // ghostty applies to its own ssh sessions).
-            if (self.wsl == null) {
-                log.warn("OSC 7 ignored: non-WSL windows surface", .{});
+            // POSIX-emulation surfaces only (WSL / MSYS2 / Git-Bash / Cygwin);
+            // other Windows surfaces keep the historical no-op. Such a surface
+            // means we spawned the shell ourselves, so the host is as local as
+            // it gets — skip the isLocal check (same trust basis ghostty
+            // applies to its own ssh sessions).
+            if (self.osc7 == null) {
+                log.warn("OSC 7 ignored: non-POSIX windows surface", .{});
                 return;
             }
         } else {
@@ -1270,17 +1275,18 @@ pub const StreamHandler = struct {
         defer arena_alloc.deinit();
         const path = try uri.path.toRawMaybeAlloc(stack_alloc.get());
 
-        // On Windows the path comes from a WSL shell as a POSIX path; translate
-        // it to its Windows form so the title and inherited cwd are usable.
-        // `reported` shares `path`'s stack-fallback arena, and setPwd/WriteReq
-        // copy synchronously, so the lifetime matches the untranslated path.
+        // On Windows the path comes from a POSIX-emulation shell; translate it
+        // to its Windows form so the title and inherited cwd are usable. Which
+        // translator depends on the surface kind (WSL UNC vs MSYS2/Cygwin
+        // install root). `reported` shares `path`'s stack-fallback arena, and
+        // setPwd/WriteReq copy synchronously, so the lifetime matches the
+        // untranslated path.
         const reported = if (comptime builtin.os.tag == .windows)
-            internal_os.wsl_path.posixToWindows(
-                stack_alloc.get(),
-                path,
-                self.wsl.?.distro,
-            ) catch |err| {
-                log.warn("OSC 7 WSL path translation failed: {}", .{err});
+            (switch (self.osc7.?) {
+                .wsl => |w| internal_os.posix_path.wslToWindows(stack_alloc.get(), path, w.distro),
+                .rooted => |r| internal_os.posix_path.rootedToWindows(stack_alloc.get(), path, r.install_root),
+            }) catch |err| {
+                log.warn("OSC 7 path translation failed: {}", .{err});
                 return;
             }
         else


### PR DESCRIPTION
## What

Extend OSC 7 cwd path translation to **MSYS2 / MinGW / Git-Bash** (`/c/…` mounts) and **Cygwin** (`/cygdrive/c/…` mounts), generalizing the WSL-only receiver shipped in #498/#499.

## Why

`stream_handler.reportPwd` was hard-gated on a WSL context, so every non-WSL Windows surface hit `OSC 7 ignored: non-WSL windows surface` — MSYS2/Git-Bash/Cygwin shells that report a POSIX cwd got it dropped, leaving cwd/title and new-surface inherited directory wrong. This completes the cross-shell consistency of the OSC 7 story on Windows.

Like #498, this is the **receiver** half (translate when a path arrives). These shells don't emit OSC 7 by default, so the value lands for users whose prompt/dotfiles emit it; the transmitter side remains a later slice.

## Key design: no family detection needed

The two default mount conventions are disjoint and self-identifying by path shape, so the translator never needs to know MSYS2-vs-Cygwin:

- `/cygdrive/<d>/…` → `<D>:\…` (Cygwin's distinctive prefix, checked first)
- `/<d>/…` (single-letter segment) → `<D>:\…` (MSYS2/Git automount — matches the already-shipped inverse `winToCygwinPath`)
- everything else → `<install_root>\…`

So the rooted context is just an `install_root`, derived from `argv[0]` (`C:\msys64\usr\bin\bash.exe` → `C:\msys64`).

## How

- **`posix_path.zig`** (renamed from `wsl_path.zig`): `wslToWindows` (renamed) + new `rootedToWindows`, sharing private `driveAfter`/`driveForm`/`appendBackslashed`. `Error` gains `UnknownRoot`.
- **`windows_shell.zig`**: `Osc7Context = union(enum){ wsl: WslContext, rooted: RootedContext }`; pure `osc7ContextFromArgs` (wsl.exe → wsl arm; bash/zsh/fish `.exe` → rooted arm with `installRootFromExe`; **strictly excludes nu/elvish/xonsh** whose native Windows builds report `C:\…` already; cmd/pwsh/unknown → null); `installRootFromExe` mirrors the existing winpty two-layout strip (`\usr\bin` / `\bin`).
- **`Termio.zig`**: builds `Osc7Context`, keeps #499's default-distro registry fill on the wsl arm (detection stays pure).
- **`stream_handler.zig`**: field `wsl` → `osc7`; gate `if (self.osc7 == null)` (same local-trust basis — we spawned the shell, so `isLocal` is skipped); `reportPwd` switches the union to the right translator.

## Error handling

All failures → safe no-op (pwd unset), never a confidently-wrong path: non-absolute → `InvalidPath`; root-relative with underivable root → `UnknownRoot`. Custom `/etc/fstab` mount remaps aren't honored (documented known limitation; no fstab parser — YAGNI).

## Testing

Pure/deterministic throughout. `posix_path.zig`: WSL tests retargeted to `wslToWindows`; new `rootedToWindows` tests (`/c/…`, `/cygdrive/d/…`, `/home/…`→root, `/usr/bin`, `/`, null-root→`UnknownRoot`, non-absolute→`InvalidPath`); OSC 7 seam test extended with a rooted case. `windows_shell.zig`: `installRootFromExe` (both layouts + unknown→null), `isRootedPosixShell`, `osc7ContextFromArgs` (wsl/rooted/non-posix). Full suite green: `zig build test -Dapp-runtime=none`.

Part of #494 (child of #80). Builds on #498, #499.
