### PR TITLE
Demo mode for feature-showcase recordings

### DIFF
--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -6,7 +6,11 @@
     wrapped in `#if DEMO` compiles to nothing and ships zero demo bytes.
   -->
   <PropertyGroup>
-    <DefineConstants Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug'">$(DefineConstants);DEMO</DefineConstants>
+    <!-- One source of truth for "is demo mode on?" so the DEMO constant and the
+         csproj Page/Compile/None conditions can't drift, and so a future
+         constant that merely contains the substring "DEMO" can't false-match. -->
+    <DemoEnabled Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug'">true</DemoEnabled>
+    <DefineConstants Condition="'$(DemoEnabled)' == 'true'">$(DefineConstants);DEMO</DefineConstants>
   </PropertyGroup>
   <!--
     'dotnet build' resolves AppxMSBuildToolsPath to the SDK directory which

--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -1,5 +1,14 @@
 <Project>
   <!--
+    Demo mode is compiled in for every Debug build (so `dotnet test` exercises
+    the Core demo logic) and for Release only when explicitly opted in with
+    `-p:Demo=true`. Public Release builds define no DEMO symbol, so every file
+    wrapped in `#if DEMO` compiles to nothing and ships zero demo bytes.
+  -->
+  <PropertyGroup>
+    <DefineConstants Condition="'$(Demo)' == 'true' or '$(Configuration)' == 'Debug'">$(DefineConstants);DEMO</DefineConstants>
+  </PropertyGroup>
+  <!--
     'dotnet build' resolves AppxMSBuildToolsPath to the SDK directory which
     lacks the PRI/Appx task DLLs. These ship with Visual Studio Build Tools.
     Redirect when missing. See WindowsAppSDK#3997.

--- a/windows/Ghostty.Core/Demo/DemoActions.cs
+++ b/windows/Ghostty.Core/Demo/DemoActions.cs
@@ -1,0 +1,25 @@
+#if DEMO
+using System;
+using Ghostty.Core.Input;
+
+namespace Ghostty.Core.Demo;
+
+/// <summary>
+/// Resolves a demo "action" beat's <c>key</c> string to a <see cref="PaneAction"/>.
+/// Tolerates snake_case and any casing ("split_vertical", "SplitVertical") by
+/// stripping underscores and parsing case-insensitively against the enum.
+/// </summary>
+internal static class DemoActions
+{
+    public static bool TryParse(string? key, out PaneAction action)
+    {
+        action = default;
+        if (string.IsNullOrWhiteSpace(key))
+            return false;
+
+        var normalized = key.Replace("_", string.Empty);
+        return Enum.TryParse(normalized, ignoreCase: true, out action)
+            && Enum.IsDefined(action);
+    }
+}
+#endif

--- a/windows/Ghostty.Core/Demo/DemoActions.cs
+++ b/windows/Ghostty.Core/Demo/DemoActions.cs
@@ -18,6 +18,15 @@ internal static class DemoActions
             return false;
 
         var normalized = key.Replace("_", string.Empty);
+        if (normalized.Length == 0)
+            return false; // e.g. "_" / "__" -- nothing left to parse.
+
+        // Reject numeric input: Enum.TryParse("8") parses the underlying value
+        // and IsDefined accepts it, silently invoking whatever action has that
+        // value instead of warn+skip. Demo action keys are always names.
+        if (char.IsDigit(normalized[0]) || normalized[0] == '-')
+            return false;
+
         return Enum.TryParse(normalized, ignoreCase: true, out action)
             && Enum.IsDefined(action);
     }

--- a/windows/Ghostty.Core/Demo/DemoKeys.cs
+++ b/windows/Ghostty.Core/Demo/DemoKeys.cs
@@ -1,0 +1,39 @@
+#if DEMO
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Demo;
+
+/// <summary>
+/// Maps friendly key names used by a demo "key" beat to the byte string the
+/// terminal expects, injected through the same text path as typed characters.
+/// Covers the small set a feature demo realistically needs (Enter, Tab, Esc,
+/// Backspace, arrows) without a full scancode encoder. Arrow keys use the
+/// normal (non-application) cursor sequences (ESC [ A..D), which is what a
+/// fresh shell uses; Backspace sends DEL (0x7f) as modern terminals do.
+/// </summary>
+internal static class DemoKeys
+{
+    // Built from char codes (not literals) to keep the control bytes explicit.
+    private static readonly string Esc = ((char)0x1b).ToString();
+    private static readonly string Del = ((char)0x7f).ToString();
+
+    private static readonly Dictionary<string, string> Map = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["enter"] = "\r",
+        ["return"] = "\r",
+        ["tab"] = "\t",
+        ["escape"] = Esc,
+        ["esc"] = Esc,
+        ["backspace"] = Del,
+        ["up"] = Esc + "[A",
+        ["down"] = Esc + "[B",
+        ["right"] = Esc + "[C",
+        ["left"] = Esc + "[D",
+    };
+
+    /// <summary>Returns the byte string for a named key, or null if unknown.</summary>
+    public static string? Resolve(string? name)
+        => name is not null && Map.TryGetValue(name, out var seq) ? seq : null;
+}
+#endif

--- a/windows/Ghostty.Core/Demo/DemoModel.cs
+++ b/windows/Ghostty.Core/Demo/DemoModel.cs
@@ -22,7 +22,7 @@ internal enum DemoMode
 /// </summary>
 internal sealed class DemoBeat
 {
-    /// <summary>caption | action | binding | type | key | wait | config</summary>
+    /// <summary>caption | action | binding | type | key | config | command | keys | wait</summary>
     public string Type { get; set; } = "";
 
     // caption / type

--- a/windows/Ghostty.Core/Demo/DemoModel.cs
+++ b/windows/Ghostty.Core/Demo/DemoModel.cs
@@ -22,14 +22,18 @@ internal enum DemoMode
 /// </summary>
 internal sealed class DemoBeat
 {
-    /// <summary>caption | action | binding | type | key | wait</summary>
+    /// <summary>caption | action | binding | type | key | wait | config</summary>
     public string Type { get; set; } = "";
 
     // caption / type
     public string? Text { get; set; }
 
-    // "action" beat: a PaneAction name (underscore/case tolerant), e.g. "split_vertical"
+    // "action" beat: a PaneAction name (underscore/case tolerant), e.g. "split_vertical".
+    // "config" beat: the config key to set, e.g. "theme" or "background-opacity".
     public string? Key { get; set; }
+
+    // "config" beat: the value to write for Key, e.g. "catppuccin-mocha" or "0.85".
+    public string? Value { get; set; }
 
     // "binding" beat: a libghostty binding action, e.g. "clear_screen"
     public string? Action { get; set; }

--- a/windows/Ghostty.Core/Demo/DemoModel.cs
+++ b/windows/Ghostty.Core/Demo/DemoModel.cs
@@ -1,0 +1,73 @@
+#if DEMO
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Ghostty.Core.Demo;
+
+/// <summary>How the player advances between beats.</summary>
+internal enum DemoMode
+{
+    Auto,
+    Stepped,
+}
+
+/// <summary>
+/// One demo beat. Heterogeneous fields keyed off <see cref="Type"/>; only the
+/// fields relevant to a beat's type are populated. Flat (non-polymorphic) so
+/// System.Text.Json source generation stays simple and AOT-safe. Mutable
+/// get/set DTO to match the codebase's JSON model convention (SessionModel,
+/// DiscoveryCache); init-only records lose absent-property initializers under
+/// the source generator.
+/// </summary>
+internal sealed class DemoBeat
+{
+    /// <summary>caption | action | binding | type | key | wait</summary>
+    public string Type { get; set; } = "";
+
+    // caption / type
+    public string? Text { get; set; }
+
+    // "action" beat: a PaneAction name (underscore/case tolerant), e.g. "split_vertical"
+    public string? Key { get; set; }
+
+    // "binding" beat: a libghostty binding action, e.g. "clear_screen"
+    public string? Action { get; set; }
+
+    // "key" beat: a named raw key, e.g. "enter", "up", "escape" (distinct from Key above)
+    public string? Chord { get; set; }
+
+    // type: send Return after the text so the shell runs it
+    public bool Enter { get; set; }
+
+    // caption display time; falls back to BeatGapMs
+    public int? DurationMs { get; set; }
+
+    // wait
+    public int? Ms { get; set; }
+
+    // type: per-character animation delay; falls back to script TypeDelayMs
+    public int? TypeDelayMs { get; set; }
+}
+
+/// <summary>A full demo: ordered beats plus default timings.</summary>
+internal sealed class DemoScript
+{
+    public string? Title { get; set; }
+    public int TypeDelayMs { get; set; } = 45;
+    public int BeatGapMs { get; set; } = 700;
+    public List<DemoBeat> Beats { get; set; } = [];
+}
+
+// Source-generated metadata keeps deserialization off reflection so the Core
+// trim/AOT analyzers stay quiet even though demo code never reaches the public
+// AOT build.
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    ReadCommentHandling = JsonCommentHandling.Skip,
+    AllowTrailingCommas = true)]
+[JsonSerializable(typeof(DemoScript))]
+internal sealed partial class DemoJsonContext : JsonSerializerContext
+{
+}
+#endif

