### PR TITLE
Session and window-state restoration on Windows

### DIFF
--- a/windows/Ghostty.Core/Hosting/WindowSaveState.cs
+++ b/windows/Ghostty.Core/Hosting/WindowSaveState.cs
@@ -1,0 +1,30 @@
+namespace Ghostty.Core.Hosting;
+
+/// <summary>
+/// Mirrors the core <c>window-save-state</c> config key. <c>Default</c>
+/// restores the previous session only after a clean exit; <c>Always</c>
+/// restores even after a crash; <c>Never</c> disables restoration.
+/// Matches the macOS semantics of the same key.
+/// </summary>
+public enum WindowSaveState
+{
+    Default,
+    Never,
+    Always,
+}
+
+public static class WindowSaveStateExtensions
+{
+    /// <summary>
+    /// Parse a libghostty-formatted enum tag. Unknown/null/blank falls
+    /// back to <see cref="WindowSaveState.Default"/>, matching the
+    /// resilient-to-config-typos philosophy used by the other enum parsers.
+    /// </summary>
+    public static WindowSaveState Parse(string? raw) =>
+        raw?.Trim().ToLowerInvariant() switch
+        {
+            "never" => WindowSaveState.Never,
+            "always" => WindowSaveState.Always,
+            _ => WindowSaveState.Default,
+        };
+}

--- a/windows/Ghostty.Core/Panes/IPaneHost.cs
+++ b/windows/Ghostty.Core/Panes/IPaneHost.cs
@@ -18,6 +18,12 @@ internal interface IPaneHost
     /// <summary>Currently focused leaf, never null after construction.</summary>
     LeafPane ActiveLeaf { get; }
 
+    /// <summary>Root of the split tree (a single leaf when unsplit).</summary>
+    PaneNode RootNode { get; }
+
+    /// <summary>The zoomed leaf, or null when no pane is zoomed.</summary>
+    LeafPane? ZoomedLeaf { get; }
+
     /// <summary>Total number of leaves currently in the tree.</summary>
     int PaneCount { get; }
 
@@ -33,6 +39,13 @@ internal interface IPaneHost
     /// <c>TerminalControl.CurrentProgress</c> but do not drive the
     /// tab-level indicator.</summary>
     event EventHandler<TabProgressState>? ProgressChanged;
+
+    /// <summary>
+    /// Raised after any structural change to the tree (split, close,
+    /// zoom toggle, equalize, resize, undo/redo restore). The session
+    /// manager coalesces this into a debounced persist.
+    /// </summary>
+    event EventHandler? LayoutChanged;
 
     /// <summary>
     /// Split the active leaf with the given orientation. The new leaf

--- a/windows/Ghostty.Core/Session/SessionCapture.cs
+++ b/windows/Ghostty.Core/Session/SessionCapture.cs
@@ -1,0 +1,25 @@
+using Ghostty.Core.Panes;
+
+namespace Ghostty.Core.Session;
+
+/// <summary>
+/// Builds the serializable per-tab record from live pane-tree references.
+/// Pure: the app layer supplies the root/active/zoomed leaves and the
+/// tab's profile id + title.
+/// </summary>
+internal static class SessionCapture
+{
+    public static TabSession CaptureTab(
+        PaneNode root,
+        LeafPane activeLeaf,
+        LeafPane? zoomed,
+        string? profileId,
+        string? userTitle) => new()
+        {
+            ProfileId = profileId,
+            UserTitle = userTitle,
+            Tree = SessionTree.CaptureTree(root),
+            ActiveLeafPath = SessionTree.PathOf(root, activeLeaf),
+            ZoomedLeafPath = zoomed is null ? null : SessionTree.PathOf(root, zoomed),
+        };
+}

--- a/windows/Ghostty.Core/Session/SessionCapture.cs
+++ b/windows/Ghostty.Core/Session/SessionCapture.cs
@@ -9,6 +9,10 @@ namespace Ghostty.Core.Session;
 /// </summary>
 internal static class SessionCapture
 {
+    // Invariant: activeLeaf and zoomed (when non-null) are leaves OF root.
+    // PathOf returns the empty path both for "is root" and "not found", so
+    // passing a foreign node would serialize as the root path; callers only
+    // ever pass live leaves of this tree, so the empty path always means root.
     public static TabSession CaptureTab(
         PaneNode root,
         LeafPane activeLeaf,

--- a/windows/Ghostty.Core/Session/SessionGate.cs
+++ b/windows/Ghostty.Core/Session/SessionGate.cs
@@ -1,0 +1,24 @@
+using Ghostty.Core.Hosting;
+
+namespace Ghostty.Core.Session;
+
+/// <summary>
+/// Decides, from the config key and the last-exit cleanliness, whether to
+/// restore a saved session and whether to persist at all. Matches macOS:
+/// <c>default</c> restores only after a clean exit, <c>always</c> always,
+/// <c>never</c> not.
+/// </summary>
+internal static class SessionGate
+{
+    public static bool ShouldRestore(WindowSaveState state, bool cleanShutdown) =>
+        state switch
+        {
+            WindowSaveState.Never => false,
+            WindowSaveState.Always => true,
+            _ => cleanShutdown, // Default
+        };
+
+    /// <summary>Whether to write session state at all (Never disables persistence).</summary>
+    public static bool ShouldPersist(WindowSaveState state) =>
+        state != WindowSaveState.Never;
+}

--- a/windows/Ghostty.Core/Session/SessionModel.cs
+++ b/windows/Ghostty.Core/Session/SessionModel.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Ghostty.Core.Panes;
+
+namespace Ghostty.Core.Session;
+
+/// <summary>Top-level persisted session. Version guards format changes.</summary>
+internal sealed class SessionState
+{
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// True only when written by the clean app-shutdown path. Mid-session
+    /// (debounced) writes set this false so <c>window-save-state=default</c>
+    /// does not restore after a crash. <c>always</c> ignores this flag.
+    /// </summary>
+    public bool CleanShutdown { get; set; }
+
+    public List<WindowSession> Windows { get; set; } = new();
+}
+
+/// <summary>One non-quake window: geometry + ordered tabs + active tab.</summary>
+internal sealed class WindowSession
+{
+    public WindowGeometry Geometry { get; set; } = new();
+    public int ActiveTabIndex { get; set; }
+    public List<TabSession> Tabs { get; set; } = new();
+}
+
+/// <summary>Mirror of the geometry fields already saved by WindowState.</summary>
+internal sealed class WindowGeometry
+{
+    public int? X { get; set; }
+    public int? Y { get; set; }
+    public int? Width { get; set; }
+    public int? Height { get; set; }
+    public bool Maximized { get; set; }
+}
+
+/// <summary>
+/// One tab: the profile it was opened with, an optional user title
+/// override, the split tree, and the paths of the active/zoomed leaves.
+/// </summary>
+internal sealed class TabSession
+{
+    public string? ProfileId { get; set; }
+    public string? UserTitle { get; set; }
+    public PaneNodeDto Tree { get; set; } = null!;
+
+    /// <summary>Path to the focused leaf (empty = root leaf).</summary>
+    public bool[] ActiveLeafPath { get; set; } = System.Array.Empty<bool>();
+
+    /// <summary>Path to the zoomed leaf, or null if no pane was zoomed.</summary>
+    public bool[]? ZoomedLeafPath { get; set; }
+}
+
+/// <summary>Polymorphic split-tree node. Leaf or split.</summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(LeafDto), "leaf")]
+[JsonDerivedType(typeof(SplitDto), "split")]
+internal abstract class PaneNodeDto { }
+
+internal sealed class LeafDto : PaneNodeDto
+{
+    /// <summary>Profile id to re-resolve at restore; null = legacy/no-profile leaf.</summary>
+    public string? ProfileId { get; set; }
+
+    /// <summary>Replayed verbatim if <see cref="ProfileId"/> no longer resolves.</summary>
+    public LeafCommand? Fallback { get; set; }
+}
+
+internal sealed class SplitDto : PaneNodeDto
+{
+    public PaneOrientation Orientation { get; set; }
+    public double Ratio { get; set; } = 0.5;
+    public PaneNodeDto Child1 { get; set; } = null!;
+    public PaneNodeDto Child2 { get; set; } = null!;
+}
+
+/// <summary>Minimal command snapshot to spawn a shell without a profile.</summary>
+internal sealed class LeafCommand
+{
+    public string ResolvedCommand { get; set; } = "";
+    public string? WorkingDirectory { get; set; }
+    public string DisplayName { get; set; } = "";
+}
+
+/// <summary>
+/// Source-generated, trim/AOT-safe serialization context (mirrors
+/// WindowStateContext). Reflection STJ would drop properties under the
+/// trimmer.
+/// </summary>
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(SessionState))]
+internal partial class SessionJsonContext : JsonSerializerContext
+{
+}

--- a/windows/Ghostty.Core/Session/SessionModel.cs
+++ b/windows/Ghostty.Core/Session/SessionModel.cs
@@ -16,7 +16,7 @@ internal sealed class SessionState
     /// </summary>
     public bool CleanShutdown { get; set; }
 
-    public List<WindowSession> Windows { get; set; } = new();
+    public List<WindowSession> Windows { get; set; } = [];
 }
 
 /// <summary>One non-quake window: geometry + ordered tabs + active tab.</summary>
@@ -24,7 +24,7 @@ internal sealed class WindowSession
 {
     public WindowGeometry Geometry { get; set; } = new();
     public int ActiveTabIndex { get; set; }
-    public List<TabSession> Tabs { get; set; } = new();
+    public List<TabSession> Tabs { get; set; } = [];
 }
 
 /// <summary>Mirror of the geometry fields already saved by WindowState.</summary>
@@ -48,7 +48,7 @@ internal sealed class TabSession
     public PaneNodeDto Tree { get; set; } = null!;
 
     /// <summary>Path to the focused leaf (empty = root leaf).</summary>
-    public bool[] ActiveLeafPath { get; set; } = System.Array.Empty<bool>();
+    public bool[] ActiveLeafPath { get; set; } = [];
 
     /// <summary>Path to the zoomed leaf, or null if no pane was zoomed.</summary>
     public bool[]? ZoomedLeafPath { get; set; }

