### PR TITLE
feat(windows): desktop notifications (toasts) for OSC 9/777 and shell exit

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -32,6 +32,7 @@ internal enum GhosttyActionTag
     EqualizeSplits = 19,
     ToggleSplitZoom = 20,
     Scrollbar = 26,
+    DesktopNotification = 31,
     SetTitle = 32,
     MouseShape = 36,
     MouseVisibility = 37,
@@ -41,6 +42,7 @@ internal enum GhosttyActionTag
     ConfigChange = 48,
     CloseWindow = 49,
     RingBell = 50,
+    ShowChildExited = 55,
     ProgressReport = 56,
     StartSearch    = 59,
     EndSearch      = 60,
@@ -130,6 +132,20 @@ internal struct GhosttyActionProgressReport
 {
     public int State;
     public sbyte Progress;
+}
+
+// ghostty_surface_message_childexited_s:
+//   { uint32 exit_code; uint64 runtime_ms; }
+// On x64: exit_code@0, 4 bytes of padding before the 8-byte-aligned u64,
+// runtime_ms@8, total 16 bytes. GhosttyHost reads this at (actionPtr + 8)
+// (the union sits at +8, and within it the u64 forces the same +0/+8
+// field layout). The C header's field is mis-typed `timetime_ms` but the
+// ABI is the u64 at +8 -- the name is irrelevant to the binary layout.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyChildExited
+{
+    public uint ExitCode;
+    public ulong RuntimeMs;
 }
 
 // ghostty_action_start_search_s:

--- a/windows/Ghostty.Core/Notifications/IToastNotifier.cs
+++ b/windows/Ghostty.Core/Notifications/IToastNotifier.cs
@@ -1,0 +1,20 @@
+namespace Ghostty.Core.Notifications;
+
+/// <summary>
+/// Shell-side sink that turns a <see cref="ToastRequest"/> into an actual OS
+/// toast. Declared in Core so <c>GhosttyHost</c> depends on the abstraction
+/// while the WinAppSDK implementation stays in the shell project. All
+/// implementations must swallow their own failures -- a toast error must
+/// never propagate back through the libghostty action callback.
+/// </summary>
+public interface IToastNotifier
+{
+    /// <summary>Raise (or replace) the toast described by <paramref name="request"/>.</summary>
+    void Show(ToastRequest request);
+
+    /// <summary>
+    /// Remove any outstanding toast for a surface. Called when the surface
+    /// regains focus so a stale notification disappears.
+    /// </summary>
+    void ClearForSurface(string surfaceKey);
+}

--- a/windows/Ghostty.Core/Notifications/NotificationPolicy.cs
+++ b/windows/Ghostty.Core/Notifications/NotificationPolicy.cs
@@ -11,36 +11,39 @@ public static class NotificationPolicy
 {
     /// <summary>
     /// OSC 9 / OSC 777 desktop notification. Suppressed when the emitting
-    /// surface is focused (the user is already looking at it -- mirrors
-    /// macOS's requireFocus default). The core already enforced the
-    /// `desktop-notifications` config before dispatching, so there is no
-    /// config check here. Returns null when nothing should be shown.
+    /// surface is active -- i.e. focused AND in the foreground window (the
+    /// user is already looking at it; mirrors macOS's requireFocus default).
+    /// The core already enforced the `desktop-notifications` config before
+    /// dispatching, so there is no config check here. Returns null when
+    /// nothing should be shown.
     /// </summary>
     public static ToastRequest? DesktopNotification(
         string title,
         string body,
         string surfaceKey,
-        bool isSurfaceFocused)
+        bool isSurfaceActive)
     {
-        if (isSurfaceFocused) return null;
+        if (isSurfaceActive) return null;
         return new ToastRequest(title, body, surfaceKey);
     }
 
     /// <summary>