--- a/windows/Ghostty.Core/Demo/DemoScriptParser.cs
+++ b/windows/Ghostty.Core/Demo/DemoScriptParser.cs
@@ -1,0 +1,51 @@
+#if DEMO
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Ghostty.Core.Demo;
+
+/// <summary>
+/// Parses demo scripts and resolves where the script file lives. Pure and
+/// side-effect free (file existence is injected) so both halves are unit-tested.
+/// </summary>
+internal static class DemoScriptParser
+{
+    /// <summary>Deserialize a demo script. Throws on malformed JSON.</summary>
+    public static DemoScript Parse(string json)
+    {
+        var script = JsonSerializer.Deserialize(json, DemoJsonContext.Default.DemoScript);
+        return script ?? throw new JsonException("Demo script deserialized to null.");
+    }
+
+    /// <summary>
+    /// Resolve the script path by precedence:
+    ///   1. <paramref name="envValue"/> if it points at an existing file,
+    ///   2. demo.json next to the executable,
+    ///   3. demo.json under the config dir's wintty/ folder.
+    /// Returns null when none exist.
+    /// </summary>
+    public static string? ResolveScriptPath(
+        string? envValue,
+        string exeDir,
+        string? configDir,
+        Func<string, bool> fileExists)
+    {
+        if (!string.IsNullOrWhiteSpace(envValue) && fileExists(envValue))
+            return envValue;
+
+        var beside = Path.Combine(exeDir, "demo.json");
+        if (fileExists(beside))
+            return beside;
+
+        if (!string.IsNullOrWhiteSpace(configDir))
+        {
+            var inConfig = Path.Combine(configDir, "wintty", "demo.json");
+            if (fileExists(inConfig))
+                return inConfig;
+        }
+
+        return null;
+    }
+}
+#endif

--- a/windows/Ghostty.Tests/Demo/DemoActionsTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoActionsTests.cs
@@ -24,5 +24,17 @@ public class DemoActionsTests
         Assert.False(DemoActions.TryParse("not_an_action", out _));
         Assert.False(DemoActions.TryParse(null, out _));
     }
+
+    [Theory]
+    [InlineData("8")]
+    [InlineData("-1")]
+    [InlineData("0")]
+    [InlineData("_")]
+    [InlineData("__")]
+    public void TryParse_NumericOrEmptyInput_ReturnsFalse(string key)
+    {
+        // Must not parse a raw enum value, and must not throw on all-underscore.
+        Assert.False(DemoActions.TryParse(key, out _));
+    }
 }
 #endif

--- a/windows/Ghostty.Tests/Demo/DemoActionsTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoActionsTests.cs
@@ -1,0 +1,28 @@
+#if DEMO
+using Ghostty.Core.Demo;
+using Ghostty.Core.Input;
+using Xunit;
+
+namespace Ghostty.Tests.Demo;
+
+public class DemoActionsTests
+{
+    [Theory]
+    [InlineData("split_vertical", PaneAction.SplitVertical)]
+    [InlineData("SplitVertical", PaneAction.SplitVertical)]
+    [InlineData("new_tab", PaneAction.NewTab)]
+    [InlineData("toggle_quick_terminal", PaneAction.ToggleQuickTerminal)]
+    public void TryParse_AcceptsUnderscoreAndCaseVariants(string key, PaneAction expected)
+    {
+        Assert.True(DemoActions.TryParse(key, out var action));
+        Assert.Equal(expected, action);
+    }
+
+    [Fact]
+    public void TryParse_UnknownKey_ReturnsFalse()
+    {
+        Assert.False(DemoActions.TryParse("not_an_action", out _));
+        Assert.False(DemoActions.TryParse(null, out _));
+    }
+}
+#endif

--- a/windows/Ghostty.Tests/Demo/DemoKeysTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoKeysTests.cs
@@ -1,0 +1,52 @@
+#if DEMO
+using Ghostty.Core.Demo;
+using Xunit;
+
+namespace Ghostty.Tests.Demo;
+
+public class DemoKeysTests
+{
+    private static readonly string Esc = ((char)0x1b).ToString();
+    private static readonly string Del = ((char)0x7f).ToString();
+
+    [Theory]
+    [InlineData("enter", "\r")]
+    [InlineData("return", "\r")]
+    [InlineData("tab", "\t")]
+    public void Resolve_SimpleKeys(string name, string expected)
+    {
+        Assert.Equal(expected, DemoKeys.Resolve(name));
+    }
+
+    [Fact]
+    public void Resolve_EscapeAndBackspace()
+    {
+        Assert.Equal(Esc, DemoKeys.Resolve("escape"));
+        Assert.Equal(Esc, DemoKeys.Resolve("esc"));
+        Assert.Equal(Del, DemoKeys.Resolve("backspace"));
+    }
+
+    [Fact]
+    public void Resolve_Arrows_HaveEscPrefix()
+    {
+        Assert.Equal(Esc + "[A", DemoKeys.Resolve("up"));
+        Assert.Equal(Esc + "[B", DemoKeys.Resolve("down"));
+        Assert.Equal(Esc + "[C", DemoKeys.Resolve("right"));
+        Assert.Equal(Esc + "[D", DemoKeys.Resolve("left"));
+    }
+
+    [Fact]
+    public void Resolve_IsCaseInsensitive()
+    {
+        Assert.Equal("\r", DemoKeys.Resolve("ENTER"));
+        Assert.Equal(DemoKeys.Resolve("up"), DemoKeys.Resolve("UP"));
+    }
+
+    [Fact]
+    public void Resolve_UnknownKey_ReturnsNull()
+    {
+        Assert.Null(DemoKeys.Resolve("f13"));
+        Assert.Null(DemoKeys.Resolve(null));
+    }
+}
+#endif

--- a/windows/Ghostty.Tests/Demo/DemoScriptParserTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoScriptParserTests.cs
@@ -46,6 +46,19 @@ public class DemoScriptParserTests
     }
 
     [Fact]
