### PR TITLE
feat(windows): pane context menu with icons

### DIFF
--- a/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
+++ b/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Panes;
+
+/// <summary>Whether a menu entry is an actionable item or a separator.</summary>
+public enum PaneMenuItemKind
+{
+    Action,
+    Separator,
+}
+
+/// <summary>
+/// The commands the pane context menu can issue. Translated to a concrete
+/// dispatch (PaneAction or libghostty binding action or title dialog) by the
+/// WinUI <c>PaneContextMenuBuilder</c>. Kept here, in Core, so the menu's
+/// shape and gating are testable without WinUI.
+/// </summary>
+public enum PaneMenuCommand
+{
+    /// <summary>Sentinel used only for separator rows; never dispatched as an action.</summary>
+    None,
+    Copy,
+    Paste,
+    SelectAll,
+    SplitRight,
+    SplitDown,
+    ZoomPane,
+    CommandPalette,
+    ResetTerminal,
+    ToggleInspector,
+    ChangeTabTitle,
+    ChangeTerminalTitle,
+}
+
+/// <summary>One row of the pane context menu.</summary>
+public readonly record struct PaneMenuItem(
+    PaneMenuItemKind Kind,
+    PaneMenuCommand Command,
+    string Label,
+    bool IsEnabled,
+    bool IsChecked);
+
+/// <summary>
+/// Builds the ordered pane context-menu model. Mirrors the macOS surface
+/// context menu (Copy/Paste/Select All, splits, Reset/Inspector, titles) plus
+/// Zoom Pane and Command Palette. The Windows pane model splits two ways only,
+/// so there is no Split Left/Up; read-only mode is not implemented on Windows
+/// so it is omitted.
+/// </summary>
+public static class PaneContextMenuModel
+{
+    private static PaneMenuItem Action(PaneMenuCommand command, string label,
+        bool isEnabled = true, bool isChecked = false)
+        => new(PaneMenuItemKind.Action, command, label, isEnabled, isChecked);
+
+    private static PaneMenuItem Separator()
+        => new(PaneMenuItemKind.Separator, PaneMenuCommand.None, string.Empty, false, false);
+
+    public static IReadOnlyList<PaneMenuItem> Build(bool hasSelection, bool isZoomed)
+        => new[]
+        {
+            Action(PaneMenuCommand.Copy, "Copy", isEnabled: hasSelection),
+            Action(PaneMenuCommand.Paste, "Paste"),
+            Action(PaneMenuCommand.SelectAll, "Select All"),
+            Separator(),
+            Action(PaneMenuCommand.SplitRight, "Split Right"),
+            Action(PaneMenuCommand.SplitDown, "Split Down"),
+            Action(PaneMenuCommand.ZoomPane, "Zoom Pane", isChecked: isZoomed),
+            Separator(),
+            Action(PaneMenuCommand.CommandPalette, "Command Palette"),
+            Action(PaneMenuCommand.ResetTerminal, "Reset Terminal"),
+            Action(PaneMenuCommand.ToggleInspector, "Toggle Inspector"),
+            Separator(),
+            Action(PaneMenuCommand.ChangeTabTitle, "Change Tab Title..."),
+            Action(PaneMenuCommand.ChangeTerminalTitle, "Change Terminal Title..."),
+        };
+}

--- a/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
+++ b/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
@@ -66,7 +66,7 @@ public static class PaneContextMenuModel
             Separator(),
             Action(PaneMenuCommand.SplitRight,          "Split Right",              "\uF57E"),
             Action(PaneMenuCommand.SplitDown,           "Split Down",               "\uF57E"),
-            Action(PaneMenuCommand.ZoomPane,            "Zoom Pane",                "\uE740", isChecked: isZoomed),
+            Action(PaneMenuCommand.ZoomPane,            "Zoom Pane",                isZoomed ? "\uE73F" : "\uE740", isChecked: isZoomed),
             Separator(),
             Action(PaneMenuCommand.CommandPalette,      "Command Palette",          "\uE756"),
             Action(PaneMenuCommand.ResetTerminal,       "Reset Terminal",           "\uE777"),

--- a/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
+++ b/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
@@ -38,7 +38,8 @@ public readonly record struct PaneMenuItem(
     PaneMenuCommand Command,
     string Label,
     bool IsEnabled,
-    bool IsChecked);
+    bool IsChecked,
+    string? Icon);
 
 /// <summary>
 /// Builds the ordered pane context-menu model. Mirrors the macOS surface