--- a/windows/Ghostty.Core/Session/SessionProfileResolver.cs
+++ b/windows/Ghostty.Core/Session/SessionProfileResolver.cs
@@ -1,0 +1,47 @@
+using Ghostty.Core.Profiles;
+
+namespace Ghostty.Core.Session;
+
+/// <summary>
+/// Turns persisted profile ids back into <see cref="ProfileSnapshot"/>s at
+/// restore time. Pure given an <see cref="IProfileRegistry"/>, so the
+/// fallback policy is unit-testable. Resolution is by exact id only: a
+/// profile that no longer exists does NOT silently become the default
+/// profile -- a leaf falls back to its saved command instead, so a tab that
+/// ran a since-deleted profile re-runs what it was actually running rather
+/// than the user's default shell.
+/// </summary>
+internal static class SessionProfileResolver
+{
+    /// <summary>
+    /// Exact-id resolution: re-resolve a still-existing profile fresh (so
+    /// profile edits take effect), or null if the id is unknown/null.
+    /// </summary>
+    public static ProfileSnapshot? ResolveById(IProfileRegistry? registry, string? profileId)
+    {
+        if (registry is null || profileId is null) return null;
+        var resolved = registry.Resolve(profileId);
+        return resolved is null ? null : ProfileSnapshotStore.From(resolved, registry.Version);
+    }
+
+    /// <summary>
+    /// Per-leaf resolution: the leaf's profile if it still exists, else the
+    /// saved fallback command, else null (legacy no-profile leaf -- the host
+    /// spawns the default shell).
+    /// </summary>
+    public static ProfileSnapshot? ResolveLeaf(IProfileRegistry? registry, LeafDto leaf)
+    {
+        var byId = ResolveById(registry, leaf.ProfileId);
+        if (byId is not null) return byId;
+        if (leaf.Fallback is { } fb)
+            return new ProfileSnapshot(
+                ProfileId: leaf.ProfileId ?? "",
+                Version: 0,
+                ResolvedCommand: fb.ResolvedCommand,
+                WorkingDirectory: fb.WorkingDirectory,
+                DisplayName: fb.DisplayName,
+                Icon: new IconSpec.BundledKey("default"),
+                Visuals: EffectiveVisualOverrides.Empty);
+        return null;
+    }
+}

--- a/windows/Ghostty.Core/Session/SessionSerializer.cs
+++ b/windows/Ghostty.Core/Session/SessionSerializer.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+
+namespace Ghostty.Core.Session;
+
+/// <summary>
+/// String &lt;-&gt; <see cref="SessionState"/> via the source-generated
+/// context. Pure (no file IO) so it is unit-testable; the app's
+/// SessionStore wraps this with file access. Malformed input deserializes
+/// to null so a corrupt session never blocks startup.
+/// </summary>
+internal static class SessionSerializer
+{
+    public static string Serialize(SessionState state) =>
+        JsonSerializer.Serialize(state, SessionJsonContext.Default.SessionState);
+
+    public static SessionState? Deserialize(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return JsonSerializer.Deserialize(json, SessionJsonContext.Default.SessionState);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/windows/Ghostty.Core/Session/SessionTree.cs
+++ b/windows/Ghostty.Core/Session/SessionTree.cs
@@ -75,7 +75,7 @@ internal static class SessionTree
         ArgumentNullException.ThrowIfNull(root);
         ArgumentNullException.ThrowIfNull(target);
         var steps = new List<bool>();
-        return Walk(root, target, steps) ? steps.ToArray() : Array.Empty<bool>();
+        return Walk(root, target, steps) ? steps.ToArray() : [];
 
         static bool Walk(PaneNode node, PaneNode target, List<bool> acc)
         {

--- a/windows/Ghostty.Core/Session/SessionTree.cs
+++ b/windows/Ghostty.Core/Session/SessionTree.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Panes;
+
+namespace Ghostty.Core.Session;
+
+/// <summary>
+/// Pure conversion between the live <see cref="PaneNode"/> tree and the
+/// serializable <see cref="PaneNodeDto"/>, plus leaf-identity paths
+/// (Child1/Child2 step lists) for the active/zoomed leaves. No UI and no
+/// profile resolution -- the caller supplies a leaf factory so the app
+/// layer owns re-resolving a profile id into a
+/// <see cref="Ghostty.Core.Profiles.ProfileSnapshot"/>.
+/// </summary>
+internal static class SessionTree
+{
+    /// <summary>Snapshot the tree structure, recording each leaf's profile id and a fallback command.</summary>
+    public static PaneNodeDto CaptureTree(PaneNode root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        switch (root)
+        {
+            case SplitPane s:
+                return new SplitDto
+                {
+                    Orientation = s.Orientation,
+                    Ratio = s.Ratio,
+                    Child1 = CaptureTree(s.Child1),
+                    Child2 = CaptureTree(s.Child2),
+                };
+            case LeafPane leaf:
+                var snap = leaf.Snapshot;
+                return new LeafDto
+                {
+                    ProfileId = snap?.ProfileId,
+                    Fallback = snap is null
+                        ? null
+                        : new LeafCommand
+                        {
+                            ResolvedCommand = snap.ResolvedCommand,
+                            WorkingDirectory = snap.WorkingDirectory,
+                            DisplayName = snap.DisplayName,
+                        },
+                };
+            default:
+                throw new ArgumentException($"Unknown PaneNode type: {root.GetType()}");
+        }
+    }
+
+    /// <summary>
+    /// Rebuild a <see cref="PaneNode"/> tree from a dto. <paramref name="makeLeaf"/>
+    /// turns a <see cref="LeafDto"/> into a <see cref="LeafPane"/> (the app
+    /// layer re-resolves the profile and sets <see cref="LeafPane.Snapshot"/>;
+    /// <see cref="LeafPane.Tag"/> is left null for the host to populate).
+    /// </summary>
+    public static PaneNode RebuildTree(PaneNodeDto dto, Func<LeafDto, LeafPane> makeLeaf)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        ArgumentNullException.ThrowIfNull(makeLeaf);
+        return dto switch
+        {
+            SplitDto s => new SplitPane(
+                s.Orientation,
+                RebuildTree(s.Child1, makeLeaf),
+                RebuildTree(s.Child2, makeLeaf),
+                Math.Clamp(s.Ratio, SplitPane.MinRatio, SplitPane.MaxRatio)),
+            LeafDto l => makeLeaf(l),
+            _ => throw new ArgumentException($"Unknown PaneNodeDto type: {dto.GetType()}"),
+        };
+    }
+
+    /// <summary>Path of Child1(false)/Child2(true) steps from root to target; empty if target is root.</summary>
+    public static bool[] PathOf(PaneNode root, PaneNode target)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(target);
+        var steps = new List<bool>();
+        return Walk(root, target, steps) ? steps.ToArray() : Array.Empty<bool>();
+
+        static bool Walk(PaneNode node, PaneNode target, List<bool> acc)
+        {
+            if (ReferenceEquals(node, target)) return true;
+            if (node is not SplitPane s) return false;
+            acc.Add(false);
+            if (Walk(s.Child1, target, acc)) return true;
+            acc[^1] = true;
+            if (Walk(s.Child2, target, acc)) return true;
+            acc.RemoveAt(acc.Count - 1);
+            return false;
+        }
+    }
+
+    /// <summary>Resolve a path back to a node, or null if the path does not fit the tree.</summary>
+    public static PaneNode? Resolve(PaneNode root, IReadOnlyList<bool> path)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(path);
+        var node = root;
+        foreach (var goChild2 in path)
+        {
+            if (node is not SplitPane s) return null;
+            node = goChild2 ? s.Child2 : s.Child1;
+        }
+        return node;
+    }
+}

--- a/windows/Ghostty.Tests/Hosting/WindowSaveStateTests.cs
+++ b/windows/Ghostty.Tests/Hosting/WindowSaveStateTests.cs
@@ -1,0 +1,21 @@
+using Ghostty.Core.Hosting;
+using Xunit;
+
+namespace Ghostty.Tests.Hosting;
+
+public class WindowSaveStateTests
+{
+    [Theory]
+    [InlineData("default", WindowSaveState.Default)]
+    [InlineData("never", WindowSaveState.Never)]
+    [InlineData("always", WindowSaveState.Always)]
+    [InlineData("DEFAULT", WindowSaveState.Default)]
+    [InlineData("  always  ", WindowSaveState.Always)]
+    [InlineData("", WindowSaveState.Default)]
+    [InlineData(null, WindowSaveState.Default)]
+    [InlineData("garbage", WindowSaveState.Default)]
+    public void Parse_MapsTagsAndFallsBackToDefault(string? raw, WindowSaveState expected)
+    {
+        Assert.Equal(expected, WindowSaveStateExtensions.Parse(raw));
+    }
+}

--- a/windows/Ghostty.Tests/Session/SessionCaptureTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionCaptureTests.cs
@@ -1,0 +1,39 @@
+using Ghostty.Core.Panes;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Session;
+using Xunit;
+
+namespace Ghostty.Tests.Session;
+
+public class SessionCaptureTests
+{
+    private static LeafPane Leaf(string id) => new()
+    {
+        Snapshot = new ProfileSnapshot(id, 1, $"{id}.exe", null, id,
+            new IconSpec.BundledKey("default"), EffectiveVisualOverrides.Empty),
+    };
+
+    [Fact]
+    public void CaptureTab_RecordsPathsProfileAndTitle()
+    {
+        var active = Leaf("b");
+        var root = new SplitPane(PaneOrientation.Vertical, Leaf("a"), active, ratio: 0.5);
+
+        var tab = SessionCapture.CaptureTab(root, active, zoomed: active, profileId: "p1", userTitle: "T");
+
+        Assert.Equal("p1", tab.ProfileId);
+        Assert.Equal("T", tab.UserTitle);
+        Assert.Equal(new[] { true }, tab.ActiveLeafPath);
+        Assert.Equal(new[] { true }, tab.ZoomedLeafPath);
+        Assert.IsType<SplitDto>(tab.Tree);
+    }
+
+    [Fact]
+    public void CaptureTab_NoZoom_LeavesZoomPathNull()
+    {
+        var only = Leaf("solo");
+        var tab = SessionCapture.CaptureTab(only, only, zoomed: null, profileId: null, userTitle: null);
+        Assert.Null(tab.ZoomedLeafPath);
+        Assert.Empty(tab.ActiveLeafPath);
+    }
+}

--- a/windows/Ghostty.Tests/Session/SessionGateTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionGateTests.cs
@@ -1,0 +1,28 @@
+using Ghostty.Core.Hosting;
+using Ghostty.Core.Session;
+using Xunit;
+
+namespace Ghostty.Tests.Session;
+
+public class SessionGateTests
+{
+    [Theory]
+    [InlineData(WindowSaveState.Never, true, false)]
+    [InlineData(WindowSaveState.Never, false, false)]
+    [InlineData(WindowSaveState.Always, true, true)]
+    [InlineData(WindowSaveState.Always, false, true)]
+    [InlineData(WindowSaveState.Default, true, true)]
+    [InlineData(WindowSaveState.Default, false, false)]
+    public void ShouldRestore(WindowSaveState state, bool cleanShutdown, bool expected)
+    {
+        Assert.Equal(expected, SessionGate.ShouldRestore(state, cleanShutdown));
+    }
+
+    [Fact]
+    public void ShouldPersist_FalseOnlyForNever()
+    {
+        Assert.False(SessionGate.ShouldPersist(WindowSaveState.Never));
+        Assert.True(SessionGate.ShouldPersist(WindowSaveState.Default));
+        Assert.True(SessionGate.ShouldPersist(WindowSaveState.Always));
+    }
+}

