### PR TITLE
feat(windows): add Close Pane to the pane context menu

### DIFF
--- a/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
+++ b/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
@@ -33,7 +33,6 @@ public enum PaneMenuCommand
     /// <summary>
     /// Smart close: closes the active split leaf when the tab has more than one
     /// pane, otherwise closes the whole tab (with the multi-pane confirmation).
-    /// Dispatched as <c>PaneAction.CloseActiveProgressive</c>.
     /// </summary>
     ClosePane,
 }

--- a/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
+++ b/windows/Ghostty.Core/Panes/PaneContextMenuModel.cs
@@ -30,6 +30,12 @@ public enum PaneMenuCommand
     ToggleInspector,
     ChangeTabTitle,
     ChangeTerminalTitle,
+    /// <summary>
+    /// Smart close: closes the active split leaf when the tab has more than one
+    /// pane, otherwise closes the whole tab (with the multi-pane confirmation).
+    /// Dispatched as <c>PaneAction.CloseActiveProgressive</c>.
+    /// </summary>
+    ClosePane,
 }
 
 /// <summary>One row of the pane context menu.</summary>
@@ -74,5 +80,7 @@ public static class PaneContextMenuModel
             Separator(),
             Action(PaneMenuCommand.ChangeTabTitle,      "Change Tab Title...",      "\uE70F"),
             Action(PaneMenuCommand.ChangeTerminalTitle, "Change Terminal Title...", "\uE8AC"),
+            Separator(),
+            Action(PaneMenuCommand.ClosePane,           "Close Pane",               "\uE711"),
         };
 }

--- a/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneContextMenuModelTests.cs
@@ -29,6 +29,7 @@ public class PaneContextMenuModelTests
             PaneMenuCommand.ToggleInspector,
             PaneMenuCommand.ChangeTabTitle,
             PaneMenuCommand.ChangeTerminalTitle,
+            PaneMenuCommand.ClosePane,
         }, commands);
     }
 
@@ -37,7 +38,7 @@ public class PaneContextMenuModelTests
     {
         var items = PaneContextMenuModel.Build(hasSelection: true, isZoomed: false);
 
-        Assert.Equal(3, items.Count(i => i.Kind == PaneMenuItemKind.Separator));
+        Assert.Equal(4, items.Count(i => i.Kind == PaneMenuItemKind.Separator));
         Assert.NotEqual(PaneMenuItemKind.Separator, items[0].Kind);
         Assert.NotEqual(PaneMenuItemKind.Separator, items[^1].Kind);
         for (var i = 1; i < items.Count; i++)

--- a/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
+++ b/windows/Ghostty/Panes/PaneContextMenuBuilder.cs
@@ -105,6 +105,10 @@ internal static class PaneContextMenuBuilder
             case PaneMenuCommand.ChangeTabTitle: promptTabTitle(); break;
             case PaneMenuCommand.ChangeTerminalTitle: promptTerminalTitle(); break;
 
+            // Smart close: the router closes the split leaf when the tab has
+            // multiple panes, else the whole tab (with the confirmation).
+            case PaneMenuCommand.ClosePane: invokePaneAction(PaneAction.CloseActiveProgressive); break;
+
             default: throw new ArgumentOutOfRangeException(nameof(command), command, null);
         }
     }


### PR DESCRIPTION
Adds a "Close Pane" entry at the bottom of the pane right-click context menu.

It dispatches the existing CloseActiveProgressive action: closes the active split leaf when the tab has more than one pane, otherwise closes the whole tab with the multi-pane confirmation dialog. Same close behavior the command palette already exposes.

Separated from the title items by its own divider, mirroring where macOS puts close in the surface menu. Pure model lives in Ghostty.Core and is unit-tested; the WinUI builder just translates and dispatches.