### PR TITLE
Wire up bindable window/title apprt actions

### DIFF
--- a/windows/Ghostty.Core/Input/ApprtActionMap.cs
+++ b/windows/Ghostty.Core/Input/ApprtActionMap.cs
@@ -64,6 +64,25 @@ internal static class ApprtActionMap
             _ => null,
         },
 
+        GhosttyActionTag.GotoWindow => (GhosttyGotoWindow)value switch
+        {
+            GhosttyGotoWindow.Previous => PaneAction.GotoWindowPrevious,
+            GhosttyGotoWindow.Next => PaneAction.GotoWindowNext,
+            _ => null,
+        },
+
+        GhosttyActionTag.FloatWindow => (GhosttyFloatWindow)value switch
+        {
+            GhosttyFloatWindow.On => PaneAction.FloatWindowOn,
+            GhosttyFloatWindow.Off => PaneAction.FloatWindowOff,
+            GhosttyFloatWindow.Toggle => PaneAction.FloatWindowToggle,
+            _ => null,
+        },
+
+        // Payload-free window actions: value is unused.
+        GhosttyActionTag.ResetWindowSize => PaneAction.ResetWindowSize,
+        GhosttyActionTag.ToggleBackgroundOpacity => PaneAction.ToggleBackgroundOpacity,
+
         _ => null,
     };
 }

--- a/windows/Ghostty.Core/Input/BackgroundOpacityToggle.cs
+++ b/windows/Ghostty.Core/Input/BackgroundOpacityToggle.cs
@@ -1,0 +1,30 @@
+namespace Ghostty.Core.Input;
+
+/// <summary>
+/// Decides the next background-opacity value when toggling between
+/// fully-opaque and the configured (transparent) baseline. On Windows
+/// there is no transient runtime opacity channel, so the toggle is
+/// realised by writing the config value and reloading; this helper keeps
+/// the decision pure and testable.
+/// </summary>
+public static class BackgroundOpacityToggle
+{
+    /// <param name="current">The current effective background opacity (0..1).</param>
+    /// <param name="baseline">The remembered transparent value to restore,
+    /// or null if we are not currently in the "forced opaque" state.</param>
+    public static Result Next(double current, double? baseline)
+    {
+        // Currently transparent -> force opaque, remember where we came from.
+        if (current < 1.0) return new Result(1.0, current);
+
+        // Currently opaque with a transparent baseline -> restore it.
+        if (baseline is { } b && b < 1.0) return new Result(b, null);
+
+        // Started opaque (or baseline is itself opaque): nothing to reveal.
+        return new Result(null, baseline);
+    }
+
+    /// <param name="OpacityToWrite">Value to persist + reload, or null for no-op.</param>
+    /// <param name="NewBaseline">Updated remembered baseline.</param>
+    public readonly record struct Result(double? OpacityToWrite, double? NewBaseline);
+}

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -109,4 +109,16 @@ public enum PaneAction
     // with fresh shells; does not resurrect the live shell.
     ReopenClosedTab = 53,
     ReopenClosedWindow = 54,
+
+    // Window-level apprt actions. These act on the window owning the
+    // surface that matched the keybind; PaneActionRouter forwards each
+    // via an event to MainWindow (no pane/tab state involved), mirroring
+    // ToggleFullscreen / ToggleQuickTerminal.
+    GotoWindowPrevious = 55,
+    GotoWindowNext = 56,
+    ResetWindowSize = 57,
+    ToggleBackgroundOpacity = 58,
+    FloatWindowOn = 59,
+    FloatWindowOff = 60,
+    FloatWindowToggle = 61,
 }

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -22,22 +22,33 @@ internal enum GhosttyActionTag
     NewTab = 2,
     CloseTab = 3,
     NewSplit = 4,
+    CloseAllWindows = 5,
     ToggleFullscreen = 7,
     ToggleQuickTerminal = 10,
     ToggleCommandPalette = 11,
+    ToggleVisibility = 12,
+    ToggleBackgroundOpacity = 13,
     MoveTab = 14,
     GotoTab = 15,
     GotoSplit = 16,
+    GotoWindow = 17,
     ResizeSplit = 18,
     EqualizeSplits = 19,
     ToggleSplitZoom = 20,
+    PresentTerminal = 21,
+    SizeLimit = 22,
+    ResetWindowSize = 23,
+    InitialSize = 24,
     Scrollbar = 26,
     DesktopNotification = 31,
     SetTitle = 32,
+    SetTabTitle = 33,
+    PromptTitle = 34,
     MouseShape = 36,
     MouseVisibility = 37,
     MouseOverLink = 38,
     OpenConfig = 40,
