### PR TITLE
fix(windows): quake slides in without an empty frame, themed resize border

### DIFF
--- a/windows/Ghostty/Hosting/QuickTerminalFrame.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalFrame.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Windows.Win32.Foundation;
 using Ghostty.Core.Hosting;
+using Ghostty.Interop;
 
 namespace Ghostty.Hosting;
 
@@ -140,6 +141,11 @@ internal sealed partial class QuickTerminalFrame : IDisposable
 
     public void Dispose()
     {
+        if (_stripBrush != IntPtr.Zero)
+        {
+            Win32Interop.DeleteObject(_stripBrush);
+            _stripBrush = IntPtr.Zero;
+        }
         if (!_installed) return;
         // Best-effort: comctl32 also removes the subclass automatically on
         // WM_NCDESTROY, so if the HWND is already gone (teardown ordering) this
@@ -244,32 +250,40 @@ internal sealed partial class QuickTerminalFrame : IDisposable
         var h = r.bottom - r.top;
         if (w <= 0 || h <= 0) return;
 
+        // Clamp the strip into the window so a transient sub-_grip size (e.g.
+        // during the borderless transition) can't produce an inside-out rect.
         var strip = edge switch
         {
-            QuickTerminalResizeEdge.Bottom => new RECT { left = 0, top = h - _grip, right = w, bottom = h },
-            QuickTerminalResizeEdge.Top => new RECT { left = 0, top = 0, right = w, bottom = _grip },
-            QuickTerminalResizeEdge.Left => new RECT { left = 0, top = 0, right = _grip, bottom = h },
-            QuickTerminalResizeEdge.Right => new RECT { left = w - _grip, top = 0, right = w, bottom = h },
+            QuickTerminalResizeEdge.Bottom => new RECT { left = 0, top = Math.Max(0, h - _grip), right = w, bottom = h },
+            QuickTerminalResizeEdge.Top => new RECT { left = 0, top = 0, right = w, bottom = Math.Min(h, _grip) },
+            QuickTerminalResizeEdge.Left => new RECT { left = 0, top = 0, right = Math.Min(w, _grip), bottom = h },
+            QuickTerminalResizeEdge.Right => new RECT { left = Math.Max(0, w - _grip), top = 0, right = w, bottom = h },
             _ => default,
         };
         if (strip.right <= strip.left || strip.bottom <= strip.top) return;
 
-        var hdc = GetWindowDC(hWnd);
+        // WM_NCPAINT can fire every frame during the reveal (SetWindowRgn with
+        // bRedraw) and on every drag-resize tick, so cache the brush and only
+        // recreate it when the theme color actually changes.
+        var color = _borderColorRef();
+        if (_stripBrush == IntPtr.Zero || color != _stripBrushColor)
+        {
+            if (_stripBrush != IntPtr.Zero) Win32Interop.DeleteObject(_stripBrush);
+            _stripBrush = Win32Interop.CreateSolidBrush(color);
+            _stripBrushColor = color;
+        }
+        if (_stripBrush == IntPtr.Zero) return;
+
+        var hdc = Win32Interop.GetWindowDC(hWnd);
         if (hdc == IntPtr.Zero) return;
-        try
-        {
-            var brush = CreateSolidBrush(_borderColorRef());
-            if (brush != IntPtr.Zero)
-            {
-                FillRect(hdc, in strip, brush);
-                DeleteObject(brush);
-            }
-        }
-        finally
-        {
-            ReleaseDC(hWnd, hdc);
-        }
+        try { Win32Interop.FillRect(hdc, in strip, _stripBrush); }
+        finally { Win32Interop.ReleaseDC(hWnd, hdc); }
     }
+
+    // Cached solid brush for the resize strip, keyed on its last color so
+    // WM_NCPAINT does not churn a GDI object per paint. Freed in Dispose.
+    private IntPtr _stripBrush;
+    private uint _stripBrushColor;
 
     /// <summary>
     /// Map the cursor position to a resize hit-code for the kept strip, or
