### PR TITLE
Opt-in single-instance mode (Windows)

### DIFF
--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -42,6 +42,14 @@ public interface IConfigService : IDisposable
     bool CommandPaletteGroupCommands { get; }
 
     /// <summary>
+    /// Windows-only: true when opt-in single-instance mode is active. A
+    /// second launch forwards its working directory and argv to the
+    /// already-running instance (which opens a new window) and then exits.
+    /// Default false. Backed by the "windows-single-instance" key.
+    /// </summary>
+    bool WindowsSingleInstance { get; }
+
+    /// <summary>
     /// Windows-only: backdrop material for the command palette.
     /// One of "acrylic", "mica", "opaque". Default "acrylic".
     /// Backed by the "command-palette-background" key.

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -53,6 +53,8 @@ public static class WindowsOnlyKeys
             "Id of the profile opened for a new tab or window when none is specified."),
         new("profile-order",
             "Comma-separated list of profile ids defining the order shown in the tab picker and command palette."),
+        new("windows-single-instance",
+            "When true, a second launch is routed into the already-running instance (opens a new window) instead of starting a separate process."),
     ];
 
     public static readonly FrozenSet<string> Set =

--- a/windows/Ghostty.Core/SingleInstance/LaunchRequest.cs
+++ b/windows/Ghostty.Core/SingleInstance/LaunchRequest.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Ghostty.Core.SingleInstance;
+
+/// <summary>
+/// The launch a secondary process forwards to the primary when
+/// single-instance mode is on: the working directory it was started in
+/// and its full argv. Immutable; serialized to a wire format the primary
+/// parses off the named pipe.
+/// </summary>
+public sealed record LaunchRequest(string WorkingDirectory, IReadOnlyList<string> Args)
+{
+    private const string Header = "V1";
+
+    /// <summary>
+    /// Length-prefixed UTF-8 encoding. Format:
+    /// <c>V1\n</c> then each string as <c>&lt;utf8ByteCount&gt;:&lt;bytes&gt;</c>:
+    /// working directory, then the arg count (as its own length-prefixed
+    /// decimal string), then each arg. Length-prefixing means args may
+    /// contain ANY bytes (newlines, colons, spaces, unicode) and still
+    /// round-trip; there is no escaping and nothing to mis-split on. No
+    /// JSON, so it is Native-AOT-safe with no reflection.
+    /// </summary>
+    public string Serialize()
+    {
+        var sb = new StringBuilder();
+        sb.Append(Header).Append('\n');
+        AppendField(sb, WorkingDirectory);
+        AppendField(sb, Args.Count.ToString(CultureInfo.InvariantCulture));
+        foreach (var arg in Args)
+            AppendField(sb, arg);
+        return sb.ToString();
+    }
+
+    private static void AppendField(StringBuilder sb, string value)
+    {
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        sb.Append(byteCount.ToString(CultureInfo.InvariantCulture)).Append(':').Append(value);
+    }
+
+    /// <summary>
+    /// Parse a serialized request. Returns false (never throws) on any
+    /// malformed input so the server loop can drop a bad client without
+    /// faulting.
+    /// </summary>
+    public static bool TryParse(string? s, out LaunchRequest? request)
+    {
+        request = null;
+        if (s is null) return false;
+
+        // Header line.
+        var nl = s.IndexOf('\n');
+        if (nl < 0 || s[..nl] != Header) return false;
+        var rest = s[(nl + 1)..];
+        var pos = 0;
+
+        if (!TryReadField(rest, ref pos, out var cwd)) return false;
+        if (!TryReadField(rest, ref pos, out var countStr)) return false;
+        if (!int.TryParse(countStr, NumberStyles.None, CultureInfo.InvariantCulture, out var count)
+            || count < 0)
+            return false;
+
+        var args = new List<string>(count);
+        for (var i = 0; i < count; i++)
+        {
+            if (!TryReadField(rest, ref pos, out var arg)) return false;
+            args.Add(arg);
+        }
+
+        // Reject trailing garbage: everything must have been consumed.
+        if (pos != rest.Length) return false;
+
+        request = new LaunchRequest(cwd, args);
+        return true;
+    }
+
+    private static bool TryReadField(string s, ref int pos, out string value)
+    {
+        value = string.Empty;
+        var colon = s.IndexOf(':', pos);
+        if (colon < 0) return false;
+
+        var lenSpan = s.AsSpan(pos, colon - pos);
+        if (!int.TryParse(lenSpan, NumberStyles.None, CultureInfo.InvariantCulture, out var byteCount)
+            || byteCount < 0)
+            return false;
+
+        var contentStart = colon + 1;
+        // We measured the field in UTF-8 bytes but index a UTF-16 string;
+        // walk forward counting bytes until we have consumed byteCount.
+        var charCount = 0;
+        var bytesSeen = 0;
+        while (contentStart + charCount < s.Length && bytesSeen < byteCount)
+        {
+            bytesSeen += Utf8ByteLengthAt(s, contentStart + charCount, out var consumedChars);
+            charCount += consumedChars;
+        }
+        if (bytesSeen != byteCount) return false;
+
+        value = s.Substring(contentStart, charCount);
+        pos = contentStart + charCount;
+        return true;
+    }
+
+    // Returns the UTF-8 byte length of the (possibly surrogate-pair)
+    // code unit(s) starting at index i, and how many UTF-16 chars it spans.
+    private static int Utf8ByteLengthAt(string s, int i, out int consumedChars)
+    {
+        var c = s[i];
+        if (char.IsHighSurrogate(c) && i + 1 < s.Length && char.IsLowSurrogate(s[i + 1]))
+        {
+            consumedChars = 2;
+            return 4; // astral plane code point
+        }
+        consumedChars = 1;
+        if (c < 0x80) return 1;
+        if (c < 0x800) return 2;
+        return 3;
+    }
+}