+    FloatWindow = 42,
     ReloadConfig = 47,
     ConfigChange = 48,
     CloseWindow = 49,
@@ -89,6 +100,42 @@ internal enum GhosttyGotoSplit { Previous = 0, Next = 1, Up = 2, Left = 3, Down 
 // ordering from GhosttySplitDirection — resize grows the split toward
 // the named edge, so the values do not line up with placement.
 internal enum GhosttyResizeSplitDirection { Up = 0, Down = 1, Left = 2, Right = 3 }
+
+// ghostty_action_goto_window_e: relative window navigation.
+internal enum GhosttyGotoWindow { Previous = 0, Next = 1 }
+
+// ghostty_action_float_window_e: always-on-top state to apply.
+internal enum GhosttyFloatWindow { On = 0, Off = 1, Toggle = 2 }
+
+// ghostty_action_prompt_title_e: whether the prompt renames the
+// individual surface (pane) or the surface's containing tab.
+internal enum GhosttyPromptTitle { Surface = 0, Tab = 1 }
+
+// ghostty_action_size_limit_s:
+//   { uint32 min_width; uint32 min_height; uint32 max_width; uint32 max_height; }
+// All values are pixels; 0 means "no limit" for that dimension. On x64
+// this is 16 bytes (4 * 4), read at actionPtr+8 via Unsafe.ReadUnaligned.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionSizeLimit
+{
+    public uint MinWidth;
+    public uint MinHeight;
+    public uint MaxWidth;
+    public uint MaxHeight;
+}
+
+// ghostty_action_initial_size_s:
+//   { uint32 width; uint32 height; }
+// Pixels. 8 bytes on x64. libghostty emits this during surface init
+// ONLY when both window-width and window-height are configured
+// (src/Surface.zig recomputeInitialSize); it is the canonical source
+// for the "return to default size" action and is not itself bindable.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionInitialSize
+{
+    public uint Width;
+    public uint Height;
+}
 
 // Sentinel tab targets carried in ghostty_action_goto_tab_s. Positive
 // values are 1-based tab indices; these negatives select relative tabs.

--- a/windows/Ghostty.Tests/Input/ApprtActionMapTests.cs
+++ b/windows/Ghostty.Tests/Input/ApprtActionMapTests.cs
@@ -57,6 +57,33 @@ public class ApprtActionMapTests
     public void MoveTab_MapsBySign(int amount, PaneAction expected) =>
         Assert.Equal(expected, ApprtActionMap.Map(GhosttyActionTag.MoveTab, amount));
 
+    [Theory]
+    [InlineData(0, PaneAction.GotoWindowPrevious)]
+    [InlineData(1, PaneAction.GotoWindowNext)]
+    public void GotoWindow_Maps_By_Direction(int value, PaneAction expected)
+        => Assert.Equal(expected, ApprtActionMap.Map(GhosttyActionTag.GotoWindow, value));
+
+    [Theory]
+    [InlineData(0, PaneAction.FloatWindowOn)]
+    [InlineData(1, PaneAction.FloatWindowOff)]
+    [InlineData(2, PaneAction.FloatWindowToggle)]
+    public void FloatWindow_Maps_By_Mode(int value, PaneAction expected)
+        => Assert.Equal(expected, ApprtActionMap.Map(GhosttyActionTag.FloatWindow, value));
+
+    [Fact]
+    public void ResetWindowSize_Maps_Ignoring_Value()
+        => Assert.Equal(PaneAction.ResetWindowSize, ApprtActionMap.Map(GhosttyActionTag.ResetWindowSize, 0));
+
+    [Fact]
+    public void ToggleBackgroundOpacity_Maps_Ignoring_Value()
+        => Assert.Equal(PaneAction.ToggleBackgroundOpacity, ApprtActionMap.Map(GhosttyActionTag.ToggleBackgroundOpacity, 0));
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(-1)]
+    public void GotoWindow_OutOfRange_ReturnsNull(int value)
+        => Assert.Null(ApprtActionMap.Map(GhosttyActionTag.GotoWindow, value));
+
     [Fact] public void UnknownTag_ReturnsNull() =>
         Assert.Null(ApprtActionMap.Map((GhosttyActionTag)9999, 0));
 

