### PR TITLE
fix(windows): write numeric config values with InvariantCulture

### DIFF
--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2333,7 +2333,7 @@ public sealed partial class MainWindow : Window
         if (Math.Abs(next - current) < 0.001) return;
 
         _configWriter.Write(
-            () => _configEditor.SetValue("background-opacity", next.ToString("F2")),
+            () => _configEditor.SetValue("background-opacity", next.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)),
             "background-opacity");
     }
 

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -282,12 +282,12 @@ internal sealed partial class AppearancePage : Page
 
     private void TintOpacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        OnValueChanged("background-tint-opacity", e.NewValue.ToString("F2"));
+        OnValueChanged("background-tint-opacity", e.NewValue.ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private void LuminosityOpacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        OnValueChanged("background-luminosity-opacity", e.NewValue.ToString("F2"));
+        OnValueChanged("background-luminosity-opacity", e.NewValue.ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private void GradientBlend_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -298,12 +298,12 @@ internal sealed partial class AppearancePage : Page
 
     private void GradientOpacity_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
     {
-        OnValueChanged("background-gradient-opacity", e.NewValue.ToString("F2"));
+        OnValueChanged("background-gradient-opacity", e.NewValue.ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private void GradientSpeed_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
     {
-        OnValueChanged("background-gradient-speed", e.NewValue.ToString("F1"));
+        OnValueChanged("background-gradient-speed", e.NewValue.ToString("F1", System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private void GradientEnabled_Toggled(object sender, RoutedEventArgs e)

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -226,12 +226,12 @@ internal sealed partial class AppearancePage : Page
 
     private void FontSize_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
     {
-        OnValueChanged("font-size", sender.Value.ToString());
+        OnValueChanged("font-size", sender.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private void Opacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        OnValueChanged("background-opacity", e.NewValue.ToString("F2"));
+        OnValueChanged("background-opacity", e.NewValue.ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private void WindowTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/TerminalPage.xaml.cs
@@ -41,7 +41,7 @@ internal sealed partial class TerminalPage : Page
 
     private void Scrollback_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
     {
-        OnValueChanged("scrollback-limit", ((int)sender.Value).ToString());
+        OnValueChanged("scrollback-limit", ((int)sender.Value).ToString(System.Globalization.CultureInfo.InvariantCulture));
     }
 
     private void CursorStyle_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
Numeric config values were formatted with the current culture before being written to the config file. The libghostty config parser expects `.` as the decimal separator, so under a comma-decimal culture a value like `background-opacity` would be written as `0,85` and misparsed.

The app sets `InvariantGlobalization=true` (Ghostty.csproj), so the running app's current culture is already invariant and these were dormant rather than field-reproducible. The csproj comment still requires passing `InvariantCulture` explicitly for any value written to config, so this brings the call sites in line with that rule and is defense-in-depth if the setting ever changes.

Eight config-write call sites now format with `InvariantCulture`:

- `MainWindow.AdjustOpacity` - `background-opacity` (Ctrl+Shift+Scroll step).
- `AppearancePage.FontSize_ValueChanged` - `font-size`.
- `AppearancePage.Opacity_ValueChanged` - `background-opacity`.
- `AppearancePage.TintOpacity_ValueChanged` - `background-tint-opacity`.
- `AppearancePage.LuminosityOpacity_ValueChanged` - `background-luminosity-opacity`.
- `AppearancePage.GradientOpacity_ValueChanged` - `background-gradient-opacity`.
- `AppearancePage.GradientSpeed_ValueChanged` - `background-gradient-speed`.
- `TerminalPage.Scrollback_ValueChanged` - `scrollback-limit`.

The gradient-point writer already uses `string.Create(InvariantCulture, ...)` and needs no change.