-    /// The shell process exited. Suppressed when the surface is focused, and
-    /// when <paramref name="runtimeMs"/> is 0 (rules out exit codes reported
-    /// at launch -- matches macOS's `timetime_ms > 0` guard). The toast is
-    /// additive: the core still prints its in-terminal "Press any key to
-    /// close" message because the apprt returns "not handled".
+    /// The shell process exited. Suppressed when the surface is active
+    /// (focused + foreground), and when <paramref name="runtimeMs"/> is 0.
+    /// The zero-runtime check is a Windows-specific launch-failure guard
+    /// (rules out exit codes reported the instant a surface spins up); the
+    /// macOS port instead classifies abnormal exits via a runtime threshold.
+    /// The toast is additive: the core still prints its in-terminal "Press
+    /// any key to close" message because the apprt returns "not handled".
     /// </summary>
     public static ToastRequest? ChildExited(
         uint exitCode,
         ulong runtimeMs,
         string surfaceKey,
-        bool isSurfaceFocused)
+        bool isSurfaceActive)
     {
         if (runtimeMs == 0) return null;
-        if (isSurfaceFocused) return null;
+        if (isSurfaceActive) return null;
 
         var title = exitCode == 0 ? "Process exited" : "Process exited abnormally";
         var body = exitCode == 0

--- a/windows/Ghostty.Core/Notifications/NotificationPolicy.cs
+++ b/windows/Ghostty.Core/Notifications/NotificationPolicy.cs
@@ -1,0 +1,51 @@
+namespace Ghostty.Core.Notifications;
+
+/// <summary>
+/// Pure decisions about whether (and with what content) a libghostty
+/// notification action should raise a Windows toast. No UI or native
+/// dependencies, so focus-gating and formatting are unit-tested without
+/// WinAppSDK. The shell feeds in the already-decoded payload plus the
+/// emitting surface's focus state.
+/// </summary>
+public static class NotificationPolicy
+{
+    /// <summary>
+    /// OSC 9 / OSC 777 desktop notification. Suppressed when the emitting
+    /// surface is focused (the user is already looking at it -- mirrors
+    /// macOS's requireFocus default). The core already enforced the
+    /// `desktop-notifications` config before dispatching, so there is no
+    /// config check here. Returns null when nothing should be shown.
+    /// </summary>
+    public static ToastRequest? DesktopNotification(
+        string title,
+        string body,
+        string surfaceKey,
+        bool isSurfaceFocused)
+    {
+        if (isSurfaceFocused) return null;
+        return new ToastRequest(title, body, surfaceKey);
+    }
+
+    /// <summary>
+    /// The shell process exited. Suppressed when the surface is focused, and
+    /// when <paramref name="runtimeMs"/> is 0 (rules out exit codes reported
+    /// at launch -- matches macOS's `timetime_ms > 0` guard). The toast is
+    /// additive: the core still prints its in-terminal "Press any key to
+    /// close" message because the apprt returns "not handled".
+    /// </summary>
+    public static ToastRequest? ChildExited(
+        uint exitCode,
+        ulong runtimeMs,
+        string surfaceKey,
+        bool isSurfaceFocused)
+    {
+        if (runtimeMs == 0) return null;
+        if (isSurfaceFocused) return null;
+
+        var title = exitCode == 0 ? "Process exited" : "Process exited abnormally";
+        var body = exitCode == 0
+            ? "The shell exited normally (code 0)."
+            : $"The shell exited with code {exitCode}.";
+        return new ToastRequest(title, body, surfaceKey);
+    }
+}

--- a/windows/Ghostty.Core/Notifications/ToastRequest.cs
+++ b/windows/Ghostty.Core/Notifications/ToastRequest.cs
@@ -1,0 +1,9 @@
+namespace Ghostty.Core.Notifications;
+
+/// <summary>
+/// A decoded, focus-checked request to raise a single Windows toast.
+/// <see cref="Title"/>/<see cref="Body"/> are display strings;
+/// <see cref="SurfaceKey"/> groups toasts per surface so a newer toast
+/// supersedes the older one and focus-regain can clear them.
+/// </summary>
+public sealed record ToastRequest(string Title, string Body, string SurfaceKey);

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -25,6 +25,8 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.MouseShape, 36)]
     [InlineData((int)GhosttyActionTag.MouseVisibility, 37)]
     [InlineData((int)GhosttyActionTag.MouseOverLink, 38)]
