### PR TITLE
Reopen closed tab and window

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -7015,10 +7015,12 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .f11 } },
                 .{ .toggle_fullscreen = {} },
             );
-            // Tabs
+            // Tabs. new_tab is ctrl+t (not ctrl+shift+t) so the apprt can
+            // own ctrl+shift+t for reopen-closed-tab (browser / VS Code
+            // convention), matched in KeyBindings.WindowsOnly.
             try self.set.put(
                 alloc,
-                .{ .key = .{ .unicode = 't' }, .mods = .{ .ctrl = true, .shift = true } },
+                .{ .key = .{ .unicode = 't' }, .mods = .{ .ctrl = true } },
                 .{ .new_tab = {} },
             );
             try self.set.put(
@@ -10668,15 +10670,21 @@ test "keybind: windows default keybinds" {
 
     const set = cfg.keybind.set;
 
-    // ctrl+shift+t -> new_tab
+    // ctrl+t -> new_tab (ctrl+shift+t is freed for apprt reopen-closed-tab)
     {
         const entry = set.get(.{
             .key = .{ .unicode = 't' },
-            .mods = .{ .ctrl = true, .shift = true },
+            .mods = .{ .ctrl = true },
         }).?.value_ptr.*;
         try testing.expect(entry == .leaf);
         try testing.expect(entry.leaf.action == .new_tab);
     }
+
+    // ctrl+shift+t is no longer a default (the apprt matches it)
+    try testing.expect(set.get(.{
+        .key = .{ .unicode = 't' },
+        .mods = .{ .ctrl = true, .shift = true },
+    }) == null);
 
     // alt+shift+'=' -> new_split right
     {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -7015,9 +7015,9 @@ pub const Keybinds = struct {
                 .{ .key = .{ .physical = .f11 } },
                 .{ .toggle_fullscreen = {} },
             );
-            // Tabs. new_tab is ctrl+t (not ctrl+shift+t) so the apprt can
-            // own ctrl+shift+t for reopen-closed-tab (browser / VS Code
-            // convention), matched in KeyBindings.WindowsOnly.
+            // Tabs. new_tab is ctrl+t (not ctrl+shift+t) so ctrl+shift+t is
+            // free for the apprt to bind reopen-closed-tab (browser / VS Code
+            // convention).
             try self.set.put(
                 alloc,
                 .{ .key = .{ .unicode = 't' }, .mods = .{ .ctrl = true } },

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -102,4 +102,11 @@ public enum PaneAction
     // About window per window (reused if already open). Mirrors
     // ShowKeybindCheatsheet (event-only, needs a window, no libghostty action).
     ShowAbout = 52,
+
+    // Reopen the most recently closed tab / window. Apprt-only (like
+    // Undo/Redo): matched in KeyBindings.WindowsOnly and routed via
+    // PaneActionRouter events. Restores the saved layout + per-pane profile
+    // with fresh shells; does not resurrect the live shell.
+    ReopenClosedTab = 53,
+    ReopenClosedWindow = 54,
 }

--- a/windows/Ghostty.Core/Panes/ClosedStack.cs
+++ b/windows/Ghostty.Core/Panes/ClosedStack.cs
@@ -36,6 +36,11 @@ internal sealed class ClosedStack<T>
             _items.RemoveFirst();
     }
 
+    /// <summary>
+    /// Remove and return the most-recently-pushed item. Returns false with
+    /// <paramref name="item"/> set to <c>default</c> when the stack is empty;
+    /// callers must check the return value before using <paramref name="item"/>.
+    /// </summary>
     public bool TryPop(out T item)
     {
         if (_items.Last is { } last)

--- a/windows/Ghostty.Core/Panes/ClosedStack.cs
+++ b/windows/Ghostty.Core/Panes/ClosedStack.cs
@@ -47,6 +47,4 @@ internal sealed class ClosedStack<T>
         item = default!;
         return false;
     }
-
-    public void Clear() => _items.Clear();
 }

--- a/windows/Ghostty.Core/Panes/ClosedStack.cs
+++ b/windows/Ghostty.Core/Panes/ClosedStack.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Panes;
+
+/// <summary>
+/// Bounded LIFO of recently-closed items (tabs or windows), for the
+/// reopen-closed-tab / reopen-closed-window commands. Pushing past
+/// <see cref="_capacity"/> evicts the oldest entry so the stack never
+/// grows unbounded. Session-scoped, in memory; no time expiry — the
+/// snapshots hold no live surfaces, so retention is cheap. Pure logic,
+/// no WinUI; unit-tested directly. Distinct from the disk session
+/// persistence (which keeps a single snapshot for next-launch restore);
+/// this is the same-session reopen history.
+/// </summary>
+internal sealed class ClosedStack<T>
+{
+    private readonly int _capacity;
+
+    // Most-recently-pushed at the end; a LinkedList gives O(1) eviction of
+    // the oldest (front) entry when capacity is exceeded.
+    private readonly LinkedList<T> _items = new();
+
+    public ClosedStack(int capacity)
+    {
+        if (capacity < 1) throw new ArgumentOutOfRangeException(nameof(capacity));
+        _capacity = capacity;
+    }
+
+    public int Count => _items.Count;
+
+    public void Push(T item)
+    {
+        _items.AddLast(item);
+        if (_items.Count > _capacity)
+            _items.RemoveFirst();
+    }
+
+    public bool TryPop(out T item)
+    {
+        if (_items.Last is { } last)
+        {
+            item = last.Value;
+            _items.RemoveLast();
+            return true;
+        }
+        item = default!;
+        return false;
+    }
+
+    public void Clear() => _items.Clear();
+}

--- a/windows/Ghostty.Core/Tabs/TabManager.cs
+++ b/windows/Ghostty.Core/Tabs/TabManager.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Profiles;
+using Ghostty.Core.Session;
 
 namespace Ghostty.Core.Tabs;
 
@@ -29,6 +30,10 @@ namespace Ghostty.Core.Tabs;
 internal sealed class TabManager
 {
     private readonly Func<ProfileSnapshot?, IPaneHost> _paneHostFactory;
+    // Shared (app-level) store of recently-closed tabs for reopen-closed-tab.
+    // Null in tests / contexts that do not wire reopen. CloseTab pushes a
+    // snapshot here before the panes are disposed.
+    private readonly ClosedStack<TabSession>? _closedTabs;
     private readonly ObservableCollection<TabModel> _tabs = new();
     private TabModel _activeTab = null!;
 
@@ -65,12 +70,12 @@ internal sealed class TabManager
     /// </summary>
     public event EventHandler<TabModel>? TabDetaching;
 
-    public TabManager(Func<ProfileSnapshot?, IPaneHost> paneHostFactory)
-        : this(paneHostFactory, seed: null) { }
-
     /// <summary>
     /// Non-null <paramref name="seed"/> is adopted as the initial tab
     /// (factory call is skipped); null falls through to the factory.
+    /// <paramref name="closedTabs"/> is the (app-shared) bounded store that
+    /// <see cref="CloseTab"/> pushes a snapshot to before tearing a tab down;
+    /// null disables capture (tests / non-reopen contexts).
     ///
     /// Seeded construction does NOT raise <see cref="TabAdded"/> for
     /// the seed: it is the initial tab, and TabAdded is for growth.
@@ -85,9 +90,13 @@ internal sealed class TabManager
     /// assigns <see cref="ActiveTab"/> directly without events because
     /// no listener is wired at ctor time.
     /// </summary>
-    public TabManager(Func<ProfileSnapshot?, IPaneHost> paneHostFactory, TabModel? seed)
+    public TabManager(
+        Func<ProfileSnapshot?, IPaneHost> paneHostFactory,
+        TabModel? seed = null,
+        ClosedStack<TabSession>? closedTabs = null)
     {
         _paneHostFactory = paneHostFactory;
+        _closedTabs = closedTabs;
         if (seed is null)
         {
             var first = CreateTab(snapshot: null);
@@ -151,6 +160,17 @@ internal sealed class TabManager
     {
         var index = _tabs.IndexOf(tab);
         if (index < 0) return;
+
+        // Capture a reopenable snapshot before the panes are torn down. Always
+        // captures (including the window's last tab): closing a tab makes it
+        // reopenable via reopen-closed-tab. Whole-window closes do not route
+        // through CloseTab, so they are captured separately as window snapshots.
+        _closedTabs?.Push(SessionCapture.CaptureTab(
+            tab.PaneHost.RootNode,
+            tab.PaneHost.ActiveLeaf,
+            tab.PaneHost.ZoomedLeaf,
+            tab.ProfileId,
+            tab.UserOverrideTitle));
 
         tab.PaneHost.LeafFocused -= OnLeafFocused;
         tab.PropertyChanged -= OnTabPropertyChanged;

--- a/windows/Ghostty.Tests/Panes/ClosedStackTests.cs
+++ b/windows/Ghostty.Tests/Panes/ClosedStackTests.cs
@@ -44,15 +44,4 @@ public class ClosedStackTests
         Assert.True(s.TryPop(out v)); Assert.Equal(2, v);
         Assert.False(s.TryPop(out _)); // 1 was evicted
     }
-
-    [Fact]
-    public void Clear_empties_the_stack()
-    {
-        var s = new ClosedStack<int>(capacity: 3);
-        s.Push(1);
-        s.Push(2);
-        s.Clear();
-        Assert.Equal(0, s.Count);
-        Assert.False(s.TryPop(out _));
-    }
 }

--- a/windows/Ghostty.Tests/Panes/ClosedStackTests.cs
+++ b/windows/Ghostty.Tests/Panes/ClosedStackTests.cs
@@ -1,0 +1,58 @@
+using Ghostty.Core.Panes;
+using Xunit;
+
+namespace Ghostty.Tests.Panes;
+
+public class ClosedStackTests
+{
+    [Fact]
+    public void Pop_returns_most_recently_pushed()
+    {
+        var s = new ClosedStack<int>(capacity: 5);
+        s.Push(1);
+        s.Push(2);
+        s.Push(3);
+
+        Assert.Equal(3, s.Count);
+        Assert.True(s.TryPop(out var v));
+        Assert.Equal(3, v);
+        Assert.True(s.TryPop(out v));
+        Assert.Equal(2, v);
+    }
+
+    [Fact]
+    public void Empty_pop_returns_false()
+    {
+        var s = new ClosedStack<int>(capacity: 5);
+        Assert.False(s.TryPop(out var v));
+        Assert.Equal(0, v);
+        Assert.Equal(0, s.Count);
+    }
+
+    [Fact]
+    public void Pushing_past_capacity_evicts_oldest()
+    {
+        var s = new ClosedStack<int>(capacity: 3);
+        s.Push(1); // oldest
+        s.Push(2);
+        s.Push(3);
+        s.Push(4); // evicts 1
+
+        Assert.Equal(3, s.Count);
+        Assert.True(s.TryPop(out var v)); Assert.Equal(4, v);
+        Assert.True(s.TryPop(out v)); Assert.Equal(3, v);
+        Assert.True(s.TryPop(out v)); Assert.Equal(2, v);
+        Assert.False(s.TryPop(out _)); // 1 was evicted
+    }
+
+    [Fact]
+    public void Clear_empties_the_stack()
+    {
+        var s = new ClosedStack<int>(capacity: 3);
+        s.Push(1);
+        s.Push(2);
+        s.Clear();
+        Assert.Equal(0, s.Count);
+        Assert.False(s.TryPop(out _));
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabManagerCloseCaptureTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabManagerCloseCaptureTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using Ghostty.Core.Panes;
+using Ghostty.Core.Session;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+public class TabManagerCloseCaptureTests
+{
+    private static TabManager NewManager(
+        ClosedStack<TabSession> closed,
+        out List<FakePaneHost> hosts)
+    {
+        var list = new List<FakePaneHost>();
+        var mgr = new TabManager(
+            paneHostFactory: _ =>
+            {
+                var h = new FakePaneHost();
+                list.Add(h);
+                return h;
+            },
+            closedTabs: closed);
+        hosts = list;
+        return mgr;
+    }
+
+    [Fact]
+    public void Closing_a_tab_pushes_a_session_snapshot()
+    {
+        var closed = new ClosedStack<TabSession>(25);
+        var mgr = NewManager(closed, out _);
+        mgr.NewTab(); // 2 tabs
+
+        mgr.CloseTab(mgr.Tabs[1]);
+
+        Assert.Equal(1, closed.Count);
+        Assert.True(closed.TryPop(out var snap));
+        Assert.NotNull(snap.Tree); // a real captured tree
+    }
+
+    [Fact]
+    public void Closing_the_last_tab_also_captures_it()
+    {
+        var closed = new ClosedStack<TabSession>(25);
+        var mgr = NewManager(closed, out _);
+
+        mgr.CloseTab(mgr.Tabs[0]); // last tab -> window would close
+
+        Assert.Equal(1, closed.Count);
+    }
+
+    [Fact]
+    public void Capture_records_user_title_and_disposes_the_tab()
+    {
+        var closed = new ClosedStack<TabSession>(25);
+        var mgr = NewManager(closed, out var hosts);
+        mgr.NewTab();
+        mgr.Tabs[1].UserOverrideTitle = "kept";
+
+        mgr.CloseTab(mgr.Tabs[1]);
+
+        Assert.True(closed.TryPop(out var snap));
+        Assert.Equal("kept", snap.UserTitle);
+        // The close path is otherwise unchanged: the tab is still disposed.
+        Assert.Equal(1, hosts[1].DisposeAllCalls);
+    }
+
+    [Fact]
+    public void Manager_without_a_stack_still_closes_normally()
+    {
+        var list = new List<FakePaneHost>();
+        var mgr = new TabManager(_ =>
+        {
+            var h = new FakePaneHost();
+            list.Add(h);
+            return h;
+        });
+        mgr.NewTab();
+
+        mgr.CloseTab(mgr.Tabs[1]); // no closedTabs injected -> no throw
+
+        Assert.Single(mgr.Tabs);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -91,16 +91,19 @@ public partial class App : Application
     /// </summary>
     internal static IEnumerable<MainWindow> AllWindows => WindowsByRoot.Values;
 
+    // How many recently-closed tabs / windows the reopen stacks retain.
+    private const int ClosedItemCapacity = 25;
+
     /// <summary>Shared, session-scoped, in-memory store of recently-closed
     /// tabs across all windows; injected into each window's TabManager.
     /// App-level so a tab closed in a window that later closes is still
     /// reopenable. Independent of the disk session persistence (which keeps
     /// one snapshot for next-launch restore).</summary>
-    internal static readonly Core.Panes.ClosedStack<Core.Session.TabSession> ClosedTabs = new(25);
+    internal static readonly Core.Panes.ClosedStack<Core.Session.TabSession> ClosedTabs = new(ClosedItemCapacity);
 
     /// <summary>Shared store of recently-closed windows. Pushed by
     /// MainWindow.OnClosedAsync; drained by ReopenClosedWindow.</summary>
-    internal static readonly Core.Panes.ClosedStack<Core.Session.WindowSession> ClosedWindows = new(25);
+    internal static readonly Core.Panes.ClosedStack<Core.Session.WindowSession> ClosedWindows = new(ClosedItemCapacity);
 
     internal static GhosttyHost? BootstrapHost { get; private set; }
     internal static ConfigService? ConfigService { get; private set; }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -91,6 +91,17 @@ public partial class App : Application
     /// </summary>
     internal static IEnumerable<MainWindow> AllWindows => WindowsByRoot.Values;
 
+    /// <summary>Shared, session-scoped, in-memory store of recently-closed
+    /// tabs across all windows; injected into each window's TabManager.
+    /// App-level so a tab closed in a window that later closes is still
+    /// reopenable. Independent of the disk session persistence (which keeps
+    /// one snapshot for next-launch restore).</summary>
+    internal static readonly Core.Panes.ClosedStack<Core.Session.TabSession> ClosedTabs = new(25);
+
+    /// <summary>Shared store of recently-closed windows. Pushed by
+    /// MainWindow.OnClosedAsync; drained by ReopenClosedWindow.</summary>
+    internal static readonly Core.Panes.ClosedStack<Core.Session.WindowSession> ClosedWindows = new(25);
+
     internal static GhosttyHost? BootstrapHost { get; private set; }
     internal static ConfigService? ConfigService { get; private set; }
     internal static Ghostty.Core.Profiles.IProfileRegistry? ProfileRegistry { get; private set; }
@@ -681,6 +692,24 @@ public partial class App : Application
         // Re-claim the chord whenever the config changes so an edited
         // quick-terminal-key takes effect without a restart.
         _configService.ConfigChanged += OnConfigReloaded_ReRegisterHotKey;
+    }
+
+    /// <summary>
+    /// Reopen the most recently closed window from the shared store, or no-op
+    /// if empty. Reuses the WindowSession restore ctor and the same
+    /// registration the startup restore loop uses.
+    /// </summary>
+    internal void ReopenClosedWindow()
+    {
+        if (_configService is null || _bootstrapHost is null ||
+            _lifetimeSupervisor is null || _loggerFactory is null) return;
+        if (!ClosedWindows.TryPop(out var windowSession)) return;
+
+        var restored = new MainWindow(
+            _configService, _bootstrapHost, _lifetimeSupervisor, _loggerFactory, windowSession);
+        restored.Closed += OnAnyWindowClosedInternal;
+        _sessionManager?.Track(restored);
+        restored.Activate();
     }
 
     /// <summary>

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -704,6 +704,9 @@ public partial class App : Application
     /// </summary>
     internal void ReopenClosedWindow()
     {
+        // The services are only null before OnLaunched or after the last window
+        // tears the app down; neither state has a live window to fire the chord,
+        // so this guard is defensive rather than a real runtime branch.
         if (_configService is null || _bootstrapHost is null ||
             _lifetimeSupervisor is null || _loggerFactory is null) return;
         if (!ClosedWindows.TryPop(out var windowSession)) return;
@@ -711,7 +714,10 @@ public partial class App : Application
         var restored = new MainWindow(
             _configService, _bootstrapHost, _lifetimeSupervisor, _loggerFactory, windowSession);
         restored.Closed += OnAnyWindowClosedInternal;
+        // Track + persist so the reopened window is in the on-disk session
+        // snapshot immediately, matching the new-window (OpenInNewWindow) path.
         _sessionManager?.Track(restored);
+        _sessionManager?.RequestPersist();
         restored.Activate();
     }
 

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -45,6 +45,8 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.SplitHorizontal, "Split Horizontally", "Split the current pane horizontally", CommandCategory.Pane, "\uF57E");
         AddPaneCommand(commands, PaneAction.NewTab, "New Tab", "Open a new terminal tab", CommandCategory.Tab, "\uE710");
         AddPaneCommand(commands, PaneAction.CloseActiveProgressive, "Close Pane / Tab", "Close active pane; if last pane, close tab; if last tab, close window", CommandCategory.Tab, "\uE711");
+        AddPaneCommand(commands, PaneAction.ReopenClosedTab, "Reopen Closed Tab", "Reopen the most recently closed tab", CommandCategory.Tab, "\uE7A7");
+        AddPaneCommand(commands, PaneAction.ReopenClosedWindow, "Reopen Closed Window", "Reopen the most recently closed window", CommandCategory.Tab, "\uE8A7");
         AddPaneCommand(commands, PaneAction.NextTab, "Next Tab", "Switch to the next tab", CommandCategory.Tab, "\uE76C");
         AddPaneCommand(commands, PaneAction.PrevTab, "Previous Tab", "Switch to the previous tab", CommandCategory.Tab, "\uE76B");
         AddPaneCommand(commands, PaneAction.FocusLeft, "Focus Pane Left", "Move focus to the left pane", CommandCategory.Pane);

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -151,6 +151,13 @@ internal sealed class KeyBindings
         // because libghostty has no Windows undo implementation.
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Z, PaneAction.Undo),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.Y, PaneAction.Redo),
+
+        // Reopen closed tab/window (browser / VS Code convention). Ctrl+Shift+T
+        // is freed from new_tab (remapped to Ctrl+T in the Windows-curated
+        // Config.zig defaults). Apprt-matched because reopen is an apprt
+        // concern (libghostty has no closed-item stack on Windows).
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.T, PaneAction.ReopenClosedTab),
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.N, PaneAction.ReopenClosedWindow),
     });
 
     /// <summary>

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -111,6 +111,20 @@ internal sealed class PaneActionRouter
     /// </summary>
     public event EventHandler? ShowAboutRequested;
 