@@ -331,27 +345,6 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool SetWindowPos(
         IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
-
-    [LibraryImport("user32.dll", EntryPoint = "GetWindowDC")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static partial IntPtr GetWindowDC(IntPtr hWnd);
-
-    [LibraryImport("user32.dll", EntryPoint = "ReleaseDC")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static partial int ReleaseDC(IntPtr hWnd, IntPtr hDC);
-
-    [LibraryImport("user32.dll", EntryPoint = "FillRect")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static partial int FillRect(IntPtr hDC, in RECT lprc, IntPtr hbr);
-
-    [LibraryImport("gdi32.dll", EntryPoint = "CreateSolidBrush")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static partial IntPtr CreateSolidBrush(uint color);
-
-    [LibraryImport("gdi32.dll", EntryPoint = "DeleteObject")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool DeleteObject(IntPtr hObject);
 }
 
 internal static partial class QuickTerminalFrameLogExtensions

--- a/windows/Ghostty/Hosting/QuickTerminalFrame.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalFrame.cs
@@ -42,6 +42,7 @@ internal sealed partial class QuickTerminalFrame : IDisposable
 {
     private const uint WM_NCCALCSIZE = 0x0083;
     private const uint WM_NCHITTEST = 0x0084;
+    private const uint WM_NCPAINT = 0x0085;
     private const uint WM_STYLECHANGING = 0x007C;
     private const uint WM_STYLECHANGED = 0x007D;
 
@@ -70,6 +71,10 @@ internal sealed partial class QuickTerminalFrame : IDisposable
 
     private readonly IntPtr _hwnd;
     private readonly Func<QuickTerminalPosition> _position;
+    // Supplies the color (COLORREF, 0x00BBGGRR) for the kept sizing strip so it
+    // matches the terminal theme instead of Windows' default frame band. Read
+    // on every WM_NCPAINT so a live theme/config reload is picked up.
+    private readonly Func<uint> _borderColorRef;
     private readonly ILogger<QuickTerminalFrame>? _logger;
 
     // Held for the subclass's lifetime: the GC must not collect the delegate
@@ -103,11 +108,14 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     public QuickTerminalFrame(
         IntPtr hwnd,
         Func<QuickTerminalPosition> position,
+        Func<uint> borderColorRef,
         ILogger<QuickTerminalFrame>? logger)
     {
         ArgumentNullException.ThrowIfNull(position);
+        ArgumentNullException.ThrowIfNull(borderColorRef);
         _hwnd = hwnd;
         _position = position;
+        _borderColorRef = borderColorRef;
         _logger = logger;
         _proc = WndProc;
         _grip = Math.Max(1, GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER));
@@ -211,10 +219,56 @@ internal sealed partial class QuickTerminalFrame : IDisposable
 
                 case WM_NCHITTEST:
                     return (IntPtr)HitTest(lParam);
+
+                // Windows paints the kept sizing strip as its default frame
+                // band, which ignores the terminal theme. Paint it ourselves
+                // with the theme color so it blends with the terminal instead of
+                // showing a stray light/dark border at the resize edge. Return
+                // handled (0) so the default frame paint is suppressed.
+                case WM_NCPAINT:
+                    PaintBorderStrip(hWnd, edge);
+                    return IntPtr.Zero;
             }
         }
 
         return DefSubclassProc(hWnd, msg, wParam, lParam);
+    }
+
+    // Fill the kept non-client sizing strip (the one edge left non-client by
+    // WM_NCCALCSIZE) with the theme color. The window DC is window-relative, so
+    // the strip rect is in window coordinates.
+    private void PaintBorderStrip(IntPtr hWnd, QuickTerminalResizeEdge edge)
+    {
+        if (!GetWindowRect(hWnd, out var r)) return;
+        var w = r.right - r.left;
+        var h = r.bottom - r.top;
+        if (w <= 0 || h <= 0) return;
+
+        var strip = edge switch
+        {
+            QuickTerminalResizeEdge.Bottom => new RECT { left = 0, top = h - _grip, right = w, bottom = h },
+            QuickTerminalResizeEdge.Top => new RECT { left = 0, top = 0, right = w, bottom = _grip },
+            QuickTerminalResizeEdge.Left => new RECT { left = 0, top = 0, right = _grip, bottom = h },
+            QuickTerminalResizeEdge.Right => new RECT { left = w - _grip, top = 0, right = w, bottom = h },
+            _ => default,
+        };
+        if (strip.right <= strip.left || strip.bottom <= strip.top) return;
+
+        var hdc = GetWindowDC(hWnd);
+        if (hdc == IntPtr.Zero) return;
+        try
+        {
+            var brush = CreateSolidBrush(_borderColorRef());
+            if (brush != IntPtr.Zero)
+            {
+                FillRect(hdc, in strip, brush);
+                DeleteObject(brush);
+            }
+        }
+        finally
+        {
+            ReleaseDC(hWnd, hdc);
+        }
     }
 
     /// <summary>
@@ -277,6 +331,27 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool SetWindowPos(
         IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowDC")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial IntPtr GetWindowDC(IntPtr hWnd);
+
+    [LibraryImport("user32.dll", EntryPoint = "ReleaseDC")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [LibraryImport("user32.dll", EntryPoint = "FillRect")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int FillRect(IntPtr hDC, in RECT lprc, IntPtr hbr);
+
+    [LibraryImport("gdi32.dll", EntryPoint = "CreateSolidBrush")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial IntPtr CreateSolidBrush(uint color);
+
+    [LibraryImport("gdi32.dll", EntryPoint = "DeleteObject")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool DeleteObject(IntPtr hObject);
 }
 
 internal static partial class QuickTerminalFrameLogExtensions

--- a/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
@@ -1,179 +1,211 @@
 using System;
-using System.Numerics;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Ghostty.Core.Hosting;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Hosting;
+using Microsoft.UI.Xaml.Media;
 
 namespace Ghostty.Hosting;
 
 /// <summary>
-/// Runs the quake show/hide animation on a window's root content visual
-/// using <see cref="Microsoft.UI.Composition"/> (the lifted
-/// DirectComposition API). The window is always placed at its final rect
-/// first (by the caller); this only translates / fades the *content*, so
-/// no swap-chain resize occurs and the SwapChainPanel-bound DX12 terminal
-/// rides along on the compositor thread.
+/// Animates the quake window's show/hide as a window-region "reveal": the
+/// window stays at its final rect the whole time and we grow (show) or shrink
+/// (hide) its visible region from the docked edge via <c>SetWindowRgn</c>. The
+/// area outside the region is not part of the window, so the desktop shows
+/// through it -- there is no empty backdrop frame, which is what translating
+/// the content inside a full-size window unavoidably produced (the window's own
+/// backdrop filled the not-yet-covered area).
 ///
-/// Edge positions (top/bottom/left/right) slide via the element's
-/// <c>Translation</c> facade (enabled once with
-/// <see cref="ElementCompositionPreview.SetIsTranslationEnabled"/>).
-/// Center has no edge to slide from, so it fades opacity 0..1.
+/// This mirrors Windows Terminal's quake dropdown
+/// (<c>IslandWindow::_doSlideAnimation</c>), which clips the window region
+/// rather than moving the window or its content. Content never moves and is
+/// always fully painted (the DirectComposition surface-handle binding ensures
+/// the surface composites on show), so the reveal exposes a live terminal.
 ///
-/// A monotonically increasing token guards completion callbacks: if the
-/// user re-toggles mid-animation, the stale batch's Completed handler is
-/// ignored so a half-finished hide does not call Hide() after a new show.
+/// Center has no edge to reveal from, so it fades opacity instead.
+///
+/// Driven per frame from <see cref="CompositionTarget.Rendering"/> with an
+/// ease-out curve. A monotonic token guards completion so a re-toggle mid
+/// animation does not fire a stale <c>Hide()</c>.
 /// </summary>
-internal sealed class QuickTerminalSlideAnimator : IDisposable
+internal sealed partial class QuickTerminalSlideAnimator : IDisposable
 {
-    private readonly UIElement _content;
-    private readonly Visual _visual;
-    private readonly Compositor _compositor;
+    private readonly nint _hwnd;
+    private readonly Visual _visual; // content visual, used only for the Center fade
+    private readonly Stopwatch _clock = new();
+
+    // Monotonic guard: bumped on every Prepare/Run/Snap/Dispose so an in-flight
+    // Rendering tick or completion from a superseded run is ignored.
     private long _token;
+    private bool _subscribed;
 
-    // Cached easing functions (constants) created once and reused across
-    // toggles, disposed in Dispose(). Avoids per-toggle allocation.
-    private CubicBezierEasingFunction? _easeIn;
-    private CubicBezierEasingFunction? _easeOut;
+    // Current run parameters.
+    private QuickTerminalPosition _position;
+    private int _w;
+    private int _h;
+    private double _durationMs;
+    private bool _appearing;
+    private Action? _onCompleted;
+    private long _runToken;
 
-    // The most recent run's compositor objects. Disposed at the start of the
-    // next run (and in Dispose()), so at most one batch+animation lingers
-    // between toggles rather than accumulating one pair per toggle.
-    private CompositionScopedBatch? _batch;
-    private CompositionAnimation? _anim;
-
-    public QuickTerminalSlideAnimator(UIElement content)
+    public QuickTerminalSlideAnimator(nint hwnd, UIElement content)
     {
         ArgumentNullException.ThrowIfNull(content);
-        _content = content;
-        // Translation composes WITH XAML layout (unlike Offset, which
-        // replaces it), so animating it never fights the layout pass.
-        ElementCompositionPreview.SetIsTranslationEnabled(content, true);
+        _hwnd = hwnd;
         _visual = ElementCompositionPreview.GetElementVisual(content);
-        _compositor = _visual.Compositor;
-    }
-
-    /// <summary>Slide / fade the content into view from the docked edge.</summary>
-    public void AnimateIn(
-        QuickTerminalPosition position,
-        double width,
-        double height,
-        TimeSpan duration,
-        Action? onCompleted)
-    {
-        Run(position, width, height, duration, appearing: true, onCompleted);
-    }
-
-    /// <summary>Slide / fade the content out, then invoke onCompleted (Hide()).</summary>
-    public void AnimateOut(
-        QuickTerminalPosition position,
-        double width,
-        double height,
-        TimeSpan duration,
-        Action? onCompleted)
-    {
-        Run(position, width, height, duration, appearing: false, onCompleted);
-    }
-
-    private void Run(
-        QuickTerminalPosition position,
-        double width,
-        double height,
-        TimeSpan duration,
-        bool appearing,
-        Action? onCompleted)
-    {
-        var token = ++_token;
-
-        // Off-screen translation vector for the docked edge. Center uses
-        // opacity instead, so its offset is zero.
-        var off = position switch
-        {
-            QuickTerminalPosition.Top => new Vector3(0f, -(float)height, 0f),
-            QuickTerminalPosition.Bottom => new Vector3(0f, (float)height, 0f),
-            QuickTerminalPosition.Left => new Vector3(-(float)width, 0f, 0f),
-            QuickTerminalPosition.Right => new Vector3((float)width, 0f, 0f),
-            _ => Vector3.Zero, // Center
-        };
-        var isCenter = position == QuickTerminalPosition.Center;
-
-        // Dispose the previous run's compositor objects before starting a
-        // new one, so at most one batch+animation lingers between toggles.
-        _anim?.Dispose();
-        _batch?.Dispose();
-
-        // Ease-out on appear (decelerate into place), ease-in on hide.
-        // Cached: the bezier control points are constants.
-        _easeIn ??= _compositor.CreateCubicBezierEasingFunction(new Vector2(0.1f, 0.9f), new Vector2(0.2f, 1.0f));
-        _easeOut ??= _compositor.CreateCubicBezierEasingFunction(new Vector2(0.8f, 0.0f), new Vector2(0.9f, 0.1f));
-        var easing = appearing ? _easeIn : _easeOut;
-
-        var batch = _compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
-        CompositionAnimation anim;
-
-        if (isCenter)
-        {
-            // Fade. Set the start opacity explicitly so a re-toggle from a
-            // partial state still animates the full range.
-            _visual.Opacity = appearing ? 0f : 1f;
-            var fade = _compositor.CreateScalarKeyFrameAnimation();
-            fade.InsertKeyFrame(1f, appearing ? 1f : 0f, easing);
-            fade.Duration = duration;
-            _visual.StartAnimation("Opacity", fade);
-            anim = fade;
-        }
-        else
-        {
-            // Seed the start translation synchronously (mirrors the fade
-            // path's Opacity pre-set) so no frame renders at the resting
-            // position before the compositor applies keyframe 0.
-            _visual.Properties.InsertVector3("Translation", appearing ? off : Vector3.Zero);
-            var slide = _compositor.CreateVector3KeyFrameAnimation();
-            slide.InsertKeyFrame(0f, appearing ? off : Vector3.Zero);
-            slide.InsertKeyFrame(1f, appearing ? Vector3.Zero : off, easing);
-            slide.Duration = duration;
-            _visual.StartAnimation("Translation", slide);
-            anim = slide;
-        }
-
-        _batch = batch;
-        _anim = anim;
-
-        batch.Completed += (_, _) =>
-        {
-            if (token != _token) return; // superseded by a newer toggle
-            // Normalize to the resting state so the next show starts clean.
-            if (isCenter) _visual.Opacity = appearing ? 1f : 0f;
-            onCompleted?.Invoke();
-        };
-        batch.End();
     }
 
     /// <summary>
-    /// Snap to the fully-shown resting state with no animation (used when
-    /// duration == 0, or to clear a half-finished animation). Bumps the
-    /// token so any in-flight batch completion is ignored.
+    /// Synchronously set the collapsed start state BEFORE the window is shown,
+    /// so the first presented frame is the reveal's frame 0 (nothing visible)
+    /// rather than the full window flashing in.
     /// </summary>
+    public void PrepareIn(QuickTerminalPosition position, double width, double height)
+    {
+        _token++;
+        StopLoop();
+        if (position == QuickTerminalPosition.Center)
+        {
+            ClearRegion();
+            _visual.Opacity = 0f;
+        }
+        else
+        {
+            _visual.Opacity = 1f;
+            ApplyRegion(position, (int)width, (int)height, 0.0);
+        }
+    }
+
+    /// <summary>Reveal the window from its docked edge.</summary>
+    public void AnimateIn(QuickTerminalPosition position, double width, double height, TimeSpan duration, Action? onCompleted)
+        => Run(position, width, height, duration, appearing: true, onCompleted);
+
+    /// <summary>Collapse the window toward its docked edge, then invoke onCompleted (Hide()).</summary>
+    public void AnimateOut(QuickTerminalPosition position, double width, double height, TimeSpan duration, Action? onCompleted)
+        => Run(position, width, height, duration, appearing: false, onCompleted);
+
+    private void Run(QuickTerminalPosition position, double width, double height, TimeSpan duration, bool appearing, Action? onCompleted)
+    {
+        var token = ++_token;
+        _runToken = token;
+        _position = position;
+        _w = (int)width;
+        _h = (int)height;
+        _durationMs = Math.Max(1.0, duration.TotalMilliseconds);
+        _appearing = appearing;
+        _onCompleted = onCompleted;
+
+        // Seed frame 0 so the first tick has no visible jump.
+        if (position == QuickTerminalPosition.Center)
+            _visual.Opacity = appearing ? 0f : 1f;
+        else
+            ApplyRegion(position, _w, _h, appearing ? 0.0 : 1.0);
+
+        _clock.Restart();
+        StartLoop();
+    }
+
+    private void OnRendering(object? sender, object e)
+    {
+        if (_runToken != _token) { StopLoop(); return; }
+
+        var p = Math.Clamp(_clock.Elapsed.TotalMilliseconds / _durationMs, 0.0, 1.0);
+        // Ease-out (decelerate into place). visibleFraction: 0->1 appearing, 1->0 hiding.
+        var eased = 1.0 - Math.Pow(1.0 - p, 3.0);
+        var visible = _appearing ? eased : 1.0 - eased;
+
+        if (_position == QuickTerminalPosition.Center)
+            _visual.Opacity = (float)visible;
+        else
+            ApplyRegion(_position, _w, _h, visible);
+
+        if (p < 1.0) return;
+
+        // Done.
+        StopLoop();
+        if (_appearing)
+        {
+            // Settled: drop the clip so the window is fully rectangular again.
+            if (_position == QuickTerminalPosition.Center) _visual.Opacity = 1f;
+            else ClearRegion();
+        }
+
+        var done = _onCompleted;
+        _onCompleted = null;
+        done?.Invoke();
+
+        // After a hide completes the window is collapsed; reset the clip so the
+        // next show starts from a clean (full) window before PrepareIn re-seeds.
+        if (!_appearing && _position != QuickTerminalPosition.Center)
+            ClearRegion();
+    }
+
+    /// <summary>Snap to the fully-shown rectangular state (duration == 0, or to
+    /// clear a half-finished animation).</summary>
     public void SnapToShown()
     {
         _token++;
-        _visual.StopAnimation("Translation");
-        _visual.StopAnimation("Opacity");
-        _anim?.Dispose();
-        _batch?.Dispose();
-        _anim = null;
-        _batch = null;
-        _visual.Properties.InsertVector3("Translation", Vector3.Zero);
+        StopLoop();
+        ClearRegion();
         _visual.Opacity = 1f;
     }
 
     public void Dispose()
     {
-        _visual.StopAnimation("Translation");
-        _visual.StopAnimation("Opacity");
-        _anim?.Dispose();
-        _batch?.Dispose();
-        _easeIn?.Dispose();
-        _easeOut?.Dispose();
+        _token++;
+        StopLoop();
+        ClearRegion();
+        _visual.Opacity = 1f;
     }
+
+    private void StartLoop()
+    {
+        if (_subscribed) return;
+        CompositionTarget.Rendering += OnRendering;
+        _subscribed = true;
+    }
+
+    private void StopLoop()
+    {
+        if (!_subscribed) return;
+        CompositionTarget.Rendering -= OnRendering;
+        _subscribed = false;
+        _clock.Stop();
+    }
+
+    // Clip the window to the revealed fraction (0..1) measured from the docked
+    // edge. The window stays put; only its visible region grows/shrinks.
+    private void ApplyRegion(QuickTerminalPosition position, int w, int h, double f)
+    {
+        if (w <= 0 || h <= 0) return;
+        var fw = Math.Clamp((int)Math.Round(f * w), 0, w);
+        var fh = Math.Clamp((int)Math.Round(f * h), 0, h);
+        var rgn = position switch
+        {
+            QuickTerminalPosition.Top => CreateRectRgn(0, 0, w, fh),
+            QuickTerminalPosition.Bottom => CreateRectRgn(0, h - fh, w, h),
+            QuickTerminalPosition.Left => CreateRectRgn(0, 0, fw, h),
+            QuickTerminalPosition.Right => CreateRectRgn(w - fw, 0, w, h),
+            _ => CreateRectRgn(0, 0, w, h),
+        };
+        // On success the system takes ownership of rgn (and frees the previous
+        // one), so we only delete it ourselves when the call fails.
+        if (SetWindowRgn(_hwnd, rgn, true) == 0)
+            DeleteObject(rgn);
+    }
+
+    // Null region == remove the clip (full rectangular window).
+    private void ClearRegion() => SetWindowRgn(_hwnd, 0, true);
+
+    [LibraryImport("gdi32.dll")]
+    private static partial nint CreateRectRgn(int x1, int y1, int x2, int y2);
+
+    [LibraryImport("user32.dll")]
+    private static partial int SetWindowRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool bRedraw);
+
+    [LibraryImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool DeleteObject(nint hObject);
 }

--- a/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Ghostty.Core.Hosting;
+using Ghostty.Interop;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Hosting;
@@ -30,7 +30,7 @@ namespace Ghostty.Hosting;
 /// ease-out curve. A monotonic token guards completion so a re-toggle mid
 /// animation does not fire a stale <c>Hide()</c>.
 /// </summary>
-internal sealed partial class QuickTerminalSlideAnimator : IDisposable
+internal sealed class QuickTerminalSlideAnimator : IDisposable
 {
     private readonly nint _hwnd;
     private readonly Visual _visual; // content visual, used only for the Center fade
@@ -123,12 +123,17 @@ internal sealed partial class QuickTerminalSlideAnimator : IDisposable
 
         if (p < 1.0) return;
 
-        // Done.
+        // Done. Snapshot the run's state before invoking the completion
+        // callback -- done() (e.g. AppWindow.Hide()) could synchronously start
+        // a new run, which would overwrite _appearing/_position mid-method.
         StopLoop();
-        if (_appearing)
+        var appearing = _appearing;
+        var position = _position;
+
+        if (appearing)
         {
             // Settled: drop the clip so the window is fully rectangular again.
-            if (_position == QuickTerminalPosition.Center) _visual.Opacity = 1f;
+            if (position == QuickTerminalPosition.Center) _visual.Opacity = 1f;
             else ClearRegion();
         }
 
@@ -138,7 +143,7 @@ internal sealed partial class QuickTerminalSlideAnimator : IDisposable
 
         // After a hide completes the window is collapsed; reset the clip so the
         // next show starts from a clean (full) window before PrepareIn re-seeds.
-        if (!_appearing && _position != QuickTerminalPosition.Center)
+        if (!appearing && position != QuickTerminalPosition.Center)
             ClearRegion();
     }
 
@@ -184,28 +189,22 @@ internal sealed partial class QuickTerminalSlideAnimator : IDisposable
         var fh = Math.Clamp((int)Math.Round(f * h), 0, h);
         var rgn = position switch
         {
-            QuickTerminalPosition.Top => CreateRectRgn(0, 0, w, fh),
-            QuickTerminalPosition.Bottom => CreateRectRgn(0, h - fh, w, h),
-            QuickTerminalPosition.Left => CreateRectRgn(0, 0, fw, h),
-            QuickTerminalPosition.Right => CreateRectRgn(w - fw, 0, w, h),
-            _ => CreateRectRgn(0, 0, w, h),
+            QuickTerminalPosition.Top => Win32Interop.CreateRectRgn(0, 0, w, fh),
+            QuickTerminalPosition.Bottom => Win32Interop.CreateRectRgn(0, h - fh, w, h),
+            QuickTerminalPosition.Left => Win32Interop.CreateRectRgn(0, 0, fw, h),
+            QuickTerminalPosition.Right => Win32Interop.CreateRectRgn(w - fw, 0, w, h),
+            _ => Win32Interop.CreateRectRgn(0, 0, w, h),
         };
+        // Bail if region creation failed (e.g. GDI exhaustion): passing a null
+        // region to SetWindowRgn would REMOVE the clip (full-window flash) --
+        // worse than skipping this frame and retrying on the next tick.
+        if (rgn == IntPtr.Zero) return;
         // On success the system takes ownership of rgn (and frees the previous
         // one), so we only delete it ourselves when the call fails.
-        if (SetWindowRgn(_hwnd, rgn, true) == 0)
-            DeleteObject(rgn);
+        if (Win32Interop.SetWindowRgn(_hwnd, rgn, true) == 0)
+            Win32Interop.DeleteObject(rgn);
     }
 
     // Null region == remove the clip (full rectangular window).
-    private void ClearRegion() => SetWindowRgn(_hwnd, 0, true);
-
-    [LibraryImport("gdi32.dll")]
-    private static partial nint CreateRectRgn(int x1, int y1, int x2, int y2);
-
-    [LibraryImport("user32.dll")]
-    private static partial int SetWindowRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool bRedraw);
-
-    [LibraryImport("gdi32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool DeleteObject(nint hObject);
+    private void ClearRegion() => Win32Interop.SetWindowRgn(_hwnd, IntPtr.Zero, true);
 }

--- a/windows/Ghostty/Interop/Win32Interop.cs
+++ b/windows/Ghostty/Interop/Win32Interop.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using Windows.Win32.Foundation;
 
 namespace Ghostty.Interop;
 
@@ -50,4 +51,29 @@ internal static partial class Win32Interop
     [LibraryImport("gdi32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool DeleteObject(IntPtr hObject);
+
+    // --- Window-region clipping (quake reveal) + non-client strip fill ---
+
+    [LibraryImport("user32.dll")]
+    public static partial int SetWindowRgn(
+        IntPtr hWnd, IntPtr hRgn, [MarshalAs(UnmanagedType.Bool)] bool bRedraw);
+
+    [LibraryImport("user32.dll")]
+    public static partial IntPtr GetWindowDC(IntPtr hWnd);
+
+    [LibraryImport("user32.dll")]
+    public static partial int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [LibraryImport("user32.dll")]
+    public static partial int FillRect(IntPtr hDC, in RECT lprc, IntPtr hbr);
+
+    [LibraryImport("gdi32.dll")]
+    public static partial IntPtr CreateSolidBrush(uint color);
+
+    /// <summary>
+    /// Convert a packed <c>0x00RRGGBB</c> color to a GDI <c>COLORREF</c>
+    /// (<c>0x00BBGGRR</c>) by swapping the red and blue bytes.
+    /// </summary>
+    public static uint RgbToColorRef(uint rgb)
+        => ((rgb & 0xFFu) << 16) | (rgb & 0xFF00u) | ((rgb >> 16) & 0xFFu);
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2187,13 +2187,8 @@ public sealed partial class MainWindow : Window
             WindowNative.GetWindowHandle(this),
             () => _configService.QuickTerminalPosition,
             // Color the kept resize strip with the terminal background so it
-            // blends instead of showing Windows' default frame band. Convert
-            // BackgroundColor (0x00RRGGBB) to a GDI COLORREF (0x00BBGGRR).
-            () =>
-            {
-                var c = _configService.BackgroundColor;
-                return ((c & 0xFFu) << 16) | (c & 0xFF00u) | ((c >> 16) & 0xFFu);
-            },
+            // blends instead of showing Windows' default frame band.
+            () => Ghostty.Interop.Win32Interop.RgbToColorRef(_configService.BackgroundColor),
             App.LoggerFactory?.CreateLogger<Ghostty.Hosting.QuickTerminalFrame>());
 
         // Borderless: a quake terminal is positioned by config and toggled by the
@@ -2404,24 +2399,22 @@ public sealed partial class MainWindow : Window
     {
         _hiding = false;
         var duration = _configService.QuickTerminalAnimationDuration;
+        if (duration > 0)
+            _slideAnimator ??= new QuickTerminalSlideAnimator(WindowNative.GetWindowHandle(this), RootGrid);
 
         if (!AppWindow.IsVisible)
         {
             MoveToQuakePosition();
 
-            // Seed the slide's start frame BEFORE the window is shown.
-            // AppWindow.Show() forces an immediate present; without this the
-            // first frame is stale -- the resting content (a full-terminal
-            // flash on the first toggle) or the leftover off-screen state from
-            // the prior hide (a held empty frame) -- before the slide begins.
+            // Seed the reveal's collapsed start region BEFORE the window is
+            // shown. AppWindow.Show() forces an immediate present; without this
+            // the first frame would be the full rectangular window before the
+            // clip-reveal begins.
             if (duration > 0)
-            {
-                _slideAnimator ??= new QuickTerminalSlideAnimator(WindowNative.GetWindowHandle(this), RootGrid);
-                _slideAnimator.PrepareIn(
+                _slideAnimator!.PrepareIn(
                     _configService.QuickTerminalPosition,
                     AppWindow.Size.Width,
                     AppWindow.Size.Height);
-            }
 
             AppWindow.Show();
         }
@@ -2435,8 +2428,7 @@ public sealed partial class MainWindow : Window
         }
 
         _autohideArmed = false;
-        _slideAnimator ??= new QuickTerminalSlideAnimator(WindowNative.GetWindowHandle(this), RootGrid);
-        _slideAnimator.AnimateIn(
+        _slideAnimator!.AnimateIn(
             _configService.QuickTerminalPosition,
             AppWindow.Size.Width,
             AppWindow.Size.Height,

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2186,6 +2186,14 @@ public sealed partial class MainWindow : Window
         _quakeFrame = new Ghostty.Hosting.QuickTerminalFrame(
             WindowNative.GetWindowHandle(this),
             () => _configService.QuickTerminalPosition,
+            // Color the kept resize strip with the terminal background so it
+            // blends instead of showing Windows' default frame band. Convert
+            // BackgroundColor (0x00RRGGBB) to a GDI COLORREF (0x00BBGGRR).
+            () =>
+            {
+                var c = _configService.BackgroundColor;
+                return ((c & 0xFFu) << 16) | (c & 0xFF00u) | ((c >> 16) & 0xFFu);
+            },
             App.LoggerFactory?.CreateLogger<Ghostty.Hosting.QuickTerminalFrame>());
 
         // Borderless: a quake terminal is positioned by config and toggled by the
@@ -2395,13 +2403,29 @@ public sealed partial class MainWindow : Window
     private void Show()
     {
         _hiding = false;
+        var duration = _configService.QuickTerminalAnimationDuration;
+
         if (!AppWindow.IsVisible)
         {
             MoveToQuakePosition();
+
+            // Seed the slide's start frame BEFORE the window is shown.
+            // AppWindow.Show() forces an immediate present; without this the
+            // first frame is stale -- the resting content (a full-terminal
+            // flash on the first toggle) or the leftover off-screen state from
+            // the prior hide (a held empty frame) -- before the slide begins.
+            if (duration > 0)
+            {
+                _slideAnimator ??= new QuickTerminalSlideAnimator(WindowNative.GetWindowHandle(this), RootGrid);
+                _slideAnimator.PrepareIn(
+                    _configService.QuickTerminalPosition,
+                    AppWindow.Size.Width,
+                    AppWindow.Size.Height);
+            }
+
             AppWindow.Show();
         }
 
-        var duration = _configService.QuickTerminalAnimationDuration;
         if (duration <= 0)
         {
             _slideAnimator?.SnapToShown();
@@ -2411,7 +2435,7 @@ public sealed partial class MainWindow : Window
         }
 
         _autohideArmed = false;
-        _slideAnimator ??= new QuickTerminalSlideAnimator(RootGrid);
+        _slideAnimator ??= new QuickTerminalSlideAnimator(WindowNative.GetWindowHandle(this), RootGrid);
         _slideAnimator.AnimateIn(
             _configService.QuickTerminalPosition,
             AppWindow.Size.Width,


### PR DESCRIPTION
The quake slide translated the terminal content inside a window already at its full size, so the window backdrop showed through the not-yet-covered area as an empty frame before the terminal slid over it.

Replace it with a window-region reveal (the approach Windows Terminal uses): the window stays at its final rect and its visible region grows from the docked edge via SetWindowRgn, so the desktop shows through the rest and there is no empty frame. Driven per frame from CompositionTarget.Rendering with an ease-out curve; the collapsed region is seeded before the window is shown so the first frame does not flash the full window.

Also paint the kept non-client resize strip (WM_NCPAINT) with the terminal background color so it matches the theme instead of Windows' default frame band.

Depends on the SwapChainPanel composition fix that landed in windows (# 538) for the revealed content to be painted on show.