### PR TITLE
inspector: add swap-chain-owning DirectX12 exports

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1340,8 +1340,14 @@ GHOSTTY_API void ghostty_inspector_directx12_render(ghostty_inspector_t, void*);
 GHOSTTY_API void ghostty_inspector_directx12_shutdown(ghostty_inspector_t);
 
 // Swap-chain-owning variant, where libghostty creates and drives the swap
-// chain bound to the embedder's SwapChainPanel. init takes the panel as an
-// IUnknown* plus the panel size in pixels; resize takes the new pixel size.
+// chain bound to the embedder's SwapChainPanel, rather than rendering into a
+// command list the embedder owns.
+//
+// init takes an ISwapChainPanelNative* plus the panel size in pixels; resize
+// takes the new pixel size. The panel pointer is borrowed for the duration of
+// the init call only: the embedder may release it once init returns, so an
+// implementation that retains the panel must AddRef it.
+//
 // Skip present/resize/shutdown when init returns false.
 GHOSTTY_API bool ghostty_inspector_directx12_surface_init(ghostty_inspector_t, void*, uint32_t, uint32_t);
 GHOSTTY_API void ghostty_inspector_directx12_surface_present(ghostty_inspector_t);

--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1338,6 +1338,15 @@ GHOSTTY_API bool ghostty_inspector_metal_shutdown(ghostty_inspector_t);
 GHOSTTY_API bool ghostty_inspector_directx12_init(ghostty_inspector_t, void*, void*, uint32_t, uint32_t);
 GHOSTTY_API void ghostty_inspector_directx12_render(ghostty_inspector_t, void*);
 GHOSTTY_API void ghostty_inspector_directx12_shutdown(ghostty_inspector_t);
+
+// Swap-chain-owning variant, where libghostty creates and drives the swap
+// chain bound to the embedder's SwapChainPanel. init takes the panel as an
+// IUnknown* plus the panel size in pixels; resize takes the new pixel size.
+// Skip present/resize/shutdown when init returns false.
+GHOSTTY_API bool ghostty_inspector_directx12_surface_init(ghostty_inspector_t, void*, uint32_t, uint32_t);
+GHOSTTY_API void ghostty_inspector_directx12_surface_present(ghostty_inspector_t);
+GHOSTTY_API void ghostty_inspector_directx12_surface_resize(ghostty_inspector_t, uint32_t, uint32_t);
+GHOSTTY_API void ghostty_inspector_directx12_surface_shutdown(ghostty_inspector_t);
 #endif
 
 // APIs I'd like to get rid of eventually but are still needed for now.

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2962,5 +2962,48 @@ pub const CAPI = struct {
             }
             ptr.deinitDx12Heap();
         }
+
+        // Swap-chain-owning inspector API. The embedder gives us its
+        // SwapChainPanel and we own the swap chain, the same split the
+        // terminal surface uses: WinUI's SwapChainPanel is a compositor sink
+        // rather than a render loop, so it can't hand us a device and command
+        // buffer the way MTKView does for the Metal inspector above.
+        //
+        // The DirectX12 implementation isn't wired up yet. The exports exist
+        // so embedders link, and init reports failure so the inspector window
+        // stays inert rather than presenting a swap chain that was never
+        // created; embedders must skip present/resize/shutdown when init
+        // returns false.
+
+        export fn ghostty_inspector_directx12_surface_init(
+            ptr: *Inspector,
+            swap_chain_panel: ?*anyopaque,
+            width: u32,
+            height: u32,
+        ) bool {
+            _ = ptr;
+            _ = swap_chain_panel;
+            _ = width;
+            _ = height;
+            return false;
+        }
+
+        export fn ghostty_inspector_directx12_surface_present(ptr: *Inspector) void {
+            _ = ptr;
+        }
+
+        export fn ghostty_inspector_directx12_surface_resize(
+            ptr: *Inspector,
+            width: u32,
+            height: u32,
+        ) void {
+            _ = ptr;
+            _ = width;
+            _ = height;
+        }
+
+        export fn ghostty_inspector_directx12_surface_shutdown(ptr: *Inspector) void {
+            _ = ptr;
+        }
     };
 };

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2969,41 +2969,28 @@ pub const CAPI = struct {
         // rather than a render loop, so it can't hand us a device and command
         // buffer the way MTKView does for the Metal inspector above.
         //
-        // The DirectX12 implementation isn't wired up yet. The exports exist
-        // so embedders link, and init reports failure so the inspector window
-        // stays inert rather than presenting a swap chain that was never
-        // created; embedders must skip present/resize/shutdown when init
-        // returns false.
+        // init reports failure while there is no DirectX12 backend behind
+        // these, which keeps the inspector window inert instead of presenting
+        // a swap chain that was never created.
 
         export fn ghostty_inspector_directx12_surface_init(
-            ptr: *Inspector,
-            swap_chain_panel: ?*anyopaque,
-            width: u32,
-            height: u32,
+            _: *Inspector,
+            _: ?*anyopaque,
+            _: u32,
+            _: u32,
         ) bool {
-            _ = ptr;
-            _ = swap_chain_panel;
-            _ = width;
-            _ = height;
+            log.warn("directx12 inspector surface backend is not implemented", .{});
             return false;
         }
 
-        export fn ghostty_inspector_directx12_surface_present(ptr: *Inspector) void {
-            _ = ptr;
-        }
+        export fn ghostty_inspector_directx12_surface_present(_: *Inspector) void {}
 
         export fn ghostty_inspector_directx12_surface_resize(
-            ptr: *Inspector,
-            width: u32,
-            height: u32,
-        ) void {
-            _ = ptr;
-            _ = width;
-            _ = height;
-        }
+            _: *Inspector,
+            _: u32,
+            _: u32,
+        ) void {}
 