@@ -49,29 +50,29 @@ public readonly record struct PaneMenuItem(
 /// </summary>
 public static class PaneContextMenuModel
 {
-    private static PaneMenuItem Action(PaneMenuCommand command, string label,
+    private static PaneMenuItem Action(PaneMenuCommand command, string label, string icon,
         bool isEnabled = true, bool isChecked = false)
-        => new(PaneMenuItemKind.Action, command, label, isEnabled, isChecked);
+        => new(PaneMenuItemKind.Action, command, label, isEnabled, isChecked, icon);
 
     private static PaneMenuItem Separator()
-        => new(PaneMenuItemKind.Separator, PaneMenuCommand.None, string.Empty, false, false);
+        => new(PaneMenuItemKind.Separator, PaneMenuCommand.None, string.Empty, false, false, null);
 
     public static IReadOnlyList<PaneMenuItem> Build(bool hasSelection, bool isZoomed)
         => new[]
         {
-            Action(PaneMenuCommand.Copy, "Copy", isEnabled: hasSelection),
-            Action(PaneMenuCommand.Paste, "Paste"),
-            Action(PaneMenuCommand.SelectAll, "Select All"),
+            Action(PaneMenuCommand.Copy,                "Copy",                     "\uE8C8", isEnabled: hasSelection),
+            Action(PaneMenuCommand.Paste,               "Paste",                    "\uE77F"),
+            Action(PaneMenuCommand.SelectAll,           "Select All",               "\uE8B3"),
             Separator(),
-            Action(PaneMenuCommand.SplitRight, "Split Right"),
-            Action(PaneMenuCommand.SplitDown, "Split Down"),
-            Action(PaneMenuCommand.ZoomPane, "Zoom Pane", isChecked: isZoomed),
+            Action(PaneMenuCommand.SplitRight,          "Split Right",              "\uF57E"),
+            Action(PaneMenuCommand.SplitDown,           "Split Down",               "\uF57E"),
+            Action(PaneMenuCommand.ZoomPane,            "Zoom Pane",                "\uE740", isChecked: isZoomed),
             Separator(),
-            Action(PaneMenuCommand.CommandPalette, "Command Palette"),
-            Action(PaneMenuCommand.ResetTerminal, "Reset Terminal"),
-            Action(PaneMenuCommand.ToggleInspector, "Toggle Inspector"),
+            Action(PaneMenuCommand.CommandPalette,      "Command Palette",          "\uE756"),
+            Action(PaneMenuCommand.ResetTerminal,       "Reset Terminal",           "\uE777"),
+            Action(PaneMenuCommand.ToggleInspector,     "Toggle Inspector",         "\uEBE8"),
             Separator(),
-            Action(PaneMenuCommand.ChangeTabTitle, "Change Tab Title..."),
-            Action(PaneMenuCommand.ChangeTerminalTitle, "Change Terminal Title..."),
+            Action(PaneMenuCommand.ChangeTabTitle,      "Change Tab Title...",      "\uE70F"),
+            Action(PaneMenuCommand.ChangeTerminalTitle, "Change Terminal Title...", "\uE8AC"),
         };
 }

--- a/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
@@ -81,4 +81,28 @@ public class PaneContextMenuModelTests
         foreach (var item in items.Where(i => i.Kind == PaneMenuItemKind.Action))
             Assert.False(string.IsNullOrWhiteSpace(item.Label));
     }
+
+    [Fact]
+    public void Build_EveryActionHasIcon()
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: true, isZoomed: false);
+        foreach (var item in items.Where(i => i.Kind == PaneMenuItemKind.Action))
+            Assert.False(string.IsNullOrEmpty(item.Icon), $"{item.Command} should have an icon");
+    }
+
+    [Fact]
+    public void Build_SeparatorsHaveNoIcon()
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: true, isZoomed: false);
+        foreach (var item in items.Where(i => i.Kind == PaneMenuItemKind.Separator))
+            Assert.Null(item.Icon);
+    }
+
+    [Fact]
+    public void Build_MapsKnownGlyphs()
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: true, isZoomed: false);
+        Assert.Equal("\uE8C8", items.Single(i => i.Command == PaneMenuCommand.Copy).Icon);
+        Assert.Equal("\uE777", items.Single(i => i.Command == PaneMenuCommand.ResetTerminal).Icon);
+    }
 }

