### PR TITLE
Accessibility: word navigation and search in the UIA text provider

### DIFF
--- a/windows/Ghostty.Core/Accessibility/TerminalDocument.cs
+++ b/windows/Ghostty.Core/Accessibility/TerminalDocument.cs
@@ -104,8 +104,11 @@ public sealed class TerminalDocument
         if (e <= s || text.Length > e - s) return null;
 
         var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        var window = Text.Substring(s, e - s);
-        var rel = backward ? window.LastIndexOf(text, comparison) : window.IndexOf(text, comparison);
+        // Search a span over the window so a find on the whole document does not
+        // copy the screen text.
+        var window = Text.AsSpan(s, e - s);
+        var needle = text.AsSpan();
+        var rel = backward ? window.LastIndexOf(needle, comparison) : window.IndexOf(needle, comparison);
         return rel < 0 ? null : new TextSpan(s + rel, s + rel + text.Length);
     }
 }

--- a/windows/Ghostty.Core/Accessibility/TerminalDocument.cs
+++ b/windows/Ghostty.Core/Accessibility/TerminalDocument.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ghostty.Core.Accessibility;
 
 /// <summary>
@@ -48,5 +50,62 @@ public sealed class TerminalDocument
         var s = ClampOffset(start);
         var e = ClampOffset(end);
         return e <= s ? "" : Text.Substring(s, e - s);
+    }
+
+    /// <summary>
+    /// True when <paramref name="i"/> begins a word: a non-whitespace char whose
+    /// previous char is whitespace (or the start of the document). Whitespace is
+    /// <see cref="char.IsWhiteSpace(char)"/>, which includes '\n', so words never
+    /// cross a line boundary.
+    /// </summary>
+    public bool IsWordStart(int i) =>
+        i >= 0 && i < Length && !char.IsWhiteSpace(Text[i]) && (i == 0 || char.IsWhiteSpace(Text[i - 1]));
+
+    /// <summary>
+    /// Start of the word unit containing <paramref name="offset"/>: the greatest
+    /// word-start at or before it, or 0 (leading whitespace forms its own unit).
+    /// </summary>
+    public int WordUnitStart(int offset)
+    {
+        var o = ClampOffset(offset);
+        for (var i = o; i >= 1; i--)
+            if (IsWordStart(i)) return i;
+        return 0;
+    }
+
+    /// <summary>First word-start strictly after <paramref name="offset"/>, else Length.</summary>
+    public int NextWordStart(int offset)
+    {
+        var o = ClampOffset(offset);
+        for (var i = o + 1; i < Length; i++)
+            if (IsWordStart(i)) return i;
+        return Length;
+    }
+
+    /// <summary>Greatest word-start strictly before <paramref name="offset"/>, else 0.</summary>
+    public int PrevWordStart(int offset)
+    {
+        var o = ClampOffset(offset);
+        for (var i = o - 1; i >= 1; i--)
+            if (IsWordStart(i)) return i;
+        return 0;
+    }
+
+    /// <summary>
+    /// Find <paramref name="text"/> within <c>[withinStart, withinEnd)</c>. Returns the
+    /// first match (or the last when <paramref name="backward"/>), or null when not found
+    /// or the needle is empty. Comparison is Ordinal, or OrdinalIgnoreCase when requested.
+    /// </summary>
+    public TextSpan? Find(string text, int withinStart, int withinEnd, bool backward, bool ignoreCase)
+    {
+        if (string.IsNullOrEmpty(text)) return null;
+        var s = ClampOffset(withinStart);
+        var e = ClampOffset(withinEnd);
+        if (e <= s || text.Length > e - s) return null;
+
+        var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var window = Text.Substring(s, e - s);
+        var rel = backward ? window.LastIndexOf(text, comparison) : window.IndexOf(text, comparison);
+        return rel < 0 ? null : new TextSpan(s + rel, s + rel + text.Length);
     }
 }

--- a/windows/Ghostty.Core/Accessibility/TextRangeNavigator.cs
+++ b/windows/Ghostty.Core/Accessibility/TextRangeNavigator.cs
@@ -18,6 +18,11 @@ public static class TextRangeNavigator
                 var (start, end) = doc.LineBounds(span.Start);
                 return new TextSpan(start, end);
 
+            case TextUnit.Word:
+                var wordStart = doc.WordUnitStart(span.Start);
+                var wordEnd = doc.NextWordStart(wordStart);
+                return new TextSpan(wordStart, wordEnd);
+
             case TextUnit.Character:
             default:
                 var s = doc.ClampOffset(span.Start);
@@ -40,6 +45,7 @@ public static class TextRangeNavigator
         return unit switch
         {
             TextUnit.Line => MoveByLine(doc, from, count),
+            TextUnit.Word => MoveByWord(doc, from, count),
             _ => MoveByCharacter(doc, from, count),
         };
     }
@@ -51,6 +57,22 @@ public static class TextRangeNavigator
         var target = doc.ClampOffset(from + count);
         // Report the characters actually traversed (signed), 0 when fully clamped.
         return (target, target - from);
