### PR TITLE
fix(terminal): reply to DECRQM ANSI form and DECXCPR (#79 triage)

### DIFF
--- a/src/terminal/device_status.zig
+++ b/src/terminal/device_status.zig
@@ -70,5 +70,8 @@ const Entry = struct {
 const entries: []const Entry = &.{
     .{ .name = "operating_status", .value = 5 },
     .{ .name = "cursor_position", .value = 6 },
+    // DECXCPR: the "?" form of value 6 reports the extended cursor position
+    // (adds a page number) rather than the plain CPR.
+    .{ .name = "cursor_position_extended", .value = 6, .question = true },
     .{ .name = "color_scheme", .value = 996, .question = true },
 };

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1555,9 +1555,12 @@ pub fn Stream(comptime H: type) type {
                     }
                 },
 
-                // DECRQM - Request Mode
+                // DECRQM - Request Mode. Accepts both the ANSI form (CSI Ps $ p,
+                // one intermediate) and the DEC form (CSI ? Ps $ p, two); the inner
+                // switch tells them apart. Non-`$` single intermediates fall through
+                // to the same unimplemented warning as before.
                 'p' => switch (input.intermediates.len) {
-                    2 => decrqm: {
+                    1, 2 => decrqm: {
                         const ansi_mode = ansi: {
                             switch (input.intermediates.len) {
                                 1 => if (input.intermediates[0] == '$') break :ansi true,

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -303,24 +303,38 @@ pub const Handler = struct {
         self.writePty(written);
     }
 
+    /// The cursor position for a CPR/DECXCPR report, honoring origin mode
+    /// (relative to the scrolling region when DECOM is set).
+    fn cursorReportPos(self: *Handler) struct { x: usize, y: usize } {
+        return if (self.terminal.modes.get(.origin)) .{
+            .x = self.terminal.screens.active.cursor.x -| self.terminal.scrolling_region.left,
+            .y = self.terminal.screens.active.cursor.y -| self.terminal.scrolling_region.top,
+        } else .{
+            .x = self.terminal.screens.active.cursor.x,
+            .y = self.terminal.screens.active.cursor.y,
+        };
+    }
+
     fn deviceStatus(self: *Handler, req: device_status.Request) void {
         switch (req) {
             .operating_status => self.writePty("\x1B[0n"),
 
             .cursor_position => {
-                const pos: struct {
-                    x: usize,
-                    y: usize,
-                } = if (self.terminal.modes.get(.origin)) .{
-                    .x = self.terminal.screens.active.cursor.x -| self.terminal.scrolling_region.left,
-                    .y = self.terminal.screens.active.cursor.y -| self.terminal.scrolling_region.top,
-                } else .{
-                    .x = self.terminal.screens.active.cursor.x,
-                    .y = self.terminal.screens.active.cursor.y,
-                };
-
+                const pos = self.cursorReportPos();
                 var buf: [64]u8 = undefined;
                 const resp = std.fmt.bufPrintZ(&buf, "\x1B[{};{}R", .{
+                    pos.y + 1,
+                    pos.x + 1,
+                }) catch return;
+                self.writePty(resp);
+            },
+
+            // DECXCPR: extended cursor position adds a page number. Ghostty has
+            // no page memory, so the page is always 1.
+            .cursor_position_extended => {
+                const pos = self.cursorReportPos();
+                var buf: [64]u8 = undefined;
+                const resp = std.fmt.bufPrintZ(&buf, "\x1B[?{};{};1R", .{
                     pos.y + 1,
                     pos.x + 1,
                 }) catch return;
@@ -1404,6 +1418,34 @@ test "request mode DECRQM ANSI form with write_pty callback" {
     s.nextSlice("\x1B[4$p");
     try testing.expect(S.last_response != null);
     try testing.expectEqualStrings("\x1B[4;2$y", S.last_response.?);
+}
+
+test "device status DECXCPR extended cursor position with write_pty callback" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(testing.allocator);
+
+    const S = struct {
+        var last_response: ?[:0]const u8 = null;
+        fn writePty(_: *Handler, data: [:0]const u8) void {
+            if (last_response) |old| testing.allocator.free(old);
+            last_response = testing.allocator.dupeZ(u8, data) catch @panic("OOM");
+        }
+    };
+    S.last_response = null;
+    defer if (S.last_response) |old| testing.allocator.free(old);
+
+    var handler: Handler = .init(&t);
+    handler.effects.write_pty = &S.writePty;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    // DECXCPR (CSI ? 6 n) reports the extended cursor position:
+    // CSI ? row ; col ; page R. Ghostty has no page memory, so page is 1.
+    s.nextSlice("\x1B[5;3H");
+    s.nextSlice("\x1B[?6n");
+    try testing.expect(S.last_response != null);
+    try testing.expectEqualStrings("\x1B[?5;3;1R", S.last_response.?);
 }
 
 test "stream: CSI W with intermediate but no params" {

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -1379,6 +1379,33 @@ test "request mode DECRQM with write_pty callback" {
     }
 }
 
+test "request mode DECRQM ANSI form with write_pty callback" {
+    var t: Terminal = try .init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(testing.allocator);
+
+    const S = struct {
+        var last_response: ?[:0]const u8 = null;
+        fn writePty(_: *Handler, data: [:0]const u8) void {
+            if (last_response) |old| testing.allocator.free(old);
+            last_response = testing.allocator.dupeZ(u8, data) catch @panic("OOM");
+        }
+    };
+    S.last_response = null;
+    defer if (S.last_response) |old| testing.allocator.free(old);
+
+    var handler: Handler = .init(&t);
+    handler.effects.write_pty = &S.writePty;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    // ANSI-form DECRQM (CSI Ps $ p, no '?') must reply like the DEC form, not be
+    // silently dropped. Insert mode (IRM, 4) is reset by default -> Pm=2.
+    s.nextSlice("\x1B[4$p");
+    try testing.expect(S.last_response != null);
+    try testing.expectEqualStrings("\x1B[4;2$y", S.last_response.?);
+}
+
 test "stream: CSI W with intermediate but no params" {
     // Regression test from AFL++ crash. CSI ? W without
     // parameters caused an out-of-bounds access on input.params[0].

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -903,6 +903,18 @@ pub const StreamHandler = struct {
         }
     }
 
+    /// The cursor position for a CPR/DECXCPR report, honoring origin mode
+    /// (relative to the scrolling region when DECOM is set).
+    fn cursorReportPos(self: *StreamHandler) struct { x: usize, y: usize } {
+        return if (self.terminal.modes.get(.origin)) .{
+            .x = self.terminal.screens.active.cursor.x -| self.terminal.scrolling_region.left,
+            .y = self.terminal.screens.active.cursor.y -| self.terminal.scrolling_region.top,
+        } else .{
+            .x = self.terminal.screens.active.cursor.x,
+            .y = self.terminal.screens.active.cursor.y,
+        };
+    }
+
     pub fn deviceStatusReport(
         self: *StreamHandler,
         req: terminal.device_status.Request,
@@ -911,16 +923,7 @@ pub const StreamHandler = struct {
             .operating_status => self.messageWriter(.{ .write_stable = "\x1B[0n" }),
 
             .cursor_position => {
-                const pos: struct {
-                    x: usize,
-                    y: usize,
-                } = if (self.terminal.modes.get(.origin)) .{
-                    .x = self.terminal.screens.active.cursor.x -| self.terminal.scrolling_region.left,
-                    .y = self.terminal.screens.active.cursor.y -| self.terminal.scrolling_region.top,
-                } else .{
-                    .x = self.terminal.screens.active.cursor.x,
-                    .y = self.terminal.screens.active.cursor.y,
-                };
+                const pos = self.cursorReportPos();
 
                 // Response always is at least 4 chars, so this leaves the
                 // remainder for the row/column as base-10 numbers. This
@@ -934,6 +937,20 @@ pub const StreamHandler = struct {
                 // in `t`, not `R`, and may precede this one.
                 var msg: termio.Message = .{ .write_small = .{} };
                 const resp = try std.fmt.bufPrint(&msg.write_small.data, "\x1B[{};{}R", .{
+                    pos.y + 1,
+                    pos.x + 1,
+                });
+                msg.write_small.len = @intCast(resp.len);
+
+                self.messageWriter(msg);
+            },
+
+            // DECXCPR: extended cursor position adds a page number. Ghostty has
+            // no page memory, so the page is always 1.
+            .cursor_position_extended => {
+                const pos = self.cursorReportPos();
+                var msg: termio.Message = .{ .write_small = .{} };
+                const resp = try std.fmt.bufPrint(&msg.write_small.data, "\x1B[?{};{};1R", .{
                     pos.y + 1,
                     pos.x + 1,
                 });

--- a/windows/docs/vt-compliance/esctest-baseline.md
+++ b/windows/docs/vt-compliance/esctest-baseline.md
@@ -125,6 +125,43 @@ test-only, security-sensitive feature, so it is not the right conformance instru
 for this port. The valuable output of this slice is this corrected characterization
 and the reusable probe that produced it.
 
+## Residual timeout triage (#79 phase 1)
+
+Classifying every non-DECRQCRA timeout class by direct evidence (the extended
+`latency-probe.py` for query responses; esctest source for the verify mechanism). The
+probe control queries (CPR/DSR/DA) answer in ~1 ms; the table records what each residual
+query actually does.
+
+| Class / query | Result | Bucket |
+|---|---|---|
+| DECRQM ANSI form (`CSI Ps $ p`) | silent (0/10) | **genuine gap -> fix** |
+| DECXCPR (`CSI ? 6 n`) | silent (0/10) | **genuine gap -> fix** |
+| DECRQM DEC form (`CSI ? Ps $ p`) | answers | already correct |
+| XTWINOPS 14/16/18 t (text-area / cell size) | answers | already correct |
+| XTWINOPS 11/13/15/19 t (window state / position / screen geometry) | silent (0/10) | deliberate omission (won't fix) |
+| XTWINOPS manipulate (1/2/3/4/8/9/10/24/30) | n/a | security-sensitive (won't fix) |
+| DECDSR `?15n`/`?25n`/`?26n` (printer / UDK / keyboard) | silent (0/10) | legacy, no consumer (defer) |
+| DECDSR `?62n`/`?55n`/`?75n`/`?85n` | n/a | legacy/niche (defer) |
+| DECDSR `?63n` (DECCKSR memory checksum) | n/a | test-only, exfil class (won't fix) |
+| DECSET / SM / RM / DECSTR | n/a | DECRQCRA-blocked (verify via checksum: decset 23, sm 6, rm 2, decstr 7 calls; decrqm 0) |
+| ChangeColor / ChangeSpecialColor / ResetColor (OSC 4/5) | n/a | ConPTY-intercepted, not Ghostty-fixable (OSC 10/11/12 finding) |
+
+Two deliberate boundaries are worth stating, because they are stances rather than gaps:
+
+- **XTWINOPS geometry (11/13/15/19) is intentionally omitted.** The handler implements
+  the terminal's own area (text-area / cell size, needed for image protocols) but not the
+  user's window position or display geometry, which is a fingerprinting surface. The
+  explicit per-op list in `src/terminal/stream.zig` (with a "we only support window title"
+  comment) shows the subset is curated, not unfinished. Not implemented.
+- **DECRQCRA / DECCKSR (screen + memory checksum) is not implemented** (decided in #504):
+  a screen-content exfiltration primitive whose only consumers are conformance harnesses.
+
+**Phase 2 (separate work):** the two genuine, safe, real-world-relevant gaps -- DECRQM in
+its ANSI form (apps querying IRM/LNM/KAM hang on no reply; the handler already intends to
+support it) and DECXCPR (completes the CPR pair, exposes nothing CPR does not). The legacy
+DECDSR status reports are deferred (no modern consumer); the geometry and checksum classes
+are not implemented by design.
+
 ## Reproduce
 
 ```powershell

--- a/windows/scripts/esctest/latency-probe.py
+++ b/windows/scripts/esctest/latency-probe.py
@@ -29,7 +29,18 @@ QUERIES = [
     ("DECRQCRA", b"\x1b[1;0;1;1;1;1*y", b"\\"), # rect checksum       -> DCS Pid!~hhhh ST  (esctest screen readback)
     ("XTWINOPS_18", b"\x1b[18t", b"t"),         # text area size chars-> ESC[8;h;wt  (esctest reset() uses this)
     ("XTWINOPS_14", b"\x1b[14t", b"t"),         # text area size px   -> ESC[4;h;wt
-    ("DECRQM_25", b"\x1b[?25$p", b"y"),         # request mode DECTCEM-> ESC[?25;Ps$y
+    ("DECRQM_25", b"\x1b[?25$p", b"y"),         # request mode DECTCEM (DEC form) -> ESC[?25;Ps$y
+    ("DECRQM_ANSI_4", b"\x1b[4$p", b"y"),       # request mode IRM (ANSI form) -> ESC[4;Ps$y (suspected silent)
+    # --- residual report-query triage (#79 phase 1) ---
+    ("WINOP_11_state",   b"\x1b[11t", b"t"),    # report window state (normal/iconified)
+    ("WINOP_13_pos",     b"\x1b[13t", b"t"),    # report window position
+    ("WINOP_15_scrpx",   b"\x1b[15t", b"t"),    # report screen size in pixels
+    ("WINOP_16_charpx",  b"\x1b[16t", b"t"),    # report char cell size in pixels
+    ("WINOP_19_scrchars",b"\x1b[19t", b"t"),    # report screen size in chars
+    ("DECXCPR_6",        b"\x1b[?6n", b"R"),    # extended cursor position (DEC ?6n -> ...R)
+    ("DECDSR_printer_15",b"\x1b[?15n",b"n"),    # printer status
+    ("DECDSR_udk_25",    b"\x1b[?25n",b"n"),    # UDK status
+    ("DECDSR_kbd_26",    b"\x1b[?26n",b"n"),    # keyboard status
 ]
 
 REPS = int(os.environ.get("PROBE_REPS", "30"))


### PR DESCRIPTION
Follow-up to # 504. That PR proved the esctest timeouts are unanswered VT queries (not transport), dominated by DECRQCRA, which we deliberately do not implement. This finishes the triage of the remaining timeouts and fixes the two that are real, safe, and worth it.

## Triage

`windows/docs/vt-compliance/esctest-baseline.md` now classifies every non-DECRQCRA timeout class with evidence from an extended round-trip probe (`latency-probe.py`). Most are DECRQCRA-blocked mode tests, ConPTY-intercepted OSC color queries, or deliberately-omitted window/display geometry reports (XTWINOPS 11/13/15/19 -- a fingerprinting surface the handler already curates against). Two were genuine gaps.

## Fixes

- **DECRQM ANSI form (`CSI Ps $ p`):** the handler only entered the DECRQM block for the DEC form (`CSI ? Ps $ p`), so apps querying ANSI modes (IRM, LNM, KAM, SRM) got no reply and would hang. The inner switch already handled both forms; the outer switch now matches.
- **DECXCPR (`CSI ? 6 n`):** plain CPR was handled but its DEC extended form was dropped. Now reports `CSI ? row ; col ; page R` (page is always 1, no page memory), sharing the cursor-position computation with CPR.

Both are read-only and add no new exposure. The geometry and checksum classes are documented as deliberate non-fixes rather than implemented.

Tests: new Zig unit tests for both replies; full suite green (3158 passed, 55 skipped).