--- a/windows/Ghostty.Tests/Input/BackgroundOpacityToggleTests.cs
+++ b/windows/Ghostty.Tests/Input/BackgroundOpacityToggleTests.cs
@@ -1,0 +1,39 @@
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Input;
+
+public class BackgroundOpacityToggleTests
+{
+    [Fact]
+    public void Transparent_GoesOpaque_AndRemembersBaseline()
+    {
+        var r = BackgroundOpacityToggle.Next(current: 0.8, baseline: null);
+        Assert.Equal(1.0, r.OpacityToWrite);
+        Assert.Equal(0.8, r.NewBaseline);
+    }
+
+    [Fact]
+    public void Opaque_WithBaseline_RestoresAndClears()
+    {
+        var r = BackgroundOpacityToggle.Next(current: 1.0, baseline: 0.8);
+        Assert.Equal(0.8, r.OpacityToWrite);
+        Assert.Null(r.NewBaseline);
+    }
+
+    [Fact]
+    public void Opaque_NoBaseline_IsNoOp()
+    {
+        var r = BackgroundOpacityToggle.Next(current: 1.0, baseline: null);
+        Assert.Null(r.OpacityToWrite);
+        Assert.Null(r.NewBaseline);
+    }
+
+    [Fact]
+    public void Opaque_WithFullyOpaqueBaseline_IsNoOp()
+    {
+        // A baseline that is itself fully opaque reveals nothing.
+        var r = BackgroundOpacityToggle.Next(current: 1.0, baseline: 1.0);
+        Assert.Null(r.OpacityToWrite);
+    }
+}

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -12,6 +12,7 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.NewTab, 2)]
     [InlineData((int)GhosttyActionTag.CloseTab, 3)]
     [InlineData((int)GhosttyActionTag.NewSplit, 4)]
+    [InlineData((int)GhosttyActionTag.CloseAllWindows, 5)]
     [InlineData((int)GhosttyActionTag.ToggleFullscreen, 7)]
     [InlineData((int)GhosttyActionTag.ToggleQuickTerminal, 10)]
     [InlineData((int)GhosttyActionTag.MoveTab, 14)]
@@ -37,6 +38,16 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.SearchSelected, 62)]
     [InlineData((int)GhosttyActionTag.PromptReady, 65)]
     [InlineData((int)GhosttyActionTag.FirstRender, 66)]
+    [InlineData((int)GhosttyActionTag.ToggleVisibility, 12)]
+    [InlineData((int)GhosttyActionTag.ToggleBackgroundOpacity, 13)]
+    [InlineData((int)GhosttyActionTag.GotoWindow, 17)]
+    [InlineData((int)GhosttyActionTag.PresentTerminal, 21)]
+    [InlineData((int)GhosttyActionTag.SizeLimit, 22)]
+    [InlineData((int)GhosttyActionTag.ResetWindowSize, 23)]
+    [InlineData((int)GhosttyActionTag.InitialSize, 24)]
+    [InlineData((int)GhosttyActionTag.SetTabTitle, 33)]
+    [InlineData((int)GhosttyActionTag.PromptTitle, 34)]
+    [InlineData((int)GhosttyActionTag.FloatWindow, 42)]
     public void ActionTag_Ordinal_Matches_Upstream(int tag, int expected)
     {
         Assert.Equal(expected, tag);
@@ -228,5 +239,45 @@ public class GhosttyActionsLayoutTests
         // Unsafe.ReadUnaligned, so the fields MUST sit at +0/+8.
         Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyChildExited>(nameof(GhosttyChildExited.ExitCode)));
         Assert.Equal(8, (int)Marshal.OffsetOf<GhosttyChildExited>(nameof(GhosttyChildExited.RuntimeMs)));
+    }
+
+    [Fact]
+    public void SizeLimitStruct_HasExpectedLayout()
+    {
+        Assert.Equal(16, Marshal.SizeOf<GhosttyActionSizeLimit>());
+        Assert.Equal(0,  (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MinWidth)));
+        Assert.Equal(4,  (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MinHeight)));
+        Assert.Equal(8,  (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MaxWidth)));
+        Assert.Equal(12, (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MaxHeight)));
+    }
+
+    [Fact]
+    public void InitialSizeStruct_HasExpectedLayout()
+    {
+        Assert.Equal(8, Marshal.SizeOf<GhosttyActionInitialSize>());
+        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionInitialSize>(nameof(GhosttyActionInitialSize.Width)));
+        Assert.Equal(4, (int)Marshal.OffsetOf<GhosttyActionInitialSize>(nameof(GhosttyActionInitialSize.Height)));
+    }
+
+    [Fact]
+    public void GotoWindowEnum_MatchesHeader()
+    {
+        Assert.Equal(0, (int)GhosttyGotoWindow.Previous);
+        Assert.Equal(1, (int)GhosttyGotoWindow.Next);
+    }
+
+    [Fact]
+    public void FloatWindowEnum_MatchesHeader()
+    {
+        Assert.Equal(0, (int)GhosttyFloatWindow.On);
+        Assert.Equal(1, (int)GhosttyFloatWindow.Off);
+        Assert.Equal(2, (int)GhosttyFloatWindow.Toggle);
+    }
+
+    [Fact]
+    public void PromptTitleEnum_MatchesHeader()
+    {
+        Assert.Equal(0, (int)GhosttyPromptTitle.Surface);
+        Assert.Equal(1, (int)GhosttyPromptTitle.Tab);
     }
 }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -898,6 +898,75 @@ public partial class App : Application
         });
     }
 