-        export fn ghostty_inspector_directx12_surface_shutdown(ptr: *Inspector) void {
-            _ = ptr;
-        }
+        export fn ghostty_inspector_directx12_surface_shutdown(_: *Inspector) void {}
     };
 };

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -63,9 +63,18 @@
       to Ghostty.csproj (which would drag WinAppSDK targets into a plain
       net10.0 test assembly).
     -->
+    <!--
+      Every file that P/Invokes libghostty, for EntryPointParityTests (and
+      NativeMethods.cs also for MarshalComplianceTests). Unlike a missing export
+      site, a missing import site fails SILENTLY (unscanned means unchecked), so
+      add a file here if it starts importing a ghostty_* symbol.
+    -->
     <EmbeddedResource Include="..\Ghostty\Interop\NativeMethods.cs"
-                      Link="Interop\NativeMethods.cs"
-                      LogicalName="Ghostty.Tests.Interop.NativeMethods.cs" />
+                      Link="Interop\Imports\NativeMethods.cs"
+                      LogicalName="Ghostty.Tests.Interop.Imports.NativeMethods.cs" />
+    <EmbeddedResource Include="..\Ghostty.Core\Version\LibGhosttyBuildInfo.cs"
+                      Link="Interop\Imports\LibGhosttyBuildInfo.cs"
+                      LogicalName="Ghostty.Tests.Interop.Imports.LibGhosttyBuildInfo.cs" />
     <!--
       Every zig file that declares `export fn ghostty_*`. EntryPointParityTests
       scans these for the symbols NativeMethods.cs imports; the C header is NOT
@@ -73,14 +82,19 @@
       Add a file here if a new one starts exporting a ghostty_* symbol.
     -->
     <EmbeddedResource Include="..\..\src\apprt\embedded.zig"
+                      Link="Interop\Exports\apprt.embedded.zig"
                       LogicalName="Ghostty.Tests.Interop.Exports.apprt.embedded.zig" />
     <EmbeddedResource Include="..\..\src\benchmark\CApi.zig"
+                      Link="Interop\Exports\benchmark.CApi.zig"
                       LogicalName="Ghostty.Tests.Interop.Exports.benchmark.CApi.zig" />
     <EmbeddedResource Include="..\..\src\config\CApi.zig"
+                      Link="Interop\Exports\config.CApi.zig"
                       LogicalName="Ghostty.Tests.Interop.Exports.config.CApi.zig" />
     <EmbeddedResource Include="..\..\src\log_bridge.zig"
+                      Link="Interop\Exports\log_bridge.zig"
                       LogicalName="Ghostty.Tests.Interop.Exports.log_bridge.zig" />
     <EmbeddedResource Include="..\..\src\main_c.zig"
+                      Link="Interop\Exports\main_c.zig"
                       LogicalName="Ghostty.Tests.Interop.Exports.main_c.zig" />
   </ItemGroup>
 

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -66,6 +66,22 @@
     <EmbeddedResource Include="..\Ghostty\Interop\NativeMethods.cs"
                       Link="Interop\NativeMethods.cs"
                       LogicalName="Ghostty.Tests.Interop.NativeMethods.cs" />