+    [InlineData((int)GhosttyActionTag.DesktopNotification, 31)]
+    [InlineData((int)GhosttyActionTag.ShowChildExited, 55)]
     [InlineData((int)GhosttyActionTag.ConfigChange, 48)]
     [InlineData((int)GhosttyActionTag.CloseWindow, 49)]
     [InlineData((int)GhosttyActionTag.RingBell, 50)]
@@ -208,5 +210,23 @@ public class GhosttyActionsLayoutTests
     public void MoveTabStruct_Size_Is_8_Bytes()
     {
         Assert.Equal(8, Marshal.SizeOf<GhosttyActionMoveTab>());
+    }
+
+    [Fact]
+    public void ChildExitedStruct_Size_Is_16_Bytes()
+    {
+        // ghostty_surface_message_childexited_s:
+        //   { uint32 exit_code; uint64 runtime_ms; }
+        // exit_code@0, 4 bytes pad, runtime_ms@8 -> 16 total on x64.
+        Assert.Equal(16, Marshal.SizeOf<GhosttyChildExited>());
+    }
+
+    [Fact]
+    public void ChildExitedStruct_Field_Offsets_Match_C_Layout()
+    {
+        // GhosttyHost reads this struct at (actionPtr + 8) via
+        // Unsafe.ReadUnaligned, so the fields MUST sit at +0/+8.
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyChildExited>(nameof(GhosttyChildExited.ExitCode)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<GhosttyChildExited>(nameof(GhosttyChildExited.RuntimeMs)));
     }
 }

--- a/windows/Ghostty.Tests/Notifications/NotificationPolicyTests.cs
+++ b/windows/Ghostty.Tests/Notifications/NotificationPolicyTests.cs
@@ -1,0 +1,61 @@
+using Ghostty.Core.Notifications;
+using Xunit;
+
+namespace Ghostty.Tests.Notifications;
+
+public class NotificationPolicyTests
+{
+    // --- DesktopNotification ---
+
+    [Fact]
+    public void DesktopNotification_Unfocused_Returns_Request_With_Content()
+    {
+        var req = NotificationPolicy.DesktopNotification("Build done", "Succeeded", "0x1234", isSurfaceFocused: false);
+        Assert.NotNull(req);
+        Assert.Equal("Build done", req!.Title);
+        Assert.Equal("Succeeded", req.Body);
+        Assert.Equal("0x1234", req.SurfaceKey);
+    }
+
+    [Fact]
+    public void DesktopNotification_Focused_Is_Suppressed()
+    {
+        var req = NotificationPolicy.DesktopNotification("Build done", "Succeeded", "0x1234", isSurfaceFocused: true);
+        Assert.Null(req);
+    }
+
+    // --- ChildExited ---
+
+    [Fact]
+    public void ChildExited_Unfocused_NonZeroRuntime_ZeroCode_Returns_Normal_Exit()
+    {
+        var req = NotificationPolicy.ChildExited(exitCode: 0, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceFocused: false);
+        Assert.NotNull(req);
+        Assert.Equal("0x99", req!.SurfaceKey);
+        Assert.Contains("0", req.Body); // body mentions code 0 / normal exit; see policy
+    }
+
+    [Fact]
+    public void ChildExited_Unfocused_NonZeroCode_Mentions_The_Code()
+    {
+        var req = NotificationPolicy.ChildExited(exitCode: 137, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceFocused: false);
+        Assert.NotNull(req);
+        Assert.Contains("137", req!.Body);
+    }
+
+    [Fact]
+    public void ChildExited_Focused_Is_Suppressed()
+    {
+        var req = NotificationPolicy.ChildExited(exitCode: 1, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceFocused: true);
+        Assert.Null(req);
+    }
+
+    [Fact]
+    public void ChildExited_ZeroRuntime_Is_Suppressed_Even_When_Unfocused()
+    {
+        // runtime_ms == 0 rules out exit codes reported at launch
+        // (matches macOS's timetime_ms > 0 guard).
+        var req = NotificationPolicy.ChildExited(exitCode: 1, runtimeMs: 0, surfaceKey: "0x99", isSurfaceFocused: false);
+        Assert.Null(req);
+    }
+}

