### PR TITLE
test(windows): drive vttest sections and record HEAD results

### DIFF
--- a/windows/docs/vt-compliance/vttest-results.md
+++ b/windows/docs/vt-compliance/vttest-results.md
@@ -45,35 +45,54 @@ vttest puts the tty in raw mode (termios), so its menus must be driven with real
 keyboard input to the Wintty window -- stdin cannot be piped (a pipe is not a
 tty). Screenshot each section and assess the render.
 
-## Host validation
+## Host validation (clean `windows`-HEAD build)
 
-Bring-up confirmed end to end: Wintty spawns `wsl.exe -> vttest`, vttest 2.7
-(20251205) runs, and its startup banner renders correctly in the pane:
+Confirmed end to end against a fresh build of the `windows` branch: Wintty spawns
+`wsl.exe -> vttest`, vttest 2.7 (20251205) runs, and the main menu (test
+selector) renders fully and correctly -- the banner, all 12 entries, and the
+prompt:
 
 ```
 VT100 test program, version 2.7 (20251205)
-Line speed 0bd
+Line speed 38400bd
 Choose test type:
+  0. Exit
+  1. Test of cursor movements
+  ...
+  12. Modify test-parameters
+Enter choice number (0 - 12):
 ```
 
-The banner text is placed by absolute cursor positioning (`CSI row;col H`) and
-renders crisply at the right cells, so the WSL/ConPTY/libghostty/DX12 pipeline is
-wired and the host is usable.
+The menu exercises absolute cursor positioning (`CSI row;col H`), erase-below
+(`CSI 0 J`), and plain text -- all correct. (An earlier observation that the menu
+list did not render came from a stale dev build / a capture taken before the draw
+finished; it does **not** reproduce on a HEAD build.)
+
+## Driving sections without GUI keyboard
+
+Synthetic keyboard input does not reach the Wintty window (WinUI lifted-input
+focus cannot be forced from a detached process), so sections are driven with
+`run-vttest-section.ps1` + `vttest-section.sh`: vttest runs under an inner
+`script` pty inside the pane and its menu choice is auto-fed from a pipe.
+
+This is reliable for **size-independent** content (character sets, glyph shapes).
+**Size-dependent** tests (full-screen borders, autowrap) are not reliably
+assessed this way yet: the inner `script` pty size and a post-launch window
+resize do not match Wintty's grid, which produces layout artifacts that are *not*
+Wintty bugs. A size-matched launch (fixed window on the primary monitor, no
+post-draw resize) is the refinement for those.
 
 ## Per-section assessment
 
-Driving each vttest menu section and recording pass / fail / renders-incorrectly
-is the next slice, and should be done against a clean build of the `windows`
-branch (the bring-up above used a local dev build, so per-section results are not
-recorded here yet).
+Representative sample against `windows`-HEAD. Remaining sections are pending.
 
 | # | vttest section | Result | Notes |
 |---|---|---|---|
-| 1 | Cursor movements | pending | |
-| 2 | Screen features | pending | |
-| 3 | Character sets | pending | |
-| 4 | Double-sized characters | pending | |
-| 5 | Keyboard | pending | |
+| 1 | Cursor movements | inconclusive | border + centered E-frame render, but size-dependent -- redo size-matched |
+| 2 | Screen features | inconclusive | autowrap layout artifact from the pty-size mismatch, not a VT bug -- redo size-matched |
+| 3 | Character sets | pass | US-ASCII, British (`#`->`£`), DEC special graphics (line drawing), DEC alternate ROM, and SI/SO G0/G1 switching all correct. The configured font ligates `<=>` (cosmetic, not a VT issue) |
+| 4 | Double-sized characters | partial | double-width (DECDWL) correct; double-height (DECDHL) renders as double-width single-height (the two halves appear as duplicate full lines), likely a shared Ghostty-core limitation -- confirm vs upstream |
+| 5 | Keyboard | pending | needs real key input (the auto-feed driver cannot exercise it) |
 | 6 | Terminal reports | pending | overlaps the esctest query findings |
 | 7 | VT52 mode | pending | |
 | 8 | VT102 Insert/Delete Char/Line | pending | |
@@ -83,4 +102,5 @@ recorded here yet).
 
 Classify each failure as a ConPTY limitation (cross-check
 [`conpty-reference.md`](conpty-reference.md)) or a Ghostty bug, consistent with
-how the esctest baseline attributes its results.
+how the esctest baseline attributes its results. The one open item so far --
+DECDHL double-height -- is a libghostty/core rendering question, not ConPTY.

