### PR TITLE
feat(windows): blend the selected tab into the terminal background

### DIFF
--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1732,9 +1732,10 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Update all accent-colored UI from the cursor color in config:
-    /// pane border, selected tab indicator, vertical tab accent bar.
-    /// Called on every config reload so theme changes take effect.
+    /// Update config-driven chrome colors: pane border and the vertical tab
+    /// accent bar track cursor-color; the horizontal selected-tab background
+    /// blends with the terminal background so the active tab connects to the
+    /// pane below it. Called on every config reload so theme changes apply.
     /// </summary>
     private void UpdateCursorAccentColors()
     {
@@ -1748,7 +1749,14 @@ public sealed partial class MainWindow : Window
         foreach (var t in _tabManager.Tabs)
             ((PaneHost)t.PaneHost).SetActiveBorderBrush(brush);
 
-        _horizontalTabHost.SetAccentColor(wuiColor);
+        var bg = _configService.BackgroundColor;
+        var fg = _configService.ForegroundColor;
+        var bgColor = Windows.UI.Color.FromArgb(0xFF,
+            (byte)(bg >> 16), (byte)(bg >> 8), (byte)bg);
+        var fgColor = Windows.UI.Color.FromArgb(0xFF,
+            (byte)(fg >> 16), (byte)(fg >> 8), (byte)fg);
+
+        _horizontalTabHost.SetSelectedTabColors(bgColor, fgColor);
         _verticalTabHost.SetAccentColor(wuiColor);
     }
 

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -497,8 +497,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private SolidColorBrush? _shellActiveTextBrush;
     private SolidColorBrush? _shellInactiveTextBrush;
 
-    // Default-path (no shell theme) selected-tab background = the cursor
-    // accent, and the contrast-safe title brush derived from it. Cached so
+    // Default-path (no shell theme) selected-tab background = the terminal
+    // background, and the contrast-safe title brush derived from it. Cached so
     // ClearShellTheme can restore a deterministic selected background and
     // RecolorTabText can keep the active title legible on it.
     private SolidColorBrush? _accentBrush;
@@ -510,11 +510,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
     // inactive titles use the muted near-bg brush — without the split,
     // inactive titles inherited the active brush and vanished (#342).
     //
-    // Shell theme off (default): only the active tab sits on the cursor
-    // accent (SetAccentColor paints the selected-tab background), which is
-    // light for the default palette. Give that one title a contrast-safe
-    // brush; leave the others on the inherited theme foreground (white on
-    // the default dark, unselected tab background).
+    // Shell theme off (default): only the active tab sits on the terminal
+    // background fill (SetSelectedTabColors paints the selected-tab
+    // background). Give that one title the contrast-safe brush; leave the
+    // others on the inherited theme foreground (white on the default dark,
+    // unselected tab background).
     private void RecolorTabText()
     {
         bool shell = _shellActiveTextBrush is not null && _shellInactiveTextBrush is not null;
@@ -553,12 +553,12 @@ internal sealed partial class TabHost : UserControl, ITabHost
         _shellInactiveTextBrush = null;
 
         // The selected-tab background resource is shared with the default
-        // (cursor-accent) path, so don't just remove it — restore the cached
-        // accent. Otherwise a config reload (which clears the shell theme
-        // after SetAccentColor has run) would drop the accent and the active
-        // title's contrast decision would be made against the wrong
-        // background. Falls back to removal only before SetAccentColor has
-        // ever run (first ClearShellTheme at startup).
+        // (terminal-background) path, so don't just remove it — restore the
+        // cached background. Otherwise a config reload (which clears the shell
+        // theme after SetSelectedTabColors has run) would drop the background
+        // and the active title's contrast decision would be made against the
+        // wrong background. Falls back to removal only before
+        // SetSelectedTabColors has ever run (first ClearShellTheme at startup).
         if (_accentBrush is not null)
             TabViewControl.Resources["TabViewItemHeaderBackgroundSelected"] = _accentBrush;
         else
@@ -581,20 +581,25 @@ internal sealed partial class TabHost : UserControl, ITabHost
     }
 
     /// <summary>
-    /// Set the accent color used for the selected tab indicator.
-    /// Driven by cursor-color from the terminal config.
+    /// Set the default-path selected-tab background and active-title colours.
+    /// The selected tab is painted with the terminal background so the active
+    /// tab visually connects to the pane below it; the active title uses the
+    /// terminal foreground (which is by definition readable on that
+    /// background). Driven by background-color/foreground from the config.
     /// </summary>
-    internal void SetAccentColor(Windows.UI.Color color)
+    internal void SetSelectedTabColors(
+        Windows.UI.Color background, Windows.UI.Color foreground)
     {
-        // Cache the cursor-derived accent as the default-path selected-tab
-        // background, and derive a title colour that stays legible on it.
-        // cursor-color falls back to the (light) foreground for the default
-        // palette, so an inherited white title would be invisible on the
-        // selected tab — EnsureReadableForeground maps it to black.
+        // Cache the terminal background as the default-path selected-tab fill,
+        // and a title colour that stays legible on it. Foreground over
+        // background is the terminal's own contrast pair, so it normally
+        // passes straight through; EnsureReadableForeground only steps in for
+        // a pathological fg/bg that doesn't contrast.
         _accentBrush = new SolidColorBrush(
-            Windows.UI.Color.FromArgb(0xFF, color.R, color.G, color.B));
+            Windows.UI.Color.FromArgb(0xFF, background.R, background.G, background.B));
         _defaultActiveTextBrush = new SolidColorBrush(UnpackColor(
-            ThemeResolution.EnsureReadableForeground(PackColor(color), 0xFFFFFF)));
+            ThemeResolution.EnsureReadableForeground(
+                PackColor(background), PackColor(foreground))));
 
         // When a shell theme is active it owns the selected-tab background
         // and the active title (ApplyShellTheme). Don't fight it here; keep


### PR DESCRIPTION
The selected tab was filled with the cursor color, which defaults to the light foreground, so the default selected tab rendered as a bright white block. It now uses the terminal background instead, so the active tab visually connects to the pane below it, with the active title drawn in the terminal foreground.

Pane borders and the vertical strip accent bar still track cursor-color. The shell-theme path is unchanged. GUI-verified on an empty config; full test suite green.