### PR TITLE
Accessibility: announce new terminal output to screen readers

### DIFF
--- a/windows/Ghostty.Core/Accessibility/TerminalOutputAnnouncer.cs
+++ b/windows/Ghostty.Core/Accessibility/TerminalOutputAnnouncer.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Decides what new terminal output to announce to a screen reader, given successive
+/// snapshots of the screen text. Pure and deterministic. Works off the screen text
+/// (append-only until a clear or redraw); announces only complete lines, holds a
+/// trailing partial line until its newline arrives, batches new lines into one
+/// string, and summarizes large bursts. On a non-prefix change (clear, redraw,
+/// scroll-out) it re-baselines silently to avoid speaking garbage.
+/// </summary>
+public sealed class TerminalOutputAnnouncer
+{
+    private readonly int _maxLines;
+    private readonly int _maxChars;
+    private string _announced = "";
+    private bool _seeded;
+
+    public TerminalOutputAnnouncer(int maxLines = 20, int maxChars = 1000)
+    {
+        _maxLines = maxLines;
+        _maxChars = maxChars;
+    }
+
+    /// <summary>
+    /// Observe the current screen text. Returns the text to announce, or null when
+    /// there is nothing new to speak yet.
+    /// </summary>
+    public string? Observe(string screenText)
+    {
+        screenText ??= "";
+        if (!_seeded)
+        {
+            _announced = screenText;
+            _seeded = true;
+            return null;
+        }
+        if (screenText.Length == _announced.Length && screenText == _announced) return null;
+        if (!screenText.StartsWith(_announced, StringComparison.Ordinal))
+        {
+            _announced = screenText; // diverged: re-baseline silently
+            return null;
+        }
+        var delta = screenText.Substring(_announced.Length);
+        var lastNewline = delta.LastIndexOf('\n');
+        if (lastNewline < 0) return null; // only a partial new line so far; hold
+        var settled = delta.Substring(0, lastNewline + 1);
+        _announced += settled;
+        return Summarize(settled);
+    }
+
+    /// <summary>Adopt <paramref name="screenText"/> as the baseline without announcing.</summary>
+    public void Reseed(string screenText)
+    {
+        _announced = screenText ?? "";
+        _seeded = true;
+    }
+
+    private string? Summarize(string settled)
+    {
+        var lines = settled.Split('\n');
+        var count = 0;
+        for (var i = 0; i < lines.Length; i++)
+            if (lines[i].Trim().Length > 0) count++;
+        if (count == 0) return null;
+        if (count > _maxLines || settled.Length > _maxChars)
+            return count + " new lines";
+
+        var sb = new StringBuilder();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].Trim();
+            if (line.Length == 0) continue;
+            if (sb.Length > 0) sb.Append('\n');
+            sb.Append(line);
+        }
+        return sb.ToString();
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/TerminalOutputAnnouncer.cs
+++ b/windows/Ghostty.Core/Accessibility/TerminalOutputAnnouncer.cs
@@ -37,10 +37,16 @@ public sealed class TerminalOutputAnnouncer
             _seeded = true;
             return null;
         }
-        if (screenText.Length == _announced.Length && screenText == _announced) return null;
+        if (screenText == _announced) return null;
         if (!screenText.StartsWith(_announced, StringComparison.Ordinal))
         {
-            _announced = screenText; // diverged: re-baseline silently
+            // The new screen is no longer a prefix of what we announced: a clear,
+            // a full-screen redraw, or scrollback that wrapped and dropped the
+            // oldest lines. Re-baseline silently. Note: under sustained output that
+            // exceeds the scrollback buffer this can recur every tick, degrading to
+            // no announcements - that is intentional fail-safe behavior (silence
+            // beats speaking garbage during redraws).
+            _announced = screenText;
             return null;
         }
         var delta = screenText.Substring(_announced.Length);
@@ -66,7 +72,7 @@ public sealed class TerminalOutputAnnouncer
             if (lines[i].Trim().Length > 0) count++;
         if (count == 0) return null;
         if (count > _maxLines || settled.Length > _maxChars)
-            return count + " new lines";
+            return count == 1 ? "1 new line" : count + " new lines";
 
         var sb = new StringBuilder();
         for (var i = 0; i < lines.Length; i++)