+    /// <summary>
+    /// Raised when the reopen-closed-tab chord or palette entry fires.
+    /// MainWindow listens and rebuilds a tab from the most recent closed-tab
+    /// snapshot into this window (reconstruction needs the WinUI factory).
+    /// </summary>
+    public event EventHandler? ReopenClosedTabRequested;
+
+    /// <summary>
+    /// Raised when the reopen-closed-window chord or palette entry fires.
+    /// App listens and creates a window from the most recent closed-window
+    /// snapshot (TabManager cannot create windows).
+    /// </summary>
+    public event EventHandler? ReopenClosedWindowRequested;
+
     public void Invoke(PaneAction action)
     {
         // Event-only actions that don't need pane/tab state — handle
@@ -140,6 +154,12 @@ internal sealed class PaneActionRouter
                 return;
             case PaneAction.ShowAbout:
                 ShowAboutRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ReopenClosedTab:
+                ReopenClosedTabRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ReopenClosedWindow:
+                ReopenClosedWindowRequested?.Invoke(this, EventArgs.Empty);
                 return;
 
             // Scrollback jumps are dispatched as libghostty binding

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -99,6 +99,14 @@ public sealed partial class MainWindow : Window
     internal TabManager TabManager => _tabManager;
 
     /// <summary>
+    /// The closed-tab store this window feeds. The quake window is excluded so
+    /// its drop-down tabs never leak into the regular reopen-closed-tab history
+    /// (mirrors CaptureSession's window-level quake exclusion).
+    /// </summary>
+    private Core.Panes.ClosedStack<Core.Session.TabSession>? ClosedTabsStore
+        => IsQuickTerminal ? null : App.ClosedTabs;
+
+    /// <summary>
     /// Raised when this (non-quake) window moves or resizes, so the
     /// session manager can debounce-persist the new geometry.
     /// </summary>
@@ -425,7 +433,7 @@ public sealed partial class MainWindow : Window
             _tabManager = new TabManager(
                 snapshot => _factory.Create(snapshot),
                 seed: restoredTabs[0],
-                closedTabs: App.ClosedTabs);
+                closedTabs: ClosedTabsStore);
             for (int i = 1; i < restoredTabs.Count; i++)
                 _tabManager.AdoptTab(restoredTabs[i]);
             if (restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
@@ -436,7 +444,7 @@ public sealed partial class MainWindow : Window
             _tabManager = new TabManager(
                 snapshot => _factory.Create(snapshot),
                 seed: seedTab,
-                closedTabs: App.ClosedTabs);
+                closedTabs: ClosedTabsStore);
         }
         _router = new PaneActionRouter(
             _tabManager,
@@ -1409,15 +1417,12 @@ public sealed partial class MainWindow : Window
     {
         if (!App.ClosedTabs.TryPop(out var tabSession)) return;
 
-        var window = new Ghostty.Core.Session.WindowSession();
-        window.Tabs.Add(tabSession);
         var restorer = new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry);
-        var tabs = restorer.BuildTabs(window);
-        if (tabs.Count == 0) return;
+        if (restorer.BuildTab(tabSession) is not { } tab) return;
 
         // AdoptTab raises TabAdded -> AddPaneHost + activation, so the rebuilt
         // tab renders and focuses just like the session-restore path.
-        _tabManager.AdoptTab(tabs[0]);
+        _tabManager.AdoptTab(tab);
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -424,7 +424,8 @@ public sealed partial class MainWindow : Window
         {
             _tabManager = new TabManager(
                 snapshot => _factory.Create(snapshot),
-                seed: restoredTabs[0]);
+                seed: restoredTabs[0],
+                closedTabs: App.ClosedTabs);
             for (int i = 1; i < restoredTabs.Count; i++)
                 _tabManager.AdoptTab(restoredTabs[i]);
             if (restore!.ActiveTabIndex >= 0 && restore.ActiveTabIndex < restoredTabs.Count)
@@ -434,7 +435,8 @@ public sealed partial class MainWindow : Window
         {
             _tabManager = new TabManager(
                 snapshot => _factory.Create(snapshot),
-                seed: seedTab);
+                seed: seedTab,
+                closedTabs: App.ClosedTabs);
         }
         _router = new PaneActionRouter(
             _tabManager,
@@ -1124,6 +1126,14 @@ public sealed partial class MainWindow : Window
         // _themeManager was disposed at the top of this method, before the
         // first await, so no theme callback can fire mid-teardown (#208).
 
+        // Capture this window for reopen-closed-window before the panes are
+        // freed. CaptureSession returns null for quake/fullscreen; skip empty
+        // windows (a window emptied by closing its tabs one-by-one has nothing
+        // to restore — those tabs were captured individually as closed tabs).
+        var closedWindow = CaptureSession();
+        if (closedWindow is { Tabs.Count: > 0 })
+            App.ClosedWindows.Push(closedWindow);
+
         // Surface lifetime is decoupled from Loaded/Unloaded
         // (see TerminalControl.DisposeSurface), so we have to
         // free every leaf in every tab explicitly before tearing
@@ -1384,6 +1394,30 @@ public sealed partial class MainWindow : Window
             _aboutWindow = aboutWin;
             aboutWin.Activate();
         };
