### PR TITLE
feat(windows): add About window

### DIFF
--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -98,8 +98,8 @@ public enum PaneAction
     Redo = 51,
 
     // Open the branded About window (app name, version/build/commit, links,
-    // license). Apprt-only: routed via event to MainWindow, which opens the
-    // singleton AboutWindow. Mirrors ShowKeybindCheatsheet (event-only,
-    // needs a window, no libghostty action).
+    // license). Apprt-only: routed via event to MainWindow, which opens one
+    // About window per window (reused if already open). Mirrors
+    // ShowKeybindCheatsheet (event-only, needs a window, no libghostty action).
     ShowAbout = 52,
 }

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -96,4 +96,10 @@ public enum PaneAction
     // dispatched to PaneHost.Undo/Redo. Time-bounded (~5s) snapshot stack.
     Undo = 50,
     Redo = 51,
+
+    // Open the branded About window (app name, version/build/commit, links,
+    // license). Apprt-only: routed via event to MainWindow, which opens the
+    // singleton AboutWindow. Mirrors ShowKeybindCheatsheet (event-only,
+    // needs a window, no libghostty action).
+    ShowAbout = 52,
 }

--- a/windows/Ghostty.Core/Version/AboutContent.cs
+++ b/windows/Ghostty.Core/Version/AboutContent.cs
@@ -1,0 +1,22 @@
+namespace Ghostty.Core.Version;
+
+/// <summary>
+/// Static, AOT-safe strings and links rendered by the About window. Kept
+/// in Core (not the WinUI shell) so the values are unit-testable without a
+/// UI thread. Version/build/commit come from <see cref="VersionRenderer"/>;
+/// only the brand-level copy and project links live here.
+/// </summary>
+public static class AboutContent
+{
+    public const string Tagline =
+        "Fast, native, feature-rich terminal emulator pushing modern features.";
+
+    public const string LicenseNote = "MIT License";
+
+    public const string Copyright = "(c) 2024 Mitchell Hashimoto, Ghostty contributors";
+
+    public const string GitHubUrl = "https://github.com/deblasis/wintty";
+    public const string DocsUrl = "https://wintty.io/docs";
+    public const string HomepageUrl = "https://wintty.io";
+    public const string SponsorUrl = "https://github.com/sponsors/deblasis";
+}

--- a/windows/Ghostty.Core/Version/AboutContent.cs
+++ b/windows/Ghostty.Core/Version/AboutContent.cs
@@ -13,6 +13,9 @@ public static class AboutContent
 
     public const string LicenseNote = "MIT License";
 
+    // Year and holders are pinned to the repo LICENSE file, not the current
+    // date: this is the copyright on the work, so it tracks LICENSE and only
+    // changes when that file does.
     public const string Copyright = "(c) 2024 Mitchell Hashimoto, Ghostty contributors";
 
     public const string GitHubUrl = "https://github.com/deblasis/wintty";

--- a/windows/Ghostty.Tests/Input/PaneActionTests.cs
+++ b/windows/Ghostty.Tests/Input/PaneActionTests.cs
@@ -30,4 +30,11 @@ public class PaneActionTests
         // their hardcoded values intact.
         Assert.Equal((int)PaneAction.ToggleCommandPalette + 1, (int)PaneAction.OpenProfile1);
     }
+
+    [Fact]
+    public void ShowAbout_HasStableValue52()
+    {
+        // Pinned so a future enum reorder is a deliberate, visible change.
+        Assert.Equal(52, (int)PaneAction.ShowAbout);
+    }
 }