--- a/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using Ghostty.Core.Panes;
+using Xunit;
+
+namespace Ghostty.Tests.Panes;
+
+public class PaneContextMenuModelTests
+{
+    [Fact]
+    public void Build_ProducesExpectedCommandOrder()
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: true, isZoomed: false);
+
+        var commands = items
+            .Where(i => i.Kind == PaneMenuItemKind.Action)
+            .Select(i => i.Command)
+            .ToArray();
+
+        Assert.Equal(new[]
+        {
+            PaneMenuCommand.Copy,
+            PaneMenuCommand.Paste,
+            PaneMenuCommand.SelectAll,
+            PaneMenuCommand.SplitRight,
+            PaneMenuCommand.SplitDown,
+            PaneMenuCommand.ZoomPane,
+            PaneMenuCommand.CommandPalette,
+            PaneMenuCommand.ResetTerminal,
+            PaneMenuCommand.ToggleInspector,
+            PaneMenuCommand.ChangeTabTitle,
+            PaneMenuCommand.ChangeTerminalTitle,
+        }, commands);
+    }
+
+    [Fact]
+    public void Build_InsertsSeparatorsBetweenGroups()
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: true, isZoomed: false);
+
+        Assert.Equal(3, items.Count(i => i.Kind == PaneMenuItemKind.Separator));
+        Assert.NotEqual(PaneMenuItemKind.Separator, items[0].Kind);
+        Assert.NotEqual(PaneMenuItemKind.Separator, items[^1].Kind);
+        for (var i = 1; i < items.Count; i++)
+            Assert.False(items[i].Kind == PaneMenuItemKind.Separator
+                && items[i - 1].Kind == PaneMenuItemKind.Separator);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Build_CopyEnabledTracksSelection(bool hasSelection)
+    {
+        var items = PaneContextMenuModel.Build(hasSelection, isZoomed: false);
+        var copy = items.Single(i => i.Command == PaneMenuCommand.Copy);
+        Assert.Equal(hasSelection, copy.IsEnabled);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Build_ZoomCheckedTracksZoomState(bool isZoomed)
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: false, isZoomed);
+        var zoom = items.Single(i => i.Command == PaneMenuCommand.ZoomPane);
+        Assert.Equal(isZoomed, zoom.IsChecked);
+    }
+
+    [Fact]
+    public void Build_NonCopyItemsAlwaysEnabled()
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: false, isZoomed: false);
+        foreach (var item in items.Where(i =>
+                     i.Kind == PaneMenuItemKind.Action && i.Command != PaneMenuCommand.Copy))
+            Assert.True(item.IsEnabled, $"{item.Command} should be enabled");
+    }
+
+    [Fact]
+    public void Build_EveryActionHasNonEmptyLabel()
+    {
+        var items = PaneContextMenuModel.Build(hasSelection: true, isZoomed: true);
+        foreach (var item in items.Where(i => i.Kind == PaneMenuItemKind.Action))
+            Assert.False(string.IsNullOrWhiteSpace(item.Label));
+    }
+}

--- a/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
@@ -105,4 +105,15 @@ public class PaneContextMenuModelTests
         Assert.Equal("\uE8C8", items.Single(i => i.Command == PaneMenuCommand.Copy).Icon);
         Assert.Equal("\uE777", items.Single(i => i.Command == PaneMenuCommand.ResetTerminal).Icon);
     }
+
+    [Fact]
+    public void Build_ZoomIconReflectsZoomState()
+    {
+        var notZoomed = PaneContextMenuModel.Build(hasSelection: false, isZoomed: false)
+            .Single(i => i.Command == PaneMenuCommand.ZoomPane);
+        var zoomed = PaneContextMenuModel.Build(hasSelection: false, isZoomed: true)
+            .Single(i => i.Command == PaneMenuCommand.ZoomPane);
+        Assert.Equal("\uE740", notZoomed.Icon);
+        Assert.Equal("\uE73F", zoomed.Icon);
+    }
 }

--- a/windows/Ghostty/Commands/BuiltInCommandSource.cs
+++ b/windows/Ghostty/Commands/BuiltInCommandSource.cs
@@ -63,7 +63,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddPaneCommand(commands, PaneAction.MoveTabLeft, "Move Tab Left", "Move the active tab one position left", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.ToggleVerticalTabsPinned, "Toggle Vertical Tabs Pinned", "Pin or unpin the vertical tab sidebar", CommandCategory.Tab);
         AddPaneCommand(commands, PaneAction.ToggleTabLayout, "Toggle Tab Layout", "Switch between horizontal and vertical tab layout", CommandCategory.Tab, "\uE8AB");
-        AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal);
+        AddPaneCommand(commands, PaneAction.ToggleQuickTerminal, "Toggle Quake Terminal", "Show or hide the singleton drop-down terminal", CommandCategory.Terminal, icon: null, pathKey: "quake");
         AddPaneCommand(commands, PaneAction.ShowKeybindCheatsheet, "Keyboard Shortcuts", "Show the keyboard shortcuts cheat sheet", CommandCategory.Terminal, "");
         AddPaneCommand(commands, PaneAction.ShowAbout, "About", "Show app version, links, and license", CommandCategory.About, "");
         // Undo/Redo are omitted when their stack is empty so the palette
@@ -80,7 +80,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
         AddBindingCommand(commands, "reset", "Reset Terminal", "Reset the terminal to a clean state", CommandCategory.Terminal, "\uE777");
         AddBindingCommand(commands, "copy_to_clipboard", "Copy to Clipboard", "Copy the current selection to clipboard", CommandCategory.Terminal, "\uE8C8");
         AddBindingCommand(commands, "paste_from_clipboard", "Paste from Clipboard", "Paste clipboard contents into terminal", CommandCategory.Terminal, "\uE77F");
-        AddBindingCommand(commands, "select_all", "Select All", "Select all terminal content", CommandCategory.Terminal);
+        AddBindingCommand(commands, "select_all", "Select All", "Select all terminal content", CommandCategory.Terminal, "");
         AddBindingCommand(commands, "increase_font_size:1", "Increase Font Size", "Make terminal text larger", CommandCategory.Terminal, "\uE8E8");
         AddBindingCommand(commands, "decrease_font_size:1", "Decrease Font Size", "Make terminal text smaller", CommandCategory.Terminal, "\uE71F");
         AddBindingCommand(commands, "reset_font_size", "Reset Font Size", "Reset font size to default", CommandCategory.Terminal);
