### PR TITLE
fix(windows): keep active tab title legible on the selected-tab background

### DIFF
--- a/windows/Ghostty.Core/Windows/ThemeResolution.cs
+++ b/windows/Ghostty.Core/Windows/ThemeResolution.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ghostty.Core.Windows;
 
 /// <summary>
@@ -94,4 +96,60 @@ public static class ThemeResolution
     /// </summary>
     public static bool PreferLightForeground(uint backgroundColor) =>
         IsBackgroundDark(backgroundColor);
+
+    /// <summary>
+    /// Relative luminance of an sRGB colour per WCAG 2.x, with each channel
+    /// gamma-expanded to linear light. 0.0 for black, 1.0 for white. Kept
+    /// separate from <see cref="IsBackgroundDark"/>'s cheap BT.709 estimate
+    /// because contrast ratios need the linearised value to match what the
+    /// eye perceives across the whole range.
+    /// </summary>
+    private static double RelativeLuminance(uint color)
+    {
+        static double Linearize(uint channel)
+        {
+            var c = channel / 255.0;
+            return c <= 0.03928 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+        }
+
+        var r = Linearize((color >> 16) & 0xFF);
+        var g = Linearize((color >> 8) & 0xFF);
+        var b = Linearize(color & 0xFF);
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    }
+
+    /// <summary>
+    /// WCAG contrast ratio between two sRGB colours packed as 0x00RRGGBB.
+    /// Ranges from 1.0 (identical luminance) to 21.0 (pure black against
+    /// pure white). Order-independent.
+    /// </summary>
+    public static double ContrastRatio(uint a, uint b)
+    {
+        var la = RelativeLuminance(a);
+        var lb = RelativeLuminance(b);
+        var hi = Math.Max(la, lb);
+        var lo = Math.Min(la, lb);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    /// <summary>
+    /// Pick a legible foreground for text drawn over
+    /// <paramref name="background"/>. Keeps <paramref name="desired"/> when it
+    /// already clears the WCAG AA contrast threshold (4.5:1); otherwise falls
+    /// back to pure white or black, whichever reads better over the backdrop.
+    /// Both arguments and the result are packed 0x00RRGGBB.
+    ///
+    /// This is what keeps the active tab title readable regardless of palette:
+    /// the selected-tab background is the accent (cursor-colour by default,
+    /// which is light), so an inherited white title would vanish — this maps
+    /// it to black. It also guards the shell-theme path, where accent and
+    /// cursor-text can both land light or both dark (#342).
+    /// </summary>
+    public static uint EnsureReadableForeground(
+        uint background, uint desired, double minContrast = 4.5)
+    {
+        if (ContrastRatio(background, desired) >= minContrast)
+            return desired;
+        return PreferLightForeground(background) ? 0xFFFFFFu : 0x000000u;
+    }
 }

--- a/windows/Ghostty.Core/Windows/ThemeResolution.cs
+++ b/windows/Ghostty.Core/Windows/ThemeResolution.cs
@@ -150,6 +150,13 @@ public static class ThemeResolution
     {
         if (ContrastRatio(background, desired) >= minContrast)
             return desired;
-        return PreferLightForeground(background) ? 0xFFFFFFu : 0x000000u;
+        // Fall back to whichever pole actually contrasts more, scored with the
+        // same WCAG ratio as the threshold check rather than a separate
+        // luminance heuristic. For mid-luminance backgrounds the two disagree
+        // (e.g. 0x7F7F7F reads better on black than white), so picking by ratio
+        // guarantees the most readable of black/white for any background.
+        return ContrastRatio(background, 0xFFFFFFu) >= ContrastRatio(background, 0x000000u)
+            ? 0xFFFFFFu
+            : 0x000000u;
     }
 }

--- a/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
+++ b/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
@@ -244,4 +244,65 @@ public sealed class ThemeResolutionTests
         foreach (uint c in new uint[] { 0x000000, 0xFFFFFF, 0x808080, 0x7F7F7F, 0x00FF00, 0x0000FF })
             Assert.Equal(ThemeResolution.IsBackgroundDark(c), ThemeResolution.PreferLightForeground(c));
     }