--- a/windows/Ghostty.Tests/Version/AboutContentTests.cs
+++ b/windows/Ghostty.Tests/Version/AboutContentTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Ghostty.Core.Version;
+using Xunit;
+
+namespace Ghostty.Tests.Version;
+
+public class AboutContentTests
+{
+    [Theory]
+    [InlineData("https://github.com/deblasis/wintty")]
+    [InlineData("https://wintty.io/docs")]
+    [InlineData("https://wintty.io")]
+    [InlineData("https://github.com/sponsors/deblasis")]
+    public void Urls_AreAbsoluteHttps(string url)
+    {
+        Assert.True(Uri.TryCreate(url, UriKind.Absolute, out var parsed));
+        Assert.Equal(Uri.UriSchemeHttps, parsed!.Scheme);
+    }
+
+    [Fact]
+    public void Urls_MatchExpectedTargets()
+    {
+        Assert.Equal("https://github.com/deblasis/wintty", AboutContent.GitHubUrl);
+        Assert.Equal("https://wintty.io/docs", AboutContent.DocsUrl);
+        Assert.Equal("https://wintty.io", AboutContent.HomepageUrl);
+        Assert.Equal("https://github.com/sponsors/deblasis", AboutContent.SponsorUrl);
+    }
+
+    [Fact]
+    public void Tagline_IsNonEmpty()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(AboutContent.Tagline));
+    }
+
+    [Fact]
+    public void License_MentionsMitAndContributors()
+    {
+        Assert.Contains("MIT", AboutContent.LicenseNote);
+        Assert.Contains("Ghostty contributors", AboutContent.Copyright);
+    }
+}

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -63,6 +63,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.ToggleTabLayout, "Toggle Tab Layout", "Switch between horizontal and vertical tab layout", CommandCategory.Tab, "\uE8AB");
         AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal);
         AddPaneCommand(commands, PaneAction.ShowKeybindCheatsheet, "Keyboard Shortcuts", "Show the keyboard shortcuts cheat sheet", CommandCategory.Terminal, "");
+        AddPaneCommand(commands, PaneAction.ShowAbout, "About", "Show app version, links, and license", CommandCategory.About, "");
         // Undo/Redo are omitted when their stack is empty so the palette
         // never offers a dead no-op. The palette rebuilds this list on every
         // open (CommandPaletteViewModel.Open -> Refresh + GetCommands), so a

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="Ghostty.Dialogs.AboutWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+      Title + AppTitleBar.Title are set in code-behind from
+      AppIdentity.ProductName so a rebrand touches one constant. Chrome
+      mirrors SettingsWindow: Mica backdrop, TitleBar primitive, themed
+      via WindowThemeManager.
+    -->
+    <Grid x:Name="RootGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TitleBar x:Name="AppTitleBar" Grid.Row="0">
+            <TitleBar.IconSource>
+                <!-- E946 = Info glyph; matches the About command icon. -->
+                <FontIconSource Glyph="&#xE946;" />
+            </TitleBar.IconSource>
+        </TitleBar>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <StackPanel HorizontalAlignment="Center"
+                        Padding="32,16,32,32"
+                        Spacing="20">
+
+                <Image x:Name="AppIcon" Width="72" Height="72"
+                       HorizontalAlignment="Center" />
+
+                <StackPanel Spacing="6" HorizontalAlignment="Center">
+                    <TextBlock x:Name="ProductNameText"
+                               HorizontalAlignment="Center"
+                               Style="{StaticResource TitleTextBlockStyle}" />
+                    <TextBlock x:Name="TaglineText"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center"
+                               MaxWidth="320"
+                               TextWrapping="Wrap"
+                               IsTextSelectionEnabled="True"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+
+                <!-- Version / Build / Commit rows -->
+                <Grid HorizontalAlignment="Center" ColumnSpacing="12" RowSpacing="4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Version"
+                               HorizontalAlignment="Right"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <TextBlock x:Name="VersionValue" Grid.Row="0" Grid.Column="1"
+                               FontFamily="Cascadia Mono, Consolas"
+                               IsTextSelectionEnabled="True" />
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Build"
+                               HorizontalAlignment="Right"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <TextBlock x:Name="BuildValue" Grid.Row="1" Grid.Column="1"
+                               FontFamily="Cascadia Mono, Consolas"
+                               IsTextSelectionEnabled="True" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Commit"
+                               x:Name="CommitLabel"
+                               HorizontalAlignment="Right"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <TextBlock x:Name="CommitValue" Grid.Row="2" Grid.Column="1"
+                               FontFamily="Cascadia Mono, Consolas"
+                               IsTextSelectionEnabled="True">
+                        <Hyperlink x:Name="CommitLink">
+                            <Run x:Name="CommitText" />
+                        </Hyperlink>
+                    </TextBlock>
+                </Grid>
+
+                <!-- Link buttons -->
+                <StackPanel Orientation="Horizontal" Spacing="8"
+                            HorizontalAlignment="Center">
+                    <HyperlinkButton x:Name="GitHubButton" Content="GitHub" />
+                    <HyperlinkButton x:Name="DocsButton" Content="Docs" />
+                    <HyperlinkButton x:Name="HomepageButton" Content="Homepage" />
+                    <HyperlinkButton x:Name="SponsorButton" Content="Sponsor" />
+                </StackPanel>
+
+                <!-- License / copyright -->
+                <StackPanel Spacing="2" HorizontalAlignment="Center">
+                    <TextBlock x:Name="LicenseText"
+                               HorizontalAlignment="Center"
+                               IsTextSelectionEnabled="True"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Style="{StaticResource CaptionTextBlockStyle}" />
+                    <TextBlock x:Name="CopyrightText"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center"
+                               IsTextSelectionEnabled="True"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Window>

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
@@ -71,22 +71,28 @@ internal sealed partial class AboutWindow : Window
         var info = VersionRenderer.Build();
         VersionValue.Text = info.WinttyVersion;
 
