### PR TITLE
fix(windows): make the Settings window a single app-wide instance

### DIFF
--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -62,6 +62,13 @@ public partial class App : Application
     // works from anywhere in the process and the hidden window stays
     // alive across regular window close/reopen cycles.
     private MainWindow? _quakeWindow;
+
+    // App-wide singleton settings window: one for the whole process,
+    // regardless of which window opened it (mirrors _quakeWindow). Its
+    // dependencies are app-global, so it outlives the window that opened it.
+    // UI-thread-only access.
+    private Window? _settingsWindow;
+
     private Ghostty.Session.SessionManager? _sessionManager;
     private Ghostty.Hosting.WindowsGlobalHotKey? _quakeHotKey;
     private Ghostty.Hosting.WindowsSystemMenuHook? _systemMenuHook;
@@ -912,6 +919,39 @@ public partial class App : Application
             if (ReferenceEquals(w, _quakeWindow)) continue;
             w.Close();
         }
+    }
+
+    /// <summary>
+    /// Show the app-wide settings window, or focus the existing one if it is
+    /// already open. One settings window serves the whole process, so opening
+    /// it from any window reuses the same instance. The caller guards on
+    /// SettingsUiEnabled. UI thread only.
+    /// </summary>
+    internal void ShowOrActivateSettings()
+    {
+        if (_settingsWindow is not null)
+        {
+            _settingsWindow.Activate();
+            return;
+        }
+
+        var keybindings = new KeyBindingsProvider(_configService!);
+        var themeProvider = new ThemeProvider(_configService!);
+        var window = new Ghostty.Settings.SettingsWindow(
+            _configService!, ConfigFileEditor!, keybindings, themeProvider);
+        window.Closed += (_, _) => _settingsWindow = null;
+        _settingsWindow = window;
+        window.Activate();
+    }
+
+    /// <summary>
+    /// Close the app-wide settings window if it is open. Called from the last
+    /// window's teardown so the settings window does not outlive the app.
+    /// </summary>
+    internal void CloseSettingsWindow()
+    {
+        _settingsWindow?.Close();
+        _settingsWindow = null;
     }
 
     // Whether the last toggle_visibility hid the windows, and the set it hid.

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -192,7 +192,6 @@ public sealed partial class MainWindow : Window
     private CaptionColors _lastButtonColors;
 
     private GradientTintVisual? _gradientVisual;
-    private Window? _settingsWindow;
     private Window? _aboutWindow;
     private InspectorWindow? _inspectorWindow;
 
@@ -695,20 +694,10 @@ public sealed partial class MainWindow : Window
             {
                 if (configService.SettingsUiEnabled)
                 {
-                    var editor = App.ConfigFileEditor!;
-                    var keybindings = new KeyBindingsProvider(configService);
-                    var themeProvider = new ThemeProvider(configService);
-                    // Reuse existing settings window if still open.
-                    if (_settingsWindow is not null)
-                    {
-                        _settingsWindow.Activate();
-                        return;
-                    }
-                    var settingsWin = new Ghostty.Settings.SettingsWindow(
-                        configService, editor, keybindings, themeProvider);
-                    settingsWin.Closed += (_, _) => _settingsWindow = null;
-                    _settingsWindow = settingsWin;
-                    settingsWin.Activate();
+                    // One settings window serves the whole process; App owns
+                    // the singleton (mirrors the quake window), so opening it
+                    // from any window reuses the same instance.
+                    ((App)Application.Current).ShowOrActivateSettings();
                     return;
                 }
 
@@ -1197,9 +1186,13 @@ public sealed partial class MainWindow : Window
             _windowState.Save();
         }
 
-        // Close settings window if open.
-        _settingsWindow?.Close();
-        _settingsWindow = null;
+        // The settings window is a single app-wide instance owned by App.
+        // Close it only when this is the last window closing -- closing it on
+        // any window's teardown would yank it away while other windows are
+        // still open. WindowsByRoot.Count <= 1 is the same "last regular
+        // window" signal used above for config shutdown.
+        if (Ghostty.App.WindowsByRoot.Count <= 1)
+            ((App)Application.Current).CloseSettingsWindow();
 
         // Close About window if open.
         _aboutWindow?.Close();


### PR DESCRIPTION
The settings window was tracked in a per-MainWindow field, so each terminal window could open its own. With more than one window open that meant several settings windows at once.

App now owns one settings window for the whole process, mirroring the quake window:
- MainWindow's open-config action calls `App.ShowOrActivateSettings`, which focuses the existing window or creates it. Its dependencies (ConfigService, ConfigFileEditor) are app-global, so it outlives the window that opened it.
- The last window to close calls `App.CloseSettingsWindow`, guarded by `WindowsByRoot.Count <= 1`, so it does not outlive the app.

Notes:
- One-per-process. Separate wintty processes each get their own (inherent to separate processes) unless single-instance routing is on.
- The About window keeps its per-window pattern (opening About is intentionally per-window); left unchanged here.