+    <!--
+      Every zig file that declares `export fn ghostty_*`. EntryPointParityTests
+      scans these for the symbols NativeMethods.cs imports; the C header is NOT
+      usable for this, because fork-added exports are routinely omitted from it.
+      Add a file here if a new one starts exporting a ghostty_* symbol.
+    -->
+    <EmbeddedResource Include="..\..\src\apprt\embedded.zig"
+                      LogicalName="Ghostty.Tests.Interop.Exports.apprt.embedded.zig" />
+    <EmbeddedResource Include="..\..\src\benchmark\CApi.zig"
+                      LogicalName="Ghostty.Tests.Interop.Exports.benchmark.CApi.zig" />
+    <EmbeddedResource Include="..\..\src\config\CApi.zig"
+                      LogicalName="Ghostty.Tests.Interop.Exports.config.CApi.zig" />
+    <EmbeddedResource Include="..\..\src\log_bridge.zig"
+                      LogicalName="Ghostty.Tests.Interop.Exports.log_bridge.zig" />
+    <EmbeddedResource Include="..\..\src\main_c.zig"
+                      LogicalName="Ghostty.Tests.Interop.Exports.main_c.zig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Tests/Interop/EntryPointParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/EntryPointParityTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+// Pins that every entry point NativeMethods.cs imports is actually exported by
+// libghostty.
+//
+// A [LibraryImport] naming a symbol libghostty never exports is invisible to
+// `dotnet build` and to JIT dev runs, because neither links native symbols. It
+// only surfaces as an unresolved-symbol failure during the NativeAOT publish
+// (DirectPInvoke + static ghostty-static.lib), i.e. at release time. The
+// inspector's DirectX12 swap chain entry points sat broken this way and blocked
+// every AOT release.
+//
+// This scans the zig `export fn` declarations, NOT include/ghostty.h: exports
+// added by this fork are routinely absent from the header (ghostty_cli_*,
+// ghostty_surface_list_themes_*, ghostty_inspector_zoom_* all export fine while
+// undeclared), so the header would produce false failures. The export sites are
+// embedded by Ghostty.Tests.csproj.
+public class EntryPointParityTests
+{
+    private const string NativeMethodsResource = "Ghostty.Tests.Interop.NativeMethods.cs";
+    private const string ExportResourcePrefix = "Ghostty.Tests.Interop.Exports.";
+
+    // EntryPoint = "name" on the [LibraryImport] attribute.
+    private static readonly Regex EntryPointPattern = new(
+        @"EntryPoint\s*=\s*""(?<name>[A-Za-z_][A-Za-z0-9_]*)""",
+        RegexOptions.Compiled);
+
+    // `export fn name(`, allowing the `pub` and whitespace variants zig permits.
+    private static readonly Regex ExportPattern = new(
+        @"export\s+fn\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+        RegexOptions.Compiled);
+
+    // The other export form: `@export(&fn, .{ .name = "ghostty_x" })`, used for
+    // symbols that are conditionally exported (e.g. ghostty_init_wide, which is
+    // Windows-only). Anchored on the ghostty_ prefix so it cannot match an
+    // unrelated `.name =` field.
+    private static readonly Regex ExportNameFieldPattern = new(
+        @"\.name\s*=\s*""(?<name>ghostty_[A-Za-z0-9_]*)""",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void EveryImportedEntryPointIsExportedByLibghostty()
+    {
+        var imported = ExtractMatches(ReadNativeMethods(), EntryPointPattern);
+        var exported = ReadExportSites()
+            .SelectMany(src => ExtractMatches(src, ExportPattern)
+                .Concat(ExtractMatches(src, ExportNameFieldPattern)))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.NotEmpty(imported);
+        Assert.NotEmpty(exported);
+
+        var missing = imported
+            .Where(name => !exported.Contains(name))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "NativeMethods.cs imports entry points that libghostty does not export. " +
+            "These link in Debug but fail the NativeAOT publish:\n" +
+            string.Join("\n", missing.Select(n => $"  {n}")));
+    }
+
+    // Guards the csproj resource glob: if the embedded export sites go missing
+    // or get renamed, the parity test above would silently pass with an empty
+    // export set instead of failing loudly.
+    [Fact]
+    public void ExportSitesAreEmbedded()
+    {
+        var sites = Assembly.GetExecutingAssembly()
+            .GetManifestResourceNames()
+            .Where(n => n.StartsWith(ExportResourcePrefix, StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(
+            sites.Count >= 5,
+            $"Expected the libghostty export sites to be embedded, found {sites.Count}: " +
+            string.Join(", ", sites));
+    }
+
+    [Fact]
+    public void EntryPointExtractionReadsAttributeLiterals()
+    {
+        const string source =
+            "[LibraryImport(Dll, EntryPoint = \"ghostty_app_new\")]\n" +
+            "internal static partial IntPtr AppNew();\n" +
+            "[LibraryImport(Dll, EntryPoint = \"ghostty_app_free\")]\n" +
+            "internal static partial void AppFree(IntPtr app);\n";
+
+        Assert.Equal(
+            new[] { "ghostty_app_free", "ghostty_app_new" },
+            ExtractMatches(source, EntryPointPattern).OrderBy(n => n, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void ExportExtractionReadsZigDeclarations()
+    {
+        const string source =
+            "export fn ghostty_app_new(opts: *Options) ?*App {\n" +
+            "export fn ghostty_inspector_directx12_surface_present(_: *Inspector) void {}\n" +
+            "fn not_exported(x: u32) void {}\n";
+
+        var names = ExtractMatches(source, ExportPattern);
+
+        Assert.Contains("ghostty_app_new", names);
+        Assert.Contains("ghostty_inspector_directx12_surface_present", names);
+        Assert.DoesNotContain("not_exported", names);
+    }
+
+    [Fact]
+    public void ExportExtractionReadsConditionalExportBlocks()
+    {
+        const string source =
+            "comptime {\n" +
+            "    if (builtin.os.tag == .windows) @export(&ghosttyInitWide, .{\n" +
+            "        .name = \"ghostty_init_wide\",\n" +
+            "        .linkage = .strong,\n" +
+            "    });\n" +
+            "}\n" +
+            "const cfg = .{ .name = \"not_an_export\" };\n";
+
+        var names = ExtractMatches(source, ExportNameFieldPattern);
+
+        Assert.Contains("ghostty_init_wide", names);
+        Assert.DoesNotContain("not_an_export", names);
+    }
+
+    private static SortedSet<string> ExtractMatches(string source, Regex pattern)
+    {
+        var names = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (Match match in pattern.Matches(source))
+        {
+            names.Add(match.Groups["name"].Value);
+        }
+        return names;
+    }
+
+    private static string ReadNativeMethods() => ReadResource(NativeMethodsResource);
+
+    private static IEnumerable<string> ReadExportSites()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        return asm.GetManifestResourceNames()
+            .Where(n => n.StartsWith(ExportResourcePrefix, StringComparison.Ordinal))
+            .Select(ReadResource)
+            .ToList();
+    }
+
+    private static string ReadResource(string name)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty.Tests/Interop/EntryPointParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/EntryPointParityTests.cs
@@ -8,29 +8,36 @@ using Xunit;
 
 namespace Ghostty.Tests.Interop;
 
-// Pins that every entry point NativeMethods.cs imports is actually exported by
+// Pins that every entry point the managed code imports is actually exported by
 // libghostty.
 //
 // A [LibraryImport] naming a symbol libghostty never exports is invisible to
 // `dotnet build` and to JIT dev runs, because neither links native symbols. It
-// only surfaces as an unresolved-symbol failure during the NativeAOT publish
+// only surfaces as an unresolved symbol during the NativeAOT publish
 // (DirectPInvoke + static ghostty-static.lib), i.e. at release time. The
 // inspector's DirectX12 swap chain entry points sat broken this way and blocked
 // every AOT release.
 //
-// This scans the zig `export fn` declarations, NOT include/ghostty.h: exports
-// added by this fork are routinely absent from the header (ghostty_cli_*,
-// ghostty_surface_list_themes_*, ghostty_inspector_zoom_* all export fine while
-// undeclared), so the header would produce false failures. The export sites are
-// embedded by Ghostty.Tests.csproj.
+// This scans the zig `export fn` sites, NOT include/ghostty.h: exports added by
+// this fork are routinely absent from the header (ghostty_cli_*,
+// ghostty_surface_list_themes_*, ghostty_inspector_zoom_*), so the header would
+// report symbols that link perfectly well. Both sets of files are embedded by
+// Ghostty.Tests.csproj.
+//
+// Known blind spot: the scan cannot see comptime platform gating. Darwin-only
+// exports (ghostty_inspector_metal_*, inside `const Darwin = struct`) look
+// exported on every platform, so importing one from Windows code would pass
+// here and still fail the Windows publish.
 public class EntryPointParityTests
 {
-    private const string NativeMethodsResource = "Ghostty.Tests.Interop.NativeMethods.cs";
+    private const string ImportResourcePrefix = "Ghostty.Tests.Interop.Imports.";
     private const string ExportResourcePrefix = "Ghostty.Tests.Interop.Exports.";
 
-    // EntryPoint = "name" on the [LibraryImport] attribute.
+    // EntryPoint = "ghostty_x" on a [LibraryImport] attribute. Anchored on the
+    // prefix so a Win32 import added to the same file does not start demanding
+    // a zig export.
     private static readonly Regex EntryPointPattern = new(
-        @"EntryPoint\s*=\s*""(?<name>[A-Za-z_][A-Za-z0-9_]*)""",
+        @"EntryPoint\s*=\s*""(?<name>ghostty_[A-Za-z0-9_]*)""",
         RegexOptions.Compiled);
 
     // `export fn name(`, allowing the `pub` and whitespace variants zig permits.
@@ -39,9 +46,7 @@ public class EntryPointParityTests
         RegexOptions.Compiled);
 
     // The other export form: `@export(&fn, .{ .name = "ghostty_x" })`, used for
-    // symbols that are conditionally exported (e.g. ghostty_init_wide, which is
-    // Windows-only). Anchored on the ghostty_ prefix so it cannot match an
-    // unrelated `.name =` field.
+    // conditionally exported symbols (ghostty_init_wide is Windows-only).
     private static readonly Regex ExportNameFieldPattern = new(
         @"\.name\s*=\s*""(?<name>ghostty_[A-Za-z0-9_]*)""",
         RegexOptions.Compiled);
@@ -49,10 +54,13 @@ public class EntryPointParityTests
     [Fact]
     public void EveryImportedEntryPointIsExportedByLibghostty()
     {
-        var imported = ExtractMatches(ReadNativeMethods(), EntryPointPattern);
-        var exported = ReadExportSites()
-            .SelectMany(src => ExtractMatches(src, ExportPattern)
-                .Concat(ExtractMatches(src, ExportNameFieldPattern)))
+        var imported = ReadSites(ImportResourcePrefix)
+            .SelectMany(src => Extract(src, EntryPointPattern))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var exported = ReadSites(ExportResourcePrefix)
+            .SelectMany(src => Extract(src, ExportPattern)
+                .Concat(Extract(src, ExportNameFieldPattern)))
             .ToHashSet(StringComparer.Ordinal);
 
         Assert.NotEmpty(imported);
@@ -63,28 +71,43 @@ public class EntryPointParityTests
             .OrderBy(name => name, StringComparer.Ordinal)
             .ToList();
 
-        Assert.True(
-            missing.Count == 0,
-            "NativeMethods.cs imports entry points that libghostty does not export. " +
-            "These link in Debug but fail the NativeAOT publish:\n" +
-            string.Join("\n", missing.Select(n => $"  {n}")));
+        if (missing.Count > 0)
+        {
+            Assert.Fail(
+                "Imported entry points that libghostty does not export. These link " +
+                "in Debug but fail the NativeAOT publish. If the symbol does exist, " +
+                "its zig file is probably missing from the Exports list in " +
+                "Ghostty.Tests.csproj:\n" +
+                string.Join("\n", missing.Select(n => $"  {n}")));
+        }
     }
 
-    // Guards the csproj resource glob: if the embedded export sites go missing
-    // or get renamed, the parity test above would silently pass with an empty
-    // export set instead of failing loudly.
+    // Guards the csproj resource lists. Without this, losing an embedded file
+    // would make the parity test scan an empty set and pass vacuously.
     [Fact]
-    public void ExportSitesAreEmbedded()
+    public void ImportAndExportSitesAreEmbedded()
     {
-        var sites = Assembly.GetExecutingAssembly()
-            .GetManifestResourceNames()
-            .Where(n => n.StartsWith(ExportResourcePrefix, StringComparison.Ordinal))
-            .ToList();
+        var names = Assembly.GetExecutingAssembly().GetManifestResourceNames();
 
-        Assert.True(
-            sites.Count >= 5,
-            $"Expected the libghostty export sites to be embedded, found {sites.Count}: " +
-            string.Join(", ", sites));
+        var expected = new[]
+        {
+            ImportResourcePrefix + "NativeMethods.cs",
+            ImportResourcePrefix + "LibGhosttyBuildInfo.cs",
+            ExportResourcePrefix + "apprt.embedded.zig",
+            ExportResourcePrefix + "benchmark.CApi.zig",
+            ExportResourcePrefix + "config.CApi.zig",
+            ExportResourcePrefix + "log_bridge.zig",
+            ExportResourcePrefix + "main_c.zig",
+        };
+
+        var absent = expected.Where(e => !names.Contains(e, StringComparer.Ordinal)).ToList();
+
+        if (absent.Count > 0)
+        {
+            Assert.Fail(
+                "Embedded resources missing from Ghostty.Tests.csproj:\n" +
+                string.Join("\n", absent.Select(n => $"  {n}")));
+        }
     }
 
     [Fact]
@@ -93,12 +116,13 @@ public class EntryPointParityTests
         const string source =
             "[LibraryImport(Dll, EntryPoint = \"ghostty_app_new\")]\n" +
             "internal static partial IntPtr AppNew();\n" +
-            "[LibraryImport(Dll, EntryPoint = \"ghostty_app_free\")]\n" +
-            "internal static partial void AppFree(IntPtr app);\n";
+            "[LibraryImport(\"user32\", EntryPoint = \"MessageBoxW\")]\n" +
+            "private static partial int MessageBox();\n";
 
-        Assert.Equal(
-            new[] { "ghostty_app_free", "ghostty_app_new" },
-            ExtractMatches(source, EntryPointPattern).OrderBy(n => n, StringComparer.Ordinal));
+        var names = Extract(source, EntryPointPattern);
+
+        Assert.Contains("ghostty_app_new", names);
+        Assert.DoesNotContain("MessageBoxW", names);
     }
 
     [Fact]
@@ -109,7 +133,7 @@ public class EntryPointParityTests
             "export fn ghostty_inspector_directx12_surface_present(_: *Inspector) void {}\n" +
             "fn not_exported(x: u32) void {}\n";
 
-        var names = ExtractMatches(source, ExportPattern);
+        var names = Extract(source, ExportPattern);
 
         Assert.Contains("ghostty_app_new", names);
         Assert.Contains("ghostty_inspector_directx12_surface_present", names);
@@ -128,29 +152,58 @@ public class EntryPointParityTests
             "}\n" +
             "const cfg = .{ .name = \"not_an_export\" };\n";
 
-        var names = ExtractMatches(source, ExportNameFieldPattern);
+        var names = Extract(source, ExportNameFieldPattern);
 
         Assert.Contains("ghostty_init_wide", names);
         Assert.DoesNotContain("not_an_export", names);
     }
 
-    private static SortedSet<string> ExtractMatches(string source, Regex pattern)
+    // Commented-out code must not count. A stale `// export fn ghostty_x(`
+    // would otherwise satisfy an import that no longer resolves.
+    [Fact]
+    public void ScannerIgnoresLineComments()
+    {
+        const string zig =
+            "// export fn ghostty_removed(ptr: *App) void {}\n" +
+            "export fn ghostty_live(ptr: *App) void {}\n";
+        const string cs =
+            "// [LibraryImport(Dll, EntryPoint = \"ghostty_removed\")]\n" +
+            "[LibraryImport(Dll, EntryPoint = \"ghostty_live\")]\n";
+
+        var exports = Extract(zig, ExportPattern);
+        var imports = Extract(cs, EntryPointPattern);
+
+        Assert.Equal(new[] { "ghostty_live" }, exports);
+        Assert.Equal(new[] { "ghostty_live" }, imports);
+    }
+
+    private static SortedSet<string> Extract(string source, Regex pattern)
     {
         var names = new SortedSet<string>(StringComparer.Ordinal);
-        foreach (Match match in pattern.Matches(source))
+        foreach (var line in source.Split('\n'))
         {
-            names.Add(match.Groups["name"].Value);
+            foreach (Match match in pattern.Matches(StripLineComment(line)))
+            {
+                names.Add(match.Groups["name"].Value);
+            }
         }
         return names;
     }
 
-    private static string ReadNativeMethods() => ReadResource(NativeMethodsResource);
+    // Both corpora are zig and C#, which share `//` line-comment syntax. String
+    // literals containing "//" would be truncated, but no entry point or export
+    // declaration contains one.
+    private static string StripLineComment(string line)
+    {
+        var idx = line.IndexOf("//", StringComparison.Ordinal);
+        return idx >= 0 ? line[..idx] : line;
+    }
 
-    private static IEnumerable<string> ReadExportSites()
+    private static IEnumerable<string> ReadSites(string prefix)
     {
         var asm = Assembly.GetExecutingAssembly();
         return asm.GetManifestResourceNames()
-            .Where(n => n.StartsWith(ExportResourcePrefix, StringComparison.Ordinal))
+            .Where(n => n.StartsWith(prefix, StringComparison.Ordinal))
             .Select(ReadResource)
             .ToList();
     }
@@ -160,7 +213,7 @@ public class EntryPointParityTests
         var asm = Assembly.GetExecutingAssembly();
         using var stream = asm.GetManifestResourceStream(name);
         Assert.NotNull(stream);
-        using var reader = new StreamReader(stream!);
+        using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
     }
 }

--- a/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
+++ b/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
@@ -11,7 +11,7 @@ namespace Ghostty.Tests.Interop;
 // (no [MarshalAs], two-BOOL-shape: byte for libghostty _Bool, int for Win32 BOOL).
 public class MarshalComplianceTests
 {
-    private const string ResourceName = "Ghostty.Tests.Interop.NativeMethods.cs";
+    private const string ResourceName = "Ghostty.Tests.Interop.Imports.NativeMethods.cs";
 
     // Note: `StringMarshalling = StringMarshalling.Utf8` is a separate,
     // supported mechanism and is NOT what this test scans for. Only the

--- a/windows/Ghostty/InspectorWindow.xaml.cs
+++ b/windows/Ghostty/InspectorWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Input;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -27,15 +28,17 @@ internal sealed partial class InspectorWindow : Window
     private static readonly TimeSpan PresentInterval = TimeSpan.FromMilliseconds(16);
 
     private readonly GhosttyInspector _inspector;
+    private readonly ILogger<InspectorWindow>? _logger;
     private readonly DispatcherTimer _timer;
     private bool _initialized;
     private bool _closed;
 
-    public InspectorWindow(GhosttyInspector inspector)
+    public InspectorWindow(GhosttyInspector inspector, ILogger<InspectorWindow>? logger = null)
     {
         InitializeComponent();
 
         _inspector = inspector;
+        _logger = logger;
 
         Title = $"{AppIdentity.ProductName} Inspector";
 
@@ -80,21 +83,39 @@ internal sealed partial class InspectorWindow : Window
     {
         if (_initialized || _closed) return;
 
-        var panelPtr = SwapChainPanelInterop.QueryInterface(Panel);
+        // QueryInterface throws on failure, and App leaves unhandled exceptions
+        // unhandled, so letting one escape a Loaded handler would tear down the
+        // terminal along with the inspector.
         try
         {
-            // libghostty creates the swap chain and binds it to the panel
-            // synchronously here, so the panel pointer can be released right
-            // after (same contract as the terminal surface).
-            _initialized = NativeMethods.InspectorDirectX12SurfaceInit(
-                _inspector, panelPtr, PixelWidth, PixelHeight);
+            var panelPtr = SwapChainPanelInterop.QueryInterface(Panel);
+            try
+            {
+                // libghostty binds the swap chain to the panel synchronously
+                // here and does not retain the pointer, so we release it as
+                // soon as init returns (same contract as the terminal surface).
+                _initialized = NativeMethods.InspectorDirectX12SurfaceInit(
+                    _inspector, panelPtr, PixelWidth, PixelHeight);
+            }
+            finally
+            {
+                SwapChainPanelInterop.Release(panelPtr);
+            }
         }
-        finally
+        catch (Exception ex)
         {
-            SwapChainPanelInterop.Release(panelPtr);
+            _initialized = false;
+            _logger?.LogWarning(ex, "inspector swap chain init failed");
         }
 
-        if (!_initialized) return;
+        // Close rather than sit here as a blank window: libghostty logs why it
+        // refused, and leaving the window open would make the next toggle press
+        // close this dead window instead of opening a working one.
+        if (!_initialized)
+        {
+            Close();
+            return;
+        }
 
         NativeMethods.InspectorSetContentScale(_inspector, RasterScale, RasterScale);
         NativeMethods.InspectorSetSize(_inspector, PixelWidth, PixelHeight);

--- a/windows/Ghostty/InspectorWindow.xaml.cs
+++ b/windows/Ghostty/InspectorWindow.xaml.cs
@@ -33,7 +33,7 @@ internal sealed partial class InspectorWindow : Window
     private bool _initialized;
     private bool _closed;
 
-    public InspectorWindow(GhosttyInspector inspector, ILogger<InspectorWindow>? logger = null)
+    public InspectorWindow(GhosttyInspector inspector, ILogger<InspectorWindow>? logger)
     {
         InitializeComponent();
 
@@ -91,9 +91,10 @@ internal sealed partial class InspectorWindow : Window
             var panelPtr = SwapChainPanelInterop.QueryInterface(Panel);
             try
             {
-                // libghostty binds the swap chain to the panel synchronously
-                // here and does not retain the pointer, so we release it as
-                // soon as init returns (same contract as the terminal surface).
+                // The panel pointer is borrowed for the duration of the call:
+                // libghostty AddRefs it if it retains anything, so we release
+                // as soon as init returns (same contract as the terminal
+                // surface).
                 _initialized = NativeMethods.InspectorDirectX12SurfaceInit(
                     _inspector, panelPtr, PixelWidth, PixelHeight);
             }
@@ -104,16 +105,20 @@ internal sealed partial class InspectorWindow : Window
         }
         catch (Exception ex)
         {
-            _initialized = false;
-            _logger?.LogWarning(ex, "inspector swap chain init failed");
+            _logger?.LogSwapChainInitFailed(ex);
         }
 
         // Close rather than sit here as a blank window: libghostty logs why it
         // refused, and leaving the window open would make the next toggle press
         // close this dead window instead of opening a working one.
+        //
+        // Queued rather than closed inline: tearing the window down from inside
+        // its own Loaded handler runs teardown during a layout pass, and a throw
+        // from Close() would escape the handler the try/catch above exists to
+        // contain.
         if (!_initialized)
         {
-            Close();
+            DispatcherQueue.TryEnqueue(Close);
             return;
         }
 
@@ -269,4 +274,16 @@ internal sealed partial class InspectorWindow : Window
                 break;
         }
     }
+}
+
+internal static partial class InspectorWindowLogExtensions
+{
+    // Warning, not Error: the inspector is a diagnostic overlay, so a failed
+    // swap chain costs the user the inspector window and nothing else. The
+    // terminal keeps running.
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Inspector.SwapChainInitFailed,
+                   Level = LogLevel.Warning,
+                   Message = "[InspectorWindow] swap chain init failed; inspector window closed")]
+    internal static partial void LogSwapChainInitFailed(
+        this ILogger<InspectorWindow> logger, Exception ex);
 }