+
+        _router.ReopenClosedTabRequested += (_, _) => ReopenClosedTab();
+        _router.ReopenClosedWindowRequested += (_, _) =>
+            ((App)Application.Current).ReopenClosedWindow();
+    }
+
+    /// <summary>
+    /// Reopen the most recently closed tab into this window. Rebuilds the tab
+    /// (fresh shells) from the saved snapshot via the same SessionRestorer the
+    /// startup restore uses, then adopts it. No-op if the store is empty.
+    /// </summary>
+    private void ReopenClosedTab()
+    {
+        if (!App.ClosedTabs.TryPop(out var tabSession)) return;
+
+        var window = new Ghostty.Core.Session.WindowSession();
+        window.Tabs.Add(tabSession);
+        var restorer = new Ghostty.Session.SessionRestorer(_factory, App.ProfileRegistry);
+        var tabs = restorer.BuildTabs(window);
+        if (tabs.Count == 0) return;
+
+        // AdoptTab raises TabAdded -> AddPaneHost + activation, so the rebuilt
+        // tab renders and focuses just like the session-restore path.
+        _tabManager.AdoptTab(tabs[0]);
     }
 
     /// <summary>

--- a/windows/Ghostty/Session/SessionRestorer.cs
+++ b/windows/Ghostty/Session/SessionRestorer.cs
@@ -28,32 +28,44 @@ internal sealed class SessionRestorer
         var result = new List<TabModel>();
         foreach (var tabDto in window.Tabs)
         {
-            if (tabDto.Tree is null) continue;
-
-            // Rebuild the structure; each leaf re-resolves its own profile
-            // (exact id, else its saved fallback command).
-            var root = SessionTree.RebuildTree(tabDto.Tree,
-                leaf => new LeafPane { Snapshot = SessionProfileResolver.ResolveLeaf(_registry, leaf) });
-
-            var active = SessionTree.Resolve(root, tabDto.ActiveLeafPath) as LeafPane
-                         ?? PaneTree.FirstLeaf(root);
-            var zoomed = tabDto.ZoomedLeafPath is { } zp
-                ? SessionTree.Resolve(root, zp) as LeafPane
-                : null;
-
-            var host = _factory.CreateFromTree(root, active, zoomed);
-            var tab = new TabModel(host) { ProfileId = tabDto.ProfileId };
-
-            // The tab's display snapshot: re-resolve the tab's own profile id
-            // if it still exists (else the tab keeps its restored title).
-            var tabSnap = SessionProfileResolver.ResolveById(_registry, tabDto.ProfileId);
-            if (tabSnap is not null)
-                tab.AttachProfileSnapshot(tabSnap);
-            if (tabDto.UserTitle is not null)
-                tab.UserOverrideTitle = tabDto.UserTitle;
-
-            result.Add(tab);
+            if (BuildTab(tabDto) is { } tab)
+                result.Add(tab);
         }
         return result;
