### PR TITLE
feat(inspector): DirectX12 render pass + C API

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1296,6 +1296,16 @@ GHOSTTY_API void ghostty_inspector_metal_render(ghostty_inspector_t, void*, void
 GHOSTTY_API bool ghostty_inspector_metal_shutdown(ghostty_inspector_t);
 #endif
 
+#ifdef _WIN32
+// device and command_queue are ID3D12Device*/ID3D12CommandQueue*; num_frames is
+// the host's frames-in-flight count; rtv_format is the host swap chain's
+// DXGI_FORMAT; command_list is an ID3D12GraphicsCommandList* with the render
+// target already bound.
+GHOSTTY_API bool ghostty_inspector_directx12_init(ghostty_inspector_t, void*, void*, uint32_t, uint32_t);
+GHOSTTY_API void ghostty_inspector_directx12_render(ghostty_inspector_t, void*);
+GHOSTTY_API void ghostty_inspector_directx12_shutdown(ghostty_inspector_t);
+#endif
+
 // APIs I'd like to get rid of eventually but are still needed for now.
 // Don't use these unless you know what you're doing.
 GHOSTTY_API void ghostty_set_window_background_blur(ghostty_app_t, void*);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -18,6 +18,13 @@ const terminal = @import("../terminal/main.zig");
 const CoreApp = @import("../App.zig");
 const CoreInspector = @import("../inspector/main.zig").Inspector;
 const CoreSurface = @import("../Surface.zig");
+
+/// DirectX12 imgui backend for the inspector (Windows only). On other
+/// platforms this is an empty namespace so the Inspector still compiles.
+const dx12_imgui = if (builtin.os.tag == .windows)
+    @import("../renderer/directx12/imgui.zig")
+else
+    struct {};
 const configpkg = @import("../config.zig");
 const Config = configpkg.Config;
 const String = @import("../main_c.zig").String;
@@ -1158,12 +1165,20 @@ pub const Inspector = struct {
     /// Our previous instant used to calculate delta time for animations.
     instant: ?std.time.Instant = null,
 
+    /// SRV descriptor heap backing the imgui font atlas for the DirectX12
+    /// backend (Windows only). Owned here so its address stays stable for
+    /// imgui's descriptor callbacks.
+    dx12_heap: if (builtin.os.tag == .windows) ?dx12_imgui.SrvHeap else void =
+        if (builtin.os.tag == .windows) null else {},
+
     const Backend = enum {
         metal,
+        directx12,
 
         pub fn deinit(self: Backend) void {
             switch (self) {
                 .metal => if (builtin.target.os.tag.isDarwin()) cimgui.ImGui_ImplMetal_Shutdown(),
+                .directx12 => if (builtin.os.tag == .windows) dx12_imgui.shutdown(),
             }
         }
     };
@@ -1191,6 +1206,7 @@ pub const Inspector = struct {
         self.surface.core_surface.deactivateInspector();
         cimgui.c.ImGui_SetCurrentContext(self.ig_ctx);
         if (self.backend) |v| v.deinit();
+        self.deinitDx12Heap();
         cimgui.c.ImGui_DestroyContext(self.ig_ctx);
     }
 
@@ -1261,6 +1277,87 @@ pub const Inspector = struct {
             cimgui.c.ImGui_GetDrawData(),
             command_buffer.value,
             encoder.value,
+        );
+    }
+
+    /// Release the DirectX12 SRV heap if one is allocated. No-op off Windows.
+    fn deinitDx12Heap(self: *Inspector) void {
+        if (comptime builtin.os.tag != .windows) return;
+        if (self.dx12_heap) |*h| {
+            h.deinit();
+            self.dx12_heap = null;
+        }
+    }
+
+    /// Initialize the inspector for a DirectX12 backend. `device` and
+    /// `command_queue` are `ID3D12Device`/`ID3D12CommandQueue` pointers from
+    /// the host's inspector window; `rtv_format` is its swap chain's
+    /// DXGI_FORMAT. Returns false on non-Windows or on failure.
+    pub fn initDirectX12(
+        self: *Inspector,
+        device: *anyopaque,
+        command_queue: *anyopaque,
+        num_frames: u32,
+        rtv_format: u32,
+    ) bool {
+        if (comptime builtin.os.tag != .windows) return false;
+
+        cimgui.c.ImGui_SetCurrentContext(self.ig_ctx);
+
+        if (self.backend) |v| {
+            v.deinit();
+            self.backend = null;
+        }
+        self.deinitDx12Heap();
+
+        const d3d12 = @import("../renderer/directx12/d3d12.zig");
+        const dev: *d3d12.ID3D12Device = @ptrCast(@alignCast(device));
+        const queue: *d3d12.ID3D12CommandQueue = @ptrCast(@alignCast(command_queue));
+
+        self.dx12_heap = dx12_imgui.createHeap(dev) catch {
+            log.warn("failed to create inspector dx12 srv heap", .{});
+            return false;
+        };
+        if (!dx12_imgui.init(dev, queue, num_frames, rtv_format, &self.dx12_heap.?)) {
+            log.warn("failed to initialize directx12 backend", .{});
+            self.deinitDx12Heap();
+            return false;
+        }
+        self.backend = .directx12;
+
+        log.debug("initialized directx12 backend", .{});
+        return true;
+    }
+
+    pub fn renderDirectX12(self: *Inspector, command_list: *anyopaque) !void {
+        if (comptime builtin.os.tag != .windows) return;
+        // The host should only call this after a successful init; bail
+        // cleanly rather than unwrap a null heap if that invariant breaks.
+        if (self.backend != .directx12) return;
+
+        cimgui.c.ImGui_SetCurrentContext(self.ig_ctx);
+
+        // Render multiple frames to ensure ImGui completes its state
+        // processing, matching the Metal backend.
+        for (0..2) |_| {
+            dx12_imgui.newFrame();
+            try self.newFrame();
+            cimgui.c.ImGui_NewFrame();
+
+            render: {
+                const surface = &self.surface.core_surface;
+                const inspector = surface.inspector orelse break :render;
+                inspector.render(surface);
+            }
+
+            cimgui.c.ImGui_Render();
+        }
+
+        const d3d12 = @import("../renderer/directx12/d3d12.zig");
+        dx12_imgui.renderDrawData(
+            cimgui.c.ImGui_GetDrawData(),
+            @as(*d3d12.ID3D12GraphicsCommandList, @ptrCast(@alignCast(command_list))),
+            &self.dx12_heap.?,
         );
     }
 
@@ -1578,6 +1675,9 @@ pub const CAPI = struct {
     comptime {
         if (builtin.target.os.tag.isDarwin()) {
             _ = Darwin;
+        }
+        if (builtin.os.tag == .windows) {
+            _ = Windows;
         }
     }
 
@@ -2696,6 +2796,42 @@ pub const CAPI = struct {
                 v.deinit();
                 ptr.backend = null;
             }
+        }
+    };
+
+    // Windows-only C APIs.
+    const Windows = struct {
+        export fn ghostty_inspector_directx12_init(
+            ptr: *Inspector,
+            device: ?*anyopaque,
+            command_queue: ?*anyopaque,
+            num_frames: u32,
+            rtv_format: u32,
+        ) bool {
+            return ptr.initDirectX12(
+                device orelse return false,
+                command_queue orelse return false,
+                num_frames,
+                rtv_format,
+            );
+        }
+
+        export fn ghostty_inspector_directx12_render(
+            ptr: *Inspector,
+            command_list: ?*anyopaque,
+        ) void {
+            return ptr.renderDirectX12(command_list orelse return) catch |err| {
+                log.err("error rendering inspector err={}", .{err});
+                return;
+            };
+        }
+
+        export fn ghostty_inspector_directx12_shutdown(ptr: *Inspector) void {
+            if (ptr.backend) |v| {
+                v.deinit();
+                ptr.backend = null;
+            }
+            ptr.deinitDx12Heap();
         }
     };
 };

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -656,6 +656,8 @@ pub fn add(
         // OpenGL3 backend should only be built on non-Apple targets.
         // Apple platforms use Metal (and macOS may also use the OSX backend).
         .@"backend-opengl3" = !target.result.os.tag.isDarwin(),
+        // DirectX12 backend powers the inspector overlay on Windows.
+        .@"backend-dx12" = target.result.os.tag == .windows,
     })) |dep| {
         step.root_module.addImport("dcimgui", dep.module("dcimgui"));
         step.linkLibrary(dep.artifact("dcimgui"));

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -1096,8 +1096,9 @@ test "device_lost flag is independent of device presence" {
     try std.testing.expect(api.device_lost);
 }
 
-// Pull the directx12 integration test file into the test graph; without
-// this @import gpu_test.zig is orphaned and never compiled by `zig build test`.
+// Pull the directx12 integration test files into the test graph; without
+// these @imports the files are orphaned and never compiled by `zig build test`.
 test {
     _ = @import("directx12/gpu_test.zig");
+    _ = @import("directx12/imgui.zig");
 }

--- a/src/renderer/directx12/imgui.zig
+++ b/src/renderer/directx12/imgui.zig
@@ -1,0 +1,279 @@
+//! DirectX12 backend for the terminal inspector's imgui overlay.
+//!
+//! This owns a shader-visible SRV descriptor heap and the alloc/free
+//! callbacks that imgui 1.92's DX12 backend uses for its dynamic font atlas,
+//! plus thin wrappers over ImGui_ImplDX12_{Init,NewFrame,RenderDrawData,
+//! Shutdown}. The embedded apprt Inspector keeps the imgui frame
+//! orchestration and delegates the DX12 specifics here.
+//!
+//! It lives in the directx12 renderer directory (rather than the apprt) so it
+//! can sit next to the d3d12 bindings it needs and be exercised by the same
+//! device-backed test harness as the rest of the renderer. It is only ever
+//! compiled on Windows: the embedded apprt imports it behind a comptime
+//! os.tag check, and the directx12 renderer itself is Windows-only.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const cimgui = @import("dcimgui");
+const com = @import("com.zig");
+const d3d12 = @import("d3d12.zig");
+const dxgi = @import("dxgi.zig");
+const DescriptorHeap = @import("descriptor_heap.zig").DescriptorHeap;
+
+/// A shader-visible CBV/SRV heap with per-slot recycling. imgui 1.92's
+/// dynamic font atlas allocates and frees texture descriptors as the atlas is
+/// (re)built (e.g. on a DPI change), so a plain linear allocator would leak
+/// slots over a long session of rebuilds. The free list lets freed slots be
+/// reused.
+pub const SrvHeap = struct {
+    base: DescriptorHeap,
+    free_buf: [capacity]u32 = undefined,
+    free_len: usize = 0,
+
+    /// Slot count. The inspector needs very few (a font atlas plus the
+    /// occasional user texture), so this is generous headroom.
+    pub const capacity = 64;
+
+    pub fn deinit(self: *SrvHeap) void {
+        self.base.deinit();
+    }
+
+    /// Allocate the next descriptor, reusing a freed slot if available.
+    pub fn allocSlot(self: *SrvHeap) !DescriptorHeap.Descriptor {
+        if (self.free_len > 0) {
+            self.free_len -= 1;
+            const idx = self.free_buf[self.free_len];
+            return .{
+                .cpu = self.base.cpuHandle(idx),
+                .gpu = self.base.gpuHandle(idx),
+                .index = idx,
+            };
+        }
+        return self.base.allocate();
+    }
+
+    /// Return a slot to the free list, identified by its CPU handle (which is
+    /// how imgui's free callback hands it back). The slot index is recovered
+    /// from the offset into the heap.
+    pub fn freeSlot(self: *SrvHeap, cpu_ptr: usize) void {
+        const idx: u32 = @intCast((cpu_ptr - self.base.cpu_start.ptr) / self.base.increment_size);
+        if (self.free_len < capacity) {
+            self.free_buf[self.free_len] = idx;
+            self.free_len += 1;
+        }
+    }
+};
+
+fn srvAlloc(
+    info: *cimgui.ImGui_ImplDX12_InitInfo,
+    out_cpu: *cimgui.ImGui_ImplDX12_CpuDescriptorHandle,
+    out_gpu: *cimgui.ImGui_ImplDX12_GpuDescriptorHandle,
+) callconv(.c) void {
+    const heap: *SrvHeap = @ptrCast(@alignCast(info.UserData.?));
+    const d = heap.allocSlot() catch {
+        out_cpu.* = .{ .ptr = 0 };
+        out_gpu.* = .{ .ptr = 0 };
+        return;
+    };
+    out_cpu.* = .{ .ptr = d.cpu.ptr };
+    out_gpu.* = .{ .ptr = d.gpu.ptr };
+}
+
+fn srvFree(
+    info: *cimgui.ImGui_ImplDX12_InitInfo,
+    cpu: cimgui.ImGui_ImplDX12_CpuDescriptorHandle,
+    gpu: cimgui.ImGui_ImplDX12_GpuDescriptorHandle,
+) callconv(.c) void {
+    _ = gpu;
+    const heap: *SrvHeap = @ptrCast(@alignCast(info.UserData.?));
+    heap.freeSlot(cpu.ptr);
+}
+
+/// Create the SRV heap that backs an inspector's imgui textures.
+pub fn createHeap(device: *d3d12.ID3D12Device) !SrvHeap {
+    return .{ .base = try DescriptorHeap.init(device, .CBV_SRV_UAV, SrvHeap.capacity, true) };
+}
+
+/// Initialize the imgui DX12 backend. `heap` must outlive the backend; its
+/// address is stored as the imgui UserData and recovered by the callbacks.
+pub fn init(
+    device: *d3d12.ID3D12Device,
+    command_queue: *d3d12.ID3D12CommandQueue,
+    num_frames: u32,
+    rtv_format: u32,
+    heap: *SrvHeap,
+) bool {
+    var info: cimgui.ImGui_ImplDX12_InitInfo = .{};
+    info.Device = @ptrCast(device);
+    info.CommandQueue = @ptrCast(command_queue);
+    info.NumFramesInFlight = @intCast(num_frames);
+    info.RTVFormat = rtv_format;
+    info.SrvDescriptorHeap = @ptrCast(heap.base.heap);
+    info.UserData = @ptrCast(heap);
+    info.SrvDescriptorAllocFn = srvAlloc;
+    info.SrvDescriptorFreeFn = srvFree;
+    return cimgui.ImGui_ImplDX12_Init(&info);
+}
+
+pub fn newFrame() void {
+    cimgui.ImGui_ImplDX12_NewFrame();
+}
+
+/// Record the imgui draw data into `command_list`. The caller must already
+/// have bound its render target and viewport; this binds the inspector's SRV
+/// heap (required before imgui's RenderDrawData issues its draws).
+pub fn renderDrawData(
+    draw_data: *cimgui.c.ImDrawData,
+    command_list: *d3d12.ID3D12GraphicsCommandList,
+    heap: *SrvHeap,
+) void {
+    const heaps = [_]*d3d12.ID3D12DescriptorHeap{heap.base.heap};
+    command_list.SetDescriptorHeaps(1, &heaps);
+    cimgui.ImGui_ImplDX12_RenderDrawData(draw_data, @ptrCast(command_list));
+}
+
+pub fn shutdown() void {
+    cimgui.ImGui_ImplDX12_Shutdown();
+}
+
+// --- Tests ---
+
+test "SrvHeap recycles freed slots" {
+    // No device: drive the base heap's pure arithmetic via known fields,
+    // following the descriptor_heap.zig test idiom.
+    var h: SrvHeap = .{ .base = undefined };
+    h.base.cpu_start = .{ .ptr = 0x1000 };
+    h.base.gpu_start = .{ .ptr = 0x2000 };
+    h.base.increment_size = 32;
+    h.base.capacity = 4;
+    h.base.allocated = 0;
+
+    const a = try h.allocSlot();
+    const b = try h.allocSlot();
+    try std.testing.expectEqual(@as(u32, 0), a.index);
+    try std.testing.expectEqual(@as(u32, 1), b.index);
+
+    // Free the first slot; the next allocation should reuse it rather than
+    // grow the linear allocator.
+    h.freeSlot(a.cpu.ptr);
+    const c = try h.allocSlot();
+    try std.testing.expectEqual(@as(u32, 0), c.index);
+    try std.testing.expectEqual(@as(usize, 0x1000), c.cpu.ptr);
+}
+
+test "SrvHeap freeSlot recovers index from cpu handle" {
+    var h: SrvHeap = .{ .base = undefined };
+    h.base.cpu_start = .{ .ptr = 0x4000 };
+    h.base.increment_size = 64;
+    h.base.capacity = 8;
+    h.base.allocated = 5;
+
+    h.freeSlot(0x4000 + 3 * 64);
+    try std.testing.expectEqual(@as(usize, 1), h.free_len);
+    try std.testing.expectEqual(@as(u32, 3), h.free_buf[0]);
+}
+
+test "imgui dx12 backend produces and records draw data on a real device" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+
+    // Device + command queue/allocator/list + fence. Skip if no GPU.
+    var device: ?*d3d12.ID3D12Device = null;
+    if (com.FAILED(d3d12.D3D12CreateDevice(
+        null,
+        d3d12.D3D_FEATURE_LEVEL_12_0,
+        &d3d12.ID3D12Device.IID,
+        @ptrCast(&device),
+    )) or device == null) return error.SkipZigTest;
+    const dev = device.?;
+    defer _ = dev.Release();
+
+    var queue: ?*d3d12.ID3D12CommandQueue = null;
+    const queue_desc = d3d12.D3D12_COMMAND_QUEUE_DESC{ .Type = .DIRECT, .Priority = 0, .Flags = .NONE, .NodeMask = 0 };
+    if (com.FAILED(dev.CreateCommandQueue(&queue_desc, &d3d12.ID3D12CommandQueue.IID, @ptrCast(&queue)))) return error.SkipZigTest;
+    defer _ = queue.?.Release();
+
+    var allocator: ?*d3d12.ID3D12CommandAllocator = null;
+    if (com.FAILED(dev.CreateCommandAllocator(.DIRECT, &d3d12.ID3D12CommandAllocator.IID, @ptrCast(&allocator)))) return error.SkipZigTest;
+    defer _ = allocator.?.Release();
+
+    var cmd_list: ?*d3d12.ID3D12GraphicsCommandList = null;
+    if (com.FAILED(dev.CreateCommandList(0, .DIRECT, allocator.?, null, &d3d12.ID3D12GraphicsCommandList.IID, @ptrCast(&cmd_list)))) return error.SkipZigTest;
+    const cl = cmd_list.?;
+    defer _ = cl.Release();
+
+    var fence: ?*d3d12.ID3D12Fence = null;
+    if (com.FAILED(dev.CreateFence(0, .NONE, &d3d12.ID3D12Fence.IID, @ptrCast(&fence)))) return error.SkipZigTest;
+    defer _ = fence.?.Release();
+    const fence_event = d3d12.CreateEventW(null, 0, 0, null) orelse return error.SkipZigTest;
+    defer _ = d3d12.CloseHandle(fence_event);
+
+    // Offscreen render target (256x256 B8G8R8A8) + RTV.
+    const rtv_format = dxgi.DXGI_FORMAT.B8G8R8A8_UNORM;
+    const heap_props = d3d12.D3D12_HEAP_PROPERTIES{ .Type = .DEFAULT, .CPUPageProperty = 0, .MemoryPoolPreference = 0, .CreationNodeMask = 0, .VisibleNodeMask = 0 };
+    const rt_desc = d3d12.D3D12_RESOURCE_DESC{
+        .Dimension = .TEXTURE2D,
+        .Alignment = 0,
+        .Width = 256,
+        .Height = 256,
+        .DepthOrArraySize = 1,
+        .MipLevels = 1,
+        .Format = rtv_format,
+        .SampleDesc = .{ .Count = 1, .Quality = 0 },
+        .Layout = .UNKNOWN,
+        .Flags = .ALLOW_RENDER_TARGET,
+    };
+    var rt: ?*d3d12.ID3D12Resource = null;
+    if (com.FAILED(dev.CreateCommittedResource(&heap_props, 0, &rt_desc, .RENDER_TARGET, null, &d3d12.ID3D12Resource.IID, @ptrCast(&rt)))) return error.SkipZigTest;
+    defer _ = rt.?.Release();
+
+    var rtv_heap = DescriptorHeap.init(dev, .RTV, 1, false) catch return error.SkipZigTest;
+    defer rtv_heap.deinit();
+    const rtv = try rtv_heap.allocate();
+    dev.CreateRenderTargetView(rt.?, null, rtv.cpu);
+
+    // imgui context + our backend.
+    cimgui.c.ImGui_SetCurrentContext(cimgui.c.ImGui_CreateContext(null));
+    defer cimgui.c.ImGui_DestroyContext(cimgui.c.ImGui_GetCurrentContext());
+    const io: *cimgui.c.ImGuiIO = cimgui.c.ImGui_GetIO();
+    io.DisplaySize = .{ .x = 256, .y = 256 };
+    io.DeltaTime = 1.0 / 60.0;
+    io.IniFilename = null; // don't write imgui.ini from the test
+
+    var srv_heap = createHeap(dev) catch return error.SkipZigTest;
+    defer srv_heap.deinit();
+    try std.testing.expect(init(dev, queue.?, 1, @intFromEnum(rtv_format), &srv_heap));
+    defer shutdown();
+
+    // Build a frame that generates geometry. imgui needs a couple of frames
+    // to settle its state (same reason the Metal backend renders twice).
+    for (0..2) |_| {
+        newFrame();
+        cimgui.c.ImGui_NewFrame();
+        cimgui.c.ImGui_ShowDemoWindow(null);
+        cimgui.c.ImGui_Render();
+    }
+
+    const draw_data = cimgui.c.ImGui_GetDrawData();
+    try std.testing.expect(draw_data != null);
+    try std.testing.expect(draw_data.*.TotalVtxCount > 0);
+
+    // Record the draw data against the offscreen RTV and execute it. This
+    // exercises the real RenderDrawData path (descriptor heap binding, PSO,
+    // draws) rather than just the draw-data generation.
+    const rtvs = [_]d3d12.D3D12_CPU_DESCRIPTOR_HANDLE{rtv.cpu};
+    cl.OMSetRenderTargets(1, &rtvs, 0, null);
+    const viewport = d3d12.D3D12_VIEWPORT{ .TopLeftX = 0, .TopLeftY = 0, .Width = 256, .Height = 256, .MinDepth = 0, .MaxDepth = 1 };
+    cl.RSSetViewports(1, @ptrCast(&viewport));
+    renderDrawData(draw_data, cl, &srv_heap);
+
+    // Execute and wait.
+    if (com.FAILED(cl.Close())) return error.CommandListCloseFailed;
+    const lists = [_]*d3d12.ID3D12GraphicsCommandList{cl};
+    queue.?.ExecuteCommandLists(1, @ptrCast(&lists));
+    if (com.FAILED(queue.?.Signal(fence.?, 1))) return error.FenceSignalFailed;
+    if (fence.?.GetCompletedValue() < 1) {
+        if (com.FAILED(fence.?.SetEventOnCompletion(1, fence_event))) return error.FenceSetEventFailed;
+        if (d3d12.WaitForSingleObject(fence_event, d3d12.INFINITE) != 0) return error.WaitFailed;
+    }
+}


