### PR TITLE
fix(windows): stop quake window startup access-violation

### DIFF
--- a/windows/Ghostty/Hosting/QuickTerminalFrame.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalFrame.cs
@@ -37,6 +37,8 @@ internal sealed partial class QuickTerminalFrame : IDisposable
 {
     private const uint WM_NCCALCSIZE = 0x0083;
     private const uint WM_NCHITTEST = 0x0084;
+    private const uint WM_STYLECHANGING = 0x007C;
+    private const uint WM_STYLECHANGED = 0x007D;
 
     // WM_NCHITTEST return codes.
     private const int HTCLIENT = 1;
@@ -79,6 +81,14 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     private readonly int _grip;
     private bool _installed;
 
+    // True while the caller is mutating the window's frame style (via
+    // OverlappedPresenter.SetBorderAndTitleBar). The window proc swallows the
+    // WM_STYLECHANGING/CHANGED notifications during that window so they never
+    // reach the host WinUI window proc, which access-violates on a frame style
+    // change while the window is in its early/unstable lifecycle. The style
+    // change still takes effect; only the framework's reaction to it is dropped.
+    private bool _suppressStyleChange;
+
     public QuickTerminalFrame(
         IntPtr hwnd,
         Func<QuickTerminalPosition> position,
@@ -120,9 +130,37 @@ internal sealed partial class QuickTerminalFrame : IDisposable
         _installed = false;
     }
 
+    /// <summary>
+    /// Arms style-change suppression for the duration of the returned scope.
+    /// Wrap the caller's <c>SetBorderAndTitleBar</c> call in it: the borderless
+    /// transition posts WM_STYLECHANGING/CHANGED into the host WinUI window proc,
+    /// which access-violates while the window is still in its early lifecycle.
+    /// The subclass eats those messages while armed, so the style change lands
+    /// without the framework's crashy reaction.
+    /// </summary>
+    public IDisposable SuppressStyleChanges() => new StyleSuppressionScope(this);
+
+    private sealed class StyleSuppressionScope : IDisposable
+    {
+        private readonly QuickTerminalFrame _owner;
+        public StyleSuppressionScope(QuickTerminalFrame owner)
+        {
+            _owner = owner;
+            _owner._suppressStyleChange = true;
+        }
+        public void Dispose() => _owner._suppressStyleChange = false;
+    }
+
     private IntPtr WndProc(
         IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, UIntPtr id, UIntPtr data)
     {
+        // While the caller is shaping the borderless frame, drop the style-change
+        // notifications before they reach the host WinUI proc (which crashes on
+        // them). Returning without DefSubclassProc swallows the message; the style
+        // change itself is already applied by SetBorderAndTitleBar.
+        if (_suppressStyleChange && (msg == WM_STYLECHANGING || msg == WM_STYLECHANGED))
+            return IntPtr.Zero;
+
         var edge = QuickTerminalFrameGeometry.ResizableEdge(_position());
 
         // None == Center docking: no edge is flush to the monitor, so leave the

--- a/windows/Ghostty/Hosting/QuickTerminalFrame.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalFrame.cs
@@ -26,6 +26,11 @@ namespace Ghostty.Hosting;
 /// can no longer be hit-tested for resize. The strip stays uncovered, which is
 /// why native OS resize (and its cursor) still works there.
 ///
+/// The subclass has a second job: while <see cref="SuppressStyleChanges"/> is
+/// armed it eats WM_STYLECHANGING/CHANGED so the caller can shape the borderless
+/// presenter without the host WinUI window proc access-violating on the frame
+/// style change.
+///
 /// The edge-direction math lives in <see cref="QuickTerminalFrameGeometry"/>
 /// (pure, unit-tested); this file is only the Win32 plumbing. Win32 surface is
 /// hand-written (matching <see cref="WindowsGlobalHotKey"/>) because the
@@ -87,6 +92,12 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     // reach the host WinUI window proc, which access-violates on a frame style
     // change while the window is in its early/unstable lifecycle. The style
     // change still takes effect; only the framework's reaction to it is dropped.
+    //
+    // A plain bool (no volatile / interlock) is correct because the field is only
+    // touched on the window's message-pump thread: the scope is armed on that
+    // thread and SetBorderAndTitleBar SENDS the style messages synchronously on
+    // the same thread, so the write happens-before the WndProc read. A single
+    // non-nesting call site keeps the flag from needing ref-counting.
     private bool _suppressStyleChange;
 
     public QuickTerminalFrame(
@@ -131,12 +142,21 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     }
 
     /// <summary>
+    /// True once the subclass is in the window-proc chain. Style-change
+    /// suppression only works when this is set, so the caller must not run the
+    /// borderless presenter transition (which would otherwise reach the crashy
+    /// WinUI proc unguarded) when it is false.
+    /// </summary>
+    public bool IsInstalled => _installed;
+
+    /// <summary>
     /// Arms style-change suppression for the duration of the returned scope.
     /// Wrap the caller's <c>SetBorderAndTitleBar</c> call in it: the borderless
-    /// transition posts WM_STYLECHANGING/CHANGED into the host WinUI window proc,
-    /// which access-violates while the window is still in its early lifecycle.
-    /// The subclass eats those messages while armed, so the style change lands
-    /// without the framework's crashy reaction.
+    /// transition sends WM_STYLECHANGING/CHANGED synchronously into the host WinUI
+    /// window proc, which access-violates while the window is still in its early
+    /// lifecycle. The subclass eats those messages while armed, so the style
+    /// change lands without the framework's crashy reaction. Single,
+    /// non-nesting call site -- the flag is not ref-counted.
     /// </summary>
     public IDisposable SuppressStyleChanges() => new StyleSuppressionScope(this);
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1986,27 +1986,34 @@ public sealed partial class MainWindow : Window
             WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE,
             unchecked((int)(ex | WINDOW_EX_STYLE.WS_EX_TOOLWINDOW)));
 
-        // Borderless: a quake terminal is positioned by config and toggled by
-        // the global hotkey, so it needs no title bar, border, caption buttons,
-        // or min/max. IsResizable=true keeps a sizing frame so the window can be
-        // resize-dragged; QuickTerminalFrame (below) reshapes that frame to drop
-        // the docked-edge band and confine resize to the edge opposite the dock.
-        if (AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
-        {
-            presenter.SetBorderAndTitleBar(hasBorder: false, hasTitleBar: false);
-            presenter.IsResizable = true;
-            presenter.IsMinimizable = false;
-            presenter.IsMaximizable = false;
-        }
-
-        // IsResizable leaves a WS_THICKFRAME sizing border that Windows paints
-        // as a dark band at the docked edge and exposes as a resize grip there.
-        // Subclass the window proc to drop that non-client frame (no band) and
-        // allow drag-resize only on the edge opposite the dock.
+        // Install the non-client frame subclass first. It reshapes the sizing
+        // frame (drops the dark band WS_THICKFRAME leaves at the docked edge and
+        // confines drag-resize to the edge opposite the dock) and, crucially,
+        // suppresses the style-change notifications the borderless transition
+        // below posts -- without that suppression, SetBorderAndTitleBar
+        // access-violates inside the WinAppSDK windowing layer while the quake
+        // window is in its early/unstable lifecycle.
         _quakeFrame = new Ghostty.Hosting.QuickTerminalFrame(
             WindowNative.GetWindowHandle(this),
             () => _configService.QuickTerminalPosition,
             App.LoggerFactory?.CreateLogger<Ghostty.Hosting.QuickTerminalFrame>());
+
+        // Borderless: a quake terminal is positioned by config and toggled by the
+        // global hotkey, so it needs no title bar, border, caption buttons, or
+        // min/max. IsResizable=true keeps a sizing frame so the window can be
+        // resize-dragged. The presenter API (not raw Win32 styles) is used so
+        // WinUI records the borderless state and does not re-add the title bar on
+        // later activations; the suppression scope keeps the call from crashing.
+        if (AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+        {
+            using (_quakeFrame.SuppressStyleChanges())
+            {
+                presenter.SetBorderAndTitleBar(hasBorder: false, hasTitleBar: false);
+                presenter.IsResizable = true;
+                presenter.IsMinimizable = false;
+                presenter.IsMaximizable = false;
+            }
+        }
 
         // Borderless quake has no OS caption buttons; collapse the dead inset
         // and drop the vertical-mode title text.

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1990,7 +1990,7 @@ public sealed partial class MainWindow : Window
         // frame (drops the dark band WS_THICKFRAME leaves at the docked edge and
         // confines drag-resize to the edge opposite the dock) and, crucially,
         // suppresses the style-change notifications the borderless transition
-        // below posts -- without that suppression, SetBorderAndTitleBar
+        // below sends -- without that suppression, SetBorderAndTitleBar
         // access-violates inside the WinAppSDK windowing layer while the quake
         // window is in its early/unstable lifecycle.
         _quakeFrame = new Ghostty.Hosting.QuickTerminalFrame(
@@ -2004,7 +2004,11 @@ public sealed partial class MainWindow : Window
         // resize-dragged. The presenter API (not raw Win32 styles) is used so
         // WinUI records the borderless state and does not re-add the title bar on
         // later activations; the suppression scope keeps the call from crashing.
-        if (AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+        // Gated on IsInstalled: the suppression only works through the subclass,
+        // so if it failed to install we skip the transition (the window keeps its
+        // frame) rather than run SetBorderAndTitleBar unguarded and risk the crash.
+        if (_quakeFrame.IsInstalled
+            && AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
         {
             using (_quakeFrame.SuppressStyleChanges())
             {


### PR DESCRIPTION
The quake / drop-down window intermittently crashed on startup with an access violation. OverlappedPresenter.SetBorderAndTitleBar faults inside the WinAppSDK windowing layer when the window's frame is shaped during its early lifecycle, and no retiming of the call avoids it (it still faults deferred to Activated, a dispatcher turn, Content.Loaded, or when the window is created lazily on first hotkey).

Fix: install the QuickTerminalFrame window-proc subclass first, then run the borderless presenter setup inside a scoped style-change suppression. The subclass swallows the WM_STYLECHANGED notification the host window proc faults on, so the style change still applies but the crashy reaction never runs. Using the presenter API rather than raw Win32 styles keeps WinUI's own state in sync, so it does not re-add the title bar on later activations.

Verified borderless and crash-free across many startup launches.