+
+    // ── ContrastRatio: WCAG ratio ────────────────────────────────────────
+
+    [Fact]
+    public void ContrastRatio_BlackOnWhite_Is21() =>
+        Assert.Equal(21.0, ThemeResolution.ContrastRatio(0x000000, 0xFFFFFF), 3);
+
+    [Fact]
+    public void ContrastRatio_SameColor_Is1() =>
+        Assert.Equal(1.0, ThemeResolution.ContrastRatio(0x3B82F6, 0x3B82F6), 3);
+
+    [Fact]
+    public void ContrastRatio_IsOrderIndependent() =>
+        Assert.Equal(
+            ThemeResolution.ContrastRatio(0x101010, 0xEEEEEE),
+            ThemeResolution.ContrastRatio(0xEEEEEE, 0x101010), 6);
+
+    // ── EnsureReadableForeground: legible active-tab title ───────────────
+
+    [Fact]
+    public void EnsureReadable_WhiteTitleOnWhiteAccent_FallsBackToBlack()
+    {
+        // The reported bug: empty config → cursor-colour (selected-tab
+        // background) defaults to white, while the inherited title brush is
+        // also white. The active title must drop to black to stay legible.
+        Assert.Equal(0x000000u,
+            ThemeResolution.EnsureReadableForeground(0xFFFFFF, 0xFFFFFF));
+    }
+
+    [Fact]
+    public void EnsureReadable_BlackTitleOnBlackAccent_FallsBackToWhite() =>
+        Assert.Equal(0xFFFFFFu,
+            ThemeResolution.EnsureReadableForeground(0x000000, 0x000000));
+
+    [Fact]
+    public void EnsureReadable_KeepsDesired_WhenItAlreadyContrasts()
+    {
+        // Shell-theme default palette: dark cursor-text over a light accent
+        // already reads fine, so the user's chosen colour is preserved.
+        Assert.Equal(0x1E1E2Eu,
+            ThemeResolution.EnsureReadableForeground(0xFFFFFF, 0x1E1E2E));
+        Assert.Equal(0xFFFFFFu,
+            ThemeResolution.EnsureReadableForeground(0x000000, 0xFFFFFF));
+    }
+
+    [Fact]
+    public void EnsureReadable_BothLight_FallsBackToBlack()
+    {
+        // Pathological shell palette where accent and active-text both land
+        // light: contrast is too low, so fall back to a dark foreground.
+        Assert.Equal(0x000000u,
+            ThemeResolution.EnsureReadableForeground(0xEEEEEE, 0xFFFFFF));
+    }
+
+    [Fact]
+    public void EnsureReadable_BothDark_FallsBackToWhite()
+    {
+        // ...and the mirror: both dark → fall back to a light foreground.
+        Assert.Equal(0xFFFFFFu,
+            ThemeResolution.EnsureReadableForeground(0x111111, 0x000000));
+    }
 }

--- a/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
+++ b/windows/Ghostty.Tests/Windows/ThemeResolutionTests.cs
@@ -305,4 +305,22 @@ public sealed class ThemeResolutionTests
         Assert.Equal(0xFFFFFFu,
             ThemeResolution.EnsureReadableForeground(0x111111, 0x000000));
     }
+
+    [Theory]
+    [InlineData(0x7F7F7Fu)]
+    [InlineData(0x808080u)]
+    [InlineData(0x777777u)]
+    public void EnsureReadable_MidGray_PicksHigherContrastPole(uint background)
+    {
+        // Mid-luminance backgrounds are the band where a plain dark/light
+        // luminance split disagrees with the WCAG ratio: 0x7F7F7F reads
+        // better on black than white. The fallback must return the pole that
+        // actually contrasts more, never the lower-contrast one.
+        var fg = ThemeResolution.EnsureReadableForeground(background, background);
+        Assert.True(fg == 0xFFFFFFu || fg == 0x000000u);
+        var chosen = ThemeResolution.ContrastRatio(background, fg);
+        var other = ThemeResolution.ContrastRatio(
+            background, fg == 0xFFFFFFu ? 0x000000u : 0xFFFFFFu);
+        Assert.True(chosen >= other);
+    }
 }

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -452,7 +452,6 @@ internal sealed partial class TabHost : UserControl, ITabHost
         if (!theme.IsEnabled) return;
 
         var accentBrush = new SolidColorBrush(theme.AccentColor);
-        var activeTextBrush = new SolidColorBrush(theme.ActiveTabText);
         var tabBgBrush = new SolidColorBrush(theme.TabBarBackground);
 
         // Background resources on TabViewControl work with a theme toggle.