--- a/windows/Ghostty.Core/SingleInstance/SingleInstanceNames.cs
+++ b/windows/Ghostty.Core/SingleInstance/SingleInstanceNames.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Ghostty.Core.SingleInstance;
+
+/// <summary>
+/// Derives the named-mutex and named-pipe identifiers used to coordinate
+/// single-instance mode. Keyed off the executable path so two different
+/// installs never collide, while two launches of the SAME install share
+/// one identity. The mutex is <c>Local\</c>-scoped: single-instance is a
+/// per-user-session notion, matching "one instance for me", and avoids
+/// the cross-session / elevation pitfalls of a <c>Global\</c> object.
+/// Pure (no I/O) so it is unit-testable.
+/// </summary>
+public static class SingleInstanceNames
+{
+    public readonly record struct Names(string Mutex, string Pipe);
+
+    public static Names For(string exePath)
+    {
+        ArgumentNullException.ThrowIfNull(exePath);
+
+        // Normalize so case / separator differences map to one identity:
+        // Windows paths are case-insensitive and Zig hands us forward
+        // slashes in places.
+        var normalized = exePath.Replace('/', '\\').ToLowerInvariant();
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        // 16 hex chars (64 bits) is plenty to avoid collisions between
+        // installs and keeps the names short.
+        var token = Convert.ToHexString(hashBytes, 0, 8).ToLowerInvariant();
+
+        return new Names(
+            Mutex: $@"Local\Wintty-SingleInstance-{token}",
+            Pipe: $"wintty-single-instance-{token}");
+    }
+}

--- a/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
+++ b/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
@@ -130,6 +130,7 @@ public class SettingsConfigWriterTests
         public double BackgroundOpacity => 1.0;
         public bool VerticalTabs => false;
         public bool CommandPaletteGroupCommands => false;
+        public bool WindowsSingleInstance => false;
         public string CommandPaletteBackground => "acrylic";
         public string LogLevel => "info";
         public string LogFilter => string.Empty;

--- a/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
@@ -59,6 +59,7 @@ public class SettingsConfigWriterLoggingTests
         public double BackgroundOpacity => 1.0;
         public bool VerticalTabs => false;
         public bool CommandPaletteGroupCommands => false;
+        public bool WindowsSingleInstance => false;
         public string CommandPaletteBackground => "acrylic";
         public string LogLevel => "info";
         public string LogFilter => string.Empty;

