### PR TITLE
chore(windows): bundle Windows App SDK 2.2.0 runtime

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -18,6 +18,10 @@
     <AssemblyName>Wintty</AssemblyName>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Bundle the Windows App SDK runtime so the app loads the framework
+         version it was built against (the referenced package) instead of
+         whatever Windows App Runtime happens to be installed system-wide. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
@@ -92,7 +96,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269" PrivateAssets="all" />
     <!--


### PR DESCRIPTION
Bump Microsoft.WindowsAppSDK to 2.2.0 and set WindowsAppSDKSelfContained so the app loads the framework version it was built against instead of whatever Windows App Runtime is installed system-wide.

Independent of the inspector work; targets windows on its own.