### PR TITLE
feat(dcimgui): add DirectX12 backend bindings

### DIFF
--- a/pkg/dcimgui/build.zig
+++ b/pkg/dcimgui/build.zig
@@ -8,6 +8,9 @@ pub fn build(b: *std.Build) !void {
     const backend_opengl3 = b.option(bool, "backend-opengl3", "OpenGL3 backend") orelse false;
     const backend_metal = b.option(bool, "backend-metal", "Metal backend") orelse false;
     const backend_osx = b.option(bool, "backend-osx", "OSX backend") orelse false;
+    // Defaults off: consumers (e.g. SharedDeps.zig) opt in with -Dbackend-dx12.
+    // Exercise the bindings with `zig build test -Dbackend-dx12=true`.
+    const backend_dx12 = b.option(bool, "backend-dx12", "DirectX12 backend") orelse false;
 
     // Build options
     const options = b.addOptions();
@@ -15,6 +18,7 @@ pub fn build(b: *std.Build) !void {
     options.addOption(bool, "backend_opengl3", backend_opengl3);
     options.addOption(bool, "backend_metal", backend_metal);
     options.addOption(bool, "backend_osx", backend_osx);
+    options.addOption(bool, "backend_dx12", backend_dx12);
 
     // Main static lib
     const lib = b.addLibrary(.{
@@ -71,6 +75,9 @@ pub fn build(b: *std.Build) !void {
     });
     if (backend_opengl3) try flags.appendSlice(b.allocator, &.{
         "-DZIGPKG_IMGUI_ENABLE_OPENGL3=1",
+    });
+    if (backend_dx12) try flags.appendSlice(b.allocator, &.{
+        "-DZIGPKG_IMGUI_ENABLE_DX12=1",
     });
     if (target.result.os.tag == .windows) {
         try flags.appendSlice(b.allocator, &.{
@@ -165,6 +172,30 @@ pub fn build(b: *std.Build) !void {
                 "",
                 .{ .include_extensions = &.{"imgui_impl_opengl3.h"} },
             );
+        }
+        if (backend_dx12) {
+            lib.addCSourceFiles(.{
+                .root = upstream.path("backends"),
+                .files = &.{"imgui_impl_dx12.cpp"},
+                .flags = flags.items,
+            });
+            lib.installHeadersDirectory(
+                upstream.path("backends"),
+                "",
+                .{ .include_extensions = &.{"imgui_impl_dx12.h"} },
+            );
+            // The DX12 backend calls into DXGI (CreateDXGIFactory1) and
+            // compiles its shaders at runtime via D3DCompile, so it needs
+            // these Windows import libs. Linking them on the static lib
+            // propagates the requirement to anything that links dcimgui.
+            lib.linkSystemLibrary("dxgi");
+            // The d3dcompiler import-lib name differs by ABI: the Windows
+            // SDK ships d3dcompiler.lib (MSVC), while Zig's bundled mingw
+            // defs only provide the versioned d3dcompiler_47.
+            lib.linkSystemLibrary(if (target.result.abi == .msvc)
+                "d3dcompiler"
+            else
+                "d3dcompiler_47");
         }
     }
 

--- a/pkg/dcimgui/ext.cpp
+++ b/pkg/dcimgui/ext.cpp
@@ -50,4 +50,27 @@ CIMGUI_API void ImGui_ImplOpenGL3_ShutdownWithLoaderCleanup()
 #endif // __has_include("backends/imgui_impl_opengl3.h")
 #endif // IMGUI_DISABLE
 
+// DX12 backend layout accessors. The Zig bindings mirror
+// ImGui_ImplDX12_InitInfo as an extern struct; these let the unit test
+// assert the Zig layout matches the compiled C++ layout (which omits the
+// obsolete LegacySingleSrv* fields because IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+// is defined).
+#ifndef IMGUI_DISABLE
+#if __has_include("backends/imgui_impl_dx12.h")
+#ifdef ZIGPKG_IMGUI_ENABLE_DX12
+#include "backends/imgui_impl_dx12.h"
+
+CIMGUI_API size_t ghostty_ImGui_ImplDX12_InitInfo_size()
+{
+    return sizeof(ImGui_ImplDX12_InitInfo);
+}
+
+CIMGUI_API size_t ghostty_ImGui_ImplDX12_InitInfo_align()
+{
+    return alignof(ImGui_ImplDX12_InitInfo);
+}
+#endif // ZIGPKG_IMGUI_ENABLE_DX12
+#endif // __has_include("backends/imgui_impl_dx12.h")
+#endif // IMGUI_DISABLE
+
 }

--- a/pkg/dcimgui/main.zig
+++ b/pkg/dcimgui/main.zig
@@ -31,6 +31,51 @@ pub extern fn ImGui_ImplOSX_Init(*anyopaque) callconv(.c) bool;
 pub extern fn ImGui_ImplOSX_Shutdown() callconv(.c) void;
 pub extern fn ImGui_ImplOSX_NewFrame(*anyopaque) callconv(.c) void;
 
+// DX12 backend
+//
+// COM interface pointers are opaque here (same as the Metal backend's
+// device: *anyopaque). The DirectX12 renderer passes its real d3d12.zig
+// pointers via @ptrCast. The InitInfo layout mirrors
+// ImGui_ImplDX12_InitInfo from imgui 1.92.5; because our build defines
+// IMGUI_DISABLE_OBSOLETE_FUNCTIONS, the trailing LegacySingleSrv* fields
+// are absent. A unit test asserts this layout against the C++ sizeof/alignof.
+pub const ImGui_ImplDX12_CpuDescriptorHandle = extern struct {
+    ptr: usize,
+};
+pub const ImGui_ImplDX12_GpuDescriptorHandle = extern struct {
+    ptr: u64,
+};
+pub const ImGui_ImplDX12_InitInfo = extern struct {
+    Device: ?*anyopaque = null,
+    CommandQueue: ?*anyopaque = null,
+    NumFramesInFlight: c_int = 0,
+    // DXGI_FORMAT values. Kept as c_uint (not dxgi.DXGI_FORMAT) so this
+    // vendored package stays independent of the renderer; the caller passes
+    // @intFromEnum(format).
+    RTVFormat: c_uint = 0,
+    DSVFormat: c_uint = 0,
+    UserData: ?*anyopaque = null,
+    SrvDescriptorHeap: ?*anyopaque = null,
+    SrvDescriptorAllocFn: ?*const fn (
+        info: *ImGui_ImplDX12_InitInfo,
+        out_cpu: *ImGui_ImplDX12_CpuDescriptorHandle,
+        out_gpu: *ImGui_ImplDX12_GpuDescriptorHandle,
+    ) callconv(.c) void = null,
+    SrvDescriptorFreeFn: ?*const fn (
+        info: *ImGui_ImplDX12_InitInfo,
+        cpu: ImGui_ImplDX12_CpuDescriptorHandle,
+        gpu: ImGui_ImplDX12_GpuDescriptorHandle,
+    ) callconv(.c) void = null,
+};
+
+pub extern fn ImGui_ImplDX12_Init(info: *ImGui_ImplDX12_InitInfo) callconv(.c) bool;
+pub extern fn ImGui_ImplDX12_Shutdown() callconv(.c) void;
+pub extern fn ImGui_ImplDX12_NewFrame() callconv(.c) void;
+pub extern fn ImGui_ImplDX12_RenderDrawData(draw_data: *c.ImDrawData, command_list: *anyopaque) callconv(.c) void;
+
+extern fn ghostty_ImGui_ImplDX12_InitInfo_size() callconv(.c) usize;
+extern fn ghostty_ImGui_ImplDX12_InitInfo_align() callconv(.c) usize;
+
 // Internal API types and functions from dcimgui_internal.h
 // We declare these manually because the internal header contains bitfields
 // that Zig's cImport cannot translate.
@@ -74,4 +119,26 @@ pub const ext = struct {
 
 test {
     _ = c;
+}
+
+test "dx12 backend bindings" {
+    if (comptime !build_options.backend_dx12) return error.SkipZigTest;
+
+    const std = @import("std");
+
+    // Force the externs to be referenced so the symbols must link.
+    std.mem.doNotOptimizeAway(&ImGui_ImplDX12_Init);
+    std.mem.doNotOptimizeAway(&ImGui_ImplDX12_Shutdown);
+    std.mem.doNotOptimizeAway(&ImGui_ImplDX12_NewFrame);
+    std.mem.doNotOptimizeAway(&ImGui_ImplDX12_RenderDrawData);
+
+    // The Zig InitInfo mirror must match the compiled C++ struct exactly.
+    try std.testing.expectEqual(
+        ghostty_ImGui_ImplDX12_InitInfo_size(),
+        @sizeOf(ImGui_ImplDX12_InitInfo),
+    );
+    try std.testing.expectEqual(
+        ghostty_ImGui_ImplDX12_InitInfo_align(),
+        @alignOf(ImGui_ImplDX12_InitInfo),
+    );
 }


### PR DESCRIPTION
First PR in the Windows terminal inspector stack (# 513), bringing the
ImGui inspector to Wintty for parity with macOS.

> [!IMPORTANT]
> Stacked series, merge in order:
> 1. **this PR** - cimgui DX12 backend (bindings + build)
> 2. DX12 inspector render pass + C API entry points
> 3. WinUI host window + toggle wiring

This PR is self-contained: it adds the Dear ImGui D3D12 renderer backend
to `pkg/dcimgui` and exposes Zig externs for it. It does not touch the
app render path or C API yet (those land in PR 2).

## What

- `backend-dx12` build option (default off) that compiles
  `imgui_impl_dx12.cpp` and links `dxgi` + `d3dcompiler`. The
  d3dcompiler link name is ABI-conditional (the Windows SDK ships
  `d3dcompiler.lib` under MSVC; Zig's bundled mingw defs only the
  versioned `d3dcompiler_47`).
- `ImGui_ImplDX12_InitInfo` mirrored as a Zig extern struct plus the
  four backend functions, in the same style as the existing Metal and
  OpenGL3 bindings. COM pointers stay opaque; the renderer will
  `@ptrCast` its own `d3d12.zig` pointers in.
- A layout-assertion unit test that pins the Zig struct against the
  compiled C++ `sizeof`/`alignof` (imgui 1.92.5 drops the obsolete
  `LegacySingleSrv*` fields under `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`).

## Test

```
cd pkg/dcimgui && zig build test -Dbackend-dx12=true   # 2/2 pass
```

The consumer default stays off, so the app build is unchanged
(`zig build test -Dapp-runtime=none` green).