+    public void Parse_ConfigBeat_ReadsKeyAndValue()
+    {
+        var script = DemoScriptParser.Parse("""
+        { "beats": [ { "type": "config", "key": "theme", "value": "catppuccin-mocha" } ] }
+        """);
+
+        var beat = Assert.Single(script.Beats);
+        Assert.Equal("config", beat.Type);
+        Assert.Equal("theme", beat.Key);
+        Assert.Equal("catppuccin-mocha", beat.Value);
+    }
+
+    [Fact]
     public void Resolve_PrefersEnvPathWhenFileExists()
     {
         var path = DemoScriptParser.ResolveScriptPath(

--- a/windows/Ghostty.Tests/Demo/DemoScriptParserTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoScriptParserTests.cs
@@ -44,5 +44,53 @@ public class DemoScriptParserTests
         var script = DemoScriptParser.Parse("""{ "beats": [] }""");
         Assert.Empty(script.Beats);
     }
+
+    [Fact]
+    public void Resolve_PrefersEnvPathWhenFileExists()
+    {
+        var path = DemoScriptParser.ResolveScriptPath(
+            envValue: @"C:\scripts\my.json",
+            exeDir: @"C:\app",
+            configDir: @"C:\cfg",
+            fileExists: p => p == @"C:\scripts\my.json");
+
+        Assert.Equal(@"C:\scripts\my.json", path);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToExeAdjacent()
+    {
+        var path = DemoScriptParser.ResolveScriptPath(
+            envValue: null,
+            exeDir: @"C:\app",
+            configDir: @"C:\cfg",
+            fileExists: p => p == @"C:\app\demo.json");
+
+        Assert.Equal(@"C:\app\demo.json", path);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToConfigDir()
+    {
+        var path = DemoScriptParser.ResolveScriptPath(
+            envValue: "1", // present but not a file path
+            exeDir: @"C:\app",
+            configDir: @"C:\cfg",
+            fileExists: p => p == @"C:\cfg\wintty\demo.json");
+
+        Assert.Equal(@"C:\cfg\wintty\demo.json", path);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsNullWhenNothingExists()
+    {
+        var path = DemoScriptParser.ResolveScriptPath(
+            envValue: "1",
+            exeDir: @"C:\app",
+            configDir: @"C:\cfg",
+            fileExists: _ => false);
+
+        Assert.Null(path);
+    }
 }
 #endif

--- a/windows/Ghostty.Tests/Demo/DemoScriptParserTests.cs
+++ b/windows/Ghostty.Tests/Demo/DemoScriptParserTests.cs
@@ -1,0 +1,48 @@
+#if DEMO
+using Ghostty.Core.Demo;
+using Xunit;
+
+namespace Ghostty.Tests.Demo;
+
+public class DemoScriptParserTests
+{
+    [Fact]
+    public void Parse_ReadsBeatsAndDefaults()
+    {
+        const string json = """
+        {
+          "title": "Tour",
+          "typeDelayMs": 30,
+          "beats": [
+            { "type": "caption", "text": "Hi", "durationMs": 1500 },
+            { "type": "action",  "key": "split_vertical" },
+            { "type": "type",    "text": "ls", "enter": true }
+          ]
+        }
+        """;
+
+        var script = DemoScriptParser.Parse(json);
+
+        Assert.Equal("Tour", script.Title);
+        Assert.Equal(30, script.TypeDelayMs);
+        Assert.Equal(700, script.BeatGapMs); // default retained
+        Assert.Equal(3, script.Beats.Count);
+        Assert.Equal("caption", script.Beats[0].Type);
+        Assert.Equal(1500, script.Beats[0].DurationMs);
+        Assert.True(script.Beats[2].Enter);
+    }
+
+    [Fact]
+    public void Parse_InvalidJson_Throws()
+    {
+        Assert.Throws<System.Text.Json.JsonException>(() => DemoScriptParser.Parse("{ not json"));
+    }
+
+    [Fact]
+    public void Parse_EmptyBeats_ReturnsEmptyList()
+    {
+        var script = DemoScriptParser.Parse("""{ "beats": [] }""");
+        Assert.Empty(script.Beats);
+    }
+}
+#endif

--- a/windows/Ghostty/Commands/CommandItem.cs
+++ b/windows/Ghostty/Commands/CommandItem.cs
@@ -12,6 +12,7 @@ internal enum CommandCategory
     Config,
     Custom,
     About,
+    Demo,
 }
 
 internal record CommandItem

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -136,8 +136,10 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
     /// </summary>
     public bool TryExecuteById(string id)
     {
-        RebuildCommands();
-        var cmd = _allCommands.FirstOrDefault(c => c.Id == id);
+        // Query a fresh local list rather than RebuildCommands(): that would
+        // overwrite the live _allCommands out from under an open/pinned palette.
+        // Sources were already refreshed when the demo built them.
+        var cmd = _sources.SelectMany(s => s.GetCommands()).FirstOrDefault(c => c.Id == id);
         if (cmd is null) return false;
         cmd.Execute(cmd);
         return true;

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -127,6 +127,23 @@ internal class CommandPaletteViewModel : INotifyPropertyChanged
         _allCommands = _sources.SelectMany(s => s.GetCommands()).ToList();
     }
 
+#if DEMO
+    /// <summary>
+    /// Find a command by its <see cref="CommandItem.Id"/> across all sources and
+    /// run it without opening the palette UI. Returns false if no command matches
+    /// (e.g. a Pro-only command id in an OSS build). Used by the demo "command"
+    /// beat to fire palette-only commands that have no PaneAction.
+    /// </summary>
+    public bool TryExecuteById(string id)
+    {
+        RebuildCommands();
+        var cmd = _allCommands.FirstOrDefault(c => c.Id == id);
+        if (cmd is null) return false;
+        cmd.Execute(cmd);
+        return true;
+    }
+#endif
+
     public void Close()
     {
         IsOpen = false;

--- a/windows/Ghostty/Commands/DemoCommandSource.cs
+++ b/windows/Ghostty/Commands/DemoCommandSource.cs
@@ -1,0 +1,51 @@
+#if DEMO
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Demo;
+
+namespace Ghostty.Commands;
+
+/// <summary>
+/// Surfaces the two demo entries in the command palette. Only constructed when
+/// the WINTTY_DEMO env var is present (gated at the call site in MainWindow),
+/// so in a demo build with the var unset the palette is unchanged.
+/// </summary>
+internal sealed class DemoCommandSource : ICommandSource
+{
+    // Segoe Fluent glyphs: Play (E768), FastForward (EB9D). Built from code
+    // points to avoid embedding private-use-area characters in source.
+    private static readonly string PlayGlyph = ((char)0xE768).ToString();
+    private static readonly string StepGlyph = ((char)0xEB9D).ToString();
+
+    private readonly IReadOnlyList<CommandItem> _commands;
+
+    public DemoCommandSource(Action<DemoMode> start)
+    {
+        _commands = new[]
+        {
+            new CommandItem
+            {
+                Id = "demo:auto",
+                Title = "Start Demo (Auto)",
+                Description = "Play the demo script hands-off for recording",
+                Category = CommandCategory.Demo,
+                LeadingIcon = PlayGlyph,
+                Execute = _ => start(DemoMode.Auto),
+            },
+            new CommandItem
+            {
+                Id = "demo:stepped",
+                Title = "Start Demo (Stepped)",
+                Description = "Play the demo script, advancing with Space / Right arrow",
+                Category = CommandCategory.Demo,
+                LeadingIcon = StepGlyph,
+                Execute = _ => start(DemoMode.Stepped),
+            },
+        };
+    }
+
+    public IReadOnlyList<CommandItem> GetCommands() => _commands;
+
+    public void Refresh() { /* static entries */ }
+}
+#endif

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
@@ -71,6 +71,7 @@
                 <!-- Title + optional description -->
                 <StackPanel Grid.Column="2"
                             VerticalAlignment="Center"
+                            Margin="8,0,0,0"
                             Spacing="1">
                     <TextBlock x:Name="ItemTitle"
                                FontSize="{StaticResource BodyTextBlockFontSize}"

--- a/windows/Ghostty/Demo/DemoOverlay.xaml
+++ b/windows/Ghostty/Demo/DemoOverlay.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Ghostty.Demo.DemoOverlay"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    IsHitTestVisible="False">
+
+    <!-- Lower-third caption. Whole control is hit-test invisible so it never
+         steals input from the terminal the demo is driving. -->
+    <Grid>
+        <Border x:Name="CaptionPill"
+                Opacity="0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Bottom"
+                Margin="0,0,0,72"
+                Padding="20,12"
+                CornerRadius="14"
+                Background="#CC1B1B1F"
+                BorderBrush="#33FFFFFF"
+                BorderThickness="1">
+            <Border.RenderTransform>
+                <TranslateTransform x:Name="PillSlide" Y="12"/>
+            </Border.RenderTransform>
+            <StackPanel Orientation="Horizontal" Spacing="14" VerticalAlignment="Center">
+                <Image x:Name="LogoImage"
+                       Width="32" Height="32"
+                       RenderTransformOrigin="0.5,0.5">
+                    <Image.RenderTransform>
+                        <RotateTransform Angle="-12"/>
+                    </Image.RenderTransform>
+                </Image>
+                <TextBlock x:Name="CaptionText"
+                           VerticalAlignment="Center"
+                           FontSize="20"
+                           FontWeight="SemiBold"
+                           Foreground="White"/>
+                <TextBlock x:Name="StepText"
+                           VerticalAlignment="Center"
+                           Margin="6,0,0,0"
+                           FontSize="13"
+                           Opacity="0.6"
+                           Foreground="White"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/windows/Ghostty/Demo/DemoOverlay.xaml.cs
+++ b/windows/Ghostty/Demo/DemoOverlay.xaml.cs
@@ -77,27 +77,37 @@ internal sealed partial class DemoOverlay : UserControl
     // deadlocks, since the decode marshals back to the UI thread.
     private async Task LoadLogoAsync()
     {
-        var asm = typeof(Ghostty.Core.Version.KittyLogo).Assembly;
-        using var stream = asm.GetManifestResourceStream("Ghostty.Core.Branding.wintty_logo.png");
-        if (stream is null) return;
-
-        using var ms = new MemoryStream();
-        await stream.CopyToAsync(ms);
-        var bytes = ms.ToArray();
-
-        var bitmap = new BitmapImage();
-        using var ras = new InMemoryRandomAccessStream();
-        using (var writer = new DataWriter(ras))
+        // The logo is cosmetic; a decode failure must not surface as an
+        // unhandled exception on the UI thread (this runs from an async-void
+        // Loaded handler). Swallow and leave the logo blank.
+        try
         {
-            writer.WriteBytes(bytes);
-            await writer.StoreAsync();
-            await writer.FlushAsync();
-            writer.DetachStream();
-        }
-        ras.Seek(0);
-        await bitmap.SetSourceAsync(ras);
+            var asm = typeof(Ghostty.Core.Version.KittyLogo).Assembly;
+            using var stream = asm.GetManifestResourceStream("Ghostty.Core.Branding.wintty_logo.png");
+            if (stream is null) return;
 
-        LogoImage.Source = bitmap;
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            var bytes = ms.ToArray();
+
+            var bitmap = new BitmapImage();
+            using var ras = new InMemoryRandomAccessStream();
+            using (var writer = new DataWriter(ras))
+            {
+                writer.WriteBytes(bytes);
+                await writer.StoreAsync();
+                await writer.FlushAsync();
+                writer.DetachStream();
+            }
+            ras.Seek(0);
+            await bitmap.SetSourceAsync(ras);
+
+            LogoImage.Source = bitmap;
+        }
+        catch
+        {
+            // Blank logo is acceptable; nothing else to do.
+        }
     }
 }
 #endif

--- a/windows/Ghostty/Demo/DemoOverlay.xaml.cs
+++ b/windows/Ghostty/Demo/DemoOverlay.xaml.cs
@@ -1,6 +1,7 @@
 #if DEMO
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Media.Imaging;
@@ -18,7 +19,7 @@ internal sealed partial class DemoOverlay : UserControl
     public DemoOverlay()
     {
         InitializeComponent();
-        Loaded += (_, _) => LoadLogo();
+        Loaded += async (_, _) => await LoadLogoAsync();
     }
 
     /// <summary>Show a caption, optionally with a step indicator (stepped mode).</summary>
@@ -71,31 +72,30 @@ internal sealed partial class DemoOverlay : UserControl
     // (see Ghostty.Core.csproj). Load it from that assembly's manifest so the
     // overlay reuses the existing brand asset instead of bundling a copy.
     // BitmapImage cannot read a managed Stream directly, hence the
-    // DataWriter/StoreAsync -> SetSourceAsync dance. The sync block here is
-    // deliberate and bounded: it runs once on Loaded over a tiny embedded PNG.
-    private void LoadLogo()
+    // DataWriter/StoreAsync -> SetSourceAsync dance. Must stay fully async:
+    // blocking SetSourceAsync on the UI thread (.GetAwaiter().GetResult())
+    // deadlocks, since the decode marshals back to the UI thread.
+    private async Task LoadLogoAsync()
     {
         var asm = typeof(Ghostty.Core.Version.KittyLogo).Assembly;
         using var stream = asm.GetManifestResourceStream("Ghostty.Core.Branding.wintty_logo.png");
         if (stream is null) return;
 
         using var ms = new MemoryStream();
-        stream.CopyTo(ms);
+        await stream.CopyToAsync(ms);
         var bytes = ms.ToArray();
 
         var bitmap = new BitmapImage();
-        using (var ras = new InMemoryRandomAccessStream())
+        using var ras = new InMemoryRandomAccessStream();
+        using (var writer = new DataWriter(ras))
         {
-            using (var writer = new DataWriter(ras))
-            {
-                writer.WriteBytes(bytes);
-                writer.StoreAsync().AsTask().GetAwaiter().GetResult();
-                writer.FlushAsync().AsTask().GetAwaiter().GetResult();
-                writer.DetachStream();
-            }
-            ras.Seek(0);
-            bitmap.SetSourceAsync(ras).AsTask().GetAwaiter().GetResult();
+            writer.WriteBytes(bytes);
+            await writer.StoreAsync();
+            await writer.FlushAsync();
+            writer.DetachStream();
         }
+        ras.Seek(0);
+        await bitmap.SetSourceAsync(ras);
 
         LogoImage.Source = bitmap;
     }

--- a/windows/Ghostty/Demo/DemoOverlay.xaml.cs
+++ b/windows/Ghostty/Demo/DemoOverlay.xaml.cs
@@ -1,0 +1,103 @@
+#if DEMO
+using System;
+using System.IO;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage.Streams;
+
+namespace Ghostty.Demo;
+
+/// <summary>
+/// Lower-third caption overlay shown during a demo. A tilted Wintty logo sits
+/// beside the caption text; an optional "n / total" step indicator appears in
+/// stepped mode. Hit-test invisible so the demo's own input is never blocked.
+/// </summary>
+internal sealed partial class DemoOverlay : UserControl
+{
+    public DemoOverlay()
+    {
+        InitializeComponent();
+        Loaded += (_, _) => LoadLogo();
+    }
+
+    /// <summary>Show a caption, optionally with a step indicator (stepped mode).</summary>
+    public void ShowCaption(string text, int? stepIndex = null, int? stepTotal = null)
+    {
+        CaptionText.Text = text;
+        if (stepIndex is int i && stepTotal is int n)
+        {
+            StepText.Text = $"{i} / {n}";
+            StepText.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+        }
+        else
+        {
+            StepText.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+        }
+        FadeTo(1, 0);
+    }
+
+    /// <summary>Hide the caption pill.</summary>
+    public void Hide() => FadeTo(0, 12);
+
+    private void FadeTo(double opacity, double slideY)
+    {
+        var sb = new Storyboard();
+
+        var fade = new DoubleAnimation
+        {
+            To = opacity,
+            Duration = TimeSpan.FromMilliseconds(180),
+            EnableDependentAnimation = true,
+        };
+        Storyboard.SetTarget(fade, CaptionPill);
+        Storyboard.SetTargetProperty(fade, "Opacity");
+        sb.Children.Add(fade);
+
+        var slide = new DoubleAnimation
+        {
+            To = slideY,
+            Duration = TimeSpan.FromMilliseconds(180),
+            EnableDependentAnimation = true,
+        };
+        Storyboard.SetTarget(slide, PillSlide);
+        Storyboard.SetTargetProperty(slide, "Y");
+        sb.Children.Add(slide);
+
+        sb.Begin();
+    }
+
+    // The logo is embedded in Ghostty.Core as Ghostty.Core.Branding.wintty_logo.png
+    // (see Ghostty.Core.csproj). Load it from that assembly's manifest so the
+    // overlay reuses the existing brand asset instead of bundling a copy.
+    // BitmapImage cannot read a managed Stream directly, hence the
+    // DataWriter/StoreAsync -> SetSourceAsync dance. The sync block here is
+    // deliberate and bounded: it runs once on Loaded over a tiny embedded PNG.
+    private void LoadLogo()
+    {
+        var asm = typeof(Ghostty.Core.Version.KittyLogo).Assembly;
+        using var stream = asm.GetManifestResourceStream("Ghostty.Core.Branding.wintty_logo.png");
+        if (stream is null) return;
+
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        var bytes = ms.ToArray();
+
+        var bitmap = new BitmapImage();
+        using (var ras = new InMemoryRandomAccessStream())
+        {
+            using (var writer = new DataWriter(ras))
+            {
+                writer.WriteBytes(bytes);
+                writer.StoreAsync().AsTask().GetAwaiter().GetResult();
+                writer.FlushAsync().AsTask().GetAwaiter().GetResult();
+                writer.DetachStream();
+            }
+            ras.Seek(0);
+            bitmap.SetSourceAsync(ras).AsTask().GetAwaiter().GetResult();
+        }
+
+        LogoImage.Source = bitmap;
+    }
+}
+#endif

--- a/windows/Ghostty/Demo/DemoPlayer.cs
+++ b/windows/Ghostty/Demo/DemoPlayer.cs
@@ -23,6 +23,7 @@ internal sealed class DemoPlayer
     private readonly Action<PaneAction> _invokeAction;
     private readonly Action<string> _invokeBinding;
     private readonly Action<string> _injectText;
+    private readonly Action<string, string> _applyConfig; // config key, value
     private readonly Action<string, int?, int?> _showCaption; // text, stepIndex, stepTotal
     private readonly Action _hideOverlay;
     private readonly ILogger _log;
@@ -37,6 +38,7 @@ internal sealed class DemoPlayer
         Action<PaneAction> invokeAction,
         Action<string> invokeBinding,
         Action<string> injectText,
+        Action<string, string> applyConfig,
         Action<string, int?, int?> showCaption,
         Action hideOverlay,
         ILogger log)
