### PR TITLE
feat(windows): taskbar attention overlay badge on bell

### DIFF
--- a/windows/Ghostty.Core/Panes/IPaneHost.cs
+++ b/windows/Ghostty.Core/Panes/IPaneHost.cs
@@ -34,6 +34,12 @@ internal interface IPaneHost
     /// tab-level indicator.</summary>
     event EventHandler<TabProgressState>? ProgressChanged;
 
+    /// <summary>Raised when the active leaf rings the bell (libghostty
+    /// ring-bell action). Only the active leaf is forwarded, matching
+    /// <see cref="ProgressChanged"/>; background panes ring audibly but
+    /// do not drive the window-level attention badge.</summary>
+    event EventHandler? BellRang;
+
     /// <summary>
     /// Split the active leaf with the given orientation. The new leaf
     /// becomes the active leaf. <paramref name="snapshot"/> is recorded

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -54,6 +54,10 @@ internal sealed class TabManager
     public event EventHandler? LastTabClosed;
     public event EventHandler? WindowTitleChanged;
 
+    /// <summary>Raised when any owned tab's active leaf rings the bell.
+    /// Window-level: the taskbar attention coordinator subscribes here.</summary>
+    public event EventHandler? BellRang;
+
     /// <summary>
     /// Raised AFTER the tab's manager subscriptions have been unwired
     /// but BEFORE the tab is removed from <see cref="Tabs"/>. Fired
@@ -230,6 +234,10 @@ internal sealed class TabManager
         // without needing a shared dictionary.
         EventHandler<TabProgressState> progressHandler = (_, state) => tab.Progress = state;
         host.ProgressChanged += progressHandler;
+        // Forward the active-leaf bell up to the window level. Captured
+        // as a local so CloseTab can unsubscribe alongside progress.
+        EventHandler bellHandler = (_, _) => BellRang?.Invoke(this, EventArgs.Empty);
+        host.BellRang += bellHandler;
         // Bridge "the last leaf in this tab closed" (e.g. the only shell
         // in this tab exited via `exit`, or libghostty's close-surface
         // callback fired for the sole pane) into a tab-level close. The
@@ -241,6 +249,7 @@ internal sealed class TabManager
         tab.OnClose = () =>
         {
             host.ProgressChanged -= progressHandler;
+            host.BellRang -= bellHandler;
             host.LastLeafClosed -= lastLeafHandler;
         };
         tab.PropertyChanged += OnTabPropertyChanged;
@@ -352,6 +361,8 @@ internal sealed class TabManager
         tab.PaneHost.LeafFocused += OnLeafFocused;
         EventHandler<TabProgressState> progressHandler = (_, state) => tab.Progress = state;
         tab.PaneHost.ProgressChanged += progressHandler;
+        EventHandler bellHandler = (_, _) => BellRang?.Invoke(this, EventArgs.Empty);
+        tab.PaneHost.BellRang += bellHandler;
         // Re-attach the last-leaf-closed bridge in the adopter's event
         // graph. See CreateTab for why the bridge exists; without it,
         // a tab detached to a new window would no longer close that
@@ -364,6 +375,7 @@ internal sealed class TabManager
         tab.OnClose = () =>
         {
             tab.PaneHost.ProgressChanged -= progressHandler;
+            tab.PaneHost.BellRang -= bellHandler;
             tab.PaneHost.LastLeafClosed -= lastLeafHandler;
         };
         tab.PropertyChanged += OnTabPropertyChanged;

--- a/windows/Ghostty.Core/Taskbar/ITaskbarOverlaySink.cs
+++ b/windows/Ghostty.Core/Taskbar/ITaskbarOverlaySink.cs
@@ -1,0 +1,16 @@
+namespace Ghostty.Core.Taskbar;
+
+/// <summary>
+/// Narrow surface the <see cref="TaskbarAttentionCoordinator"/> writes
+/// to. Implemented in the WinUI project by a facade forwarding to
+/// <c>ITaskbarList3::SetOverlayIcon</c>. Tests use a recording fake.
+///
+/// Pure Ghostty.Core — no WinUI types so the coordinator is unit-
+/// testable without dragging WinAppSDK in.
+/// </summary>
+internal interface ITaskbarOverlaySink
+{
+    /// <summary>Show (<paramref name="active"/> == true) or clear the
+    /// attention overlay badge. Expected to be idempotent.</summary>
+    void SetAttention(bool active);
+}

