### PR TITLE
perf(windows): resolve tab overview theme resources once per open

### DIFF
--- a/windows/Ghostty/Tabs/PanePreviewRenderer.cs
+++ b/windows/Ghostty/Tabs/PanePreviewRenderer.cs
@@ -58,32 +58,38 @@ internal sealed class PanePreviewRenderer
                 Width = w,
                 Height = h,
                 Background = new SolidColorBrush(Color.FromArgb(0xFF, 0x0B, 0x0B, 0x0E)),
-                Child = BuildPaneContent(leaf, w, h, fontSize),
             };
+            // A null child means "draw nothing" (blank/too-small/dead pane): the
+            // Border's dark fill is the whole preview, so we skip allocating a
+            // throwaway placeholder element for it.
+            if (BuildPaneContent(leaf, w, h, fontSize) is { } content)
+                pane.Child = content;
             Canvas.SetLeft(pane, x);
             Canvas.SetTop(pane, y);
             body.Children.Add(pane);
         }
     }
 
-    // The colored preview for one leaf, or an empty element when blank/too-small/dead.
-    private UIElement BuildPaneContent(LeafPane leaf, double w, double h, double fontSize)
+    // The colored preview for one leaf, or null when blank/too-small/dead. Null
+    // lets the caller leave the Border childless (its dark fill is the preview)
+    // rather than allocating a throwaway placeholder element per such pane.
+    private UIElement? BuildPaneContent(LeafPane leaf, double w, double h, double fontSize)
     {
         if (w < MinPaneSideForText || h < MinPaneSideForText)
-            return new Grid(); // geometry-only: just the dark fill
+            return null; // geometry-only: just the dark fill
 
         var lineHeight = fontSize * 1.36;
         var charWidth = fontSize * 0.6;
         var rows = Math.Min(MaxPreviewRows, (int)((h - 8) / lineHeight));
         var cols = (int)((w - 12) / charWidth);
-        if (rows < 1 || cols < 1) return new Grid();
+        if (rows < 1 || cols < 1) return null;
 
         var grid = ReadGrid(leaf);
         var lines = grid is { } g
             ? CellGridFormatter.Format(g, rows, cols)
             : (IReadOnlyList<PreviewLine>)Array.Empty<PreviewLine>();
 
-        if (lines.Count == 0) return new Grid(); // blank pane: just the dark fill
+        if (lines.Count == 0) return null; // blank pane: just the dark fill
 
         return BuildLinesView(lines, fontSize);
     }

--- a/windows/Ghostty/Tabs/TabOverviewControl.xaml.cs
+++ b/windows/Ghostty/Tabs/TabOverviewControl.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Ghostty.Branding;
+using Ghostty.Controls;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Tabs;
 using Microsoft.UI.Xaml;
@@ -27,12 +28,12 @@ internal sealed partial class TabOverviewControl : UserControl
     private PanePreviewRenderer _renderer = new(PreviewFont.Resolve(null));
 
     // Fluent theme resources the per-tile build helpers need, resolved once per
-    // Show() instead of re-hitting Application.Current.Resources for every element
-    // of every tile. Re-resolved on each open (not cached at ctor) so a theme
+    // Show() instead of re-hitting the resource dictionary for every element of
+    // every tile. Re-resolved on each open (not cached at ctor) so a theme
     // switch between openings is honored.
-    private ThemeResources _theme;
+    private OverviewTheme _theme;
 