+    /// <summary>
+    /// Close every normal terminal window (close_all_windows). The quake
+    /// window is intentionally skipped: when the last normal window closes,
+    /// the internal teardown force-closes the quake window and the bootstrap
+    /// host, so the process exits cleanly. Snapshot first because Close()
+    /// mutates WindowsByRoot during the loop.
+    /// </summary>
+    internal void CloseAllWindows()
+    {
+        foreach (var w in AllWindows.ToList())
+        {
+            if (ReferenceEquals(w, _quakeWindow)) continue;
+            w.Close();
+        }
+    }
+
+    // Whether the last toggle_visibility hid the windows, and the set it hid.
+    // The hide/show decision is driven by this flag rather than inferred from
+    // IsVisible: a window opened between a hide and the next toggle would flip
+    // an IsVisible-based check and strand the earlier-hidden windows.
+    private bool _windowsHiddenByVisibilityToggle;
+    private readonly List<MainWindow> _hiddenByVisibilityToggle = new();
+
+    /// <summary>
+    /// Hide/show all normal windows (toggle_visibility). If they are not
+    /// currently hidden by a prior toggle, hide every visible one and remember
+    /// the set; otherwise re-show exactly that set. The quake window is excluded
+    /// -- it has its own global-hotkey toggle.
+    /// </summary>
+    internal void ToggleAllWindowsVisibility()
+    {
+        var normal = AllWindows.Where(w => !ReferenceEquals(w, _quakeWindow)).ToList();
+        if (!_windowsHiddenByVisibilityToggle)
+        {
+            _hiddenByVisibilityToggle.Clear();
+            foreach (var w in normal)
+            {
+                if (!w.AppWindow.IsVisible) continue;
+                _hiddenByVisibilityToggle.Add(w);
+                w.AppWindow.Hide();
+            }
+            // Only enter the hidden state if we actually hid something, so a
+            // no-op toggle doesn't leave us unable to "restore" on the next one.
+            _windowsHiddenByVisibilityToggle = _hiddenByVisibilityToggle.Count > 0;
+        }
+        else
+        {
+            // Restore exactly the windows we hid, skipping any closed since.
+            foreach (var w in _hiddenByVisibilityToggle.Where(normal.Contains))
+                w.AppWindow.Show();
+            _hiddenByVisibilityToggle.Clear();
+            _windowsHiddenByVisibilityToggle = false;
+        }
+    }
+
+    /// <summary>
+    /// Focus the previous/next normal window relative to <paramref name="current"/>
+    /// (goto_window), wrapping at the ends. Direction: -1 previous, +1 next.
+    /// </summary>
+    internal void ActivateRelativeWindow(MainWindow current, int direction)
+    {
+        var normal = AllWindows.Where(w => !ReferenceEquals(w, _quakeWindow)).ToList();
+        if (normal.Count <= 1) return;
+        var idx = normal.IndexOf(current);
+        if (idx < 0) return;
+        var next = ((idx + direction) % normal.Count + normal.Count) % normal.Count;
+        normal[next].Activate();
+    }
+
     private void RegisterQuakeHotKey()
     {
         if (_quakeHotKey is null) return;

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -161,19 +161,35 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         return pid > int.MaxValue ? null : (int)pid;
     }
 
+    // The raw title libghostty last pushed (shell OSC 0/2 or set_title).
+    private string? _shellTitle;
+    // The user's explicit per-surface override (prompt_title surface mode).
+    // Beats the shell title; null means "follow the shell".
+    private string? _userTitleOverride;
+
     /// <summary>
-    /// Last title pushed by libghostty for this surface, or null if no
-    /// title has been set yet. Used by MainWindow to update the window
-    /// chrome immediately on focus change without waiting for the next
-    /// TitleChanged.
+    /// Effective title for this surface: the user's per-surface override if
+    /// set, otherwise the shell-reported title. Read by MainWindow's title
+    /// coordinator to populate the tab label on focus change, so a pane with
+    /// an override shows that override when focused.
     /// </summary>