@@ -44,6 +46,7 @@ internal sealed class DemoPlayer
         _invokeAction = invokeAction;
         _invokeBinding = invokeBinding;
         _injectText = injectText;
+        _applyConfig = applyConfig;
         _showCaption = showCaption;
         _hideOverlay = hideOverlay;
         _log = log;
@@ -150,6 +153,13 @@ internal sealed class DemoPlayer
                     _injectText(seq);
                 else
                     _log.LogWarning("Demo: unknown key '{Chord}', skipping.", beat.Chord);
+                break;
+
+            case "config":
+                if (!string.IsNullOrWhiteSpace(beat.Key) && beat.Value is not null)
+                    _applyConfig(beat.Key, beat.Value);
+                else
+                    _log.LogWarning("Demo: config beat needs 'key' and 'value', skipping.");
                 break;
 
             case "wait":

--- a/windows/Ghostty/Demo/DemoPlayer.cs
+++ b/windows/Ghostty/Demo/DemoPlayer.cs
@@ -1,0 +1,201 @@
+#if DEMO
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Demo;
+using Ghostty.Core.Input;
+using Microsoft.Extensions.Logging;
+
+namespace Ghostty.Demo;
+
+/// <summary>
+/// Drives a <see cref="DemoScript"/> against the live app. Runs as an async
+/// coroutine on the UI dispatcher thread: each beat is dispatched, then the
+/// player awaits either a timed gap (auto) or a step signal (stepped). Esc
+/// cancels via the token; cleanup always runs in finally.
+///
+/// Decoupled from XAML via callbacks: invokeAction, invokeBinding, and
+/// injectText are the three ways it touches the terminal; the overlay
+/// callbacks render captions.
+/// </summary>
+internal sealed class DemoPlayer
+{
+    private readonly Action<PaneAction> _invokeAction;
+    private readonly Action<string> _invokeBinding;
+    private readonly Action<string> _injectText;
+    private readonly Action<string, int?, int?> _showCaption; // text, stepIndex, stepTotal
+    private readonly Action _hideOverlay;
+    private readonly ILogger _log;
+
+    private CancellationTokenSource? _cts;
+    private TaskCompletionSource<bool>? _stepGate;
+    private volatile bool _paused;
+
+    public bool IsRunning { get; private set; }
+
+    public DemoPlayer(
+        Action<PaneAction> invokeAction,
+        Action<string> invokeBinding,
+        Action<string> injectText,
+        Action<string, int?, int?> showCaption,
+        Action hideOverlay,
+        ILogger log)
+    {
+        _invokeAction = invokeAction;
+        _invokeBinding = invokeBinding;
+        _injectText = injectText;
+        _showCaption = showCaption;
+        _hideOverlay = hideOverlay;
+        _log = log;
+    }
+
+    /// <summary>Advance one beat in stepped mode (no-op otherwise).</summary>
+    public void Step() => _stepGate?.TrySetResult(true);
+
+    /// <summary>Toggle pause in auto mode.</summary>
+    public void TogglePause() => _paused = !_paused;
+
+    /// <summary>Abort a running demo.</summary>
+    public void Abort() => _cts?.Cancel();
+
+    public async Task RunAsync(DemoScript script, DemoMode mode)
+    {
+        if (IsRunning)
+        {
+            _log.LogInformation("Demo already running; ignoring start request.");
+            return;
+        }
+
+        IsRunning = true;
+        _paused = false;
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+
+        try
+        {
+            for (var i = 0; i < script.Beats.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var beat = script.Beats[i];
+
+                await DispatchBeatAsync(script, beat, mode, i + 1, ct);
+
+                if (mode == DemoMode.Stepped)
+                    await WaitForStepAsync(ct);
+                else
+                {
+                    var gap = beat.DurationMs ?? script.BeatGapMs;
+                    await DelayWithPauseAsync(gap, ct);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _log.LogInformation("Demo aborted.");
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "Demo failed.");
+        }
+        finally
+        {
+            _hideOverlay();
+            _cts?.Dispose();
+            _cts = null;
+            _stepGate = null;
+            IsRunning = false;
+        }
+    }
+
+    private async Task DispatchBeatAsync(
+        DemoScript script, DemoBeat beat, DemoMode mode, int stepNumber, CancellationToken ct)
+    {
+        switch (beat.Type)
+        {
+            case "caption":
+                if (beat.Text is { } caption)
+                {
+                    // Show the "n / total" indicator only in stepped mode.
+                    var stepped = mode == DemoMode.Stepped;
+                    _showCaption(
+                        caption,
+                        stepped ? stepNumber : null,
+                        stepped ? script.Beats.Count : null);
+                }
+                break;
+
+            case "action":
+                if (DemoActions.TryParse(beat.Key, out var action))
+                    _invokeAction(action);
+                else
+                    _log.LogWarning("Demo: unknown action key '{Key}', skipping.", beat.Key);
+                break;
+
+            case "binding":
+                if (!string.IsNullOrWhiteSpace(beat.Action))
+                    _invokeBinding(beat.Action);
+                else
+                    _log.LogWarning("Demo: binding beat missing 'action', skipping.");
+                break;
+
+            case "type":
+                await TypeAsync(beat.Text ?? "", beat.TypeDelayMs ?? script.TypeDelayMs, ct);
+                if (beat.Enter)
+                    _injectText("\r");
+                break;
+
+            case "key":
+                var seq = DemoKeys.Resolve(beat.Chord);
+                if (seq is not null)
+                    _injectText(seq);
+                else
+                    _log.LogWarning("Demo: unknown key '{Chord}', skipping.", beat.Chord);
+                break;
+
+            case "wait":
+                await DelayWithPauseAsync(beat.Ms ?? 0, ct);
+                break;
+
+            default:
+                _log.LogWarning("Demo: unknown beat type '{Type}', skipping.", beat.Type);
+                break;
+        }
+    }
+
+    // Type one character at a time so it looks hand-typed. Each char goes
+    // through the same SurfaceText path real keystrokes use.
+    private async Task TypeAsync(string text, int perCharMs, CancellationToken ct)
+    {
+        foreach (var rune in text.EnumerateRunes())
+        {
+            ct.ThrowIfCancellationRequested();
+            _injectText(rune.ToString());
+            if (perCharMs > 0)
+                await Task.Delay(perCharMs, ct);
+        }
+    }
+
+    private async Task DelayWithPauseAsync(int ms, CancellationToken ct)
+    {
+        if (ms > 0)
+            await Task.Delay(ms, ct);
+
+        // Hold here while paused (auto mode). Poll lightly; pause is a
+        // recording convenience, not a hot path.
+        while (_paused)
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Delay(100, ct);
+        }
+    }
+
+    private async Task WaitForStepAsync(CancellationToken ct)
+    {
+        _stepGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (ct.Register(() => _stepGate.TrySetCanceled()))
+        {
+            await _stepGate.Task;
+        }
+    }
+}
+#endif