--- a/windows/Ghostty.Core/Taskbar/TaskbarAttentionCoordinator.cs
+++ b/windows/Ghostty.Core/Taskbar/TaskbarAttentionCoordinator.cs
@@ -1,0 +1,55 @@
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Core.Taskbar;
+
+/// <summary>
+/// Drives the Windows taskbar overlay "attention" badge. The badge is
+/// the Windows equivalent of Ghostty's <c>bell-features = attention</c>
+/// (on by default): request the user's attention when an unfocused
+/// window rings the bell, until the window is refocused.
+///
+/// Pure-logic state machine. <see cref="OnBell"/> is wired to
+/// <see cref="TabManager.BellRang"/>; <see cref="SetFocused"/> is driven
+/// by the window's activation event. The WinUI-side facade writes to
+/// <c>ITaskbarList3::SetOverlayIcon</c>.
+///
+/// State (implicit in two flags):
+///   _focused         — window currently has focus.
+///   _attentionActive — badge currently shown. The guard in OnBell means
+///                      exactly one sink write per attention episode no
+///                      matter how many bells fire.
+/// </summary>
+internal sealed class TaskbarAttentionCoordinator
+{
+    private readonly ITaskbarOverlaySink _sink;
+    private bool _focused;          // false until the first activation
+    private bool _attentionActive;
+
+    public TaskbarAttentionCoordinator(TabManager manager, ITaskbarOverlaySink sink)
+    {
+        _sink = sink;
+        manager.BellRang += (_, _) => OnBell();
+    }
+
+    /// <summary>A bell rang on the active leaf of some owned tab.</summary>
+    public void OnBell()
+    {
+        if (_focused) return;
+        if (_attentionActive) return;
+        _attentionActive = true;
+        _sink.SetAttention(true);
+    }
+
+    /// <summary>Window focus changed. Gaining focus clears any pending
+    /// attention badge; losing focus only records the state (the badge
+    /// appears later, if and when a bell actually rings).</summary>
+    public void SetFocused(bool focused)
+    {
+        _focused = focused;
+        if (focused && _attentionActive)
+        {
+            _attentionActive = false;
+            _sink.SetAttention(false);
+        }
+    }
+}

--- a/windows/Ghostty.Core/Taskbar/TaskbarAttentionCoordinator.cs
+++ b/windows/Ghostty.Core/Taskbar/TaskbarAttentionCoordinator.cs
@@ -11,13 +11,9 @@ namespace Ghostty.Core.Taskbar;
 /// Pure-logic state machine. <see cref="OnBell"/> is wired to
 /// <see cref="TabManager.BellRang"/>; <see cref="SetFocused"/> is driven
 /// by the window's activation event. The WinUI-side facade writes to
