### PR TITLE
fix(windows): drop MarshalAs from inspector focus P/Invoke

### DIFF
--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -644,12 +644,10 @@ internal static partial class NativeMethods
 
     [LibraryImport(Dll, EntryPoint = "ghostty_inspector_set_focus")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    private static partial void InspectorSetFocusNative(
-        GhosttyInspector inspector,
-        [MarshalAs(UnmanagedType.U1)] bool focused);
+    private static partial void InspectorSetFocusNative(GhosttyInspector inspector, byte focused);
 
     internal static void InspectorSetFocus(GhosttyInspector inspector, bool focused)
-        => InspectorSetFocusNative(inspector, focused);
+        => InspectorSetFocusNative(inspector, focused ? (byte)1 : (byte)0);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_inspector_set_content_scale")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]


### PR DESCRIPTION
The `ghostty_inspector_set_focus` P/Invoke declared its `bool` parameter with `[MarshalAs(UnmanagedType.U1)]`. That attribute is forbidden under `[assembly: DisableRuntimeMarshalling]`, so `MarshalComplianceTests.NativeMethods_HasNoMarshalAsAttributes` failed on the `windows` branch.

Switch to the byte-for-bool pattern already used by the other focus bindings (`ghostty_app_set_focus`, `ghostty_surface_set_focus`): the native param is `byte` and the wrapper converts the `bool`.

Pre-existing on `windows` (came in with the inspector work), unrelated to any in-flight feature, so it stands alone.

Verified: `dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj -p:Platform=x64 --filter MarshalComplianceTests` -> 5 passed, 0 failed.