@@ -476,7 +475,17 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // accent background, so the active brush gives them zero contrast
         // (#342). Pick a luminance-readable foreground over the tab-bar
         // background and mute it to ~70% so inactive reads as inactive.
-        _shellActiveTextBrush = activeTextBrush;
+        //
+        // Calibrate the active title against the accent it sits on. The raw
+        // ActiveTabText (cursor-text, or the bg fallback) can land at the
+        // same luminance pole as the accent for some palettes (both light or
+        // both dark), which erases the title. Keep it when it contrasts;
+        // otherwise drop to a readable black/white. (#342)
+        uint accentPacked = PackColor(theme.AccentColor);
+        uint activePacked = PackColor(theme.ActiveTabText);
+        _shellActiveTextBrush = new SolidColorBrush(UnpackColor(
+            ThemeResolution.EnsureReadableForeground(accentPacked, activePacked)));
+
         uint tabBgPacked = (uint)((theme.TabBarBackground.R << 16)
             | (theme.TabBarBackground.G << 8)
             | theme.TabBarBackground.B);
@@ -490,20 +499,47 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private SolidColorBrush? _shellActiveTextBrush;
     private SolidColorBrush? _shellInactiveTextBrush;
 
-    // Recolor every tab title to its active/inactive shell-theme brush.
-    // No-op unless a shell theme is active (brushes non-null). The active
-    // brush is calibrated against the accent background; the inactive
-    // brush is a muted, luminance-readable foreground over the near-bg
-    // tab-bar background — without this, inactive titles inherited the
-    // active brush and vanished (#342).
+    // Default-path (no shell theme) selected-tab background = the cursor
+    // accent, and the contrast-safe title brush derived from it. Cached so
+    // ClearShellTheme can restore a deterministic selected background and
+    // RecolorTabText can keep the active title legible on it.
+    private SolidColorBrush? _accentBrush;
+    private SolidColorBrush? _defaultActiveTextBrush;
+
+    // Recolor every tab title for the current selection.
+    //
+    // Shell theme on: active titles use the accent-calibrated brush and
+    // inactive titles use the muted near-bg brush — without the split,
+    // inactive titles inherited the active brush and vanished (#342).
+    //
+    // Shell theme off (default): only the active tab sits on the cursor
+    // accent (SetAccentColor paints the selected-tab background), which is
+    // light for the default palette. Give that one title a contrast-safe
+    // brush; leave the others on the inherited theme foreground (white on
+    // the default dark, unselected tab background).
     private void RecolorTabText()
     {
-        if (_shellActiveTextBrush is null || _shellInactiveTextBrush is null) return;
+        bool shell = _shellActiveTextBrush is not null && _shellInactiveTextBrush is not null;
         foreach (var (model, tb) in _headerTextByModel)
-            tb.Foreground = ReferenceEquals(model, _manager.ActiveTab)
-                ? _shellActiveTextBrush
-                : _shellInactiveTextBrush;
+        {
+            bool active = ReferenceEquals(model, _manager.ActiveTab);
+            if (shell)
+                tb.Foreground = active ? _shellActiveTextBrush! : _shellInactiveTextBrush!;
+            else if (active && _defaultActiveTextBrush is not null)
+                tb.Foreground = _defaultActiveTextBrush;
+            else
+                tb.ClearValue(TextBlock.ForegroundProperty);
+        }
     }
