### PR TITLE
fix(windows): esctest #79 timeouts are missing VT queries, not transport

### DIFF
--- a/windows/docs/vt-compliance/esctest-baseline.md
+++ b/windows/docs/vt-compliance/esctest-baseline.md
@@ -1,88 +1,139 @@
 # VT-compliance baseline: Wintty/ConPTY via WSL (esctest)
 
-First empirical esctest run for the Windows port, driven through the real
-`WSL -> ConPTY -> libghostty` path. The headline finding: this run measures the
-**ConPTY + WSL transport ceiling**, not Ghostty VT-core correctness. No esctest
-failure is cleanly attributable to a Ghostty rendering/behavior bug.
+Empirical esctest run for the Windows port, driven through the real
+`WSL -> ConPTY -> libghostty` path, plus a follow-up that pins down *why* most
+tests fail. The headline, corrected by direct measurement:
+
+**The ConPTY + WSL response channel is fast and lossless. It is not the limiter.**
+The timeouts come from VT query types libghostty does not answer -- dominated by
+**DECRQCRA** (rectangular-area checksum), which is esctest's own screen-readback
+primitive. ~2/3 of the timeout bucket is tests that ran their operation correctly
+and then could not verify it because that one query goes unanswered.
+
+> An earlier draft of this baseline read the 307 timeouts as a "ConPTY + WSL
+> transport ceiling" (latency/buffering through the double PTY). The latency probe
+> below disproves that: query replies return in ~1 ms with zero loss. The prior
+> conclusion is corrected here.
 
 ## Run context
 
 - Date: 2026-06-12
-- Terminal under test: Wintty (this fork), DX12, hosting the WSL session over its bundled ConPTY.
-- Backend: `wsl.exe -d Ubuntu-24.04 -- bash -l <script>` (esctest cannot host on the
-  native cmd/pwsh backends -- it needs Unix `termios`/`tty`, so WSL is the only host).
+- Terminal under test: Wintty (this fork), DX12, hosting WSL over its bundled ConPTY.
+- Backend: `wsl.exe -d Ubuntu-24.04 -- bash -l <script>` (esctest needs Unix
+  `termios`/`tty`, so WSL is the only host; native cmd/pwsh cannot run it).
 - esctest2 `664be3c` (github.com/ThomasDickey/esctest2), python 3.12.3.
-- Invocation: `python3 esctest.py --expected-terminal=xterm --max-vt-level=5 --timeout=1`.
-- Harness: `windows/scripts/esctest/run-esctest.ps1` (reproduces this run end to end).
-- esctest exited rc=0 after ~255s; 568 tests.
+- Invocation: `python3 esctest.py --expected-terminal=xterm --max-vt-level=5 --timeout=N`.
+- Harness: `windows/scripts/esctest/run-esctest.ps1` (`-ReadTimeoutSec` sets N).
 
-## Summary
+## Summary (read-timeout 1s, 568 tests)
 
 | Bucket | Count | Meaning |
 |---|---:|---|
 | Pass | 141 | terminal behaved correctly (readback returned and matched) |
 | Known-bug | 42 | esctest's own xterm known-bug exemptions |
-| ConPTY-timeout | 307 | the response esctest needed never arrived within its 1s read timeout |
+| ConPTY-timeout | 307 | a query reply esctest needed never arrived |
 | Mismatch-review | 77 | readback returned but differed from expected |
 | Fail-other | 1 | a non-timeout, non-mismatch internal error |
 
-## Interpretation
+The "ConPTY-timeout" label is retained for continuity but is a misnomer: the
+measurements below show these are **unanswered-query** failures, not transport.
 
-esctest verifies behavior by **reading the terminal's responses** (cursor-position
-reports, DSR, DECRQCRA checksums, OSC/DCS query replies). That makes it a stress test
-of the response/readback channel, which here traverses two PTYs (`esctest -> WSL pty ->
-ConPTY -> libghostty` and back).
+## What actually causes the timeouts (measured)
 
-- **ConPTY-timeout (307, 54%)** is the dominant mode: over half of all tests could not
-  read their result back within 1s. The channel is intermittent, not dead -- 141 tests
-  *did* read back and pass -- which points at latency/buffering through the double-PTY
-  rather than a hard break. A useful next experiment is re-running with a larger
-  `--timeout` to see how far the pass rate climbs (distinguishes "slow" from "lost").
+Three measurements, each disproving a transport explanation:
 
