### PR TITLE
os: pass explicit delimiter to prependEnv for CLINK_PATH

### DIFF
--- a/src/os/env.zig
+++ b/src/os/env.zig
@@ -45,19 +45,27 @@ pub fn appendEnvAlways(
     });
 }
 
-/// Prepend a value to an environment variable such as PATH.
-/// The returned value is always allocated so it must be freed.
+/// Prepend a value to a delimiter-separated environment variable, joining
+/// `value` in front of `current` with `delimiter`. The returned value is
+/// always allocated so it must be freed.
+///
+/// `delimiter` is explicit because the right separator is not always the
+/// host's: pass `std.fs.path.delimiter` for host PATH-style lists, but a
+/// fixed `';'` for variables whose format is host-independent, such as
+/// Windows' CLINK_PATH (always `;`-separated, even when set off-Windows in
+/// tests).
 pub fn prependEnv(
     alloc: Allocator,
     current: []const u8,
     value: []const u8,
+    delimiter: u8,
 ) Error![]u8 {
     // If there is no prior value, we return it as-is
     if (current.len == 0) return try alloc.dupe(u8, value);
 
     return try std.fmt.allocPrint(alloc, "{s}{c}{s}", .{
         value,
-        std.fs.path.delimiter,
+        delimiter,
         current,
     });
 }
@@ -159,20 +167,25 @@ test "prependEnv empty" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    const result = try prependEnv(alloc, "", "foo");
+    const result = try prependEnv(alloc, "", "foo", ':');
     defer alloc.free(result);
     try testing.expectEqualStrings(result, "foo");
 }
 
-test "prependEnv existing" {
+test "prependEnv existing colon delimiter" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
-    const result = try prependEnv(alloc, "a:b", "foo");
+    const result = try prependEnv(alloc, "a:b", "foo", ':');
     defer alloc.free(result);
-    if (builtin.os.tag == .windows) {
-        try testing.expectEqualStrings(result, "foo;a:b");
-    } else {
-        try testing.expectEqualStrings(result, "foo:a:b");
-    }
+    try testing.expectEqualStrings(result, "foo:a:b");
+}
+
+test "prependEnv existing semicolon delimiter" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const result = try prependEnv(alloc, "a;b", "foo", ';');
+    defer alloc.free(result);
+    try testing.expectEqualStrings(result, "foo;a;b");
 }

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -1333,10 +1333,15 @@ fn setupCmd(
         dir.close();
         try env.put(
             "CLINK_PATH",
+            // CLINK_PATH is a Windows-format list and is always
+            // ';'-separated, independent of the host (Clink only runs on
+            // Windows; using the host path delimiter would emit ':' under
+            // unit tests on POSIX).
             try internal_os.prependEnv(
                 alloc_arena,
                 env.get("CLINK_PATH") orelse "",
                 clink_dir,
+                ';',
             ),
         );
     } else |err| switch (err) {


### PR DESCRIPTION
## Problem

`prependEnv` joined with `std.fs.path.delimiter` — `;` on Windows but **`:` on POSIX**. Its **only** caller builds `CLINK_PATH`, a Windows-format list that Clink always reads as `;`-separated. On Windows this was correct; under unit tests on macOS it produced `dir:C:\my\scripts`, so the test `cmd: CLINK_PATH prepends ours and preserves existing entries` saw no `;` and failed.

This failure had been **masked**: the `wslDistro` SIGABRT (fixed in #547) aborted the test process before `shell_integration` tests ran. With that fixed, this surfaced — Zig mislabels it as the last-indexed test (`apprt.ipc.Target.Key`/`cli.ssh.Joined`), but the real assertion failure is at `shell_integration.zig:1437`.

## Fix

Same class as #547: make the Windows-specific value **host-independent** instead of skipping the test. `prependEnv` now takes an explicit `delimiter`, and the CLINK caller passes `;`. The `prependEnv` unit tests assert both `:` and `;` directly instead of branching on the host (which also fixes their latent Windows-side wrongness).

## Test

- `-Dtest-filter=prependEnv` → 71/71; `-Dtest-filter="cmd: CLINK_PATH prepends..."` → 70/70 (previously failed) on macOS.
- **Full suite: `3090/3183 passed, 93 skipped, 0 failed`** — green for the first time (this was the last of three failures the `wslDistro` crash had masked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)