--- a/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionProfileResolverTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Session;
+using Xunit;
+
+namespace Ghostty.Tests.Session;
+
+public class SessionProfileResolverTests
+{
+    private sealed class FakeProfileRegistry : IProfileRegistry
+    {
+        private readonly Dictionary<string, ResolvedProfile> _byId = new();
+        public long Version { get; } = 7;
+        public IReadOnlyList<ResolvedProfile> Profiles => new List<ResolvedProfile>(_byId.Values);
+        public IReadOnlyList<ResolvedProfile> HiddenProfiles => Array.Empty<ResolvedProfile>();
+        public string? DefaultProfileId { get; set; }
+        public event Action<IProfileRegistry>? ProfilesChanged { add { } remove { } }
+
+        public void Add(ResolvedProfile p) => _byId[p.Id] = p;
+        public ResolvedProfile? Resolve(string profileId) =>
+            _byId.TryGetValue(profileId, out var p) ? p : null;
+        public Task RefreshDiscoveryAsync(CancellationToken ct) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private static ResolvedProfile Profile(string id, string command) =>
+        new(id, id, command, WorkingDirectory: null, Icon: new IconSpec.BundledKey("default"),
+            TabTitle: id, Visuals: EffectiveVisualOverrides.Empty, ProbeId: null,
+            OrderIndex: 0, IsDefault: false);
+
+    private static LeafDto Leaf(string? profileId, string? fallbackCommand) => new()
+    {
+        ProfileId = profileId,
+        Fallback = fallbackCommand is null ? null
+            : new LeafCommand { ResolvedCommand = fallbackCommand, DisplayName = "fb" },
+    };
+
+    [Fact]
+    public void ResolveById_ExistingProfile_ResolvesFresh()
+    {
+        var reg = new FakeProfileRegistry();
+        reg.Add(Profile("pwsh", "pwsh.exe"));
+
+        var snap = SessionProfileResolver.ResolveById(reg, "pwsh");
+
+        Assert.NotNull(snap);
+        Assert.Equal("pwsh", snap!.ProfileId);
+        Assert.Equal("pwsh.exe", snap.ResolvedCommand);
+        Assert.Equal(7, snap.Version);
+    }
+
+    [Fact]
+    public void ResolveById_RemovedProfile_ReturnsNull_NoDefaultSubstitution()
+    {
+        var reg = new FakeProfileRegistry { DefaultProfileId = "pwsh" };
+        reg.Add(Profile("pwsh", "pwsh.exe"));
+
+        // "gone" no longer resolves; we must NOT silently substitute the default.
+        Assert.Null(SessionProfileResolver.ResolveById(reg, "gone"));
+    }
+
+    [Fact]
+    public void ResolveById_NullIdOrRegistry_ReturnsNull()
+    {
+        Assert.Null(SessionProfileResolver.ResolveById(new FakeProfileRegistry(), null));
+        Assert.Null(SessionProfileResolver.ResolveById(null, "pwsh"));
+    }
+
+    [Fact]
+    public void ResolveLeaf_RemovedProfile_FallsBackToSavedCommand_NotDefault()
+    {
+        var reg = new FakeProfileRegistry { DefaultProfileId = "pwsh" };
+        reg.Add(Profile("pwsh", "pwsh.exe"));
+
+        // Leaf ran a since-deleted profile; it must re-run its saved command,
+        // not the user's default shell.
+        var snap = SessionProfileResolver.ResolveLeaf(reg, Leaf("deleted", "cmd.exe /k echo hi"));
+
+        Assert.NotNull(snap);
+        Assert.Equal("cmd.exe /k echo hi", snap!.ResolvedCommand);
+    }
+
+    [Fact]
+    public void ResolveLeaf_ExistingProfile_PrefersFreshOverFallback()
+    {
+        var reg = new FakeProfileRegistry();
+        reg.Add(Profile("pwsh", "pwsh.exe"));
+
+        var snap = SessionProfileResolver.ResolveLeaf(reg, Leaf("pwsh", "stale.exe"));
+
+        Assert.Equal("pwsh.exe", snap!.ResolvedCommand);
+    }
+
+    [Fact]
+    public void ResolveLeaf_NoProfileNoFallback_ReturnsNull()
+    {
+        Assert.Null(SessionProfileResolver.ResolveLeaf(new FakeProfileRegistry(), Leaf(null, null)));
+    }
+}

--- a/windows/Ghostty.Tests/Session/SessionSerializerTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionSerializerTests.cs
@@ -1,0 +1,63 @@
+using Ghostty.Core.Panes;
+using Ghostty.Core.Session;
+using Xunit;
+
+namespace Ghostty.Tests.Session;
+
+public class SessionSerializerTests
+{
+    private static SessionState Sample()
+    {
+        var tree = new SplitDto
+        {
+            Orientation = PaneOrientation.Vertical,
+            Ratio = 0.4,
+            Child1 = new LeafDto { ProfileId = "pwsh", Fallback = new LeafCommand { ResolvedCommand = "pwsh.exe", DisplayName = "PowerShell" } },
+            Child2 = new LeafDto { ProfileId = "cmd", Fallback = new LeafCommand { ResolvedCommand = "cmd.exe", DisplayName = "Command Prompt" } },
+        };
+        return new SessionState
+        {
+            CleanShutdown = true,
+            Windows =
+            {
+                new WindowSession
+                {
+                    Geometry = new WindowGeometry { X = 10, Y = 20, Width = 800, Height = 600, Maximized = false },
+                    ActiveTabIndex = 1,
+                    Tabs =
+                    {
+                        new TabSession { ProfileId = "pwsh", UserTitle = "work", Tree = tree, ActiveLeafPath = new[] { true }, ZoomedLeafPath = new[] { false } },
+                    },
+                },
+            },
+        };
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesEverything()
+    {
+        var json = SessionSerializer.Serialize(Sample());
+        var back = SessionSerializer.Deserialize(json);
+
+        Assert.NotNull(back);
+        Assert.True(back!.CleanShutdown);
+        var w = Assert.Single(back.Windows);
+        Assert.Equal(800, w.Geometry.Width);
+        Assert.Equal(1, w.ActiveTabIndex);
+        var t = Assert.Single(w.Tabs);
+        Assert.Equal("work", t.UserTitle);
+        Assert.Equal(new[] { true }, t.ActiveLeafPath);
+        Assert.Equal(new[] { false }, t.ZoomedLeafPath);
+        var split = Assert.IsType<SplitDto>(t.Tree);
+        Assert.Equal(0.4, split.Ratio, precision: 6);
+        Assert.Equal("pwsh", Assert.IsType<LeafDto>(split.Child1).ProfileId);
+        Assert.Equal("cmd.exe", Assert.IsType<LeafDto>(split.Child2).Fallback!.ResolvedCommand);
+    }
+
+    [Fact]
+    public void Deserialize_Garbage_ReturnsNull()
+    {
+        Assert.Null(SessionSerializer.Deserialize("{ not json"));
+        Assert.Null(SessionSerializer.Deserialize(""));
+    }
+}

--- a/windows/Ghostty.Tests/Session/SessionTreeTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionTreeTests.cs
@@ -82,4 +82,36 @@ public class SessionTreeTests
         // Path too deep for this tree.
         Assert.Null(SessionTree.Resolve(root, new[] { true, true, true }));
     }
+
+    [Fact]
+    public void Resolve_PartialPath_ReturnsInteriorSplit()
+    {
+        // A path that stops above a leaf resolves to a SplitPane, not a leaf.
+        // SessionRestorer relies on `Resolve(...) as LeafPane ?? FirstLeaf`,
+        // so this must be a non-leaf node (cast yields null -> fallback).
+        var inner = new SplitPane(PaneOrientation.Horizontal, Leaf("a"), Leaf("b"), ratio: 0.5);
+        var root = new SplitPane(PaneOrientation.Vertical, Leaf("x"), inner, ratio: 0.5);
+
+        var node = SessionTree.Resolve(root, new[] { true }); // -> inner split
+        Assert.IsType<SplitPane>(node);
+        Assert.Null(node as LeafPane);
+    }
+
+    [Theory]
+    [InlineData(1.5, SplitPane.MaxRatio)]
+    [InlineData(-0.2, SplitPane.MinRatio)]
+    [InlineData(0.99, SplitPane.MaxRatio)]
+    public void RebuildTree_ClampsOutOfRangeRatio(double persisted, double expected)
+    {
+        var dto = new SplitDto
+        {
+            Orientation = PaneOrientation.Vertical,
+            Ratio = persisted,
+            Child1 = new LeafDto { ProfileId = "a" },
+            Child2 = new LeafDto { ProfileId = "b" },
+        };
+
+        var rebuilt = (SplitPane)SessionTree.RebuildTree(dto, d => new LeafPane { Snapshot = Snap(d.ProfileId!) });
+        Assert.Equal(expected, rebuilt.Ratio, precision: 6);
+    }
 }

