### PR TITLE
Accessibility: report cell colors in the UIA text provider

### DIFF
--- a/windows/Ghostty.Core/Accessibility/UiaColor.cs
+++ b/windows/Ghostty.Core/Accessibility/UiaColor.cs
@@ -1,0 +1,17 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Converts a libghostty cell color (<c>0x00RRGGBB</c>) to a Win32 COLORREF
+/// (<c>0x00BBGGRR</c>), which is the value UIA expects for the
+/// ForegroundColor / BackgroundColor text attributes. Pure.
+/// </summary>
+internal static class UiaColor
+{
+    public static int ToColorRef(uint rgb)
+    {
+        var r = (rgb >> 16) & 0xFF;
+        var g = (rgb >> 8) & 0xFF;
+        var b = rgb & 0xFF;
+        return (int)((b << 16) | (g << 8) | r);
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
@@ -57,11 +57,15 @@ internal sealed class ViewportColorMap
         if (end <= start) return ColorResult.NotMapped;
 
         // Establish line index and line start once, then maintain them
-        // incrementally so the scan is linear in the span length.
+        // incrementally so the scan is linear in the span length. The column is
+        // the UTF-16 distance from the line start: identity with the grid column
+        // for BMP text. Astral codepoints take two UTF-16 units but one cell, so
+        // the column drifts past them and the codepoint check below declines the
+        // range (no wrong color); declining emoji-heavy spans is an accepted
+        // best-effort limitation.
         var line = _doc.LineIndexForOffset(start);
         var lineStart = _doc.LineBounds(start).Start;
 
-        var haveColor = false;
         uint color = 0;
         var mixed = false;
         var sawCell = false;
@@ -79,9 +83,8 @@ internal sealed class ViewportColorMap
             var cell = _cells.Cells[gridRow * _cells.Cols + col];
             if (!CodepointMatches(cell.Codepoint, text, o)) return ColorResult.NotMapped;
 
-            sawCell = true;
             var c = fg ? cell.Fg : cell.Bg;
-            if (!haveColor) { color = c; haveColor = true; }
+            if (!sawCell) { color = c; sawCell = true; }
             else if (c != color) mixed = true;
         }
 

--- a/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
@@ -1,0 +1,128 @@
+using System;
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Core.Accessibility;
+
+internal enum ColorResultKind { NotMapped, Uniform, Mixed }
+
+/// <summary>Result of a color query. <c>Rgb</c> (0x00RRGGBB) is only meaningful
+/// when <c>Kind == Uniform</c>.</summary>
+internal readonly record struct ColorResult(ColorResultKind Kind, uint Rgb)
+{
+    public static readonly ColorResult NotMapped = new(ColorResultKind.NotMapped, 0);
+    public static readonly ColorResult Mixed = new(ColorResultKind.Mixed, 0);
+    public static ColorResult Uniform(uint rgb) => new(ColorResultKind.Uniform, rgb);
+}
+
+/// <summary>
+/// Maps a screen-document text range to viewport cell colors. The viewport grid
+/// (from read_cells) is anchored as a suffix of the document: the last grid row
+/// that has content corresponds to the last document line that has content.
+/// Every queried cell is validated by codepoint against the document character,
+/// so any misalignment (scrolled up, soft-wrap, wide chars, a stale snapshot)
+/// declines to NotMapped instead of reporting a wrong color. Pure; no platform
+/// dependencies. Best-effort and viewport-only by design.
+/// </summary>
+internal sealed class ViewportColorMap
+{
+    private readonly TerminalDocument _doc;
+    private readonly CellGrid _cells;
+    private readonly int _rowShift; // gridRow = docLine - _rowShift
+    private readonly bool _hasContent;
+
+    public ViewportColorMap(TerminalDocument doc, CellGrid cells)
+    {
+        _doc = doc;
+        _cells = cells;
+
+        var lastContentRow = LastContentRow(cells);
+        var lastContentDocLine = LastContentDocLine(doc);
+        if (lastContentRow < 0 || lastContentDocLine < 0) return; // _hasContent = false
+
+        _hasContent = true;
+        _rowShift = lastContentDocLine - lastContentRow;
+    }
+
+    public ColorResult Foreground(TextSpan span) => Reduce(span, fg: true);
+
+    public ColorResult Background(TextSpan span) => Reduce(span, fg: false);
+
+    private ColorResult Reduce(TextSpan span, bool fg)
+    {
+        if (!_hasContent) return ColorResult.NotMapped;
+
+        var text = _doc.Text;
+        var start = _doc.ClampOffset(span.Start);
+        var end = _doc.ClampOffset(span.End);
+        if (end <= start) return ColorResult.NotMapped;
+
+        // Establish line index and line start once, then maintain them
+        // incrementally so the scan is linear in the span length.
+        var line = _doc.LineIndexForOffset(start);
+        var lineStart = _doc.LineBounds(start).Start;
+
+        var haveColor = false;
+        uint color = 0;
+        var mixed = false;
+        var sawCell = false;
+
+        for (var o = start; o < end; o++)
+        {
+            if (text[o] == '\n') { line++; lineStart = o + 1; continue; }
+
+            var gridRow = line - _rowShift;
+            if (gridRow < 0 || gridRow >= _cells.Rows) return ColorResult.NotMapped;
+
+            var col = o - lineStart;
+            if (col >= _cells.Cols) return ColorResult.NotMapped;
+
+            var cell = _cells.Cells[gridRow * _cells.Cols + col];
+            if (!CodepointMatches(cell.Codepoint, text, o)) return ColorResult.NotMapped;
+
+            sawCell = true;
+            var c = fg ? cell.Fg : cell.Bg;
+            if (!haveColor) { color = c; haveColor = true; }
+            else if (c != color) mixed = true;
+        }
+
+        if (!sawCell) return ColorResult.NotMapped;
+        return mixed ? ColorResult.Mixed : ColorResult.Uniform(color);
+    }
+
+    // True when the cell's codepoint, encoded as UTF-16, matches the document
+    // text at `offset`. Empty / wide-spacer cells (codepoint 0) and astral
+    // codepoints whose surrogate pair does not line up both return false, which
+    // makes the caller decline rather than guess.
+    private static bool CodepointMatches(uint codepoint, string text, int offset)
+    {
+        if (codepoint == 0) return false;
+        if (codepoint > 0x10FFFF || (codepoint >= 0xD800 && codepoint <= 0xDFFF)) return false;
+        if (codepoint <= 0xFFFF) return text[offset] == (char)codepoint;
+
+        var s = char.ConvertFromUtf32((int)codepoint);
+        return offset + 1 < text.Length && text[offset] == s[0] && text[offset + 1] == s[1];
+    }
+
+    // Greatest document line index that contains a non-newline character, or -1.
+    private static int LastContentDocLine(TerminalDocument doc)
+    {
+        var t = doc.Text;
+        for (var i = t.Length - 1; i >= 0; i--)
+            if (t[i] != '\n') return doc.LineIndexForOffset(i);
+        return -1;
+    }
+
+    // Greatest grid row index that has a non-blank cell, or -1. A cell is blank
+    // when its codepoint is 0 (empty / spacer) or whitespace, matching how
+    // read_text trims trailing blank rows.
+    private static int LastContentRow(CellGrid cells)
+    {
+        for (var r = cells.Rows - 1; r >= 0; r--)
+            for (var c = 0; c < cells.Cols; c++)
+            {
+                var cp = cells.Cells[r * cells.Cols + c].Codepoint;
+                if (cp != 0 && !(cp <= 0xFFFF && char.IsWhiteSpace((char)cp))) return r;
+            }
+        return -1;
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
@@ -35,6 +35,15 @@ internal sealed class ViewportColorMap
         _doc = doc;
         _cells = cells;
 
+        // Decline a malformed or concurrently-torn grid (null backing array or a
+        // length that disagrees with rows*cols) instead of risking an out-of-range
+        // index below. The grid comes from a 500ms cache read off the UI thread, and
+        // CellGrid is a multi-field struct, so a partially-published snapshot is
+        // possible; bail out and report NotMapped rather than crash.
+        if (cells.Rows <= 0 || cells.Cols <= 0 ||
+            cells.Cells is null || cells.Cells.Length < (long)cells.Rows * cells.Cols)
+            return; // _hasContent stays false
+
         var lastContentRow = LastContentRow(cells);
         var lastContentDocLine = LastContentDocLine(doc);
         if (lastContentRow < 0 || lastContentDocLine < 0) return; // _hasContent = false
@@ -106,12 +115,15 @@ internal sealed class ViewportColorMap
         return offset + 1 < text.Length && text[offset] == s[0] && text[offset + 1] == s[1];
     }
 
-    // Greatest document line index that contains a non-newline character, or -1.
+    // Greatest document line index that contains a non-whitespace character, or -1.
+    // Mirrors LastContentRow's "blank" rule (which skips whitespace cells) so the two
+    // anchors agree: a trailing whitespace-only line would otherwise shift the anchor
+    // by a row and make every cell mis-map.
     private static int LastContentDocLine(TerminalDocument doc)
     {
         var t = doc.Text;
         for (var i = t.Length - 1; i >= 0; i--)
-            if (t[i] != '\n') return doc.LineIndexForOffset(i);
+            if (!char.IsWhiteSpace(t[i])) return doc.LineIndexForOffset(i);
         return -1;
     }
 

--- a/windows/Ghostty.Tests/Accessibility/UiaColorTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/UiaColorTests.cs
@@ -1,0 +1,26 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class UiaColorTests
+{
+    [Fact]
+    public void ToColorRef_SwapsRgbToBgr()
+    {
+        // 0x00RRGGBB = 0x00112233 -> COLORREF 0x00BBGGRR = 0x00332211
+        Assert.Equal(0x00332211, UiaColor.ToColorRef(0x00112233u));
+    }
+
+    [Fact]
+    public void ToColorRef_Black_IsZero()
+    {
+        Assert.Equal(0x00000000, UiaColor.ToColorRef(0x00000000u));
+    }
+
+    [Fact]
+    public void ToColorRef_White_IsWhite()
+    {
+        Assert.Equal(0x00FFFFFF, UiaColor.ToColorRef(0x00FFFFFFu));
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
@@ -125,4 +125,28 @@ public class ViewportColorMapTests
         var map = Map("abc", Grid(3, new[] { (0u, 0u, 0u), (0u, 0u, 0u), (0u, 0u, 0u) }));
         Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(0, 3)).Kind);
     }
+
+    [Fact]
+    public void TrailingWhitespaceLine_DoesNotShiftAnchor()
+    {
+        // The document's last line is whitespace only; the grid trims it as blank.
+        // Both anchors must treat trailing whitespace the same way, or the content
+        // line shifts off-grid and maps to nothing.
+        var map = Map("ab\n  ", Grid(2,
+            new[] { (A, 3u, 0u), (B, 3u, 0u) },
+            new[] { (0u, 0u, 0u), (0u, 0u, 0u) }));
+        var r = map.Foreground(new TextSpan(0, 2)); // "ab"
+        Assert.Equal(ColorResultKind.Uniform, r.Kind);
+        Assert.Equal(3u, r.Rgb);
+    }
+
+    [Fact]
+    public void MalformedGrid_LengthMismatch_ReturnsNotMapped()
+    {
+        // Rows*Cols disagrees with the backing array (e.g. a torn off-thread snapshot):
+        // decline instead of indexing out of range.
+        var grid = new CellGrid(new[] { new Cell(A, 1u, 0u) }, 5, 5);
+        var map = new ViewportColorMap(new TerminalDocument("abc"), grid);
+        Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(0, 3)).Kind);
+    }
 }