--- a/windows/Ghostty/Demo/DemoPlayer.cs
+++ b/windows/Ghostty/Demo/DemoPlayer.cs
@@ -27,6 +27,7 @@ internal sealed class DemoPlayer
     private readonly Func<string, bool> _runCommand; // palette command id -> handled
     private readonly Action<string> _injectRealChar; // real WM_CHAR (keycast-visible)
     private readonly Action _injectRealEnter; // real VK_RETURN
+    private readonly Action<bool> _setInjecting; // gate the abort/step/pause keys
     private readonly Action<string, int?, int?> _showCaption; // text, stepIndex, stepTotal
     private readonly Action _hideOverlay;
     private readonly ILogger _log;
@@ -45,6 +46,7 @@ internal sealed class DemoPlayer
         Func<string, bool> runCommand,
         Action<string> injectRealChar,
         Action injectRealEnter,
+        Action<bool> setInjecting,
         Action<string, int?, int?> showCaption,
         Action hideOverlay,
         ILogger log)
@@ -56,6 +58,7 @@ internal sealed class DemoPlayer
         _runCommand = runCommand;
         _injectRealChar = injectRealChar;
         _injectRealEnter = injectRealEnter;
+        _setInjecting = setInjecting;
         _showCaption = showCaption;
         _hideOverlay = hideOverlay;
         _log = log;
@@ -184,9 +187,23 @@ internal sealed class DemoPlayer
                 // Like "type", but injects REAL key events (WM_CHAR / VK), so
                 // features that observe the input pipeline (e.g. Pro keycast) see
                 // them. Requires the window to be focused/foreground.
-                await TypeRealAsync(beat.Text ?? "", beat.TypeDelayMs ?? script.TypeDelayMs, ct);
-                if (beat.Enter)
-                    _injectRealEnter();
+                //
+                // The injected keys are real, so the demo's own abort/step/pause
+                // handler (OnDemoKeyDown) would otherwise observe them -- an
+                // injected Space would Step and be swallowed. Gate that handler
+                // for the beat's duration plus a short drain for the last events.
+                _setInjecting(true);
+                try
+                {
+                    await TypeRealAsync(beat.Text ?? "", beat.TypeDelayMs ?? script.TypeDelayMs, ct);
+                    if (beat.Enter)
+                        _injectRealEnter();
+                    await Task.Delay(80, ct);
+                }
+                finally
+                {
+                    _setInjecting(false);
+                }
                 break;
 
             case "wait":

--- a/windows/Ghostty/Demo/DemoPlayer.cs
+++ b/windows/Ghostty/Demo/DemoPlayer.cs
@@ -24,6 +24,9 @@ internal sealed class DemoPlayer
     private readonly Action<string> _invokeBinding;
     private readonly Action<string> _injectText;
     private readonly Action<string, string> _applyConfig; // config key, value
+    private readonly Func<string, bool> _runCommand; // palette command id -> handled
+    private readonly Action<string> _injectRealChar; // real WM_CHAR (keycast-visible)
+    private readonly Action _injectRealEnter; // real VK_RETURN
     private readonly Action<string, int?, int?> _showCaption; // text, stepIndex, stepTotal
     private readonly Action _hideOverlay;
     private readonly ILogger _log;
@@ -39,6 +42,9 @@ internal sealed class DemoPlayer
         Action<string> invokeBinding,
         Action<string> injectText,
         Action<string, string> applyConfig,
+        Func<string, bool> runCommand,
+        Action<string> injectRealChar,
+        Action injectRealEnter,
         Action<string, int?, int?> showCaption,
         Action hideOverlay,
         ILogger log)
@@ -47,6 +53,9 @@ internal sealed class DemoPlayer
         _invokeBinding = invokeBinding;
         _injectText = injectText;
         _applyConfig = applyConfig;
+        _runCommand = runCommand;
+        _injectRealChar = injectRealChar;
+        _injectRealEnter = injectRealEnter;
         _showCaption = showCaption;
         _hideOverlay = hideOverlay;
         _log = log;
@@ -162,6 +171,24 @@ internal sealed class DemoPlayer
                     _log.LogWarning("Demo: config beat needs 'key' and 'value', skipping.");
                 break;
 
+            case "command":
+                // Fire a palette command by id (for command-only features with no
+                // PaneAction, e.g. Pro sessions "shell:open_sessions").
+                if (string.IsNullOrWhiteSpace(beat.Key))
+                    _log.LogWarning("Demo: command beat missing 'key' (command id), skipping.");
+                else if (!_runCommand(beat.Key))
+                    _log.LogWarning("Demo: command id '{Key}' not found, skipping.", beat.Key);
+                break;
+
+            case "keys":
+                // Like "type", but injects REAL key events (WM_CHAR / VK), so
+                // features that observe the input pipeline (e.g. Pro keycast) see
+                // them. Requires the window to be focused/foreground.
+                await TypeRealAsync(beat.Text ?? "", beat.TypeDelayMs ?? script.TypeDelayMs, ct);
+                if (beat.Enter)
+                    _injectRealEnter();
+                break;
+
             case "wait":
                 await DelayWithPauseAsync(beat.Ms ?? 0, ct);
                 break;