--- a/windows/scripts/vttest/run-vttest-section.ps1
+++ b/windows/scripts/vttest/run-vttest-section.ps1
@@ -1,0 +1,59 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+Launch Wintty hosting a single vttest menu section, driven without GUI keyboard.
+
+.DESCRIPTION
+A companion to run-vttest.ps1 for capturing individual vttest sections during a
+visual VT-compliance pass. Synthetic keyboard input does not reach the Wintty
+window (WinUI lifted-input focus cannot be forced from a detached process), so
+this uses vttest-section.sh: vttest runs under an inner `script` pty inside
+Wintty's pane and its menu choice is auto-fed from a pipe. The selected screen
+stays up (vttest-section.sh holds it) so you can screenshot and assess it.
+
+Build vttest first with build-vttest.sh. The runner prints the launched PID;
+stop it with `Stop-Process -Id <pid>` when done.
+
+.EXAMPLE
+# Character-set test (menu 3):
+./run-vttest-section.ps1 -WinttyExe C:\path\to\Wintty.exe -Section 3
+#>
+[CmdletBinding()] param(
+    [Parameter(Mandatory)][string]$WinttyExe,
+    [Parameter(Mandatory)][ValidatePattern('^\d+$')][string]$Section,  # vttest menu digits, e.g. "3"
+    [int]$Pages = 0,                                    # paging RETURNs within the test
+    [string]$Distro = 'Ubuntu-24.04',
+    [string]$OutDir = "$env:TEMP\vttest-section"
+)
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force $OutDir | Out-Null
+
+# LF-normalize the committed driver into the distro: a Windows checkout may carry
+# CRLF, which bash rejects. Translate the script's own path to its /mnt mount.
+$srcSh = Join-Path $PSScriptRoot 'vttest-section.sh'
+$srcDrive = $srcSh.Substring(0, 1).ToLower()
+$srcMnt = "/mnt/$srcDrive" + ($srcSh.Substring(2) -replace '\\', '/')
+wsl.exe -d $Distro -- bash -lc "tr -d '\r' < '$srcMnt' > /tmp/vttest-section.sh" | Out-Null
+
+# Temp ghostty config (same XDG harness as run-vttest.ps1; the `ghostty/` subdir
+# is required). The command splits on spaces into wsl.exe argv; Section/Pages are
+# bare digits.
+$cfgDir = Join-Path $OutDir 'cfg'
+$cfgGhostty = Join-Path $cfgDir 'ghostty'
+New-Item -ItemType Directory -Force $cfgGhostty | Out-Null
+"command = wsl.exe -d $Distro -- bash -l /tmp/vttest-section.sh $Section $Pages" |
+    Set-Content -LiteralPath (Join-Path $cfgGhostty 'config') -Encoding utf8
+
+$prevXdg = $env:XDG_CONFIG_HOME
+$proc = $null
+try {
+    $env:XDG_CONFIG_HOME = $cfgDir
+    $proc = Start-Process -FilePath $WinttyExe -PassThru
+}
+finally {
+    $env:XDG_CONFIG_HOME = $prevXdg
+}
+
+Write-Host "Wintty PID $($proc.Id) hosting vttest section $Section ($Distro)."
+Write-Host "Move the window to the primary monitor, screenshot, then: Stop-Process -Id $($proc.Id)"
+$proc.Id

--- a/windows/scripts/vttest/vttest-section.sh
+++ b/windows/scripts/vttest/vttest-section.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Drive vttest to a menu selection WITHOUT GUI keyboard input.
+#
+# vttest reads its menu from the controlling tty in raw mode, so stdin cannot be
+# piped to it directly. Instead run it under an inner `script` pty (which gives
+# vttest a real tty) and forward the menu choice + paging RETURNs from a pipe;
+# vttest's rendering still flows script -> Wintty ConPTY -> libghostty, so it
+# shows in the pane. A short pre-delay lets vttest start and prompt (it flushes
+# any input fed before the prompt), and the trailing sleep freezes the selected
+# screen for a screenshot instead of racing to the end on EOF.
+#
+#   $1 = menu digits to select (e.g. "3" for the character-set test)
+#   $2 = number of paging RETURNs to advance within a multi-screen test
+sel="${1:-0}"
+pages="${2:-0}"
+{
+  sleep 4
+  printf '%s\r' "$sel"
+  for _ in $(seq 1 "$pages"); do sleep 2; printf '\r'; done
+  sleep 90
+} | script -qec "$HOME/vttest" /dev/null


### PR DESCRIPTION
Continues the vttest visual pass (#507) against a clean `windows`-HEAD build.

First, the open lead from #509 is cleared: the earlier observation that vttest's main menu list did not render came from a stale dev build / a pre-draw capture. On a fresh HEAD build the menu renders fully and correctly (banner, all 12 entries, the prompt) -- CUP positioning, erase-below, and text all correct.

Adds a keyboard-free section driver, since synthetic keys do not reach the WinUI window: `vttest-section.sh` runs vttest under an inner `script` pty inside the pane and auto-feeds the menu choice from a pipe; `run-vttest-section.ps1` wires it through the same isolated-XDG launch as the interactive runner.

Representative results recorded in `vttest-results.md`:

- character sets (section 3): pass -- ASCII, British, DEC special graphics line-drawing, DEC alternate ROM, SI/SO G0/G1 switching. The configured font ligates `<=>` (cosmetic).
- double-sized (section 4): double-width correct; double-height (DECDHL) renders as double-width single-height -- likely a shared Ghostty-core limitation, to confirm against the base project (not a ConPTY issue).
- size-dependent tests (borders, autowrap) are inconclusive under the current driver (inner pty size vs grid); a size-matched run is the refinement. Remaining sections pending.

Scripts + doc only, no product code.