--- a/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
@@ -80,4 +80,49 @@ public class ViewportColorMapTests
         Assert.Equal(ColorResultKind.Uniform, r.Kind);
         Assert.Equal(7u, r.Rgb);
     }
+
+    [Fact]
+    public void CodepointMismatch_ReturnsNotMapped()
+    {
+        var map = Map("zzz", Grid(3, new[] { (A, 1u, 0u), (B, 1u, 0u), (C, 1u, 0u) }));
+        Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(0, 3)).Kind);
+    }
+
+    [Fact]
+    public void WideChar_DeclinesAcrossSpacer()
+    {
+        var map = Map("中x", Grid(3,
+            new[] { (0x4e2du, 1u, 0u), (0u, 1u, 0u), ((uint)'x', 1u, 0u) }));
+        Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(0, 2)).Kind);
+    }
+
+    [Fact]
+    public void ColumnPastGridWidth_ReturnsNotMapped()
+    {
+        var map = Map("abcd", Grid(3, new[] { (A, 1u, 0u), (B, 1u, 0u), (C, 1u, 0u) }));
+        Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(0, 4)).Kind);
+    }
+
+    [Fact]
+    public void EmptyRange_ReturnsNotMapped()
+    {
+        var map = Map("abc", Grid(3, new[] { (A, 1u, 0u), (B, 1u, 0u), (C, 1u, 0u) }));
+        Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(1, 1)).Kind);
+    }
+
+    [Fact]
+    public void NewlineOnlyRange_ReturnsNotMapped()
+    {
+        var map = Map("a\nb", Grid(1,
+            new[] { (A, 1u, 0u) },
+            new[] { (B, 1u, 0u) }));
+        Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(1, 2)).Kind);
+    }
+
+    [Fact]
+    public void BlankGrid_ReturnsNotMapped()
+    {
+        var map = Map("abc", Grid(3, new[] { (0u, 0u, 0u), (0u, 0u, 0u), (0u, 0u, 0u) }));
+        Assert.Equal(ColorResultKind.NotMapped, map.Foreground(new TextSpan(0, 3)).Kind);
+    }
 }