-        // Build = edition, plus channel when libghostty reports one.
+        // The Version row already carries the semantic version, so the Build
+        // row surfaces the distribution identity instead: edition, plus the
+        // libghostty channel (tip/stable) when reported. Mirrors the split in
+        // `wintty +version`.
         var edition = EditionLabel.Format(info.Edition);
         BuildValue.Text = string.IsNullOrEmpty(info.LibGhostty.Channel)
             ? edition
             : $"{edition} ({info.LibGhostty.Channel})";
 
+        // CommitUrl is null when the commit is unknown. Guard the parse too:
+        // the commit string is build-derived, so a malformed value collapses
+        // the row rather than throwing and taking down the whole window.
         var commitUrl = VersionRenderer.CommitUrl(info);
-        if (commitUrl is null)
+        if (commitUrl is not null && Uri.TryCreate(commitUrl, UriKind.Absolute, out var commitUri))
         {
-            CommitLabel.Visibility = Visibility.Collapsed;
-            CommitValue.Visibility = Visibility.Collapsed;
+            CommitText.Text = info.WinttyCommit;
+            CommitLink.NavigateUri = commitUri;
         }
         else
         {
-            CommitText.Text = info.WinttyCommit;
-            CommitLink.NavigateUri = new Uri(commitUrl);
+            CommitLabel.Visibility = Visibility.Collapsed;
+            CommitValue.Visibility = Visibility.Collapsed;
         }
 
         GitHubButton.NavigateUri = new Uri(AboutContent.GitHubUrl);

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
@@ -1,0 +1,140 @@
+using System;
+using Ghostty.Branding;
+using Ghostty.Core;
+using Ghostty.Core.Config;
+using Ghostty.Core.Version;
+using Ghostty.Core.Windows;
+using Ghostty.Services;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using WinRT.Interop;
+
+namespace Ghostty.Dialogs;
+
+internal sealed partial class AboutWindow : Window
+{
+    private readonly IConfigService _configService;
+    private readonly WindowThemeManager _themeManager;
+
+    public AboutWindow(IConfigService configService)
+    {
+        _configService = configService;
+        InitializeComponent();
+
+        WindowHelper.TryApplyAppIcon(this);
+
+        var titleText = $"About {AppIdentity.ProductName}";
+        Title = titleText;
+        AppTitleBar.Title = titleText;
+        ExtendsContentIntoTitleBar = true;
+        SetTitleBar(AppTitleBar);
+
+        SystemBackdrop = new MicaBackdrop();
+
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
+        var appWindow = AppWindow.GetFromWindowId(windowId);
+
+        // Small panel centered on the cursor's display, like SettingsWindow
+        // but sized to the content rather than the 1100x750 settings shell.
+        const int width = 420;
+        const int height = 560;
+        var display = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Primary);
+        var work = display.WorkArea;
+        var x = work.X + (work.Width - width) / 2;
+        var y = work.Y + (work.Height - height) / 2;
+        appWindow.MoveAndResize(new Windows.Graphics.RectInt32(x, y, width, height));
+
+        // Follow OS theme unless window-theme forces light/dark, matching
+        // the Settings window's System fallback.
+        _themeManager = new WindowThemeManager(
+            _configService, DispatcherQueue, ThemeFallbackStyle.System);
+        ApplyTheme();
+        _themeManager.ThemeChanged += OnThemeChanged;
+
+        PopulateContent();
+
+        Closed += OnClosed;
+    }
+
+    private void PopulateContent()
+    {
+        AppIcon.Source = new BitmapImage(AppIconSource.Current);
+        ProductNameText.Text = AppIdentity.ProductName;
+        TaglineText.Text = AboutContent.Tagline;
+        LicenseText.Text = AboutContent.LicenseNote;
+        CopyrightText.Text = AboutContent.Copyright;
+
+        var info = VersionRenderer.Build();
+        VersionValue.Text = info.WinttyVersion;
+
+        // Build = edition, plus channel when libghostty reports one.
+        var edition = EditionLabel.Format(info.Edition);
+        BuildValue.Text = string.IsNullOrEmpty(info.LibGhostty.Channel)
+            ? edition
+            : $"{edition} ({info.LibGhostty.Channel})";
+
+        var commitUrl = VersionRenderer.CommitUrl(info);
+        if (commitUrl is null)
+        {
+            CommitLabel.Visibility = Visibility.Collapsed;
+            CommitValue.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            CommitText.Text = info.WinttyCommit;
+            CommitLink.NavigateUri = new Uri(commitUrl);
+        }
+
+        GitHubButton.NavigateUri = new Uri(AboutContent.GitHubUrl);
+        DocsButton.NavigateUri = new Uri(AboutContent.DocsUrl);
+        HomepageButton.NavigateUri = new Uri(AboutContent.HomepageUrl);
+        SponsorButton.NavigateUri = new Uri(AboutContent.SponsorUrl);
+    }
+
+    private void OnThemeChanged(bool _) => ApplyTheme();
+
+    private void ApplyTheme()
+    {
+        RootGrid.RequestedTheme = _themeManager.ElementTheme;
+        _themeManager.ApplyToWindow(this);
+        ApplyCaptionButtonColors();
+    }
+
+    // Mirror SettingsWindow: system caption buttons default to white glyphs,
+    // invisible on a light Mica backdrop; pick colors that follow the window
+    // theme.
+    private const byte CaptionButtonHoverAlpha = 0x33;
+    private const byte CaptionButtonPressedAlpha = 0x66;
+    private static readonly Windows.UI.Color CaptionButtonInactiveFg =
+        Windows.UI.Color.FromArgb(0xFF, 0x99, 0x99, 0x99);
+
+    private void ApplyCaptionButtonColors()
+    {
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
+        var titleBar = AppWindow.GetFromWindowId(windowId).TitleBar;
+        var dark = _themeManager.ElementTheme == ElementTheme.Dark;
+        var fg = dark ? Microsoft.UI.Colors.White : Microsoft.UI.Colors.Black;
+
+        titleBar.ButtonBackgroundColor = Microsoft.UI.Colors.Transparent;
+        titleBar.ButtonInactiveBackgroundColor = Microsoft.UI.Colors.Transparent;
+        titleBar.ButtonForegroundColor = fg;
+        titleBar.ButtonInactiveForegroundColor = CaptionButtonInactiveFg;
+        titleBar.ButtonHoverBackgroundColor =
+            Windows.UI.Color.FromArgb(CaptionButtonHoverAlpha, fg.R, fg.G, fg.B);
+        titleBar.ButtonHoverForegroundColor = fg;
+        titleBar.ButtonPressedBackgroundColor =
+            Windows.UI.Color.FromArgb(CaptionButtonPressedAlpha, fg.R, fg.G, fg.B);
+        titleBar.ButtonPressedForegroundColor = fg;
+    }
+
+    private void OnClosed(object sender, WindowEventArgs args)
+    {
+        _themeManager.ThemeChanged -= OnThemeChanged;
+        _themeManager.Dispose();
+    }
+}

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -105,6 +105,12 @@ internal sealed class PaneActionRouter
     /// </summary>
     public event EventHandler? ShowKeybindCheatsheetRequested;
 
