### PR TITLE
feat(windows): optional build-time BuildLabel in Version/About

### DIFF
--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -123,8 +123,9 @@
       parallel local builds are tellable apart in `wintty +version` and the
       About window. Default empty -> nothing renders. Pass it at build time:
         dotnet build -p:Platform=x64 -p:BuildLabel="session-foo"
-      The value is injected verbatim into a C# string literal, so keep it
-      simple text - no double quotes or backslashes.
+      The value is baked into a C# string literal; backslashes and double
+      quotes are escaped below so an arbitrary label stays valid source.
+      (A literal newline in the value is still not supported.)
     -->
     <Exec Command="git rev-parse --short HEAD"
           ConsoleToMSBuild="true"
@@ -150,6 +151,9 @@
       <_WinttyChannel Condition="'$(Channel)' == 'Stable'">stable</_WinttyChannel>
       <_WinttyChannel Condition="'$(_WinttyChannel)' == ''">tip</_WinttyChannel>
       <_WinttyVersionString>$(_WinttyVersion)-$(_WinttyChannel)+$(_WinttyCommit)$(_WinttyCommitDirty)</_WinttyVersionString>
+      <!-- Escape backslash first, then double-quote, so an arbitrary BuildLabel
+           stays a valid C# string literal in the generated source. -->
+      <_WinttyBuildLabel>$(BuildLabel.Replace('\','\\').Replace('"','\"'))</_WinttyBuildLabel>
     </PropertyGroup>
 
     <ItemGroup>
@@ -161,7 +165,7 @@
       <_BuildInfoLines Include="    public const string WinttyVersionString = &quot;$(_WinttyVersionString)&quot;%3B"/>
       <_BuildInfoLines Include="    public const string WinttyCommit = &quot;$(_WinttyCommit)$(_WinttyCommitDirty)&quot;%3B"/>
       <_BuildInfoLines Include="    public const string MsbuildConfig = &quot;$(Configuration)&quot;%3B"/>
-      <_BuildInfoLines Include="    public const string BuildLabel = &quot;$(BuildLabel)&quot;%3B"/>
+      <_BuildInfoLines Include="    public const string BuildLabel = &quot;$(_WinttyBuildLabel)&quot;%3B"/>
       <_BuildInfoLines Include="    public const Edition Edition = Edition.Oss%3B"/>
       <_BuildInfoLines Include="}"/>
     </ItemGroup>

--- a/windows/Ghostty.Core/Ghostty.Core.csproj
+++ b/windows/Ghostty.Core/Ghostty.Core.csproj
@@ -118,6 +118,14 @@
       <_WinttyDirtyOutput></_WinttyDirtyOutput>
     </PropertyGroup>
 
+    <!--
+      BuildLabel is an optional, free-form identifier baked into the binary so
+      parallel local builds are tellable apart in `wintty +version` and the
+      About window. Default empty -> nothing renders. Pass it at build time:
+        dotnet build -p:Platform=x64 -p:BuildLabel="session-foo"
+      The value is injected verbatim into a C# string literal, so keep it
+      simple text - no double quotes or backslashes.
+    -->
     <Exec Command="git rev-parse --short HEAD"
           ConsoleToMSBuild="true"
           IgnoreExitCode="true"
@@ -153,6 +161,7 @@
       <_BuildInfoLines Include="    public const string WinttyVersionString = &quot;$(_WinttyVersionString)&quot;%3B"/>
       <_BuildInfoLines Include="    public const string WinttyCommit = &quot;$(_WinttyCommit)$(_WinttyCommitDirty)&quot;%3B"/>
       <_BuildInfoLines Include="    public const string MsbuildConfig = &quot;$(Configuration)&quot;%3B"/>
+      <_BuildInfoLines Include="    public const string BuildLabel = &quot;$(BuildLabel)&quot;%3B"/>
       <_BuildInfoLines Include="    public const Edition Edition = Edition.Oss%3B"/>
       <_BuildInfoLines Include="}"/>
     </ItemGroup>

--- a/windows/Ghostty.Core/Version/VersionInfo.cs
+++ b/windows/Ghostty.Core/Version/VersionInfo.cs
@@ -9,6 +9,9 @@ namespace Ghostty.Core.Version;
 public sealed record VersionInfo(
     // Wintty-side (BuildInfo.g.cs constants)
     string WinttyVersion,
+    // Optional free-form build identifier, empty by default. Rendered only
+    // when non-empty so parallel local builds are tellable apart.
+    string BuildLabel,
     string WinttyVersionString,
     string WinttyCommit,
     Edition Edition,

--- a/windows/Ghostty.Core/Version/VersionRenderer.cs
+++ b/windows/Ghostty.Core/Version/VersionRenderer.cs
@@ -26,6 +26,7 @@ public static class VersionRenderer
         var lib = LibGhosttyBuildInfoBridge.Read();
         return new VersionInfo(
             WinttyVersion:       BuildInfo.WinttyVersion,
+            BuildLabel:          BuildInfo.BuildLabel,
             WinttyVersionString: BuildInfo.WinttyVersionString,
             WinttyCommit:        BuildInfo.WinttyCommit,
             Edition:             BuildInfo.Edition,
@@ -105,6 +106,10 @@ public static class VersionRenderer
     private static void AppendBody(StringBuilder sb, VersionInfo info)
     {
         sb.Append("Version\n");
+        // Free-form build identifier first, so it is the most prominent line
+        // when present. Omitted entirely when empty (the default).
+        if (!string.IsNullOrEmpty(info.BuildLabel))
+            Field(sb, "label", info.BuildLabel);
         Field(sb, "version",     info.WinttyVersion);
         Field(sb, "channel",     info.LibGhostty.Channel);
         Field(sb, "edition",     EditionLabel.Format(info.Edition));

--- a/windows/Ghostty.Tests/Version/VersionRendererTests.cs
+++ b/windows/Ghostty.Tests/Version/VersionRendererTests.cs
@@ -7,6 +7,7 @@ public sealed class VersionRendererTests
 {
     private static VersionInfo Sample() => new(
         WinttyVersion:       "1.2.0",
+        BuildLabel:          "",
         WinttyVersionString: "1.2.0-tip+abc1234",
         WinttyCommit:        "abc1234",
         Edition:             Edition.Oss,
@@ -128,5 +129,27 @@ public sealed class VersionRendererTests
     {
         var info = Sample() with { WinttyCommit = "" };
         Assert.Null(VersionRenderer.CommitUrl(info));
+    }
+
+    [Fact]
+    public void RenderPlainBody_WithLabel_RendersLabelFirstInVersionBlock()
+    {
+        var info = Sample() with { BuildLabel = "session-foo" };
+        var output = VersionRenderer.RenderPlainBody(info);
+
+        Assert.StartsWith(
+            "Version\n" +
+            "  label:          session-foo\n" +
+            "  version:        1.2.0\n" +
+            "  channel:        tip\n" +
+            "  edition:        oss\n",
+            output);
+    }
+
+    [Fact]
+    public void RenderPlainBody_EmptyLabel_OmitsLabelLine()
+    {
+        var output = VersionRenderer.RenderPlainBody(Sample());
+        Assert.DoesNotContain("label:", output);
     }
 }

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml
@@ -55,6 +55,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Version"
@@ -64,18 +65,26 @@
                                FontFamily="Cascadia Mono, Consolas"
                                IsTextSelectionEnabled="True" />
 
-                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Build"
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Label"
+                               x:Name="LabelLabel"
                                HorizontalAlignment="Right"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                    <TextBlock x:Name="BuildValue" Grid.Row="1" Grid.Column="1"
+                    <TextBlock x:Name="LabelValue" Grid.Row="1" Grid.Column="1"
                                FontFamily="Cascadia Mono, Consolas"
                                IsTextSelectionEnabled="True" />
 
-                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Commit"
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Build"
+                               HorizontalAlignment="Right"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <TextBlock x:Name="BuildValue" Grid.Row="2" Grid.Column="1"
+                               FontFamily="Cascadia Mono, Consolas"
+                               IsTextSelectionEnabled="True" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Commit"
                                x:Name="CommitLabel"
                                HorizontalAlignment="Right"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                    <TextBlock x:Name="CommitValue" Grid.Row="2" Grid.Column="1"
+                    <TextBlock x:Name="CommitValue" Grid.Row="3" Grid.Column="1"
                                FontFamily="Cascadia Mono, Consolas"
                                IsTextSelectionEnabled="True">
                         <Hyperlink x:Name="CommitLink">

--- a/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
+++ b/windows/Ghostty/Dialogs/AboutWindow.xaml.cs
@@ -80,6 +80,18 @@ internal sealed partial class AboutWindow : Window
             ? edition
             : $"{edition} ({info.LibGhostty.Channel})";
 
+        // Free-form build identifier. Empty by default, in which case the row
+        // collapses (both cells hidden) just like the Commit row below.
+        if (string.IsNullOrEmpty(info.BuildLabel))
+        {
+            LabelLabel.Visibility = Visibility.Collapsed;
+            LabelValue.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            LabelValue.Text = info.BuildLabel;
+        }
+
         // CommitUrl is null when the commit is unknown. Guard the parse too:
         // the commit string is build-derived, so a malformed value collapses
         // the row rather than throwing and taking down the whole window.


### PR DESCRIPTION
@
Adds an optional `BuildLabel` MSBuild property so we can tell parallel local builds apart. Defaults to empty, in which case nothing renders.

Pass it at build time:

```
dotnet build -p:Platform=x64 -p:BuildLabel="session-foo"
```

It then shows up in `wintty +version` (and the Version dialog) as the first `label:` line of the Version block, and as a "Label" row in the About window. Both hide when the value is empty.

Mechanism reuses the existing `GenerateBuildInfo` target that already bakes the version and commit constants, threaded through `VersionInfo` / `VersionRenderer` and surfaced in `AboutWindow` (collapses like the Commit row).
@