--- a/windows/Ghostty.Tests/Notifications/NotificationPolicyTests.cs
+++ b/windows/Ghostty.Tests/Notifications/NotificationPolicyTests.cs
@@ -8,9 +8,9 @@ public class NotificationPolicyTests
     // --- DesktopNotification ---
 
     [Fact]
-    public void DesktopNotification_Unfocused_Returns_Request_With_Content()
+    public void DesktopNotification_Inactive_Returns_Request_With_Content()
     {
-        var req = NotificationPolicy.DesktopNotification("Build done", "Succeeded", "0x1234", isSurfaceFocused: false);
+        var req = NotificationPolicy.DesktopNotification("Build done", "Succeeded", "0x1234", isSurfaceActive: false);
         Assert.NotNull(req);
         Assert.Equal("Build done", req!.Title);
         Assert.Equal("Succeeded", req.Body);
@@ -18,44 +18,43 @@ public class NotificationPolicyTests
     }
 
     [Fact]
-    public void DesktopNotification_Focused_Is_Suppressed()
+    public void DesktopNotification_Active_Is_Suppressed()
     {
-        var req = NotificationPolicy.DesktopNotification("Build done", "Succeeded", "0x1234", isSurfaceFocused: true);
+        var req = NotificationPolicy.DesktopNotification("Build done", "Succeeded", "0x1234", isSurfaceActive: true);
         Assert.Null(req);
     }
 
     // --- ChildExited ---
 
     [Fact]
-    public void ChildExited_Unfocused_NonZeroRuntime_ZeroCode_Returns_Normal_Exit()
+    public void ChildExited_Inactive_NonZeroRuntime_ZeroCode_Returns_Normal_Exit()
     {
-        var req = NotificationPolicy.ChildExited(exitCode: 0, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceFocused: false);
+        var req = NotificationPolicy.ChildExited(exitCode: 0, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceActive: false);
         Assert.NotNull(req);
         Assert.Equal("0x99", req!.SurfaceKey);
-        Assert.Contains("0", req.Body); // body mentions code 0 / normal exit; see policy
+        Assert.Contains("normally", req.Body); // normal-exit copy, not an incidental digit
     }
 
     [Fact]
-    public void ChildExited_Unfocused_NonZeroCode_Mentions_The_Code()
+    public void ChildExited_Inactive_NonZeroCode_Mentions_The_Code()
     {
-        var req = NotificationPolicy.ChildExited(exitCode: 137, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceFocused: false);
+        var req = NotificationPolicy.ChildExited(exitCode: 137, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceActive: false);
         Assert.NotNull(req);
         Assert.Contains("137", req!.Body);
     }
 
     [Fact]
-    public void ChildExited_Focused_Is_Suppressed()
+    public void ChildExited_Active_Is_Suppressed()
     {
-        var req = NotificationPolicy.ChildExited(exitCode: 1, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceFocused: true);
+        var req = NotificationPolicy.ChildExited(exitCode: 1, runtimeMs: 5000, surfaceKey: "0x99", isSurfaceActive: true);
         Assert.Null(req);
     }
 
     [Fact]
-    public void ChildExited_ZeroRuntime_Is_Suppressed_Even_When_Unfocused()
+    public void ChildExited_ZeroRuntime_Is_Suppressed_Even_When_Inactive()
     {
-        // runtime_ms == 0 rules out exit codes reported at launch
-        // (matches macOS's timetime_ms > 0 guard).
-        var req = NotificationPolicy.ChildExited(exitCode: 1, runtimeMs: 0, surfaceKey: "0x99", isSurfaceFocused: false);
+        // runtime_ms == 0 is the launch-failure guard (see NotificationPolicy).
+        var req = NotificationPolicy.ChildExited(exitCode: 1, runtimeMs: 0, surfaceKey: "0x99", isSurfaceActive: false);
         Assert.Null(req);
     }
 }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -380,6 +380,20 @@ public partial class App : Application
             Ghostty.Logging.StaticLoggers.App.LogJumpListFailed(ex);
         }
 