-- **Mismatch-review (77)** breaks down almost entirely into known, non-Ghostty causes:
-  - **OSC color query interception (~21):** `ChangeColorTests` (10),
-    `ChangeDynamicColorTests` (10), `ResetSpecialColorTests` (1). ConPTY intercepts the
-    OSC 10/11/12 color queries, so the readback differs regardless of Ghostty. This is a
-    documented ConPTY limitation (the raw-pipe bypass that fixed it was removed in #474
-    in favour of bundled ConPTY).
-  - **DCS responses (~7):** `DECRQSSTests`. ConPTY mangles unrecognized DCS, so the
-    `DCS $q` replies don't survive intact.
-  - **xterm-specific expectations (~7):** `DATests`/`DA2Tests` (device attributes Ghostty
-    advertises differently from xterm), `XtermSaveTests`, `XtermWinopsTests`, `TBCTests`.
-    esctest was run with `--expected-terminal=xterm`; Ghostty is not xterm.
-  - **cursor/mode readback (~42):** `BSTests`, `DECSETTests`, `DECRQMTests`,
-    `DECSTRTests`, and the cursor-movement classes (`CUD/CUB/HPA/HVP/HPR/CPL/RI/DECBI/DECFI`).
-    These verify via cursor-position reports on the same intermittent channel; a stale or
-    wrong-state CPR (e.g. `expected Point(9,3), got Point(1,6)`) reads as a mismatch. Not
-    separable from channel noise without the Linux baseline.
+1. **Read-timeout sweep is flat.** Re-running at `--timeout` 1s / 3s / 5s, restricted
+   to the identical test set, leaves Pass and timeout counts unchanged (105/105/105
+   pass, 170/170/169 timeout on the common 369-test subset). If replies were merely
+   *slow*, a wider window would convert timeouts to passes. None convert -> nothing is
+   arriving late.
 
-- **Fail-other (1):** `DECRQMTests.test_DECRQM_DEC_DECARM` -- a DECRQM auto-repeat-mode
-  query that failed with neither a read-timeout nor a value mismatch (an esctest
-  "should have failed" internal error); same DECRQM mode-query family as above.
+2. **The response channel is fast and lossless.** A direct round-trip probe
+   (`latency-probe.py`) issues each query 20x and times the reply:
 
-**No follow-up Ghostty bug issues are filed from this run:** every failure maps to the
-ConPTY response-channel limit, a documented ConPTY OSC/DCS interception, or an
-xterm-specific expectation. Ghostty's actual VT-core correctness is covered by the Zig
-unit tests (`src/terminal/Terminal.zig`, `Parser.zig`); esctest-over-ConPTY cannot add
-signal there until the response channel is addressed.
+   | Query | Got | Lost | Median |
+   |---|---:|---:|---:|
+   | CPR `CSI 6n` | 20/20 | 0 | 0.8 ms |
+   | DSR `CSI 5n` | 20/20 | 0 | 0.9 ms |
+   | DA1 `CSI c` | 20/20 | 0 | 0.8 ms |
+   | DA2 `CSI >c` | 20/20 | 0 | 0.9 ms |
+   | XTWINOPS `CSI 18 t` / `14 t` | 20/20 | 0 | ~0.9 ms |
+   | DECRQM `CSI ?25 $p` | 20/20 | 0 | 1.0 ms |
+   | **DECRQCRA `CSI ...*y`** | **0/20** | **20** | -- never answers |
 
-## Limits of this baseline (and next steps)
+   Every query Ghostty *does* implement returns in about a millisecond, every time.
+   The double PTY is not slow and does not drop replies.
 