--- a/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Ghostty.Core.SingleInstance;
+using Xunit;
+
+namespace Ghostty.Tests.SingleInstance;
+
+public sealed class LaunchRequestTests
+{
+    [Fact]
+    public void RoundTrips_SimpleArgs()
+    {
+        var req = new LaunchRequest(@"C:\Users\me\proj", ["wintty", "--flag", "value"]);
+        Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
+        Assert.Equal(req.WorkingDirectory, back!.WorkingDirectory);
+        Assert.Equal(req.Args, back.Args);
+    }
+
+    [Fact]
+    public void RoundTrips_EmptyArgs()
+    {
+        var req = new LaunchRequest(@"C:\dir", []);
+        Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
+        Assert.Equal(@"C:\dir", back!.WorkingDirectory);
+        Assert.Empty(back.Args);
+    }
+
+    [Fact]
+    public void RoundTrips_ArgsWithNewlinesColonsSpacesUnicode()
+    {
+        var req = new LaunchRequest(
+            "/tmp/some dir:weird\nname",
+            ["a b", "x:y", "line1\nline2", "naïve 中文", ""]);
+        Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
+        Assert.Equal(req.WorkingDirectory, back!.WorkingDirectory);
+        Assert.Equal(req.Args, back.Args);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("V1")]
+    [InlineData("V2\n3:abc")]              // wrong version
+    [InlineData("V1\n9:ab")]               // declared length exceeds bytes
+    [InlineData("V1\n3:abcX")]             // trailing garbage after a field
+    [InlineData("V1\nnotanumber:abc")]     // non-numeric length prefix
+    [InlineData("V1\n3:cwd")]              // missing arg-count field
+    public void TryParse_Malformed_ReturnsFalse(string s)
+    {
+        Assert.False(LaunchRequest.TryParse(s, out var back));
+        Assert.Null(back);
+    }
+}

