### PR TITLE
chore(windows): fix root global.json SDK roll-forward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.202",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
The .NET 10 migration (5c535ad15) left the root `global.json` pinned to `rollForward: latestPatch`, which refuses to cross SDK feature bands (10.0.2xx to 10.0.3xx). Builds run from the repo root (e.g. `just build-win`, which runs `dotnet build windows/Ghostty.sln` with cwd at the root) resolve this file rather than `windows/global.json`, so they fail on machines that only have a newer band such as 10.0.302 installed.

`windows/global.json` already uses `latestFeature`. This aligns the root file to match, so the build resolves installed 10.0.3xx SDKs while staying pinned within 10.0.x (no drift to 11.x).

No CI change needed: no workflow builds the .NET tree, so there is no CI SDK band to reconcile with.