-/// <c>ITaskbarList3::SetOverlayIcon</c>.
-///
-/// State (implicit in two flags):
-///   _focused         — window currently has focus.
-///   _attentionActive — badge currently shown. The guard in OnBell means
-///                      exactly one sink write per attention episode no
-///                      matter how many bells fire.
+/// <c>ITaskbarList3::SetOverlayIcon</c>. The <c>_attentionActive</c> guard
+/// keeps it to one sink write per attention episode regardless of how many
+/// bells fire.
 /// </summary>
 internal sealed class TaskbarAttentionCoordinator
 {

--- a/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
+++ b/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
@@ -41,6 +41,9 @@ internal sealed class FakePaneHost : IPaneHost
     public void RaiseProgressChanged(TabProgressState state)
         => ProgressChanged?.Invoke(this, state);
 
+    public event EventHandler? BellRang;
+    public void RaiseBellRang() => BellRang?.Invoke(this, EventArgs.Empty);
+
     public void CloseActive()
     {
         CloseActiveCalls++;

--- a/windows/Ghostty.Tests/Tabs/TabManagerBellTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerBellTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class TabManagerBellTests
+{
+    private static (TabManager mgr, List<FakePaneHost> hosts) NewManager()
+    {
+        var hosts = new List<FakePaneHost>();
+        var mgr = new TabManager(_ =>
+        {
+            var h = new FakePaneHost();
+            hosts.Add(h);
+            return h;
+        });
+        return (mgr, hosts);
+    }
+
+    [Fact]
+    public void PaneHost_bell_is_forwarded_to_manager()
+    {
+        var (mgr, hosts) = NewManager();
+        int count = 0;
+        mgr.BellRang += (_, _) => count++;
+
+        hosts[0].RaiseBellRang();
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Closed_tab_bell_is_not_forwarded()
+    {
+        var (mgr, hosts) = NewManager();
+        mgr.NewTab();              // hosts[1]
+        int count = 0;
+        mgr.BellRang += (_, _) => count++;
+
+        mgr.CloseTab(mgr.Tabs[1]); // unwires hosts[1]
+        hosts[1].RaiseBellRang();
+
+        Assert.Equal(0, count);
+    }
+}

--- a/windows/Ghostty.Tests/Taskbar/FakeTaskbarOverlaySink.cs
+++ b/windows/Ghostty.Tests/Taskbar/FakeTaskbarOverlaySink.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Ghostty.Core.Taskbar;
+
+namespace Ghostty.Tests.Taskbar;
+
+/// <summary>Recording fake for <see cref="ITaskbarOverlaySink"/>.
+/// Stores every <see cref="SetAttention"/> argument in order.</summary>
+internal sealed class FakeTaskbarOverlaySink : ITaskbarOverlaySink
+{
+    public List<bool> Writes { get; } = new();
+    public void SetAttention(bool active) => Writes.Add(active);
+}

--- a/windows/Ghostty.Tests/Taskbar/TaskbarAttentionCoordinatorTests.cs
+++ b/windows/Ghostty.Tests/Taskbar/TaskbarAttentionCoordinatorTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Ghostty.Core.Taskbar;
+using Ghostty.Tests.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Taskbar;
+
+public class TaskbarAttentionCoordinatorTests
+{
+    private static (TabManager mgr, List<FakePaneHost> hosts, FakeTaskbarOverlaySink sink, TaskbarAttentionCoordinator coord) New()
+    {
+        var hosts = new List<FakePaneHost>();
+        var mgr = new TabManager(_ =>
+        {
+            var h = new FakePaneHost();
+            hosts.Add(h);
+            return h;
+        });
+        var sink = new FakeTaskbarOverlaySink();
+        var coord = new TaskbarAttentionCoordinator(mgr, sink);
+        return (mgr, hosts, sink, coord);
+    }
+
+    [Fact]
+    public void No_writes_on_construction()
+    {
+        var (_, _, sink, _) = New();
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
+    public void Bell_while_unfocused_shows_badge()
+    {
+        var (_, hosts, sink, coord) = New();
+        coord.SetFocused(false);
+
+        hosts[0].RaiseBellRang();
+
+        Assert.Equal(new[] { true }, sink.Writes);
+    }
+
+    [Fact]
+    public void Bell_while_focused_does_nothing()
+    {
+        var (_, hosts, sink, coord) = New();
+        coord.SetFocused(true);
+
+        hosts[0].RaiseBellRang();
+
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
+    public void Focus_clears_active_badge()
+    {
+        var (_, hosts, sink, coord) = New();
+        coord.SetFocused(false);
+        hosts[0].RaiseBellRang();
+
+        coord.SetFocused(true);
+
+        Assert.Equal(new[] { true, false }, sink.Writes);
+    }
+
+    [Fact]
+    public void Repeated_bells_coalesce_to_one_show()
+    {
+        var (_, hosts, sink, coord) = New();
+        coord.SetFocused(false);
+
+        hosts[0].RaiseBellRang();
+        hosts[0].RaiseBellRang();
+        hosts[0].RaiseBellRang();
+
+        Assert.Equal(new[] { true }, sink.Writes);
+    }
+
+    [Fact]
+    public void Focus_with_no_pending_attention_does_not_clear()
+    {
+        var (_, _, sink, coord) = New();
+        coord.SetFocused(false);
+        coord.SetFocused(true);
+
+        Assert.Empty(sink.Writes);
+    }
+
+    [Fact]
+    public void Re_arms_after_clear()
+    {
+        var (_, hosts, sink, coord) = New();
+        coord.SetFocused(false);
+        hosts[0].RaiseBellRang();   // true
+        coord.SetFocused(true);     // false
+        coord.SetFocused(false);
+        hosts[0].RaiseBellRang();   // true
+
+        Assert.Equal(new[] { true, false, true }, sink.Writes);
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -183,6 +183,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     }
     internal void RaisePromptReady() => PromptReady?.Invoke(this, EventArgs.Empty);
     internal void RaiseFirstRender() => FirstRender?.Invoke(this, EventArgs.Empty);
+    internal void RaiseBellRang() => BellRang?.Invoke(this, EventArgs.Empty);
 
     // Called on the libghostty thread. Stashes the latest state and
     // enqueues a single UI-thread flush. Coalescing: if libghostty
@@ -306,6 +307,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     public event EventHandler<string>? TitleChanged;
     public event EventHandler? CloseRequested;
     internal event EventHandler<Ghostty.Core.Tabs.TabProgressState>? ProgressChanged;
+
+    /// <summary>Raised when libghostty rings the bell for this surface
+    /// (ring-bell action). PaneHost forwards the active leaf's bell up
+    /// to the window-level taskbar attention badge.</summary>
+    internal event EventHandler? BellRang;
 
     /// <summary>Raised when the shell prompt becomes interactive (OSC 133;B).
     /// The first such event per surface marks the shell as responsive.</summary>
@@ -545,6 +551,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         ProgressChanged = null;
         PromptReady = null;
         FirstRender = null;
+        BellRang = null;
     }
 
     private static IntPtr AllocEmptyUtf8()

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -625,7 +625,16 @@ internal sealed class GhosttyHost : IDisposable
 
                 case GhosttyActionTag.RingBell:
                 {
+                    // Audible system bell rings immediately on the
+                    // libghostty thread; the attention badge is a UI
+                    // concern, so hop to the UI thread to resolve the
+                    // owning surface and raise BellRang.
                     PInvoke.MessageBeep(MESSAGEBOX_STYLE.MB_OK);
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                            c.RaiseBellRang();
+                    });
                     return 1;
                 }
 

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -47,6 +47,18 @@ SYSTEM_METRICS_INDEX
 // gdi32 - CreateSolidBrush and SetClassLongPtr are not in CsWin32
 // 0.3.269 metadata for this platform target; hand-written in MainWindow.
 
+// gdi32 / shell - taskbar overlay attention icon (AttentionOverlayIcon)
+CreateDIBSection
+CreateBitmap
+CreateIconIndirect
+DeleteObject
+DestroyIcon
+GetDC
+ReleaseDC
+ICONINFO
+BITMAPV5HEADER
+DIB_USAGE
+
 // dwmapi
 DwmSetWindowAttribute
 DWMWINDOWATTRIBUTE

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -160,6 +160,26 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     private void OnActiveLeafProgressChanged(object? sender, Ghostty.Core.Tabs.TabProgressState state)
         => ProgressChanged?.Invoke(this, state);
 
+    /// <summary>Raised when the active leaf's terminal rings the bell.
+    /// Rewired across leaf-focus changes, mirroring
+    /// <see cref="ProgressChanged"/>.</summary>
+    public event EventHandler? BellRang;
+
+    private TerminalControl? _bellBoundTerminal;
+
+    private void BindActiveLeafBell()
+    {
+        var next = _activeLeaf.Terminal();
+        if (ReferenceEquals(next, _bellBoundTerminal)) return;
+        if (_bellBoundTerminal is not null)
+            _bellBoundTerminal.BellRang -= OnActiveLeafBellRang;
+        _bellBoundTerminal = next;
+        next.BellRang += OnActiveLeafBellRang;
+    }
+
+    private void OnActiveLeafBellRang(object? sender, EventArgs e)
+        => BellRang?.Invoke(this, EventArgs.Empty);
+
     /// <summary>
     /// Raised when the last leaf in the tree closes. The owning
     /// <c>TabManager</c> subscribes and routes to
@@ -315,6 +335,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         Loaded += (_, _) =>
         {
             BindActiveLeafProgress();
+            BindActiveLeafBell();
             LeafFocused?.Invoke(this, _activeLeaf);
             // Evict expired undo entries ~once a second; dispose any shell
             // that is no longer reachable from the live tree or history.
@@ -327,8 +348,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
                     TimeSpan.FromSeconds(1),
                     TimeSpan.FromSeconds(1));
         };
-        // Rebind progress whenever the active leaf changes later.
-        LeafFocused += (_, _) => BindActiveLeafProgress();
+        // Rebind progress and bell whenever the active leaf changes later.
+        LeafFocused += (_, _) => { BindActiveLeafProgress(); BindActiveLeafBell(); };
     }
 
     // Public operations -------------------------------------------------
@@ -509,6 +530,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // must always be dropped. Matches TerminalControl.DisposeSurface.
         LeafFocused = null;
         ProgressChanged = null;
+        BellRang = null;
         LastLeafClosed = null;
     }
 

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -171,8 +171,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     {
         var next = _activeLeaf.Terminal();
         if (ReferenceEquals(next, _bellBoundTerminal)) return;
-        if (_bellBoundTerminal is not null)
-            _bellBoundTerminal.BellRang -= OnActiveLeafBellRang;
+        _bellBoundTerminal?.BellRang -= OnActiveLeafBellRang;
         _bellBoundTerminal = next;
         next.BellRang += OnActiveLeafBellRang;
     }

