### PR TITLE
feat(inspector): Windows terminal inspector

### DIFF
--- a/dist/windows/IconGen/GlyphMasters.cs
+++ b/dist/windows/IconGen/GlyphMasters.cs
@@ -6,25 +6,22 @@ using System.Drawing.Text;
 namespace Ghostty.IconGen;
 
 /// <summary>
-/// Renders the Settings gear glyph (Segoe Fluent Icons E713) to
-/// multi-size bitmap masters at the exact frame sizes IcoWriter packs
-/// into the final .ico. The same code point already drives
-/// SettingsWindow's in-chrome TitleBar.IconSource, so the OS-level
-/// slots (taskbar group, alt-tab) end up with the same affordance as
-/// the title bar.
+/// Renders a single Segoe Fluent Icons glyph to multi-size bitmap
+/// masters at the exact frame sizes IcoWriter packs into the final
+/// .ico. Used for the auxiliary-window icons (the Settings gear and the
+/// inspector bug) so each window is distinguishable from a terminal
+/// window in the taskbar group and alt-tab list. The glyph code point
+/// matches the in-chrome affordance for that window (SettingsWindow's
+/// TitleBar.IconSource, the command palette's inspector entry), so the
+/// OS-level slots read the same as the UI.
 ///
 /// Rendering happens at build time on a Windows host (CA1416 is
 /// suppressed for IconGen). Segoe Fluent Icons ships with Win11 22H2+;
 /// we fall back to Segoe MDL2 Assets (Win10+) when Fluent is absent.
-/// Both fonts carry E713 at the same code point and render visually
-/// identically at icon sizes.
+/// Both fonts carry these code points identically at icon sizes.
 /// </summary>
-internal static class GearMasters
+internal static class GlyphMasters
 {
-    // U+E713 = "Settings" in both Segoe Fluent Icons and the older
-    // Segoe MDL2 Assets. Matches SettingsWindow.xaml's FontIconSource.
-    private const string GearGlyph = "\uE713";
-
     // Dual-tone palette: a single tone in either direction goes
     // invisible against the opposite Windows theme (the taskbar
     // tracks dark/light mode and the alt-tab pane tints with the
@@ -35,21 +32,21 @@ internal static class GearMasters
     private static readonly Color FillColor = Color.FromArgb(0xFF, 0xF5, 0xF5, 0xF5);
     private static readonly Color StrokeColor = Color.FromArgb(0xFF, 0x1A, 0x1A, 0x1A);
 
-    public static MasterRasters Render()
+    public static MasterRasters Render(string glyph)
     {
         var fontName = ResolveIconFontName();
         var dict = new Dictionary<int, Bitmap>();
         // Render one master per IcoWriter frame size so each frame is
         // rasterized directly at its target px; downscaling from a
-        // single 256-px master loses the gear-tooth detail at 16/20/24
+        // single 256-px master loses fine glyph detail at 16/20/24
         // (exactly where the taskbar lives). Shared array prevents the
         // two size lists from drifting silently.
         foreach (var px in IcoWriter.FrameSizes)
-            dict[px] = RenderOne(px, fontName);
+            dict[px] = RenderOne(px, fontName, glyph);
         return MasterRasters.FromDictionary(dict);
     }
 
-    private static Bitmap RenderOne(int px, string fontName)
+    private static Bitmap RenderOne(int px, string fontName, string glyph)
     {
         var bmp = new Bitmap(px, px, PixelFormat.Format32bppArgb);
         using var g = Graphics.FromImage(bmp);
@@ -60,15 +57,14 @@ internal static class GearMasters
         // Glyph fills ~72% of the canvas. Slightly tighter than a
         // single-tone render because the stroke adds a halo on top:
         // at the 16 px frame, a 78% glyph + 1 px stroke would clip
-        // the outer teeth at the canvas edge.
+        // the outer extents at the canvas edge.
         var fontPx = px * 0.72f;
         using var family = new FontFamily(fontName);
         using var path = new GraphicsPath
         {
             // Glyph paths use non-zero winding; the default Alternate
-            // mode would hollow out the inner contours (the gear arms
-            // and hub), leaving FillPath painting only the thin
-            // outline rim.
+            // mode would hollow out inner contours, leaving FillPath
+            // painting only the thin outline rim.
             FillMode = FillMode.Winding,
         };
         using var fmt = new StringFormat(StringFormat.GenericTypographic)
@@ -80,7 +76,7 @@ internal static class GearMasters
         // parameter is typed as int. Keep the explicit cast --
         // dropping it to FontStyle.Regular fails to compile.
         path.AddString(
-            GearGlyph,
+            glyph,
             family,
             (int)FontStyle.Regular,
             fontPx,
@@ -96,7 +92,7 @@ internal static class GearMasters
         // sub-46 frame (16/20/24/32/40) the floor wins and the stroke
         // is a flat 1 px. That's the design: the floor keeps the
         // outline visible at small sizes; the ratio only kicks in on
-        // the 48/64/256 frames so the halo doesn't eat the arm
+        // the 48/64/256 frames so the halo doesn't eat the glyph
         // interior on the 256 frame.
         var strokePx = MathF.Max(px * 0.022f, 1f);
         using var pen = new Pen(StrokeColor, strokePx)
@@ -119,9 +115,9 @@ internal static class GearMasters
         if (families.Contains("Segoe MDL2 Assets")) return "Segoe MDL2 Assets";
 
         throw new InvalidOperationException(
-            "Cannot render the Settings gear .ico: neither 'Segoe Fluent Icons' " +
+            "Cannot render the auxiliary-window .ico: neither 'Segoe Fluent Icons' " +
             "nor 'Segoe MDL2 Assets' is installed on this build host. " +
             "Install one (both ship with Windows 10+ by default) or update " +
-            "GearMasters to ship its own glyph asset.");
+            "GlyphMasters to ship its own glyph asset.");
     }
 }