+    }
+
+    private static (int, int) MoveByWord(TerminalDocument doc, int from, int count)
+    {
+        var pos = from;
+        var moved = 0;
+        var step = count > 0 ? 1 : -1;
+        var times = count > 0 ? count : -count;
+        for (var i = 0; i < times; i++)
+        {
+            var next = step > 0 ? doc.NextWordStart(pos) : doc.PrevWordStart(pos);
+            if (next == pos) break; // clamped at a boundary
+            pos = next;
+            moved += step;
+        }
+        return (pos, moved);
     }
 
     private static (int, int) MoveByLine(TerminalDocument doc, int from, int count)

--- a/windows/Ghostty.Core/Accessibility/TextSpan.cs
+++ b/windows/Ghostty.Core/Accessibility/TextSpan.cs
@@ -15,6 +15,7 @@ public readonly record struct TextSpan(int Start, int End)
 public enum TextUnit
 {
     Character,
+    Word,
     Line,
     Document,
 }

--- a/windows/Ghostty.Tests/Accessibility/FindTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/FindTests.cs
@@ -1,0 +1,52 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class FindTests
+{
+    private static readonly TerminalDocument Doc = new("abc ABC abc"); // len 11
+
+    [Fact]
+    public void Find_Forward_FirstMatch()
+    {
+        Assert.Equal(new TextSpan(0, 3), Doc.Find("abc", 0, Doc.Length, backward: false, ignoreCase: false));
+    }
+
+    [Fact]
+    public void Find_Backward_LastMatch()
+    {
+        Assert.Equal(new TextSpan(8, 11), Doc.Find("abc", 0, Doc.Length, backward: true, ignoreCase: false));
+    }
+
+    [Fact]
+    public void Find_IgnoreCase_MatchesUppercase()
+    {
+        Assert.Equal(new TextSpan(0, 3), Doc.Find("ABC", 0, Doc.Length, backward: false, ignoreCase: true));
+    }
+
+    [Fact]
+    public void Find_CaseSensitive_SkipsToExactCase()
+    {
+        Assert.Equal(new TextSpan(4, 7), Doc.Find("ABC", 0, Doc.Length, backward: false, ignoreCase: false));
+    }
+
+    [Fact]
+    public void Find_WithinSubRange_OnlySearchesThatRange()
+    {
+        // Restrict to [4,11): the first "abc" at 0 is excluded.
+        Assert.Equal(new TextSpan(8, 11), Doc.Find("abc", 4, 11, backward: false, ignoreCase: false));
+    }
+
+    [Fact]
+    public void Find_NotFound_ReturnsNull()
+    {
+        Assert.Null(Doc.Find("zzz", 0, Doc.Length, backward: false, ignoreCase: false));
+    }
+
+    [Fact]
+    public void Find_EmptyNeedle_ReturnsNull()
+    {
+        Assert.Null(Doc.Find("", 0, Doc.Length, backward: false, ignoreCase: false));
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/WordUnitTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/WordUnitTests.cs
@@ -1,0 +1,113 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class WordUnitTests
+{
+    // "ab cd  ef" -> word-starts at 0, 3, 7
+    private static readonly TerminalDocument Doc = new("ab cd  ef");
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(2, false)] // space
+    [InlineData(3, true)]
+    [InlineData(7, true)]
+    public void IsWordStart_DetectsBoundaries(int i, bool expected)
+    {
+        Assert.Equal(expected, Doc.IsWordStart(i));
+    }
+
+    [Fact]
+    public void IsWordStart_FalseAcrossNewline()
+    {
+        // '\n' is whitespace, so the char after it is a word-start, the '\n' is not.
+        var d = new TerminalDocument("ab\ncd");
+        Assert.False(d.IsWordStart(2)); // the '\n'
+        Assert.True(d.IsWordStart(3));  // 'c'
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(4, 3)]
+    [InlineData(6, 3)] // in the double space, belongs to the "cd  " unit
+    [InlineData(8, 7)]
+    public void WordUnitStart_ReturnsContainingWordStart(int offset, int expected)
+    {
+        Assert.Equal(expected, Doc.WordUnitStart(offset));
+    }
+
+    [Theory]
+    [InlineData(0, 3)]
+    [InlineData(3, 7)]
+    [InlineData(7, 9)] // no further word-start -> Length
+    public void NextWordStart_FindsNext(int offset, int expected)
+    {
+        Assert.Equal(expected, Doc.NextWordStart(offset));
+    }
+
+    [Theory]
+    [InlineData(9, 7)]
+    [InlineData(7, 3)]
+    [InlineData(3, 0)]
+    [InlineData(0, 0)] // already at/before first word-start
+    public void PrevWordStart_FindsPrevious(int offset, int expected)
+    {
+        Assert.Equal(expected, Doc.PrevWordStart(offset));
+    }
+
+    [Fact]
+    public void LeadingWhitespace_FirstUnitIsTheWhitespace()
+    {
+        var d = new TerminalDocument("  hi");
+        Assert.Equal(0, d.WordUnitStart(1)); // inside leading ws -> 0
+        Assert.Equal(2, d.NextWordStart(0)); // first word-start at 2
+    }
+
+    [Fact]
+    public void ExpandToWord_CoversWordPlusTrailingWhitespace()
+    {
+        // "ab cd  ef": word-starts 0,3,7. Expanding inside "cd" -> [3,7) = "cd  ".
+        Assert.Equal(new TextSpan(3, 7),
+            TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(4, 4), TextUnit.Word));
+    }
+
+    [Fact]
+    public void ExpandToWord_LeadingWhitespaceIsItsOwnUnit()
+    {
+        var d = new TerminalDocument("  hi");
+        Assert.Equal(new TextSpan(0, 2),
+            TextRangeNavigator.ExpandToEnclosingUnit(d, new TextSpan(1, 1), TextUnit.Word));
+    }
+
+    [Fact]
+    public void ExpandToWord_LastWordRunsToEnd()
+    {
+        Assert.Equal(new TextSpan(7, 9),
+            TextRangeNavigator.ExpandToEnclosingUnit(Doc, new TextSpan(8, 8), TextUnit.Word));
+    }
+
+    [Fact]
+    public void MoveByWord_ForwardHopsWordStarts()
+    {
+        Assert.Equal((3, 1), TextRangeNavigator.MoveEndpointByUnit(Doc, 0, TextUnit.Word, 1));
+        Assert.Equal((7, 2), TextRangeNavigator.MoveEndpointByUnit(Doc, 0, TextUnit.Word, 2));
+    }
+
+    [Fact]
+    public void MoveByWord_ForwardClampsPastLastWord()
+    {
+        // From the last word, the next boundary is end-of-doc; one more move is clamped.
+        Assert.Equal((9, 1), TextRangeNavigator.MoveEndpointByUnit(Doc, 7, TextUnit.Word, 1));
+        Assert.Equal((9, 0), TextRangeNavigator.MoveEndpointByUnit(Doc, 9, TextUnit.Word, 1));
+    }
+
+    [Fact]
+    public void MoveByWord_BackwardIsSigned()
+    {
+        Assert.Equal((3, -1), TextRangeNavigator.MoveEndpointByUnit(Doc, 7, TextUnit.Word, -1));
+        Assert.Equal((0, -2), TextRangeNavigator.MoveEndpointByUnit(Doc, 7, TextUnit.Word, -2));
+    }
+}