+        // Register for toast notifications. Unpackaged apps must call
+        // Register() so AppNotificationManager wires up the COM activator
+        // under the AUMID before any Show(); without it Show() throws. The
+        // registration persists in the registry (we never Unregister) so the
+        // app can be toast-activated later. AUMID is already set above.
+        try
+        {
+            Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
+        }
+        catch (System.Exception ex)
+        {
+            Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex);
+        }
+
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
         ConfigService = _configService;
 
@@ -951,5 +965,11 @@ internal static partial class AppLogExtensions
                    Level = LogLevel.Warning,
                    Message = "Failed to build jump list")]
     internal static partial void LogJumpListFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.ToastRegisterFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to register for toast notifications")]
+    internal static partial void LogToastRegisterFailed(
         this ILogger<App> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -699,6 +699,21 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private bool _focused;
 
+    /// <summary>
+    /// Whether this surface currently holds focus. True implies the owning
+    /// window is foreground AND this surface is the active element (WinUI
+    /// only raises GotFocus then). Used by the toast policy to suppress
+    /// notifications the user is already looking at.
+    /// </summary>
+    internal bool IsFocused => _focused;
+
+    /// <summary>
+    /// Stable per-surface key used to group/clear toast notifications. Both
+    /// GhosttyHost (when showing) and the focus-regain clear below resolve
+    /// the same control, so the key is consistent for a surface's lifetime.
+    /// </summary>
+    internal string ToastSurfaceKey => _surface.Handle.ToString();
+
     private void OnGotFocus(object sender, RoutedEventArgs e)
     {
         // Stamp the focus instant so a focus-driven relayout in the next
@@ -727,6 +742,10 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // move the pointer, so without this the banner would stay frozen
         // on screen until the user returned and moved the mouse.
         if (!focused) UpdateUrlHoverBanner(null);
+
+        // On focus regain, drop any toast we raised for this surface while it
+        // was in the background so a stale notification does not linger.
+        if (focused) Host?.ClearSurfaceToasts(ToastSurfaceKey);
     }
 
     // Mouse --------------------------------------------------------------

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -700,19 +700,38 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     private bool _focused;
 
     /// <summary>
-    /// Whether this surface currently holds focus. True implies the owning
-    /// window is foreground AND this surface is the active element (WinUI
-    /// only raises GotFocus then). Used by the toast policy to suppress
-    /// notifications the user is already looking at.
+    /// True only when this surface is focused AND its window is the OS
+    /// foreground window — i.e. the user is actively looking at it. Used by
+    /// the toast policy to suppress notifications for the surface in view.
+    ///
+    /// <see cref="_focused"/> alone is NOT sufficient: WinUI keeps XAML
+    /// keyboard focus across window deactivation, so a backgrounded window's
+    /// focused surface still reports <c>_focused == true</c>. Gating toasts
+    /// on <c>_focused</c> only would wrongly suppress a notification raised
+    /// while the user is in another app — exactly the case the feature
+    /// exists for — so we AND in a real foreground-window check.
     /// </summary>
-    internal bool IsFocused => _focused;
+    internal bool IsActive => _focused && IsOwningWindowForeground();
 
-    /// <summary>
-    /// Stable per-surface key used to group/clear toast notifications. Both
-    /// GhosttyHost (when showing) and the focus-regain clear below resolve
-    /// the same control, so the key is consistent for a surface's lifetime.
-    /// </summary>
-    internal string ToastSurfaceKey => _surface.Handle.ToString();
+    private bool IsOwningWindowForeground()
+    {
+        // Resolve this control's top-level window HWND via its XamlRoot and
+        // compare to the OS foreground window. If the island environment is
+        // not available yet, fail "not foreground" so we err toward showing
+        // the toast rather than silently swallowing it.
+        var env = XamlRoot?.ContentIslandEnvironment;
+        if (env is null) return false;
+        nint mine = Microsoft.UI.Win32Interop.GetWindowFromWindowId(env.AppWindowId);
+        return mine != 0 && mine == PInvoke.GetForegroundWindow();
+    }
+
+    // Stable per-surface key for the toast Group (dedupe + focus-regain
+    // clear). A fresh Guid rather than the native surface handle, so a
+    // recycled handle value can never alias another surface's toasts. The
+    // same control instance is resolved for both Show and ClearForSurface,
+    // so the key stays consistent for the surface's lifetime.
+    private readonly string _toastSurfaceKey = Guid.NewGuid().ToString();
+    internal string ToastSurfaceKey => _toastSurfaceKey;
 
     private void OnGotFocus(object sender, RoutedEventArgs e)
     {

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -117,6 +117,12 @@ internal sealed class GhosttyHost : IDisposable
     private readonly ConcurrentDictionary<IntPtr, TerminalControl> _surfaces = new();
     private readonly DispatcherQueue _dispatcher;
 
+    // Process-wide toast sink. Constructed in both ctors (stateless;
+    // AppNotificationManager.Default is itself a singleton). The bootstrap
+    // host uses it from OnAction (Show); per-window hosts use it from the
+    // focus-regain clear forwarded by their controls.
+    private readonly Ghostty.Core.Notifications.IToastNotifier _toasts;
+
     public GhosttyApp App => _app;
 
     /// <summary>
@@ -138,6 +144,8 @@ internal sealed class GhosttyHost : IDisposable
             supervisor);
         _config = config;
         _logger = loggerFactory.CreateLogger<GhosttyHost>();
+        _toasts = new Ghostty.Notifications.AppNotificationToastNotifier(
+            loggerFactory.CreateLogger<Ghostty.Notifications.AppNotificationToastNotifier>());
 
         _wakeupCb = OnWakeup;
         _actionCb = OnAction;
@@ -202,6 +210,8 @@ internal sealed class GhosttyHost : IDisposable
             supervisor.RegisterPerWindow(),
             supervisor);
         _logger = loggerFactory.CreateLogger<GhosttyHost>();