--- a/windows/Ghostty.Tests/Session/SessionTreeTests.cs
+++ b/windows/Ghostty.Tests/Session/SessionTreeTests.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using Ghostty.Core.Panes;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Session;
+using Xunit;
+
+namespace Ghostty.Tests.Session;
+
+public class SessionTreeTests
+{
+    private static LeafPane Leaf(string profileId) =>
+        new() { Snapshot = Snap(profileId) };
+
+    private static ProfileSnapshot Snap(string id) =>
+        new(id, 1, $"{id}.exe", $"C:\\wd\\{id}", id, new IconSpec.BundledKey("default"),
+            EffectiveVisualOverrides.Empty);
+
+    [Fact]
+    public void CaptureThenRebuild_PreservesStructureRatiosAndProfiles()
+    {
+        // (a | (b - c)) with non-default ratios
+        var inner = new SplitPane(PaneOrientation.Horizontal, Leaf("b"), Leaf("c"), ratio: 0.3);
+        var root = new SplitPane(PaneOrientation.Vertical, Leaf("a"), inner, ratio: 0.7);
+
+        var dto = SessionTree.CaptureTree(root);
+        var rebuilt = SessionTree.RebuildTree(dto, d => new LeafPane { Snapshot = Snap(d.ProfileId!) });
+
+        var outer = Assert.IsType<SplitPane>(rebuilt);
+        Assert.Equal(PaneOrientation.Vertical, outer.Orientation);
+        Assert.Equal(0.7, outer.Ratio, precision: 6);
+        var inner2 = Assert.IsType<SplitPane>(outer.Child2);
+        Assert.Equal(PaneOrientation.Horizontal, inner2.Orientation);
+        Assert.Equal(0.3, inner2.Ratio, precision: 6);
+
+        var ids = PaneTree.Leaves(rebuilt).Select(l => l.Snapshot!.ProfileId).ToArray();
+        Assert.Equal(new[] { "a", "b", "c" }, ids);
+    }
+
+    [Fact]
+    public void CaptureLeaf_StoresProfileIdAndFallbackCommand()
+    {
+        var dto = Assert.IsType<LeafDto>(SessionTree.CaptureTree(Leaf("pwsh")));
+        Assert.Equal("pwsh", dto.ProfileId);
+        Assert.Equal("pwsh.exe", dto.Fallback!.ResolvedCommand);
+        Assert.Equal("C:\\wd\\pwsh", dto.Fallback.WorkingDirectory);
+        Assert.Equal("pwsh", dto.Fallback.DisplayName);
+    }
+
+    [Fact]
+    public void CaptureLeaf_NullSnapshot_YieldsNullProfileAndFallback()
+    {
+        var dto = Assert.IsType<LeafDto>(SessionTree.CaptureTree(new LeafPane()));
+        Assert.Null(dto.ProfileId);
+        Assert.Null(dto.Fallback);
+    }
+
+    [Fact]
+    public void PathOf_AndResolve_RoundTrip()
+    {
+        var b = Leaf("b");
+        var inner = new SplitPane(PaneOrientation.Horizontal, Leaf("a"), b, ratio: 0.5);
+        var root = new SplitPane(PaneOrientation.Vertical, Leaf("x"), inner, ratio: 0.5);
+
+        var path = SessionTree.PathOf(root, b);
+        Assert.Equal(new[] { true, true }, path); // Child2 -> Child2
+
+        Assert.Same(b, SessionTree.Resolve(root, path));
+    }
+
+    [Fact]
+    public void PathOf_RootLeaf_IsEmpty()
+    {
+        var only = Leaf("solo");
+        Assert.Empty(SessionTree.PathOf(only, only));
+        Assert.Same(only, SessionTree.Resolve(only, System.Array.Empty<bool>()));
+    }
+
+    [Fact]
+    public void Resolve_StalePath_ReturnsNull()
+    {
+        var root = new SplitPane(PaneOrientation.Vertical, Leaf("a"), Leaf("b"), ratio: 0.5);
+        // Path too deep for this tree.
+        Assert.Null(SessionTree.Resolve(root, new[] { true, true, true }));
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
+++ b/windows/Ghostty.Tests/Tabs/FakePaneHost.cs
@@ -18,6 +18,8 @@ namespace Ghostty.Tests.Tabs;
 internal sealed class FakePaneHost : IPaneHost
 {
     public LeafPane ActiveLeaf { get; } = new LeafPane();
+    public PaneNode RootNode => ActiveLeaf;
+    public LeafPane? ZoomedLeaf => null;
     public int PaneCount { get; private set; } = 1;
     public int CloseActiveCalls { get; private set; }
     public int DisposeAllCalls { get; private set; }
@@ -37,6 +39,7 @@ internal sealed class FakePaneHost : IPaneHost
     public event EventHandler<LeafPane>? LeafFocused;
     public event EventHandler? LastLeafClosed;
     public event EventHandler<TabProgressState>? ProgressChanged;
+    public event EventHandler? LayoutChanged { add { } remove { } }
 
     public void RaiseProgressChanged(TabProgressState state)
         => ProgressChanged?.Invoke(this, state);

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -62,6 +62,7 @@ public partial class App : Application
     // works from anywhere in the process and the hidden window stays
     // alive across regular window close/reopen cycles.
     private MainWindow? _quakeWindow;
+    private Ghostty.Session.SessionManager? _sessionManager;
     private Ghostty.Hosting.WindowsGlobalHotKey? _quakeHotKey;
     private Ghostty.Hosting.WindowsSystemMenuHook? _systemMenuHook;
     // Reentrancy guard for the Alt+Space system menu: TrackPopupMenu runs
@@ -93,6 +94,7 @@ public partial class App : Application
     internal static GhosttyHost? BootstrapHost { get; private set; }
     internal static ConfigService? ConfigService { get; private set; }
     internal static Ghostty.Core.Profiles.IProfileRegistry? ProfileRegistry { get; private set; }
+    internal static Ghostty.Session.SessionManager? SessionManager { get; private set; }
     internal static Ghostty.Core.Input.IModifierKeyState? ModifierKeyState { get; private set; }
     internal static Ghostty.Core.Profiles.IIconResolver? IconResolver { get; private set; }
 
@@ -596,9 +598,36 @@ public partial class App : Application
             System.Diagnostics.Debug.WriteLine($"[app] protocol activation probe failed: {ex.Message}");
         }
 
-        var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor, factory);
-        window.Closed += OnAnyWindowClosedInternal;
-        window.Activate();
+        // Session manager: owns restore decision + debounced persistence.
+        // Constructed before window creation so we can decide whether to
+        // rebuild a saved session or open a single default window.
+        _sessionManager = new Ghostty.Session.SessionManager(
+            new Ghostty.Session.SessionStore(
+                factory.CreateLogger<Ghostty.Session.SessionStore>()),
+            _configService,
+            DispatcherQueue.GetForCurrentThread(),
+            () => AllWindows);
+        SessionManager = _sessionManager;
+
+        var restoreState = _sessionManager.LoadForRestore();
+        if (restoreState is { Windows.Count: > 0 })
+        {
+            foreach (var ws in restoreState.Windows)
+            {
+                var restored = new MainWindow(
+                    _configService, _bootstrapHost, _lifetimeSupervisor, factory, ws);
+                restored.Closed += OnAnyWindowClosedInternal;
+                _sessionManager.Track(restored);
+                restored.Activate();
+            }
+        }
+        else
+        {
+            var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor, factory);
+            window.Closed += OnAnyWindowClosedInternal;
+            _sessionManager.Track(window);
+            window.Activate();
+        }
 
         // Singleton quake / drop-down window. Created hidden; summoned
         // by the global hotkey via WindowsGlobalHotKey. Same MainWindow
@@ -783,13 +812,24 @@ public partial class App : Application
         // here. By the time Window.Closed fires in WinUI 3, Content may
         // already have a null XamlRoot, so re-reading would silently
         // skip the removal and leak the entry.
-        if (sender is MainWindow w && w.RegisteredRoot is { } root)
+        var closing = sender as MainWindow;
+        if (closing is { RegisteredRoot: { } root })
             WindowsByRoot.Remove(root);
+
+        // A non-last window closed: refresh the persisted set so the closed
+        // window drops out (debounced; the app keeps running).
+        if (WindowsByRoot.Count > 0)
+            _sessionManager?.RequestPersist();
 
         if (WindowsByRoot.Count == 0)
         {
             try
             {
+                // Final clean-shutdown write while the closing window's panes
+                // are still alive (teardown happens below). Marks the session
+                // clean so window-save-state=default restores it next launch.
+                _sessionManager?.FinalizeCleanShutdown(closing);
+
                 // Stop config reloads FIRST, before anything below frees the
                 // libghostty app or the DX12 renderer. A debounced reload
                 // from a last-moment config change (e.g. a window-theme

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -629,6 +629,12 @@ public partial class App : Application
             window.Activate();
         }
 
+        // Persist the just-created window set with CleanShutdown=false. This
+        // arms the dirty flag at startup: a stale CleanShutdown=true left by
+        // the previous clean exit would otherwise let `default` wrongly
+        // restore if this run crashes before the first layout change.
+        _sessionManager.PersistLiveWindows();
+
         // Singleton quake / drop-down window. Created hidden; summoned
         // by the global hotkey via WindowsGlobalHotKey. Same MainWindow
         // class as a regular window, just with IsQuickTerminal = true
@@ -816,10 +822,12 @@ public partial class App : Application
         if (closing is { RegisteredRoot: { } root })
             WindowsByRoot.Remove(root);
 
-        // A non-last window closed: refresh the persisted set so the closed
-        // window drops out (debounced; the app keeps running).
-        if (WindowsByRoot.Count > 0)
-            _sessionManager?.RequestPersist();
+        // A deliberately-closed (non-last) window is left in the persisted
+        // set on purpose: we cannot tell a single close apart from the first
+        // close of a multi-window quit, so we never shrink the set on close
+        // (that would lose windows on a slow quit cascade). It self-heals out
+        // on the next layout/tab/move change in a surviving window. Biasing to
+        // "never lose a window" over "never restore a closed one".
 
         if (WindowsByRoot.Count == 0)
         {

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -629,12 +629,6 @@ public partial class App : Application
             window.Activate();
         }
 
-        // Persist the just-created window set with CleanShutdown=false. This
-        // arms the dirty flag at startup: a stale CleanShutdown=true left by
-        // the previous clean exit would otherwise let `default` wrongly
-        // restore if this run crashes before the first layout change.
-        _sessionManager.PersistLiveWindows();
-
         // Singleton quake / drop-down window. Created hidden; summoned
         // by the global hotkey via WindowsGlobalHotKey. Same MainWindow
         // class as a regular window, just with IsQuickTerminal = true

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -816,6 +816,10 @@ public partial class App : Application
         if (closing is { RegisteredRoot: { } root })
             WindowsByRoot.Remove(root);
 
+        // Detach this window's session-persistence subscriptions.
+        if (closing is not null)
+            _sessionManager?.Untrack(closing);
+
         // A deliberately-closed (non-last) window is left in the persisted
         // set on purpose: we cannot tell a single close apart from the first
         // close of a multi-window quit, so we never shrink the set on close

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -69,4 +69,12 @@ internal static class LogEvents
         public const int CheatSheetShowFailed = 2602;
         public const int CheatSheetExportFailed = 2603;
     }
+
+    // 2700-2799: Session restoration
+    internal static class Session
+    {
+        public const int LoadFailed   = 2700;
+        public const int SaveFailed   = 2701;
+        public const int DeleteFailed = 2702;
+    }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -886,6 +886,10 @@ public sealed partial class MainWindow : Window
         var newWindow = CreateForNewTab(
             _configService, bootstrap, supervisor, loggerFactory, snapshot);
         newWindow.Closed += ((App)Application.Current).OnAnyWindowClosedInternal;
+        // Track for session persistence (mirrors App.OnLaunched) so a window
+        // opened mid-session is captured and restored.
+        App.SessionManager?.Track(newWindow);
+        App.SessionManager?.RequestPersist();
         newWindow.Activate();
     }
 