-- Classification of the 77 mismatches is heuristic. The clean disambiguation is the
-  deferred **Linux upstream-Ghostty baseline** (same esctest, no ConPTY): any test that
-  passes there but fails here is ConPTY/transport, not Ghostty.
-- Re-run with `--timeout 3` (and `5`) to quantify how much of the 307-timeout bucket is
-  latency vs genuinely lost.
-- Native cmd/pwsh VT compliance needs a different tool (esctest can't host there); vttest
-  (visual) is the path, tracked separately.
-- CI integration (#79 section 3) is out of scope here.
+3. **DECRQCRA is unanswered.** `CSI ...*y` (Request Checksum of Rectangular Area)
+   gets no reply. libghostty recognizes it and deliberately drops it (the "ignoring
+   unimplemented CSI" path in `src/terminal/stream.zig`).
+
+### Why DECRQCRA dominates
+
+esctest verifies screen contents with `AssertScreenCharsInRectEqual`
+(`escutil.py`), which reads each cell back via `GetChecksumOfRect` -> `DECRQCRA`.
+With no reply, every test that checks the screen blocks at its verification step --
+*after* it has already performed the operation under test correctly. That is the
+entire editing / erase / scroll / cursor-position population.
+
+Splitting the 354 timeouts (a `--timeout 1` full run) by cause:
+
+- **~239 (67%) DECRQCRA-driven:** `DL`, `ED`, `EL`, `SU`, `SD`, `ICH`, `DCH`, `IL`,
+  `ECH`, `IND`, `RI`, `NEL`, `LF`, `FF`, `VT`, `CR`, `BS`, `CHA`, `CUP`, `VPA`, `VPR`,
+  `DECCRA`, `DECFRA`, `DECERA`, `DECSERA`, `DECDC`, `DECIC`, `DECBI`, `DECFI`,
+  `DECALN`, `DECSTBM`, `DECSTR`, `DECRC`, `DECSED`, `DECSEL`, `SCORC`, `REP`, `RIS`, ...
+  -- all verify only via the checksum readback.
+- **~115 (33%) own-query gaps:** specific unimplemented query variants, not the whole
+  class -- `XtermWinops` (28; note `18t`/`14t` *do* answer, so these are other report
+  variants), `DECRQM` modes (17; mode 25 *does* answer), `ChangeSpecialColor`/OSC 4/5
+  (14), extended `DECDSR` (11), `ResetSpecialColor`/`ResetColor` OSC (7), mode
+  set+verify (`DECSET`/`SM`/`RM` ~15), title-stack and C1-string classes (rest).
+
+The `Mismatch-review` bucket (77) is unchanged from the original analysis: OSC 10/11/12
+color-query interception (a documented ConPTY limit, ~21), DCS mangling
+(`DECRQSS`, ~7), and xterm-specific expectations / cursor-state reads run with
+`--expected-terminal=xterm` against a non-xterm terminal.
+
+## Decision: DECRQCRA is not implemented to chase this score
+
+The pass rate would climb substantially if libghostty answered DECRQCRA. We are not
+doing that, for three reasons:
+
+- **It is teaching to the test.** DECRQCRA is, in practice, a conformance-harness
+  self-verification primitive (esctest, vttest). Real applications almost never use
+  it. The correctness it would let esctest re-check -- delete/erase/scroll/insert -- is
+  already covered directly by libghostty's own unit tests (`Terminal.zig` 374 tests,
+  `Screen.zig` 187 tests; e.g. `deleteLines` x20, `eraseLine` x22, `eraseDisplay` x19).
+- **It is a security surface.** A rectangular-checksum report lets an application read
+  back arbitrary screen contents (an exfiltration vector). xterm gates it; libghostty
+  currently drops it.
+- **It diverges shared core.** `src/terminal/` rebases on upstream; upstream does not
+  implement DECRQCRA either, so this would be permanent rebase friction for a
+  test-only feature.
+
+The genuine own-query gaps (a DECRQM mode libghostty supports but does not report; a
+benign XTWINOPS *report* variant) are worth fixing only after per-gap review that they
+are real-world-relevant and non-sensitive -- and never the window-manipulation
+XTWINOPS variants. None are filed as Ghostty bugs from this run.
+
+## Bottom line for #79
+
+The Windows-specific risk for VT compliance was the transport, and it is clean
+(~1 ms, lossless). VT-core correctness is platform-independent and unit-tested.
+esctest-over-ConPTY adds little signal beyond those unit tests without implementing a
+test-only, security-sensitive feature, so it is not the right conformance instrument
+for this port. The valuable output of this slice is this corrected characterization
+and the reusable probe that produced it.
 
 ## Reproduce
 
 ```powershell
-windows/scripts/esctest/run-esctest.ps1 -WinttyExe <path-to-Wintty.exe> -TimeoutSec 900
+# Aggregate run (classified report under the output dir):
+windows/scripts/esctest/run-esctest.ps1 -WinttyExe <Wintty.exe> -ReadTimeoutSec 1
+
+# Direct query round-trip latency + loss (the measurement that found the cause):
+windows/scripts/esctest/run-latency-probe.ps1 -WinttyExe <Wintty.exe>
 ```
 
-(Clones esctest into the distro on first run; writes the log + this report under the
-output dir. The parser/classifier are unit-tested in
-`windows/scripts/esctest/EsctestParse.Tests.ps1`.)
+(First esctest run clones esctest2 into the distro. The parser/classifier are
+unit-tested in `windows/scripts/esctest/EsctestParse.Tests.ps1`.)

--- a/windows/scripts/esctest/latency-probe.py
+++ b/windows/scripts/esctest/latency-probe.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Measure VT query round-trip latency through the live terminal/PTY stack.
+
+esctest's aggregate pass/fail at a fixed --timeout cannot separate a response
+that arrives *slowly* (just past the window) from one that is genuinely *lost*.
+This probe answers that directly: it sends each query many times with a generous
+per-read timeout and records, per query class, the latency of every response and
+the count that never returned. Run it as the spawned command of a real terminal
+(same WSL-over-ConPTY mechanism the esctest harness uses) so the path measured is
+the same double-PTY the interactive apps (vim CPR, DSR, DA) traverse.
+
+stdin and stdout are the same tty under a pty: the query is written to fd 1 and
+the response read back from fd 0. Between queries stdin is drained non-blocking so
+a late-arriving (or lost-then-trailing) response can't be misattributed to the
+next query.
+"""
+import sys, os, time, termios, tty, select, json
+
+# (label, query bytes, terminating byte). The terminator is the last byte of the
+# expected reply, used to frame it; DECRQCRA replies with a DCS ... ST, whose final
+# byte is the ST backslash. These map onto the esctest timeout buckets: CPR/DSR/DA
+# are the answered classes (they land in mismatch, not timeout), while DECRQCRA,
+# XTWINOPS and DECRQM are the suspected no-response classes driving the timeouts.
+QUERIES = [
+    ("CPR", b"\x1b[6n", b"R"),                  # cursor position    -> ESC[row;colR  (control: answered)
+    ("DSR", b"\x1b[5n", b"n"),                  # device status      -> ESC[0n
+    ("DA1", b"\x1b[c",  b"c"),                  # primary attrs       -> ESC[?...c
+    ("DA2", b"\x1b[>c", b"c"),                  # secondary attrs      -> ESC[>...c
+    ("DECRQCRA", b"\x1b[1;0;1;1;1;1*y", b"\\"), # rect checksum       -> DCS Pid!~hhhh ST  (esctest screen readback)
+    ("XTWINOPS_18", b"\x1b[18t", b"t"),         # text area size chars-> ESC[8;h;wt  (esctest reset() uses this)
+    ("XTWINOPS_14", b"\x1b[14t", b"t"),         # text area size px   -> ESC[4;h;wt
+    ("DECRQM_25", b"\x1b[?25$p", b"y"),         # request mode DECTCEM-> ESC[?25;Ps$y
+]
+
+REPS = int(os.environ.get("PROBE_REPS", "30"))
+PER_READ_TIMEOUT = float(os.environ.get("PROBE_TIMEOUT", "10"))  # slow (<this) vs lost
+
+
+def drain(fd):
+    """Discard any bytes already waiting (late/partial from a prior query)."""
+    while True:
+        r, _, _ = select.select([fd], [], [], 0)
+        if not r:
+            return
+        if not os.read(fd, 4096):
+            return
+
+
+def read_response(fd, terminator, timeout):
+    """Return (latency_seconds, raw_bytes) or (None, partial) on timeout."""
+    start = time.monotonic()
+    buf = b""
+    while True:
+        remaining = timeout - (time.monotonic() - start)
+        if remaining <= 0:
+            return None, buf
+        r, _, _ = select.select([fd], [], [], remaining)
+        if not r:
+            return None, buf
+        chunk = os.read(fd, 64)
+        if not chunk:
+            return None, buf
+        buf += chunk
+        if terminator in buf:
+            return time.monotonic() - start, buf
+
+
+def main(outpath):
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    tty.setraw(fd)
+    results = {}
+    try:
+        for label, query, term in QUERIES:
+            lats = []
+            lost = 0
+            for _ in range(REPS):
+                drain(fd)
+                os.write(1, query)
+                dt, _buf = read_response(fd, term, PER_READ_TIMEOUT)
+                if dt is None:
+                    lost += 1
+                else:
+                    lats.append(dt * 1000.0)  # ms
+                time.sleep(0.05)
+            lats_sorted = sorted(lats)
+            n = len(lats_sorted)
+            results[label] = {
+                "reps": REPS,
+                "got": n,
+                "lost": lost,
+                "min_ms": round(lats_sorted[0], 1) if n else None,
+                "median_ms": round(lats_sorted[n // 2], 1) if n else None,
+                "p95_ms": round(lats_sorted[min(n - 1, int(n * 0.95))], 1) if n else None,
+                "max_ms": round(lats_sorted[-1], 1) if n else None,
+                "all_ms": [round(x, 1) for x in lats],
+            }
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    with open(outpath, "w") as f:
+        json.dump(results, f, indent=2)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "/tmp/latency-probe.json")

--- a/windows/scripts/esctest/run-esctest.ps1
+++ b/windows/scripts/esctest/run-esctest.ps1
@@ -4,7 +4,8 @@
     [string]$Distro = 'Ubuntu-24.04',
     [string]$EsctestDir = '~/esctest2/esctest',     # path inside the distro
     [string]$OutDir = "$env:TEMP\esctest-run",       # Windows-side output dir
-    [int]$TimeoutSec = 900
+    [int]$ReadTimeoutSec = 1,                         # esctest per-read --timeout
+    [int]$TimeoutSec = 900                            # overall wall-clock deadline
 )
 $ErrorActionPreference = 'Stop'
 Import-Module "$PSScriptRoot/EsctestParse.psm1" -Force
@@ -32,7 +33,7 @@ $scriptMnt = "$mnt/run.sh"
 $bash = @(
     '#!/usr/bin/env bash'
     "cd $EsctestDir || exit 3"
-    "python3 esctest.py --expected-terminal=xterm --max-vt-level=5 --timeout=1 --logfile='$logMnt'"
+    "python3 esctest.py --expected-terminal=xterm --max-vt-level=5 --timeout=$ReadTimeoutSec --logfile='$logMnt'"
     "echo `$? > '$rcMnt'"
     "touch '$doneMnt'"
 ) -join "`n"
@@ -84,7 +85,7 @@ if (-not $complete) { Write-Warning "esctest did not finish within ${TimeoutSec}
 $recs = @(ConvertFrom-EsctestLog -Path $logWin)
 if ($recs.Count -eq 0) { Write-Warning "No test records parsed from $logWin (esctest may have crashed before running tests)." }
 $cls  = ConvertTo-EsctestClassification -Records $recs
-$title = "Wintty/ConPTY via WSL $Distro" + ($(if (-not $complete) { ' (INCOMPLETE)' } else { '' }))
+$title = "Wintty/ConPTY via WSL $Distro (read-timeout ${ReadTimeoutSec}s)" + ($(if (-not $complete) { ' (INCOMPLETE)' } else { '' }))
 $report = Format-EsctestReport -Classified $cls -Title $title
 $reportPath = Join-Path $OutDir 'esctest-baseline.md'
 $report | Set-Content -LiteralPath $reportPath -Encoding utf8

--- a/windows/scripts/esctest/run-latency-probe.ps1
+++ b/windows/scripts/esctest/run-latency-probe.ps1
@@ -1,0 +1,85 @@
+#requires -Version 7
+# Launch a real Wintty hosting latency-probe.py over WSL and report CPR/DSR/DA
+# round-trip latency + loss. Uses the same launch mechanism as run-esctest.ps1
+# (temp ghostty config under an isolated XDG_CONFIG_HOME, since the WinUI shell
+# ignores --command; markers + JSON written distro-side onto the /mnt DrvFs mount).
+[CmdletBinding()] param(
+    [Parameter(Mandatory)][string]$WinttyExe,
+    [string]$Distro = 'Ubuntu-24.04',
+    [string]$OutDir = "$env:TEMP\latency-probe-run",
+    [int]$Reps = 30,
+    [double]$ReadTimeoutSec = 10,   # generous: a response under this is slow, not lost
+    [int]$TimeoutSec = 900
+)
+$ErrorActionPreference = 'Stop'
+
+New-Item -ItemType Directory -Force $OutDir | Out-Null
+$jsonWin = Join-Path $OutDir 'latency.json'
+$doneWin = Join-Path $OutDir 'probe.done'
+Remove-Item $doneWin, $jsonWin -ErrorAction SilentlyContinue
+
+$drive    = $OutDir.Substring(0,1).ToLower()
+$mnt      = "/mnt/$drive" + ($OutDir.Substring(2) -replace '\\','/')
+$jsonMnt  = "$mnt/latency.json"
+$doneMnt  = "$mnt/probe.done"
+
+# The probe script lives in the repo; reach it from the distro via its /mnt path
+# (the worktree path is space-free, so it splits cleanly through the config).
+$probeWin = Join-Path $PSScriptRoot 'latency-probe.py'
+$pdrive   = $probeWin.Substring(0,1).ToLower()
+$probeMnt = "/mnt/$pdrive" + ($probeWin.Substring(2) -replace '\\','/')
+
+# LF-only bash script (CRLF makes bash choke on \r); env vars feed the probe knobs.
+$scriptWin = Join-Path $OutDir 'run.sh'
+$scriptMnt = "$mnt/run.sh"
+$bash = @(
+    '#!/usr/bin/env bash'
+    "export PROBE_REPS=$Reps"
+    "export PROBE_TIMEOUT=$ReadTimeoutSec"
+    "python3 '$probeMnt' '$jsonMnt'"
+    "touch '$doneMnt'"
+) -join "`n"
+[System.IO.File]::WriteAllText($scriptWin, $bash + "`n", (New-Object System.Text.UTF8Encoding($false)))
+
+$cfgDir = Join-Path $OutDir 'cfg'
+$cfgGhostty = Join-Path $cfgDir 'ghostty'
+New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
+"command = wsl.exe -d $Distro -- bash -l $scriptMnt" |
+    Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
+
+$prevXdg = $env:XDG_CONFIG_HOME
+$proc = $null
+try {
+    $env:XDG_CONFIG_HOME = $cfgDir
+    $proc = Start-Process -FilePath $WinttyExe -PassThru
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while (-not (Test-Path $doneWin) -and (Get-Date) -lt $deadline) {
+        if ($proc.HasExited -and -not (Test-Path $jsonWin)) { break }
+        Start-Sleep -Seconds 2
+    }
+}
+finally {
+    $env:XDG_CONFIG_HOME = $prevXdg
+    if ($proc) { try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {} }
+}
+
+if (-not (Test-Path $jsonWin)) {
+    throw "No probe JSON at $jsonWin -- the run never started. Check the Wintty surface spawned wsl.exe (temp config at $cfgDir) and $probeMnt is reachable."
+}
+
+$data = Get-Content -LiteralPath $jsonWin -Raw | ConvertFrom-Json
+Write-Host "Latency probe ($Distro, $Reps reps/query, ${ReadTimeoutSec}s read-timeout):`n"
+$rows = foreach ($p in $data.PSObject.Properties) {
+    $v = $p.Value
+    [pscustomobject]@{
+        Query    = $p.Name
+        Got      = $v.got
+        Lost     = $v.lost
+        'Min ms' = $v.min_ms
+        'Med ms' = $v.median_ms
+        'P95 ms' = $v.p95_ms
+        'Max ms' = $v.max_ms
+    }
+}
+$rows | Format-Table -AutoSize | Out-String | Write-Host
+Write-Host "Raw JSON: $jsonWin"


### PR DESCRIPTION
## What

Corrects the #79 esctest baseline conclusion and adds the probe that found the real cause.

The first baseline (# 503) read the 307 timeouts as a ConPTY+WSL transport ceiling. Direct measurement shows that is wrong:

- A read-timeout sweep (1s/3s/5s) is flat on the same test set, so nothing is arriving late.
- A round-trip probe shows every query Ghostty implements (CPR, DSR, DA, XTWINOPS, DECRQM) comes back in about 1ms with zero loss. The channel is fine.
- DECRQCRA (rectangular-area checksum) gets no reply. It is esctest's screen-readback primitive, so every editing/erase/scroll test blocks at its verify step after running correctly. That one missing query is about two thirds of the timeouts.

## Decision

We do not implement DECRQCRA to lift the score. It is a test-harness primitive almost no real app uses, it is a screen-content exfiltration surface that xterm gates, and it would diverge shared terminal core. The behavior it would re-check is already covered by the Zig unit tests.

## Changes

- Rewrites `windows/docs/vt-compliance/esctest-baseline.md` with the measured finding.
- Adds `latency-probe.py` and `run-latency-probe.ps1` (the round-trip probe).
- Adds a `-ReadTimeoutSec` param to `run-esctest.ps1`.

No `src/` change. The ~115 own-query gaps (XTWINOPS variants, DECRQM modes, OSC special-color, extended DSR) are noted in the doc as a possible separate follow-up.