--- a/windows/Ghostty.Tests/SingleInstance/SingleInstanceNamesTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/SingleInstanceNamesTests.cs
@@ -1,0 +1,44 @@
+using Ghostty.Core.SingleInstance;
+using Xunit;
+
+namespace Ghostty.Tests.SingleInstance;
+
+public sealed class SingleInstanceNamesTests
+{
+    [Fact]
+    public void SamePath_ProducesStableNames()
+    {
+        var a = SingleInstanceNames.For(@"C:\Program Files\Wintty\Wintty.exe");
+        var b = SingleInstanceNames.For(@"C:\Program Files\Wintty\Wintty.exe");
+        Assert.Equal(a.Mutex, b.Mutex);
+        Assert.Equal(a.Pipe, b.Pipe);
+    }
+
+    [Fact]
+    public void PathIsCaseAndSeparatorInsensitive()
+    {
+        var a = SingleInstanceNames.For(@"C:\Apps\Wintty\Wintty.exe");
+        var b = SingleInstanceNames.For(@"c:/apps/wintty/wintty.exe");
+        Assert.Equal(a.Mutex, b.Mutex);
+        Assert.Equal(a.Pipe, b.Pipe);
+    }
+
+    [Fact]
+    public void DifferentPaths_ProduceDifferentNames()
+    {
+        var a = SingleInstanceNames.For(@"C:\A\Wintty.exe");
+        var b = SingleInstanceNames.For(@"C:\B\Wintty.exe");
+        Assert.NotEqual(a.Mutex, b.Mutex);
+        Assert.NotEqual(a.Pipe, b.Pipe);
+    }
+
+    [Fact]
+    public void MutexIsSessionLocalScoped()
+    {
+        var n = SingleInstanceNames.For(@"C:\X\Wintty.exe");
+        Assert.StartsWith(@"Local\", n.Mutex);
+        // Pipe names live under \\.\pipe\ and must not contain backslashes
+        // in the user-supplied portion.
+        Assert.DoesNotContain(@"\", n.Pipe);
+    }
+}

--- a/windows/Ghostty.Tests/SingleInstance/WindowsSingleInstanceKeyTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/WindowsSingleInstanceKeyTests.cs
@@ -1,0 +1,30 @@
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.SingleInstance;
+
+public sealed class WindowsSingleInstanceKeyTests
+{
+    [Fact]
+    public void Key_IsRegisteredAsWindowsOnly()
+    {
+        Assert.True(WindowsOnlyKeys.Contains("windows-single-instance"));
+    }
+
+    [Fact]
+    public void Key_HasDescription()
+    {
+        Assert.True(WindowsOnlyKeys.ByKey.TryGetValue("windows-single-instance", out var entry));
+        Assert.False(string.IsNullOrWhiteSpace(entry.Description));
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("", false)]      // unset => default OFF
+    [InlineData("1", false)]     // only canonical true/false honored
+    public void ParseBool_MatchesGateSemantics(string raw, bool expected)
+    {
+        Assert.Equal(expected, WindowsOnlyKeyParsers.ParseBool(raw, defaultValue: false));
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -70,6 +70,15 @@ public partial class App : Application
     // repeat press would otherwise stack a second menu on top.
     private bool _systemMenuOpen;
 
+    // Single-instance mode (opt-in via windows-single-instance). When this
+    // process is the primary it holds the mutex for the whole process
+    // lifetime, so the GC must not collect it -- hence the field. Null when
+    // single-instance is off, or when mutex acquisition threw (we then fall
+    // back to launching as a normal independent process). The server runs
+    // the forwarding pipe and only exists on the primary.
+    private System.Threading.Mutex? _singleInstanceMutex;
+    private Ghostty.Hosting.SingleInstanceServer? _singleInstanceServer;
+
     // The quake chord comes from the quick-terminal-key config value
     // (read via ConfigService.QuickTerminalKeyChord). QuickTerminalKeyChord.Default
     // is Ctrl+backtick (MOD_CONTROL|MOD_NOREPEAT, VK_OEM_3) when the
@@ -399,6 +408,18 @@ public partial class App : Application
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
         ConfigService = _configService;
 
+        // Single-instance gate. Decided here -- after ConfigService gives
+        // us the value and the config path, but before the bootstrap host,
+        // window, and DX12 renderer are created -- so a secondary process
+        // forwards its launch and exits without ever creating a window or
+        // paying for the renderer. Off by default: the call is a no-op and
+        // this stays a normal independent process. Returns normally when
+        // this process should keep launching (primary, or a forward that
+        // failed and falls back); calls Environment.Exit(0) itself when it
+        // was a secondary that handed its launch to the primary.
+        if (_configService.WindowsSingleInstance)
+            HandleSingleInstanceGate();
+
         // build the factory from Ghostty config before any other service constructs an
         // ILogger<T>. Log directory under the same %LOCALAPPDATA%\Ghostty root that
         // App.LogUnhandled already uses for crash.log, so a user reporting a bug only has
@@ -681,6 +702,139 @@ public partial class App : Application
         // Re-claim the chord whenever the config changes so an edited
         // quick-terminal-key takes effect without a restart.
         _configService.ConfigChanged += OnConfigReloaded_ReRegisterHotKey;
+
+        // Start the single-instance forwarding server last, once the UI
+        // dispatcher and logger factory exist. No-op unless this process is
+        // the single-instance primary (it holds the mutex).
+        StartSingleInstanceServer();
+    }
+
+    /// <summary>
+    /// Acquire the single-instance mutex. If we win it, keep it (this
+    /// process is the primary) and let OnLaunched continue. If another
+    /// process already holds it, forward our launch over the named pipe
+    /// and exit. Any failure on the secondary path falls back to a normal
+    /// independent launch so the user never loses a window.
+    /// </summary>
+    private void HandleSingleInstanceGate()
+    {
+        var exePath = Environment.ProcessPath ?? string.Empty;
+        var names = Ghostty.Core.SingleInstance.SingleInstanceNames.For(exePath);
+
+        bool createdNew;
+        try
+        {
+            _singleInstanceMutex = new System.Threading.Mutex(
+                initiallyOwned: true, name: names.Mutex, out createdNew);
+        }
+        catch (Exception ex)
+        {
+            // Could not create the coordination primitive at all. Do not
+            // block the launch: behave as a normal single window.
+            System.Diagnostics.Debug.WriteLine(
+                $"[single-instance] mutex create failed; launching normally. {ex.Message}");
+            _singleInstanceMutex = null;
+            return;
+        }
+
+        if (createdNew)
+        {
+            // Primary. The server is started later in OnLaunched once the
+            // UI dispatcher exists (see StartSingleInstanceServer()).
+            return;
+        }
+
+        // Secondary: a primary is already running. Forward and exit.
+        var request = new Ghostty.Core.SingleInstance.LaunchRequest(
+            Environment.CurrentDirectory,
+            Environment.GetCommandLineArgs());
+
+        try
+        {
+            using var client = new System.IO.Pipes.NamedPipeClientStream(
+                ".", names.Pipe, System.IO.Pipes.PipeDirection.Out);
+            client.Connect(2000); // 2s: primary should answer promptly
+            using var writer = new System.IO.StreamWriter(client) { AutoFlush = true };
+            writer.Write(request.Serialize());
+            writer.Flush();
+            client.WaitForPipeDrain();
+
+            // Release our mutex handle (we never owned it) and exit. The
+            // primary owns the launch now.
+            _singleInstanceMutex.Dispose();
+            _singleInstanceMutex = null;
+            Environment.Exit(0);
+        }
+        catch (Exception ex)
+        {
+            // Primary may be mid-shutdown or the pipe is wedged. Fall back
+            // to launching normally rather than dropping the user's launch.
+            // Drop the mutex handle first: we did not create it, and a new
+            // primary election is irrelevant now that we are becoming a
+            // standalone window.
+            System.Diagnostics.Debug.WriteLine(
+                $"[single-instance] forward failed; launching normally. {ex.Message}");
+            try { _singleInstanceMutex?.Dispose(); } catch { /* ignore */ }
+            _singleInstanceMutex = null;
+        }
+    }
+
+    /// <summary>
+    /// Start the forwarding pipe server. Called near the end of OnLaunched
+    /// (after _uiDispatcher is set) only when this process is the
+    /// single-instance primary (it holds the mutex).
+    /// </summary>
+    private void StartSingleInstanceServer()
+    {
+        if (_singleInstanceMutex is null || _loggerFactory is null) return;
+
+        var exePath = Environment.ProcessPath ?? string.Empty;
+        var names = Ghostty.Core.SingleInstance.SingleInstanceNames.For(exePath);
+        try
+        {
+            _singleInstanceServer = new Ghostty.Hosting.SingleInstanceServer(
+                names.Pipe,
+                req => _uiDispatcher?.TryEnqueue(() => OpenWindowFromLaunch(req)),
+                _loggerFactory.CreateLogger<Ghostty.Hosting.SingleInstanceServer>());
+            _singleInstanceServer.Start();
+        }
+        catch (Exception ex)
+        {
+            // A primary that cannot serve simply behaves like a normal
+            // window; secondaries will fail to connect and fall back to
+            // independent launches.
+            System.Diagnostics.Debug.WriteLine(
+                $"[single-instance] server start failed. {ex.Message}");
+            _singleInstanceServer = null;
+        }
+    }
+
+    /// <summary>
+    /// Open a new top-level window for a launch forwarded from a secondary
+    /// instance, seeded with the forwarded working directory. Runs on the
+    /// UI thread. Mirrors MainWindow.OpenInNewWindow's wiring.
+    /// </summary>
+    internal void OpenWindowFromLaunch(Ghostty.Core.SingleInstance.LaunchRequest req)
+    {
+        if (_configService is null || _bootstrapHost is null
+            || _lifetimeSupervisor is null || _loggerFactory is null)
+            return;
+
+        Ghostty.Core.Profiles.ProfileSnapshot? snapshot = null;
+        var registry = ProfileRegistry;
+        if (registry?.DefaultProfileId is { } defaultId
+            && registry.Resolve(defaultId) is { } resolved)
+        {
+            snapshot = Ghostty.Core.Profiles.ProfileSnapshotStore.From(
+                resolved, registry.Version);
+            if (!string.IsNullOrEmpty(req.WorkingDirectory))
+                snapshot = snapshot with { WorkingDirectory = req.WorkingDirectory };
+        }
+
+        var window = MainWindow.CreateForNewTab(
+            _configService, _bootstrapHost, _lifetimeSupervisor, _loggerFactory, snapshot);
+        window.Closed += OnAnyWindowClosedInternal;
+        window.Activate();
     }
 
     /// <summary>
@@ -913,6 +1067,12 @@ public partial class App : Application
                     quake.Close();
                 }
 
+                // Stop the single-instance forwarding server before the
+                // host tears down so no inbound forwarded launch races a
+                // half-disposed app (the callback enqueues OpenWindowFromLaunch
+                // onto the UI thread).
+                _singleInstanceServer?.Dispose();
+
                 // Bootstrap host is the LAST host. Its Dispose drains
                 // _hostBySurface (asserts empty), notifies the
                 // supervisor (which throws if anything is still live),
@@ -992,6 +1152,12 @@ public partial class App : Application
                 _fileLogSink = null;
                 _loggerFactory = null;
                 LoggerFactory = null;
+
+                _singleInstanceServer = null;
+                // Release the single-instance mutex last so a relaunch can
+                // become the new primary immediately after we exit.
+                try { _singleInstanceMutex?.Dispose(); } catch { /* ignore */ }
+                _singleInstanceMutex = null;
 
                 Exit();
             }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -408,18 +408,6 @@ public partial class App : Application
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
         ConfigService = _configService;
 
-        // Single-instance gate. Decided here -- after ConfigService gives
-        // us the value and the config path, but before the bootstrap host,
-        // window, and DX12 renderer are created -- so a secondary process
-        // forwards its launch and exits without ever creating a window or
-        // paying for the renderer. Off by default: the call is a no-op and
-        // this stays a normal independent process. Returns normally when
-        // this process should keep launching (primary, or a forward that
-        // failed and falls back); calls Environment.Exit(0) itself when it
-        // was a secondary that handed its launch to the primary.
-        if (_configService.WindowsSingleInstance)
-            HandleSingleInstanceGate();
-
         // build the factory from Ghostty config before any other service constructs an
         // ILogger<T>. Log directory under the same %LOCALAPPDATA%\Ghostty root that
         // App.LogUnhandled already uses for crash.log, so a user reporting a bug only has
@@ -454,6 +442,19 @@ public partial class App : Application
         // the factory exists, and cannot receive a logger through its ctor) and for call
         // sites inside static scopes.
         Ghostty.Logging.StaticLoggers.Initialize(factory);
+
+        // Single-instance gate. Decided here -- after ConfigService gives us
+        // the value and the logger factory exists (so failures are visible
+        // in Release), but before the bootstrap host, window, and DX12
+        // renderer are created -- so a secondary process forwards its launch
+        // and exits without ever creating a window or paying for the
+        // renderer. Off by default: the call is a no-op and this stays a
+        // normal independent process. Returns normally when this process
+        // should keep launching (primary, or a forward that failed and falls
+        // back); calls Environment.Exit(0) itself when it was a secondary
+        // that handed its launch to the primary.
+        if (_configService.WindowsSingleInstance)
+            HandleSingleInstanceGate();
 
         // Power-saving monitor. Reads power-saver-mode from config every
         // time it resolves (Func thunk decouples it from ConfigService
@@ -731,8 +732,7 @@ public partial class App : Application
         {
             // Could not create the coordination primitive at all. Do not
             // block the launch: behave as a normal single window.
-            System.Diagnostics.Debug.WriteLine(
-                $"[single-instance] mutex create failed; launching normally. {ex.Message}");
+            Ghostty.Logging.StaticLoggers.App.LogSingleInstanceMutexFailed(ex);
             _singleInstanceMutex = null;
             return;
         }
@@ -759,8 +759,12 @@ public partial class App : Application
             writer.Flush();
             client.WaitForPipeDrain();
 
-            // Release our mutex handle (we never owned it) and exit. The
-            // primary owns the launch now.
+            // The primary owns the launch now. Release everything this
+            // throwaway process holds -- the config service (and its file
+            // watcher + native config handle) and the mutex handle (we never
+            // owned it) -- then exit deterministically rather than leaving
+            // the OS to reclaim them at teardown.
+            _configService?.Dispose();
             _singleInstanceMutex.Dispose();
             _singleInstanceMutex = null;
             Environment.Exit(0);
@@ -772,8 +776,7 @@ public partial class App : Application
             // Drop the mutex handle first: we did not create it, and a new
             // primary election is irrelevant now that we are becoming a
             // standalone window.
-            System.Diagnostics.Debug.WriteLine(
-                $"[single-instance] forward failed; launching normally. {ex.Message}");
+            Ghostty.Logging.StaticLoggers.App.LogSingleInstanceForwardFailed(ex);
             try { _singleInstanceMutex?.Dispose(); } catch { /* ignore */ }
             _singleInstanceMutex = null;
         }