@@ -132,7 +132,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
     }
 
     private void AddPaneCommand(List<CommandItem> list, PaneAction action, string title,
-        string description, CommandCategory category, string? icon = null)
+        string description, CommandCategory category, string? icon = null, string? pathKey = null)
     {
         var shortcut = FindShortcut(action);
         list.Add(new CommandItem
@@ -143,6 +143,7 @@ internal sealed class BuiltInCommandSource : ICommandSource
             ActionKey = action.ToString().ToLowerInvariant(),
             Category = category,
             LeadingIcon = icon,
+            LeadingIconPathKey = pathKey,
             Shortcut = shortcut,
             Execute = _paneActionFactory(action),
         });

--- a/windows/Ghostty/Commands/CommandItem.cs
+++ b/windows/Ghostty/Commands/CommandItem.cs
@@ -25,6 +25,9 @@ internal record CommandItem
     public CommandCategory Category { get; init; }
     public Color? LeadingColor { get; init; }
     public string? LeadingIcon { get; init; }
+    // When set, the palette renders a custom PathIcon for this command instead
+    // of the LeadingIcon glyph. Only "quake" is handled today.
+    public string? LeadingIconPathKey { get; init; }
     public bool Emphasis { get; init; }
     public string? Badge { get; init; }
     public string? PreviewText { get; init; }

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
@@ -99,6 +99,15 @@
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                FontFamily="Cascadia Code, Consolas, Courier New"/>
                 </Border>
+
+                <Viewbox x:Name="LeadingPathHost"
+                         Grid.Column="1"
+                         Width="16" Height="16"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         Visibility="Collapsed">
+                    <PathIcon Data="F1 M100,190 A90,90 0 1 1 280,190 A90,90 0 1 1 100,190 Z M132,170 A58,58 0 1 0 248,170 A58,58 0 1 0 132,170 Z M186,206 L206,186 L276,276 Z"/>
+                </Viewbox>
             </Grid>
         </DataTemplate>
 

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -344,10 +344,13 @@ internal sealed partial class CommandPaletteControl : UserControl
             }
         }
 
-        // Leading icon glyph (column 1)
+        // Leading icon (column 1): a custom path icon (e.g. the Quake mark) wins
+        // over the glyph; otherwise fall back to the LeadingIcon glyph.
+        var usePathIcon = !string.IsNullOrEmpty(item.LeadingIconPathKey);
+
         if (root.Children[1] is FontIcon icon)
         {
-            if (!string.IsNullOrEmpty(item.LeadingIcon))
+            if (!usePathIcon && !string.IsNullOrEmpty(item.LeadingIcon))
             {
                 icon.Glyph = item.LeadingIcon;
                 icon.Visibility = Visibility.Visible;
@@ -357,6 +360,9 @@ internal sealed partial class CommandPaletteControl : UserControl
                 icon.Visibility = Visibility.Collapsed;
             }
         }
+
+        if (root.Children[^1] is Viewbox pathHost)
+            pathHost.Visibility = usePathIcon ? Visibility.Visible : Visibility.Collapsed;
 
         // Title + Description (column 2 = StackPanel with 2 TextBlocks)
         if (root.Children[2] is StackPanel stack && stack.Children.Count >= 2)

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.ComponentModel;
 using Ghostty.Commands;
 using Ghostty.Core.Config;
@@ -361,7 +362,10 @@ internal sealed partial class CommandPaletteControl : UserControl
             }
         }
 
-        if (root.Children[^1] is Viewbox pathHost)
+        // Locate the custom path-icon host by type rather than by child index,
+        // so reordering the template's children can't silently break it (the
+        // template has exactly one Viewbox).
+        if (root.Children.OfType<Viewbox>().FirstOrDefault() is { } pathHost)
             pathHost.Visibility = usePathIcon ? Visibility.Visible : Visibility.Collapsed;
 
         // Title + Description (column 2 = StackPanel with 2 TextBlocks)

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -68,7 +68,8 @@
             PointerPressed="OnPointerPressed"
             PointerMoved="OnPointerMoved"
             PointerReleased="OnPointerReleased"