+
+    // Pack/unpack between WinUI's Windows.UI.Color and the 0x00RRGGBB form
+    // ThemeResolution works in.
+    private static uint PackColor(Windows.UI.Color c) =>
+        ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
+
+    private static Windows.UI.Color UnpackColor(uint packed) =>
+        Windows.UI.Color.FromArgb(0xFF,
+            (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed);
 
     private ElementTheme _cachedTheme = ElementTheme.Default;
 
@@ -515,18 +551,27 @@ internal sealed partial class TabHost : UserControl, ITabHost
     internal void ClearShellTheme()
     {
         TabViewControl.Resources.Remove("TabViewBackground");
-        TabViewControl.Resources.Remove("TabViewItemHeaderBackgroundSelected");
         _shellActiveTextBrush = null;
         _shellInactiveTextBrush = null;
 
-        // Revert each tab title's Foreground to its inherited theme
-        // brush so the default WinUI text color returns.
-        foreach (var tb in _headerTextByModel.Values)
-            tb.ClearValue(TextBlock.ForegroundProperty);
+        // The selected-tab background resource is shared with the default
+        // (cursor-accent) path, so don't just remove it — restore the cached
+        // accent. Otherwise a config reload (which clears the shell theme
+        // after SetAccentColor has run) would drop the accent and the active
+        // title's contrast decision would be made against the wrong
+        // background. Falls back to removal only before SetAccentColor has
+        // ever run (first ClearShellTheme at startup).
+        if (_accentBrush is not null)
+            TabViewControl.Resources["TabViewItemHeaderBackgroundSelected"] = _accentBrush;
+        else
+            TabViewControl.Resources.Remove("TabViewItemHeaderBackgroundSelected");
 
-        // Toggle theme to force WinUI to re-read the default
-        // background resources now that the overrides are gone.
-        // Foregrounds don't need this — ClearValue above is immediate.
+        // Recolor titles for the default path: the active tab gets the
+        // contrast-safe brush, the rest revert to the inherited theme brush.
+        RecolorTabText();
+
+        // Toggle theme to force WinUI to re-read the background resources.
+        // Foregrounds don't need this — RecolorTabText above is immediate.
         TabViewControl.RequestedTheme = ElementTheme.Light;
         TabViewControl.RequestedTheme = _cachedTheme;
     }
@@ -543,9 +588,24 @@ internal sealed partial class TabHost : UserControl, ITabHost
     /// </summary>
     internal void SetAccentColor(Windows.UI.Color color)
     {
-        var c = Microsoft.UI.ColorHelper.FromArgb(color.A, color.R, color.G, color.B);
-        TabViewControl.Resources["TabViewItemHeaderBackgroundSelected"] =
-            new SolidColorBrush(c);
+        // Cache the cursor-derived accent as the default-path selected-tab
+        // background, and derive a title colour that stays legible on it.
+        // cursor-color falls back to the (light) foreground for the default
+        // palette, so an inherited white title would be invisible on the
+        // selected tab — EnsureReadableForeground maps it to black.
+        _accentBrush = new SolidColorBrush(
+            Windows.UI.Color.FromArgb(0xFF, color.R, color.G, color.B));
+        _defaultActiveTextBrush = new SolidColorBrush(UnpackColor(
+            ThemeResolution.EnsureReadableForeground(PackColor(color), 0xFFFFFF)));
+
+        // When a shell theme is active it owns the selected-tab background
+        // and the active title (ApplyShellTheme). Don't fight it here; keep
+        // the cache warm for the moment the shell theme is turned off.
+        if (_shellActiveTextBrush is not null) return;
+
+        TabViewControl.Resources["TabViewItemHeaderBackgroundSelected"] = _accentBrush;
+        RecolorTabText();
+
         // Force re-apply by toggling selection so the TabView picks
         // up the new brush. Suppress the event to avoid side effects.
         if (TabViewControl.SelectedItem is not null)

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -486,9 +486,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
         _shellActiveTextBrush = new SolidColorBrush(UnpackColor(
             ThemeResolution.EnsureReadableForeground(accentPacked, activePacked)));
 
-        uint tabBgPacked = (uint)((theme.TabBarBackground.R << 16)
-            | (theme.TabBarBackground.G << 8)
-            | theme.TabBarBackground.B);
+        uint tabBgPacked = PackColor(theme.TabBarBackground);
         var inactiveColor = ThemeResolution.PreferLightForeground(tabBgPacked)
             ? Windows.UI.Color.FromArgb(0xB3, 0xFF, 0xFF, 0xFF)  // white @ ~70%
             : Windows.UI.Color.FromArgb(0xB3, 0x00, 0x00, 0x00); // black @ ~70%


### PR DESCRIPTION
On a fresh empty-config launch the active tab title was unreadable: the selected-tab background is painted with the cursor accent (cursor-color, which falls back to the light foreground by default), while the title text stayed at the inherited white foreground, so the title was white on a white tab.

The active title is now color-picked with a WCAG contrast check against the selected-tab background in both the default and shell-theme paths: keep the desired color when it already contrasts, otherwise fall back to black or white. The default path's selected background is cached and restored so a config reload can't strip it and leave the contrast decision pointing at the wrong background.

Adds ContrastRatio and EnsureReadableForeground to Ghostty.Core with unit tests (full suite green).