--- a/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
@@ -1,0 +1,53 @@
+using Ghostty.Core.Accessibility;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class ViewportColorMapTests
+{
+    // Build a grid from rows of (codepoint, fg, bg) tuples padded to `cols`.
+    private static CellGrid Grid(int cols, params (uint cp, uint fg, uint bg)[][] rows)
+    {
+        var cells = new Cell[rows.Length * cols];
+        for (var r = 0; r < rows.Length; r++)
+            for (var c = 0; c < cols; c++)
+            {
+                var src = c < rows[r].Length ? rows[r][c] : (0u, 0u, 0u);
+                cells[r * cols + c] = new Cell(src.Item1, src.Item2, src.Item3);
+            }
+        return new CellGrid(cells, rows.Length, cols);
+    }
+
+    private static ViewportColorMap Map(string text, CellGrid grid) =>
+        new(new TerminalDocument(text), grid);
+
+    private const uint A = 'a', B = 'b', C = 'c', D = 'd';
+
+    [Fact]
+    public void FreshShell_TopAligned_UniformForeground()
+    {
+        var map = Map("abc", Grid(3, new[] { (A, 1u, 2u), (B, 1u, 2u), (C, 1u, 2u) }));
+        var r = map.Foreground(new TextSpan(0, 3));
+        Assert.Equal(ColorResultKind.Uniform, r.Kind);
+        Assert.Equal(1u, r.Rgb);
+    }
+
+    [Fact]
+    public void Background_ReturnsBgChannel()
+    {
+        var map = Map("abc", Grid(3, new[] { (A, 1u, 2u), (B, 1u, 2u), (C, 1u, 2u) }));
+        var r = map.Background(new TextSpan(0, 3));
+        Assert.Equal(ColorResultKind.Uniform, r.Kind);
+        Assert.Equal(2u, r.Rgb);
+    }
+
+    [Fact]
+    public void Scrollback_BottomAligned_MapsViewportLine()
+    {
+        var map = Map("x\nabc", Grid(3, new[] { (A, 7u, 0u), (B, 7u, 0u), (C, 7u, 0u) }));
+        var r = map.Foreground(new TextSpan(2, 5));
+        Assert.Equal(ColorResultKind.Uniform, r.Kind);
+        Assert.Equal(7u, r.Rgb);
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/ViewportColorMapTests.cs
@@ -50,4 +50,34 @@ public class ViewportColorMapTests
         Assert.Equal(ColorResultKind.Uniform, r.Kind);
         Assert.Equal(7u, r.Rgb);
     }
+
+    [Fact]
+    public void DifferentColors_ReturnMixed()
+    {
+        var map = Map("ab", Grid(2, new[] { (A, 1u, 0u), (B, 9u, 0u) }));
+        Assert.Equal(ColorResultKind.Mixed, map.Foreground(new TextSpan(0, 2)).Kind);
+    }
+
+    [Fact]
+    public void RangeCrossingNewline_SkipsDelimiter()
+    {
+        var map = Map("ab\ncd", Grid(2,
+            new[] { (A, 4u, 0u), (B, 4u, 0u) },
+            new[] { (C, 4u, 0u), (D, 4u, 0u) }));
+        var r = map.Foreground(new TextSpan(0, 5));
+        Assert.Equal(ColorResultKind.Uniform, r.Kind);
+        Assert.Equal(4u, r.Rgb);
+    }
+
+    [Fact]
+    public void BlankMiddleLine_StillMapsLaterLine()
+    {
+        var map = Map("ab\n\ncd", Grid(2,
+            new[] { (A, 5u, 0u), (B, 5u, 0u) },
+            new[] { (0u, 0u, 0u), (0u, 0u, 0u) },
+            new[] { (C, 7u, 0u), (D, 7u, 0u) }));
+        var r = map.Foreground(new TextSpan(4, 6));
+        Assert.Equal(ColorResultKind.Uniform, r.Kind);
+        Assert.Equal(7u, r.Rgb);
+    }
 }

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -22,6 +22,10 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     private readonly TerminalControl _owner;
     private readonly CachedValue<TerminalDocument> _document;