+    /// <summary>
+    /// Raised when the About chord or palette entry fires. MainWindow
+    /// listens and opens the singleton About window.
+    /// </summary>
+    public event EventHandler? ShowAboutRequested;
+
     public void Invoke(PaneAction action)
     {
         // Event-only actions that don't need pane/tab state — handle
@@ -131,6 +137,9 @@ internal sealed class PaneActionRouter
                 return;
             case PaneAction.ShowKeybindCheatsheet:
                 ShowKeybindCheatsheetRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ShowAbout:
+                ShowAboutRequested?.Invoke(this, EventArgs.Empty);
                 return;
 
             // Scrollback jumps are dispatched as libghostty binding

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -176,6 +176,7 @@ public sealed partial class MainWindow : Window
 
     private GradientTintVisual? _gradientVisual;
     private Window? _settingsWindow;
+    private Window? _aboutWindow;
 
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
@@ -1048,6 +1049,10 @@ public sealed partial class MainWindow : Window
         _settingsWindow?.Close();
         _settingsWindow = null;
 
+        // Close About window if open.
+        _aboutWindow?.Close();
+        _aboutWindow = null;
+
         // Let any in-flight ContentDialog complete before tearing
         // down the libghostty host. files-community/Files # 17363
         // documents the COMException that fires otherwise.
@@ -1314,6 +1319,20 @@ public sealed partial class MainWindow : Window
                 _configService,
                 Content?.XamlRoot,
                 WinRT.Interop.WindowNative.GetWindowHandle(this));