@@ -180,6 +207,19 @@ internal sealed class DemoPlayer
         {
             ct.ThrowIfCancellationRequested();
             _injectText(rune.ToString());
+            if (perCharMs > 0)
+                await Task.Delay(perCharMs, ct);
+        }
+    }
+
+    // Same hand-typed animation as TypeAsync, but each char is a REAL injected
+    // keystroke (WM_CHAR) so the input pipeline observes it (Pro keycast chips).
+    private async Task TypeRealAsync(string text, int perCharMs, CancellationToken ct)
+    {
+        foreach (var rune in text.EnumerateRunes())
+        {
+            ct.ThrowIfCancellationRequested();
+            _injectRealChar(rune.ToString());
             if (perCharMs > 0)
                 await Task.Delay(perCharMs, ct);
         }

--- a/windows/Ghostty/Demo/demo.sample.json
+++ b/windows/Ghostty/Demo/demo.sample.json
@@ -1,0 +1,21 @@
+{
+  "title": "Wintty feature tour",
+  "typeDelayMs": 45,
+  "beatGapMs": 800,
+  "beats": [
+    { "type": "caption", "text": "Welcome to Wintty", "durationMs": 2000 },
+    { "type": "type",    "text": "echo hello from wintty", "enter": true },
+    { "type": "wait",    "ms": 1000 },
+    { "type": "caption", "text": "Splitting panes" },
+    { "type": "action",  "key": "split_vertical" },
+    { "type": "type",    "text": "ls", "enter": true },
+    { "type": "wait",    "ms": 1200 },
+    { "type": "caption", "text": "Clearing the screen" },
+    { "type": "binding", "action": "clear_screen" },
+    { "type": "caption", "text": "Drop-down quake terminal" },
+    { "type": "action",  "key": "toggle_quick_terminal" },
+    { "type": "wait",    "ms": 1500 },
+    { "type": "action",  "key": "toggle_quick_terminal" },
+    { "type": "caption", "text": "Thanks for watching", "durationMs": 2500 }
+  ]
+}

--- a/windows/Ghostty/Demo/demo.sample.json
+++ b/windows/Ghostty/Demo/demo.sample.json
@@ -1,21 +1,97 @@
 {
   "title": "Wintty feature tour",
-  "typeDelayMs": 45,
-  "beatGapMs": 800,
+  "typeDelayMs": 40,
+  "beatGapMs": 750,
+
+  "_comment": "OSS feature showcase. Note: 'config' beats write to your config file and persist (theme/opacity); record with a throwaway XDG_CONFIG_HOME if you don't want that. Shell-output beats use pwsh and [char]27 for ESC.",
+
   "beats": [
-    { "type": "caption", "text": "Welcome to Wintty", "durationMs": 2000 },
-    { "type": "type",    "text": "echo hello from wintty", "enter": true },
-    { "type": "wait",    "ms": 1000 },
-    { "type": "caption", "text": "Splitting panes" },
-    { "type": "action",  "key": "split_vertical" },
-    { "type": "type",    "text": "ls", "enter": true },
-    { "type": "wait",    "ms": 1200 },
-    { "type": "caption", "text": "Clearing the screen" },
-    { "type": "binding", "action": "clear_screen" },
+    { "type": "caption", "text": "Welcome to Wintty", "durationMs": 2200 },
+    { "type": "type", "text": "echo hello from wintty", "enter": true },
+    { "type": "wait", "ms": 900 },
+
+    { "type": "caption", "text": "Split panes any direction" },
+    { "type": "action", "key": "split_vertical" },
+    { "type": "type", "text": "ls", "enter": true },
+    { "type": "wait", "ms": 700 },
+    { "type": "action", "key": "split_horizontal" },
+    { "type": "type", "text": "Get-Date", "enter": true },
+    { "type": "wait", "ms": 800 },
+
+    { "type": "caption", "text": "Equalize, then zoom one pane" },
+    { "type": "action", "key": "equalize_splits" },
+    { "type": "wait", "ms": 900 },
+    { "type": "action", "key": "toggle_split_zoom" },
+    { "type": "wait", "ms": 1300 },
+    { "type": "action", "key": "toggle_split_zoom" },
+    { "type": "wait", "ms": 700 },
+
+    { "type": "caption", "text": "Tabs, horizontal or vertical" },
+    { "type": "action", "key": "new_tab" },
+    { "type": "type", "text": "echo a fresh tab", "enter": true },
+    { "type": "wait", "ms": 700 },
+    { "type": "action", "key": "toggle_tab_layout" },
+    { "type": "wait", "ms": 1400 },
+    { "type": "action", "key": "toggle_tab_layout" },
+    { "type": "wait", "ms": 600 },
+
+    { "type": "caption", "text": "See every tab at a glance" },
+    { "type": "action", "key": "show_tab_overview" },
+    { "type": "wait", "ms": 1800 },
+    { "type": "key", "chord": "escape" },
+    { "type": "wait", "ms": 500 },
+
     { "type": "caption", "text": "Drop-down quake terminal" },
-    { "type": "action",  "key": "toggle_quick_terminal" },
-    { "type": "wait",    "ms": 1500 },
-    { "type": "action",  "key": "toggle_quick_terminal" },
-    { "type": "caption", "text": "Thanks for watching", "durationMs": 2500 }
+    { "type": "action", "key": "toggle_quick_terminal" },
+    { "type": "wait", "ms": 1500 },
+    { "type": "action", "key": "toggle_quick_terminal" },
+    { "type": "wait", "ms": 600 },
+
+    { "type": "caption", "text": "Built-in terminal inspector" },
+    { "type": "action", "key": "toggle_inspector" },
+    { "type": "wait", "ms": 1800 },
+    { "type": "action", "key": "toggle_inspector" },
+    { "type": "wait", "ms": 600 },
+
+    { "type": "caption", "text": "Switch themes live" },
+    { "type": "config", "key": "theme", "value": "dracula" },
+    { "type": "wait", "ms": 1600 },
+    { "type": "config", "key": "theme", "value": "catppuccin-mocha" },
+    { "type": "wait", "ms": 1600 },
+
+    { "type": "caption", "text": "Transparency, your way" },
+    { "type": "config", "key": "background-opacity", "value": "0.82" },
+    { "type": "wait", "ms": 1600 },
+    { "type": "config", "key": "background-opacity", "value": "1.00" },
+    { "type": "wait", "ms": 600 },
+
+    { "type": "caption", "text": "Scale the text instantly" },
+    { "type": "binding", "action": "increase_font_size:2" },
+    { "type": "wait", "ms": 1200 },
+    { "type": "binding", "action": "reset_font_size" },
+    { "type": "wait", "ms": 600 },
+
+    { "type": "caption", "text": "Window titles, progress, toasts" },
+    { "type": "type", "text": "$e=[char]27; Write-Host \"$e]2;Wintty by deblasis$([char]7)\"", "enter": true },
+    { "type": "wait", "ms": 900 },
+    { "type": "type", "text": "$e=[char]27; 1..100 | % { Write-Host -NoNewline \"$e]9;4;1;$_$([char]7)\"; Start-Sleep -Milliseconds 20 }", "enter": true },
+    { "type": "wait", "ms": 1400 },
+    { "type": "type", "text": "$e=[char]27; Write-Host \"$e]9;Demo finished building$([char]7)\"", "enter": true },
+    { "type": "wait", "ms": 1200 },
+
+    { "type": "caption", "text": "Search your scrollback" },
+    { "type": "action", "key": "open_search" },
+    { "type": "wait", "ms": 1400 },
+    { "type": "key", "chord": "escape" },
+    { "type": "wait", "ms": 500 },
+
+    { "type": "caption", "text": "Undo and redo pane edits" },
+    { "type": "action", "key": "undo" },
+    { "type": "wait", "ms": 1100 },
+    { "type": "action", "key": "redo" },
+    { "type": "wait", "ms": 900 },
+
+    { "type": "binding", "action": "clear_screen" },
+    { "type": "caption", "text": "That's Wintty", "durationMs": 2600 }
   ]
 }

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -253,7 +253,7 @@
     non-demo build, leaking the type. Exclude both from non-demo builds so
     public Release binaries carry zero demo bytes.
   -->
-  <ItemGroup Condition="!$(DefineConstants.Contains('DEMO'))">
+  <ItemGroup Condition="'$(DemoEnabled)' != 'true'">
     <Page Remove="Demo\DemoOverlay.xaml" />
     <Compile Remove="Demo\**\*.cs" />
   </ItemGroup>
@@ -263,7 +263,7 @@
     works without setting WINTTY_DEMO. The resolver looks for "demo.json", so
     rename or point WINTTY_DEMO at this sample. Public builds never copy it.
   -->
-  <ItemGroup Condition="$(DefineConstants.Contains('DEMO'))">
+  <ItemGroup Condition="'$(DemoEnabled)' == 'true'">
     <None Update="Demo\demo.sample.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -247,6 +247,27 @@
   </ItemGroup>
 
   <!--
+    Demo mode files compile only when the DEMO constant is set (see
+    windows/Directory.Build.props). The *.cs are self-gated with #if DEMO, but
+    the XAML toolchain would still generate a g.cs for DemoOverlay.xaml in a
+    non-demo build, leaking the type. Exclude both from non-demo builds so
+    public Release binaries carry zero demo bytes.
+  -->
+  <ItemGroup Condition="!$(DefineConstants.Contains('DEMO'))">
+    <Page Remove="Demo\DemoOverlay.xaml" />
+    <Compile Remove="Demo\**\*.cs" />
+  </ItemGroup>
+
+  <!--
+    Copy the sample script beside the exe in demo builds so a bare "Start Demo"
+    works without setting WINTTY_DEMO. The resolver looks for "demo.json", so
+    rename or point WINTTY_DEMO at this sample. Public builds never copy it.
+  -->
+  <ItemGroup Condition="$(DefineConstants.Contains('DEMO'))">
+    <None Update="Demo\demo.sample.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!--
     Fail the build (do not just warn) when ghostty.dll is missing. The
     Condition="Exists(...)" on the <None Include> above is evaluated at
     MSBuild project-load time, not target-execution time, so a missing

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -202,6 +202,7 @@ public sealed partial class MainWindow : Window
 #if DEMO
     private Ghostty.Demo.DemoPlayer? _demoPlayer;
     private Ghostty.Demo.DemoOverlay? _demoOverlay;
+    private Windows.UI.Input.Preview.Injection.InputInjector? _demoInjector;
 #endif
 
     // Last libghostty-computed default window size (initial_size action), in
@@ -2942,6 +2943,64 @@ public sealed partial class MainWindow : Window
         _configWriter.Write(() => _configEditor.SetValue(key, value), key);
     }
 
