### PR TITLE
feat(windows): WSL shell integration (OSC 133) via WSLENV (#494)

### DIFF
--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -76,6 +76,38 @@ pub fn rootedToWindows(
     return buf.toOwnedSlice(alloc);
 }
 
+/// Translate a Windows path into its WSL automount form (the inverse direction
+/// of `wslToWindows`'s `/mnt/` case):
+///
+///   C:\Users\x[\rest]  -> /mnt/c/Users/x/rest
+///
+/// Lowercases the drive letter, converts `\` -> `/`, and strips a leading
+/// `\\?\` extended-length prefix. Returns null for any path that is not
+/// drive-rooted (UNC such as `\\server\share` or `\\wsl.localhost\...`, or a
+/// relative path): such a path has no `/mnt` automount equivalent reachable
+/// from inside the distro, so the caller skips integration rather than emit a
+/// confidently-wrong path. Caller owns the returned slice.
+pub fn windowsToWsl(alloc: Allocator, win_path: []const u8) Allocator.Error!?[]u8 {
+    // Strip an extended-length prefix (`\\?\C:\...`) so the drive is detectable.
+    // `\\?\UNC\...` becomes `UNC\...` which fails the drive check below (correct:
+    // UNC has no /mnt form).
+    const p = if (std.mem.startsWith(u8, win_path, "\\\\?\\"))
+        win_path["\\\\?\\".len..]
+    else
+        win_path;
+
+    // Require a `<letter>:` drive root; UNC and relative paths have no /mnt form.
+    if (p.len < 2 or p[1] != ':' or !std.ascii.isAlphabetic(p[0])) return null;
+
+    const rest = p[2..]; // keeps the leading separator if any
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    errdefer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "/mnt/");
+    try buf.append(alloc, std.ascii.toLower(p[0]));
+    for (rest) |c| try buf.append(alloc, if (c == '\\') '/' else c);
+    return try buf.toOwnedSlice(alloc);
+}
+
 const Mount = struct { drive: u8, rest: []const u8 };
 
 /// Match `<prefix><drive>(/...)?` where `<drive>` is a single ASCII letter and
@@ -277,4 +309,40 @@ test "posix_path: rooted non-absolute or empty is invalid" {
         error.InvalidPath,
         rootedToWindows(std.testing.allocator, "rel/path", "C:\\msys64"),
     );
+}
+
+fn expectWinToWsl(expected: ?[]const u8, win_path: []const u8) !void {
+    const got = try windowsToWsl(std.testing.allocator, win_path);
+    defer if (got) |g| std.testing.allocator.free(g);
+    if (expected) |e| {
+        try std.testing.expectEqualStrings(e, got orelse return error.UnexpectedNull);
+    } else {
+        try std.testing.expect(got == null);
+    }
+}
+
+test "posix_path: windowsToWsl drive-rooted" {
+    try expectWinToWsl("/mnt/c/Users/x/share/ghostty", "C:\\Users\\x\\share\\ghostty");
+}
+
+test "posix_path: windowsToWsl lowercases drive" {
+    try expectWinToWsl("/mnt/d/Foo", "D:\\Foo");
+}
+
+test "posix_path: windowsToWsl accepts forward slashes" {
+    try expectWinToWsl("/mnt/c/a/b", "C:/a/b");
+}
+
+test "posix_path: windowsToWsl strips extended-length prefix" {
+    try expectWinToWsl("/mnt/c/Users/x", "\\\\?\\C:\\Users\\x");
+}
+
+test "posix_path: windowsToWsl rejects UNC" {
+    try expectWinToWsl(null, "\\\\server\\share");
+    try expectWinToWsl(null, "\\\\wsl.localhost\\Ubuntu\\home\\a");
+    try expectWinToWsl(null, "\\\\?\\UNC\\server\\share");
+}
+
+test "posix_path: windowsToWsl rejects relative" {
+    try expectWinToWsl(null, "relative\\path");
 }