--- a/windows/Ghostty/Shell/TaskbarHost.cs
+++ b/windows/Ghostty/Shell/TaskbarHost.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace Ghostty.Shell;
 
@@ -45,9 +47,13 @@ internal sealed class TaskbarHost : IDisposable
             _overlayFacade = new TaskbarOverlayFacade(hwnd);
             _attention = new TaskbarAttentionCoordinator(tabs, _overlayFacade);
             _window = window;
-            // Window focus drives the attention badge: gaining focus
-            // clears it, an unfocused bell sets it. Activated fires on
-            // every focus transition (Deactivated vs *Activated).
+            // Window focus drives the attention badge: an unfocused bell
+            // sets it, regaining focus clears it. Seed from the current
+            // foreground state so a bell that arrives before the first
+            // Activated event is judged against real focus, not the
+            // coordinator's pessimistic default; Activated then tracks
+            // every later transition.
+            _attention.SetFocused(PInvoke.GetForegroundWindow() == new HWND(hwnd));
             window.Activated += OnWindowActivated;
 
             _tickTimer = window.DispatcherQueue.CreateTimer();

--- a/windows/Ghostty/Shell/TaskbarHost.cs
+++ b/windows/Ghostty/Shell/TaskbarHost.cs
@@ -25,6 +25,9 @@ internal sealed class TaskbarHost : IDisposable
     private readonly TaskbarList3Facade? _facade;
     private readonly TaskbarProgressCoordinator? _coordinator;
     private readonly DispatcherQueueTimer? _tickTimer;