+    // Run a command-palette command by id without opening the palette. Lets the
+    // demo "command" beat fire palette-only commands that have no PaneAction
+    // (e.g. Pro "shell:open_sessions"). Returns false if no such command exists.
+    private bool RunDemoCommand(string id) => _commandPaletteVm?.TryExecuteById(id) ?? false;
+
+    // Inject REAL keystrokes (not SurfaceText) so features watching the WinUI
+    // input pipeline observe them (e.g. Pro keycast chips). Goes to the focused
+    // surface, which is correct during a recording. Chars are injected as Unicode
+    // (WM_CHAR); special keys as virtual-key down/up.
+    private Windows.UI.Input.Preview.Injection.InputInjector? DemoInjector =>
+        _demoInjector ??= Windows.UI.Input.Preview.Injection.InputInjector.TryCreate();
+
+    // SAFETY: InjectKeyboardInput is global -- it reaches whatever window is
+    // foreground. Never inject unless OUR window is foreground, so the demo can
+    // never leak keystrokes into another app (e.g. while focus is elsewhere).
+    private bool DemoWindowIsForeground()
+    {
+        var hwnd = new HWND(WindowNative.GetWindowHandle(this));
+        return PInvoke.GetForegroundWindow() == hwnd;
+    }
+
+    private void InjectRealChar(string s)
+    {
+        var injector = DemoInjector;
+        if (injector is null || !DemoWindowIsForeground()) return;
+        foreach (var ch in s)
+        {
+            var down = new Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo
+            {
+                ScanCode = ch,
+                KeyOptions = Windows.UI.Input.Preview.Injection.InjectedInputKeyOptions.Unicode,
+            };
+            var up = new Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo
+            {
+                ScanCode = ch,
+                KeyOptions = Windows.UI.Input.Preview.Injection.InjectedInputKeyOptions.Unicode
+                    | Windows.UI.Input.Preview.Injection.InjectedInputKeyOptions.KeyUp,
+            };
+            injector.InjectKeyboardInput(new[] { down, up });
+        }
+    }
+
+    private void InjectRealEnter()
+    {
+        var injector = DemoInjector;
+        if (injector is null || !DemoWindowIsForeground()) return;
+        var down = new Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo
+        {
+            VirtualKey = (ushort)Windows.System.VirtualKey.Enter,
+        };
+        var up = new Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo
+        {
+            VirtualKey = (ushort)Windows.System.VirtualKey.Enter,
+            KeyOptions = Windows.UI.Input.Preview.Injection.InjectedInputKeyOptions.KeyUp,
+        };
+        injector.InjectKeyboardInput(new[] { down, up });
+    }
+
     // Lazily build the overlay (spanning the whole root grid) and the player.
     private Ghostty.Demo.DemoPlayer EnsureDemoPlayer()
     {
@@ -2957,6 +3016,9 @@ public sealed partial class MainWindow : Window
             invokeBinding: ExecuteBindingAction,
             injectText: InjectDemoText,
             applyConfig: ApplyDemoConfig,
+            runCommand: RunDemoCommand,
+            injectRealChar: InjectRealChar,
+            injectRealEnter: InjectRealEnter,
             showCaption: (text, idx, total) => _demoOverlay!.ShowCaption(text, idx, total),
             hideOverlay: () => _demoOverlay!.Hide(),
             log: App.LoggerFactory?.CreateLogger("Demo")

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -203,6 +203,9 @@ public sealed partial class MainWindow : Window
     private Ghostty.Demo.DemoPlayer? _demoPlayer;
     private Ghostty.Demo.DemoOverlay? _demoOverlay;
     private Windows.UI.Input.Preview.Injection.InputInjector? _demoInjector;
+    // True while a "keys" beat is injecting real keystrokes; suppresses the
+    // demo's own abort/step/pause handler so injected keys aren't consumed.
+    private volatile bool _demoInjecting;
 #endif
 
     // Last libghostty-computed default window size (initial_size action), in
@@ -325,6 +328,18 @@ public sealed partial class MainWindow : Window
                 new Microsoft.UI.Xaml.Input.KeyEventHandler(OnDemoKeyDown),
                 handledEventsToo: true);
         }
+
+        // If the window loses focus while a demo runs, abort it. The "keys" beat
+        // injects global input, so a recording that switches away should stop
+        // rather than keep puppeting (and never risk input landing elsewhere).
+        Activated += (_, args) =>
+        {
+            if (args.WindowActivationState == Microsoft.UI.Xaml.WindowActivationState.Deactivated
+                && _demoPlayer is { IsRunning: true })
+            {
+                _demoPlayer.Abort();
+            }
+        };
 
         // Hands-free recording: WINTTY_DEMO_AUTOSTART=auto|stepped plays the demo
         // a few seconds after launch, so you can hit record then start the app.
@@ -2968,6 +2983,9 @@ public sealed partial class MainWindow : Window
     {
         var injector = DemoInjector;
         if (injector is null || !DemoWindowIsForeground()) return;
+        // Iterate UTF-16 code units: Unicode injection wants the surrogate pair
+        // of a non-BMP rune as two separate ScanCode events, which is exactly
+        // what enumerating chars produces.
         foreach (var ch in s)
         {
             var down = new Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo
@@ -3019,6 +3037,7 @@ public sealed partial class MainWindow : Window
             runCommand: RunDemoCommand,
             injectRealChar: InjectRealChar,
             injectRealEnter: InjectRealEnter,
+            setInjecting: v => _demoInjecting = v,
             showCaption: (text, idx, total) => _demoOverlay!.ShowCaption(text, idx, total),
             hideOverlay: () => _demoOverlay!.Hide(),
             log: App.LoggerFactory?.CreateLogger("Demo")
@@ -3069,6 +3088,10 @@ public sealed partial class MainWindow : Window
     private void OnDemoKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
     {
         if (_demoPlayer is null || !_demoPlayer.IsRunning) return;
+
+        // Ignore keys while a "keys" beat is injecting: those events are the
+        // demo's own synthetic input, not the operator's abort/step/pause.
+        if (_demoInjecting) return;
 
         switch (e.Key)
         {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2917,6 +2917,15 @@ public sealed partial class MainWindow : Window
         }
     }
 
+    // Write a config key=value and reload, so the demo can showcase appearance
+    // settings (theme, opacity, gradients, fonts, ...) that have no action. Same
+    // write+reload path AdjustOpacity uses; the change persists in the config
+    // file, which is fine for a throwaway recording profile.
+    private void ApplyDemoConfig(string key, string value)
+    {
+        _configWriter.Write(() => _configEditor.SetValue(key, value), key);
+    }
+
     // Lazily build the overlay (spanning the whole root grid) and the player.
     private Ghostty.Demo.DemoPlayer EnsureDemoPlayer()
     {
@@ -2931,6 +2940,7 @@ public sealed partial class MainWindow : Window
             invokeAction: action => _router.Invoke(action),
             invokeBinding: ExecuteBindingAction,
             injectText: InjectDemoText,
+            applyConfig: ApplyDemoConfig,
             showCaption: (text, idx, total) => _demoOverlay!.ShowCaption(text, idx, total),
             hideOverlay: () => _demoOverlay!.Hide(),
             log: App.LoggerFactory?.CreateLogger("Demo")

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -199,6 +199,10 @@ public sealed partial class MainWindow : Window
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
     private Controls.TerminalControl? _previousFocusSurface;
+#if DEMO
+    private Ghostty.Demo.DemoPlayer? _demoPlayer;
+    private Ghostty.Demo.DemoOverlay? _demoOverlay;
+#endif
 
     // Last libghostty-computed default window size (initial_size action), in
     // physical pixels. null until received; reset_window_size is a no-op
@@ -308,6 +312,19 @@ public sealed partial class MainWindow : Window
         Ghostty.Core.Session.WindowSession? restore = null)
     {
         InitializeComponent();
+
+#if DEMO
+        // Demo mode key handling: while a demo runs, Esc aborts, Space/Right
+        // step (stepped mode), P toggles pause (auto mode). handledEventsToo
+        // so these are seen even if the focused terminal marks them handled.
+        if (this.Content is Microsoft.UI.Xaml.UIElement demoRoot)
+        {
+            demoRoot.AddHandler(
+                Microsoft.UI.Xaml.UIElement.KeyDownEvent,
+                new Microsoft.UI.Xaml.Input.KeyEventHandler(OnDemoKeyDown),
+                handledEventsToo: true);
+        }
+#endif
 
         IsQuickTerminal = isQuickTerminal;
 
@@ -2757,6 +2774,13 @@ public sealed partial class MainWindow : Window
 
         var sources = new List<ICommandSource> { builtIn, jump, config, version };
 
+#if DEMO
+        // Demo entries appear only when WINTTY_DEMO is set, so a demo build with
+        // the var unset leaves the palette unchanged.
+        if (Environment.GetEnvironmentVariable("WINTTY_DEMO") is not null)
+            sources.Add(new DemoCommandSource(StartDemo));
+#endif
+
         // Null-check App services as a defensive belt (cold-start where App.ProfileRegistry
         // isn't wired yet would skip the source entirely; ProfileCommandSource itself
         // returns an empty list when its registry has no profiles).
@@ -2865,6 +2889,109 @@ public sealed partial class MainWindow : Window
             }
         }
     }
