### PR TITLE
Accessibility: UIA text provider for the terminal grid

### DIFF
--- a/windows/Ghostty.Core/Accessibility/CachedValue.cs
+++ b/windows/Ghostty.Core/Accessibility/CachedValue.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Time-boxed single-value cache, ported from the macOS surface's
+/// <c>CachedValue</c>. Screen readers poll frequently and each fetch takes the
+/// renderer mutex, so we serve a cached value for <c>durationMs</c> before
+/// refetching. The clock is injected (<paramref name="nowMs"/>) so expiry is
+/// deterministic in tests; production passes <c>Environment.TickCount64</c>.
+/// Not thread-safe; call on the UI thread.
+/// </summary>
+public sealed class CachedValue<T>
+{
+    private readonly long _durationMs;
+    private readonly Func<T> _fetch;
+    private readonly Func<long> _nowMs;
+    private bool _has;
+    private T _value = default!;
+    private long _storedAt;
+
+    public CachedValue(long durationMs, Func<T> fetch, Func<long> nowMs)
+    {
+        _durationMs = durationMs;
+        _fetch = fetch ?? throw new ArgumentNullException(nameof(fetch));
+        _nowMs = nowMs ?? throw new ArgumentNullException(nameof(nowMs));
+    }
+
+    public T Get()
+    {
+        var now = _nowMs();
+        if (_has && now - _storedAt < _durationMs) return _value;
+        _value = _fetch();
+        _storedAt = now;
+        _has = true;
+        return _value;
+    }
+
+    public void Invalidate() => _has = false;
+}