+    // Viewport cells for color attributes. Fetched lazily (only when a color
+    // attribute is queried) and cached for the same 500ms window as the
+    // document, since read_cells is expensive and takes the renderer mutex.
+    private readonly CachedValue<Ghostty.Core.Tabs.CellGrid?> _cells;
     private readonly TerminalOutputAnnouncer _announcer = new();
     private readonly DispatcherTimer _announceTimer;
 
@@ -31,6 +35,10 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
         _document = new CachedValue<TerminalDocument>(
             durationMs: ScreenTextCacheMs,
             fetch: () => new TerminalDocument(_owner.AccessibilityReadScreenText()),
+            nowMs: () => Environment.TickCount64);
+        _cells = new CachedValue<Ghostty.Core.Tabs.CellGrid?>(
+            durationMs: ScreenTextCacheMs,
+            fetch: () => _owner.AccessibilityReadViewportCells(),
             nowMs: () => Environment.TickCount64);
 
         // Poll on the UI thread; the body is inert unless a screen reader is
@@ -72,6 +80,10 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     /// <summary>Current cached screen document. Refreshed at most every 500ms.</summary>
     internal TerminalDocument Document => _document.Get();
+
+    /// <summary>Current cached viewport cells, or null. Refreshed at most every
+    /// 500ms; fetched only when a color attribute is queried.</summary>
+    internal Ghostty.Core.Tabs.CellGrid? ViewportCells => _cells.Get();
 
     /// <summary>Bridge this peer to its UIA provider, for range GetEnclosingElement.</summary>
     internal IRawElementProviderSimple Provider => ProviderFromPeer(this);

