### PR TITLE
Accessibility: Windows High Contrast support for the terminal surface

### DIFF
--- a/windows/Ghostty.Core/Accessibility/HighContrastColors.cs
+++ b/windows/Ghostty.Core/Accessibility/HighContrastColors.cs
@@ -1,0 +1,13 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// The four Windows system colors that define the High Contrast surface
+/// palette. Each value is a raw Win32 COLORREF (0x00BBGGRR) as returned by
+/// GetSysColor; conversion to Ghostty's #rrggbb config form happens in
+/// <see cref="HighContrastConfigWriter"/>.
+/// </summary>
+public readonly record struct HighContrastColors(
+    uint Background,
+    uint Foreground,
+    uint SelectionBackground,
+    uint SelectionForeground);

--- a/windows/Ghostty.Core/Accessibility/HighContrastConfigWriter.cs
+++ b/windows/Ghostty.Core/Accessibility/HighContrastConfigWriter.cs
@@ -1,0 +1,47 @@
+using System.Globalization;
+using System.Text;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Renders the config override body layered on top of the user's config
+/// when Windows High Contrast is active. Pure string formatting so it can
+/// be unit-tested without the XAML runtime or libghostty.
+/// </summary>
+public static class HighContrastConfigWriter
+{
+    /// <summary>
+    /// WCAG AAA contrast ratio. Bumps libghostty's per-cell minimum-contrast
+    /// so ANSI-colored output stays legible against the HC background without
+    /// any renderer change.
+    /// </summary>
+    public const int DefaultMinimumContrast = 7;
+
+    /// <summary>
+    /// Convert a Win32 COLORREF (0x00BBGGRR) to Ghostty's lowercase
+    /// zero-padded #rrggbb config form.
+    /// </summary>
+    public static string FormatColor(uint colorRef)
+    {
+        var r = colorRef & 0xFF;
+        var g = (colorRef >> 8) & 0xFF;
+        var b = (colorRef >> 16) & 0xFF;
+        return string.Create(CultureInfo.InvariantCulture, $"#{r:x2}{g:x2}{b:x2}");
+    }
+
+    public static string Render(
+        HighContrastColors colors,
+        int minimumContrast = DefaultMinimumContrast)
+    {
+        // '\n' line endings: libghostty's line parser is newline-agnostic
+        // and the file is written/consumed by us, never edited by hand.
+        var sb = new StringBuilder();
+        sb.Append("background = ").Append(FormatColor(colors.Background)).Append('\n');
+        sb.Append("foreground = ").Append(FormatColor(colors.Foreground)).Append('\n');
+        sb.Append("selection-background = ").Append(FormatColor(colors.SelectionBackground)).Append('\n');
+        sb.Append("selection-foreground = ").Append(FormatColor(colors.SelectionForeground)).Append('\n');
+        sb.Append("minimum-contrast = ")
+          .Append(minimumContrast.ToString(CultureInfo.InvariantCulture)).Append('\n');
+        return sb.ToString();
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/HighContrastState.cs
+++ b/windows/Ghostty.Core/Accessibility/HighContrastState.cs
@@ -1,0 +1,17 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// The decision of whether to layer the High Contrast override onto the
+/// user's config. Kept as tested Core logic rather than living inline in
+/// the WinUI monitor.
+/// </summary>
+public static class HighContrastState
+{
+    /// <param name="osHighContrast">True when Windows is in a High Contrast theme.</param>
+    /// <param name="userOptOut">
+    /// True when the user disabled the auto-override via
+    /// <c>windows-high-contrast = false</c>.
+    /// </param>
+    public static bool ShouldApply(bool osHighContrast, bool userOptOut)
+        => osHighContrast && !userOptOut;
+}

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -50,6 +50,22 @@ public interface IConfigService : IDisposable
     bool WindowsSingleInstance { get; }
 
     /// <summary>
+    /// Windows-only: default true. Backed by the "windows-high-contrast"
+    /// key. When true, the terminal surface follows the OS High Contrast
+    /// theme; false keeps the user's configured colors regardless of OS
+    /// High Contrast.
+    /// </summary>
+    bool WindowsHighContrast { get; }
+
+    /// <summary>
+    /// Set (or clear, with null) the High Contrast color override body to
+    /// layer on top of the user's config, then reload so it takes effect.
+    /// Called by the High Contrast monitor. A no-op when the body is
+    /// unchanged.
+    /// </summary>
+    void SetHighContrastOverride(string? body);
+
+    /// <summary>
     /// Windows-only: backdrop material for the command palette.
     /// One of "acrylic", "mica", "opaque". Default "acrylic".
     /// Backed by the "command-palette-background" key.

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -55,6 +55,8 @@ public static class WindowsOnlyKeys
             "Comma-separated list of profile ids defining the order shown in the tab picker and command palette."),
         new("windows-single-instance",
             "When true, a second launch is routed into the already-running instance (opens a new window) instead of starting a separate process."),
+        new("windows-high-contrast",
+            "When true (default), the terminal surface follows the Windows High Contrast theme automatically; set false to keep your configured colors even in High Contrast mode."),
     ];
 
     public static readonly FrozenSet<string> Set =