-            PointerWheelChanged="OnPointerWheelChanged" />
+            PointerWheelChanged="OnPointerWheelChanged"
+            ContextRequested="OnContextRequested" />
 
         <primitives:ScrollBar
             x:Name="VerticalScrollBar"

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1005,20 +1005,21 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
     {
-        // Complete the suppressed right-click: open the context menu instead
-        // of forwarding the button. We open on release so it feels like a
-        // normal Windows right-click.
-        if (_rightButtonOpensMenu)
+        // Complete the suppressed right-click on its matching right-release,
+        // opening the menu so it feels like a normal Windows right-click. We
+        // consume the flag ONLY on the right-release: an unrelated release (or
+        // a right-release that never arrives because the pointer left the
+        // panel) must not clear it early and forward an orphan button to
+        // libghostty. A stale flag self-heals on the next right-press.
+        if (_rightButtonOpensMenu
+            && e.GetCurrentPoint(Panel).Properties.PointerUpdateKind
+               == PointerUpdateKind.RightButtonReleased)
         {
             _rightButtonOpensMenu = false;
-            var props = e.GetCurrentPoint(Panel).Properties;
-            if (props.PointerUpdateKind == PointerUpdateKind.RightButtonReleased)
-            {
-                e.Handled = true;
-                var pos = e.GetCurrentPoint(this).Position;
-                ContextMenuRequested?.Invoke(this, pos);
-                return;
-            }
+            e.Handled = true;
+            var pos = e.GetCurrentPoint(this).Position;
+            ContextMenuRequested?.Invoke(this, pos);
+            return;
         }
 
         SendMouseButton(e, GhosttyMouseState.Release);

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -37,6 +37,27 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// </summary>
     internal bool CommandPaletteIsOpen { get; set; }
 
+    /// <summary>
+    /// Raised when the user requests the pane context menu over this surface.
+    /// The argument is the pointer position in this control's coordinates, or
+    /// null when the request came from the keyboard (Shift+F10 / Menu key).
+    /// The owner (MainWindow, via PaneHost) builds and shows the flyout.
+    /// </summary>
+    internal event EventHandler<Windows.Foundation.Point?>? ContextMenuRequested;
+
+    /// <summary>
+    /// True when the surface has a non-empty selection. Used to gate the
+    /// context-menu Copy item. False when the surface is gone.
+    /// </summary>
+    internal bool HasSelection =>
+        _surface.Handle != IntPtr.Zero && NativeMethods.SurfaceHasSelection(_surface);
+
+    // Set on a right-button press that we are NOT forwarding to libghostty
+    // (because the program has not captured the mouse, so the click opens our
+    // context menu instead). Consumed by the matching release so we never
+    // forward a half-pair (press without release, or vice versa) to libghostty.
+    private bool _rightButtonOpensMenu;
+
     // Handles ------------------------------------------------------------
 
     private GhosttySurface _surface;
@@ -949,6 +970,18 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
             return;
         }
 
+        // Right-click: if the running program has captured the mouse (vim,
+        // tmux mouse mode), forward the button so the program handles it.
+        // Otherwise suppress forwarding and open our context menu on release.
+        if (props.PointerUpdateKind == PointerUpdateKind.RightButtonPressed
+            && _surface.Handle != IntPtr.Zero
+            && !NativeMethods.SurfaceMouseCaptured(_surface))
+        {
+            _rightButtonOpensMenu = true;
+            e.Handled = true;
+            return;
+        }
+
         SendMouseButton(e, GhosttyMouseState.Press);
     }
 
@@ -970,8 +1003,39 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         }
     }
 
-    private void OnPointerReleased(object sender, PointerRoutedEventArgs e) =>
+    private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        // Complete the suppressed right-click: open the context menu instead
+        // of forwarding the button. We open on release so it feels like a
+        // normal Windows right-click.
+        if (_rightButtonOpensMenu)
+        {
+            _rightButtonOpensMenu = false;
+            var props = e.GetCurrentPoint(Panel).Properties;
+            if (props.PointerUpdateKind == PointerUpdateKind.RightButtonReleased)
+            {
+                e.Handled = true;
+                var pos = e.GetCurrentPoint(this).Position;
+                ContextMenuRequested?.Invoke(this, pos);
+                return;
+            }
+        }
+
         SendMouseButton(e, GhosttyMouseState.Release);
+    }
+
+    private void OnContextRequested(UIElement sender, ContextRequestedEventArgs args)
+    {
+        // ContextRequested fires for both right-click and keyboard. The
+        // pointer path (OnPointerPressed/Released) already handles right-click
+        // with the mouse-capture gate, so here we only act on keyboard
+        // invocation (Shift+F10 / Menu key), where TryGetPosition is false.
+        // For the mouse case we mark it handled so WinUI does not show an
+        // empty default menu, then defer to the pointer path.
+        args.Handled = true;
+        if (!args.TryGetPosition(this, out _))
+            ContextMenuRequested?.Invoke(this, null);
+    }
 
     private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
     {

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -490,6 +490,31 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void SurfaceMousePos(GhosttySurface surface, double x, double y, GhosttyMods mods);
 
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_mouse_captured")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceMouseCapturedNative(GhosttySurface surface);
+
+    /// <summary>
+    /// True when the running program has enabled mouse reporting and is
+    /// capturing mouse events (e.g. vim/tmux with mouse mode). The apprt
+    /// uses this to decide whether a right-click belongs to the program or
+    /// should open our context menu.
+    /// </summary>
+    internal static bool SurfaceMouseCaptured(GhosttySurface surface)
+        => SurfaceMouseCapturedNative(surface) != 0;
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_has_selection")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceHasSelectionNative(GhosttySurface surface);
+
+    /// <summary>
+    /// True when the surface currently has a non-empty text selection. Used
+    /// to enable the context-menu "Copy" item only when there is something
+    /// to copy.
+    /// </summary>
+    internal static bool SurfaceHasSelection(GhosttySurface surface)
+        => SurfaceHasSelectionNative(surface) != 0;
+
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_mouse_scroll")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void SurfaceMouseScroll(GhosttySurface surface, double x, double y, int scrollMods);

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -646,10 +646,10 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     private static partial void InspectorSetFocusNative(
         GhosttyInspector inspector,
-        [MarshalAs(UnmanagedType.U1)] bool focused);
+        byte focused);
 
     internal static void InspectorSetFocus(GhosttyInspector inspector, bool focused)