--- a/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
+++ b/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
@@ -75,7 +75,10 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
     // Resolve the fg/bg color for the current range against the cached viewport
     // cells. Best-effort and viewport-only: NotMapped (scrollback, misalignment,
     // surface gone) maps to the UIA NotSupported sentinel; Mixed maps to the
-    // mixed sentinel (or NotSupported if the platform can't provide it).
+    // mixed sentinel (or NotSupported if the platform can't provide it). The
+    // NotSupported()! sites are null-forgiving on purpose: if UIAutomationCore
+    // yields no sentinel, a null attribute value is itself read as "unsupported"
+    // by clients, so the fallback is safe.
     private object ColorAttribute(bool fg)
     {
         if (_peer.ViewportCells is not { } grid) return UiaReservedValues.NotSupported()!;

--- a/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
+++ b/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
@@ -73,24 +73,26 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
     }
 
     // Resolve the fg/bg color for the current range against the cached viewport
-    // cells. Best-effort and viewport-only: NotMapped (scrollback, misalignment,
-    // surface gone) maps to the UIA NotSupported sentinel; Mixed maps to the
-    // mixed sentinel (or NotSupported if the platform can't provide it). The
-    // NotSupported()! sites are null-forgiving on purpose: if UIAutomationCore
-    // yields no sentinel, a null attribute value is itself read as "unsupported"
-    // by clients, so the fallback is safe.
+    // cells. Best-effort and viewport-only. A uniform run reports its COLORREF;
+    // everything else reports NotSupported. The NotSupported()! sites are
+    // null-forgiving on purpose: if UIAutomationCore yields no sentinel, a null
+    // attribute value is itself read as "unsupported" by clients, so the fallback
+    // is safe.
+    //
+    // A multi-color (Mixed) range should report the UIA reserved "mixed" value,
+    // but WinUI 3's ITextRangeProvider projection does not surface that sentinel
+    // to clients (verified live: a mixed range comes back as NotSupported, not
+    // Mixed). Reporting NotSupported is therefore the honest result for Mixed and
+    // NotMapped alike, instead of picking one cell's color and lying.
     private object ColorAttribute(bool fg)
     {
         if (_peer.ViewportCells is not { } grid) return UiaReservedValues.NotSupported()!;
 
         var map = new ViewportColorMap(Doc, grid);
         var result = fg ? map.Foreground(_span) : map.Background(_span);
-        return result.Kind switch
-        {
-            ColorResultKind.Uniform => UiaColor.ToColorRef(result.Rgb),
-            ColorResultKind.Mixed => UiaReservedValues.Mixed() ?? UiaReservedValues.NotSupported()!,
-            _ => UiaReservedValues.NotSupported()!,
-        };
+        return result.Kind == ColorResultKind.Uniform
+            ? UiaColor.ToColorRef(result.Rgb)
+            : UiaReservedValues.NotSupported()!;
     }
 
     public void GetBoundingRectangles(out double[] rectangles) => rectangles = Array.Empty<double>();