+    }
+
+    /// <summary>
+    /// Rebuild a single <see cref="TabModel"/> (tree-seeded pane host, fresh
+    /// shells) from one persisted <see cref="TabSession"/>, or null if the
+    /// snapshot has no tree. Used by <see cref="BuildTabs"/> and by the
+    /// same-session reopen-closed-tab path.
+    /// </summary>
+    public TabModel? BuildTab(TabSession tabDto)
+    {
+        if (tabDto.Tree is null) return null;
+
+        // Rebuild the structure; each leaf re-resolves its own profile
+        // (exact id, else its saved fallback command).
+        var root = SessionTree.RebuildTree(tabDto.Tree,
+            leaf => new LeafPane { Snapshot = SessionProfileResolver.ResolveLeaf(_registry, leaf) });
+
+        var active = SessionTree.Resolve(root, tabDto.ActiveLeafPath) as LeafPane
+                     ?? PaneTree.FirstLeaf(root);
+        var zoomed = tabDto.ZoomedLeafPath is { } zp
+            ? SessionTree.Resolve(root, zp) as LeafPane
+            : null;
+
+        var host = _factory.CreateFromTree(root, active, zoomed);
+        var tab = new TabModel(host) { ProfileId = tabDto.ProfileId };
+
+        // The tab's display snapshot: re-resolve the tab's own profile id
+        // if it still exists (else the tab keeps its restored title).
+        var tabSnap = SessionProfileResolver.ResolveById(_registry, tabDto.ProfileId);
+        if (tabSnap is not null)
+            tab.AttachProfileSnapshot(tabSnap);
+        if (tabDto.UserTitle is not null)
+            tab.UserOverrideTitle = tabDto.UserTitle;
+
+        return tab;
     }
 }


### PR DESCRIPTION
Adds reopen-closed-tab (Ctrl+Shift+T) and reopen-closed-window (Ctrl+Shift+N), with matching command-palette entries, for parity with macOS at the whole-tab and whole-window level. Pane-level close was already undoable (#166); this adds the tab and window granularity.

Reopen restores the saved layout and per-pane profile/command and spawns fresh shells. It does not resurrect the live shell.

Implementation reuses the session-restoration snapshot infra from #517 (SessionCapture, SessionRestorer, the WindowSession restore ctor, PaneHostFactory.CreateFromTree). The only new primitive is a count-capped in-memory LIFO (ClosedStack, cap 25, session-scoped). A tab close captures a TabSession in TabManager.CloseTab; a window close captures a WindowSession in MainWindow.OnClosedAsync. Reopen pops and rebuilds. Independent of the on-disk session persistence, which is gated by window-save-state.

new_tab moves from Ctrl+Shift+T to Ctrl+T (Windows-curated defaults in Config.zig) to free Ctrl+Shift+T for reopen, matching browser and VS Code conventions.

Tests: ClosedStack and TabManager capture are pure-logic unit tested; full suite green (1433).