--- a/windows/Ghostty.Core/Accessibility/SelectionRange.cs
+++ b/windows/Ghostty.Core/Accessibility/SelectionRange.cs
@@ -1,0 +1,21 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Maps libghostty's selection offsets (<c>offset_start</c> / <c>offset_len</c>
+/// from <c>ghostty_surface_read_selection</c>) to a document-bounded
+/// <see cref="TextSpan"/>. Core documents these as linear flattened-viewport
+/// offsets that can be imprecise for partially visible selections but always
+/// stay within text bounds, so clamping is sufficient and safe.
+/// </summary>
+public static class SelectionRange
+{
+    public static TextSpan FromOffsets(uint offsetStart, uint offsetLen, int docLength)
+    {
+        var max = docLength < 0 ? 0 : docLength;
+        var start = offsetStart > (uint)max ? max : (int)offsetStart;
+        long endL = (long)offsetStart + offsetLen;
+        var end = endL > max ? max : (int)endL;
+        if (end < start) end = start;
+        return new TextSpan(start, end);
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/TerminalDocument.cs
+++ b/windows/Ghostty.Core/Accessibility/TerminalDocument.cs
@@ -1,0 +1,52 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Immutable snapshot of the terminal's screen contents as a single string,
+/// with line and offset queries used by the UIA text range provider. Offsets
+/// are UTF-16 code unit indices into <see cref="Text"/>; lines are delimited
+/// by '\n'. Pure; no platform dependencies.
+/// </summary>
+public sealed class TerminalDocument
+{
+    public string Text { get; }
+    public int Length => Text.Length;
+
+    public TerminalDocument(string text) => Text = text ?? "";
+
+    /// <summary>Clamp an arbitrary offset to <c>[0, Length]</c>.</summary>
+    public int ClampOffset(int offset) =>
+        offset < 0 ? 0 : (offset > Length ? Length : offset);
+
+    /// <summary>Zero-based line index for an offset (count of '\n' before it).</summary>
+    public int LineIndexForOffset(int offset)
+    {
+        var end = ClampOffset(offset);
+        var count = 0;
+        for (var i = 0; i < end; i++)
+            if (Text[i] == '\n') count++;
+        return count;
+    }
+
+    /// <summary>
+    /// Half-open bounds <c>[start, end)</c> of the line containing <paramref name="offset"/>.
+    /// <c>start</c> is just after the previous '\n' (or 0); <c>end</c> is the next
+    /// '\n' (or Length). A '\n' character belongs to the line it terminates.
+    /// </summary>
+    public (int Start, int End) LineBounds(int offset)
+    {
+        var o = ClampOffset(offset);
+        var start = o;
+        while (start > 0 && Text[start - 1] != '\n') start--;
+        var end = o;
+        while (end < Length && Text[end] != '\n') end++;
+        return (start, end);
+    }
+
+    /// <summary>Substring for <c>[start, end)</c>, clamped; empty if start &gt;= end.</summary>
+    public string Slice(int start, int end)
+    {
+        var s = ClampOffset(start);
+        var e = ClampOffset(end);
+        return e <= s ? "" : Text.Substring(s, e - s);
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/TextRangeNavigator.cs
+++ b/windows/Ghostty.Core/Accessibility/TextRangeNavigator.cs
@@ -1,0 +1,90 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Pure range navigation over a <see cref="TerminalDocument"/>: the math behind
+/// UIA's ExpandToEnclosingUnit / MoveEndpointByUnit / CompareEndpoints. Endpoints
+/// are UTF-16 offsets; all results are clamped to the document.
+/// </summary>
+public static class TextRangeNavigator
+{
+    public static TextSpan ExpandToEnclosingUnit(TerminalDocument doc, TextSpan span, TextUnit unit)
+    {
+        switch (unit)
+        {
+            case TextUnit.Document:
+                return new TextSpan(0, doc.Length);
+
+            case TextUnit.Line:
+                var (start, end) = doc.LineBounds(span.Start);
+                return new TextSpan(start, end);
+
+            case TextUnit.Character:
+            default:
+                var s = doc.ClampOffset(span.Start);
+                var e = doc.ClampOffset(s + 1);
+                return new TextSpan(s, e);
+        }
+    }
+
+    /// <summary>
+    /// Move a single endpoint by <paramref name="count"/> units. Returns the new
+    /// endpoint and the number of units actually moved (0 when fully clamped),
+    /// matching UIA's MoveEndpointByUnit contract.
+    /// </summary>
+    public static (int Endpoint, int Moved) MoveEndpointByUnit(
+        TerminalDocument doc, int endpoint, TextUnit unit, int count)
+    {
+        var from = doc.ClampOffset(endpoint);
+        if (count == 0) return (from, 0);
+
+        return unit switch
+        {
+            TextUnit.Line => MoveByLine(doc, from, count),
+            _ => MoveByCharacter(doc, from, count),
+        };
+    }
+
+    public static int CompareEndpoints(int a, int b) => a.CompareTo(b);
+
+    private static (int, int) MoveByCharacter(TerminalDocument doc, int from, int count)
+    {
+        var target = doc.ClampOffset(from + count);
+        // Report the characters actually traversed (signed), 0 when fully clamped.
+        return (target, target - from);
+    }
+
+    private static (int, int) MoveByLine(TerminalDocument doc, int from, int count)
+    {
+        // Normalize to the start of the current line, then walk line starts.
+        var (lineStart, _) = doc.LineBounds(from);
+        var pos = lineStart;
+        var moved = 0;
+        var step = count > 0 ? 1 : -1;
+        var times = count > 0 ? count : -count;
+        for (var i = 0; i < times; i++)
+        {
+            var next = step > 0 ? NextLineStart(doc, pos) : PrevLineStart(doc, pos);
+            if (next == pos) break; // clamped at a boundary
+            pos = next;
+            moved += step;
+        }
+        return (pos, moved);
+    }
+
+    private static int NextLineStart(TerminalDocument doc, int pos)
+    {
+        var (_, end) = doc.LineBounds(pos);
+        // end is at the '\n' (or Length). Start of the next line is end+1.
+        if (end < doc.Length) return end + 1;
+        return pos; // already on the last line
+    }
+
+    private static int PrevLineStart(TerminalDocument doc, int pos)
+    {
+        var (start, _) = doc.LineBounds(pos);
+        if (start == 0) return pos; // already on the first line
+        // start-1 is the previous line's terminating '\n'; find that line's start.
+        var (prevStart, _) = doc.LineBounds(start - 1);
+        return prevStart;
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/TextSpan.cs
+++ b/windows/Ghostty.Core/Accessibility/TextSpan.cs
@@ -1,0 +1,20 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>A half-open text range <c>[Start, End)</c> in UTF-16 offsets.</summary>
+public readonly record struct TextSpan(int Start, int End)
+{
+    public int Length => End - Start;
+    public bool IsDegenerate => Start == End;
+}
+
+/// <summary>
+/// Text units the range provider supports in this stage. Word and Page are
+/// added in a later stage; the WinUI adapter maps the projection's TextUnit
+/// onto this enum and treats unsupported units as the nearest supported one.
+/// </summary>
+public enum TextUnit
+{
+    Character,
+    Line,
+    Document,
+}

--- a/windows/Ghostty.Tests/Accessibility/CachedValueTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/CachedValueTests.cs
@@ -1,0 +1,45 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class CachedValueTests
+{
+    [Fact]
+    public void Get_WithinWindow_ReturnsCachedAndDoesNotRefetch()
+    {
+        long now = 0;
+        var fetches = 0;
+        var cv = new CachedValue<int>(durationMs: 500, fetch: () => ++fetches, nowMs: () => now);
+
+        Assert.Equal(1, cv.Get());
+        now = 499;
+        Assert.Equal(1, cv.Get()); // still cached
+        Assert.Equal(1, fetches);
+    }
+
+    [Fact]
+    public void Get_AfterExpiry_Refetches()
+    {
+        long now = 0;
+        var fetches = 0;
+        var cv = new CachedValue<int>(durationMs: 500, fetch: () => ++fetches, nowMs: () => now);
+
+        Assert.Equal(1, cv.Get());
+        now = 500;
+        Assert.Equal(2, cv.Get()); // expired exactly at the boundary
+        Assert.Equal(2, fetches);
+    }
+
+    [Fact]
+    public void Invalidate_ForcesRefetch()
+    {
+        long now = 0;
+        var fetches = 0;
+        var cv = new CachedValue<int>(durationMs: 500, fetch: () => ++fetches, nowMs: () => now);
+
+        Assert.Equal(1, cv.Get());
+        cv.Invalidate();
+        Assert.Equal(2, cv.Get());
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/SelectionRangeTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/SelectionRangeTests.cs
@@ -1,0 +1,31 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class SelectionRangeTests
+{
+    [Fact]
+    public void FromOffsets_WithinBounds_IsExact()
+    {
+        Assert.Equal(new TextSpan(2, 5), SelectionRange.FromOffsets(2, 3, docLength: 10));
+    }
+
+    [Fact]
+    public void FromOffsets_StartBeyondLength_ClampsToDegenerateAtEnd()
+    {
+        Assert.Equal(new TextSpan(10, 10), SelectionRange.FromOffsets(99, 4, docLength: 10));
+    }
+
+    [Fact]
+    public void FromOffsets_LengthOverflowsDoc_ClampsEnd()
+    {
+        Assert.Equal(new TextSpan(8, 10), SelectionRange.FromOffsets(8, 50, docLength: 10));
+    }
+
+    [Fact]
+    public void FromOffsets_ZeroLength_IsDegenerate()
+    {
+        Assert.Equal(new TextSpan(3, 3), SelectionRange.FromOffsets(3, 0, docLength: 10));
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/TerminalDocumentTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/TerminalDocumentTests.cs
@@ -1,0 +1,68 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class TerminalDocumentTests
+{
+    [Fact]
+    public void NullText_BecomesEmpty()
+    {
+        var doc = new TerminalDocument(null!);
+        Assert.Equal("", doc.Text);
+        Assert.Equal(0, doc.Length);
+    }
+
+    [Fact]
+    public void Length_IsUtf16Length()
+    {
+        Assert.Equal(5, new TerminalDocument("hello").Length);
+    }
+
+    [Theory]
+    [InlineData(-5, 0)]
+    [InlineData(0, 0)]
+    [InlineData(3, 3)]
+    [InlineData(99, 5)]
+    public void ClampOffset_StaysInBounds(int input, int expected)
+    {
+        Assert.Equal(expected, new TerminalDocument("hello").ClampOffset(input));
+    }
+
+    [Fact]
+    public void LineIndexForOffset_CountsNewlinesBefore()
+    {
+        var doc = new TerminalDocument("ab\ncd\nef");
+        Assert.Equal(0, doc.LineIndexForOffset(0));
+        Assert.Equal(0, doc.LineIndexForOffset(2)); // the '\n' itself is on line 0
+        Assert.Equal(1, doc.LineIndexForOffset(3));
+        Assert.Equal(2, doc.LineIndexForOffset(7));
+        Assert.Equal(2, doc.LineIndexForOffset(999)); // clamped
+    }
+
+    [Fact]
+    public void LineBounds_ReturnsStartAfterPrevNewline_AndEndAtNextNewline()
+    {
+        var doc = new TerminalDocument("ab\ncd\nef");
+        Assert.Equal((0, 2), doc.LineBounds(1));   // "ab"
+        Assert.Equal((3, 5), doc.LineBounds(4));   // "cd"
+        Assert.Equal((6, 8), doc.LineBounds(7));   // "ef"
+    }
+
+    [Fact]
+    public void LineBounds_OnNewlineChar_BelongsToPrecedingLine()
+    {
+        var doc = new TerminalDocument("ab\ncd");
+        Assert.Equal((0, 2), doc.LineBounds(2)); // offset 2 is the '\n'
+    }
+
+    [Theory]
+    [InlineData(0, 5, "hello")]
+    [InlineData(1, 3, "el")]
+    [InlineData(-2, 99, "hello")] // clamped both ends
+    [InlineData(3, 1, "")]         // start > end yields empty
+    public void Slice_ClampsAndOrders(int start, int end, string expected)
+    {
+        Assert.Equal(expected, new TerminalDocument("hello").Slice(start, end));
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/TextRangeNavigatorTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/TextRangeNavigatorTests.cs
@@ -1,0 +1,62 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class TextRangeNavigatorTests
+{
+    private static readonly TerminalDocument Doc = new("ab\ncd\nef"); // 3 lines, len 8
+
+    [Fact]
+    public void ExpandToDocument_CoversWholeText()
+    {
+        var span = TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(4, 4), TextUnit.Document);
+        Assert.Equal(new TextSpan(0, 8), span);
+    }
+
+    [Fact]
+    public void ExpandToLine_CoversContainingLine()
+    {
+        var span = TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(4, 4), TextUnit.Line);
+        Assert.Equal(new TextSpan(3, 5), span); // "cd"
+    }
+
+    [Fact]
+    public void ExpandToCharacter_DegenerateBecomesSingleChar()
+    {
+        var span = TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(1, 1), TextUnit.Character);
+        Assert.Equal(new TextSpan(1, 2), span);
+    }
+
+    [Fact]
+    public void ExpandToCharacter_AtEnd_StaysDegenerate()
+    {
+        var span = TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(8, 8), TextUnit.Character);
+        Assert.Equal(new TextSpan(8, 8), span);
+    }
+
+    [Fact]
+    public void MoveEndpointByCharacter_ClampsAtBounds()
+    {
+        Assert.Equal((2, 2), TextRangeNavigator.MoveEndpointByUnit(Doc, 0, TextUnit.Character, 2));
+        Assert.Equal((0, 0), TextRangeNavigator.MoveEndpointByUnit(Doc, 0, TextUnit.Character, -5)); // clamped, moved 0
+        Assert.Equal((8, 0), TextRangeNavigator.MoveEndpointByUnit(Doc, 8, TextUnit.Character, 3));  // clamped, moved 0
+    }
+
+    [Fact]
+    public void MoveEndpointByLine_MovesToLineStart()
+    {
+        // from offset 4 (line 1) forward one line -> start of line 2 (offset 6)
+        Assert.Equal((6, 1), TextRangeNavigator.MoveEndpointByUnit(Doc, 4, TextUnit.Line, 1));
+        // backward one line -> start of line 0 (offset 0); moved is signed (UIA convention)
+        Assert.Equal((0, -1), TextRangeNavigator.MoveEndpointByUnit(Doc, 4, TextUnit.Line, -1));
+    }
+
+    [Fact]
+    public void CompareEndpoints_OrdersByOffset()
+    {
+        Assert.True(TextRangeNavigator.CompareEndpoints(3, 5) < 0);
+        Assert.Equal(0, TextRangeNavigator.CompareEndpoints(4, 4));
+        Assert.True(TextRangeNavigator.CompareEndpoints(7, 2) > 0);
+    }
+}

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -15,6 +15,10 @@ namespace Ghostty.Accessibility;
 /// </summary>
 internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomationPeer, ITextProvider
 {
+    // Screen reads take the renderer mutex, so we serve a cached document for
+    // this long between fetches. Matches the macOS surface's 500ms CachedValue.
+    private const long ScreenTextCacheMs = 500;
+
     private readonly TerminalControl _owner;
     private readonly CachedValue<TerminalDocument> _document;
 
@@ -22,7 +26,7 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     {
         _owner = owner;
         _document = new CachedValue<TerminalDocument>(
-            durationMs: 500,
+            durationMs: ScreenTextCacheMs,
             fetch: () => new TerminalDocument(_owner.AccessibilityReadScreenText()),
             nowMs: () => Environment.TickCount64);
     }

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -1,0 +1,69 @@
+using System;
+using Ghostty.Controls;
+using Ghostty.Core.Accessibility;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// UIA automation peer for the terminal surface. Exposes the screen contents and
+/// current selection to screen readers through the Text pattern, mirroring the
+/// macOS VoiceOver model (textArea role, cached screen contents, read_selection
+/// offsets as the selected range). Read-only in this stage.
+/// </summary>
+internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomationPeer, ITextProvider
+{
+    private readonly TerminalControl _owner;
+    private readonly CachedValue<TerminalDocument> _document;
+
+    internal TerminalAutomationPeer(TerminalControl owner) : base(owner)
+    {
+        _owner = owner;
+        _document = new CachedValue<TerminalDocument>(
+            durationMs: 500,
+            fetch: () => new TerminalDocument(_owner.AccessibilityReadScreenText()),
+            nowMs: () => Environment.TickCount64);
+    }
+
+    /// <summary>Current cached screen document. Refreshed at most every 500ms.</summary>
+    internal TerminalDocument Document => _document.Get();
+
+    /// <summary>Bridge this peer to its UIA provider, for range GetEnclosingElement.</summary>
+    internal IRawElementProviderSimple Provider => ProviderFromPeer(this);
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+        => AutomationControlType.Text;
+
+    protected override string GetClassNameCore() => nameof(TerminalControl);
+
+    protected override string GetNameCore() => "Terminal";
+
+    protected override object GetPatternCore(PatternInterface patternInterface)
+        => patternInterface == PatternInterface.Text ? this : base.GetPatternCore(patternInterface);
+
+    // ---- ITextProvider ----------------------------------------------------
+
+    public ITextRangeProvider DocumentRange =>
+        new TerminalTextRangeProvider(this, new TextSpan(0, Document.Length));
+
+    public SupportedTextSelection SupportedTextSelection => SupportedTextSelection.Single;
+
+    public ITextRangeProvider[] GetSelection()
+    {
+        var offsets = _owner.AccessibilitySelectionOffsets();
+        if (offsets is not { } o) return Array.Empty<ITextRangeProvider>();
+        var span = SelectionRange.FromOffsets(o.OffsetStart, o.OffsetLen, Document.Length);
+        return new ITextRangeProvider[] { new TerminalTextRangeProvider(this, span) };
+    }
+
+    // The whole screen is treated as visible (macOS parity).
+    public ITextRangeProvider[] GetVisibleRanges() =>
+        new ITextRangeProvider[] { DocumentRange };
+
+    public ITextRangeProvider RangeFromChild(IRawElementProviderSimple childElement) => DocumentRange;
+
+    public ITextRangeProvider RangeFromPoint(global::Windows.Foundation.Point screenLocation) =>
+        new TerminalTextRangeProvider(this, new TextSpan(0, 0));
+}

--- a/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
+++ b/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
@@ -1,0 +1,122 @@
+using System;
+using Ghostty.Core.Accessibility;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Automation.Text;
+using CoreTextUnit = Ghostty.Core.Accessibility.TextUnit;
+using WinTextUnit = Microsoft.UI.Xaml.Automation.Text.TextUnit;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// A UIA text range over the terminal document, backed by an immutable
+/// <see cref="TextSpan"/>. All navigation math is delegated to the pure
+/// <see cref="TextRangeNavigator"/>; this type only adapts WinUI projection
+/// types. Read-only in this stage: selection and scroll mutators are no-ops.
+/// </summary>
+internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
+{
+    private readonly TerminalAutomationPeer _peer;
+    private TextSpan _span;
+
+    internal TerminalTextRangeProvider(TerminalAutomationPeer peer, TextSpan span)
+    {
+        _peer = peer;
+        _span = span;
+    }
+
+    private TerminalDocument Doc => _peer.Document;
+
+    private static CoreTextUnit MapUnit(WinTextUnit unit) => unit switch
+    {
+        WinTextUnit.Character => CoreTextUnit.Character,
+        WinTextUnit.Format => CoreTextUnit.Character,
+        WinTextUnit.Word => CoreTextUnit.Line,
+        WinTextUnit.Line => CoreTextUnit.Line,
+        WinTextUnit.Paragraph => CoreTextUnit.Line,
+        _ => CoreTextUnit.Document,
+    };
+
+    public ITextRangeProvider Clone() => new TerminalTextRangeProvider(_peer, _span);
+
+    public bool Compare(ITextRangeProvider other) =>
+        other is TerminalTextRangeProvider o && o._span == _span;
+
+    public int CompareEndpoints(
+        TextPatternRangeEndpoint endpoint,
+        ITextRangeProvider targetRange,
+        TextPatternRangeEndpoint targetEndpoint)
+    {
+        var a = EndpointOf(_span, endpoint);
+        var b = EndpointOf(((TerminalTextRangeProvider)targetRange)._span, targetEndpoint);
+        return TextRangeNavigator.CompareEndpoints(a, b);
+    }
+
+    public void ExpandToEnclosingUnit(WinTextUnit unit) =>
+        _span = TextRangeNavigator.ExpandToEnclosingUnit(Doc, _span, MapUnit(unit));
+
+    public ITextRangeProvider FindAttribute(int attributeId, object value, bool backward) => null!;
+
+    public ITextRangeProvider FindText(string text, bool backward, bool ignoreCase) => null!;
+
+    // Text attributes (foreground/background color, etc.) are added in a later
+    // stage; null signals "no value" to clients until then.
+    public object GetAttributeValue(int attributeId) => null!;
+
+    public void GetBoundingRectangles(out double[] rectangles) => rectangles = Array.Empty<double>();
+
+    public IRawElementProviderSimple GetEnclosingElement() => _peer.Provider;
+
+    public string GetText(int maxLength)
+    {
+        var text = Doc.Slice(_span.Start, _span.End);
+        return maxLength >= 0 && maxLength < text.Length ? text.Substring(0, maxLength) : text;
+    }
+
+    public int Move(WinTextUnit unit, int count)
+    {
+        // Collapse to the start, move that endpoint, then expand by one unit.
+        var (offset, moved) = TextRangeNavigator.MoveEndpointByUnit(Doc, _span.Start, MapUnit(unit), count);
+        _span = TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(offset, offset), MapUnit(unit));
+        return moved;
+    }
+
+    public void MoveEndpointByRange(
+        TextPatternRangeEndpoint endpoint,
+        ITextRangeProvider targetRange,
+        TextPatternRangeEndpoint targetEndpoint)
+    {
+        var value = EndpointOf(((TerminalTextRangeProvider)targetRange)._span, targetEndpoint);
+        _span = SetEndpoint(_span, endpoint, value);
+    }
+
+    public int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, WinTextUnit unit, int count)
+    {
+        var from = EndpointOf(_span, endpoint);
+        var (newOffset, moved) = TextRangeNavigator.MoveEndpointByUnit(Doc, from, MapUnit(unit), count);
+        _span = SetEndpoint(_span, endpoint, newOffset);
+        return moved;
+    }
+
+    public void Select() { /* read-only: selection is driven from the terminal, not UIA */ }
+
+    public void AddToSelection() { }
+
+    public void RemoveFromSelection() { }
+
+    public void ScrollIntoView(bool alignToTop) { }
+
+    public IRawElementProviderSimple[] GetChildren() => Array.Empty<IRawElementProviderSimple>();
+
+    // ---- helpers ----------------------------------------------------------
+
+    private static int EndpointOf(TextSpan span, TextPatternRangeEndpoint endpoint) =>
+        endpoint == TextPatternRangeEndpoint.Start ? span.Start : span.End;
+
+    private TextSpan SetEndpoint(TextSpan span, TextPatternRangeEndpoint endpoint, int value)
+    {
+        value = Doc.ClampOffset(value);
+        if (endpoint == TextPatternRangeEndpoint.Start)
+            return new TextSpan(value, Math.Max(value, span.End));
+        return new TextSpan(Math.Min(span.Start, value), value);
+    }
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -166,6 +166,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// Returns "" once the surface is gone so a screen reader polling during
     /// teardown can't touch freed native state. Takes the renderer mutex; the
     /// automation peer caches the result for 500ms.
+    ///
+    /// UIA calls arrive on a UIA/RPC thread, so there is a narrow race between
+    /// this guard and the native read if the surface is disposed concurrently.
+    /// libghostty serializes the read on its renderer mutex and the guard makes
+    /// the window small; macOS accepts the same race for the same reason. An
+    /// empty string on a transient/teardown miss is the intended graceful
+    /// degradation (a screen reader must not crash on a momentary read failure).
     /// </summary>
     internal string AccessibilityReadScreenText()
     {

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -162,6 +162,32 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     }
 
     /// <summary>
+    /// Read the full screen contents for accessibility (UIA text provider).
+    /// Returns "" once the surface is gone so a screen reader polling during
+    /// teardown can't touch freed native state. Takes the renderer mutex; the
+    /// automation peer caches the result for 500ms.
+    /// </summary>
+    internal string AccessibilityReadScreenText()
+    {
+        if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return "";
+        return NativeMethods.SurfaceReadScreenText(_surface);
+    }
+
+    /// <summary>
+    /// Read the current selection's flattened-viewport offsets for accessibility,
+    /// or null when there is no selection or the surface is gone.
+    /// </summary>
+    internal (uint OffsetStart, uint OffsetLen)? AccessibilitySelectionOffsets()
+    {
+        if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return null;
+        var sel = NativeMethods.SurfaceReadSelection(_surface);
+        return sel is { } s ? (s.OffsetStart, s.OffsetLen) : null;
+    }
+
+    protected override Microsoft.UI.Xaml.Automation.Peers.AutomationPeer OnCreateAutomationPeer()
+        => new Ghostty.Accessibility.TerminalAutomationPeer(this);
+
+    /// <summary>
     /// Returns the pid of the shell process attached to this surface, or
     /// null when libghostty cannot report one (surface not yet created,
     /// already disposed, or the platform's pty layer is a stub). The

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -191,6 +191,56 @@ internal struct GhosttyCells
     public ushort Cols;
 }
 
+// Mirrors ghostty_point_tag_e.
+internal enum GhosttyPointTag
+{
+    Active = 0,
+    Viewport = 1,
+    Screen = 2,
+    Surface = 3,
+}
+
+// Mirrors ghostty_point_coord_e.
+internal enum GhosttyPointCoord
+{
+    Exact = 0,
+    TopLeft = 1,
+    BottomRight = 2,
+}
+
+// Mirrors ghostty_point_s.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyPoint
+{
+    public GhosttyPointTag Tag;
+    public GhosttyPointCoord Coord;
+    public uint X;
+    public uint Y;
+}
+
+// Mirrors ghostty_selection_s. Passed by value to ghostty_surface_read_text.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttySelection
+{
+    public GhosttyPoint TopLeft;
+    public GhosttyPoint BottomRight;
+    // C99 _Bool on the C side; byte on the managed side.
+    public byte Rectangle;
+}
+
+// Mirrors ghostty_text_s. Text is a NUL-terminated UTF-8 buffer of TextLen
+// bytes owned by libghostty; copy it out then free with ghostty_surface_free_text.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyText
+{
+    public double TlPxX;
+    public double TlPxY;
+    public uint OffsetStart;
+    public uint OffsetLen;
+    public IntPtr Text;
+    public UIntPtr TextLen;
+}
+
 // Runtime callback delegates. These are called from the Zig side on its
 // own thread; marshal to the UI dispatcher before touching XAML.
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -499,6 +549,64 @@ internal static partial class NativeMethods
         {
             SurfaceFreeCellsNative(surface, ref native);
         }
+    }
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_read_text")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceReadTextNative(GhosttySurface surface, GhosttySelection sel, out GhosttyText text);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_read_selection")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial byte SurfaceReadSelectionNative(GhosttySurface surface, out GhosttyText text);
+
+    [LibraryImport(Dll, EntryPoint = "ghostty_surface_free_text")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial void SurfaceFreeTextNative(GhosttySurface surface, ref GhosttyText text);
+
+    // A whole-region selection (top-left -> bottom-right) over the given point space.
+    private static GhosttySelection WholeRegion(GhosttyPointTag tag) => new()
+    {
+        TopLeft = new GhosttyPoint { Tag = tag, Coord = GhosttyPointCoord.TopLeft, X = 0, Y = 0 },
+        BottomRight = new GhosttyPoint { Tag = tag, Coord = GhosttyPointCoord.BottomRight, X = 0, Y = 0 },
+        Rectangle = 0,
+    };
+
+    private static string CopyAndFree(GhosttySurface surface, ref GhosttyText native)
+    {
+        try
+        {
+            if (native.Text == IntPtr.Zero) return "";
+            var len = (int)native.TextLen;
+            return len <= 0 ? "" : (Marshal.PtrToStringUTF8(native.Text, len) ?? "");
+        }
+        finally
+        {
+            SurfaceFreeTextNative(surface, ref native);
+        }
+    }
+
+    /// <summary>
+    /// Read the full screen contents (scrollback + viewport) as a string for
+    /// accessibility. Returns "" on failure. Takes the renderer mutex; callers
+    /// must cache + throttle.
+    /// </summary>
+    internal static string SurfaceReadScreenText(GhosttySurface surface)
+    {
+        if (SurfaceReadTextNative(surface, WholeRegion(GhosttyPointTag.Screen), out var native) == 0) return "";
+        return CopyAndFree(surface, ref native);
+    }
+
+    /// <summary>
+    /// Read the current selection's text and its flattened-viewport offsets.
+    /// Returns null when there is no selection.
+    /// </summary>
+    internal static (string Text, uint OffsetStart, uint OffsetLen)? SurfaceReadSelection(GhosttySurface surface)
+    {
+        if (SurfaceReadSelectionNative(surface, out var native) == 0) return null;
+        var start = native.OffsetStart;
+        var len = native.OffsetLen;
+        var text = CopyAndFree(surface, ref native);
+        return (text, start, len);
     }
 
     // Returns the pid of the foreground process attached to the pty, or


### PR DESCRIPTION
Adds a Microsoft UI Automation text provider on the terminal surface so screen
readers (Narrator, NVDA, JAWS) can read terminal contents. This is the Windows
side of the VoiceOver support the macOS app already has (# 77).

It follows the macOS accessibility model directly. The document text comes from
ghostty_surface_read_text over the screen region, cached briefly because each
read takes the renderer lock. The selection range comes from
ghostty_surface_read_selection. There are no native changes; it binds C exports
that already exist.

The index math, range navigation, selection clamping, and the cache are pure
types in Ghostty.Core with unit tests. The WinUI automation peer and text range
provider are thin adapters over them.

This is the first of a short series. It covers the read model: screen text plus
the current selection. Color text attributes and throttled output announcements
follow in later changes. Windows high contrast for the terminal surface colors
is also a separate follow up.

Verified locally:
- dotnet build and dotnet test pass on x64 (the new pure types add 27 tests).
- Launched the app and confirmed through the automation tree that the terminal
  exposes the Text control type and the Text pattern, and that reading the
  document range returns the on-screen contents.

Left for manual testing: a real pass with NVDA and JAWS.