--- a/src/os/posix_path.zig
+++ b/src/os/posix_path.zig
@@ -346,3 +346,8 @@ test "posix_path: windowsToWsl rejects UNC" {
 test "posix_path: windowsToWsl rejects relative" {
     try expectWinToWsl(null, "relative\\path");
 }
+
+test "posix_path: windowsToWsl bare drive" {
+    // A drive root with no remainder maps to `/mnt/<d>` (no trailing slash).
+    try expectWinToWsl("/mnt/c", "C:");
+}

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -895,6 +895,10 @@ const Subprocess = struct {
                 defer it.deinit();
                 const arg0 = it.next() orelse break :wsl;
                 if (!internal_os.windows_shell.isWslExe(arg0)) break :wsl;
+                // WSL integration is best-effort, so unlike the native
+                // shell_integration.setup below (which `try`s and treats OOM as
+                // fatal) we catch and downgrade to a warning: a failed WSL
+                // injection should never abort the spawn.
                 wsl_shell_integration.setup(alloc, dir, &env) catch |err| {
                     log.warn("WSL shell integration failed: {}", .{err});
                 };

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -18,6 +18,7 @@ const fastmem = @import("../fastmem.zig");
 const internal_os = @import("../os/main.zig");
 const renderer = @import("../renderer.zig");
 const shell_integration = @import("shell_integration.zig");
+const wsl_shell_integration = @import("wsl_shell_integration.zig");
 const terminfo_install = @import("../terminfo/install.zig");
 const DiskCache = @import("../cli/ssh-cache/DiskCache.zig");
 const terminal = @import("../terminal/main.zig");
@@ -884,6 +885,22 @@ const Subprocess = struct {
                 log.warn("no resources dir set, shell integration disabled", .{});
                 break :shell default_shell_command;
             };
+
+            // On Windows, a `wsl.exe` launch can't be integrated through
+            // detectShell (it sees the launcher, not the distro's shell).
+            // Inject zsh/fish integration into the distro via WSLENV instead.
+            // Login bash is unreachable (documented no-op).
+            if (comptime builtin.os.tag == .windows) wsl: {
+                var it = default_shell_command.argIterator(alloc) catch break :wsl;
+                defer it.deinit();
+                const arg0 = it.next() orelse break :wsl;
+                if (!internal_os.windows_shell.isWslExe(arg0)) break :wsl;
+                wsl_shell_integration.setup(alloc, dir, &env) catch |err| {
+                    log.warn("WSL shell integration failed: {}", .{err});
+                };
+                log.info("WSL shell integration injected via WSLENV", .{});
+                break :shell default_shell_command;
+            }
 
             const integration = try shell_integration.setup(
                 alloc,

--- a/src/termio/wsl_shell_integration.zig
+++ b/src/termio/wsl_shell_integration.zig
@@ -1,0 +1,55 @@
+//! Inject ghostty shell integration into a WSL (`wsl.exe`) session by setting
+//! the distro-side env vars (in `/mnt` form) and forwarding them through
+//! WSLENV. Covers zsh (ZDOTDIR) and fish (XDG_DATA_DIRS). Login bash is a
+//! documented no-op: it ignores `$ENV` without `--posix` (which we cannot
+//! inject into wsl.exe), and we will not write into the distro filesystem —
+//! the same stance ghostty takes for Apple's patched `/bin/bash` on macOS.
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const EnvMap = std.process.EnvMap;
+const posix_path = @import("../os/posix_path.zig");
+
+const log = std.log.scoped(.wsl_shell_integration);
+
+/// Append `names` (env var names already set in `env`, with no path-translation
+/// flags) to the `WSLENV` variable, preserving any existing value. WSL forwards
+/// only variables listed in WSLENV into the distro; a flag-less entry passes
+/// through verbatim (no path translation), which is what we want — our values
+/// are already in `/mnt` form. No-op when `names` is empty.
+fn appendWslenv(alloc: Allocator, env: *EnvMap, names: []const []const u8) !void {
+    if (names.len == 0) return;
+
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(alloc);
+
+    if (env.get("WSLENV")) |existing| try buf.appendSlice(alloc, existing);
+    for (names) |name| {
+        if (buf.items.len > 0) try buf.append(alloc, ':');
+        try buf.appendSlice(alloc, name);
+    }
+    // EnvMap.put copies the value, so the temp buf is safe to free after.
+    try env.put("WSLENV", buf.items);
+}
+
+test "appendWslenv: empty names is a no-op" {
+    var env = EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try appendWslenv(std.testing.allocator, &env, &.{});
+    try std.testing.expect(env.get("WSLENV") == null);
+}
+
+test "appendWslenv: sets WSLENV when none existed" {
+    var env = EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try appendWslenv(std.testing.allocator, &env, &.{ "ZDOTDIR", "XDG_DATA_DIRS" });
+    try std.testing.expectEqualStrings("ZDOTDIR:XDG_DATA_DIRS", env.get("WSLENV").?);
+}
+
+test "appendWslenv: preserves existing WSLENV" {
+    var env = EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("WSLENV", "USERPROFILE/p");
+    try appendWslenv(std.testing.allocator, &env, &.{"ZDOTDIR"});
+    try std.testing.expectEqualStrings("USERPROFILE/p:ZDOTDIR", env.get("WSLENV").?);
+}

--- a/src/termio/wsl_shell_integration.zig
+++ b/src/termio/wsl_shell_integration.zig
@@ -26,6 +26,13 @@ pub fn setup(alloc: Allocator, resource_dir: []const u8, env: *EnvMap) !void {
 
     // zsh: ZDOTDIR -> <resource_dir>/shell-integration/zsh (holds our .zshenv,
     // which restores the user's real zsh config).
+    //
+    // Unlike native setupZsh, we do NOT preserve a pre-existing ZDOTDIR into
+    // GHOSTTY_ZSH_ZDOTDIR. Any inbound ZDOTDIR here is a Windows-side value,
+    // meaningless inside the distro; forwarding it would make our .zshenv
+    // "restore" ZDOTDIR to a bogus Windows path in the distro. The distro's
+    // own default (unset -> $HOME) is the correct chain target, which leaving
+    // GHOSTTY_ZSH_ZDOTDIR unset yields.
     {
         var buf: [std.fs.max_path_bytes]u8 = undefined;
         const win = try std.fmt.bufPrint(&buf, "{s}/shell-integration/zsh", .{resource_dir});

--- a/src/termio/wsl_shell_integration.zig
+++ b/src/termio/wsl_shell_integration.zig
@@ -12,6 +12,69 @@ const posix_path = @import("../os/posix_path.zig");
 
 const log = std.log.scoped(.wsl_shell_integration);
 
+/// Inject zsh + fish shell integration for a WSL session. Best-effort: any
+/// failure logs and leaves that piece of the env untouched; absence of
+/// integration is the existing behavior, never a wrong value. Both vars are
+/// injected unconditionally (no login-shell detection): ZDOTDIR is read only by
+/// zsh, and an extra XDG_DATA_DIRS entry is inert for non-fish shells.
+/// `resource_dir` is the Windows resources dir; `alloc` is expected to be an
+/// arena (values are placed into `env`).
+pub fn setup(alloc: Allocator, resource_dir: []const u8, env: *EnvMap) !void {
+    // Names we actually set, to register in WSLENV at the end.
+    var names: std.ArrayListUnmanaged([]const u8) = .{};
+    defer names.deinit(alloc);
+
+    // zsh: ZDOTDIR -> <resource_dir>/shell-integration/zsh (holds our .zshenv,
+    // which restores the user's real zsh config).
+    {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const win = try std.fmt.bufPrint(&buf, "{s}/shell-integration/zsh", .{resource_dir});
+        if (dirExists(win)) {
+            if (try posix_path.windowsToWsl(alloc, win)) |wsl_path| {
+                defer alloc.free(wsl_path);
+                try env.put("ZDOTDIR", wsl_path);
+                try names.append(alloc, "ZDOTDIR");
+            } else log.warn("WSL: resources dir not drive-rooted, zsh skipped: {s}", .{win});
+        } else log.warn("WSL: missing {s}, zsh integration skipped", .{win});
+    }
+
+    // fish: prepend <resource_dir>/shell-integration to XDG_DATA_DIRS.
+    {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const win = try std.fmt.bufPrint(&buf, "{s}/shell-integration", .{resource_dir});
+        if (dirExists(win)) {
+            if (try posix_path.windowsToWsl(alloc, win)) |wsl_dir| {
+                defer alloc.free(wsl_dir);
+                try env.put("GHOSTTY_SHELL_INTEGRATION_XDG_DIR", wsl_dir);
+                try names.append(alloc, "GHOSTTY_SHELL_INTEGRATION_XDG_DIR");
+
+                const current = env.get("XDG_DATA_DIRS") orelse "/usr/local/share:/usr/share";
+                const joined = if (current.len == 0)
+                    try alloc.dupe(u8, wsl_dir)
+                else
+                    try std.fmt.allocPrint(alloc, "{s}:{s}", .{ wsl_dir, current });
+                defer alloc.free(joined);
+                try env.put("XDG_DATA_DIRS", joined);
+                try names.append(alloc, "XDG_DATA_DIRS");
+            } else log.warn("WSL: resources dir not drive-rooted, fish skipped: {s}", .{win});
+        } else log.warn("WSL: missing {s}, fish integration skipped", .{win});
+    }
+
+    // GHOSTTY_SHELL_FEATURES is set upstream by setupFeatures (omitted when all
+    // features are disabled). Forward it iff present.
+    if (env.get("GHOSTTY_SHELL_FEATURES") != null) {
+        try names.append(alloc, "GHOSTTY_SHELL_FEATURES");
+    }
+
+    try appendWslenv(alloc, env, names.items);
+}
+
+fn dirExists(path: []const u8) bool {
+    var dir = std.fs.openDirAbsolute(path, .{}) catch return false;
+    dir.close();
+    return true;
+}
+
 /// Append `names` (env var names already set in `env`, with no path-translation
 /// flags) to the `WSLENV` variable, preserving any existing value. WSL forwards
 /// only variables listed in WSLENV into the distro; a flag-less entry passes
@@ -52,4 +115,76 @@ test "appendWslenv: preserves existing WSLENV" {
     try env.put("WSLENV", "USERPROFILE/p");
     try appendWslenv(std.testing.allocator, &env, &.{"ZDOTDIR"});
     try std.testing.expectEqualStrings("USERPROFILE/p:ZDOTDIR", env.get("WSLENV").?);
+}
+
+test "setup: injects zsh + fish env and registers WSLENV" {
+    // The translator only produces a /mnt path from a Windows drive path, so
+    // this end-to-end assertion is meaningful only on Windows (tmp realpath is
+    // a drive path there). The translator itself is unit-tested cross-platform.
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("shell-integration/zsh");
+    const res = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(res);
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+    try env.put("GHOSTTY_SHELL_FEATURES", "cursor:blink,title");
+
+    try setup(alloc, res, &env);
+
+    // ZDOTDIR -> /mnt form of <res>/shell-integration/zsh
+    {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const zsh_win = try std.fmt.bufPrint(&buf, "{s}/shell-integration/zsh", .{res});
+        const expected = (try posix_path.windowsToWsl(alloc, zsh_win)).?;
+        defer alloc.free(expected);
+        try std.testing.expectEqualStrings(expected, env.get("ZDOTDIR").?);
+    }
+
+    // XDG_DATA_DIRS prefixed with the /mnt integration dir + Linux defaults.
+    {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const integ_win = try std.fmt.bufPrint(&buf, "{s}/shell-integration", .{res});
+        const integ = (try posix_path.windowsToWsl(alloc, integ_win)).?;
+        defer alloc.free(integ);
+        try std.testing.expectEqualStrings(integ, env.get("GHOSTTY_SHELL_INTEGRATION_XDG_DIR").?);
+        const xdg = env.get("XDG_DATA_DIRS").?;
+        try std.testing.expect(std.mem.startsWith(u8, xdg, integ));
+        try std.testing.expect(std.mem.endsWith(u8, xdg, "/usr/local/share:/usr/share"));
+    }
+
+    // WSLENV lists all four forwarded vars.
+    {
+        const wslenv = env.get("WSLENV").?;
+        try std.testing.expect(std.mem.indexOf(u8, wslenv, "ZDOTDIR") != null);
+        try std.testing.expect(std.mem.indexOf(u8, wslenv, "XDG_DATA_DIRS") != null);
+        try std.testing.expect(std.mem.indexOf(u8, wslenv, "GHOSTTY_SHELL_INTEGRATION_XDG_DIR") != null);
+        try std.testing.expect(std.mem.indexOf(u8, wslenv, "GHOSTTY_SHELL_FEATURES") != null);
+    }
+}
+
+test "setup: omits GHOSTTY_SHELL_FEATURES from WSLENV when unset" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("shell-integration/zsh");
+    const res = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(res);
+
+    var env = EnvMap.init(alloc);
+    defer env.deinit();
+    // No GHOSTTY_SHELL_FEATURES set.
+
+    try setup(alloc, res, &env);
+
+    const wslenv = env.get("WSLENV").?;
+    try std.testing.expect(std.mem.indexOf(u8, wslenv, "GHOSTTY_SHELL_FEATURES") == null);
+    try std.testing.expect(std.mem.indexOf(u8, wslenv, "ZDOTDIR") != null);
 }


### PR DESCRIPTION
## What

Give **WSL** (`wsl.exe`) sessions ghostty shell integration — OSC 133 prompt marks, title reporting, cursor shape, sudo integration — for **zsh and fish**. This is the final tail slice (2b) of #494 (child of #80).

Until now, WSL sessions got **no** shell integration: native `detectShell` only recognizes bare shell names, so it returns `null` for `wsl.exe` and `setup` no-ops. The distro shell never saw the integration env vars.

## How

The integration mechanism sets Windows-side env vars (`ZDOTDIR` for zsh, `XDG_DATA_DIRS` for fish) pointing at ghostty's integration scripts. Two things have to happen for that to cross the WSL boundary:

1. Paths must be in the distro's filesystem view (`/mnt/c/...`), not Windows (`C:\...`) or Cygwin (`/c/...`) form.
2. The vars must be named in **`WSLENV`** — WSL drops every env var not listed there.

A new Windows-only `src/termio/wsl_shell_integration.zig`, parallel to the native module, does exactly this: it pre-translates the resources dir to `/mnt` form (`posix_path.windowsToWsl`), sets `ZDOTDIR` + `XDG_DATA_DIRS` + `GHOSTTY_SHELL_INTEGRATION_XDG_DIR` (+ `GHOSTTY_SHELL_FEATURES` if present), and registers them as plain (flag-less) `WSLENV` entries that WSL forwards verbatim. `Exec.zig` gates on `isWslExe` and runs this instead of the native `setup`. Terminfo is already provisioned by #497.

### Design decisions

- **zsh + fish only; login bash is a deliberate, documented no-op.** Login bash ignores `$ENV` without `--posix`, which can't be injected into `wsl.exe`, and we will not write sourcing stubs into the user's distro. This is the *same* stance ghostty already takes for Apple's patched `/bin/bash` on macOS (`detectShell` returns `null` by design). zsh (`.zshenv`) and fish (`vendor_conf.d`) are read on every login-shell start, so injected vars reach them. Strictly additive, zero-regression: bash behaves exactly as before.
- **Pre-translate to `/mnt` + plain WSLENV entries**, rather than WSLENV `/p`/`/lp` translation flags. `/lp` path-translates *every* element of a list, but `XDG_DATA_DIRS` must carry the Linux defaults `/usr/local/share:/usr/share`, which `wslpath` would mangle. Pre-translation sidesteps that and keeps all logic pure and unit-testable.
- **No login-shell detection.** Both `ZDOTDIR` and `XDG_DATA_DIRS` are injected unconditionally — `ZDOTDIR` is read only by zsh, an extra `XDG_DATA_DIRS` entry is inert for non-fish shells.
- **Best-effort safe-no-op.** Missing dir, non-drive-rooted (UNC) resources dir, or empty features → skip that piece, log, proceed. Never a confidently-wrong value.

### Known boundaries (documented in code)

- Login bash: structurally unreachable → no-op.
- Custom `/etc/wsl.conf` automount root (`!= /mnt`): assumed `/mnt` — same boundary accepted in #500.
- Legacy `C:\Windows\System32\bash.exe` launcher: unchanged (native path silently no-ops as today).

## Tests

- `posix_path.windowsToWsl` — pure, cross-platform: drive-rooted, lowercase, forward slashes, `\\?\` strip, UNC→null, relative→null, bare-`C:` edge.
- `appendWslenv` — empty/new/preserve-existing.
- `wsl_shell_integration.setup` — Windows-gated end-to-end: asserts `ZDOTDIR`, `XDG_DATA_DIRS` prefix+suffix, `GHOSTTY_SHELL_INTEGRATION_XDG_DIR`, all four names in `WSLENV`, and `GHOSTTY_SHELL_FEATURES` omitted when unset.

**Verification:** full `zig build test -Dapp-runtime=none` green on Windows; Linux build verified via cross-compile (`-Dtarget=x86_64-linux-gnu`) — the change is `comptime`-Windows-gated, so the Linux/macOS build is provably unaffected. ghostty-reviewer (Mitchell-pattern) pass: APPROVED, NITs applied.

## Issue

Closes the last tail item of #494. OSC 7 cwd receiver (already shipped #498–#500) + this OSC 133 integration complete the WSL shell-awareness story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