-        => InspectorSetFocusNative(inspector, focused);
+        => InspectorSetFocusNative(inspector, focused ? (byte)1 : (byte)0);
 
     [LibraryImport(Dll, EntryPoint = "ghostty_inspector_set_content_scale")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1203,12 +1203,38 @@ public sealed partial class MainWindow : Window
         paneHost.VerticalAlignment = VerticalAlignment.Stretch;
         paneHost.Visibility = Visibility.Collapsed;
         PaneHostContainer.Children.Add(paneHost);
+        paneHost.ContextMenuRequested += OnPaneContextMenuRequested;
     }
 
     private void RemovePaneHost(TabModel tab)
     {
         var paneHost = (PaneHost)tab.PaneHost;
+        paneHost.ContextMenuRequested -= OnPaneContextMenuRequested;
         PaneHostContainer.Children.Remove(paneHost);
+    }
+
+    private void OnPaneContextMenuRequested(object? sender, Panes.PaneContextMenuRequest request)
+    {
+        var control = request.Control;
+
+        // Focus the right-clicked surface so the menu's binding/pane actions
+        // (which target the active surface / active pane) act on this pane.
+        control.Focus(FocusState.Programmatic);
+
+        var paneHost = (Panes.PaneHost)_tabManager.ActiveTab.PaneHost;
+
+        var flyout = PaneContextMenuBuilder.Build(
+            invokePaneAction: _router.Invoke,
+            invokeBindingAction: ExecuteBindingAction,
+            hasSelection: () => control.HasSelection,
+            isZoomed: () => paneHost.IsZoomed,
+            promptTabTitle: () => _ = ShowPromptTitleDialogAsync(isTab: true, control),
+            promptTerminalTitle: () => _ = ShowPromptTitleDialogAsync(isTab: false, control));
+
+        if (request.Position is { } pos)
+            flyout.ShowAt(control, new Microsoft.UI.Xaml.Controls.Primitives.FlyoutShowOptions { Position = pos });
+        else
+            flyout.ShowAt(control);
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1221,7 +1221,11 @@ public sealed partial class MainWindow : Window
         // (which target the active surface / active pane) act on this pane.
         control.Focus(FocusState.Programmatic);
 
-        var paneHost = (Panes.PaneHost)_tabManager.ActiveTab.PaneHost;
+        // Use the PaneHost that raised the event (the sender) so the Zoom state
+        // reflects the right-clicked pane directly, without depending on the
+        // (async) focus change having settled ActiveTab.
+        var paneHost = sender as Panes.PaneHost
+            ?? (Panes.PaneHost)_tabManager.ActiveTab.PaneHost;
 
         var flyout = PaneContextMenuBuilder.Build(
             invokePaneAction: _router.Invoke,

--- a/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
+++ b/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
@@ -1,7 +1,9 @@
 using System;
 using Ghostty.Core.Input;
 using Ghostty.Core.Panes;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace Ghostty.Panes;
 
@@ -67,6 +69,7 @@ internal static class PaneContextMenuBuilder
                 toggle.Click += (_, _) => Dispatch(item.Command,
                     invokePaneAction, invokeBindingAction,
                     promptTabTitle, promptTerminalTitle);
+                ApplyIcon(toggle, item.Icon);
                 flyout.Items.Add(toggle);
                 continue;
             }
@@ -79,8 +82,21 @@ internal static class PaneContextMenuBuilder
             menuItem.Click += (_, _) => Dispatch(item.Command,
                 invokePaneAction, invokeBindingAction,
                 promptTabTitle, promptTerminalTitle);
+            ApplyIcon(menuItem, item.Icon);
             flyout.Items.Add(menuItem);
         }