+
+#if DEMO
+    // Inject raw UTF-8 text into the active surface, exactly as typed input
+    // would arrive via SurfaceText. Used by the demo player for "type"/"key".
+    private void InjectDemoText(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return;
+
+        var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
+        if (leaf is null) return;
+
+        var surfaceHandle = leaf.Terminal().SurfaceHandle;
+        if (surfaceHandle == IntPtr.Zero) return;
+
+        var surface = new GhosttySurface(surfaceHandle);
+        var bytes = Encoding.UTF8.GetBytes(text);
+        unsafe
+        {
+            fixed (byte* p = bytes)
+            {
+                NativeMethods.SurfaceText(surface, (IntPtr)p, (UIntPtr)bytes.Length);
+            }
+        }
+    }
+
+    // Lazily build the overlay (spanning the whole root grid) and the player.
+    private Ghostty.Demo.DemoPlayer EnsureDemoPlayer()
+    {
+        if (_demoPlayer is not null) return _demoPlayer;
+
+        _demoOverlay = new Ghostty.Demo.DemoOverlay();
+        RootGrid.Children.Add(_demoOverlay);
+        Microsoft.UI.Xaml.Controls.Grid.SetRowSpan(_demoOverlay, 99);
+        Microsoft.UI.Xaml.Controls.Grid.SetColumnSpan(_demoOverlay, 99);
+
+        _demoPlayer = new Ghostty.Demo.DemoPlayer(
+            invokeAction: action => _router.Invoke(action),
+            invokeBinding: ExecuteBindingAction,
+            injectText: InjectDemoText,
+            showCaption: (text, idx, total) => _demoOverlay!.ShowCaption(text, idx, total),
+            hideOverlay: () => _demoOverlay!.Hide(),
+            log: App.LoggerFactory?.CreateLogger("Demo")
+                ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+        return _demoPlayer;
+    }
+
+    private async void StartDemo(Ghostty.Core.Demo.DemoMode mode)
+    {
+        // Guard at entry, not just inside RunAsync: a fast double-trigger would
+        // otherwise start two script reads before the first sets IsRunning.
+        if (_demoPlayer is { IsRunning: true }) return;
+
+        var exeDir = AppContext.BaseDirectory;
+        var configDir = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
+            ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var envValue = Environment.GetEnvironmentVariable("WINTTY_DEMO");
+
+        var path = Ghostty.Core.Demo.DemoScriptParser.ResolveScriptPath(
+            envValue, exeDir, configDir, System.IO.File.Exists);
+
+        var player = EnsureDemoPlayer();
+        if (path is null)
+        {
+            _demoOverlay!.ShowCaption("No demo script found (set WINTTY_DEMO to a .json path)");
+            return;
+        }
+
+        try
+        {
+            var json = await System.IO.File.ReadAllTextAsync(path);
+            var script = Ghostty.Core.Demo.DemoScriptParser.Parse(json);
+            await player.RunAsync(script, mode);
+        }
+        catch (Exception ex)
+        {
+            (App.LoggerFactory?.CreateLogger("Demo"))?.LogError(ex, "Failed to start demo.");
+            _demoOverlay!.ShowCaption("Demo script failed to load");
+        }
+    }
+
+    private void OnDemoKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    {
+        if (_demoPlayer is null || !_demoPlayer.IsRunning) return;
+
+        switch (e.Key)
+        {
+            case Windows.System.VirtualKey.Escape:
+                _demoPlayer.Abort();
+                e.Handled = true;
+                break;
+            case Windows.System.VirtualKey.Space:
+            case Windows.System.VirtualKey.Right:
+                _demoPlayer.Step();
+                e.Handled = true;
+                break;
+            case Windows.System.VirtualKey.P:
+                _demoPlayer.TogglePause();
+                e.Handled = true;
+                break;
+        }
+    }
+#endif
 
     // Prevent the delegates from being GC'd while the picker holds pointers.
     private NativeMethods.InlineThemeCallback? _inlineThemeCb;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -324,6 +324,22 @@ public sealed partial class MainWindow : Window
                 new Microsoft.UI.Xaml.Input.KeyEventHandler(OnDemoKeyDown),
                 handledEventsToo: true);
         }
+
+        // Hands-free recording: WINTTY_DEMO_AUTOSTART=auto|stepped plays the demo
+        // a few seconds after launch, so you can hit record then start the app.
+        // The delay lets the first pane's shell come up before the type beats.
+        var autoStart = Environment.GetEnvironmentVariable("WINTTY_DEMO_AUTOSTART");
+        if (!string.IsNullOrEmpty(autoStart))
+        {
+            var mode = autoStart.Equals("stepped", StringComparison.OrdinalIgnoreCase)
+                ? Ghostty.Core.Demo.DemoMode.Stepped
+                : Ghostty.Core.Demo.DemoMode.Auto;
+            var startTimer = DispatcherQueue.CreateTimer();
+            startTimer.Interval = TimeSpan.FromSeconds(3);
+            startTimer.IsRepeating = false;
+            startTimer.Tick += (_, _) => { startTimer.Stop(); StartDemo(mode); };
+            startTimer.Start();
+        }
 #endif
 
         IsQuickTerminal = isQuickTerminal;
@@ -2955,6 +2971,8 @@ public sealed partial class MainWindow : Window
         // otherwise start two script reads before the first sets IsRunning.
         if (_demoPlayer is { IsRunning: true }) return;
 
+        var demoLog = App.LoggerFactory?.CreateLogger("Demo");
+
         // Whole body in try: EnsureDemoPlayer mutates the visual tree, so a
         // throw must not escape as an unhandled async-void exception.
         try
@@ -2966,6 +2984,7 @@ public sealed partial class MainWindow : Window
 
             var path = Ghostty.Core.Demo.DemoScriptParser.ResolveScriptPath(
                 envValue, exeDir, configDir, System.IO.File.Exists);
+            demoLog?.LogInformation("Demo script resolved: env='{Env}' path='{Path}'", envValue, path);
 
             var player = EnsureDemoPlayer();
             if (path is null)
@@ -2980,7 +2999,7 @@ public sealed partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            (App.LoggerFactory?.CreateLogger("Demo"))?.LogError(ex, "Failed to start demo.");
+            demoLog?.LogError(ex, "Failed to start demo.");
             _demoOverlay?.ShowCaption("Demo failed to start (see logs)");
         }
     }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2776,9 +2776,12 @@ public sealed partial class MainWindow : Window
 
 #if DEMO
         // Demo entries appear only when WINTTY_DEMO is set, so a demo build with
-        // the var unset leaves the palette unchanged.
+        // the var unset leaves the palette unchanged. Defer to the next tick so
+        // the palette popup closes before the overlay mutates the visual tree,
+        // matching the other command sources.
         if (Environment.GetEnvironmentVariable("WINTTY_DEMO") is not null)
-            sources.Add(new DemoCommandSource(StartDemo));
+            sources.Add(new DemoCommandSource(
+                mode => DispatcherQueue.TryEnqueue(() => StartDemo(mode))));
 #endif
 
         // Null-check App services as a defensive belt (cold-start where App.ProfileRegistry
@@ -2942,23 +2945,25 @@ public sealed partial class MainWindow : Window
         // otherwise start two script reads before the first sets IsRunning.
         if (_demoPlayer is { IsRunning: true }) return;
 
-        var exeDir = AppContext.BaseDirectory;
-        var configDir = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
-            ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        var envValue = Environment.GetEnvironmentVariable("WINTTY_DEMO");
-
-        var path = Ghostty.Core.Demo.DemoScriptParser.ResolveScriptPath(
-            envValue, exeDir, configDir, System.IO.File.Exists);
-
-        var player = EnsureDemoPlayer();
-        if (path is null)
-        {
-            _demoOverlay!.ShowCaption("No demo script found (set WINTTY_DEMO to a .json path)");
-            return;
-        }
-
+        // Whole body in try: EnsureDemoPlayer mutates the visual tree, so a
+        // throw must not escape as an unhandled async-void exception.
         try
         {
+            var exeDir = AppContext.BaseDirectory;
+            var configDir = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
+                ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var envValue = Environment.GetEnvironmentVariable("WINTTY_DEMO");
+
+            var path = Ghostty.Core.Demo.DemoScriptParser.ResolveScriptPath(
+                envValue, exeDir, configDir, System.IO.File.Exists);
+
+            var player = EnsureDemoPlayer();
+            if (path is null)
+            {
+                _demoOverlay!.ShowCaption("No demo script found (set WINTTY_DEMO to a .json path)");
+                return;
+            }
+
             var json = await System.IO.File.ReadAllTextAsync(path);
             var script = Ghostty.Core.Demo.DemoScriptParser.Parse(json);
             await player.RunAsync(script, mode);
@@ -2966,7 +2971,7 @@ public sealed partial class MainWindow : Window
         catch (Exception ex)
         {
             (App.LoggerFactory?.CreateLogger("Demo"))?.LogError(ex, "Failed to start demo.");
-            _demoOverlay!.ShowCaption("Demo script failed to load");
+            _demoOverlay?.ShowCaption("Demo failed to start (see logs)");
         }
     }
 


### PR DESCRIPTION
Adds a scripted "demo mode" that drives the real app from an external JSON file, so feature-tour videos can be recorded hands-free.

Gating is layered: a `DEMO` compile constant (defined for Debug, or Release with `-p:Demo=true`) keeps all demo code out of public Release builds, and within a demo build the `WINTTY_DEMO` env var must be set for the two palette commands to appear. `WINTTY_DEMO_AUTOSTART=auto|stepped` plays the script a few seconds after launch.

The script is a list of beats run by an async coroutine (`DemoPlayer`):
- `caption` - captioned overlay pill with the tilted logo
- `action` - a PaneAction; `binding` - a libghostty action
- `type` - per-char text via SurfaceText; `key` - a named key
- `config` - write a config key and reload (themes, opacity, fonts)
- `command` - fire a palette command by id
- `keys` - real keystroke injection (InputInjector), guarded so it only fires while this window is foreground
- `wait`

Pure logic (model, parser, path resolution, key/action maps) lives in `Ghostty.Core/Demo/` with unit tests; the player and overlay are in the app project. A sample tour ships in demo builds only.

Verified: public Release builds contain zero demo symbols; Debug builds include them; 21 Core tests pass; config/command beats confirmed live.