-    public string? CurrentTitle { get; private set; }
+    public string? CurrentTitle => _userTitleOverride ?? _shellTitle;
 
     // Raisers invoked by GhosttyHost after routing an action to this leaf.
     internal void RaiseTitleChanged(string title)
     {
-        CurrentTitle = title;
-        TitleChanged?.Invoke(this, title);
+        _shellTitle = title;
+        TitleChanged?.Invoke(this, CurrentTitle ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Set (or clear, with null/whitespace) the user's per-surface title
+    /// override. Fires TitleChanged with the new effective title.
+    /// </summary>
+    internal void SetUserTitleOverride(string? title)
+    {
+        _userTitleOverride = string.IsNullOrWhiteSpace(title) ? null : title;
+        TitleChanged?.Invoke(this, CurrentTitle ?? string.Empty);
     }
     internal void RaiseCloseRequested() => CloseRequested?.Invoke(this, EventArgs.Empty);
     internal void RaiseProgressChanged(Ghostty.Core.Tabs.TabProgressState state)

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -17,6 +17,9 @@ using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Ghostty.Hosting;
 
+internal readonly record struct SizeLimitRequest(
+    uint MinWidth, uint MinHeight, uint MaxWidth, uint MaxHeight);
+
 /// <summary>
 /// Per-window owner of the libghostty surface registry and the runtime
 /// callback surface. Each host has its OWN per-window
@@ -96,6 +99,26 @@ internal sealed class GhosttyHost : IDisposable
         _dispatcher.TryEnqueue(() =>
             OpacityAdjustRequested?.Invoke(this, direction));
     }
+
+    /// <summary>Raised for size_limit: apply min/max window dimensions
+    /// (pixels; 0 = no limit). Surface-targeted; raised on the owning host.</summary>
+    public event EventHandler<SizeLimitRequest>? SizeLimitRequested;
+
+    /// <summary>Raised for set_tab_title: set the active tab's title
+    /// override directly. Empty string clears the override.</summary>
+    public event EventHandler<string>? SetTabTitleRequested;
+
+    /// <summary>Raised for prompt_title: prompt the user to rename either
+    /// the surface (pane) or its tab. Carries (isTab, surface control).</summary>
+    public event Action<bool, TerminalControl>? PromptTitleRequested;
+
+    /// <summary>Raised for present_terminal: bring the owning window to the
+    /// front and focus this surface (switching tabs if needed).</summary>
+    public event Action<TerminalControl>? PresentSurfaceRequested;
+
+    /// <summary>Raised for initial_size (private): the libghostty-computed
+    /// default window size in pixels, used to back reset_window_size.</summary>
+    public event Action<uint, uint>? InitialSizeReceived;
 
     private ClipboardBridge? _clipboardBridge;
 
@@ -476,6 +499,16 @@ internal sealed class GhosttyHost : IDisposable
                         _logger.LogWarning("MouseVisibility action received with app target; ignoring");
                         return 1;
 
+                    case GhosttyActionTag.CloseAllWindows:
+                        _dispatcher.TryEnqueue(() =>
+                            ((Ghostty.App)Microsoft.UI.Xaml.Application.Current).CloseAllWindows());
+                        return 1;
+
+                    case GhosttyActionTag.ToggleVisibility:
+                        _dispatcher.TryEnqueue(() =>
+                            ((Ghostty.App)Microsoft.UI.Xaml.Application.Current).ToggleAllWindowsVisibility());
+                        return 1;
+
                     default:
                         return 0;
                 }
@@ -512,11 +545,15 @@ internal sealed class GhosttyHost : IDisposable
                 case GhosttyActionTag.ToggleFullscreen:
                 case GhosttyActionTag.EqualizeSplits:
                 case GhosttyActionTag.ToggleSplitZoom:
+                case GhosttyActionTag.ResetWindowSize:
+                case GhosttyActionTag.ToggleBackgroundOpacity:
                     return DispatchPaneAction(owner, tag.Value, 0);
 
                 case GhosttyActionTag.NewSplit:
                 case GhosttyActionTag.GotoSplit:
                 case GhosttyActionTag.GotoTab:
+                case GhosttyActionTag.GotoWindow:
+                case GhosttyActionTag.FloatWindow:
                     return DispatchPaneAction(owner, tag.Value, Marshal.ReadInt32(actionPtr, 8));
 
                 case GhosttyActionTag.ResizeSplit:
@@ -550,6 +587,65 @@ internal sealed class GhosttyHost : IDisposable
                         if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                             c.RaiseTitleChanged(title);
                     });