-    private readonly record struct ThemeResources(
+    private readonly record struct OverviewTheme(
         double CaptionFontSize,
         double BodyFontSize,
         Brush TextPrimary,
@@ -88,16 +89,18 @@ internal sealed partial class TabOverviewControl : UserControl
             TilesView.SelectedIndex = activeIndex;
     }
 
-    private static ThemeResources ResolveTheme()
-    {
-        var res = Application.Current.Resources;
-        return new ThemeResources(
-            CaptionFontSize: (double)res["CaptionTextBlockFontSize"],
-            BodyFontSize: (double)res["BodyTextBlockFontSize"],
-            TextPrimary: (Brush)res["TextFillColorPrimaryBrush"],
-            TextSecondary: (Brush)res["TextFillColorSecondaryBrush"],
-            TextTertiary: (Brush)res["TextFillColorTertiaryBrush"]);
-    }
+    // Fallbacks mirror the Fluent dark-theme token values; they only apply if a
+    // key is missing or mistyped (e.g. an early-init/teardown race), which the
+    // AOT-safe ThemeResources.Get swallows instead of throwing mid-open.
+    private static OverviewTheme ResolveTheme() => new(
+        CaptionFontSize: ThemeResources.Get("CaptionTextBlockFontSize", 12.0),
+        BodyFontSize: ThemeResources.Get("BodyTextBlockFontSize", 14.0),
+        TextPrimary: ThemeResources.Get<Brush>("TextFillColorPrimaryBrush",
+            new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF))),
+        TextSecondary: ThemeResources.Get<Brush>("TextFillColorSecondaryBrush",
+            new SolidColorBrush(Color.FromArgb(0xC5, 0xFF, 0xFF, 0xFF))),
+        TextTertiary: ThemeResources.Get<Brush>("TextFillColorTertiaryBrush",
+            new SolidColorBrush(Color.FromArgb(0x87, 0xFF, 0xFF, 0xFF))));
 
     /// <summary>
     /// Move keyboard focus into the grid so arrow keys, Enter and Esc work without
@@ -179,7 +182,7 @@ internal sealed partial class TabOverviewControl : UserControl
     }
 
     // Shared header row used by both thumbnails (with chip) and the rail (no chip).
-    private static FrameworkElement BuildHeader(TabModel tab, ThemeResources theme, double titleFontSize, double dotSize, bool includeChip)
+    private static FrameworkElement BuildHeader(TabModel tab, OverviewTheme theme, double titleFontSize, double dotSize, bool includeChip)
     {
         var grid = new Grid { Padding = new Thickness(10, 7, 10, 7), ColumnSpacing = 6 };
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });

--- a/windows/Ghostty/Tabs/TabOverviewControl.xaml.cs
+++ b/windows/Ghostty/Tabs/TabOverviewControl.xaml.cs
@@ -26,6 +26,19 @@ internal sealed partial class TabOverviewControl : UserControl
     private FontFamily _previewFont = PreviewFont.Resolve(null);
     private PanePreviewRenderer _renderer = new(PreviewFont.Resolve(null));
 
+    // Fluent theme resources the per-tile build helpers need, resolved once per
+    // Show() instead of re-hitting Application.Current.Resources for every element
+    // of every tile. Re-resolved on each open (not cached at ctor) so a theme
+    // switch between openings is honored.
+    private ThemeResources _theme;
+
+    private readonly record struct ThemeResources(
+        double CaptionFontSize,
+        double BodyFontSize,
+        Brush TextPrimary,
+        Brush TextSecondary,
+        Brush TextTertiary);
+
     // Thumbnail geometry. Body is a fixed-size canvas so per-pane pixel rects can
     // be computed at build time (before layout).
     private const double TileWidth = 216;
@@ -51,6 +64,7 @@ internal sealed partial class TabOverviewControl : UserControl
     {
         _previewFont = PreviewFont.Resolve(fontFamily);
         _renderer = new PanePreviewRenderer(_previewFont);
+        _theme = ResolveTheme();
 
         BrandLogo.Source = new BitmapImage(AppIconSource.Current);
         CountChip.Text = tabs.Count.ToString();
@@ -74,6 +88,17 @@ internal sealed partial class TabOverviewControl : UserControl
             TilesView.SelectedIndex = activeIndex;
     }
 