--- a/windows/Ghostty.Tests/Accessibility/HighContrastConfigWriterTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/HighContrastConfigWriterTests.cs
@@ -1,0 +1,52 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public sealed class HighContrastConfigWriterTests
+{
+    [Fact]
+    public void FormatColor_ByteSwapsColorRefToRgbHex()
+    {
+        // COLORREF is 0x00BBGGRR. 0x00123456 => B=0x12 G=0x34 R=0x56 => #563412.
+        Assert.Equal("#563412", HighContrastConfigWriter.FormatColor(0x00123456u));
+    }
+
+    [Fact]
+    public void FormatColor_PadsAndLowercases()
+    {
+        // Pure white COLORREF 0x00FFFFFF => #ffffff; black => #000000.
+        Assert.Equal("#ffffff", HighContrastConfigWriter.FormatColor(0x00FFFFFFu));
+        Assert.Equal("#000000", HighContrastConfigWriter.FormatColor(0x00000000u));
+        // COLORREF low byte is R: 0x0000000A => R=0x0A => #0a0000 (zero-pad each channel).
+        Assert.Equal("#0a0000", HighContrastConfigWriter.FormatColor(0x0000000Au));
+    }
+
+    [Fact]
+    public void Render_EmitsAllFiveLinesInOrder()
+    {
+        var colors = new HighContrastColors(
+            Background: 0x00000000u,        // black -> #000000
+            Foreground: 0x00FFFFFFu,        // white -> #ffffff
+            SelectionBackground: 0x00FF0000u, // blue COLORREF -> #0000ff
+            SelectionForeground: 0x0000FFFFu); // yellow COLORREF -> #ffff00
+
+        var body = HighContrastConfigWriter.Render(colors);
+
+        var expected =
+            "background = #000000\n" +
+            "foreground = #ffffff\n" +
+            "selection-background = #0000ff\n" +
+            "selection-foreground = #ffff00\n" +
+            "minimum-contrast = 7\n";
+        Assert.Equal(expected, body);
+    }
+
+    [Fact]
+    public void Render_AllowsCustomMinimumContrast()
+    {
+        var colors = new HighContrastColors(0, 0, 0, 0);
+        var body = HighContrastConfigWriter.Render(colors, minimumContrast: 21);
+        Assert.Contains("minimum-contrast = 21\n", body);
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/HighContrastKeyTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/HighContrastKeyTests.cs
@@ -1,0 +1,23 @@
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public sealed class HighContrastKeyTests
+{
+    [Fact]
+    public void Registered_AsWindowsOnlyKey()
+    {
+        Assert.True(WindowsOnlyKeys.Contains("windows-high-contrast"));
+    }
+
+    [Theory]
+    [InlineData("", true)]        // unset -> default on (auto-follow OS)
+    [InlineData("true", true)]    // explicit on
+    [InlineData("false", false)]  // opt out
+    [InlineData("garbage", true)] // unparseable -> default
+    public void OptOut_ParsesAsBoolDefaultTrue(string raw, bool expected)
+    {
+        Assert.Equal(expected, WindowsOnlyKeyParsers.ParseBool(raw, defaultValue: true));
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/HighContrastStateTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/HighContrastStateTests.cs
@@ -1,0 +1,18 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public sealed class HighContrastStateTests
+{
+    [Theory]
+    [InlineData(true, false, true)]   // OS HC on, not opted out -> apply
+    [InlineData(true, true, false)]   // OS HC on, opted out -> don't apply
+    [InlineData(false, false, false)] // OS HC off -> don't apply
+    [InlineData(false, true, false)]  // OS HC off + opted out -> don't apply
+    public void ShouldApply_IsOsHighContrastAndNotOptedOut(
+        bool osHighContrast, bool userOptOut, bool expected)
+    {
+        Assert.Equal(expected, HighContrastState.ShouldApply(osHighContrast, userOptOut));
+    }
+}

--- a/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
+++ b/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
@@ -131,6 +131,8 @@ public class SettingsConfigWriterTests
         public bool VerticalTabs => false;
         public bool CommandPaletteGroupCommands => false;
         public bool WindowsSingleInstance => false;
+        public bool WindowsHighContrast => false;
+        public void SetHighContrastOverride(string? body) { }
         public string CommandPaletteBackground => "acrylic";
         public string LogLevel => "info";
         public string LogFilter => string.Empty;

--- a/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
@@ -60,6 +60,8 @@ public class SettingsConfigWriterLoggingTests
         public bool VerticalTabs => false;
         public bool CommandPaletteGroupCommands => false;
         public bool WindowsSingleInstance => false;
+        public bool WindowsHighContrast => false;
+        public void SetHighContrastOverride(string? body) { }
         public string CommandPaletteBackground => "acrylic";
         public string LogLevel => "info";
         public string LogFilter => string.Empty;

--- a/windows/Ghostty/Accessibility/HighContrastDetector.cs
+++ b/windows/Ghostty/Accessibility/HighContrastDetector.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// Detects whether Windows is in a High Contrast theme via
+/// SystemParametersInfo(SPI_GETHIGHCONTRAST). Mirrors ScreenReaderDetector:
+/// a blittable Win32 query with no WinRT thread affinity.
+/// </summary>
+internal static partial class HighContrastDetector
+{
+    private const uint SPI_GETHIGHCONTRAST = 0x0042;
+    private const uint HCF_HIGHCONTRASTON = 0x00000001;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct HIGHCONTRAST
+    {
+        public uint cbSize;
+        public uint dwFlags;
+        public IntPtr lpszDefaultScheme;
+    }
+
+    // Returns a Win32 BOOL (int): nonzero on success. HIGHCONTRAST is
+    // blittable, so passing it by ref is fine under DisableRuntimeMarshalling.
+    [LibraryImport("user32.dll", EntryPoint = "SystemParametersInfoW")]
+    private static partial int SystemParametersInfo(
+        uint uiAction, uint uiParam, ref HIGHCONTRAST pvParam, uint fWinIni);
+
+    public static bool IsActive()
+    {
+        var hc = new HIGHCONTRAST { cbSize = (uint)Marshal.SizeOf<HIGHCONTRAST>() };
+        if (SystemParametersInfo(SPI_GETHIGHCONTRAST, hc.cbSize, ref hc, 0) == 0)
+            return false;
+        return (hc.dwFlags & HCF_HIGHCONTRASTON) != 0;
+    }
+}

--- a/windows/Ghostty/Accessibility/HighContrastMonitor.cs
+++ b/windows/Ghostty/Accessibility/HighContrastMonitor.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Runtime.InteropServices;
+using Ghostty.Core.Accessibility;
+using Ghostty.Core.Config;
+using Microsoft.UI.Dispatching;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// Watches the Windows High Contrast state and palette and asks
+/// ConfigService to layer (or clear) the HC color override. App-level,
+/// single instance (config is app-wide). Mirrors WindowThemeManager's
+/// lifecycle: subscribe in the ctor, unsubscribe in Dispose, marshal
+/// background-thread events to the UI dispatcher.
+/// </summary>
+internal sealed partial class HighContrastMonitor : IDisposable
+{
+    // GetSysColor indices (winuser.h).
+    private const int COLOR_WINDOW = 5;
+    private const int COLOR_WINDOWTEXT = 8;
+    private const int COLOR_HIGHLIGHT = 13;
+    private const int COLOR_HIGHLIGHTTEXT = 14;
+
+    [LibraryImport("user32.dll")]
+    private static partial uint GetSysColor(int nIndex);
+
+    private readonly IConfigService _configService;
+    private readonly DispatcherQueue _dispatcher;
+    private readonly Windows.UI.ViewManagement.UISettings _uiSettings;
+    private bool _isDisposed;
+
+    public HighContrastMonitor(IConfigService configService, DispatcherQueue dispatcher)
+    {
+        _configService = configService;
+        _dispatcher = dispatcher;
+        _uiSettings = new Windows.UI.ViewManagement.UISettings();
+
+        // HC on/off changes the system palette, so ColorValuesChanged fires.
+        _uiSettings.ColorValuesChanged += OnColorValuesChanged;
+        // The user toggling windows-high-contrast=false must re-evaluate too.
+        _configService.ConfigChanged += OnConfigChanged;
+
+        Apply();
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+        _uiSettings.ColorValuesChanged -= OnColorValuesChanged;
+        _configService.ConfigChanged -= OnConfigChanged;
+    }
+
+    private void OnColorValuesChanged(
+        Windows.UI.ViewManagement.UISettings sender, object args)
+        => _dispatcher.TryEnqueue(Apply);
+
+    private void OnConfigChanged(IConfigService _)
+        => _dispatcher.TryEnqueue(Apply);
+
+    // Always runs on the UI thread (ctor + dispatched events).
+    private void Apply()
+    {
+        if (_isDisposed) return;
+
+        var shouldApply = HighContrastState.ShouldApply(
+            HighContrastDetector.IsActive(),
+            userOptOut: !_configService.WindowsHighContrast);
+
+        if (!shouldApply)
+        {
+            _configService.SetHighContrastOverride(null);
+            return;
+        }
+
+        var colors = new HighContrastColors(
+            Background: GetSysColor(COLOR_WINDOW),
+            Foreground: GetSysColor(COLOR_WINDOWTEXT),
+            SelectionBackground: GetSysColor(COLOR_HIGHLIGHT),
+            SelectionForeground: GetSysColor(COLOR_HIGHLIGHTTEXT));
+
+        _configService.SetHighContrastOverride(HighContrastConfigWriter.Render(colors));
+    }
+}

--- a/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
+++ b/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// Writes the High Contrast override config body to an app-managed file so
+/// ConfigService can layer it via ghostty_config_load_file. The file lives
+/// in the per-user local app-data dir (same root as crash.log), never the
+/// user's config, and holds only colors -- no hostnames/usernames/secrets.
+/// </summary>
+internal static class HighContrastOverrideFile
+{
+    /// <summary>
+    /// Write <paramref name="body"/> and return its absolute path, or null
+    /// if the file could not be written (caller then skips layering and the
+    /// surface keeps the user's colors -- a safe degradation).
+    /// </summary>
+    public static string? Write(string body)
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Wintty");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "high-contrast.conf");
+            File.WriteAllText(path, body);
+            return path;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+}

--- a/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
+++ b/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Security;
 
 namespace Ghostty.Accessibility;
 
@@ -28,8 +29,16 @@ internal static class HighContrastOverrideFile
             File.WriteAllText(path, body);
             return path;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or SecurityException
+            or ArgumentException
+            or NotSupportedException)
         {
+            // Best-effort: any write failure degrades to "no override", so the
+            // surface keeps the user's colors rather than aborting the whole
+            // reload. Covers the documented failure surface of CreateDirectory
+            // / WriteAllText (PathTooLongException derives from IOException).
             return null;
         }
     }

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -29,6 +29,7 @@ public partial class App : Application
 {
     // Process-global libghostty: bootstrap host owns the app handle; per-window hosts own only their surfaces.
     private ConfigService? _configService;
+    private Ghostty.Accessibility.HighContrastMonitor? _highContrastMonitor;
     private ConfigFileEditor? _configEditor;
     private ConfigWriteScheduler? _configWriteScheduler;
     private WindowsPowerStateMonitor? _powerStateMonitor;
@@ -625,6 +626,16 @@ public partial class App : Application
             factory);
         BootstrapHost = _bootstrapHost;
         _configService.SetApp(_bootstrapHost.App);
+
+        // App-level: High Contrast is a system-wide state and config is
+        // applied app-wide, so a single monitor drives the surface override.
+        // Constructed AFTER SetApp so its initial Apply() reloads into a live
+        // app -- before SetApp, ConfigService.Reload() bails at the
+        // _app.Handle==Zero guard and the override would never apply. Placed
+        // before window creation so AppUpdateConfig lands before any surface
+        // renders (no flash of the user's colors when HC is already on).
+        _highContrastMonitor = new Ghostty.Accessibility.HighContrastMonitor(
+            _configService, DispatcherQueue.GetForCurrentThread());
 
         Uri? activationUri = null;
         try
@@ -1292,6 +1303,8 @@ public partial class App : Application
                 BootstrapHost = null;
                 _lifetimeSupervisor = null;
                 LifetimeSupervisor = null;
+                _highContrastMonitor?.Dispose();
+                _highContrastMonitor = null;
                 _configService = null;
                 ConfigService = null;
                 _powerStateMonitor = null;

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -384,6 +384,16 @@ internal static partial class NativeMethods
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial void ConfigFinalize(GhosttyConfig config);
 
+    // Layer an additional config file on top of already-loaded config
+    // (e.g. the High Contrast override). Path is null-terminated UTF-8;
+    // StringMarshalling.Utf8 is a [LibraryImport] option, not a [MarshalAs],
+    // so it coexists with DisableRuntimeMarshalling (see the clipboard
+    // request binding for the same rationale).
+    [LibraryImport(Dll, EntryPoint = "ghostty_config_load_file",
+        StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    internal static partial void ConfigLoadFile(GhosttyConfig config, string path);
+
     [LibraryImport(Dll, EntryPoint = "ghostty_config_clone")]
     [UnmanagedCallConv(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     internal static partial GhosttyConfig ConfigClone(GhosttyConfig config);

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -58,7 +58,14 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     public bool VerticalTabs { get; private set; }
     public bool CommandPaletteGroupCommands { get; private set; }
     public bool WindowsSingleInstance { get; private set; }
+    public bool WindowsHighContrast { get; private set; } = true;
     public string CommandPaletteBackground { get; private set; } = "acrylic";
+
+    // The High Contrast override config body to layer on top of the user's
+    // config, or null when HC is inactive/opted-out. Set by
+    // HighContrastMonitor; consumed in Reload. Only touched on the UI thread
+    // (the monitor marshals its events, and Reload runs on the UI thread).
+    private string? _highContrastOverrideBody;
     public string LogLevel { get; private set; } = "info";
     public string LogFilter { get; private set; } = string.Empty;
 
@@ -389,6 +396,15 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         {
             newConfig = NativeMethods.ConfigNew();
             NativeMethods.ConfigLoadDefaultFiles(newConfig);
+            // Layer the High Contrast override last so it wins over the
+            // user's colors while HC is active. Skipped (body == null) when
+            // HC is off or opted-out, restoring the user's config.
+            if (_highContrastOverrideBody is { } hcBody)
+            {
+                var hcPath = Ghostty.Accessibility.HighContrastOverrideFile.Write(hcBody);
+                if (hcPath is not null)
+                    NativeMethods.ConfigLoadFile(newConfig, hcPath);
+            }
             NativeMethods.ConfigFinalize(newConfig);
         }
         catch (Exception ex)
@@ -467,6 +483,21 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// own save does not trigger a redundant reload.
     /// </summary>
     public void SuppressWatcher(bool suppress) => _suppressWatcher = suppress;
+
+    /// <summary>
+    /// Set (or clear, with null) the High Contrast override config body and
+    /// reload so the layered colors take effect. Called by
+    /// <c>HighContrastMonitor</c> on the UI thread. Skips the reload when the
+    /// body is unchanged, so spurious palette-change events don't churn the
+    /// config.
+    /// </summary>
+    public void SetHighContrastOverride(string? body)
+    {
+        if (string.Equals(_highContrastOverrideBody, body, StringComparison.Ordinal))
+            return;
+        _highContrastOverrideBody = body;
+        Reload();
+    }
 
     private void CacheDiagnostics()
     {
@@ -572,6 +603,9 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         WindowsSingleInstance = WindowsOnlyKeyParsers.ParseBool(
             GetFileValue("windows-single-instance", ""),
             defaultValue: false);
+        WindowsHighContrast = WindowsOnlyKeyParsers.ParseBool(
+            GetFileValue("windows-high-contrast", ""),
+            defaultValue: true);
         CommandPaletteBackground = WindowsOnlyKeyParsers.ParseStringAllowed(
             GetFileValue("command-palette-background", ""),
             allowed: CommandPaletteBackgroundAllowed,


### PR DESCRIPTION
When Windows is in a High Contrast theme, the terminal surface now follows
the system HC palette: background, foreground, and a distinct selection
highlight. Colored output stays legible because minimum-contrast is raised
so per-cell text keeps enough contrast against the HC background.

It follows the OS automatically and reverts when High Contrast turns off.
Set `windows-high-contrast = false` to keep your own colors in High Contrast
mode.

How it works: a monitor detects the HC state (SPI_GETHIGHCONTRAST) and
palette (GetSysColor), generates a small color override, and layers it on
top of the user's config via the existing `ghostty_config_load_file`, then
reloads. No Zig changes.

Verification: build clean, 1634 tests pass, and live-verified that the
surface flips to the HC palette with the override applied deterministically
on launch.

Part of # 77.