--- a/dist/windows/IconGen/IcoWriter.cs
+++ b/dist/windows/IconGen/IcoWriter.cs
@@ -7,7 +7,7 @@ internal static class IcoWriter
 {
     // Standard Windows icon sizes for an app .ico. Covers taskbar (16,
     // 20, 24, 32, 40, 48), larger icon views (64), and full-size (256).
-    // Exposed internally so procedural-master generators (GearMasters)
+    // Exposed internally so procedural-master generators (GlyphMasters)
     // can render directly at each frame size and avoid downscale-loss
     // on fine detail, without the two arrays drifting silently.
     internal static readonly int[] FrameSizes = { 16, 20, 24, 32, 40, 48, 64, 256 };

--- a/dist/windows/IconGen/Program.cs
+++ b/dist/windows/IconGen/Program.cs
@@ -31,16 +31,27 @@ internal static class Program
                 IcoWriter.Write(masters, Path.Combine(options.OutputDir, "wintty.ico"));
             }
 
-            // The Settings window uses a separate gear .ico so the
-            // taskbar / alt-tab distinguish it from a terminal window.
-            // The glyph matches SettingsWindow.xaml's TitleBar.IconSource;
-            // channel-independent because the gear is a UI affordance,
-            // not a brand mark.
-            using (var gearMasters = GearMasters.Render())
+            // The Settings and inspector windows get their own glyph .icos so
+            // the taskbar group / alt-tab list distinguish them from a terminal
+            // window. Each glyph matches that window's in-chrome affordance, so
+            // the OS-level slots read the same as the UI:
+            //   U+E713 "Settings" (gear) = SettingsWindow.xaml's TitleBar.IconSource
+            //   U+EBE8 "Bug"             = the command palette's "Toggle Inspector"
+            // Channel-independent because these are UI affordances, not brand
+            // marks. Both code points exist identically in Segoe Fluent Icons
+            // and Segoe MDL2 Assets.
+            using (var settingsMasters = GlyphMasters.Render("\uE713"))
             {
                 IcoWriter.Write(
-                    gearMasters,
+                    settingsMasters,
                     Path.Combine(options.OutputDir, "wintty-settings.ico"));
+            }
+
+            using (var inspectorMasters = GlyphMasters.Render("\uEBE8"))
+            {
+                IcoWriter.Write(
+                    inspectorMasters,
+                    Path.Combine(options.OutputDir, "wintty-inspector.ico"));
             }
 
             return 0;

--- a/pkg/dcimgui/ext.cpp
+++ b/pkg/dcimgui/ext.cpp
@@ -73,4 +73,21 @@ CIMGUI_API size_t ghostty_ImGui_ImplDX12_InitInfo_align()
 #endif // __has_include("backends/imgui_impl_dx12.h")
 #endif // IMGUI_DISABLE
 
+// Core struct layout accessors. The Zig cImport in main.zig translates
+// dcimgui.h with only IMGUI_USE_WCHAR32 + IMGUI_HAS_DOCK, while this library
+// is compiled with IMGUI_DISABLE_OBSOLETE_FUNCTIONS + IMGUI_ENABLE_FREETYPE
+// on top. If any of those change the layout of structs the embedded apprt
+// writes through (ImGuiIO every frame, ImGuiStyle on content-scale changes),
+// Zig would write fields at the wrong offsets and corrupt adjacent heap.
+// These let a unit test assert the Zig view matches the compiled layout.
+CIMGUI_API size_t ghostty_ImGuiIO_size()
+{
+    return sizeof(cimgui::ImGuiIO);
+}
+
+CIMGUI_API size_t ghostty_ImGuiStyle_size()
+{
+    return sizeof(cimgui::ImGuiStyle);
+}
+
 }

--- a/pkg/dcimgui/main.zig
+++ b/pkg/dcimgui/main.zig
@@ -1,12 +1,16 @@
 pub const build_options = @import("build_options");
 
 pub const c = @cImport({
-    // This is set during the build so it also has to be set
-    // during import time to get the right types. Without this
-    // you get stack size mismatches on some structs.
+    // These must match the defines the library is compiled with (see
+    // build.zig); otherwise the cImport-translated structs get a different
+    // layout than the compiled code and writing their fields corrupts memory.
+    // IMGUI_DISABLE_OBSOLETE_FUNCTIONS in particular removes obsolete fields,
+    // so omitting it here made Zig's ImGuiIO 32 bytes larger than the real
+    // allocation and per-frame io writes clobbered adjacent heap.
     @cDefine("IMGUI_USE_WCHAR32", "1");
-
     @cDefine("IMGUI_HAS_DOCK", "1");
+    @cDefine("IMGUI_DISABLE_OBSOLETE_FUNCTIONS", "1");
+    if (build_options.freetype) @cDefine("IMGUI_ENABLE_FREETYPE", "1");
     @cInclude("dcimgui.h");
 });
 