+        _toasts = new Ghostty.Notifications.AppNotificationToastNotifier(
+            loggerFactory.CreateLogger<Ghostty.Notifications.AppNotificationToastNotifier>());
         _app = new GhosttyApp(sharedApp);
         // Per-window hosts do not own or read _config; the bootstrap host
         // manages the single GhosttyConfig. Left as default intentionally.
@@ -757,6 +767,54 @@ internal sealed class GhosttyHost : IDisposable
                     return 1;
                 }
 
+                case GhosttyActionTag.DesktopNotification:
+                {
+                    // ghostty_action_desktop_notification_s:
+                    //   { const char* title; const char* body; }
+                    // title@+8, body@+16. The core already gated this on the
+                    // `desktop-notifications` config before dispatching, so no
+                    // config check here. Copy the strings on the libghostty
+                    // thread before the buffer frees, then decide + show on the
+                    // UI thread where focus state is valid.
+                    var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
+                    var bodyPtr = Marshal.ReadIntPtr(actionPtr, 16);
+                    var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
+                    var body = Marshal.PtrToStringUTF8(bodyPtr) ?? string.Empty;
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (!TryResolveControl(surfaceHandle, out var c) || c is null) return;
+                        var req = Ghostty.Core.Notifications.NotificationPolicy.DesktopNotification(
+                            title, body, c.ToastSurfaceKey, c.IsFocused);
+                        if (req is not null) _toasts.Show(req);
+                    });
+                    return 1;
+                }
+
+                case GhosttyActionTag.ShowChildExited:
+                {
+                    // ghostty_surface_message_childexited_s:
+                    //   { uint32 exit_code; uint64 runtime_ms; }
+                    // The union sits at +8; within it exit_code@+0 and the
+                    // 8-byte-aligned runtime_ms@+8, so read the struct at +8.
+                    GhosttyChildExited info;
+                    unsafe
+                    {
+                        info = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyChildExited>(
+                            (void*)(actionPtr + 8));
+                    }
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (!TryResolveControl(surfaceHandle, out var c) || c is null) return;
+                        var req = Ghostty.Core.Notifications.NotificationPolicy.ChildExited(
+                            info.ExitCode, info.RuntimeMs, c.ToastSurfaceKey, c.IsFocused);
+                        if (req is not null) _toasts.Show(req);
+                    });
+                    // Return 0 ("not handled") so the core keeps its in-terminal
+                    // "Process exited. Press any key to close" fallback. The
+                    // toast is additive, not a replacement for that affordance.
+                    return 0;
+                }
+
                 default:
                     return 0;
             }