+    private static ThemeResources ResolveTheme()
+    {
+        var res = Application.Current.Resources;
+        return new ThemeResources(
+            CaptionFontSize: (double)res["CaptionTextBlockFontSize"],
+            BodyFontSize: (double)res["BodyTextBlockFontSize"],
+            TextPrimary: (Brush)res["TextFillColorPrimaryBrush"],
+            TextSecondary: (Brush)res["TextFillColorSecondaryBrush"],
+            TextTertiary: (Brush)res["TextFillColorTertiaryBrush"]);
+    }
+
     /// <summary>
     /// Move keyboard focus into the grid so arrow keys, Enter and Esc work without
     /// a mouse click. Must be called AFTER the hosting popup is open.
@@ -91,7 +116,8 @@ internal sealed partial class TabOverviewControl : UserControl
     {
         var header = BuildHeader(
             tab,
-            titleFontSize: (double)Application.Current.Resources["CaptionTextBlockFontSize"],
+            _theme,
+            titleFontSize: _theme.CaptionFontSize,
             dotSize: DotSizeThumbnail,
             includeChip: true);
 
@@ -117,7 +143,8 @@ internal sealed partial class TabOverviewControl : UserControl
     {
         var header = BuildHeader(
             tab,
-            titleFontSize: (double)Application.Current.Resources["BodyTextBlockFontSize"],
+            _theme,
+            titleFontSize: _theme.BodyFontSize,
             dotSize: DotSizeRail,
             includeChip: false);
 
@@ -139,8 +166,8 @@ internal sealed partial class TabOverviewControl : UserControl
         var paneCount = new TextBlock
         {
             Text = PaneCountLabel(tab.PaneHost.PaneCount),
-            FontSize = (double)Application.Current.Resources["CaptionTextBlockFontSize"],
-            Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"],
+            FontSize = _theme.CaptionFontSize,
+            Foreground = _theme.TextTertiary,
             Margin = new Thickness(2, 8, 0, 0),
         };
 
@@ -152,7 +179,7 @@ internal sealed partial class TabOverviewControl : UserControl
     }
 
     // Shared header row used by both thumbnails (with chip) and the rail (no chip).
-    private static FrameworkElement BuildHeader(TabModel tab, double titleFontSize, double dotSize, bool includeChip)
+    private static FrameworkElement BuildHeader(TabModel tab, ThemeResources theme, double titleFontSize, double dotSize, bool includeChip)
     {
         var grid = new Grid { Padding = new Thickness(10, 7, 10, 7), ColumnSpacing = 6 };
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -187,7 +214,7 @@ internal sealed partial class TabOverviewControl : UserControl
             TextTrimming = TextTrimming.CharacterEllipsis,
             VerticalAlignment = VerticalAlignment.Center,
             FontSize = titleFontSize,
-            Foreground = (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"],
+            Foreground = theme.TextPrimary,
         };
         Grid.SetColumn(title, 2);
         grid.Children.Add(title);
@@ -198,9 +225,9 @@ internal sealed partial class TabOverviewControl : UserControl
             {
                 Text = PaneCountLabel(tab.PaneHost.PaneCount),
                 Opacity = 0.7,
-                FontSize = (double)Application.Current.Resources["CaptionTextBlockFontSize"],
+                FontSize = theme.CaptionFontSize,
                 VerticalAlignment = VerticalAlignment.Center,
-                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                Foreground = theme.TextSecondary,
             };
             Grid.SetColumn(chip, 3);
             grid.Children.Add(chip);


### PR DESCRIPTION
Two low-priority perf nits in the tab overview build path, from a review of #522. Neither is a hot path (the overview opens occasionally), so this is just tidying.

- `TabOverviewControl` resolves the Fluent theme resources (font sizes and text brushes) once per `Show()` instead of re-hitting `Application.Current.Resources` for every element of every tile. Kept per open (not at construction) so a theme switch between openings is still honored.
- `PanePreviewRenderer.BuildPaneContent` returns `null` for blank, too-small or dead panes instead of allocating a throwaway empty `Grid`. The caller leaves the `Border` childless; its dark fill already is the preview.

Renders identically: nit 1 passes the same values resolved fewer times, nit 2 swaps an empty transparent child for no child on a `Border` that already has explicit size and a dark background.

Build clean (`-p:Platform=x64 -c Debug`) and `Ghostty.Tests` green.