--- a/windows/Ghostty.Tests/Accessibility/TerminalOutputAnnouncerTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/TerminalOutputAnnouncerTests.cs
@@ -1,0 +1,82 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class TerminalOutputAnnouncerTests
+{
+    [Fact]
+    public void FirstObserve_SeedsAndAnnouncesNothing()
+    {
+        var a = new TerminalOutputAnnouncer();
+        Assert.Null(a.Observe("PS C:\\> existing screen\n"));
+    }
+
+    [Fact]
+    public void NoChange_AnnouncesNothing()
+    {
+        var a = new TerminalOutputAnnouncer();
+        a.Observe("prompt\n");
+        Assert.Null(a.Observe("prompt\n"));
+    }
+
+    [Fact]
+    public void AppendCompleteLine_AnnouncesIt()
+    {
+        var a = new TerminalOutputAnnouncer();
+        a.Observe("prompt\n");
+        Assert.Equal("hello", a.Observe("prompt\nhello\n"));
+    }
+
+    [Fact]
+    public void PartialLine_IsHeldUntilNewline()
+    {
+        var a = new TerminalOutputAnnouncer();
+        a.Observe("prompt\n");
+        Assert.Null(a.Observe("prompt\nhel"));        // no newline yet
+        Assert.Equal("hello", a.Observe("prompt\nhello\n"));
+    }
+
+    [Fact]
+    public void MultipleLines_AreBatched()
+    {
+        var a = new TerminalOutputAnnouncer();
+        a.Observe("p\n");
+        Assert.Equal("one\ntwo\nthree", a.Observe("p\none\ntwo\nthree\n"));
+    }
+
+    [Fact]
+    public void LargeBurst_IsSummarized()
+    {
+        var a = new TerminalOutputAnnouncer(maxLines: 3, maxChars: 1000);
+        a.Observe("p\n");
+        var added = "a\nb\nc\nd\ne\n";
+        Assert.Equal("5 new lines", a.Observe("p\n" + added));
+    }
+
+    [Fact]
+    public void AllWhitespaceAppend_AnnouncesNothing()
+    {
+        var a = new TerminalOutputAnnouncer();
+        a.Observe("p\n");
+        Assert.Null(a.Observe("p\n   \n\n"));
+    }
+
+    [Fact]
+    public void Divergence_ReBaselinesSilently_ThenAppendsWork()
+    {
+        var a = new TerminalOutputAnnouncer();
+        a.Observe("prompt\nold\n");
+        Assert.Null(a.Observe("cleared screen\n")); // not a prefix -> re-baseline, silent
+        Assert.Equal("new", a.Observe("cleared screen\nnew\n"));
+    }
+
+    [Fact]
+    public void Reseed_MakesOnlyLaterAppendsAnnounce()
+    {
+        var a = new TerminalOutputAnnouncer();
+        a.Observe("p\n");
+        a.Reseed("p\nbacklog\n");                 // adopt backlog as baseline, no announce
+        Assert.Equal("fresh", a.Observe("p\nbacklog\nfresh\n"));
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/TerminalOutputAnnouncerTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/TerminalOutputAnnouncerTests.cs
@@ -55,6 +55,14 @@ public class TerminalOutputAnnouncerTests
     }
 
     [Fact]
+    public void SingleLongLine_OverCharCap_UsesSingularSummary()
+    {
+        var a = new TerminalOutputAnnouncer(maxLines: 20, maxChars: 5);
+        a.Observe("p\n");
+        Assert.Equal("1 new line", a.Observe("p\nthis line is long\n"));
+    }
+
+    [Fact]
     public void AllWhitespaceAppend_AnnouncesNothing()
     {
         var a = new TerminalOutputAnnouncer();

--- a/windows/Ghostty/Accessibility/ScreenReaderDetector.cs
+++ b/windows/Ghostty/Accessibility/ScreenReaderDetector.cs
@@ -1,0 +1,23 @@
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// Reports whether the OS has a screen reader active, via the SPI_GETSCREENREADER
+/// system parameter. Used to keep output announcements completely inert unless an
+/// assistive technology is present. BOOL is marshalled as int per the project's
+/// DisableRuntimeMarshalling convention.
+/// </summary>
+internal static partial class ScreenReaderDetector
+{
+    private const uint SPI_GETSCREENREADER = 0x0046;
+
+    [LibraryImport("user32.dll", EntryPoint = "SystemParametersInfoW")]
+    private static partial int SystemParametersInfo(uint uiAction, uint uiParam, ref int pvParam, uint fWinIni);
+
+    public static bool IsRunning()
+    {
+        int enabled = 0;
+        return SystemParametersInfo(SPI_GETSCREENREADER, 0, ref enabled, 0) != 0 && enabled != 0;
+    }
+}

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -23,7 +23,7 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     private readonly TerminalControl _owner;
     private readonly CachedValue<TerminalDocument> _document;
     private readonly TerminalOutputAnnouncer _announcer = new();
-    private DispatcherTimer? _announceTimer;
+    private readonly DispatcherTimer _announceTimer;
 
     internal TerminalAutomationPeer(TerminalControl owner) : base(owner)
     {
@@ -35,23 +35,20 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
         // Poll on the UI thread; the body is inert unless a screen reader is
         // present and this surface is active, so non-AT users pay nothing beyond
-        // a cached read. The 500ms document cache throttles announcements.
+        // a cached read. The 500ms document cache throttles announcements. The
+        // timer runs only while the owner is loaded (started/stopped on its
+        // Loaded/Unloaded, including across tab/split reloads); a cached peer
+        // means one timer per control, not one per UIA query.
         _announceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(300) };
         _announceTimer.Tick += OnAnnounceTick;
-        _announceTimer.Start();
+        owner.Loaded += OnOwnerLoaded;
         owner.Unloaded += OnOwnerUnloaded;
+        if (owner.IsLoaded) _announceTimer.Start();
     }
 
-    private void OnOwnerUnloaded(object sender, RoutedEventArgs e)
-    {
-        if (_announceTimer is { } timer)
-        {
-            timer.Stop();
-            timer.Tick -= OnAnnounceTick;
-            _announceTimer = null;
-        }
-        _owner.Unloaded -= OnOwnerUnloaded;
-    }
+    private void OnOwnerLoaded(object sender, RoutedEventArgs e) => _announceTimer.Start();
+
+    private void OnOwnerUnloaded(object sender, RoutedEventArgs e) => _announceTimer.Stop();
 
     private void OnAnnounceTick(object? sender, object e)
     {

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -1,6 +1,7 @@
 using System;
 using Ghostty.Controls;
 using Ghostty.Core.Accessibility;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Automation.Provider;
@@ -21,6 +22,8 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     private readonly TerminalControl _owner;
     private readonly CachedValue<TerminalDocument> _document;
+    private readonly TerminalOutputAnnouncer _announcer = new();
+    private DispatcherTimer? _announceTimer;
 
     internal TerminalAutomationPeer(TerminalControl owner) : base(owner)
     {
@@ -29,6 +32,45 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
             durationMs: ScreenTextCacheMs,
             fetch: () => new TerminalDocument(_owner.AccessibilityReadScreenText()),
             nowMs: () => Environment.TickCount64);
+
+        // Poll on the UI thread; the body is inert unless a screen reader is
+        // present and this surface is active, so non-AT users pay nothing beyond
+        // a cached read. The 500ms document cache throttles announcements.
+        _announceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(300) };
+        _announceTimer.Tick += OnAnnounceTick;
+        _announceTimer.Start();
+        owner.Unloaded += OnOwnerUnloaded;
+    }
+
+    private void OnOwnerUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_announceTimer is { } timer)
+        {
+            timer.Stop();
+            timer.Tick -= OnAnnounceTick;
+            _announceTimer = null;
+        }
+        _owner.Unloaded -= OnOwnerUnloaded;
+    }
+
+    private void OnAnnounceTick(object? sender, object e)
+    {
+        // Inert unless a screen reader is attached and this surface is active.
+        if (!ScreenReaderDetector.IsRunning() || !_owner.IsActive)
+        {
+            _announcer.Reseed(Document.Text);
+            return;
+        }
+
+        var text = _announcer.Observe(Document.Text);
+        if (!string.IsNullOrEmpty(text))
+        {
+            RaiseNotificationEvent(
+                AutomationNotificationKind.Other,
+                AutomationNotificationProcessing.All,
+                text,
+                "terminal-output");
+        }
     }
 
     /// <summary>Current cached screen document. Refreshed at most every 500ms.</summary>

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -191,8 +191,12 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         return sel is { } s ? (s.OffsetStart, s.OffsetLen) : null;
     }
 