@@ -973,6 +977,10 @@ public sealed partial class MainWindow : Window
         // handler. WindowsByRoot insertion happens inside the new
         // window's own Content.Loaded handler.
         newWindow.Closed += ((App)Application.Current).OnAnyWindowClosedInternal;
+        // Track for session persistence so a detached-to-new-window tab is
+        // captured and restored.
+        App.SessionManager?.Track(newWindow);
+        App.SessionManager?.RequestPersist();
 
         newWindow.Activate();
     }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -95,6 +95,15 @@ public sealed partial class MainWindow : Window
     private readonly TabManager _tabManager;
     private readonly PaneActionRouter _router;
 
+    /// <summary>This window's tab manager, exposed for session capture.</summary>
+    internal TabManager TabManager => _tabManager;
+
+    /// <summary>
+    /// Raised when this (non-quake) window moves or resizes, so the
+    /// session manager can debounce-persist the new geometry.
+    /// </summary>
+    internal event EventHandler? PositionChanged;
+
     // Static cache so the router's getProfiles lambda does not allocate a
     // fresh empty array on every Ctrl+Shift+N chord when ProfileRegistry is
     // not yet wired (cold-start path) or returns an unset snapshot.
@@ -241,6 +250,22 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Restore ctor: rebuild a window from a saved <paramref name="restore"/>
+    /// session (tabs + split layout + geometry). Used at startup by
+    /// <see cref="App"/> when session restoration is enabled.
+    /// </summary>
+    internal MainWindow(
+        ConfigService configService,
+        GhosttyHost bootstrapHost,
+        HostLifetimeSupervisor supervisor,
+        ILoggerFactory loggerFactory,
+        Ghostty.Core.Session.WindowSession restore)
+        : this(configService, bootstrapHost, supervisor, loggerFactory,
+               seedTab: null, isQuickTerminal: false, restore: restore)
+    {
+    }
+
+    /// <summary>
     /// Full ctor. <paramref name="seedTab"/>, when non-null, is
     /// adopted as the sole initial tab (used by Move Tab to New
     /// Window); when null, the normal "create a fresh tab via the
@@ -259,7 +284,8 @@ public sealed partial class MainWindow : Window
         HostLifetimeSupervisor supervisor,
         ILoggerFactory loggerFactory,
         TabModel? seedTab,
-        bool isQuickTerminal = false)
+        bool isQuickTerminal = false,
+        Ghostty.Core.Session.WindowSession? restore = null)
     {
         InitializeComponent();
 
@@ -382,16 +408,45 @@ public sealed partial class MainWindow : Window
         _themePreview.ListThemesRequested += OnListThemesRequested;
 
         _factory = new PaneHostFactory(_host, configService);
-        _tabManager = new TabManager(
-            snapshot => _factory.Create(snapshot),
-            seed: seedTab);
+        // Restore a saved session into this window when one was passed and
+        // it rebuilds at least one tab; otherwise fall through to the normal
+        // "fresh tab (or seedTab) via the factory" path.
+        List<TabModel>? restoredTabs = null;
+        if (restore is { Tabs.Count: > 0 })
+        {
+            var restorer = new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry);
+            var built = restorer.BuildTabs(restore);
+            if (built.Count > 0) restoredTabs = built;
+        }
+
+        if (restoredTabs is not null)
+        {
+            _tabManager = new TabManager(
+                snapshot => _factory.Create(snapshot),
+                seed: restoredTabs[0]);
+            for (int i = 1; i < restoredTabs.Count; i++)
+                _tabManager.AdoptTab(restoredTabs[i]);
+            if (restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
+                _tabManager.ActivateIndex(restore.ActiveTabIndex);
+        }
+        else
+        {
+            _tabManager = new TabManager(
+                snapshot => _factory.Create(snapshot),
+                seed: seedTab);
+        }
         _router = new PaneActionRouter(
             _tabManager,
             getProfiles: () => App.ProfileRegistry?.Profiles ?? EmptyProfiles,
             openProfile: OpenProfile,
             bindingAction: ExecuteBindingAction);
         _windowState = WindowState.Load();
-        RestoreWindowPlacement();
+        // Apply the restored window geometry when restoring; otherwise use
+        // the window-state.json fallback placement.
+        if (restoredTabs is not null)
+            ApplyGeometry(restore!.Geometry);
+        else
+            RestoreWindowPlacement();
 
         _horizontalTabHost = new TabHost(_tabManager, _router, _dialogs);
         _horizontalTabHost.AttachOwner(this);
@@ -494,6 +549,8 @@ public sealed partial class MainWindow : Window
             {
                 _quakeSessionHeight = AppWindow.Size.Height;
             }
+            if (!IsQuickTerminal && (args.DidPositionChange || args.DidSizeChange))
+                PositionChanged?.Invoke(this, EventArgs.Empty);
         };
 
         WirePaneActionEvents();
@@ -1017,30 +1074,16 @@ public sealed partial class MainWindow : Window
         }
         else if (AppWindow.Presenter.Kind != Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen)
         {
-            var hwnd = new HWND(WindowNative.GetWindowHandle(this));
-            var style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
-            var isMaximized = (style & WINDOW_STYLE.WS_MAXIMIZE) != 0;
-            _windowState.WindowMaximized = isMaximized;
-
-            // Save the restored (non-maximized) bounds so we don't
-            // persist a maximized rect that fills the whole monitor.
-            if (isMaximized)
-            {
-                var placement = new WINDOWPLACEMENT { length = (uint)Marshal.SizeOf<WINDOWPLACEMENT>() };
-                PInvoke.GetWindowPlacement(hwnd, ref placement);
-                var rc = placement.rcNormalPosition;
-                _windowState.WindowX = rc.left;
-                _windowState.WindowY = rc.top;
-                _windowState.WindowWidth = rc.right - rc.left;
-                _windowState.WindowHeight = rc.bottom - rc.top;
-            }
-            else
-            {
-                _windowState.WindowX = AppWindow.Position.X;
-                _windowState.WindowY = AppWindow.Position.Y;
-                _windowState.WindowWidth = AppWindow.Size.Width;
-                _windowState.WindowHeight = AppWindow.Size.Height;
-            }
+            // Keep writing window-state.json for normal windows: it is the
+            // geometry fallback used by RestoreWindowPlacement when session
+            // restoration is off (window-save-state=never) or no session is
+            // restored. The session file carries geometry for the restore path.
+            var g = CaptureGeometry();
+            _windowState.WindowMaximized = g.Maximized;
+            _windowState.WindowX = g.X;
+            _windowState.WindowY = g.Y;
+            _windowState.WindowWidth = g.Width;
+            _windowState.WindowHeight = g.Height;
             _windowState.Save();
         }
 
@@ -2136,14 +2179,30 @@ public sealed partial class MainWindow : Window
     /// Validates that at least part of the window is visible on a
     /// current monitor (handles monitor disconnects, DPI changes).
     /// </summary>
-    private void RestoreWindowPlacement()
+    private void RestoreWindowPlacement() =>
+        ApplyGeometry(new Ghostty.Core.Session.WindowGeometry
+        {
+            X = _windowState.WindowX,
+            Y = _windowState.WindowY,
+            Width = _windowState.WindowWidth,
+            Height = _windowState.WindowHeight,
+            Maximized = _windowState.WindowMaximized,
+        });
+
+    /// <summary>
+    /// Apply a saved geometry to this window, validating that at least
+    /// part of it is visible on a current monitor (handles monitor
+    /// disconnects, DPI changes). Shared by the window-state.json restore
+    /// path and the session restore path.
+    /// </summary>
+    private void ApplyGeometry(Ghostty.Core.Session.WindowGeometry geometry)
     {
-        var w = _windowState.WindowWidth;
-        var h = _windowState.WindowHeight;
+        var w = geometry.Width;
+        var h = geometry.Height;
         if (w is null || h is null || w < 200 || h < 150) return;
 
-        var x = _windowState.WindowX ?? 0;
-        var y = _windowState.WindowY ?? 0;
+        var x = geometry.X ?? 0;
+        var y = geometry.Y ?? 0;
 
         // Ensure the window's top-left quadrant is on a live monitor.
         // DisplayArea.GetFromPoint returns the nearest display if the
@@ -2165,8 +2224,66 @@ public sealed partial class MainWindow : Window
         AppWindow.Resize(new Windows.Graphics.SizeInt32(w.Value, h.Value));
         AppWindow.Move(new Windows.Graphics.PointInt32(x, y));
 
-        if (_windowState.WindowMaximized)
+        if (geometry.Maximized)
             PInvoke.ShowWindow(new HWND(WindowNative.GetWindowHandle(this)), SHOW_WINDOW_CMD.SW_SHOWMAXIMIZED);
+    }
+
+    /// <summary>
+    /// Capture this window's current placement (restored bounds when
+    /// maximized, so a maximized rect never becomes the saved size).
+    /// </summary>
+    private Ghostty.Core.Session.WindowGeometry CaptureGeometry()
+    {
+        var hwnd = new HWND(WindowNative.GetWindowHandle(this));
+        var style = (WINDOW_STYLE)PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
+        var isMaximized = (style & WINDOW_STYLE.WS_MAXIMIZE) != 0;
+        var g = new Ghostty.Core.Session.WindowGeometry { Maximized = isMaximized };
+        if (isMaximized)
+        {
+            var placement = new WINDOWPLACEMENT { length = (uint)Marshal.SizeOf<WINDOWPLACEMENT>() };
+            PInvoke.GetWindowPlacement(hwnd, ref placement);
+            var rc = placement.rcNormalPosition;
+            g.X = rc.left;
+            g.Y = rc.top;
+            g.Width = rc.right - rc.left;
+            g.Height = rc.bottom - rc.top;
+        }
+        else
+        {
+            g.X = AppWindow.Position.X;
+            g.Y = AppWindow.Position.Y;
+            g.Width = AppWindow.Size.Width;
+            g.Height = AppWindow.Size.Height;
+        }
+        return g;
+    }
+
+    /// <summary>
+    /// Capture this window's geometry + ordered tabs into a serializable
+    /// record, or null for the quake window (never persisted) and
+    /// full-screen windows (no meaningful restore geometry).
+    /// </summary>
+    internal Ghostty.Core.Session.WindowSession? CaptureSession()
+    {
+        if (IsQuickTerminal) return null;
+        if (AppWindow.Presenter.Kind == Microsoft.UI.Windowing.AppWindowPresenterKind.FullScreen)
+            return null;
+
+        var win = new Ghostty.Core.Session.WindowSession
+        {
+            Geometry = CaptureGeometry(),
+            ActiveTabIndex = _tabManager.IndexOf(_tabManager.ActiveTab),
+        };
+        foreach (var tab in _tabManager.Tabs)
+        {
+            win.Tabs.Add(Ghostty.Core.Session.SessionCapture.CaptureTab(
+                tab.PaneHost.RootNode,
+                tab.PaneHost.ActiveLeaf,
+                tab.PaneHost.ZoomedLeaf,
+                tab.ProfileId,
+                tab.UserOverrideTitle));
+        }
+        return win;
     }
 
     /// <summary>

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -64,8 +64,11 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     // a parent Grid is not a sibling of a leaf's chrome and cannot
     // be defeated with Canvas.ZIndex. The overlay sits above
     // everything and is tracked via TransformToVisual on each layout.