@@ -785,6 +843,12 @@ internal sealed class GhosttyHost : IDisposable
             owner.PaneActionRequested?.Invoke(paneAction));
         return 1;
     }
+
+    /// <summary>
+    /// Forwarded from a TerminalControl when its surface regains focus:
+    /// remove any background toast we raised for that surface.
+    /// </summary>
+    internal void ClearSurfaceToasts(string surfaceKey) => _toasts.ClearForSurface(surfaceKey);
 
     /// <summary>
     /// Raise <see cref="PaneActionRequested"/> for a chord that the

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -784,7 +784,7 @@ internal sealed class GhosttyHost : IDisposable
                     {
                         if (!TryResolveControl(surfaceHandle, out var c) || c is null) return;
                         var req = Ghostty.Core.Notifications.NotificationPolicy.DesktopNotification(
-                            title, body, c.ToastSurfaceKey, c.IsFocused);
+                            title, body, c.ToastSurfaceKey, c.IsActive);
                         if (req is not null) _toasts.Show(req);
                     });
                     return 1;
@@ -806,7 +806,7 @@ internal sealed class GhosttyHost : IDisposable
                     {
                         if (!TryResolveControl(surfaceHandle, out var c) || c is null) return;
                         var req = Ghostty.Core.Notifications.NotificationPolicy.ChildExited(
-                            info.ExitCode, info.RuntimeMs, c.ToastSurfaceKey, c.IsFocused);
+                            info.ExitCode, info.RuntimeMs, c.ToastSurfaceKey, c.IsActive);
                         if (req is not null) _toasts.Show(req);
                     });
                     // Return 0 ("not handled") so the core keeps its in-terminal

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -11,6 +11,7 @@ internal static class LogEvents
     {
         public const int AumidFailed    = 2000;
         public const int JumpListFailed = 2001;
+        public const int ToastRegisterFailed = 2002;
     }
 
     // 2100-2199: Clipboard
@@ -68,5 +69,12 @@ internal static class LogEvents
         public const int KeybindWriteFailed = 2601;
         public const int CheatSheetShowFailed = 2602;
         public const int CheatSheetExportFailed = 2603;
+    }
+
+    // 2700-2799: Notifications
+    internal static class Notifications
+    {
+        public const int ShowFailed  = 2701;
+        public const int ClearFailed = 2702;
     }
 }

--- a/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
+++ b/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
@@ -30,10 +30,13 @@ internal sealed class AppNotificationToastNotifier : IToastNotifier
     {
         try
         {
-            var notification = new AppNotificationBuilder()
-                .AddText(request.Title)
-                .AddText(request.Body)
-                .BuildNotification();
+            // OSC 9 carries only a body (title is empty); OSC 777 and the
+            // child-exited toast set both. Skip the title line when empty so
+            // OSC 9 does not render a blank bold heading above the message.
+            var builder = new AppNotificationBuilder();
+            if (!string.IsNullOrEmpty(request.Title)) builder.AddText(request.Title);
+            builder.AddText(request.Body);
+            var notification = builder.BuildNotification();
             notification.Tag = NotificationTag;
             notification.Group = request.SurfaceKey;
             AppNotificationManager.Default.Show(notification);

--- a/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
+++ b/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
@@ -43,6 +43,10 @@ internal sealed class AppNotificationToastNotifier : IToastNotifier
         }
         catch (Exception ex)
         {
+            // Intentional catch-all: Show is reached from the libghostty
+            // action callback, and a managed exception must never cross back
+            // into native code. COMException/InvalidOperationException are the
+            // expected failures; anything else is logged, not propagated.
             _logger.LogToastShowFailed(ex);
         }
     }
@@ -52,8 +56,11 @@ internal sealed class AppNotificationToastNotifier : IToastNotifier
         try
         {
             // Best-effort cleanup; fire-and-forget. We deliberately do not
-            // await -- ClearForSurface is called from a UI focus handler and
-            // a stale toast lingering a few ms longer is harmless.
+            // await and do not observe the returned IAsyncAction --
+            // ClearForSurface is called from a UI focus handler and a stale
+            // toast lingering a few ms longer (or a failed removal) is
+            // harmless. The try/catch covers only a synchronous throw from
+            // kicking off the call.
             _ = AppNotificationManager.Default.RemoveByGroupAsync(surfaceKey);
         }
         catch (Exception ex)