@@ -76,6 +80,9 @@ pub extern fn ImGui_ImplDX12_RenderDrawData(draw_data: *c.ImDrawData, command_li
 extern fn ghostty_ImGui_ImplDX12_InitInfo_size() callconv(.c) usize;
 extern fn ghostty_ImGui_ImplDX12_InitInfo_align() callconv(.c) usize;
 
+extern fn ghostty_ImGuiIO_size() callconv(.c) usize;
+extern fn ghostty_ImGuiStyle_size() callconv(.c) usize;
+
 // Internal API types and functions from dcimgui_internal.h
 // We declare these manually because the internal header contains bitfields
 // that Zig's cImport cannot translate.
@@ -119,6 +126,16 @@ pub const ext = struct {
 
 test {
     _ = c;
+}
+
+test "core struct layouts match the compiled library" {
+    const std = @import("std");
+    // The embedded apprt writes ImGuiIO fields every frame and copies a whole
+    // ImGuiStyle on content-scale changes. The cImport above must produce the
+    // exact same layout as the compiled library or those writes land at the
+    // wrong offsets and corrupt adjacent heap allocations.
+    try std.testing.expectEqual(ghostty_ImGuiIO_size(), @sizeOf(c.ImGuiIO));
+    try std.testing.expectEqual(ghostty_ImGuiStyle_size(), @sizeOf(c.ImGuiStyle));
 }
 
 test "dx12 backend bindings" {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1162,6 +1162,11 @@ pub const Inspector = struct {
     backend: ?Backend = null,
     content_scale: f64 = 1,
 
+    /// User-controlled zoom for the inspector UI (font + spacing), adjusted
+    /// with Ctrl++/Ctrl+- (and Ctrl+0 to reset). Multiplies on top of the
+    /// platform content scale.
+    ui_scale: f64 = 1,
+
     /// Our previous instant used to calculate delta time for animations.
     instant: ?std.time.Instant = null,
 
@@ -1363,19 +1368,45 @@ pub const Inspector = struct {
 
     pub fn updateContentScale(self: *Inspector, x: f64, y: f64) void {
         _ = y;
-        cimgui.c.ImGui_SetCurrentContext(self.ig_ctx);
 
         // Cache our scale because we use it for cursor position calculations.
         self.content_scale = x;
+        self.applyScale();
+    }
+
+    /// (Re)build the imgui style from defaults and apply the effective scale.
+    /// Spacing/padding scale with content_scale * ui_scale; the font scales
+    /// with ui_scale via FontScaleMain (the imgui 1.92 font zoom factor).
+    fn applyScale(self: *Inspector) void {
+        cimgui.c.ImGui_SetCurrentContext(self.ig_ctx);
 
         // Setup a new style and scale it appropriately. We must use the
         // ImGuiStyle constructor to get proper default values (e.g.,
         // CurveTessellationTol) rather than zero-initialized values.
         var style: cimgui.c.ImGuiStyle = undefined;
         cimgui.ext.ImGuiStyle_ImGuiStyle(&style);
-        cimgui.c.ImGuiStyle_ScaleAllSizes(&style, @floatCast(x));
+        cimgui.c.ImGuiStyle_ScaleAllSizes(
+            &style,
+            @floatCast(self.content_scale * self.ui_scale),
+        );
+        style.FontScaleMain = @floatCast(self.ui_scale);
         const active_style = cimgui.c.ImGui_GetStyle();
         active_style.* = style;
+    }
+
+    /// Multiply the user zoom by `factor` (e.g. 1.1 to zoom in, 1/1.1 to
+    /// zoom out), clamped to a sane range, and re-apply the style.
+    pub fn zoomBy(self: *Inspector, factor: f64) void {
+        self.ui_scale = std.math.clamp(self.ui_scale * factor, 0.5, 3.0);
+        self.applyScale();
+        self.queueRender();
+    }
+
+    /// Reset the user zoom to 1.0.
+    pub fn zoomReset(self: *Inspector) void {
+        self.ui_scale = 1;
+        self.applyScale();
+        self.queueRender();
     }
 
     pub fn updateSize(self: *Inspector, width: u32, height: u32) void {
@@ -2585,6 +2616,16 @@ pub const CAPI = struct {
 
     export fn ghostty_inspector_set_content_scale(ptr: *Inspector, x: f64, y: f64) void {
         ptr.updateContentScale(x, y);
+    }
+
+    /// Multiply the inspector's user zoom by `factor` (>1 zooms in, <1 out).
+    export fn ghostty_inspector_zoom_by(ptr: *Inspector, factor: f64) void {
+        ptr.zoomBy(factor);
+    }
+
+    /// Reset the inspector's user zoom to 1.0.
+    export fn ghostty_inspector_zoom_reset(ptr: *Inspector) void {
+        ptr.zoomReset();
     }
 
     export fn ghostty_inspector_mouse_button(

--- a/src/inspector/widgets/surface.zig
+++ b/src/inspector/widgets/surface.zig
@@ -133,7 +133,13 @@ pub const Inspector = struct {
 
         // In debug we show the ImGui demo window so we can easily view
         // available widgets and such.
-        if (comptime builtin.mode == .Debug) {
+        //
+        // Excluded on Windows: ImGui_ShowDemoWindow corrupts the heap on the
+        // Windows (Zig/clang MSVC) build of imgui after a few seconds of
+        // continuous rendering, taking down the whole app. The demo is only a
+        // development aid and the rest of the inspector is unaffected, so we
+        // skip it here rather than crash. The demo works on macOS/Linux.
+        if (comptime builtin.mode == .Debug and builtin.os.tag != .windows) {
             if (self.show_demo_window) {
                 cimgui.c.ImGui_ShowDemoWindow(&self.show_demo_window);
             }

--- a/windows/Ghostty.Core/Input/PaneAction.cs
+++ b/windows/Ghostty.Core/Input/PaneAction.cs
@@ -121,4 +121,11 @@ public enum PaneAction
     FloatWindowOn = 59,
     FloatWindowOff = 60,
     FloatWindowToggle = 61,
+
+    // Toggle the terminal inspector window. Apprt-only on Windows: the
+    // libghostty inspector keybind is not dispatched to the embedded apprt via
+    // the keyboard, so Ctrl+Shift+I is matched in KeyBindings.WindowsOnly and
+    // routed via PaneActionRouter to MainWindow (mirrors the command palette's
+    // inspector:toggle, which goes through ghostty_surface_binding_action).
+    ToggleInspector = 62,
 }

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -40,6 +40,7 @@ internal enum GhosttyActionTag
     ResetWindowSize = 23,
     InitialSize = 24,
     Scrollbar = 26,
+    Inspector = 28,
     DesktopNotification = 31,
     SetTitle = 32,
     SetTabTitle = 33,

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -22,6 +22,7 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.EqualizeSplits, 19)]
     [InlineData((int)GhosttyActionTag.ToggleSplitZoom, 20)]
     [InlineData((int)GhosttyActionTag.Scrollbar, 26)]
+    [InlineData((int)GhosttyActionTag.Inspector, 28)]
     [InlineData((int)GhosttyActionTag.SetTitle, 32)]
     [InlineData((int)GhosttyActionTag.MouseShape, 36)]
     [InlineData((int)GhosttyActionTag.MouseVisibility, 37)]

--- a/windows/Ghostty/Branding/WindowHelper.cs
+++ b/windows/Ghostty/Branding/WindowHelper.cs
@@ -52,6 +52,14 @@ internal static class WindowHelper
         => TryApplyIcon(window, "wintty-settings.ico");
 
     /// <summary>
+    /// Inspector-window variant. Uses the bug .ico so the taskbar /
+    /// alt-tab icon matches the command palette's "Toggle Inspector"
+    /// glyph and the window is distinguishable from terminal windows.
+    /// </summary>
+    public static void TryApplyInspectorIcon(Window window)
+        => TryApplyIcon(window, "wintty-inspector.ico");
+
+    /// <summary>
     /// Swallows the file-not-found race (asset deleted between the
     /// File.Exists check and the SetIcon call) and the native HRESULT
     /// path. A missing window icon is cosmetic, not crash-worthy.

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -91,6 +91,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddBindingCommand(commands, "jump_to_prompt:1", "Jump to Next Prompt", "Scroll to the next shell prompt (requires OSC 133)", CommandCategory.Terminal);
         AddBindingCommand(commands, "open_config", "Open Config", "Open the Ghostty configuration file", CommandCategory.Config, "\uE713");
         AddBindingCommand(commands, "reload_config", "Reload Config", "Reload configuration from disk", CommandCategory.Config, "\uE72C");
+        AddBindingCommand(commands, "inspector:toggle", "Toggle Inspector", "Show or hide the terminal inspector", CommandCategory.Terminal, "\uEBE8");
 
         // Opacity adjustment (Ctrl+Shift+Scroll, or from palette)
         if (_opacityAction is not null)

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -294,7 +294,7 @@
   <Target Name="GenerateBrandingAssets"
           BeforeTargets="BeforeBuild"
           Inputs="..\..\dist\windows\IconGen\**\*.cs;..\..\images\icons\icon_*.png"
-          Outputs="$(GeneratedBrandingDir)wintty.ico;$(GeneratedBrandingDir)wintty-settings.ico">
+          Outputs="$(GeneratedBrandingDir)wintty.ico;$(GeneratedBrandingDir)wintty-settings.ico;$(GeneratedBrandingDir)wintty-inspector.ico">
     <MakeDir Directories="$(GeneratedBrandingDir)" />
     <Exec Command="dotnet run --project ..\..\dist\windows\IconGen --no-launch-profile -c Release -- --channel $(Channel) --out &quot;$(GeneratedBrandingDir.TrimEnd('\'))&quot;"
           WorkingDirectory="$(MSBuildThisFileDirectory)" />
@@ -344,6 +344,17 @@
     -->
     <Content Include="$(GeneratedBrandingDir)wintty-settings.ico">
       <Link>Assets\wintty-settings.ico</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+    <!--
+      Inspector-window variant. Generated procedurally from the Segoe
+      Fluent Icons bug glyph (U+EBE8) by IconGen so the taskbar / alt-tab
+      icon for InspectorWindow matches the command palette's "Toggle
+      Inspector" entry and is distinguishable from a terminal window.
+    -->
+    <Content Include="$(GeneratedBrandingDir)wintty-inspector.ico">
+      <Link>Assets\wintty-inspector.ico</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </Content>

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -72,6 +72,15 @@ internal sealed class GhosttyHost : IDisposable
     public event EventHandler? ReloadConfigRequested;
 
     /// <summary>
+    /// Raised when libghostty requests the terminal inspector be toggled
+    /// (the GHOSTTY_ACTION_INSPECTOR apprt action, triggered by the
+    /// <c>inspector:toggle</c> keybind/command). <c>MainWindow</c> opens or
+    /// closes the inspector window for the active surface. Raised on the
+    /// surface's owning per-window host, like the other per-window events.
+    /// </summary>
+    public event EventHandler? InspectorToggleRequested;
+
+    /// <summary>
     /// Raised when libghostty matches a keybind that resolves to a pane/tab
     /// apprt action this window should perform (new tab/split, focus or
     /// resize a split, switch/move tabs, fullscreen, zoom, equalize). The
@@ -532,6 +541,14 @@ internal sealed class GhosttyHost : IDisposable
                 case GhosttyActionTag.ToggleCommandPalette:
                     _dispatcher.TryEnqueue(() =>
                         owner.CommandPaletteToggleRequested?.Invoke(owner, EventArgs.Empty));
+                    return 1;
+
+                // inspector:toggle keybind/command. The action payload carries
+                // a toggle/show/hide mode, but v1 treats it as a toggle: the
+                // window opens if closed and closes if open.
+                case GhosttyActionTag.Inspector:
+                    _dispatcher.TryEnqueue(() =>
+                        owner.InspectorToggleRequested?.Invoke(owner, EventArgs.Empty));
                     return 1;
 
                 // Pane/tab actions libghostty matched from a keybind. The

--- a/windows/Ghostty/Input/KeyBindings.cs
+++ b/windows/Ghostty/Input/KeyBindings.cs
@@ -158,6 +158,12 @@ internal sealed class KeyBindings
         // concern (libghostty has no closed-item stack on Windows).
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.T, PaneAction.ReopenClosedTab),
         new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.N, PaneAction.ReopenClosedWindow),
+
+        // Toggle the terminal inspector (Chromium-style Ctrl+Shift+I). Matched
+        // here because the libghostty inspector keybind is not delivered to the
+        // embedded apprt via the keyboard on Windows; the command palette's
+        // inspector:toggle still works through ghostty_surface_binding_action.
+        new KeyBinding(VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.I, PaneAction.ToggleInspector),
     });
 
     /// <summary>

--- a/windows/Ghostty/Input/PaneActionRouter.cs
+++ b/windows/Ghostty/Input/PaneActionRouter.cs
@@ -112,6 +112,13 @@ internal sealed class PaneActionRouter
     public event EventHandler? ShowAboutRequested;
 
     /// <summary>
+    /// Raised when the Ctrl+Shift+I inspector chord fires. MainWindow listens
+    /// and toggles the inspector window (same handler the command palette and
+    /// the libghostty inspector apprt action use).
+    /// </summary>
+    public event EventHandler? InspectorToggleRequested;
+
+    /// <summary>
     /// Raised when the reopen-closed-tab chord or palette entry fires.
     /// MainWindow listens and rebuilds a tab from the most recent closed-tab
     /// snapshot into this window (reconstruction needs the WinUI factory).
@@ -175,6 +182,9 @@ internal sealed class PaneActionRouter
                 return;
             case PaneAction.ShowAbout:
                 ShowAboutRequested?.Invoke(this, EventArgs.Empty);
+                return;
+            case PaneAction.ToggleInspector:
+                InspectorToggleRequested?.Invoke(this, EventArgs.Empty);
                 return;
             case PaneAction.ReopenClosedTab:
                 ReopenClosedTabRequested?.Invoke(this, EventArgs.Empty);

--- a/windows/Ghostty/InspectorWindow.xaml
+++ b/windows/Ghostty/InspectorWindow.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="Ghostty.InspectorWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+      The inspector renders entirely through libghostty's DX12 swap chain
+      bound to this SwapChainPanel (same handoff the terminal uses). The
+      panel is a tab stop so it can receive pointer + character input that we
+      forward into the ImGui context.
+    -->
+    <SwapChainPanel x:Name="Panel" IsTabStop="True" />
+</Window>

--- a/windows/Ghostty/InspectorWindow.xaml.cs
+++ b/windows/Ghostty/InspectorWindow.xaml.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Microsoft.UI.Input;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+
+using Ghostty.Core;
+using Ghostty.Interop;
+
+using WinRT.Interop;
+
+namespace Ghostty;
+
+// Separate window hosting the terminal inspector (ImGui overlay), mirroring
+// the macOS inspector window. libghostty owns the DX12 swap chain bound to the
+// SwapChainPanel; we drive a frame on a timer and forward pointer/character
+// input into the ImGui context. The inspector is bound to the surface that was
+// active when it opened (one inspector window per main window, per v1 scope).
+internal sealed partial class InspectorWindow : Window
+{
+    // ~60fps. ImGui is immediate-mode, so we redraw continuously while the
+    // window is open; this can later be made on-demand (present on input +
+    // when ImGui wants another frame).
+    private static readonly TimeSpan PresentInterval = TimeSpan.FromMilliseconds(16);
+
+    private readonly GhosttyInspector _inspector;
+    private readonly DispatcherTimer _timer;
+    private bool _initialized;
+    private bool _closed;
+
+    public InspectorWindow(GhosttyInspector inspector)
+    {
+        InitializeComponent();
+
+        _inspector = inspector;
+
+        Title = $"{AppIdentity.ProductName} Inspector";
+
+        // Center at a reasonable default size.
+        var hwnd = WindowNative.GetWindowHandle(this);
+        var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hwnd);
+        var appWindow = AppWindow.GetFromWindowId(windowId);
+        const int width = 900;
+        const int height = 700;
+        var display = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Primary);
+        var work = display.WorkArea;
+        var x = work.X + (work.Width - width) / 2;
+        var y = work.Y + (work.Height - height) / 2;
+        appWindow.MoveAndResize(new Windows.Graphics.RectInt32(x, y, width, height));
+
+        _timer = new DispatcherTimer { Interval = PresentInterval };
+        _timer.Tick += OnPresentTick;
+
+        Panel.Loaded += OnPanelLoaded;
+        Panel.SizeChanged += OnPanelSizeChanged;
+        Panel.PointerPressed += OnPointerPressed;
+        Panel.PointerReleased += OnPointerReleased;
+        Panel.PointerMoved += OnPointerMoved;
+        Panel.PointerWheelChanged += OnPointerWheelChanged;
+        Panel.CharacterReceived += OnCharacterReceived;
+        Activated += OnActivated;
+        Closed += OnClosed;
+    }
+
+    private double RasterScale => Panel.XamlRoot?.RasterizationScale ?? 1.0;
+
+    private uint PixelWidth => (uint)Math.Max(1, Math.Round(Panel.ActualWidth * RasterScale));
+    private uint PixelHeight => (uint)Math.Max(1, Math.Round(Panel.ActualHeight * RasterScale));
+
+    private void OnPanelLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_initialized || _closed) return;
+
+        var panelPtr = SwapChainPanelInterop.QueryInterface(Panel);
+        try
+        {
+            // libghostty creates the swap chain and binds it to the panel
+            // synchronously here, so the panel pointer can be released right
+            // after (same contract as the terminal surface).
+            _initialized = NativeMethods.InspectorDirectX12SurfaceInit(
+                _inspector, panelPtr, PixelWidth, PixelHeight);
+        }
+        finally
+        {
+            SwapChainPanelInterop.Release(panelPtr);
+        }
+
+        if (!_initialized) return;
+
+        NativeMethods.InspectorSetContentScale(_inspector, RasterScale, RasterScale);
+        NativeMethods.InspectorSetSize(_inspector, PixelWidth, PixelHeight);
+        // Seed focus: the window's first Activated fires before this Loaded, so
+        // OnActivated skips it (not yet initialized). ImGui needs focus to take
+        // keyboard/text input.
+        NativeMethods.InspectorSetFocus(_inspector, true);
+        Panel.Focus(FocusState.Programmatic);
+        _timer.Start();
+    }
+
+    private void OnPresentTick(object? sender, object e)
+    {
+        if (!_initialized || _closed) return;
+        NativeMethods.InspectorDirectX12SurfacePresent(_inspector);
+    }
+
+    private void OnPanelSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (!_initialized || _closed) return;
+        NativeMethods.InspectorDirectX12SurfaceResize(_inspector, PixelWidth, PixelHeight);
+        NativeMethods.InspectorSetSize(_inspector, PixelWidth, PixelHeight);
+    }
+
+    private void OnActivated(object sender, WindowActivatedEventArgs e)
+    {
+        if (!_initialized || _closed) return;
+        NativeMethods.InspectorSetFocus(
+            _inspector, e.WindowActivationState != WindowActivationState.Deactivated);
+    }
+
+    private void OnClosed(object sender, WindowEventArgs e)
+    {
+        if (_closed) return;
+        _closed = true;
+        _timer.Stop();
+        _timer.Tick -= OnPresentTick;
+        if (_initialized)
+        {
+            NativeMethods.InspectorDirectX12SurfaceShutdown(_inspector);
+            _initialized = false;
+        }
+    }
+
+    // ---- input forwarding ----------------------------------------------
+
+    private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        Panel.Focus(FocusState.Pointer);
+        SendMouseButton(e);
+        e.Handled = true;
+    }
+
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        SendMouseButton(e);
+        e.Handled = true;
+    }
+
+    private void SendMouseButton(PointerRoutedEventArgs e)
+    {
+        if (!_initialized) return;
+        var kind = e.GetCurrentPoint(Panel).Properties.PointerUpdateKind;
+        var (button, state) = kind switch
+        {
+            PointerUpdateKind.LeftButtonPressed => (GhosttyMouseButton.Left, GhosttyMouseState.Press),
+            PointerUpdateKind.LeftButtonReleased => (GhosttyMouseButton.Left, GhosttyMouseState.Release),
+            PointerUpdateKind.RightButtonPressed => (GhosttyMouseButton.Right, GhosttyMouseState.Press),
+            PointerUpdateKind.RightButtonReleased => (GhosttyMouseButton.Right, GhosttyMouseState.Release),
+            PointerUpdateKind.MiddleButtonPressed => (GhosttyMouseButton.Middle, GhosttyMouseState.Press),
+            PointerUpdateKind.MiddleButtonReleased => (GhosttyMouseButton.Middle, GhosttyMouseState.Release),
+            _ => (GhosttyMouseButton.Unknown, GhosttyMouseState.Release),
+        };
+        if (button == GhosttyMouseButton.Unknown) return;
+        // The core inspector ignores mouse-button mods, so pass None.
+        NativeMethods.InspectorMouseButton(_inspector, state, button, GhosttyMods.None);
+    }
+
+    private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_initialized) return;
+        // Logical coordinates: the core scales by content_scale internally.
+        var pos = e.GetCurrentPoint(Panel).Position;
+        NativeMethods.InspectorMousePos(_inspector, pos.X, pos.Y);
+    }
+
+    private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_initialized) return;
+        var point = e.GetCurrentPoint(Panel);
+        // Wheel delta is +/-120 per notch; ImGui expects ~1.0 per notch.
+        var delta = point.Properties.MouseWheelDelta / 120.0;
+        var horizontal = point.Properties.IsHorizontalMouseWheel;
+        NativeMethods.InspectorMouseScroll(
+            _inspector,
+            horizontal ? delta : 0.0,
+            horizontal ? 0.0 : delta,
+            0);
+        e.Handled = true;
+    }
+
+    private void OnCharacterReceived(UIElement sender, CharacterReceivedRoutedEventArgs e)
+    {
+        if (!_initialized) return;
+        // ghostty_inspector_text takes a NUL-terminated UTF-8 string.
+        var bytes = Encoding.UTF8.GetBytes(e.Character.ToString());
+        var buf = new byte[bytes.Length + 1];
+        Array.Copy(bytes, buf, bytes.Length);
+        var handle = GCHandle.Alloc(buf, GCHandleType.Pinned);
+        try
+        {
+            NativeMethods.InspectorText(_inspector, handle.AddrOfPinnedObject());
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
+}

--- a/windows/Ghostty/InspectorWindow.xaml.cs
+++ b/windows/Ghostty/InspectorWindow.xaml.cs
@@ -39,6 +39,11 @@ internal sealed partial class InspectorWindow : Window
 
         Title = $"{AppIdentity.ProductName} Inspector";
 
+        // Stamp the bug .ico into the OS slots (taskbar group, alt-tab,
+        // thumbnail) so the inspector is distinguishable from a terminal
+        // window, mirroring how SettingsWindow uses the gear .ico.
+        Ghostty.Branding.WindowHelper.TryApplyInspectorIcon(this);
+
         // Center at a reasonable default size.
         var hwnd = WindowNative.GetWindowHandle(this);
         var windowId = Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hwnd);