--- a/windows/Ghostty/Interop/ISwapChainPanelNative.cs
+++ b/windows/Ghostty/Interop/ISwapChainPanelNative.cs
@@ -46,12 +46,15 @@ internal static class SwapChainPanelInterop
 
     /// <summary>
     /// QueryInterfaces a WinUI 3 SwapChainPanel for ISwapChainPanelNative
-    /// and returns the raw interface pointer, used as the SwapChainPanel
-    /// mode selector passed to ghostty_surface_new. libghostty does not
-    /// call through this pointer (it presents into a composition surface
-    /// handle instead), so the caller MUST Release it once SurfaceNew
-    /// returns. The managed SwapChainPanel keeps composition alive via its
-    /// own ref.
+    /// and returns the raw interface pointer. Two callers, both of which
+    /// borrow it only for the duration of the call they pass it to, so the
+    /// caller MUST Release it as soon as that call returns. The managed
+    /// SwapChainPanel keeps composition alive via its own ref.
+    ///
+    /// For ghostty_surface_new it is only a mode selector: libghostty does
+    /// not call through it, and presents into a composition surface handle
+    /// instead. For the inspector's swap chain init libghostty does bind
+    /// the panel, but still does not retain the pointer.
     /// </summary>
     public static IntPtr QueryInterface(Microsoft.UI.Xaml.Controls.SwapChainPanel panel)
     {

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -96,4 +96,10 @@ internal static class LogEvents
         public const int ForwardFailed     = 2904;
         public const int ServerStartFailed = 2905;
     }