--- a/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
+++ b/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
@@ -30,7 +30,7 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
     {
         WinTextUnit.Character => CoreTextUnit.Character,
         WinTextUnit.Format => CoreTextUnit.Character,
-        WinTextUnit.Word => CoreTextUnit.Line,
+        WinTextUnit.Word => CoreTextUnit.Word,
         WinTextUnit.Line => CoreTextUnit.Line,
         WinTextUnit.Paragraph => CoreTextUnit.Line,
         _ => CoreTextUnit.Document,
@@ -56,7 +56,11 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
 
     public ITextRangeProvider FindAttribute(int attributeId, object value, bool backward) => null!;
 
-    public ITextRangeProvider FindText(string text, bool backward, bool ignoreCase) => null!;
+    public ITextRangeProvider FindText(string text, bool backward, bool ignoreCase)
+    {
+        var match = Doc.Find(text, _span.Start, _span.End, backward, ignoreCase);
+        return match is { } m ? new TerminalTextRangeProvider(_peer, m) : null!;
+    }
 
     // Text attributes (foreground/background color, etc.) are added in a later
     // stage; null signals "no value" to clients until then.


### PR DESCRIPTION
Builds on the merged UIA text provider with the navigation half of the text
pattern, so screen readers can move and search word by word.

Adds a real Word text unit: a word is the run starting at a non-whitespace
character whose previous character is whitespace, and a word unit covers the
word plus its trailing whitespace up to the next word start. Whitespace includes
newlines, so words never cross a line. ExpandToEnclosingUnit and
MoveEndpointByUnit both handle the Word unit now, with the same clamping and
signed move count as the existing Character and Line units.

Adds FindText: search the current range for a string, forward or backward, case
sensitive or not, returning the matching range or null.

The word boundary logic and the search are pure types in Ghostty.Core with unit
tests. The range provider maps the Word unit through and delegates the search.
No native changes.

Color text attributes are intentionally not included. UIA would map a range to
per cell colors, but read_cells only covers the viewport while the document is
the full screen including scrollback, so scrollback text has no cell data and
the viewport offset mapping is unreliable. macOS exposes no colors either. Left
as an optional follow up.

Verified locally:
- dotnet build and dotnet test pass on x64 (the new pure logic adds 32 tests).
- Launched the app with a command that prints a known multi word line, and
  through the automation tree confirmed ExpandToEnclosingUnit(Word) returns a
  single word and FindText finds a known word.

Left for manual testing: a real pass with NVDA and JAWS.