@@ -61,6 +66,7 @@ internal sealed partial class InspectorWindow : Window
         Panel.PointerMoved += OnPointerMoved;
         Panel.PointerWheelChanged += OnPointerWheelChanged;
         Panel.CharacterReceived += OnCharacterReceived;
+        Panel.KeyDown += OnKeyDown;
         Activated += OnActivated;
         Closed += OnClosed;
     }
@@ -205,6 +211,41 @@ internal sealed partial class InspectorWindow : Window
         finally
         {
             handle.Free();
+        }
+    }
+
+    // Ctrl++ / Ctrl+- zoom the inspector UI, Ctrl+0 resets. Handled here (not
+    // forwarded to ImGui) since we don't route key events into the context.
+    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (!_initialized) return;
+
+        var ctrl = (InputKeyboardSource.GetKeyStateForCurrentThread(
+            Windows.System.VirtualKey.Control) &
+            Windows.UI.Core.CoreVirtualKeyStates.Down) != 0;
+        if (!ctrl) return;
+
+        // OemPlus/OemMinus are the main-row '='/'-' keys; Add/Subtract are the
+        // numpad equivalents. '+' needs no Shift here (Ctrl+= zooms in).
+        const Windows.System.VirtualKey OemPlus = (Windows.System.VirtualKey)0xBB;
+        const Windows.System.VirtualKey OemMinus = (Windows.System.VirtualKey)0xBD;
+        switch (e.Key)
+        {
+            case OemPlus:
+            case Windows.System.VirtualKey.Add:
+                NativeMethods.InspectorZoomBy(_inspector, 1.1);
+                e.Handled = true;
+                break;
+            case OemMinus:
+            case Windows.System.VirtualKey.Subtract:
+                NativeMethods.InspectorZoomBy(_inspector, 1.0 / 1.1);
+                e.Handled = true;
+                break;
+            case Windows.System.VirtualKey.Number0:
+            case Windows.System.VirtualKey.NumberPad0:
+                NativeMethods.InspectorZoomReset(_inspector);
+                e.Handled = true;
+                break;
         }
     }
 }

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -655,6 +655,14 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void InspectorSetContentScale(GhosttyInspector inspector, double x, double y);
 
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_zoom_by")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorZoomBy(GhosttyInspector inspector, double factor);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_zoom_reset")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorZoomReset(GhosttyInspector inspector);
+
     [LibraryImport(Dll, EntryPoint = "ghostty_inspector_set_size")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void InspectorSetSize(GhosttyInspector inspector, uint width, uint height);

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -17,6 +17,7 @@ namespace Ghostty.Interop;
 internal readonly record struct GhosttyApp(IntPtr Handle);
 internal readonly record struct GhosttyConfig(IntPtr Handle);
 internal readonly record struct GhosttySurface(IntPtr Handle);
+internal readonly record struct GhosttyInspector(IntPtr Handle);
 
 internal enum GhosttyPlatform
 {
@@ -597,4 +598,88 @@ internal static partial class NativeMethods
     [LibraryImport(Dll, EntryPoint = "ghostty_log_set_callback")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void LogSetCallback(IntPtr callback, IntPtr userData);
+
+    // ---- inspector -----------------------------------------------------
+    //
+    // The inspector is an ImGui overlay 1:1 with a surface. On Windows it
+    // lives in its own WinUI window whose swap chain libghostty owns: the
+    // surface_* functions create/drive/tear down that swap chain (bound to a
+    // SwapChainPanel), and the input functions forward UI events into the
+    // ImGui context. Keyboard key events (ghostty_inspector_key) are not yet
+    // wired -- text input via ghostty_inspector_text plus mouse covers v1.
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_inspector")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial GhosttyInspector SurfaceInspector(GhosttySurface surface);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_directx12_surface_init")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte InspectorDirectX12SurfaceInitNative(
+        GhosttyInspector inspector,
+        IntPtr swapChainPanel,
+        uint width,
+        uint height);
+
+    internal static bool InspectorDirectX12SurfaceInit(
+        GhosttyInspector inspector,
+        IntPtr swapChainPanel,
+        uint width,
+        uint height)
+        => InspectorDirectX12SurfaceInitNative(inspector, swapChainPanel, width, height) != 0;
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_directx12_surface_present")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorDirectX12SurfacePresent(GhosttyInspector inspector);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_directx12_surface_resize")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorDirectX12SurfaceResize(
+        GhosttyInspector inspector,
+        uint width,
+        uint height);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_directx12_surface_shutdown")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorDirectX12SurfaceShutdown(GhosttyInspector inspector);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_set_focus")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial void InspectorSetFocusNative(
+        GhosttyInspector inspector,
+        [MarshalAs(UnmanagedType.U1)] bool focused);
+
+    internal static void InspectorSetFocus(GhosttyInspector inspector, bool focused)
+        => InspectorSetFocusNative(inspector, focused);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_set_content_scale")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorSetContentScale(GhosttyInspector inspector, double x, double y);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_set_size")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorSetSize(GhosttyInspector inspector, uint width, uint height);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_mouse_button")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorMouseButton(
+        GhosttyInspector inspector,
+        GhosttyMouseState state,
+        GhosttyMouseButton button,
+        GhosttyMods mods);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_mouse_pos")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorMousePos(GhosttyInspector inspector, double x, double y);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_mouse_scroll")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorMouseScroll(
+        GhosttyInspector inspector,
+        double x,
+        double y,
+        int scrollMods);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_inspector_text")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void InspectorText(GhosttyInspector inspector, IntPtr utf8z);
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1405,6 +1405,10 @@ public sealed partial class MainWindow : Window
 
         _router.CommandPaletteToggleRequested += (_, _) => ToggleCommandPalette();
 