@@ -803,8 +806,7 @@ public partial class App : Application
             // A primary that cannot serve simply behaves like a normal
             // window; secondaries will fail to connect and fall back to
             // independent launches.
-            System.Diagnostics.Debug.WriteLine(
-                $"[single-instance] server start failed. {ex.Message}");
+            Ghostty.Logging.StaticLoggers.App.LogSingleInstanceServerStartFailed(ex);
             _singleInstanceServer = null;
         }
     }
@@ -1183,5 +1185,23 @@ internal static partial class AppLogExtensions
                    Level = LogLevel.Warning,
                    Message = "Failed to register for toast notifications")]
     internal static partial void LogToastRegisterFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SingleInstance.MutexFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Single-instance mutex could not be created; launching as a normal independent process.")]
+    internal static partial void LogSingleInstanceMutexFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SingleInstance.ForwardFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Single-instance forward to the primary failed; launching as a normal independent process.")]
+    internal static partial void LogSingleInstanceForwardFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SingleInstance.ServerStartFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Single-instance pipe server failed to start; secondaries will launch independently.")]
+    internal static partial void LogSingleInstanceServerStartFailed(
         this ILogger<App> logger, System.Exception ex);
 }

--- a/windows/Ghostty/Hosting/SingleInstanceServer.cs
+++ b/windows/Ghostty/Hosting/SingleInstanceServer.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Pipes;
+using Ghostty.Core.SingleInstance;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Hosting;
+
+/// <summary>
+/// The primary instance's named-pipe server for single-instance mode.
+/// Accepts one forwarded <see cref="LaunchRequest"/> per client
+/// connection and hands it to the <c>onLaunch</c> callback. The accept
+/// loop is bounded by the shared <see cref="PipeServerRetryPolicy"/>
+/// (the same policy the theme-preview pipe uses) so a server-creation
+/// failure stands the loop down instead of busy-looping.
+/// </summary>
+public sealed class SingleInstanceServer : IDisposable
+{
+    private readonly string _pipeName;
+    private readonly Action<LaunchRequest> _onLaunch;
+    private readonly ILogger<SingleInstanceServer> _logger;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly PipeServerRetryPolicy _retryPolicy = new();
+    private Task? _loop;
+
+    public SingleInstanceServer(
+        string pipeName,
+        Action<LaunchRequest> onLaunch,
+        ILogger<SingleInstanceServer> logger)
+    {
+        _pipeName = pipeName;
+        _onLaunch = onLaunch;
+        _logger = logger;
+    }
+
+    public void Start()
+    {
+        // Fire-and-forget: the loop owns its own cancellation and never
+        // throws out (RunOneSession maps every fault to an outcome).
+        _loop = Task.Run(() => RunServer(_cts.Token));
+    }
+
+    private async Task RunServer(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var outcome = await RunOneSession(ct);
+            switch (_retryPolicy.Decide(outcome))
+            {
+                case PipeLoopDecision.Stop:
+                case PipeLoopDecision.StandDown:
+                    return;
+                case PipeLoopDecision.RetryAfterBackoff:
+                    try { await Task.Delay(_retryPolicy.Backoff, ct); }
+                    catch (OperationCanceledException) { return; }
+                    break;
+                case PipeLoopDecision.RetryImmediately:
+                default:
+                    break;
+            }
+        }
+    }
+
+    private async Task<PipeLoopOutcome> RunOneSession(CancellationToken ct)
+    {
+        NamedPipeServerStream server;
+        try
+        {
+            server = new NamedPipeServerStream(
+                _pipeName,
+                PipeDirection.In,
+                1, // single instance: one forwarded launch at a time
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous | PipeOptions.FirstPipeInstance);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogSingleInstancePipeUnavailable(ex);
+            return PipeLoopOutcome.ServerCreationFailed;
+        }
+
+        try
+        {
+            using (server)
+            {
+                await server.WaitForConnectionAsync(ct);
+                using var reader = new StreamReader(server);
+                // The secondary writes Serialize() (which may itself
+                // contain '\n' inside fields), so read the whole stream,
+                // not a single line.
+                var payload = await reader.ReadToEndAsync(ct);
+                if (LaunchRequest.TryParse(payload, out var req) && req is not null)
+                    _onLaunch(req);
+                else
+                    _logger.LogSingleInstanceBadPayload();
+            }
+            return PipeLoopOutcome.SessionEnded;
+        }
+        catch (OperationCanceledException)
+        {
+            return PipeLoopOutcome.Cancelled;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogSingleInstancePipeError(ex);
+            return PipeLoopOutcome.SessionFaulted;
+        }
+    }
+
+    public void Dispose()
+    {
+        try { _cts.Cancel(); } catch { /* already disposed */ }
+        // Best-effort: nudge a blocked WaitForConnectionAsync awake by
+        // connecting a throwaway client, so the loop observes cancellation
+        // promptly rather than at the next OS timeout.
+        try
+        {
+            using var nudge = new NamedPipeClientStream(".", _pipeName, PipeDirection.Out);
+            nudge.Connect(50);
+        }
+        catch { /* server may already be gone */ }
+        try { _loop?.Wait(TimeSpan.FromSeconds(2)); } catch { /* best effort */ }
+        _cts.Dispose();
+    }
+}
+
+internal static partial class SingleInstanceServerLog
+{
+    [LoggerMessage(
+        EventId = Ghostty.Logging.LogEvents.SingleInstance.PipeUnavailable,
+        Level = LogLevel.Warning,
+        Message = "Single-instance pipe server could not be created; standing down.")]
+    internal static partial void LogSingleInstancePipeUnavailable(
+        this ILogger<SingleInstanceServer> logger, Exception ex);
+
+    [LoggerMessage(
+        EventId = Ghostty.Logging.LogEvents.SingleInstance.PipeError,
+        Level = LogLevel.Warning,
+        Message = "Single-instance pipe session faulted.")]
+    internal static partial void LogSingleInstancePipeError(
+        this ILogger<SingleInstanceServer> logger, Exception ex);
+
+    [LoggerMessage(
+        EventId = Ghostty.Logging.LogEvents.SingleInstance.BadPayload,
+        Level = LogLevel.Warning,
+        Message = "Single-instance pipe received an unparseable launch payload; ignoring.")]
+    internal static partial void LogSingleInstanceBadPayload(
+        this ILogger<SingleInstanceServer> logger);
+}

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -89,8 +89,11 @@ internal static class LogEvents
     // 2900-2999: Single-instance mode
     internal static class SingleInstance
     {
-        public const int PipeUnavailable = 2900;
-        public const int PipeError       = 2901;
-        public const int BadPayload      = 2902;
+        public const int PipeUnavailable   = 2900;
+        public const int PipeError         = 2901;
+        public const int BadPayload        = 2902;
+        public const int MutexFailed       = 2903;
+        public const int ForwardFailed     = 2904;
+        public const int ServerStartFailed = 2905;
     }
 }

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -85,4 +85,12 @@ internal static class LogEvents
         public const int SaveFailed   = 2801;
         public const int DeleteFailed = 2802;
     }
