### PR TITLE
fix(windows): composite SwapChainPanel via DirectComposition surface handle

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1171,6 +1171,12 @@ GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t)
 // cross-device synchronization issues. Returns NULL on non-DX12 builds or if
 // the renderer device is not yet initialized.
 GHOSTTY_API void* ghostty_surface_get_d3d12_device(ghostty_surface_t);
+// Returns the DirectComposition surface handle backing this surface's swap
+// chain in SwapChainPanel mode. Bind it to a WinUI 3 SwapChainPanel via
+// ISwapChainPanelNative2::SetSwapChainHandle. Returns NULL on non-DX12
+// builds or when the surface is not in SwapChainPanel mode. Ghostty owns
+// the handle for the surface lifetime -- do NOT CloseHandle it.
+GHOSTTY_API void* ghostty_surface_get_swap_chain_handle(ghostty_surface_t);
 
 // Snapshot of the shared-texture state for a surface. All fields are
 // filled in atomically by a single ghostty_surface_shared_texture()

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -369,7 +369,10 @@ pub const Platform = union(PlatformTag) {
     pub const Windows = if (builtin.target.os.tag == .windows) struct {
         /// The HWND to render into, or null for composition/shared texture modes.
         hwnd: ?std.os.windows.HANDLE,
-        /// ISwapChainPanelNative pointer for composition swap chain, or null.
+        /// Non-null selects SwapChainPanel mode. The renderer only checks
+        /// it for null; it no longer binds the panel itself. The embedder
+        /// binds the surface handle from ghostty_surface_get_swap_chain_handle
+        /// via ISwapChainPanelNative2::SetSwapChainHandle.
         swap_chain_panel: ?*anyopaque = null,
         /// Shared-texture surface configuration. Only honoured when
         /// both `hwnd` and `swap_chain_panel` are null and

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2270,6 +2270,19 @@ pub const CAPI = struct {
         return @ptrCast(sc);
     }
 
+    /// Return the DirectComposition surface handle backing this surface's
+    /// swap chain in SwapChainPanel mode. Bind it to a WinUI 3
+    /// SwapChainPanel via ISwapChainPanelNative2::SetSwapChainHandle.
+    /// Returns null on non-DX12 builds or when the surface is not in
+    /// SwapChainPanel mode.
+    export fn ghostty_surface_get_swap_chain_handle(surface: *Surface) ?*anyopaque {
+        if (comptime builtin.os.tag != .windows) return null;
+        const api = surface.core_surface.renderer.api;
+        if (comptime !@hasField(@TypeOf(api), "dev")) return null;
+        const dev = api.dev orelse return null;
+        return @ptrCast(dev.swap_chain_surface_handle orelse return null);
+    }
+
     /// Mirrors ghostty_surface_shared_texture_s in include/ghostty.h.
     const SharedTextureSnapshotC = extern struct {
         resource_handle: ?*anyopaque,

--- a/src/renderer/DirectX12.zig
+++ b/src/renderer/DirectX12.zig
@@ -195,9 +195,12 @@ pub fn init(alloc: Allocator, opts: rendererpkg.Options) !DirectX12 {
 
     const surface: surface_pkg.Surface = if (w.hwnd) |hwnd|
         .{ .hwnd = hwnd }
-    else if (w.swap_chain_panel) |panel|
-        // panel is an opaque COM-compatible pointer from apprt; alignment is guaranteed.
-        .{ .swap_chain_panel = @ptrCast(@alignCast(panel)) }
+    else if (w.swap_chain_panel != null)
+        // Presence of the panel pointer selects SwapChainPanel mode. The
+        // renderer no longer binds the panel itself: it creates a
+        // DirectComposition surface handle + swap chain, and the embedder
+        // binds the handle via ISwapChainPanelNative2::SetSwapChainHandle.
+        .swap_chain_panel
     else if (w.shared_texture.enabled)
         .{ .shared_texture = .{
             .width = w.shared_texture.width,

--- a/src/renderer/directx12/com_test.zig
+++ b/src/renderer/directx12/com_test.zig
@@ -51,6 +51,14 @@ test "ISwapChainPanelNative IID" {
     try std.testing.expectEqualSlices(u8, &iid.data4, &[_]u8{ 0xa2, 0x0c, 0xf6, 0xf1, 0xea, 0x90, 0x55, 0x4b });
 }
 
+test "IDXGIFactoryMedia IID" {
+    const iid = dxgi.IDXGIFactoryMedia.IID;
+    try std.testing.expectEqual(iid.data1, 0x41e7d1f2);
+    try std.testing.expectEqual(iid.data2, 0xa591);
+    try std.testing.expectEqual(iid.data3, 0x4f7b);
+    try std.testing.expectEqualSlices(u8, &iid.data4, &[_]u8{ 0xa2, 0xe5, 0xfa, 0x9c, 0x84, 0x3e, 0x1c, 0x12 });
+}
+
 // Verify DXGI error constants match the Windows SDK values.
 // These are HRESULT codes that cross the COM boundary, so wrong
 // values would silently miss device-loss events.

--- a/src/renderer/directx12/dcomp.zig
+++ b/src/renderer/directx12/dcomp.zig
@@ -108,3 +108,22 @@ pub extern "dcomp" fn DCompositionCreateDevice(
     iid: *const GUID,
     dcompositionDevice: *?*anyopaque,
 ) callconv(.winapi) HRESULT;
+
+/// Access mask passed to DCompositionCreateSurfaceHandle. This value is
+/// not exposed by any public header; DirectComposition's own samples and
+/// Windows Terminal both use it to request full access to the surface
+/// handle.
+pub const COMPOSITIONOBJECT_ALL_ACCESS: u32 = 0x0003;
+
+/// Create a standalone DirectComposition surface handle. A composition
+/// swap chain created against this handle (via
+/// IDXGIFactoryMedia.CreateSwapChainForCompositionSurfaceHandle) can be
+/// bound to a XAML SwapChainPanel through
+/// ISwapChainPanelNative2::SetSwapChainHandle. The handle is the stable
+/// composition primitive: the panel references the handle, not the swap
+/// chain object, so the binding survives ResizeBuffers untouched.
+pub extern "dcomp" fn DCompositionCreateSurfaceHandle(
+    desiredAccess: u32,
+    securityAttributes: ?*anyopaque,
+    surfaceHandle: *std.os.windows.HANDLE,
+) callconv(.winapi) HRESULT;

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -38,6 +38,13 @@ fence_event: std.os.windows.HANDLE,
 
 swap_chain: ?*dxgi.IDXGISwapChain1,
 
+/// DirectComposition surface handle backing the swap chain in
+/// SwapChainPanel mode. Owned by Device: created in init, closed in
+/// deinit. The embedder retrieves it via
+/// ghostty_surface_get_swap_chain_handle and binds it to the panel with
+/// ISwapChainPanelNative2::SetSwapChainHandle. Null in all other modes.
+swap_chain_surface_handle: ?std.os.windows.HANDLE = null,
+
 // DirectComposition objects, only used for HWND surfaces.
 dcomp_device: ?*dcomp.IDCompositionDevice,
 dcomp_target: ?*dcomp.IDCompositionTarget,
@@ -282,6 +289,7 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
 
     // -- Swap chain + composition (surface-dependent) --
     var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
+    var swap_chain_surface_handle: ?std.os.windows.HANDLE = null;
     var dcomp_device_ptr: ?*dcomp.IDCompositionDevice = null;
     var dcomp_target_ptr: ?*dcomp.IDCompositionTarget = null;
     var dcomp_visual_ptr: ?*dcomp.IDCompositionVisual = null;
@@ -322,21 +330,28 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
                 return error.DCompCommitFailed;
             }
         },
-        .swap_chain_panel => |panel| {
-            // SwapChainPanel surface: composition swap chain, panel owns composition.
-            swap_chain = try createCompositionSwapChain(
+        .swap_chain_panel => {
+            // SwapChainPanel surface: present into a DirectComposition
+            // surface handle rather than binding the swap chain object to
+            // the panel directly. The embedder binds the handle via
+            // ISwapChainPanelNative2::SetSwapChainHandle. Binding the
+            // handle (a stable composition primitive) instead of the swap
+            // chain object means DWM composites the panel as soon as the
+            // window is shown -- the direct SetSwapChain path could leave
+            // presented frames uncomposited until the first OS activation
+            // (the blank-until-focus startup race) -- and the binding
+            // survives ResizeBuffers without re-binding.
+            const result = try createSurfaceHandleSwapChain(
                 factory.?,
                 command_queue.?,
                 opts.width,
                 opts.height,
             );
-            errdefer _ = swap_chain.?.Release();
-
-            // Tell the panel about the swap chain.
-            const hr = panel.SetSwapChain(@ptrCast(swap_chain.?));
-            if (FAILED(hr)) {
-                log.err("ISwapChainPanelNative.SetSwapChain failed: 0x{x}", .{@as(u32, @bitCast(hr))});
-                return error.SwapChainPanelBindFailed;
+            swap_chain = result.swap_chain;
+            swap_chain_surface_handle = result.handle;
+            errdefer {
+                _ = swap_chain.?.Release();
+                _ = d3d12.CloseHandle(swap_chain_surface_handle.?);
             }
         },
         .composition => {
@@ -379,6 +394,7 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
         .fence_value = std.atomic.Value(u64).init(0),
         .fence_event = fence_event,
         .swap_chain = swap_chain,
+        .swap_chain_surface_handle = swap_chain_surface_handle,
         .dcomp_device = dcomp_device_ptr,
         .dcomp_target = dcomp_target_ptr,
         .dcomp_visual = dcomp_visual_ptr,
@@ -398,6 +414,9 @@ pub fn deinit(self: *Device) void {
     if (self.dcomp_target) |t| _ = t.Release();
     if (self.dcomp_device) |d| _ = d.Release();
     if (self.swap_chain) |sc| _ = sc.Release();
+    // Close the composition surface handle after releasing the swap
+    // chain that presents into it.
+    if (self.swap_chain_surface_handle) |h| _ = d3d12.CloseHandle(h);
 
     if (self.shared_texture) |st| {
         _ = d3d12.CloseHandle(st.fence_handle);
@@ -516,17 +535,14 @@ fn enableDebugLayer() void {
     }
 }
 
-fn createCompositionSwapChain(
-    factory: *dxgi.IDXGIFactory2,
-    queue: *d3d12.ID3D12CommandQueue,
-    width: u32,
-    height: u32,
-) !*dxgi.IDXGISwapChain1 {
+/// Build the swap-chain description shared by every composition path
+/// (HWND, SwapChainPanel via surface handle, and bare composition).
+fn compositionSwapChainDesc(width: u32, height: u32) dxgi.DXGI_SWAP_CHAIN_DESC1 {
     // DXGI rejects 0-dimension swap chains.
     const actual_width = @max(width, 1);
     const actual_height = @max(height, 1);
 
-    const desc = dxgi.DXGI_SWAP_CHAIN_DESC1{
+    return .{
         .Width = actual_width,
         .Height = actual_height,
         .Format = .B8G8R8A8_UNORM,
@@ -553,6 +569,15 @@ fn createCompositionSwapChain(
         .AlphaMode = .PREMULTIPLIED,
         .Flags = 0,
     };
+}
+
+fn createCompositionSwapChain(
+    factory: *dxgi.IDXGIFactory2,
+    queue: *d3d12.ID3D12CommandQueue,
+    width: u32,
+    height: u32,
+) !*dxgi.IDXGISwapChain1 {
+    const desc = compositionSwapChainDesc(width, height);
 
     var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
     // DX12 passes the command queue (not the device) to swap chain creation.
@@ -567,6 +592,70 @@ fn createCompositionSwapChain(
         return error.SwapChainCreationFailed;
     }
     return swap_chain.?;
+}
+
+const SurfaceHandleSwapChain = struct {
+    swap_chain: *dxgi.IDXGISwapChain1,
+    handle: std.os.windows.HANDLE,
+};
+
+/// Create a DirectComposition surface handle and a composition swap chain
+/// bound to it. The caller owns both: Release the swap chain and
+/// CloseHandle the handle. Used by SwapChainPanel mode so the embedder
+/// can bind the handle via ISwapChainPanelNative2::SetSwapChainHandle.
+fn createSurfaceHandleSwapChain(
+    factory: *dxgi.IDXGIFactory2,
+    queue: *d3d12.ID3D12CommandQueue,
+    width: u32,
+    height: u32,
+) !SurfaceHandleSwapChain {
+    // The composition-surface-handle entry point lives on IDXGIFactoryMedia,
+    // which the factory we already created supports via QueryInterface.
+    var media: ?*dxgi.IDXGIFactoryMedia = null;
+    {
+        const hr = factory.vtable.QueryInterface(
+            factory,
+            &dxgi.IDXGIFactoryMedia.IID,
+            @ptrCast(&media),
+        );
+        if (FAILED(hr)) {
+            log.err("QueryInterface for IDXGIFactoryMedia failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return error.FactoryMediaQueryFailed;
+        }
+    }
+    defer _ = media.?.Release();
+
+    var handle: std.os.windows.HANDLE = undefined;
+    {
+        const hr = dcomp.DCompositionCreateSurfaceHandle(
+            dcomp.COMPOSITIONOBJECT_ALL_ACCESS,
+            null,
+            &handle,
+        );
+        if (FAILED(hr)) {
+            log.err("DCompositionCreateSurfaceHandle failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+            return error.SurfaceHandleCreationFailed;
+        }
+    }
+    errdefer _ = d3d12.CloseHandle(handle);
+
+    const desc = compositionSwapChainDesc(width, height);
+
+    var swap_chain: ?*dxgi.IDXGISwapChain1 = null;
+    // DX12 passes the command queue (not the device) to swap chain creation.
+    const hr = media.?.CreateSwapChainForCompositionSurfaceHandle(
+        @ptrCast(queue),
+        handle,
+        &desc,
+        null,
+        &swap_chain,
+    );
+    if (FAILED(hr)) {
+        log.err("CreateSwapChainForCompositionSurfaceHandle failed: 0x{x}", .{@as(u32, @bitCast(hr))});
+        return error.SwapChainCreationFailed;
+    }
+
+    return .{ .swap_chain = swap_chain.?, .handle = handle };
 }
 
 fn createDCompDevice() !*dcomp.IDCompositionDevice {

--- a/src/renderer/directx12/device.zig
+++ b/src/renderer/directx12/device.zig
@@ -349,10 +349,6 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
             );
             swap_chain = result.swap_chain;
             swap_chain_surface_handle = result.handle;
-            errdefer {
-                _ = swap_chain.?.Release();
-                _ = d3d12.CloseHandle(swap_chain_surface_handle.?);
-            }
         },
         .composition => {
             // Composition surface: create the swap chain but don't bind
@@ -380,7 +376,14 @@ pub fn init(surface: @import("surface.zig").Surface, opts: InitOptions) !Device 
         },
     }
     // Defensive: if a future fallible step lands between here and the
-    // return, this prevents leaking the resource and both NT handles.
+    // return, these prevent leaking the surface handle / swap chain (panel
+    // mode) and the shared resource + both NT handles (shared-texture
+    // mode). swap_chain_surface_handle is only set in panel mode, so this
+    // errdefer is a no-op for the other surface variants.
+    errdefer if (swap_chain_surface_handle) |h| {
+        _ = swap_chain.?.Release();
+        _ = d3d12.CloseHandle(h);
+    };
     errdefer if (result_shared_texture) |st| {
         _ = d3d12.CloseHandle(st.fence_handle);
         _ = d3d12.CloseHandle(st.resource_handle);
@@ -603,6 +606,12 @@ const SurfaceHandleSwapChain = struct {
 /// bound to it. The caller owns both: Release the swap chain and
 /// CloseHandle the handle. Used by SwapChainPanel mode so the embedder
 /// can bind the handle via ISwapChainPanelNative2::SetSwapChainHandle.
+///
+/// Each call mints a fresh surface handle. The embedder binds the handle
+/// to the panel exactly once after surface creation, so any future
+/// device-removed (TDR) recovery that recreates the swap chain must also
+/// mint a new handle here AND have the embedder re-bind it via
+/// SetSwapChainHandle, or the panel would composite a dead handle.
 fn createSurfaceHandleSwapChain(
     factory: *dxgi.IDXGIFactory2,
     queue: *d3d12.ID3D12CommandQueue,

--- a/src/renderer/directx12/dxgi.zig
+++ b/src/renderer/directx12/dxgi.zig
@@ -608,6 +608,60 @@ pub const IDXGIFactory2 = extern struct {
     }
 };
 
+// IDXGIFactoryMedia
+// QI'd from the IDXGIFactory2 we already create. Exposes the
+// composition-surface-handle swap chain entry point used by the
+// SwapChainPanel path.
+pub const IDXGIFactoryMedia = extern struct {
+    vtable: *const VTable,
+
+    pub const IID = GUID{
+        .data1 = 0x41e7d1f2,
+        .data2 = 0xa591,
+        .data3 = 0x4f7b,
+        .data4 = .{ 0xa2, 0xe5, 0xfa, 0x9c, 0x84, 0x3e, 0x1c, 0x12 },
+    };
+
+    pub const VTable = extern struct {
+        // IUnknown
+        QueryInterface: *const fn (*IDXGIFactoryMedia, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IDXGIFactoryMedia) callconv(.winapi) u32,
+        Release: *const fn (*IDXGIFactoryMedia) callconv(.winapi) u32,
+        // IDXGIFactoryMedia
+        CreateSwapChainForCompositionSurfaceHandle: *const fn (
+            self: *IDXGIFactoryMedia,
+            pDevice: *IUnknown,
+            hSurface: HWND,
+            pDesc: *const DXGI_SWAP_CHAIN_DESC1,
+            pRestrictToOutput: ?*anyopaque, // IDXGIOutput, nullable
+            ppSwapChain: *?*IDXGISwapChain1,
+        ) callconv(.winapi) HRESULT,
+        CreateDecodeSwapChainForCompositionSurfaceHandle: Reserved,
+    };
+
+    pub inline fn CreateSwapChainForCompositionSurfaceHandle(
+        self: *IDXGIFactoryMedia,
+        device: *IUnknown,
+        surface: HWND,
+        desc: *const DXGI_SWAP_CHAIN_DESC1,
+        restrict_to_output: ?*anyopaque,
+        swap_chain: *?*IDXGISwapChain1,
+    ) HRESULT {
+        return self.vtable.CreateSwapChainForCompositionSurfaceHandle(
+            self,
+            device,
+            surface,
+            desc,
+            restrict_to_output,
+            swap_chain,
+        );
+    }
+
+    pub inline fn Release(self: *IDXGIFactoryMedia) u32 {
+        return self.vtable.Release(self);
+    }
+};
+
 // ISwapChainPanelNative
 pub const ISwapChainPanelNative = extern struct {
     vtable: *const VTable,

--- a/src/renderer/directx12/surface.zig
+++ b/src/renderer/directx12/surface.zig
@@ -2,7 +2,11 @@
 //!
 //! The renderer supports four surface modes at the library level:
 //! - HWND: for standalone windows and test harnesses
-//! - SwapChainPanel: for WinUI 3 / XAML composition hosts (opaque)
+//! - SwapChainPanel: for WinUI 3 / XAML composition hosts. The renderer
+//!   creates a DirectComposition surface handle and a swap chain bound to
+//!   it; the embedder retrieves the handle via
+//!   ghostty_surface_get_swap_chain_handle and binds it to the panel with
+//!   ISwapChainPanelNative2::SetSwapChainHandle.
 //! - Composition: swap chain created but not bound; embedder retrieves
 //!   the pointer and binds it to a Windows.UI.Composition visual for
 //!   per-pixel alpha transparency
@@ -13,7 +17,7 @@ pub const HWND = dxgi.HWND;
 
 pub const Surface = union(enum) {
     hwnd: HWND,
-    swap_chain_panel: *dxgi.ISwapChainPanelNative,
+    swap_chain_panel: void,
     composition: void,
     shared_texture: SharedTextureConfig,
 };

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -530,6 +530,15 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         SwapChainPanelInterop.Release(panelPtr);
         Host.Register(_surface, this);
 
+        // Bind the renderer's DirectComposition surface handle to the
+        // panel. libghostty presents into this handle; binding it (rather
+        // than the swap chain object) lets DWM composite the panel as soon
+        // as the window is shown, avoiding the blank-until-focus startup
+        // race, and keeps the binding valid across resizes.
+        var swapChainHandle = NativeMethods.SurfaceGetSwapChainHandle(_surface);
+        if (swapChainHandle != IntPtr.Zero)
+            SwapChainPanelInterop.SetSwapChainHandle(Panel, swapChainHandle);
+
         // Request focus so keyboard input starts flowing immediately.
         // Focus lives on the UserControl now, not the panel.
         this.Focus(FocusState.Programmatic);

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -9,6 +9,7 @@ using Ghostty.Core.Search;
 using Ghostty.Hosting;
 using Ghostty.Input;
 using Ghostty.Interop;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -535,9 +536,29 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // than the swap chain object) lets DWM composite the panel as soon
         // as the window is shown, avoiding the blank-until-focus startup
         // race, and keeps the binding valid across resizes.
+        //
+        // Best-effort: a bind failure must not abort surface setup, since
+        // the surface is already created and registered above. Worst case
+        // the panel composites on the next OS activation (the pre-fix
+        // behavior), so log and continue rather than throwing.
         var swapChainHandle = NativeMethods.SurfaceGetSwapChainHandle(_surface);
-        if (swapChainHandle != IntPtr.Zero)
-            SwapChainPanelInterop.SetSwapChainHandle(Panel, swapChainHandle);
+        if (swapChainHandle == IntPtr.Zero)
+        {
+            Ghostty.Logging.StaticLoggers.App.LogWarning(
+                "SwapChainPanel surface handle was null; panel left unbound");
+        }
+        else
+        {
+            try
+            {
+                SwapChainPanelInterop.SetSwapChainHandle(Panel, swapChainHandle);
+            }
+            catch (Exception ex)
+            {
+                Ghostty.Logging.StaticLoggers.App.LogWarning(
+                    "Binding swap-chain handle to panel failed: {Message}", ex.Message);
+            }
+        }
 
         // Request focus so keyboard input starts flowing immediately.
         // Focus lives on the UserControl now, not the panel.

--- a/windows/Ghostty/Interop/ISwapChainPanelNative.cs
+++ b/windows/Ghostty/Interop/ISwapChainPanelNative.cs
@@ -86,7 +86,11 @@ internal static class SwapChainPanelInterop
             unsafe
             {
                 var vtbl = *(IntPtr*)ppv;
-                // slot 4: SetSwapChainHandle(HANDLE swapChainHandle)
+                // slot 4: SetSwapChainHandle(HANDLE swapChainHandle). Read
+                // the slot as a raw pointer and invoke it directly on
+                // purpose: a [GeneratedComInterface]/ComWrappers projection
+                // would reintroduce the marshalling layer this whole file
+                // avoids for NativeAOT trim-safety.
                 var setSwapChainHandle =
                     (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>)(*((IntPtr*)vtbl + 4));
                 var shr = setSwapChainHandle(ppv, swapChainHandle);

--- a/windows/Ghostty/Interop/ISwapChainPanelNative.cs
+++ b/windows/Ghostty/Interop/ISwapChainPanelNative.cs
@@ -1,18 +1,23 @@
 // COM interop for Microsoft.UI.Xaml.Controls.SwapChainPanel. The managed
-// SwapChainPanel type does not expose a way to attach a native swap chain
-// directly, so we QueryInterface for ISwapChainPanelNative and call
-// SetSwapChain(IDXGISwapChain*) manually.
+// SwapChainPanel type does not expose a way to attach a native swap chain,
+// so we QueryInterface for the native interop interfaces and call them
+// manually.
 //
-// libghostty's Windows renderer lives inside ghostty.dll and uses the panel
-// handle we pass via ghostty_surface_config_s.platform.windows.swap_chain_panel.
-// We hand it the IUnknown* of the panel (which is QI-able to
-// ISwapChainPanelNative), so nothing on the C# side actually calls
-// SetSwapChain - but we keep the interface here for any case where the
-// shell needs to present its own swap chain (overlays, inspector, etc).
+// libghostty's Windows renderer (inside ghostty.dll) presents into a
+// DirectComposition surface handle rather than binding a swap chain object
+// to the panel. We pass the panel via
+// ghostty_surface_config_s.platform.windows.swap_chain_panel purely as the
+// mode selector (the renderer only checks it for non-null), then after the
+// surface is created we fetch the surface handle with
+// ghostty_surface_get_swap_chain_handle and hand it to the panel via
+// ISwapChainPanelNative2::SetSwapChainHandle. Binding the handle instead of
+// the swap chain object lets DWM composite the panel as soon as the window
+// is shown and keeps the binding valid across ResizeBuffers.
 //
 // hand-written: WinUI 3 SwapChainPanel responds to the legacy XAML interop
-// IID 63aad0b8-7c24-40ff-85a8-640d944cc325, which CsWin32-generated bindings
-// don't surface (they emit the Microsoft.UI.Xaml IID instead).
+// IIDs, which CsWin32-generated bindings don't surface (they emit the
+// Microsoft.UI.Xaml IID instead). We call through the raw v-table so the
+// path stays NativeAOT-safe (no ComWrappers marshalling required).
 
 using System;
 using System.Runtime.InteropServices;
@@ -34,22 +39,20 @@ internal static class SwapChainPanelInterop
     private static readonly Guid IID_ISwapChainPanelNative =
         new("63aad0b8-7c24-40ff-85a8-640d944cc325");
 
+    // ISwapChainPanelNative2 inherits ISwapChainPanelNative; its v-table is
+    // IUnknown (0-2), SetSwapChain (3), SetSwapChainHandle (4).
+    private static readonly Guid IID_ISwapChainPanelNative2 =
+        new("88fd8248-10da-4810-bb4c-010dd27faea9");
+
     /// <summary>
     /// QueryInterfaces a WinUI 3 SwapChainPanel for ISwapChainPanelNative
-    /// and returns the raw interface pointer. libghostty's DX12 renderer
-    /// calls SetSwapChain (v-table slot 3) directly on the pointer we
-    /// pass, so it must already be the ISwapChainPanelNative v-table, not
-    /// the IUnknown of the WinRT projection.
+    /// and returns the raw interface pointer, used as the SwapChainPanel
+    /// mode selector passed to ghostty_surface_new. libghostty does not
+    /// call through this pointer (it presents into a composition surface
+    /// handle instead), so the caller MUST Release it once SurfaceNew
+    /// returns. The managed SwapChainPanel keeps composition alive via its
+    /// own ref.
     /// </summary>
-    /// <remarks>
-    /// Returns an AddRef'd pointer. libghostty's DX12 device init only uses
-    /// the pointer synchronously during ghostty_surface_new (it calls
-    /// ISwapChainPanelNative::SetSwapChain once and never stores it), so the
-    /// caller MUST Release this pointer immediately after SurfaceNew returns.
-    /// Confirmed in src/renderer/directx12/device.zig (swap_chain_panel
-    /// branch only calls SetSwapChain, no field retention). The managed
-    /// SwapChainPanel keeps composition alive via its own ref.
-    /// </remarks>
     public static IntPtr QueryInterface(Microsoft.UI.Xaml.Controls.SwapChainPanel panel)
     {
         var objRef = ((IWinRTObject)panel).NativeObject;
@@ -59,6 +62,43 @@ internal static class SwapChainPanelInterop
             throw new InvalidOperationException(
                 $"QueryInterface for ISwapChainPanelNative failed: 0x{hr:X8}");
         return ppv;
+    }
+
+    /// <summary>
+    /// Bind a DirectComposition surface handle (from
+    /// ghostty_surface_get_swap_chain_handle) to the panel via
+    /// ISwapChainPanelNative2::SetSwapChainHandle. Call on the UI thread
+    /// that owns the panel, after the surface (and its swap chain) exist.
+    /// </summary>
+    public static void SetSwapChainHandle(
+        Microsoft.UI.Xaml.Controls.SwapChainPanel panel,
+        IntPtr swapChainHandle)
+    {
+        var objRef = ((IWinRTObject)panel).NativeObject;
+        var iid = IID_ISwapChainPanelNative2;
+        var hr = Marshal.QueryInterface(objRef.ThisPtr, in iid, out var ppv);
+        if (hr < 0 || ppv == IntPtr.Zero)
+            throw new InvalidOperationException(
+                $"QueryInterface for ISwapChainPanelNative2 failed: 0x{hr:X8}");
+
+        try
+        {
+            unsafe
+            {
+                var vtbl = *(IntPtr*)ppv;
+                // slot 4: SetSwapChainHandle(HANDLE swapChainHandle)
+                var setSwapChainHandle =
+                    (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>)(*((IntPtr*)vtbl + 4));
+                var shr = setSwapChainHandle(ppv, swapChainHandle);
+                if (shr < 0)
+                    throw new InvalidOperationException(
+                        $"ISwapChainPanelNative2::SetSwapChainHandle failed: 0x{shr:X8}");
+            }
+        }
+        finally
+        {
+            Marshal.Release(ppv);
+        }
     }
 
     /// <summary>

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -519,6 +519,15 @@ internal static partial class NativeMethods
     internal static bool SurfaceSharedTexture(GhosttySurface surface, out GhosttySharedTextureSnapshot snapshot)
         => SurfaceSharedTextureNative(surface, out snapshot) != 0;
 
+    // Returns the DirectComposition surface handle backing this surface's
+    // swap chain in SwapChainPanel mode, or IntPtr.Zero on non-DX12 builds
+    // or before the swap chain is created. Bind it to the SwapChainPanel
+    // via ISwapChainPanelNative2::SetSwapChainHandle. Ghostty owns the
+    // handle for the surface lifetime - do not close it.
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_get_swap_chain_handle")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial IntPtr SurfaceGetSwapChainHandle(GhosttySurface surface);
+
     // ---- surface input -------------------------------------------------
 
     [LibraryImport(Dll, EntryPoint = "ghostty_surface_key")]


### PR DESCRIPTION
The first terminal window often rendered blank until clicked. The renderer presented frames but DWM did not composite the SwapChainPanel until the window received a real OS activation.

Bind a DirectComposition surface handle to the panel via `ISwapChainPanelNative2::SetSwapChainHandle` instead of binding the swap chain object with `SetSwapChain`. The renderer creates the handle (`DCompositionCreateSurfaceHandle`) and a swap chain against it (`IDXGIFactoryMedia`), and the shell binds the handle. The handle is a stable composition primitive, so DWM composites the panel as soon as the window is shown and the binding survives `ResizeBuffers`. Mirrors how Windows Terminal hosts its swap chain.