+        // Ctrl+Shift+I toggles the terminal inspector (same handler as the
+        // command palette / libghostty inspector action).
+        _router.InspectorToggleRequested += (_, _) => ToggleInspector();
+
         // Fullscreen toggle via F11.
         _router.ToggleFullscreenRequested += (_, _) => ToggleFullscreen();
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -194,6 +194,7 @@ public sealed partial class MainWindow : Window
     private GradientTintVisual? _gradientVisual;
     private Window? _settingsWindow;
     private Window? _aboutWindow;
+    private InspectorWindow? _inspectorWindow;
 
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
@@ -624,6 +625,9 @@ public sealed partial class MainWindow : Window
 
         _host.CommandPaletteToggleRequested += (_, _) =>
             DispatcherQueue.TryEnqueue(ToggleCommandPalette);
+
+        _host.InspectorToggleRequested += (_, _) =>
+            DispatcherQueue.TryEnqueue(ToggleInspector);
 
         // Pane/tab keybinds libghostty matched arrive already mapped to a
         // PaneAction (and already hopped to the UI thread by the host);
@@ -1073,6 +1077,14 @@ public sealed partial class MainWindow : Window
         // teardown begins.
         _isClosed = true;
         _themeManager.Dispose();
+
+        // Close the inspector window before any surface/host teardown below.
+        // Its present timer drives libghostty against the bound surface every
+        // frame; closing it now runs its shutdown (stop timer + tear down the
+        // swap chain) while the surface and DX12 device are still valid,
+        // avoiding a use-after-free.
+        _inspectorWindow?.Close();
+        _inspectorWindow = null;
 
         // If this is the last regular window the app is exiting: the
         // bootstrap libghostty app and the DX12 renderer are about to be
