### PR TITLE
feat(windows): handle SELECTION_CHANGED → UIA TextSelectionChanged

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -54,8 +54,9 @@ internal enum GhosttyActionTag
     ConfigChange = 48,
     CloseWindow = 49,
     RingBell = 50,
-    // SELECTION_CHANGED (51) was inserted upstream, shifting every later
-    // tag +1. These dispatched tags are realigned to the current header.
+    // SELECTION_CHANGED was inserted upstream at 51, shifting every later
+    // tag +1 (the dispatched tags below are realigned to the current header).
+    SelectionChanged = 51,
     ShowChildExited = 56,
     ProgressReport = 57,
     StartSearch    = 60,

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -32,6 +32,7 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.ConfigChange, 48)]
     [InlineData((int)GhosttyActionTag.CloseWindow, 49)]
     [InlineData((int)GhosttyActionTag.RingBell, 50)]
+    [InlineData((int)GhosttyActionTag.SelectionChanged, 51)]
     [InlineData((int)GhosttyActionTag.ProgressReport, 57)]
     [InlineData((int)GhosttyActionTag.StartSearch, 60)]
     [InlineData((int)GhosttyActionTag.EndSearch, 61)]

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -78,6 +78,18 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
         }
     }
 
+    /// <summary>
+    /// Raise the UIA TextSelectionChanged event so assistive tech re-queries
+    /// <see cref="GetSelection"/>. Mirrors the macOS surface posting
+    /// NSAccessibility .selectedTextChanged. Guarded by ListenerExists so it
+    /// is inert when no AT client is attached.
+    /// </summary>
+    internal void RaiseSelectionChangedEvent()
+    {
+        if (AutomationPeer.ListenerExists(AutomationEvents.TextPatternOnTextSelectionChanged))
+            RaiseAutomationEvent(AutomationEvents.TextPatternOnTextSelectionChanged);
+    }
+
     /// <summary>Current cached screen document. Refreshed at most every 500ms.</summary>
     internal TerminalDocument Document => _document.Get();
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -270,6 +270,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     internal void RaisePromptReady() => PromptReady?.Invoke(this, EventArgs.Empty);
     internal void RaiseFirstRender() => FirstRender?.Invoke(this, EventArgs.Empty);
 
+    /// <summary>
+    /// Notify the UIA automation peer that the terminal selection changed so
+    /// assistive tech re-queries it. No-op when no automation peer has been
+    /// created (i.e. no AT client is attached), so non-AT users pay nothing.
+    /// </summary>
+    internal void RaiseSelectionChanged() => _automationPeer?.RaiseSelectionChangedEvent();
+
     private bool _bellBorderActive;
     private bool _bellTitlePending;
     private BellAudioPlayer? _bellAudio;

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -736,6 +736,24 @@ internal sealed class GhosttyHost : IDisposable
                     return 1;
                 }
 
+                case GhosttyActionTag.SelectionChanged:
+                {
+                    // Payload-less: core fires this on a selection state
+                    // transition (already coalesced in Surface.zig). Route it
+                    // to the surface's UIA peer so assistive tech re-queries
+                    // the selection, mirroring macOS posting NSAccessibility
+                    // .selectedTextChanged. The resolve-guard drops the action
+                    // if the surface was torn down before the dispatched
+                    // callback runs; the raise itself is inert when no AT
+                    // client is listening (same as SetTitle/MouseShape).
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (TryResolveControl(surfaceHandle, out var c) && c is not null)
+                            c.RaiseSelectionChanged();
+                    });
+                    return 1;
+                }
+
                 case GhosttyActionTag.RingBell:
                 {
                     // Core already debounces the bell (100ms in Surface.zig)


### PR DESCRIPTION
Closes #550. **Stacked on #552** (base = `fix/windows-action-tag-realign`); review/merge that first.

## What

Upstream **#12902** added a payload-less `GHOSTTY_ACTION_SELECTION_CHANGED`, fired on a selection state transition. macOS posts NSAccessibility `.selectedTextChanged`; this wires the Windows equivalent so the UIA text provider (added in #542–#545) notifies assistive tech.

Flow: `GhosttyHost.OnAction` → resolve `TerminalControl` → `RaiseSelectionChanged()` → `TerminalAutomationPeer.RaiseSelectionChangedEvent()` → `RaiseAutomationEvent(TextPatternOnTextSelectionChanged)`.

## Changes
- `GhosttyActions.cs`: add `SelectionChanged = 51` to the dispatched subset (+ pin in `GhosttyActionsLayoutTests`).
- `GhosttyHost.cs`: dispatch case (payload-less, resolve-guarded, same shape as `SetTitle`/`MouseShape`).
- `TerminalControl.xaml.cs`: `RaiseSelectionChanged()` — no-ops when no peer exists (no AT client).
- `TerminalAutomationPeer.cs`: `RaiseSelectionChangedEvent()` — raises the UIA event, guarded by `ListenerExists`.

## Design notes
- **No debounce** — matches macOS (posts directly) and core already coalesces selection transitions (Surface.zig); the raise is inert without an AT listener, so per-change cost under drag-select is negligible. (Issue listed debounce as optional; can add if profiling shows churn.)

## ⚠️ Verification (cannot build on macOS — CsWin32; no C# CI)
- [ ] Windows build of `Ghostty.sln`
- [ ] `Ghostty.Tests` → `GhosttyActionsLayoutTests` green
- [ ] **Confirm `AutomationEvents.TextPatternOnTextSelectionChanged` is the correct WinUI 3 event id** (highest-risk line — API name verified against UWP/WinUI UIA, not compiled here)
- [ ] Smoke test under Narrator / an automation client: selecting + clearing fires `TextSelectionChanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)