### PR TITLE
test(windows): add vttest host harness for VT compliance

### DIFF
--- a/windows/docs/vt-compliance/vttest-results.md
+++ b/windows/docs/vt-compliance/vttest-results.md
@@ -1,0 +1,86 @@
+# vttest on Windows (ConPTY) -- host and results
+
+[vttest](https://invisible-island.net/vttest/) is the interactive, *visual* VT
+compliance tester (cursor movement, screen features, character sets, double-size
+glyphs, VT52/VT102/VT220 behavior). Unlike esctest it writes no machine-readable
+log -- you read the rendered screen. This page covers how the vttest host is set
+up for the Windows port and records the per-section assessment.
+
+For the non-visual, query-response half of VT compliance see
+[`esctest-baseline.md`](esctest-baseline.md); for how ConPTY handles VT sequences
+see [`conpty-reference.md`](conpty-reference.md).
+
+## Host
+
+vttest runs inside WSL and is hosted in Wintty over the same
+`wsl.exe -> ConPTY -> libghostty` path the esctest harness uses. Native
+MSYS2/MinGW vttest is optional and not required for this.
+
+`apt-get install vttest` needs a sudo password (non-interactive), so vttest is
+built from the upstream tarball to a per-user prefix instead -- gcc/make/termios
+are already present in a default Ubuntu WSL image and the build needs no network.
+
+```bash
+# Inside WSL. With no argument it downloads the tarball (needs WSL network).
+windows/scripts/vttest/build-vttest.sh
+```
+
+WSL often has no outbound network even when the Windows host is online (DNS
+fails). In that case download the tarball on the Windows side and pass its
+`/mnt/c/...` path:
+
+```powershell
+Invoke-WebRequest https://invisible-island.net/archives/vttest/vttest.tar.gz -OutFile C:\temp\vttest.tar.gz
+wsl.exe -d Ubuntu-24.04 -- bash windows/scripts/vttest/build-vttest.sh /mnt/c/temp/vttest.tar.gz
+```
+
+The build produces a `~/vttest` symlink the runner targets.
+
+```powershell
+# Launch Wintty hosting vttest; prints the PID to stop when done.
+windows/scripts/vttest/run-vttest.ps1 -WinttyExe <path-to-Wintty.exe>
+```
+
+vttest puts the tty in raw mode (termios), so its menus must be driven with real
+keyboard input to the Wintty window -- stdin cannot be piped (a pipe is not a
+tty). Screenshot each section and assess the render.
+
+## Host validation
+
+Bring-up confirmed end to end: Wintty spawns `wsl.exe -> vttest`, vttest 2.7
+(20251205) runs, and its startup banner renders correctly in the pane:
+
+```
+VT100 test program, version 2.7 (20251205)
+Line speed 0bd
+Choose test type:
+```
+
+The banner text is placed by absolute cursor positioning (`CSI row;col H`) and
+renders crisply at the right cells, so the WSL/ConPTY/libghostty/DX12 pipeline is
+wired and the host is usable.
+
+## Per-section assessment
+
+Driving each vttest menu section and recording pass / fail / renders-incorrectly
+is the next slice, and should be done against a clean build of the `windows`
+branch (the bring-up above used a local dev build, so per-section results are not
+recorded here yet).
+
+| # | vttest section | Result | Notes |
+|---|---|---|---|
+| 1 | Cursor movements | pending | |
+| 2 | Screen features | pending | |
+| 3 | Character sets | pending | |
+| 4 | Double-sized characters | pending | |
+| 5 | Keyboard | pending | |
+| 6 | Terminal reports | pending | overlaps the esctest query findings |
+| 7 | VT52 mode | pending | |
+| 8 | VT102 Insert/Delete Char/Line | pending | |
+| 9 | Known bugs | pending | |
+| 10 | Reset and self-test | pending | |
+| 11 | Non-VT100 (VT220 / xterm) | pending | |
+
+Classify each failure as a ConPTY limitation (cross-check
+[`conpty-reference.md`](conpty-reference.md)) or a Ghostty bug, consistent with
+how the esctest baseline attributes its results.

--- a/windows/scripts/vttest/build-vttest.sh
+++ b/windows/scripts/vttest/build-vttest.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Build vttest inside a WSL distro without root.
+#
+# vttest is not packaged-installable here because `apt-get install` needs a
+# sudo password (non-interactive), so we build the upstream tarball to a
+# per-user prefix instead. gcc/make/termios are already present in a default
+# Ubuntu WSL image; the build itself needs no network.
+#
+# Usage:
+#   build-vttest.sh [path-to-vttest.tar.gz]
+#
+# With no argument the script downloads the tarball (needs WSL network). When
+# the WSL distro has no outbound network (common -- DNS often fails in WSL while
+# the Windows host is online), download it on the Windows side and pass the
+# /mnt/c/... path:
+#   curl/Invoke-WebRequest https://invisible-island.net/archives/vttest/vttest.tar.gz
+#   build-vttest.sh /mnt/c/temp/vttest.tar.gz
+#
+# Result: a `vttest` binary plus a stable ~/vttest symlink the runner uses.
+set -euo pipefail
+
+src="${1:-}"
+build="$HOME/vttest-build"
+mkdir -p "$build"
+
+if [ -z "$src" ]; then
+    src="$build/vttest.tar.gz"
+    echo "downloading vttest tarball (needs WSL network)..."
+    curl -fSL --max-time 60 -o "$src" \
+        https://invisible-island.net/archives/vttest/vttest.tar.gz
+fi
+
+rm -rf "$build/src"
+mkdir -p "$build/src"
+tar -xzf "$src" -C "$build/src" --strip-components=1
+
+cd "$build/src"
+./configure >/tmp/vttest-configure.log 2>&1
+make >/tmp/vttest-make.log 2>&1
+
+ln -sf "$build/src/vttest" "$HOME/vttest"
+# Smoke check only -- never fail the build on it (guard against a future vttest
+# changing the version flag, which `set -e` would otherwise turn into a failure).
+"$HOME/vttest" -V || true
+echo "vttest ready: $HOME/vttest -> $(readlink -f "$HOME/vttest")"

--- a/windows/scripts/vttest/run-vttest.ps1
+++ b/windows/scripts/vttest/run-vttest.ps1
@@ -1,0 +1,61 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+Launch Wintty hosting vttest over WSL/ConPTY for visual VT-compliance testing.
+
+.DESCRIPTION
+vttest is interactive and visual: unlike esctest it produces no machine-readable
+log, so this runner only stands up the host. It launches Wintty with an isolated
+XDG_CONFIG_HOME whose `command` spawns vttest inside a WSL distro -- the same
+`wsl.exe -> ConPTY -> libghostty` path the esctest harness uses. vttest then
+renders its menu in the Wintty pane; drive the menus from the keyboard and
+screenshot each section to assess rendering (see vttest-results.md).
+
+vttest reads menu selections from its controlling tty, so navigation needs real
+keyboard input to the Wintty window -- it cannot be driven by piping stdin
+(vttest puts the tty in raw mode via termios and a pipe is not a tty).
+
+Build vttest first with build-vttest.sh (see that script's header). The runner
+prints the launched PID; stop it with `Stop-Process -Id <pid>` when done.
+
+.EXAMPLE
+./run-vttest.ps1 -WinttyExe C:\path\to\Wintty.exe
+#>
+[CmdletBinding()] param(
+    [Parameter(Mandatory)][string]$WinttyExe,        # path to built Wintty.exe
+    [string]$Distro = 'Ubuntu-24.04',
+    [string]$VttestPath = '~/vttest',                 # vttest path inside the distro
+    [string]$OutDir = "$env:TEMP\vttest-run"          # holds the temp ghostty config
+)
+$ErrorActionPreference = 'Stop'
+
+New-Item -ItemType Directory -Force $OutDir | Out-Null
+
+# The WinUI app ignores --command; XDG_CONFIG_HOME + `command =` is the proven
+# launch harness (see the esctest runner / #494 OSC7 work). ghostty reads
+# $XDG_CONFIG_HOME/ghostty/config -- the `ghostty/` subdir is required, or the
+# surface silently falls back to the default shell. The command splits on spaces
+# into wsl.exe argv; `bash -lc ~/vttest` runs vttest as a login shell so tilde
+# expansion and PATH are sane, and all paths here are space-free.
+$cfgDir = Join-Path $OutDir 'cfg'
+$cfgGhostty = Join-Path $cfgDir 'ghostty'
+New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
+"command = wsl.exe -d $Distro -- bash -lc $VttestPath" |
+    Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
+
+# Inherit the full environment and add only the XDG override (rather than
+# -Environment, whose merge-vs-replace semantics vary). Restore afterward.
+$prevXdg = $env:XDG_CONFIG_HOME
+$proc = $null
+try {
+    $env:XDG_CONFIG_HOME = $cfgDir
+    $proc = Start-Process -FilePath $WinttyExe -PassThru
+}
+finally {
+    $env:XDG_CONFIG_HOME = $prevXdg
+}
+
+Write-Host "Wintty PID $($proc.Id) is hosting vttest ($Distro)."
+Write-Host "Drive the menus from the keyboard and screenshot each section."
+Write-Host "Stop it with: Stop-Process -Id $($proc.Id)"
+$proc.Id


### PR DESCRIPTION
Stands up the vttest visual VT-compliance host for the Windows port (box 1 of #507).

vttest is the interactive, visual half of VT testing (the esctest baseline already covers the query-response half). `apt install vttest` needs a sudo password non-interactively, so:

- `windows/scripts/vttest/build-vttest.sh` builds the upstream tarball to a per-user prefix without root (gcc/make/termios are already in a default Ubuntu WSL image; the build needs no network -- it can take a Windows-downloaded tarball path for when WSL has no DNS).
- `windows/scripts/vttest/run-vttest.ps1` launches Wintty hosting vttest over the same `wsl.exe -> ConPTY -> libghostty` path the esctest runner uses, via an isolated XDG config.
- `windows/docs/vt-compliance/vttest-results.md` documents the host and holds the per-section results table.

Validated end to end: Wintty spawns wsl -> vttest, vttest 2.7 runs, and its banner renders correctly in the pane. Per-section assessment is the next slice (to be run against a clean windows-branch build).

Scripts only, no product code. Reviewed for correctness against the existing esctest harness.