### PR TITLE
deps: bump zioshade to v0.4.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -92,12 +92,13 @@
         // HLSL/MSL/GLSL cross compiler. It replaces the glslang and
         // spirv-cross C++ packages, so custom shader compilation is
         // in-process with no C++ dependencies.
-        // Pinned to a main commit rather than v0.3.0: that tag hard-errors on
-        // Zig 0.16. Move to a tag once one is cut past zioshade PR 492, which
-        // carries the 0.16 build and packaging fix this pin depends on.
+        // Pinned to the v0.4.0 tag (cut past PR #492, which carries the Zig 0.16
+        // build + packaging fix this pin depends on; the older v0.3.0 tag
+        // hard-errored on 0.16). v0.4.0 also completes the float-comparison
+        // NaN-correctness campaign and a fully-clean compile-validity matrix.
         .zioshade = .{
-            .url = "https://github.com/zioShade/zioshade/archive/194fe60.tar.gz",
-            .hash = "zioshade-0.3.0-8s3a2jwtRAD_DxI5B-ULCA3dcBhOPwN3KI2keGqsEONI",
+            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.4.0.tar.gz",
+            .hash = "zioshade-0.4.0-8s3a2sRrRACbnWG3W-IvO9Z2s2X4jsvBaO0aU3gd8bbo",
             .lazy = true,
         },
 

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -179,9 +179,9 @@
     "url": "git+https://github.com/zigimg/zigimg#d695acd97c02e57bb151e8f659d1280f5cd6ca70",
     "hash": "sha256-0IYATQldT6eJxRR2T/2CsIYZuzomqjvmdVyjmsjguyE="
   },
-  "zioshade-0.3.0-8s3a2uVYOwAHpAAk_zLu4kTfOSj7v8dc_PVtujKe78MZ": {
+  "zioshade-0.4.0-8s3a2sRrRACbnWG3W-IvO9Z2s2X4jsvBaO0aU3gd8bbo": {
     "name": "zioshade",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.3.0.tar.gz",
-    "hash": "sha256-QgPZELB4NeeAOAMpffbXI2G6hXlc91tL9+tQ7z3sWWA="
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.4.0.tar.gz",
+    "hash": "sha256-AiCGgtCDgPULUQeBup5AccAkjiMxI67f0j8CvHkg2Bs="
   }
 }

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -413,11 +413,11 @@ in
       };
     }
     {
-      name = "zioshade-0.3.0-8s3a2uVYOwAHpAAk_zLu4kTfOSj7v8dc_PVtujKe78MZ";
+      name = "zioshade-0.4.0-8s3a2sRrRACbnWG3W-IvO9Z2s2X4jsvBaO0aU3gd8bbo";
       path = fetchZigArtifact {
         name = "zioshade";
-        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.3.0.tar.gz";
-        hash = "sha256-QgPZELB4NeeAOAMpffbXI2G6hXlc91tL9+tQ7z3sWWA=";
+        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.4.0.tar.gz";
+        hash = "sha256-AiCGgtCDgPULUQeBup5AccAkjiMxI67f0j8CvHkg2Bs=";
         unpack = false;
       };
     }

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -34,4 +34,4 @@ https://deps.files.ghostty.org/zig_js-3c23860e47fdcdc5af805efb7fd0bdac5fd3e9bc.t
 https://deps.files.ghostty.org/zig_objc-c8de82ff80281215ad92900866dab7103a8efa8b.tar.gz
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz
-https://github.com/zioShade/zioshade/archive/refs/tags/v0.3.0.tar.gz
+https://github.com/zioShade/zioshade/archive/refs/tags/v0.4.0.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -217,8 +217,8 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.3.0.tar.gz",
-    "dest": "vendor/p/zioshade-0.3.0-8s3a2uVYOwAHpAAk_zLu4kTfOSj7v8dc_PVtujKe78MZ",
-    "sha256": "4203d910b07835e7803803297df6d72361ba85795cf75b4bf7eb50ef3dec5960"
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.4.0.tar.gz",
+    "dest": "vendor/p/zioshade-0.4.0-8s3a2sRrRACbnWG3W-IvO9Z2s2X4jsvBaO0aU3gd8bbo",
+    "sha256": "02208682d08380f50b510781ba9e4071c0248e233123aedfd23f02bc7920d81b"
   }
 ]


### PR DESCRIPTION
Bumps the zioshade dependency from the main commit pin (194fe60) to the **v0.4.0 tag**.

v0.4.0 is the first tag cut past zioshade PR #492, which carries the Zig 0.16 build + packaging fix this pin depends on (the older v0.3.0 tag hard-errored on 0.16, which is why the pin was on a commit). It also completes the float-comparison NaN-correctness campaign (all 12 opcodes, all 4 backends) and ships a fully-clean compile-validity matrix across HLSL/GLSL/MSL/WGSL x fragment/vertex/compute.

Updates the build.zig.zon pin (url + zig dependency hash) and syncs the mirror lockfiles (build.zig.zon.json, .nix, .txt, flatpak/zig-packages.json) to v0.4.0 with the correct tarball sha256 in each format. The mirrors previously referenced v0.3.0 while the manifest pinned a commit; this resolves that drift.

Tag: https://github.com/zioShade/zioshade/releases/tag/v0.4.0