### PR TITLE
chore(windows): remove redundant windows/global.json

### DIFF
--- a/windows/global.json
+++ b/windows/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "10.0.202",
-    "rollForward": "latestFeature"
-  }
-}


### PR DESCRIPTION
Follow-up to #561. The repo-root `global.json` is an ancestor of `windows/`, so its SDK pin already governs every build under that directory. `windows/global.json` held identical settings, which meant both files had to be hand-synced on every SDK bump - the exact drift that briefly left the root file on the wrong roll-forward policy.

Removing the redundant copy leaves a single source of truth.

Verified safe:
- Nothing references `global.json` by path (no justfile recipe, script, or workflow).
- `dotnet --version` resolves 10.0.302 from the repo root, from `windows/`, and from `dist/windows/` (all fall back to the root file).
- `dotnet build Ghostty.sln` run from within `windows/` compiles the full C#/XAML tree (only the pre-existing unrelated native ghostty.dll prerequisite remains).
- `dotnet test Ghostty.Tests`: 1653 passed, 0 failed, 1 skipped.