+
+    // 2900-2999: Single-instance mode
+    internal static class SingleInstance
+    {
+        public const int PipeUnavailable = 2900;
+        public const int PipeError       = 2901;
+        public const int BadPayload      = 2902;
+    }
 }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -57,6 +57,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     // optimization.
     public bool VerticalTabs { get; private set; }
     public bool CommandPaletteGroupCommands { get; private set; }
+    public bool WindowsSingleInstance { get; private set; }
     public string CommandPaletteBackground { get; private set; } = "acrylic";
     public string LogLevel { get; private set; } = "info";
     public string LogFilter { get; private set; } = string.Empty;
@@ -561,6 +562,9 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
             defaultValue: false);
         CommandPaletteGroupCommands = WindowsOnlyKeyParsers.ParseBool(
             GetFileValue("command-palette-group-commands", ""),
+            defaultValue: false);
+        WindowsSingleInstance = WindowsOnlyKeyParsers.ParseBool(
+            GetFileValue("windows-single-instance", ""),
             defaultValue: false);
         CommandPaletteBackground = WindowsOnlyKeyParsers.ParseStringAllowed(
             GetFileValue("command-palette-background", ""),


### PR DESCRIPTION
Adds an opt-in single-instance mode for parity with GTK's gtk-single-instance.

New windows-only config key windows-single-instance (bool, default false). When off, every launch is its own process, exactly as today.

When on, the first launch is the primary: it holds a named mutex and runs a named-pipe server. A later launch detects the primary via the mutex, forwards its working directory and argv over the pipe, and exits. The primary opens a new window seeded with the forwarded working directory.

The mutex and pipe names are keyed off the executable path so different installs don't collide. The launch payload uses a length-prefixed wire format (no JSON) so it stays Native-AOT-safe and unit-testable. The gate runs early in OnLaunched, after the config and logger exist but before any window or the DX12 renderer, so a forwarding process exits without paying for the renderer.

## Testing
- Unit: LaunchRequest round-trip (newlines, colons, unicode, empty args), malformed-input rejection, name derivation stability and path sensitivity. Full suite green (1384 passed).
- In-app: with the key off, two launches give two independent windows. With it on, a second launch opens a new window in the first instance and the second process exits. Launching with no primary opens one normal window. Closing the last window shuts down cleanly with no teardown hang.