+                    return 1;
+                }
+
+                case GhosttyActionTag.SetTabTitle:
+                {
+                    // char* title at +8, same shape as SetTitle. Empty -> clear.
+                    var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
+                    var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
+                    _dispatcher.TryEnqueue(() =>
+                        owner.SetTabTitleRequested?.Invoke(owner, title));
+                    return 1;
+                }
+
+                case GhosttyActionTag.PromptTitle:
+                {
+                    // c_int mode at +8: 0 = surface, 1 = tab.
+                    var isTab = Marshal.ReadInt32(actionPtr, 8) == (int)GhosttyPromptTitle.Tab;
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                            owner.PromptTitleRequested?.Invoke(isTab, c);
+                    });
+                    return 1;
+                }
+
+                case GhosttyActionTag.PresentTerminal:
+                {
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                            owner.PresentSurfaceRequested?.Invoke(c);
+                    });
+                    return 1;
+                }
+
+                case GhosttyActionTag.SizeLimit:
+                {
+                    GhosttyActionSizeLimit s;
+                    unsafe
+                    {
+                        s = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyActionSizeLimit>(
+                            (void*)(actionPtr + 8));
+                    }
+                    _dispatcher.TryEnqueue(() =>
+                        owner.SizeLimitRequested?.Invoke(owner,
+                            new SizeLimitRequest(s.MinWidth, s.MinHeight, s.MaxWidth, s.MaxHeight)));
+                    return 1;
+                }
+
+                case GhosttyActionTag.InitialSize:
+                {
+                    GhosttyActionInitialSize s;
+                    unsafe
+                    {
+                        s = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyActionInitialSize>(
+                            (void*)(actionPtr + 8));
+                    }
+                    _dispatcher.TryEnqueue(() =>
+                        owner.InitialSizeReceived?.Invoke(s.Width, s.Height));
                     return 1;
                 }
 

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -125,6 +125,27 @@ internal sealed class PaneActionRouter
     /// </summary>
     public event EventHandler? ReopenClosedWindowRequested;
 
+    /// <summary>
+    /// Raised for goto_window. The argument is the direction:
+    /// -1 = previous, +1 = next. MainWindow forwards to
+    /// App.ActivateRelativeWindow.
+    /// </summary>
+    public event EventHandler<int>? GotoWindowRequested;
+
+    /// <summary>Raised for reset_window_size. MainWindow resizes the
+    /// AppWindow back to the captured initial (config-default) size.</summary>
+    public event EventHandler? ResetWindowSizeRequested;
+
+    /// <summary>Raised for toggle_background_opacity. MainWindow flips the
+    /// configured opacity between 1.0 and the remembered baseline.</summary>
+    public event EventHandler? ToggleBackgroundOpacityRequested;
+
+    /// <summary>
+    /// Raised for float_window. The argument matches ghostty_action_float_window_e:
+    /// 0 = on, 1 = off, 2 = toggle. MainWindow applies always-on-top.
+    /// </summary>
+    public event EventHandler<int>? FloatWindowRequested;
+
     public void Invoke(PaneAction action)
     {
         // Event-only actions that don't need pane/tab state — handle
@@ -160,6 +181,27 @@ internal sealed class PaneActionRouter
                 return;
             case PaneAction.ReopenClosedWindow:
                 ReopenClosedWindowRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.GotoWindowPrevious:
+                GotoWindowRequested?.Invoke(this, -1);
+                return;
+            case PaneAction.GotoWindowNext:
+                GotoWindowRequested?.Invoke(this, +1);
+                return;
+            case PaneAction.ResetWindowSize:
+                ResetWindowSizeRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ToggleBackgroundOpacity:
+                ToggleBackgroundOpacityRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.FloatWindowOn:
+                FloatWindowRequested?.Invoke(this, 0);
+                return;
+            case PaneAction.FloatWindowOff:
+                FloatWindowRequested?.Invoke(this, 1);
+                return;
+            case PaneAction.FloatWindowToggle:
+                FloatWindowRequested?.Invoke(this, 2);
                 return;
 
             // Scrollback jumps are dispatched as libghostty binding

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -199,6 +199,16 @@ public sealed partial class MainWindow : Window
     private FrecencyStore? _frecencyStore;
     private Controls.TerminalControl? _previousFocusSurface;
 
+    // Last libghostty-computed default window size (initial_size action), in
+    // physical pixels. null until received; reset_window_size is a no-op
+    // before then (mirrors core, which only emits initial_size when
+    // window-width/window-height are configured).
+    private Windows.Graphics.SizeInt32? _defaultWindowSizePx;
+
+    // Remembered transparent opacity baseline for toggle_background_opacity.
+    // null when not in the forced-opaque state.
+    private double? _opacityToggleBaseline;
+
     /// <summary>
     /// Palette close state: prevents re-entrant close handling between
     /// ViewModel.PropertyChanged and Popup.Closed callbacks.
@@ -681,6 +691,26 @@ public sealed partial class MainWindow : Window
 
         // Ctrl+Shift+Scroll wheel opacity adjustment from any terminal surface.
         _host.OpacityAdjustRequested += (_, direction) => AdjustOpacity(direction);
+
+        // Window-level keybind actions routed through the per-window router.
+        // These are per-window events, so every window wires them.
+        _router.GotoWindowRequested += (_, dir) =>
+            ((App)Application.Current).ActivateRelativeWindow(this, dir);
+        _router.ResetWindowSizeRequested += (_, _) => ResetWindowSize();
+        _router.ToggleBackgroundOpacityRequested += (_, _) => ToggleBackgroundOpacity();
+        _router.FloatWindowRequested += (_, mode) => ApplyFloat(mode);
+
+        // Surface-targeted window actions raised on the per-window host.
+        _host.SizeLimitRequested += (_, lim) => ApplySizeLimit(lim);
+        _host.SetTabTitleRequested += (_, title) =>
+            _tabManager.ActiveTab.UserOverrideTitle = string.IsNullOrWhiteSpace(title) ? null : title;
+        // The host already raises these on the UI thread (OnAction dispatches
+        // before invoking), so no extra hop is needed here. The dialog helper
+        // is fire-and-forget and self-contains its exception handling.
+        _host.PromptTitleRequested += (isTab, control) => _ = ShowPromptTitleDialogAsync(isTab, control);
+        _host.PresentSurfaceRequested += PresentSurface;
+        _host.InitialSizeReceived += (w, h) =>
+            _defaultWindowSizePx = new Windows.Graphics.SizeInt32((int)w, (int)h);
 
         // Re-evaluate transparency state after every config reload so
         // Ctrl+Shift+Scroll and Settings UI changes take effect live.
@@ -2374,6 +2404,134 @@ public sealed partial class MainWindow : Window
         _configWriter.Write(
             () => _configEditor.SetValue("background-opacity", next.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)),
             "background-opacity");