+    private readonly TaskbarOverlayFacade? _overlayFacade;
+    private readonly TaskbarAttentionCoordinator? _attention;
+    private readonly Window? _window;
 
     public bool IsAvailable => _coordinator is not null;
 
@@ -38,6 +41,14 @@ internal sealed class TaskbarHost : IDisposable
                 tabs,
                 _facade,
                 () => DateTime.UtcNow);
+
+            _overlayFacade = new TaskbarOverlayFacade(hwnd);
+            _attention = new TaskbarAttentionCoordinator(tabs, _overlayFacade);
+            _window = window;
+            // Window focus drives the attention badge: gaining focus
+            // clears it, an unfocused bell sets it. Activated fires on
+            // every focus transition (Deactivated vs *Activated).
+            window.Activated += OnWindowActivated;
 
             _tickTimer = window.DispatcherQueue.CreateTimer();
             _tickTimer.Interval = TimeSpan.FromSeconds(2);
@@ -68,9 +79,21 @@ internal sealed class TaskbarHost : IDisposable
         }
     }
 
+    /// <summary>
+    /// Drive the attention badge from window focus. Gaining focus clears
+    /// any pending badge; an unfocused bell sets it.
+    /// </summary>
+    private void OnWindowActivated(object sender, WindowActivatedEventArgs args)
+    {
+        _attention?.SetFocused(
+            args.WindowActivationState != WindowActivationState.Deactivated);
+    }
+
     public void Dispose()
     {
         _tickTimer?.Stop();
+        if (_window is not null) _window.Activated -= OnWindowActivated;
+        _overlayFacade?.Dispose();
     }
 }
 