--- a/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
+++ b/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using Ghostty.Core.Accessibility;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Automation.Text;
 using CoreTextUnit = Ghostty.Core.Accessibility.TextUnit;
@@ -62,9 +63,32 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
         return match is { } m ? new TerminalTextRangeProvider(_peer, m) : null!;
     }
 
-    // Text attributes (foreground/background color, etc.) are added in a later
-    // stage; null signals "no value" to clients until then.
-    public object GetAttributeValue(int attributeId) => null!;
+    public object GetAttributeValue(int attributeId)
+    {
+        if (attributeId == (int)AutomationTextAttributesEnum.ForegroundColorAttribute)
+            return ColorAttribute(fg: true);
+        if (attributeId == (int)AutomationTextAttributesEnum.BackgroundColorAttribute)
+            return ColorAttribute(fg: false);
+        return UiaReservedValues.NotSupported()!;
+    }
+
+    // Resolve the fg/bg color for the current range against the cached viewport
+    // cells. Best-effort and viewport-only: NotMapped (scrollback, misalignment,
+    // surface gone) maps to the UIA NotSupported sentinel; Mixed maps to the
+    // mixed sentinel (or NotSupported if the platform can't provide it).
+    private object ColorAttribute(bool fg)
+    {
+        if (_peer.ViewportCells is not { } grid) return UiaReservedValues.NotSupported()!;
+
+        var map = new ViewportColorMap(Doc, grid);
+        var result = fg ? map.Foreground(_span) : map.Background(_span);
+        return result.Kind switch
+        {
+            ColorResultKind.Uniform => UiaColor.ToColorRef(result.Rgb),
+            ColorResultKind.Mixed => UiaReservedValues.Mixed() ?? UiaReservedValues.NotSupported()!,
+            _ => UiaReservedValues.NotSupported()!,
+        };
+    }
 
     public void GetBoundingRectangles(out double[] rectangles) => rectangles = Array.Empty<double>();
 