-    private readonly Canvas _highlightOverlay;
-    private readonly Rectangle _activeBorderRect;
+    // Assigned once in BuildChrome() (called from every ctor), never
+    // reassigned. Not readonly because BuildChrome is a shared helper
+    // rather than the ctor body itself.
+    private Canvas _highlightOverlay = null!;
+    private Rectangle _activeBorderRect = null!;
     private readonly Dictionary<LeafPane, Rectangle> _dimRects = new();
     private FrameworkElement _treeRoot = null!; // assigned in ctor before use
 
@@ -75,8 +78,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     // hover it swaps to the zoom-out magnifier (action hint: click to
     // restore). Lives permanently in the host Grid above the floated
     // pane, Collapsed except during zoom.
-    private readonly Button _restoreZoomButton;
-    private readonly FontIcon _restoreZoomIcon;
+    private Button _restoreZoomButton = null!;
+    private FontIcon _restoreZoomIcon = null!;
     private const string RestoreZoomGlyphRest = "";  // Zoom (magnifier)
     private const string RestoreZoomGlyphHover = ""; // ZoomOut (magnifier minus)
 
@@ -175,7 +178,18 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     /// </summary>
     public LeafPane ActiveLeaf => _activeLeaf;
 
-    internal PaneNode RootNode => _root;
+    public PaneNode RootNode => _root;
+
+    public LeafPane? ZoomedLeaf => _zoomedLeaf;
+
+    /// <summary>
+    /// Raised after any structural change to the tree (split, close,
+    /// zoom toggle, equalize, resize, undo/redo restore). The session
+    /// manager coalesces this into a debounced persist.
+    /// </summary>
+    public event EventHandler? LayoutChanged;
+
+    private void RaiseLayoutChanged() => LayoutChanged?.Invoke(this, EventArgs.Empty);
 
     /// <summary>
     /// Number of leaves in the tree. Implemented via a tree walk; the
@@ -235,6 +249,91 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         _undoEnabled = policy.Enabled;
         _history = new Core.Panes.PaneHistory(_time, policy.Window);
 
+        BuildChrome();
+
+        // Initial single leaf. Pass the initialSnapshot so the terminal
+        // spawns with the right command/working-directory from OnLoaded.
+        var firstTerminal = CreateTerminal(initialSnapshot);
+        _activeLeaf = new LeafPane { Tag = firstTerminal, Snapshot = initialSnapshot };
+        _root = _activeLeaf;
+
+        // Two-layer host Grid: the actual split tree below, the
+        // highlight overlay above. The overlay Canvas does not
+        // capture pointer events (IsHitTestVisible=false), so the
+        // tree below receives all input normally.
+        var hostGrid = new Grid();
+        _treeRoot = BuildVisual(_root);
+        hostGrid.Children.Add(_treeRoot);
+        hostGrid.Children.Add(_highlightOverlay);
+        hostGrid.Children.Add(_restoreZoomButton);
+        Content = hostGrid;
+
+        WireCommonHandlers();
+    }
+
+    /// <summary>
+    /// Restore-seeded ctor: adopt a pre-built tree instead of a single
+    /// fresh leaf. Leaves must carry their <see cref="LeafPane.Snapshot"/>
+    /// with <see cref="LeafPane.Tag"/> null; this ctor creates each leaf's
+    /// TerminalControl via the same wiring as a live split, then rebuilds
+    /// the visual and re-applies zoom exactly like Undo's RestoreFrom.
+    /// <paramref name="activeLeaf"/> must be a leaf of <paramref name="root"/>;
+    /// <paramref name="zoomedLeaf"/>, when non-null and present in the tree,
+    /// is re-zoomed after the rebuild.
+    /// </summary>
+    public PaneHost(
+        GhosttyHost host,
+        Func<ProfileSnapshot?, TerminalControl> terminalFactory,
+        PaneNode root,
+        LeafPane activeLeaf,
+        LeafPane? zoomedLeaf,
+        Core.Panes.UndoPolicy? undoPolicy = null)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(activeLeaf);
+
+        _host = host;
+        _terminalFactory = terminalFactory;
+        var policy = undoPolicy ?? Core.Panes.UndoPolicy.Default;
+        _undoEnabled = policy.Enabled;
+        _history = new Core.Panes.PaneHistory(_time, policy.Window);
+
+        BuildChrome();
+
+        // Materialize a TerminalControl for every restored leaf via the
+        // same wiring a live split uses, so titles/progress/close-surface
+        // callbacks route correctly. Leaves arrive with Tag null.
+        foreach (var leaf in PaneTree.Leaves(root))
+            leaf.Tag = CreateTerminal(leaf.Snapshot);
+
+        _root = root;
+        _activeLeaf = activeLeaf;
+
+        var hostGrid = new Grid();
+        _treeRoot = BuildVisual(_root);
+        hostGrid.Children.Add(_treeRoot);
+        hostGrid.Children.Add(_highlightOverlay);
+        hostGrid.Children.Add(_restoreZoomButton);
+        Content = hostGrid;
+
+        // Re-enter zoom on the restored leaf via the existing enter-path,
+        // mirroring RestoreFrom. Only if it is still present in the tree.
+        if (zoomedLeaf is not null && PaneTree.Leaves(_root).Contains(zoomedLeaf))
+        {
+            _activeLeaf = zoomedLeaf;
+            ToggleSplitZoom();
+        }
+
+        WireCommonHandlers();
+    }
+
+    /// <summary>
+    /// Build the highlight overlay + restore-from-zoom button chrome.
+    /// Shared by both constructors so the chrome is identical regardless
+    /// of how the initial tree is seeded.
+    /// </summary>
+    private void BuildChrome()
+    {
         _activeBorderRect = new Rectangle
         {
             Stroke = DefaultActiveBorderBrush,
@@ -286,24 +385,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // Resting glyph signals "zoomed"; hover previews the zoom-out action.
         _restoreZoomButton.PointerEntered += (_, _) => _restoreZoomIcon.Glyph = RestoreZoomGlyphHover;
         _restoreZoomButton.PointerExited += (_, _) => _restoreZoomIcon.Glyph = RestoreZoomGlyphRest;
+    }
 
-        // Initial single leaf. Pass the initialSnapshot so the terminal
-        // spawns with the right command/working-directory from OnLoaded.
-        var firstTerminal = CreateTerminal(initialSnapshot);
-        _activeLeaf = new LeafPane { Tag = firstTerminal, Snapshot = initialSnapshot };
-        _root = _activeLeaf;
-
-        // Two-layer host Grid: the actual split tree below, the
-        // highlight overlay above. The overlay Canvas does not
-        // capture pointer events (IsHitTestVisible=false), so the
-        // tree below receives all input normally.
-        var hostGrid = new Grid();
-        _treeRoot = BuildVisual(_root);
-        hostGrid.Children.Add(_treeRoot);
-        hostGrid.Children.Add(_highlightOverlay);
-        hostGrid.Children.Add(_restoreZoomButton);
-        Content = hostGrid;
-
+    /// <summary>
+    /// Wire the layout/focus/prune handlers after Content is set. Shared
+    /// by both constructors.
+    /// </summary>
+    private void WireCommonHandlers()
+    {
         // Reposition the highlight whenever layout settles. Cheap;
         // single TransformToVisual + four set-property calls. Covers
         // window resize, splitter drag, and the post-Split layout
@@ -427,6 +516,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             newTerminal.Focus(FocusState.Programmatic);
             UpdateHighlightPosition();
         });
+
+        RaiseLayoutChanged();
     }
 
     /// <summary>
@@ -629,6 +720,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             _activeLeaf = zoomedBefore;
             ToggleSplitZoom();
         }
+
+        RaiseLayoutChanged();
     }
 
     /// <summary>
@@ -723,6 +816,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // (and needlessly clear redo).
         if (_root is SplitPane) CaptureForUndo(Core.Panes.PaneOpKind.Equalize);
         PaneTree.Equalize(_root);
+        RaiseLayoutChanged();
         // When zoomed, only update the model - unzoom re-applies every
         // ratio to the live tree when the user toggles back.
         if (_zoomedLeaf is not null) return;
@@ -750,6 +844,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // Record the pre-toggle zoom state. No-op while restoring so the
         // re-zoom that RestoreFrom performs is not itself recorded.
         CaptureForUndo(Core.Panes.PaneOpKind.Zoom);
+        RaiseLayoutChanged();
 
         if (_zoomedLeaf is not null)
         {
@@ -881,6 +976,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         {
             _restoring = false;
         }
+
+        RaiseLayoutChanged();
     }
 
     // Hide the restore-from-zoom button and reset its glyph to the
@@ -1049,6 +1146,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // than Rebuild(), which ghosts dividers on deep trees.
         ApplyAllRatios();
         UpdateHighlightPosition();
+        RaiseLayoutChanged();
     }
 
     // Internals ---------------------------------------------------------

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -318,10 +318,20 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
 
         // Re-enter zoom on the restored leaf via the existing enter-path,
         // mirroring RestoreFrom. Only if it is still present in the tree.
+        // _restoring guards CaptureForUndo so the re-zoom is not itself
+        // recorded as an undoable op (same as RestoreFrom).
         if (zoomedLeaf is not null && PaneTree.Leaves(_root).Contains(zoomedLeaf))
         {
-            _activeLeaf = zoomedLeaf;
-            ToggleSplitZoom();
+            _restoring = true;
+            try
+            {
+                _activeLeaf = zoomedLeaf;
+                ToggleSplitZoom();
+            }
+            finally
+            {
+                _restoring = false;
+            }
         }
 
         WireCommonHandlers();

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -75,6 +75,8 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     public string GradientBlend { get; private set; } = "overlay";
     public float GradientOpacity { get; private set; } = 0.05f;
     public string WindowTheme { get; private set; } = "auto";
+    public Ghostty.Core.Hosting.WindowSaveState WindowSaveState { get; private set; }
+        = Ghostty.Core.Hosting.WindowSaveState.Default;
     public uint ForegroundColor { get; private set; } = 0x00FFFFFF;
     public uint BackgroundColor { get; private set; } = 0x001E1E2E;
     public uint? CursorColor { get; private set; }