@@ -2660,6 +2672,49 @@ public sealed partial class MainWindow : Window
             // next tick so the palette closes before the action runs.
             commandLineDispatch: actionKey =>
                 DispatcherQueue.TryEnqueue(() => ExecuteBindingAction(actionKey)));
+    }
+
+    // Toggle the inspector window for the active surface. v1: one inspector
+    // window per main window; re-toggling closes it, and it stays bound to the
+    // surface it opened for (re-open to retarget a different pane).
+    private void ToggleInspector()
+    {
+        if (_inspectorWindow is not null)
+        {
+            _inspectorWindow.Close();
+            return;
+        }
+
+        var paneHost = _tabManager.ActiveTab?.PaneHost;
+        var leaf = paneHost?.ActiveLeaf;
+        if (leaf is null) return;
+        var surfaceHandle = leaf.Terminal().SurfaceHandle;
+        if (surfaceHandle == IntPtr.Zero) return;
+
+        // ghostty_surface_inspector lazily creates the inspector and can return
+        // null; don't open a window we can't drive.
+        var inspector = NativeMethods.SurfaceInspector(new GhosttySurface(surfaceHandle));
+        if (inspector.Handle == IntPtr.Zero) return;
+
+        var window = new InspectorWindow(inspector);
+
+        // The inspector presents into the bound surface every frame. If the
+        // active surface changes (pane focus/close, tab switch) that surface
+        // may be torn down, so close the inspector first to avoid presenting
+        // into freed state. v1 retargets by reopening on the new active pane.
+        EventHandler<LeafPane> onLeafFocused = (_, _) => _inspectorWindow?.Close();
+        EventHandler<TabModel> onTabChanged = (_, _) => _inspectorWindow?.Close();
+        if (paneHost is not null) paneHost.LeafFocused += onLeafFocused;
+        _tabManager.ActiveTabChanged += onTabChanged;
+
+        window.Closed += (_, _) =>
+        {
+            if (paneHost is not null) paneHost.LeafFocused -= onLeafFocused;
+            _tabManager.ActiveTabChanged -= onTabChanged;
+            _inspectorWindow = null;
+        };
+        _inspectorWindow = window;
+        window.Activate();
     }
 
     private void ExecuteBindingAction(string actionKey)


### PR DESCRIPTION
Brings the ImGui terminal inspector to the Windows/DX12 build for parity with macOS and Linux. Completes the inspector stack (PR1 # 514, PR2 # 518, both merged).

- Separate WinUI window hosts the inspector; libghostty owns the DX12 swap chain and the app drives a present timer.
- Ctrl+Shift+I toggles it; Ctrl++/Ctrl+-/Ctrl+0 zoom the panels.
- Dedicated bug-glyph window icon so it stands out in the taskbar and alt-tab.
- Fixes a dcimgui cImport struct-layout mismatch and gates the Debug-only ImGui demo window off on Windows (it overran the heap).

Relates to # 513.