+    }
+
+    private static void ApplyIcon(MenuFlyoutItem item, string? glyph)
+    {
+        if (string.IsNullOrEmpty(glyph)) return;
+        var fontIcon = new FontIcon { Glyph = glyph };
+        // Pin to the symbol font the rest of the app uses; FontIcon's default
+        // family is not guaranteed to be the symbol set on every machine.
+        if (Application.Current.Resources.TryGetValue("SymbolThemeFontFamily", out var ff)
+            && ff is FontFamily family)
+            fontIcon.FontFamily = family;
+        item.Icon = fontIcon;
     }
 
     private static void Dispatch(

--- a/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
+++ b/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
@@ -24,13 +24,11 @@ internal static class PaneContextMenuBuilder
         Action promptTerminalTitle)
     {
         var flyout = new MenuFlyout();
-        Populate(flyout, invokePaneAction, invokeBindingAction,
-            hasSelection(), isZoomed(),
-            promptTabTitle, promptTerminalTitle);
 
-        // Rebuild on each open so Copy's enabled state and the Zoom icon
-        // reflect current selection/zoom. Matches TabContextMenuBuilder's
-        // Opening re-check.
+        // Populate on each open so Copy's enabled state and the Zoom icon
+        // reflect current selection/zoom. Opening fires before the flyout is
+        // shown, so there's no need to populate eagerly here. Matches
+        // TabContextMenuBuilder's Opening re-check.
         flyout.Opening += (_, _) =>
         {
             flyout.Items.Clear();

--- a/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
+++ b/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
@@ -1,0 +1,112 @@
+using System;
+using Ghostty.Core.Input;
+using Ghostty.Core.Panes;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Panes;
+
+/// <summary>
+/// Translates the pure <see cref="PaneContextMenuModel"/> into a WinUI
+/// <see cref="MenuFlyout"/> and wires each command to its dispatch. Mirrors
+/// <see cref="Ghostty.Tabs.TabContextMenuBuilder"/>: a thin, logic-free
+/// translation so the tested Core model carries the behavior.
+/// </summary>
+internal static class PaneContextMenuBuilder
+{
+    public static MenuFlyout Build(
+        Action<PaneAction> invokePaneAction,
+        Action<string> invokeBindingAction,
+        Func<bool> hasSelection,
+        Func<bool> isZoomed,
+        Action promptTabTitle,
+        Action promptTerminalTitle)
+    {
+        var flyout = new MenuFlyout();
+        Populate(flyout, invokePaneAction, invokeBindingAction,
+            hasSelection(), isZoomed(),
+            promptTabTitle, promptTerminalTitle);
+
+        // Rebuild on each open so Copy's enabled state and the Zoom checkmark
+        // reflect current selection/zoom. Matches TabContextMenuBuilder's
+        // Opening re-check.
+        flyout.Opening += (_, _) =>
+        {
+            flyout.Items.Clear();
+            Populate(flyout, invokePaneAction, invokeBindingAction,
+                hasSelection(), isZoomed(),
+                promptTabTitle, promptTerminalTitle);
+        };
+
+        return flyout;
+    }
+
+    private static void Populate(
+        MenuFlyout flyout,
+        Action<PaneAction> invokePaneAction,
+        Action<string> invokeBindingAction,
+        bool hasSelection,
+        bool isZoomed,
+        Action promptTabTitle,
+        Action promptTerminalTitle)
+    {
+        foreach (var item in PaneContextMenuModel.Build(hasSelection, isZoomed))
+        {
+            if (item.Kind == PaneMenuItemKind.Separator)
+            {
+                flyout.Items.Add(new MenuFlyoutSeparator());
+                continue;
+            }
+
+            if (item.Command == PaneMenuCommand.ZoomPane)
+            {
+                var toggle = new ToggleMenuFlyoutItem
+                {
+                    Text = item.Label,
+                    IsChecked = item.IsChecked,
+                };
+                toggle.Click += (_, _) => Dispatch(item.Command,
+                    invokePaneAction, invokeBindingAction,
+                    promptTabTitle, promptTerminalTitle);
+                flyout.Items.Add(toggle);
+                continue;
+            }
+
+            var menuItem = new MenuFlyoutItem
+            {
+                Text = item.Label,
+                IsEnabled = item.IsEnabled,
+            };
+            menuItem.Click += (_, _) => Dispatch(item.Command,
+                invokePaneAction, invokeBindingAction,
+                promptTabTitle, promptTerminalTitle);
+            flyout.Items.Add(menuItem);
+        }
+    }
+
+    private static void Dispatch(
+        PaneMenuCommand command,
+        Action<PaneAction> invokePaneAction,
+        Action<string> invokeBindingAction,
+        Action promptTabTitle,
+        Action promptTerminalTitle)
+    {
+        switch (command)
+        {
+            case PaneMenuCommand.Copy: invokeBindingAction("copy_to_clipboard"); break;
+            case PaneMenuCommand.Paste: invokeBindingAction("paste_from_clipboard"); break;
+            case PaneMenuCommand.SelectAll: invokeBindingAction("select_all"); break;
+            case PaneMenuCommand.ResetTerminal: invokeBindingAction("reset"); break;
+
+            case PaneMenuCommand.SplitRight: invokePaneAction(PaneAction.SplitVertical); break;
+            case PaneMenuCommand.SplitDown: invokePaneAction(PaneAction.SplitHorizontal); break;
+            case PaneMenuCommand.ZoomPane: invokePaneAction(PaneAction.ToggleSplitZoom); break;
+            case PaneMenuCommand.CommandPalette: invokePaneAction(PaneAction.ToggleCommandPalette); break;
+            case PaneMenuCommand.ToggleInspector: invokePaneAction(PaneAction.ToggleInspector); break;
+
+            case PaneMenuCommand.ChangeTabTitle: promptTabTitle(); break;
+            case PaneMenuCommand.ChangeTerminalTitle: promptTerminalTitle(); break;
+
+            default: throw new ArgumentOutOfRangeException(nameof(command), command, null);
+        }
+    }
+}

--- a/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
+++ b/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
@@ -28,7 +28,7 @@ internal static class PaneContextMenuBuilder
             hasSelection(), isZoomed(),
             promptTabTitle, promptTerminalTitle);
 
-        // Rebuild on each open so Copy's enabled state and the Zoom checkmark
+        // Rebuild on each open so Copy's enabled state and the Zoom icon
         // reflect current selection/zoom. Matches TabContextMenuBuilder's
         // Opening re-check.
         flyout.Opening += (_, _) =>
@@ -56,21 +56,6 @@ internal static class PaneContextMenuBuilder
             if (item.Kind == PaneMenuItemKind.Separator)
             {
                 flyout.Items.Add(new MenuFlyoutSeparator());
-                continue;
-            }
-
-            if (item.Command == PaneMenuCommand.ZoomPane)
-            {
-                var toggle = new ToggleMenuFlyoutItem
-                {
-                    Text = item.Label,
-                    IsChecked = item.IsChecked,
-                };
-                toggle.Click += (_, _) => Dispatch(item.Command,
-                    invokePaneAction, invokeBindingAction,
-                    promptTabTitle, promptTerminalTitle);
-                ApplyIcon(toggle, item.Icon);
-                flyout.Items.Add(toggle);
                 continue;
             }
 

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -207,6 +207,15 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     public event EventHandler? LastLeafClosed;
 
     /// <summary>
+    /// Raised when a leaf requests its pane context menu. Carries the
+    /// originating <see cref="TerminalControl"/> and the pointer position in
+    /// that control's coordinates (null when requested from the keyboard).
+    /// MainWindow listens and shows the flyout (it owns the dispatch entry
+    /// points the menu commands route through).
+    /// </summary>
+    public event EventHandler<PaneContextMenuRequest>? ContextMenuRequested;
+
+    /// <summary>
     /// Currently focused leaf. Never null after construction; closing
     /// the last leaf raises <see cref="LastLeafClosed"/> instead of
     /// nulling this.
@@ -784,6 +793,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         var t = leaf.Terminal();
         t.GotFocus -= OnTerminalGotFocus;
         t.CloseRequested -= OnTerminalCloseRequested;
+        t.ContextMenuRequested -= OnTerminalContextMenuRequested;
         t.DisposeSurface();
     }
 