+    private Ghostty.Accessibility.TerminalAutomationPeer? _automationPeer;
+
+    // Cache the peer so UIA re-querying a still-loaded control reuses one instance
+    // (and its single announcement timer) instead of accumulating peers/timers.
     protected override Microsoft.UI.Xaml.Automation.Peers.AutomationPeer OnCreateAutomationPeer()
-        => new Ghostty.Accessibility.TerminalAutomationPeer(this);
+        => _automationPeer ??= new Ghostty.Accessibility.TerminalAutomationPeer(this);
 
     /// <summary>
     /// Returns the pid of the shell process attached to this surface, or


### PR DESCRIPTION
Completes the screen reader support for the terminal: new output is now spoken
as it arrives when a screen reader is attached.

On Windows, a screen reader does not automatically read new text in a plain UIA
text control, so command output was readable on navigation but not heard. This
adds a conservative announcement path. A short timer on the UI thread feeds the
cached screen text to a pure diff policy that announces only complete new lines,
holds a partial line until its newline arrives, batches new lines into one
notification, and summarizes large bursts as a count. The result is raised as a
UIA notification.

It is gated to be completely inert unless an assistive technology is present: the
timer body returns early unless the OS reports a screen reader is running and the
surface is focused and foreground. Users without a screen reader see no behavior
change and pay nothing beyond a cached read.

macOS has no equivalent here. Its accessibility is pull only, with no
announcements and no timer, because VoiceOver reads the value on its own. This
announcement path is a Windows specific addition.

The diff, batch, and summary policy is a pure type in Ghostty.Core with unit
tests. The only native addition is a single Win32 call to read the screen reader
flag. No Zig changes.

Verified locally:
- dotnet build and dotnet test pass on x64 (the announcer adds 9 tests).
- With the OS screen reader flag set and a command printing known output, the app
  runs the announcement path live with no crash and the output present for the
  policy to consume. The flag is restored afterward.

Left for manual testing: a real pass with NVDA and JAWS to hear the spoken output.