--- a/windows/Ghostty/Taskbar/AttentionOverlayIcon.cs
+++ b/windows/Ghostty/Taskbar/AttentionOverlayIcon.cs
@@ -13,7 +13,10 @@ namespace Ghostty.Taskbar;
 /// </summary>
 internal static class AttentionOverlayIcon
 {
-    // Opaque accent (early-sunrise amber). Written premultiplied below.
+    // A filled dot reads as a standard corner "attention" badge on the
+    // taskbar button and, unlike FlashWindowEx, stays put until focus
+    // clears it and coexists with the progress indicator on the same
+    // button. Opaque early-sunrise amber, written premultiplied below.
     private const byte ColorR = 0xFF, ColorG = 0x8A, ColorB = 0x1E;
 
     public static unsafe HICON Create()
@@ -96,10 +99,10 @@ internal static class AttentionOverlayIcon
                 double cover = radius - d;
                 double a = cover >= 1 ? 1.0 : cover <= 0 ? 0.0 : cover;
                 byte* px = p + (y * w + x) * 4;
-                px[0] = (byte)(ColorB * a);    // blue (premultiplied)
-                px[1] = (byte)(ColorG * a);    // green
-                px[2] = (byte)(ColorR * a);    // red
-                px[3] = (byte)(0xFF * a);      // alpha
+                px[0] = (byte)(ColorB * a + 0.5);    // blue (premultiplied)
+                px[1] = (byte)(ColorG * a + 0.5);    // green
+                px[2] = (byte)(ColorR * a + 0.5);    // red
+                px[3] = (byte)(0xFF * a + 0.5);      // alpha
             }
         }
     }

--- a/windows/Ghostty/Taskbar/AttentionOverlayIcon.cs
+++ b/windows/Ghostty/Taskbar/AttentionOverlayIcon.cs
@@ -50,7 +50,15 @@ internal static class AttentionOverlayIcon
         {
             PInvoke.ReleaseDC(default, screen);
         }
-        if (color.IsNull || bits is null) return default;
+        if (color.IsNull) return default;
+        if (bits is null)
+        {
+            // CreateDIBSection never hands back a live handle with null
+            // bits in practice, but free it rather than leak the section
+            // if it ever did.
+            PInvoke.DeleteObject(color);
+            return default;
+        }
 
         RasterizeDot((byte*)bits, w, h);
 

