### PR TITLE
renderer: cover non-dx12 staging-bytes contract in pending test

### DIFF
--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -1216,8 +1216,17 @@ test "Image.estimatedUploadStagingBytes returns imageStagingBytes for .pending" 
         .pixel_format = .rgba,
         .data = &data,
     } };
-    // 2x2 RGBA -> aligned pitch 256 * height 2 = 512.
-    try std.testing.expectEqual(@as(u64, 512), img.estimatedUploadStagingBytes());
+    // estimatedUploadStagingBytes only tracks staging bytes on backends whose
+    // Texture carries pending_staging_bytes (DX12); the rest return 0 by
+    // contract. A .pending image builds on every backend, so assert both arms
+    // rather than skipping (unlike the .ready/.replace siblings, which gate
+    // because their Texture is not zero-initializable off DX12).
+    if (comptime @hasField(Texture, "pending_staging_bytes")) {
+        // 2x2 RGBA -> aligned pitch 256 * height 2 = 512.
+        try std.testing.expectEqual(@as(u64, 512), img.estimatedUploadStagingBytes());
+    } else {
+        try std.testing.expectEqual(@as(u64, 0), img.estimatedUploadStagingBytes());
+    }
 }
 
 test "Image.estimatedUploadStagingBytes returns 0 for .ready" {


### PR DESCRIPTION
## Problem

`Image.estimatedUploadStagingBytes` only reports nonzero on backends whose `Texture` carries `pending_staging_bytes` (DX12); on Metal/OpenGL it returns `0` by contract (`if (comptime @hasField(Texture, "pending_staging_bytes")) ... else return 0`). The `.pending` test asserted `512` unconditionally, so it failed (`expected 512, found 0`) on non-DX12 hosts such as macOS CI.

## Fix

A `.pending` image constructs on **every** backend (it never builds a `Texture`), so rather than skipping, assert both arms: `512` on DX12, `0` elsewhere. This fixes the failure **and** adds the only coverage of the documented `0`-return path. (The `.ready`/`.replace` sibling tests skip off-DX12 only because their `Texture` is not zero-initializable there — a structural reason that doesn't apply here.)

## Test

`zig build test -Dapp-runtime=none -Dtest-filter=estimatedUploadStagingBytes` → 70 passed, 2 skipped on macOS (previously 1 failed); the `.pending` arm now runs and asserts `0`. Unchanged on DX12, where it still asserts `512`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)