### PR TITLE
os: detect wsl.exe via identify in isWslExe

### DIFF
--- a/src/os/windows_shell.zig
+++ b/src/os/windows_shell.zig
@@ -481,13 +481,23 @@ test "isCjkAnsiCodePageFor: non-CJK codepages return false" {
 
 /// True if `arg0` is the WSL launcher (`wsl`/`wsl.exe`, case-insensitive,
 /// any path). Cheap pre-check so callers can skip work for non-WSL commands.
+///
+/// Delegates to `identify`, which strips surrounding quotes and splits on
+/// both path separators, so it is deterministic regardless of host. A
+/// hand-rolled `std.fs.path.basename` here would follow the *host* separator
+/// and miss a `C:\...\wsl.exe` arg0 on POSIX (and silently disagree with
+/// `identify` on quoted paths).
 pub fn isWslExe(arg0: []const u8) bool {
-    const exe = std.fs.path.basename(arg0);
-    const name = if (std.ascii.endsWithIgnoreCase(exe, ".exe"))
-        exe[0 .. exe.len - 4]
-    else
-        exe;
-    return std.ascii.eqlIgnoreCase("wsl", name);
+    return identify(arg0) == .wsl;
+}
+
+test "isWslExe: windows path, forward slashes, quoted, bare, non-wsl" {
+    try testing.expect(isWslExe("C:\\Windows\\System32\\wsl.exe"));
+    try testing.expect(isWslExe("C:/Windows/System32/wsl.exe"));
+    try testing.expect(isWslExe("\"wsl.exe\""));
+    try testing.expect(isWslExe("wsl"));
+    try testing.expect(!isWslExe("C:\\Windows\\System32\\cmd.exe"));
+    try testing.expect(!isWslExe(""));
 }
 
 /// If `argv` invokes the WSL launcher, return the target distro from


### PR DESCRIPTION
## Problem

`isWslExe` rolled its own basename + `.exe` stripping on top of `std.fs.path.basename`, which follows the **host** path separator. On POSIX (macOS/Linux CI) a Windows `arg0` like `C:\Windows\System32\wsl.exe` has no `/` to split on, so the `"wsl"` check failed, `wslDistro` returned `null`, and the cross-platform test `wslDistro: detects distro and default, ignores non-WSL` unwrapped that `null` (`.?`) → SIGABRT, failing the full suite on non-Windows hosts.

## Fix

Delegate to the existing `identify()`, which already strips surrounding quotes, splits on **both** separators, strips `.exe` case-insensitively, and is unit-tested against full Windows paths (`identify("C:\\Windows\\System32\\wsl.exe") == .wsl`). This:
- removes the duplicated path logic,
- fixes a latent inconsistency (`isWslExe` now agrees with `identify` on **quoted** paths, e.g. `"wsl.exe"`),
- makes detection deterministic on every host.

Adds a direct `isWslExe` unit test covering the absolute Windows path that was crashing, forward slashes, a quoted path, the bare name, and negatives.

## Test

`zig build test -Dapp-runtime=none -Dtest-filter=isWslExe` → 70/70; `-Dtest-filter=wslDistro` → 71/71, on macOS (previously SIGABRT). No behaviour change on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)