--- a/windows/Ghostty/Taskbar/AttentionOverlayIcon.cs
+++ b/windows/Ghostty/Taskbar/AttentionOverlayIcon.cs
@@ -1,0 +1,98 @@
+using System;
+using Windows.Win32;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Ghostty.Taskbar;
+
+/// <summary>
+/// Builds a small filled-dot HICON for the taskbar attention overlay,
+/// sized to the system small-icon metrics. Zero external assets: the
+/// pixels are rasterized into a 32-bpp ARGB DIB section at runtime.
+/// Caller owns the returned HICON and must <c>DestroyIcon</c> it.
+/// </summary>
+internal static class AttentionOverlayIcon
+{
+    // Opaque accent (early-sunrise amber). Written premultiplied below.
+    private const byte ColorR = 0xFF, ColorG = 0x8A, ColorB = 0x1E;
+
+    public static unsafe HICON Create()
+    {
+        int w = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON);
+        int h = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON);
+        if (w <= 0) w = 16;
+        if (h <= 0) h = 16;
+
+        var header = new BITMAPV5HEADER
+        {
+            bV5Size = (uint)sizeof(BITMAPV5HEADER),
+            bV5Width = w,
+            bV5Height = -h,                       // negative => top-down rows
+            bV5Planes = 1,
+            bV5BitCount = 32,
+            bV5Compression = BI_COMPRESSION.BI_BITFIELDS,
+            bV5RedMask = 0x00FF0000,
+            bV5GreenMask = 0x0000FF00,
+            bV5BlueMask = 0x000000FF,
+            bV5AlphaMask = 0xFF000000,
+        };
+
+        void* bits;
+        HDC screen = PInvoke.GetDC(default);
+        HBITMAP color;
+        try
+        {
+            color = PInvoke.CreateDIBSection(
+                screen, (BITMAPINFO*)&header, DIB_USAGE.DIB_RGB_COLORS,
+                out bits, default, 0);
+        }
+        finally
+        {
+            PInvoke.ReleaseDC(default, screen);
+        }
+        if (color.IsNull || bits is null) return default;
+
+        RasterizeDot((byte*)bits, w, h);
+
+        // CreateIconIndirect needs a mask bitmap even for a 32-bpp alpha
+        // color plane; an all-zero monochrome mask leaves the alpha in
+        // charge of the shape.
+        HBITMAP mask = PInvoke.CreateBitmap(w, h, 1, 1, null);
+        var info = new ICONINFO
+        {
+            fIcon = true,
+            hbmMask = mask,
+            hbmColor = color,
+        };
+        HICON icon = PInvoke.CreateIconIndirect(in info);
+
+        // CreateIconIndirect copies the bitmaps; free our originals.
+        if (!color.IsNull) PInvoke.DeleteObject(color);
+        if (!mask.IsNull) PInvoke.DeleteObject(mask);
+        return icon;
+    }
+
+    // Fill a centered, edge-feathered disc into a top-down BGRA buffer
+    // with premultiplied alpha (CreateIconIndirect honors the alpha).
+    private static unsafe void RasterizeDot(byte* p, int w, int h)
+    {
+        double cx = (w - 1) / 2.0, cy = (h - 1) / 2.0;
+        double radius = (w < h ? w : h) / 2.0 - 0.5;
+        for (int y = 0; y < h; y++)
+        {
+            for (int x = 0; x < w; x++)
+            {
+                double dx = x - cx, dy = y - cy;
+                double d = Math.Sqrt(dx * dx + dy * dy);
+                // 1px feather at the edge for anti-aliasing.
+                double cover = radius - d;
+                double a = cover >= 1 ? 1.0 : cover <= 0 ? 0.0 : cover;
+                byte* px = p + (y * w + x) * 4;
+                px[0] = (byte)(ColorB * a);    // blue (premultiplied)
+                px[1] = (byte)(ColorG * a);    // green
+                px[2] = (byte)(ColorR * a);    // red
+                px[3] = (byte)(0xFF * a);      // alpha
+            }
+        }
+    }
+}

--- a/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
@@ -59,6 +59,10 @@ internal sealed class TaskbarOverlayFacade : ITaskbarOverlaySink, IDisposable
         }
         catch (COMException)
         {
+            // Deliberately not logged: this fires on every focus
+            // transition, the indicator is cosmetic, and the sibling
+            // TaskbarList3Facade is likewise logger-free. A failure here
+            // just leaves the badge unchanged until the next bell/focus.
         }
     }
 