@@ -593,6 +595,8 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         GradientBlend = GetFileValue("background-gradient-blend", "overlay");
         GradientOpacity = ParseFloat(GetFileValue("background-gradient-opacity", "")) ?? 0.05f;
         WindowTheme = GetString("window-theme", "auto");
+        WindowSaveState = Ghostty.Core.Hosting.WindowSaveStateExtensions.Parse(
+            GetString("window-save-state", "default"));
 
         // For background and foreground we go through GetThemeValue first
         // because libghostty's _config was finalized with the default

--- a/windows/Ghostty/Session/SessionManager.cs
+++ b/windows/Ghostty/Session/SessionManager.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Session;
+using Ghostty.Services;
+using Microsoft.UI.Dispatching;
+
+namespace Ghostty.Session;
+
+/// <summary>
+/// Owns session persistence: a debounced "capture all live windows and
+/// write" triggered by layout/tab/window changes (CleanShutdown=false),
+/// plus a final clean write on app shutdown (CleanShutdown=true). Decides
+/// at startup whether to restore. UI-thread affine.
+/// </summary>
+internal sealed class SessionManager
+{
+    private readonly SessionStore _store;
+    private readonly ConfigService _config;
+    private readonly DispatcherQueue _dispatcher;
+    private readonly Func<IEnumerable<MainWindow>> _windows;
+    private DispatcherQueueTimer? _debounce;
+
+    public SessionManager(
+        SessionStore store,
+        ConfigService config,
+        DispatcherQueue dispatcher,
+        Func<IEnumerable<MainWindow>> windows)
+    {
+        _store = store;
+        _config = config;
+        _dispatcher = dispatcher;
+        _windows = windows;
+    }
+
+    /// <summary>Load and decide whether to restore. Null = launch default window.</summary>
+    public SessionState? LoadForRestore()
+    {
+        if (!SessionGate.ShouldPersist(_config.WindowSaveState))
+        {
+            // window-save-state=never: drop any stale session.
+            _store.Delete();
+            return null;
+        }
+        var state = _store.Load();
+        if (state is null) return null;
+        return SessionGate.ShouldRestore(_config.WindowSaveState, state.CleanShutdown)
+            ? state
+            : null;
+    }
+
+    /// <summary>Subscribe a window's change signals to the debounced persist.</summary>
+    public void Track(MainWindow window)
+    {
+        if (window.IsQuickTerminal) return;
+
+        var tm = window.TabManager;
+        tm.TabAdded += OnTabAdded;
+        tm.TabRemoved += OnLayoutSignal;
+        tm.TabMoved += OnTabMoved;
+        tm.ActiveTabChanged += OnActiveTabChanged;
+        // Pane-level structural changes for the tabs present now, plus any
+        // added later (OnTabAdded wires those).
+        foreach (var t in tm.Tabs)
+            t.PaneHost.LayoutChanged += OnLayoutSignal;
+        window.PositionChanged += OnLayoutSignal;
+    }
+
+    private void OnTabAdded(object? sender, Ghostty.Core.Tabs.TabModel tab)
+    {
+        tab.PaneHost.LayoutChanged += OnLayoutSignal;
+        RequestPersist();
+    }
+
+    private void OnTabMoved(object? sender, (Ghostty.Core.Tabs.TabModel tab, int from, int to) e)
+        => RequestPersist();
+
+    private void OnActiveTabChanged(object? sender, Ghostty.Core.Tabs.TabModel tab)
+        => RequestPersist();
+
+    private void OnLayoutSignal(object? sender, EventArgs e) => RequestPersist();
+    private void OnLayoutSignal(object? sender, Ghostty.Core.Tabs.TabModel tab) => RequestPersist();
+
+    public void RequestPersist()
+    {
+        if (!SessionGate.ShouldPersist(_config.WindowSaveState)) return;
+        _debounce ??= _dispatcher.CreateTimer();
+        _debounce.Interval = TimeSpan.FromMilliseconds(750);
+        _debounce.IsRepeating = false;
+        _debounce.Tick -= OnDebounceTick;
+        _debounce.Tick += OnDebounceTick;
+        _debounce.Start();
+    }
+
+    private void OnDebounceTick(DispatcherQueueTimer sender, object args)
+    {
+        sender.Stop();
+        PersistLiveWindows();
+    }
+
+    /// <summary>
+    /// Capture every live window and write with CleanShutdown=false. The
+    /// running file therefore always reflects the set of open windows
+    /// (debounced), which is what `always` restores after a crash.
+    /// </summary>
+    public void PersistLiveWindows()
+    {
+        if (!SessionGate.ShouldPersist(_config.WindowSaveState)) return;
+        var state = new SessionState { CleanShutdown = false };
+        foreach (var w in _windows())
+        {
+            var ws = w.CaptureSession();
+            if (ws is not null && ws.Tabs.Count > 0) state.Windows.Add(ws);
+        }
+        // Nothing to save mid-session: skip rather than blank the file.
+        if (state.Windows.Count == 0) return;
+        _store.Save(state);
+    }
+
+    /// <summary>
+    /// Mark the session clean at app shutdown. The running file already
+    /// reflects the open windows (continuously persisted), so we re-read
+    /// it and flip the flag rather than recapture -- by the time the last
+    /// window closes, earlier windows have already left the live set.
+    /// <paramref name="closingFallback"/> covers the cold case where no
+    /// mid-session write happened (e.g. launch then immediate quit): we
+    /// capture the last window directly. Windows close within the 750 ms
+    /// debounce of one another on a multi-window quit, so the pre-quit
+    /// snapshot still holds them all.
+    /// </summary>
+    public void FinalizeCleanShutdown(MainWindow? closingFallback)
+    {
+        _debounce?.Stop();
+        if (!SessionGate.ShouldPersist(_config.WindowSaveState)) return;
+
+        var onDisk = _store.Load();
+        if (onDisk is { Windows.Count: > 0 })
+        {
+            onDisk.CleanShutdown = true;
+            _store.Save(onDisk);
+            return;
+        }
+
+        // Cold path: nothing persisted this run. Capture the last window.
+        var state = new SessionState { CleanShutdown = true };
+        var ws = closingFallback?.CaptureSession();
+        if (ws is not null && ws.Tabs.Count > 0)
+        {
+            state.Windows.Add(ws);
+            _store.Save(state);
+        }
+    }
+}

--- a/windows/Ghostty/Session/SessionManager.cs
+++ b/windows/Ghostty/Session/SessionManager.cs
@@ -68,7 +68,7 @@ internal sealed class SessionManager
 
         var tm = window.TabManager;
         tm.TabAdded += OnTabAdded;
-        tm.TabRemoved += OnLayoutSignal;
+        tm.TabRemoved += OnTabRemoved;
         tm.TabMoved += OnTabMoved;
         tm.ActiveTabChanged += OnActiveTabChanged;
         // Pane-level structural changes for the tabs present now, plus any
@@ -78,9 +78,36 @@ internal sealed class SessionManager
         window.PositionChanged += OnLayoutSignal;
     }
 
+    /// <summary>
+    /// Mirror of <see cref="Track"/>: detach every handler when a window
+    /// closes. Defensive hygiene -- the dead window would not fire these, but
+    /// leaving subscriptions on the app-lifetime manager is a smell.
+    /// </summary>
+    public void Untrack(MainWindow window)
+    {
+        if (window.IsQuickTerminal) return;
+
+        var tm = window.TabManager;
+        tm.TabAdded -= OnTabAdded;
+        tm.TabRemoved -= OnTabRemoved;
+        tm.TabMoved -= OnTabMoved;
+        tm.ActiveTabChanged -= OnActiveTabChanged;
+        foreach (var t in tm.Tabs)
+            t.PaneHost.LayoutChanged -= OnLayoutSignal;
+        window.PositionChanged -= OnLayoutSignal;
+    }
+
     private void OnTabAdded(object? sender, Ghostty.Core.Tabs.TabModel tab)
     {
         tab.PaneHost.LayoutChanged += OnLayoutSignal;
+        RequestPersist();
+    }
+
+    private void OnTabRemoved(object? sender, Ghostty.Core.Tabs.TabModel tab)
+    {
+        // Unhook the closed tab's pane host so a per-tab subscription does not
+        // outlive the tab within a still-open window.
+        tab.PaneHost.LayoutChanged -= OnLayoutSignal;
         RequestPersist();
     }
 
@@ -91,7 +118,6 @@ internal sealed class SessionManager
         => RequestPersist();
 
     private void OnLayoutSignal(object? sender, EventArgs e) => RequestPersist();
-    private void OnLayoutSignal(object? sender, Ghostty.Core.Tabs.TabModel tab) => RequestPersist();
 
     public void RequestPersist()
     {

--- a/windows/Ghostty/Session/SessionManager.cs
+++ b/windows/Ghostty/Session/SessionManager.cs
@@ -14,6 +14,11 @@ namespace Ghostty.Session;
 /// </summary>
 internal sealed class SessionManager
 {
+    // Coalesce bursts of layout/tab/move signals into a single write. Long
+    // enough that a multi-window quit (windows close within this window of
+    // one another) does not refire before FinalizeCleanShutdown runs.
+    private const int DebounceMs = 750;
+
     private readonly SessionStore _store;
     private readonly ConfigService _config;
     private readonly DispatcherQueue _dispatcher;
@@ -84,7 +89,7 @@ internal sealed class SessionManager
     {
         if (!SessionGate.ShouldPersist(_config.WindowSaveState)) return;
         _debounce ??= _dispatcher.CreateTimer();
-        _debounce.Interval = TimeSpan.FromMilliseconds(750);
+        _debounce.Interval = TimeSpan.FromMilliseconds(DebounceMs);
         _debounce.IsRepeating = false;
         _debounce.Tick -= OnDebounceTick;
         _debounce.Tick += OnDebounceTick;

--- a/windows/Ghostty/Session/SessionManager.cs
+++ b/windows/Ghostty/Session/SessionManager.cs
@@ -48,9 +48,17 @@ internal sealed class SessionManager
         }
         var state = _store.Load();
         if (state is null) return null;
-        return SessionGate.ShouldRestore(_config.WindowSaveState, state.CleanShutdown)
-            ? state
-            : null;
+        if (!SessionGate.ShouldRestore(_config.WindowSaveState, state.CleanShutdown))
+            return null;
+
+        // Arm the dirty flag: rewrite the restored set as not-clean now, so a
+        // crash later this run does not leave the previous clean snapshot on
+        // disk for `default` to wrongly restore. Uses the on-disk windows (live
+        // windows are not yet registered at startup). A normal clean exit
+        // re-marks it clean via FinalizeCleanShutdown.
+        state.CleanShutdown = false;
+        _store.Save(state);
+        return state;
     }
 
     /// <summary>Subscribe a window's change signals to the debounced persist.</summary>

--- a/windows/Ghostty/Session/SessionRestorer.cs
+++ b/windows/Ghostty/Session/SessionRestorer.cs
@@ -30,9 +30,10 @@ internal sealed class SessionRestorer
         {
             if (tabDto.Tree is null) continue;
 
-            // Rebuild the structure; each leaf re-resolves its own profile.
+            // Rebuild the structure; each leaf re-resolves its own profile
+            // (exact id, else its saved fallback command).
             var root = SessionTree.RebuildTree(tabDto.Tree,
-                leaf => new LeafPane { Snapshot = ResolveSnapshot(leaf) });
+                leaf => new LeafPane { Snapshot = SessionProfileResolver.ResolveLeaf(_registry, leaf) });
 
             var active = SessionTree.Resolve(root, tabDto.ActiveLeafPath) as LeafPane
                          ?? PaneTree.FirstLeaf(root);
@@ -43,8 +44,9 @@ internal sealed class SessionRestorer
             var host = _factory.CreateFromTree(root, active, zoomed);
             var tab = new TabModel(host) { ProfileId = tabDto.ProfileId };
 
-            // The tab's display snapshot: re-resolve the tab's own profile id.
-            var tabSnap = ResolveById(tabDto.ProfileId);
+            // The tab's display snapshot: re-resolve the tab's own profile id
+            // if it still exists (else the tab keeps its restored title).
+            var tabSnap = SessionProfileResolver.ResolveById(_registry, tabDto.ProfileId);
             if (tabSnap is not null)
                 tab.AttachProfileSnapshot(tabSnap);
             if (tabDto.UserTitle is not null)
@@ -53,29 +55,5 @@ internal sealed class SessionRestorer
             result.Add(tab);
         }
         return result;