--- a/windows/Ghostty/Accessibility/UiaReservedValues.cs
+++ b/windows/Ghostty/Accessibility/UiaReservedValues.cs
@@ -12,28 +12,18 @@ namespace Ghostty.Accessibility;
 /// </summary>
 internal static partial class UiaReservedValues
 {
-    private static object? _notSupported;
-    private static bool _notSupportedResolved;
-    private static object? _mixed;
-    private static bool _mixedResolved;
+    // Resolved once on first use. Lazy gives thread-safe publication because UIA
+    // GetAttributeValue can be called from UIA/RPC threads, not just the UI thread.
+    private static readonly Lazy<object?> _notSupported =
+        new(() => FromIUnknown(UiaGetReservedNotSupportedValue));
+    private static readonly Lazy<object?> _mixed =
+        new(() => FromIUnknown(UiaGetReservedMixedAttributeValue));
 
     /// <summary>The reserved "not supported" value, or null if unavailable.</summary>
-    public static object? NotSupported()
-    {
-        if (_notSupportedResolved) return _notSupported;
-        _notSupportedResolved = true;
-        _notSupported = FromIUnknown(UiaGetReservedNotSupportedValue);
-        return _notSupported;
-    }
+    public static object? NotSupported() => _notSupported.Value;
 
     /// <summary>The reserved "mixed attribute value", or null if unavailable.</summary>
-    public static object? Mixed()
-    {
-        if (_mixedResolved) return _mixed;
-        _mixedResolved = true;
-        _mixed = FromIUnknown(UiaGetReservedMixedAttributeValue);
-        return _mixed;
-    }
+    public static object? Mixed() => _mixed.Value;
 
     private delegate int ReservedGetter(out IntPtr value);
 

--- a/windows/Ghostty/Accessibility/UiaReservedValues.cs
+++ b/windows/Ghostty/Accessibility/UiaReservedValues.cs
@@ -4,26 +4,28 @@ using System.Runtime.InteropServices;
 namespace Ghostty.Accessibility;
 
 /// <summary>
-/// UIA reserved attribute-value sentinels for ITextRangeProvider.GetAttributeValue.
-/// WinUI 3 does not surface these as managed constants, so we fetch the canonical
-/// COM sentinels from UIAutomationCore once and reuse them. Each resolves to null
-/// if it cannot be obtained; a null attribute value is itself treated as
-/// "unsupported" by clients, so that is a safe degradation.
+/// The UIA reserved "not supported" attribute value for
+/// ITextRangeProvider.GetAttributeValue. WinUI 3 does not surface it as a managed
+/// constant, so we fetch the canonical COM sentinel from UIAutomationCore once and
+/// reuse it; it resolves to null if it cannot be obtained, and a null attribute
+/// value is itself treated as "unsupported" by clients, so that is a safe
+/// degradation.
 /// </summary>
+/// <remarks>
+/// There is also a reserved "mixed attribute value" sentinel, but WinUI 3's
+/// ITextRangeProvider projection does not pass it through to clients (verified
+/// live: a multi-color range surfaces as NotSupported, not Mixed), so we do not
+/// fetch it. The provider reports NotSupported for mixed ranges instead.
+/// </remarks>
 internal static partial class UiaReservedValues
 {
     // Resolved once on first use. Lazy gives thread-safe publication because UIA
     // GetAttributeValue can be called from UIA/RPC threads, not just the UI thread.
     private static readonly Lazy<object?> _notSupported =
         new(() => FromIUnknown(UiaGetReservedNotSupportedValue));
-    private static readonly Lazy<object?> _mixed =
-        new(() => FromIUnknown(UiaGetReservedMixedAttributeValue));
 
     /// <summary>The reserved "not supported" value, or null if unavailable.</summary>
     public static object? NotSupported() => _notSupported.Value;
-
-    /// <summary>The reserved "mixed attribute value", or null if unavailable.</summary>
-    public static object? Mixed() => _mixed.Value;
 
     private delegate int ReservedGetter(out IntPtr value);
 
@@ -48,8 +50,4 @@ internal static partial class UiaReservedValues
     // HRESULT UiaGetReservedNotSupportedValue(IUnknown** value)
     [LibraryImport("UIAutomationCore.dll")]
     private static partial int UiaGetReservedNotSupportedValue(out IntPtr value);
-
-    // HRESULT UiaGetReservedMixedAttributeValue(IUnknown** value)
-    [LibraryImport("UIAutomationCore.dll")]
-    private static partial int UiaGetReservedMixedAttributeValue(out IntPtr value);
 }

--- a/windows/Ghostty/Accessibility/UiaReservedValues.cs
+++ b/windows/Ghostty/Accessibility/UiaReservedValues.cs
@@ -31,6 +31,10 @@ internal static partial class UiaReservedValues
     {
         try
         {
+            // UIA reserved values are process-lifetime singletons, so we do not
+            // Release p: the RCW's own reference is harmless against an object
+            // that outlives the process, and releasing a borrowed static pointer
+            // would risk an over-release.
             if (getter(out var p) == 0 && p != IntPtr.Zero)
                 return Marshal.GetObjectForIUnknown(p);
         }

--- a/windows/Ghostty/Accessibility/UiaReservedValues.cs
+++ b/windows/Ghostty/Accessibility/UiaReservedValues.cs
@@ -33,10 +33,18 @@ internal static partial class UiaReservedValues
     {
         try
         {
-            // UIA reserved values are process-lifetime singletons, so we do not
-            // Release p: the RCW's own reference is harmless against an object
-            // that outlives the process, and releasing a borrowed static pointer
-            // would risk an over-release.
+            // Use Marshal.GetObjectForIUnknown here, NOT the codebase's usual
+            // ComCreate.Wrap (StrategyBasedComWrappers). UIA recognizes a reserved value
+            // by exact IUnknown pointer identity; ComWrappers produces a fresh CCW on the
+            // return trip, so UIA no longer matches it and the color attribute silently
+            // defaults to black (verified live). GetObjectForIUnknown preserves the pointer
+            // so UIA reports it as "not supported" as intended. SYSLIB1099 is accepted for
+            // this special case (NativeAOT is not a shipping target yet).
+            //
+            // UIA reserved values are process-lifetime singletons, so we deliberately do not
+            // Release p afterwards: the extra reference is harmless against an object that
+            // outlives the process, and releasing a possibly-borrowed static pointer would
+            // risk an over-release.
             if (getter(out var p) == 0 && p != IntPtr.Zero)
                 return Marshal.GetObjectForIUnknown(p);
         }

--- a/windows/Ghostty/Accessibility/UiaReservedValues.cs
+++ b/windows/Ghostty/Accessibility/UiaReservedValues.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// UIA reserved attribute-value sentinels for ITextRangeProvider.GetAttributeValue.
+/// WinUI 3 does not surface these as managed constants, so we fetch the canonical
+/// COM sentinels from UIAutomationCore once and reuse them. Each resolves to null
+/// if it cannot be obtained; a null attribute value is itself treated as
+/// "unsupported" by clients, so that is a safe degradation.
+/// </summary>
+internal static partial class UiaReservedValues
+{
+    private static object? _notSupported;
+    private static bool _notSupportedResolved;
+    private static object? _mixed;
+    private static bool _mixedResolved;
+
+    /// <summary>The reserved "not supported" value, or null if unavailable.</summary>
+    public static object? NotSupported()
+    {
+        if (_notSupportedResolved) return _notSupported;
+        _notSupportedResolved = true;
+        _notSupported = FromIUnknown(UiaGetReservedNotSupportedValue);
+        return _notSupported;
+    }
+
+    /// <summary>The reserved "mixed attribute value", or null if unavailable.</summary>
+    public static object? Mixed()
+    {
+        if (_mixedResolved) return _mixed;
+        _mixedResolved = true;
+        _mixed = FromIUnknown(UiaGetReservedMixedAttributeValue);
+        return _mixed;
+    }
+
+    private delegate int ReservedGetter(out IntPtr value);
+
+    private static object? FromIUnknown(ReservedGetter getter)
+    {
+        try
+        {
+            if (getter(out var p) == 0 && p != IntPtr.Zero)
+                return Marshal.GetObjectForIUnknown(p);
+        }
+        catch
+        {
+            // Defensive: a missing export or marshalling failure degrades to null.
+        }
+        return null;
+    }
+
+    // HRESULT UiaGetReservedNotSupportedValue(IUnknown** value)
+    [LibraryImport("UIAutomationCore.dll")]
+    private static partial int UiaGetReservedNotSupportedValue(out IntPtr value);
+
+    // HRESULT UiaGetReservedMixedAttributeValue(IUnknown** value)
+    [LibraryImport("UIAutomationCore.dll")]
+    private static partial int UiaGetReservedMixedAttributeValue(out IntPtr value);
+}

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -191,6 +191,17 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         return sel is { } s ? (s.OffsetStart, s.OffsetLen) : null;
     }
 
+    /// <summary>
+    /// Read the viewport cells (codepoint + resolved fg/bg) for accessibility,
+    /// or null when the surface is gone or the read fails. Takes the renderer
+    /// mutex; the automation peer caches the result for 500ms.
+    /// </summary>
+    internal Ghostty.Core.Tabs.CellGrid? AccessibilityReadViewportCells()
+    {
+        if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return null;
+        return NativeMethods.SurfaceReadCells(_surface);
+    }
+
     private Ghostty.Accessibility.TerminalAutomationPeer? _automationPeer;
 
     // Cache the peer so UIA re-querying a still-loaded control reuses one instance


### PR DESCRIPTION
Returns ForegroundColor and BackgroundColor from the terminal's UIA text range provider so screen readers can report cell colors. Part of # 77.

read_cells is viewport-only while the UIA document is the whole screen, so colors are best-effort and viewport-only. The viewport grid is anchored as the bottom of the screen document and each cell is checked against the document character, so a range only reports a color when it provably maps to the viewport. A uniform run returns its color as a COLORREF; a multi-colored or unmapped range returns not-supported.

The mapping lives in a pure ViewportColorMap in Ghostty.Core with unit tests. The WinUI provider builds it from the cached viewport cells and translates the result to a COLORREF or the UIA not-supported sentinel.

Verified live with a UIA client: a uniform red run reports its color, the background reports its color, and multi-colored or unsupported attributes report not-supported.