--- a/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Ghostty.Core.Taskbar;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -35,16 +36,29 @@ internal sealed class TaskbarOverlayFacade : ITaskbarOverlaySink, IDisposable
 
     public void SetAttention(bool active)
     {
-        if (active)
+        // The overlay badge is a nice-to-have, like the progress
+        // indicator. SetAttention runs on the UI thread off Window.
+        // Activated and the bell path, so a COM failure here must not
+        // bubble into those callbacks and tear the window down — swallow
+        // it and leave the badge in its previous state.
+        try
         {
-            if (_icon.IsNull) _icon = AttentionOverlayIcon.Create();
-            _taskbar.SetOverlayIcon(_hwnd, _icon, OverlayDescription);
+            if (active)
+            {
+                // Create() returns a null HICON on the rare GDI failure;
+                // SetOverlayIcon then just clears, and the next bell retries.
+                if (_icon.IsNull) _icon = AttentionOverlayIcon.Create();
+                _taskbar.SetOverlayIcon(_hwnd, _icon, OverlayDescription);
+            }
+            else
+            {
+                // Null HICON clears the overlay; empty description clears
+                // the accessibility text alongside it.
+                _taskbar.SetOverlayIcon(_hwnd, default, string.Empty);
+            }
         }
-        else
+        catch (COMException)
         {
-            // Null HICON clears the overlay; empty description clears the
-            // accessibility text alongside it.
-            _taskbar.SetOverlayIcon(_hwnd, default, string.Empty);
         }
     }
 

--- a/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
@@ -1,0 +1,59 @@
+using System;
+using Ghostty.Core.Taskbar;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Shell;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Ghostty.Taskbar;
+
+/// <summary>
+/// Real implementation of <see cref="ITaskbarOverlaySink"/>. CoCreates
+/// an <see cref="ITaskbarList3"/>, calls HrInit once, and forwards
+/// attention writes to <c>SetOverlayIcon</c> against the window's HWND.
+/// The dot HICON is built lazily on first show and cached for the
+/// lifetime of the facade.
+///
+/// One facade per window. <see cref="Ghostty.Shell.TaskbarHost"/>
+/// constructs it. Mirrors <see cref="TaskbarList3Facade"/>.
+/// </summary>
+internal sealed class TaskbarOverlayFacade : ITaskbarOverlaySink, IDisposable
+{
+    // Accessibility text surfaced by screen readers on the overlay.
+    private const string OverlayDescription = "Bell";
+
+    private readonly HWND _hwnd;
+    private readonly ITaskbarList3 _taskbar;
+    private HICON _icon;
+
+    public TaskbarOverlayFacade(IntPtr hwnd)
+    {
+        _hwnd = new HWND(hwnd);
+        _taskbar = TaskbarList.CreateInstance<ITaskbarList3>();
+        _taskbar.HrInit();
+    }
+
+    public void SetAttention(bool active)
+    {
+        if (active)
+        {
+            if (_icon.IsNull) _icon = AttentionOverlayIcon.Create();
+            _taskbar.SetOverlayIcon(_hwnd, _icon, OverlayDescription);
+        }
+        else
+        {
+            // Null HICON clears the overlay; empty description clears the
+            // accessibility text alongside it.
+            _taskbar.SetOverlayIcon(_hwnd, default, string.Empty);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!_icon.IsNull)
+        {
+            PInvoke.DestroyIcon(_icon);
+            _icon = default;
+        }
+    }
+}


### PR DESCRIPTION
Adds a taskbar overlay badge that lights up when an unfocused window rings the bell, and clears when the window regains focus. This is the Windows equivalent of `bell-features = attention` (which bounces the dock on macOS).

Mirrors the existing taskbar progress spine: a pure-logic `TaskbarAttentionCoordinator` in Ghostty.Core writes to a narrow `ITaskbarOverlaySink`; a WinUI facade forwards to `ITaskbarList3::SetOverlayIcon`. The bell flows surface -> PaneHost -> TabManager -> coordinator the same way progress does; window focus drives it from `Window.Activated`. The badge is a small amber dot rasterized at runtime via GDI (no assets, AOT-safe).

Ungated, consistent with the taskbar progress indicator.

Tested: unit tests cover the coordinator state machine and the bell forwarding through TabManager. In-app, the badge appears on the taskbar button when a backgrounded window rings the bell, clears when the window is focused, and coexists with the progress bar.