+    }
+
+    /// <summary>Apply always-on-top (float_window). mode: 0 on, 1 off, 2 toggle.</summary>
+    private void ApplyFloat(int mode)
+    {
+        if (AppWindow.Presenter is not Microsoft.UI.Windowing.OverlappedPresenter p) return;
+        p.IsAlwaysOnTop = mode switch
+        {
+            0 => true,
+            1 => false,
+            _ => !p.IsAlwaysOnTop,
+        };
+    }
+
+    /// <summary>
+    /// Resize back to the libghostty-computed default (reset_window_size).
+    /// No-op until an initial_size has been received (window-width/height set),
+    /// matching core behaviour.
+    /// </summary>
+    private void ResetWindowSize()
+    {
+        if (_defaultWindowSizePx is not { } size) return;
+        if (AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter
+            { State: Microsoft.UI.Windowing.OverlappedPresenterState.Maximized } op)
+        {
+            op.Restore();
+        }
+        // AppWindow.Resize takes physical pixels, so the initial_size payload
+        // (already in physical pixels) is passed through as-is -- unlike the
+        // DIP-based PreferredMinimum/Maximum sizes in ApplySizeLimit.
+        AppWindow.Resize(size);
+    }
+
+    /// <summary>
+    /// Flip the configured background opacity between 1.0 and the remembered
+    /// baseline (toggle_background_opacity). Persists + reloads, consistent
+    /// with the Ctrl+Shift+scroll opacity behaviour.
+    /// </summary>
+    private void ToggleBackgroundOpacity()
+    {
+        var r = Ghostty.Core.Input.BackgroundOpacityToggle.Next(
+            _configService.BackgroundOpacity, _opacityToggleBaseline);
+        _opacityToggleBaseline = r.NewBaseline;
+        if (r.OpacityToWrite is not { } next) return; // no-op (started opaque)
+        _configWriter.Write(
+            // Invariant culture: libghostty's config parser expects a '.'
+            // decimal separator, so a comma-decimal locale would corrupt the value.
+            () => _configEditor.SetValue(
+                "background-opacity",
+                next.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)),
+            "background-opacity");
+    }
+
+    /// <summary>
+    /// Apply min/max window size (size_limit). Payload is physical pixels;
+    /// OverlappedPresenter wants DIPs, so scale by the window DPI. 0 means
+    /// "no limit" for that dimension.
+    /// </summary>
+    private void ApplySizeLimit(Ghostty.Hosting.SizeLimitRequest lim)
+    {
+        if (AppWindow.Presenter is not Microsoft.UI.Windowing.OverlappedPresenter p) return;
+        var hwnd = new HWND(WindowNative.GetWindowHandle(this));
+        var dpi = PInvoke.GetDpiForWindow(hwnd);
+        var scale = dpi == 0 ? 1.0 : dpi / 96.0;
+        int Dip(uint px) => px == 0 ? 0 : (int)Math.Round(px / scale);
+
+        p.PreferredMinimumWidth = Dip(lim.MinWidth);
+        p.PreferredMinimumHeight = Dip(lim.MinHeight);
+        p.PreferredMaximumWidth = Dip(lim.MaxWidth);
+        p.PreferredMaximumHeight = Dip(lim.MaxHeight);
+    }
+
+    /// <summary>
+    /// Prompt to rename either the tab or the surface (prompt_title), reusing
+    /// the existing rename dialog.
+    /// </summary>
+    private async Task ShowPromptTitleDialogAsync(bool isTab, Controls.TerminalControl control)
+    {
+        var root = Content?.XamlRoot;
+        if (root is null) return;
+
+        var initial = isTab ? _tabManager.ActiveTab.UserOverrideTitle : control.CurrentTitle;
+        var dlg = new RenameTabDialog(initial) { XamlRoot = root };
+        using (_dialogs.Track(dlg))
+        {
+            ContentDialogResult outcome;
+            try
+            {
+                // ShowAsync throws if another ContentDialog is already open;
+                // a keybind can fire while one is up, and this runs as a
+                // fire-and-forget continuation, so swallow that race rather
+                // than let it crash the process.
+                outcome = await dlg.ShowAsync();
+            }
+            catch (InvalidOperationException)
+            {
+                return;
+            }
+
+            if (outcome != ContentDialogResult.Primary) return;
+            var result = string.IsNullOrWhiteSpace(dlg.Result) ? null : dlg.Result;
+            if (isTab)
+                _tabManager.ActiveTab.UserOverrideTitle = result;
+            else
+                control.SetUserTitleOverride(result);
+        }
+    }
+
+    /// <summary>
+    /// Bring this window to the front and focus the target surface, switching
+    /// to its tab if it lives in a background tab (present_terminal).
+    /// </summary>
+    private void PresentSurface(Controls.TerminalControl target)
+    {
+        Activate();
+        foreach (var tab in _tabManager.Tabs)
+        {
+            var ph = (Panes.PaneHost)tab.PaneHost;
+            foreach (var leaf in PaneTree.Leaves(ph.RootNode))
+            {
+                if (!ReferenceEquals(leaf.Terminal(), target)) continue;
+                var idx = _tabManager.IndexOf(tab);
+                if (idx >= 0) _tabManager.JumpTo(idx);
+                target.Focus(FocusState.Programmatic);
+                return;
+            }
+        }
+        FocusActiveLeaf();
     }
 
     private void ToggleCommandPalette()