--- a/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
+++ b/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
@@ -1,0 +1,76 @@
+using System;
+using Ghostty.Core.Notifications;
+using Microsoft.Extensions.Logging;
+using Microsoft.Windows.AppNotifications;
+using Microsoft.Windows.AppNotifications.Builder;
+
+namespace Ghostty.Notifications;
+
+/// <summary>
+/// <see cref="IToastNotifier"/> backed by WinAppSDK
+/// <see cref="AppNotificationManager"/>. Each toast carries a constant Tag
+/// plus a per-surface Group (the surface key): Windows replaces a toast when
+/// both match, so a newer toast for a surface supersedes the older one, and
+/// <see cref="ClearForSurface"/> removes a surface's toast by group on focus
+/// regain. Every call is guarded -- a toast failure must never propagate back
+/// through GhosttyHost into the libghostty callback.
+/// </summary>
+internal sealed class AppNotificationToastNotifier : IToastNotifier
+{
+    // Constant Tag + per-surface Group means two toasts for the same surface
+    // collide (same Tag+Group) and the second replaces the first.
+    private const string NotificationTag = "wintty-notification";
+
+    private readonly ILogger<AppNotificationToastNotifier> _logger;
+
+    public AppNotificationToastNotifier(ILogger<AppNotificationToastNotifier> logger)
+        => _logger = logger;
+
+    public void Show(ToastRequest request)
+    {
+        try
+        {
+            var notification = new AppNotificationBuilder()
+                .AddText(request.Title)
+                .AddText(request.Body)
+                .BuildNotification();
+            notification.Tag = NotificationTag;
+            notification.Group = request.SurfaceKey;
+            AppNotificationManager.Default.Show(notification);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogToastShowFailed(ex);
+        }
+    }
+
+    public void ClearForSurface(string surfaceKey)
+    {
+        try
+        {
+            // Best-effort cleanup; fire-and-forget. We deliberately do not
+            // await -- ClearForSurface is called from a UI focus handler and
+            // a stale toast lingering a few ms longer is harmless.
+            _ = AppNotificationManager.Default.RemoveByGroupAsync(surfaceKey);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogToastClearFailed(ex);
+        }
+    }
+}
+
+internal static partial class ToastNotifierLogExtensions
+{
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Notifications.ShowFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to show toast notification")]
+    internal static partial void LogToastShowFailed(
+        this ILogger<AppNotificationToastNotifier> logger, Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Notifications.ClearFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to clear toast notifications")]
+    internal static partial void LogToastClearFailed(
+        this ILogger<AppNotificationToastNotifier> logger, Exception ex);
+}


### PR DESCRIPTION
Adds Windows toast notifications for parity with macOS/GTK. Both sources are already dispatched by libghostty core as apprt actions, so this is a Windows-shell-only change (no Zig):

- OSC 9 / OSC 777 desktop notifications (desktop_notification action, tag 31)
- The shell process exiting (show_child_exited action, tag 55)

Toasts use WinAppSDK AppNotificationManager under the existing AUMID, registered once at startup. A toast is suppressed when its surface is focused in the foreground window, so you are not notified about the terminal you are already looking at (a plain XAML-focus check is not enough since WinUI keeps focus across window deactivation, so it is AND-ed with a real foreground-window check). The child-exited handler returns "not handled" to the core, so the in-terminal "Press any key to close" message is preserved; the toast is additive and only fires when the window is in the background.

Pure decision/formatting logic (NotificationPolicy, ToastRequest) lives in Ghostty.Core and is unit-tested for focus gating, the zero-runtime launch guard, and exit formatting; the layout tests pin the new action tags and the child-exited struct ABI. The WinAppSDK notifier and the OnAction wiring live in the shell project.

Testing: full suite green; AppNotificationManager registration verified in the registry. Visual toast rendering still wants a manual eyeball on a machine with notifications enabled (Focus Assist off).