@@ -1210,7 +1220,14 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         // (via GhosttyHost). Route it to the leaf-level close path so
         // multi-pane closing collapses correctly.
         t.CloseRequested += OnTerminalCloseRequested;
+        t.ContextMenuRequested += OnTerminalContextMenuRequested;
         return t;
+    }
+
+    private void OnTerminalContextMenuRequested(object? sender, Windows.Foundation.Point? position)
+    {
+        if (sender is not TerminalControl tc) return;
+        ContextMenuRequested?.Invoke(this, new PaneContextMenuRequest(tc, position));
     }
 
     private void OnTerminalGotFocus(object sender, RoutedEventArgs e)
@@ -1614,3 +1631,11 @@ internal enum FocusDirection
     Up,
     Down,
 }
+
+/// <summary>
+/// Payload for <see cref="PaneHost.ContextMenuRequested"/>: which surface and
+/// where (null position = keyboard-invoked).
+/// </summary>
+public readonly record struct PaneContextMenuRequest(
+    Ghostty.Controls.TerminalControl Control,
+    Windows.Foundation.Point? Position);


### PR DESCRIPTION
Right-click context menu for terminal panes with macOS surface-menu parity, plus Command Palette and Zoom Pane actions, and an icon on every item.

Menu items: Copy / Paste / Select All, Split Right / Split Down, Zoom Pane, Command Palette / Reset Terminal / Toggle Inspector, Change Tab Title / Change Terminal Title. Copy is enabled only when there is a selection. Zoom Pane is a normal item whose icon reflects zoom state.

Right-click respects mouse capture: when the running program has grabbed the mouse (vim/tmux mouse mode) the click goes to the program; otherwise the menu opens. Shift+F10 opens it from the keyboard.

Icons reuse the command palette glyphs where they exist; the palette also gains a Select All glyph and a custom drop-down-terminal icon for Toggle Quake Terminal.

Also marshals the inspector focus bool as a blittable byte (it was MarshalAs(UnmanagedType.U1) bool, which the DisableRuntimeMarshalling convention disallows) which unblocks MarshalComplianceTests. Two new libghostty bindings: mouse_captured and has_selection. No Zig changes.