+
+        _router.ShowAboutRequested += (_, _) =>
+        {
+            // Reuse the existing About window if it is still open.
+            if (_aboutWindow is not null)
+            {
+                _aboutWindow.Activate();
+                return;
+            }
+            var aboutWin = new Ghostty.Dialogs.AboutWindow(_configService);
+            aboutWin.Closed += (_, _) => _aboutWindow = null;
+            _aboutWindow = aboutWin;
+            aboutWin.Activate();
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
Adds a dedicated About window for parity with macOS. Until now the only version surface was the command-palette Version command, which shows a technical build-config dump.

The About window is a branded panel: app name, tagline, version/build/commit rows, GitHub/Docs/Homepage/Sponsor links, and the MIT license note. Version data reuses `VersionRenderer.Build()`; the brand strings and links live in a unit-tested `AboutContent` class in Core. Window chrome mirrors `SettingsWindow` (Mica, custom title bar, themed).

Reachable from the command palette and keybindable via a new Windows-only `PaneAction.ShowAbout`, routed through `PaneActionRouter` the same way as the keyboard cheat sheet. `MainWindow` opens it as a singleton.

## Test
- Unit: `AboutContent` links/license and `PaneAction.ShowAbout` value
- In-app: command palette -> About opens the window with correct version/build/commit; links and close work