--- a/windows/Ghostty/NativeMethods.txt
+++ b/windows/Ghostty/NativeMethods.txt
@@ -14,6 +14,7 @@ FlashWindowEx
 FLASHWINFO
 FLASHWINFO_FLAGS
 GetCursorPos
+GetDpiForWindow
 GetForegroundWindow
 GetKeyState
 GetMonitorInfo


### PR DESCRIPTION
@
Several apprt actions are bindable but silently do nothing on Windows because their tags are missing from `GhosttyActionTag`. This adds the FFI tags, mappings, and handlers so the keybinds work, matching the macOS/GTK behavior.

Actions wired:
- `goto_window` - focus previous/next window
- `present_terminal` - bring the target surface window to front and focus it
- `prompt_title` / `set_tab_title` - rename the surface (pane) or tab title
- `reset_window_size` - restore the configured default window size
- `size_limit` - apply min/max window dimensions
- `toggle_visibility` - hide/show all windows (excludes the quick terminal)
- `toggle_background_opacity` - flip between opaque and the configured opacity
- `float_window` - toggle always-on-top
- `close_all_windows` - close all terminal windows

Notes:
- `goto_window` is previous/next navigation (matching the action payload), not an index.
- Each pane carries its own title override, so `prompt_title:surface` renames just the focused pane and the tab label follows the focused pane.
- `toggle_background_opacity` persists to config and reloads, consistent with the existing Ctrl+Shift+scroll opacity behavior; there is no transient runtime opacity path on Windows.

ABI ordinals/struct layouts, the action mappings, and the opacity-toggle decision are unit tested (full suite passes). Built and smoke-launched clean.
@