### PR DESCRIPTION
Second PR in the Windows terminal inspector stack (# 513). Makes the
inspector renderable on Windows via DX12 and exposes the C API the WinUI
host (PR 3) will drive.

> [!IMPORTANT]
> Stacked series, merge in order:
> 1. cimgui DX12 backend (# 514, merged)
> 2. **this PR** - DX12 render pass + C API
> 3. WinUI host window + toggle wiring

Host-driven, mirroring macOS Metal: the inspector renders into a separate
window's own swap chain, so the terminal renderer (`DirectX12.zig`) is not
modified.

## What

- `src/renderer/directx12/imgui.zig`: a recycling shader-visible SRV heap
  (`SrvHeap`) wrapping `DescriptorHeap`, the imgui alloc/free descriptor
  callbacks for the 1.92 dynamic font atlas, and thin wrappers over the
  imgui DX12 backend.
- `embedded.zig` Inspector: a `directx12` backend variant, an owned SRV
  heap, and `initDirectX12`/`renderDirectX12` (two frames per render, like
  Metal).
- C API `ghostty_inspector_directx12_init/render/shutdown`, exported from a
  Windows-only `Windows` CAPI struct and declared in `ghostty.h` under
  `_WIN32`, mirroring the Metal trio.
- Enable the dcimgui DirectX12 backend on Windows in the build.

All DX12 paths are Windows-gated; other platforms are unaffected.

## Test

- `zig build test -Dapp-runtime=none` (Windows): SrvHeap recycling unit
  tests + a device-backed smoke test that drives init + a 2-frame render +
  `RenderDrawData` against a real D3D12 device and asserts draw data is
  produced. 0 failures.
- `zig build` produces libghostty with the three
  `ghostty_inspector_directx12_*` symbols exported (verified with dumpbin).

No visible in-app rendering yet: the caller (a WinUI inspector window)
arrives in PR 3.