+
+    // 3000-3099: Inspector
+    internal static class Inspector
+    {
+        public const int SwapChainInitFailed = 3000;
+    }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -2900,7 +2900,8 @@ public sealed partial class MainWindow : Window
         var inspector = NativeMethods.SurfaceInspector(new GhosttySurface(surfaceHandle));
         if (inspector.Handle == IntPtr.Zero) return;
 
-        var window = new InspectorWindow(inspector);
+        var window = new InspectorWindow(
+            inspector, App.LoggerFactory?.CreateLogger<InspectorWindow>());
 
         // The inspector presents into the bound surface every frame. If the
         // active surface changes (pane focus/close, tab switch) that surface


### PR DESCRIPTION
`InspectorWindow` calls `ghostty_inspector_directx12_surface_init/present/resize/shutdown`, but only the host-driven `init/render/shutdown` trio was ever exported. Those four names resolve to nothing, so:

- a NativeAOT publish fails to link (`DirectPInvoke` + static `ghostty-static.lib` means every P/Invoke must resolve at link time), and
- opening the inspector on a debug build throws `EntryPointNotFoundException`.

This is why the Windows inspector has never worked, and it blocked every AOT release. Normal `dotnet build` and JIT dev runs never link native symbols, so nothing caught it.

Add the four exports so embedders link. `init` returns false for now, which keeps the window inert instead of presenting a swap chain that was never created (`InspectorWindow` already guards every subsequent call on the init result). The DirectX12 implementation lands separately.

## Why a swap-chain-owning API

The existing trio mirrors macOS, where `InspectorView` is an `MTKView` and AppKit hands Swift a device, drawable and command buffer. WinUI's `SwapChainPanel` is a compositor sink rather than a render loop, so the same shape would make C# build an entire mini-renderer. Nothing in this fork's C# owns GPU state today; the terminal surface already uses the split where libghostty owns the swap chain.

The three host-driven exports currently have no callers anywhere.

## Follow-up

The real implementation should reuse `device.zig` / `descriptor_heap.zig` / the imgui `SrvHeap`, and mirror the terminal's handle contract (`ISwapChainPanelNative2::SetSwapChainHandle`) rather than the panel pointer this C# signature implies, since `device.zig` documents that binding the swap chain object directly can leave the panel blank until first activation. It also needs gating on `renderer == .directx12` so the DX11-only build still links with `init` returning false.
