### PR TITLE
fix(windows): bypass execution policy for pwsh shell integration (#80)

### DIFF
--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -1153,7 +1153,7 @@ test "nushell: missing resources" {
 /// arguments of their own) we go further and rewrite the launch command to
 /// auto-source the script:
 ///
-///     <pwsh> -NoExit -Command ". '<resource_dir>/.../ghostty.ps1'"
+///     <pwsh> -NoExit -ExecutionPolicy Bypass -Command ". '<resource_dir>/.../ghostty.ps1'"
 ///
 /// PowerShell still loads the user's `$PROFILE` first, then runs the
 /// `-Command`, which dot-sources our script. The script wraps the
@@ -1203,11 +1203,21 @@ fn setupPowerShell(
         0,
     );
 
-    const argv = try alloc_arena.alloc([:0]const u8, 4);
+    // `-ExecutionPolicy Bypass` is process-scoped (it only affects the pwsh we
+    // spawn, never the user's persisted machine/user policy) and is required
+    // for correctness: Windows PowerShell 5.1 defaults to `Restricted` on
+    // client Windows, under which dot-sourcing our `.ps1` fails with
+    // "running scripts is disabled on this system", breaking integration and
+    // printing a security error on every launch. The script we source is
+    // Ghostty's own local file (no Mark-of-the-Web), so the bypass only
+    // unblocks our trusted script.
+    const argv = try alloc_arena.alloc([:0]const u8, 6);
     argv[0] = try alloc_arena.dupeZ(u8, exe);
     argv[1] = try alloc_arena.dupeZ(u8, "-NoExit");
-    argv[2] = try alloc_arena.dupeZ(u8, "-Command");
-    argv[3] = dot_source;
+    argv[2] = try alloc_arena.dupeZ(u8, "-ExecutionPolicy");
+    argv[3] = try alloc_arena.dupeZ(u8, "Bypass");
+    argv[4] = try alloc_arena.dupeZ(u8, "-Command");
+    argv[5] = dot_source;
 
     return .{ .direct = argv };
 }
@@ -1229,13 +1239,17 @@ test "powershell" {
     const command = try setupPowerShell(alloc, .{ .shell = "pwsh" }, res.path, &env);
     try testing.expect(command.? == .direct);
     const argv = command.?.direct;
-    try testing.expectEqual(@as(usize, 4), argv.len);
+    try testing.expectEqual(@as(usize, 6), argv.len);
     try testing.expectEqualStrings("pwsh", argv[0]);
     try testing.expectEqualStrings("-NoExit", argv[1]);
-    try testing.expectEqualStrings("-Command", argv[2]);
+    // Process-scoped policy bypass so a default-Restricted Windows
+    // PowerShell 5.1 can still dot-source our integration script.
+    try testing.expectEqualStrings("-ExecutionPolicy", argv[2]);
+    try testing.expectEqualStrings("Bypass", argv[3]);
+    try testing.expectEqualStrings("-Command", argv[4]);
     // The dot-source argument references our integration script.
-    try testing.expect(std.mem.indexOf(u8, argv[3], "ghostty.ps1") != null);
-    try testing.expect(std.mem.startsWith(u8, argv[3], ". '"));
+    try testing.expect(std.mem.indexOf(u8, argv[5], "ghostty.ps1") != null);
+    try testing.expect(std.mem.startsWith(u8, argv[5], ". '"));
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     try testing.expectEqualStrings(


### PR DESCRIPTION
## What

Pass `-ExecutionPolicy Bypass` when auto-injecting the PowerShell shell-integration script, so it works on a stock **Windows PowerShell 5.1** (`Restricted` policy) host.

## Why — reproduced

`setupPowerShell` rewrites a bare `pwsh`/`powershell` launch to `-NoExit -Command ". '…ghostty.ps1'"`. Windows PowerShell 5.1 defaults to **`Restricted`** execution policy on client Windows, under which **dot-sourcing a `.ps1` is blocked**. Live repro (forcing the stock-client default):

```
. : File …\ghostty.ps1 cannot be loaded because running scripts is disabled on this system.
    + FullyQualifiedErrorId : UnauthorizedAccess          (exit 1)
```

So a user who sets `command = powershell` gets a SecurityError **and no integration on every launch**. Adding `-ExecutionPolicy Bypass` sources it cleanly (exit 0, `5.1.26100`).

## How

Insert `-ExecutionPolicy Bypass` into the auto-injected argv, before `-Command`:

```
<pwsh> -NoExit -ExecutionPolicy Bypass -Command ". '…ghostty.ps1'"
```

- **Process-scoped** — affects only the pwsh we spawn, never the user's persisted machine/user policy.
- **Trusted target** — the sourced file is Ghostty's own local resource (no Mark-of-the-Web), so the bypass only unblocks our own script.
- **Unconditional** (also on pwsh 7) — harmless under pwsh 7's `RemoteSigned` default, and avoids fragile 5.1-vs-7 detection at spawn time. Only the auto-inject path (bare shell) is touched; user-supplied commands are left untouched.

## Tests

`powershell` test updated to assert the 6-element argv (`-ExecutionPolicy`/`Bypass` at 2/3, `-Command` at 4, dot-source at 5). Full `zig build test -Dapp-runtime=none` green. ghostty-reviewer: APPROVED.

## Issue

Final item of the #80 shell-compatibility umbrella (the PowerShell 5.1 execution-policy box). Closes the native-shell tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
