### PR TITLE
terminal: implement DECSTR soft reset (CSI ! p)

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -3913,6 +3913,44 @@ pub fn fullReset(self: *Terminal) void {
     self.flags.dirty.clear = true;
 }
 
+/// Soft terminal reset (DECSTR, `CSI ! p`). Unlike `fullReset` (RIS), resets
+/// programmable state to power-up defaults without clearing the screen or
+/// moving the cursor.
+pub fn softReset(self: *Terminal) void {
+    const screen: *Screen = self.screens.active;
+
+    // Modes reset by DECSTR (DEC STD 070).
+    self.modes.set(.cursor_visible, true); // DECTCEM
+    self.modes.set(.insert, false); // IRM
+    self.modes.set(.origin, false); // DECOM
+    self.modes.set(.disable_keyboard, false); // KAM
+    self.modes.set(.cursor_keys, false); // DECCKM
+    self.modes.set(.keypad_keys, false); // DECNKM
+    // DECAWM: spec says off, but we match conhost/xterm and reset to default.
+    self.modes.set(.wraparound, true);
+
+    // SGR back to default.
+    screen.cursor.style = .{};
+    screen.manualStyleUpdate() catch unreachable;
+
+    // Charsets (G0-G3) back to ASCII.
+    screen.charset = .{};
+
+    self.setProtectedMode(.off); // DECSCA
+
+    // Full scrolling region.
+    self.scrolling_region = .{
+        .top = 0,
+        .bottom = self.rows - 1,
+        .left = 0,
+        .right = self.cols - 1,
+    };
+
+    screen.cursor.pending_wrap = false;
+    screen.saved_cursor = null; // DECSC
+    self.previous_char = null; // REP
+}
+
 /// Returns true if the point is dirty, used for testing.
 fn isDirty(t: *const Terminal, pt: point.Point) bool {
     return t.screens.active.pages.getCell(pt).?.isDirty();
@@ -13775,6 +13813,71 @@ test "Terminal: fullReset origin mode" {
     try testing.expectEqual(@as(usize, 0), t.screens.active.cursor.y);
     try testing.expectEqual(@as(usize, 0), t.screens.active.cursor.x);
     try testing.expect(!t.modes.get(.origin));
+}
+
+test "Terminal: softReset resets state without clearing the screen" {
+    var t = try init(testing.allocator, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(testing.allocator);
+
+    // Put content on the screen so we can confirm it survives.
+    try t.printString("hello");
+
+    // Pile on non-default programmable state.
+    t.modes.set(.origin, true);
+    t.modes.set(.insert, true);
+    t.modes.set(.wraparound, false);
+    t.modes.set(.cursor_visible, false);
+    t.modes.set(.disable_keyboard, true);
+    t.modes.set(.cursor_keys, true);
+    t.modes.set(.keypad_keys, true);
+    t.scrolling_region = .{ .top = 2, .bottom = 5, .left = 0, .right = 9 };
+    t.configureCharset(.G0, .dec_special);
+    t.setProtectedMode(.iso);
+    t.saveCursor();
+    try t.setAttribute(.{ .bold = {} });
+
+    // DECSTR must not move the cursor (unlike RIS).
+    const cursor_x = t.screens.active.cursor.x;
+    const cursor_y = t.screens.active.cursor.y;
+
+    t.softReset();
+
+    // Modes back to their power-up defaults.
+    try testing.expect(t.modes.get(.cursor_visible));
+    try testing.expect(!t.modes.get(.insert));
+    try testing.expect(!t.modes.get(.origin));
+    try testing.expect(t.modes.get(.wraparound));
+    try testing.expect(!t.modes.get(.disable_keyboard));
+    try testing.expect(!t.modes.get(.cursor_keys));
+    try testing.expect(!t.modes.get(.keypad_keys));
+
+    // Cursor position is unchanged.
+    try testing.expectEqual(cursor_x, t.screens.active.cursor.x);
+    try testing.expectEqual(cursor_y, t.screens.active.cursor.y);
+
+    // Scrolling region restored to the full screen.
+    try testing.expectEqual(@as(usize, 0), t.scrolling_region.top);
+    try testing.expectEqual(@as(usize, 9), t.scrolling_region.bottom);
+
+    // SGR back to normal rendition.
+    try testing.expect(!t.screens.active.cursor.style.flags.bold);
+
+    // Character set reset (no pending single shift after G0->ASCII).
+    try testing.expect(t.screens.active.charset.single_shift == null);
+
+    // Protected-character bit cleared.
+    try testing.expect(!t.screens.active.cursor.protected);
+
+    // Saved cursor (DECSC) cleared.
+    try testing.expect(t.screens.active.saved_cursor == null);
+
+    // The screen content is preserved — this is the key difference from
+    // fullReset (RIS), which clears it.
+    {
+        const str = try t.plainString(testing.allocator);
+        defer testing.allocator.free(str);
+        try testing.expectEqualStrings("hello", str);
+    }
 }
 
 test "Terminal: fullReset status display" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -77,6 +77,7 @@ pub const Action = union(Key) {
     next_line,
     reverse_index,
     full_reset,
+    soft_reset,
     set_mode: Mode,
     reset_mode: Mode,
     save_mode: Mode,
@@ -176,6 +177,7 @@ pub const Action = union(Key) {
             "next_line",
             "reverse_index",
             "full_reset",
+            "soft_reset",
             "set_mode",
             "reset_mode",
             "save_mode",
@@ -1855,8 +1857,17 @@ pub fn Stream(comptime H: type) type {
                     }
                 },
 
-                // DECRQM - Request Mode
+                // DECSTR (soft reset) / DECRQM (request mode)
                 'p' => switch (input.intermediates.len) {
+                    1 => switch (input.intermediates[0]) {
+                        // DECSTR - Soft Terminal Reset (CSI ! p)
+                        '!' => self.handler.vt(.soft_reset, {}),
+                        else => log.warn(
+                            "ignoring unimplemented CSI p with intermediates: {s}",
+                            .{input.intermediates},
+                        ),
+                    },
+
                     2 => decrqm: {
                         const ansi_mode = ansi: {
                             switch (input.intermediates.len) {

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -271,6 +271,7 @@ pub const Handler = struct {
                 self.terminal.modes.set(.cursor_blinking, self.default_cursor_blink);
                 self.terminal.screens.active.cursor.cursor_style = self.default_cursor_style;
             },
+            .soft_reset => self.terminal.softReset(),
             .start_hyperlink => try self.terminal.screens.active.startHyperlink(value.uri, value.id),
             .end_hyperlink => self.terminal.screens.active.endHyperlink(),
             .semantic_prompt => try self.terminal.semanticPrompt(value),

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -270,6 +270,7 @@ pub const StreamHandler = struct {
             .next_line => try self.nextLine(),
             .reverse_index => try self.reverseIndex(),
             .full_reset => try self.fullReset(),
+            .soft_reset => self.terminal.softReset(),
             .set_mode => try self.setMode(value.mode, true),
             .reset_mode => try self.setMode(value.mode, false),
             .save_mode => self.terminal.modes.save(value.mode),


### PR DESCRIPTION
`CSI ! p` (DECSTR, soft terminal reset) was logged as unimplemented and
ignored. So state a program set (scroll region, origin mode, SGR, charset)
survived the reset, and later output ended up in the wrong place, color, or
charset until a full reset (RIS) or `reset(1)`.

This resets the programmable state to power-up defaults per DEC STD 070
(cursor visible, replace mode, absolute origin, autowrap on, default SGR,
ASCII charsets, full scrolling region, unprotected, cleared saved cursor). It
doesn't clear the screen or move the cursor, which is the difference from RIS.

## Repro

```
printf '\e[4;9r\e[?6h\e[?7l\e[1;31;44m\e(0\e[!p\e[1;1Hplain-abc\n'
```

That sets a scroll region, origin mode, bold red on blue, and the DEC
line-drawing charset, then soft resets and prints. Without this change the
reset does nothing, so `plain-abc` comes out mangled in the leftover state.
With it, you get clean text at the top left.

## Before / after

Same reproducer through the terminal model. Left is `CSI ! p` ignored, so
state leaks past the reset. Right is with this change.

| ignored (today) | soft reset (this PR) |
|---|---|
| <img width="340" src="https://raw.githubusercontent.com/deblasis/wintty/decstr-demo-assets/.github/decstr-demo/decstr-before.png"> | <img width="340" src="https://raw.githubusercontent.com/deblasis/wintty/decstr-demo-assets/.github/decstr-demo/decstr-after.png"> |

xterm, VTE, and conhost all implement this. Test included.

Note: DEC STD 070 says autowrap resets off, but this matches xterm/conhost and
resets it to the default (on).