-    }
-
-    private ProfileSnapshot? ResolveSnapshot(LeafDto leaf)
-    {
-        var byId = ResolveById(leaf.ProfileId);
-        if (byId is not null) return byId;
-        if (leaf.Fallback is { } fb)
-            return new ProfileSnapshot(
-                ProfileId: leaf.ProfileId ?? "",
-                Version: 0,
-                ResolvedCommand: fb.ResolvedCommand,
-                WorkingDirectory: fb.WorkingDirectory,
-                DisplayName: fb.DisplayName,
-                Icon: new IconSpec.BundledKey("default"),
-                Visuals: EffectiveVisualOverrides.Empty);
-        return null; // legacy no-profile leaf: host spawns the default shell
-    }
-
-    private ProfileSnapshot? ResolveById(string? profileId)
-    {
-        if (_registry is null || profileId is null) return null;
-        var resolved = _registry.Resolve(profileId)
-            ?? (_registry.DefaultProfileId is { } d ? _registry.Resolve(d) : null);
-        return resolved is null ? null : ProfileSnapshotStore.From(resolved, _registry.Version);
     }
 }

--- a/windows/Ghostty/Session/SessionRestorer.cs
+++ b/windows/Ghostty/Session/SessionRestorer.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Ghostty.Core.Panes;
+using Ghostty.Core.Profiles;
+using Ghostty.Core.Session;
+using Ghostty.Core.Tabs;
+using Ghostty.Tabs;
+
+namespace Ghostty.Session;
+
+/// <summary>
+/// Reconstructs <see cref="TabModel"/>s (with tree-seeded pane hosts) from
+/// a persisted <see cref="WindowSession"/>. Profiles are re-resolved by id
+/// so edits take effect; a removed profile falls back to the saved command.
+/// </summary>
+internal sealed class SessionRestorer
+{
+    private readonly PaneHostFactory _factory;
+    private readonly IProfileRegistry? _registry;
+
+    public SessionRestorer(PaneHostFactory factory, IProfileRegistry? registry)
+    {
+        _factory = factory;
+        _registry = registry;
+    }
+
+    public List<TabModel> BuildTabs(WindowSession window)
+    {
+        var result = new List<TabModel>();
+        foreach (var tabDto in window.Tabs)
+        {
+            if (tabDto.Tree is null) continue;
+
+            // Rebuild the structure; each leaf re-resolves its own profile.
+            var root = SessionTree.RebuildTree(tabDto.Tree,
+                leaf => new LeafPane { Snapshot = ResolveSnapshot(leaf) });
+
+            var active = SessionTree.Resolve(root, tabDto.ActiveLeafPath) as LeafPane
+                         ?? PaneTree.FirstLeaf(root);
+            var zoomed = tabDto.ZoomedLeafPath is { } zp
+                ? SessionTree.Resolve(root, zp) as LeafPane
+                : null;
+
+            var host = _factory.CreateFromTree(root, active, zoomed);
+            var tab = new TabModel(host) { ProfileId = tabDto.ProfileId };
+
+            // The tab's display snapshot: re-resolve the tab's own profile id.
+            var tabSnap = ResolveById(tabDto.ProfileId);
+            if (tabSnap is not null)
+                tab.AttachProfileSnapshot(tabSnap);
+            if (tabDto.UserTitle is not null)
+                tab.UserOverrideTitle = tabDto.UserTitle;
+
+            result.Add(tab);
+        }
+        return result;
+    }
+
+    private ProfileSnapshot? ResolveSnapshot(LeafDto leaf)
+    {
+        var byId = ResolveById(leaf.ProfileId);
+        if (byId is not null) return byId;
+        if (leaf.Fallback is { } fb)
+            return new ProfileSnapshot(
+                ProfileId: leaf.ProfileId ?? "",
+                Version: 0,
+                ResolvedCommand: fb.ResolvedCommand,
+                WorkingDirectory: fb.WorkingDirectory,
+                DisplayName: fb.DisplayName,
+                Icon: new IconSpec.BundledKey("default"),
+                Visuals: EffectiveVisualOverrides.Empty);
+        return null; // legacy no-profile leaf: host spawns the default shell
+    }
+
+    private ProfileSnapshot? ResolveById(string? profileId)
+    {
+        if (_registry is null || profileId is null) return null;
+        var resolved = _registry.Resolve(profileId)
+            ?? (_registry.DefaultProfileId is { } d ? _registry.Resolve(d) : null);
+        return resolved is null ? null : ProfileSnapshotStore.From(resolved, _registry.Version);
+    }
+}

--- a/windows/Ghostty/Session/SessionStore.cs
+++ b/windows/Ghostty/Session/SessionStore.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using Ghostty.Core.Session;
+using Ghostty.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Session;
+
+/// <summary>
+/// File-backed persistence for <see cref="SessionState"/> at
+/// <c>%APPDATA%\Wintty\session.json</c>. Thin wrapper over the pure
+/// <see cref="SessionSerializer"/>; a malformed/inaccessible file never
+/// blocks startup.
+/// </summary>
+internal sealed class SessionStore
+{
+    private readonly ILogger<SessionStore> _logger;
+
+    public SessionStore(ILogger<SessionStore> logger) => _logger = logger;
+
+    private static string Dir
+    {
+        get
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Wintty");
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+    }
+
+    internal static string FilePath => Path.Combine(Dir, "session.json");
+
+    public SessionState? Load()
+    {
+        try
+        {
+            return File.Exists(FilePath)
+                ? SessionSerializer.Deserialize(File.ReadAllText(FilePath))
+                : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogSessionLoadFailed(ex);
+            return null;
+        }
+    }
+
+    public void Save(SessionState state)
+    {
+        try
+        {
+            File.WriteAllText(FilePath, SessionSerializer.Serialize(state));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogSessionSaveFailed(ex);
+        }
+    }
+
+    public void Delete()
+    {
+        try
+        {
+            if (File.Exists(FilePath)) File.Delete(FilePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogSessionDeleteFailed(ex);
+        }
+    }
+}
+
+internal static partial class SessionStoreLogExtensions
+{
+    [LoggerMessage(EventId = LogEvents.Session.LoadFailed,
+                   Level = LogLevel.Warning, Message = "Session load failed, ignoring saved session")]
+    internal static partial void LogSessionLoadFailed(this ILogger<SessionStore> logger, Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Session.SaveFailed,
+                   Level = LogLevel.Warning, Message = "Session save failed")]
+    internal static partial void LogSessionSaveFailed(this ILogger<SessionStore> logger, Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Session.DeleteFailed,
+                   Level = LogLevel.Warning, Message = "Session delete failed")]
+    internal static partial void LogSessionDeleteFailed(this ILogger<SessionStore> logger, Exception ex);
+}

--- a/windows/Ghostty/Tabs/PaneHostFactory.cs
+++ b/windows/Ghostty/Tabs/PaneHostFactory.cs
@@ -38,4 +38,20 @@ internal sealed class PaneHostFactory
             // helper, which maps 0 to a disabled policy (upstream fidelity)
             // and a negative/corrupt value to the safe 5s default.
             undoPolicy: UndoPolicy.FromConfigMilliseconds(_config.UndoTimeoutMs));
+
+    /// <summary>
+    /// Build a host seeded from a restored tree. Leaves carry their
+    /// <see cref="LeafPane.Snapshot"/> (Tag null); the host creates the
+    /// TerminalControls. <paramref name="activeLeaf"/> must be a leaf of
+    /// <paramref name="root"/>; <paramref name="zoomedLeaf"/> re-zooms when
+    /// non-null and present.
+    /// </summary>
+    public IPaneHost CreateFromTree(PaneNode root, LeafPane activeLeaf, LeafPane? zoomedLeaf) =>
+        new PaneHost(
+            _host,
+            terminalFactory: snap => new TerminalControl { Snapshot = snap },
+            root: root,
+            activeLeaf: activeLeaf,
+            zoomedLeaf: zoomedLeaf,
+            undoPolicy: UndoPolicy.FromConfigMilliseconds(_config.UndoTimeoutMs));
 }


### PR DESCRIPTION
Persists each non-quake window's geometry, ordered tabs, and split-pane tree on quit, and recreates them on relaunch. Live shells are not restored; each pane re-runs its profile/command (matches macOS).

Gated by the existing `window-save-state` config key (default/never/always): default restores after a clean exit, always restores regardless, never disables. No Zig/core change.

- Serialization model, pane-tree capture/rebuild, and the restore gate live in Ghostty.Core and are unit-tested.
- SessionManager debounce-writes the live window set and marks it clean on exit. A tree-seeded PaneHost constructor rebuilds the split layout by reusing the existing undo restore path.
- Quake / quick-terminal windows are never persisted or restored.

Test plan
- [ ] Open several tabs with splits, quit, relaunch: layout, active tab, focused pane, zoom restored
- [ ] Normal single-window launch unaffected
- [ ] Quake window unaffected