### PR TITLE
termio: read ConPTY output in 64 KiB batches

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1876,7 +1876,16 @@ pub const ReadThread = struct {
         };
         defer crash.sentry.thread_state = null;
 
-        var buf: [1024]u8 = undefined;
+        // Match the posix pipeline's batch size. ConPTY has no analogue
+        // of the ~1 KiB pty read cap on macOS/Linux: measured against
+        // both the in-box conhost and our bundled OpenConsole pair,
+        // a 64 KiB read returns ~46-65 KiB per call under bulk output.
+        // A 1 KiB buffer forced 45-63x more ReadFile calls, terminal
+        // lock acquisitions, and render wakeups for the same data.
+        // Throughput itself is capped by ConPTY's own VT rendering
+        // (~10-13 MB/s), so this is an overhead reduction, not a
+        // throughput win.
+        var buf: [buffer_capacity]u8 = undefined;
         while (true) {
             while (true) {
                 var n: windows.DWORD = 0;

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1512,6 +1512,23 @@ pub const ReadThread = struct {
     /// this bounds both gather latency and lock hold time.
     const buffer_capacity = 64 * 1024;
 
+    /// Read buffer size for the Windows serial loop
+    /// (threadMainWindows). ConPTY has no analogue of the ~1 KiB pty
+    /// read cap on macOS/Linux: measured against both the in-box
+    /// conhost and the bundled OpenConsole pair, a read this size
+    /// returns 46-65 KiB per call under bulk output, so a 1 KiB
+    /// buffer only multiplied ReadFile calls, terminal lock
+    /// acquisitions, and render wakeups 45-63x for the same stream.
+    /// Throughput doesn't change either way; ConPTY's own VT
+    /// rendering caps it well below what either buffer size can
+    /// drain.
+    ///
+    /// Deliberately equal to buffer_capacity so one batch bounds
+    /// terminal lock hold time the same on every platform. If the
+    /// posix pipeline ever retunes that const for gather-specific
+    /// reasons, revisit this value independently.
+    const windows_read_capacity = buffer_capacity;
+
     /// How many gathered bytes mark a stream as saturated. The macOS
     /// kernel tty output queue hands the master at most about 1 KiB
     /// per read, so gathering a full 1 KiB means the writer filled
@@ -1876,16 +1893,7 @@ pub const ReadThread = struct {
         };
         defer crash.sentry.thread_state = null;
 
-        // Match the posix pipeline's batch size. ConPTY has no analogue
-        // of the ~1 KiB pty read cap on macOS/Linux: measured against
-        // both the in-box conhost and our bundled OpenConsole pair,
-        // a 64 KiB read returns ~46-65 KiB per call under bulk output.
-        // A 1 KiB buffer forced 45-63x more ReadFile calls, terminal
-        // lock acquisitions, and render wakeups for the same data.
-        // Throughput itself is capped by ConPTY's own VT rendering
-        // (~10-13 MB/s), so this is an overhead reduction, not a
-        // throughput win.
-        var buf: [buffer_capacity]u8 = undefined;
+        var buf: [windows_read_capacity]u8 = undefined;
         while (true) {
             while (true) {
                 var n: windows.DWORD = 0;


### PR DESCRIPTION
The Windows read loop still used a 1 KiB buffer, a leftover from the posix loop shape where the kernel caps pty reads at ~1 KiB anyway. ConPTY has no such cap.

Measured on Server 2025 (32 MiB bulk stream, both the in-box conhost and our bundled OpenConsole pair, harness on the `probe/conpty-read` branch):

| | 1 KiB buffer | 64 KiB buffer |
|---|---|---|
| in-box conhost | 32,977 reads (97.8% exactly 1024) | 723 reads, avg ~46 KiB |
| bundled OpenConsole | 32,779 reads (98.4% exactly 1024) | 516 reads, avg ~65 KiB |

Throughput is unchanged in every configuration (ConPTY's own VT rendering caps it at 10-13 MB/s), so this is purely a 45-63x reduction in ReadFile calls, terminal lock acquisitions, and render wakeups under bulk output. The new size matches `buffer_capacity`, the batch unit the posix gather pipeline uses, which also bounds terminal lock hold time per batch.

The same measurements showed upstream's io-gather thread (#13209 shape) buys nothing while ConPTY is the transport — the reader idles waiting on conhost regardless. That part is deliberately not ported; it should be revisited as part of any future transport change.