### PR TITLE
a11y: expose the terminal caret to UI Automation

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1293,6 +1293,12 @@ typedef struct {
   ghostty_cell_s* cells;
   uint16_t rows;
   uint16_t cols;
+  // Cursor in viewport coordinates, resolved under the same renderer-lock hold
+  // as the cells. Valid only when cursor_in_viewport is true; false means the
+  // cursor is below the viewport (it only ever scrolls up into scrollback).
+  uint16_t cursor_row;
+  uint16_t cursor_col;
+  bool cursor_in_viewport;
 } ghostty_cells_s;
 
 GHOSTTY_API bool ghostty_surface_read_cells(ghostty_surface_t, ghostty_cells_s*);

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -2092,30 +2092,38 @@ pub const CAPI = struct {
             }
         }
 
-        // Clamp into the grid we just emitted: the render state and the row
-        // data are consistent here, but the consumer indexes `out` with these
-        // and must not be handed an out-of-range cell.
-        const cursor_vp = state.cursor.viewport;
-        const cursor_row: u16 = if (cursor_vp) |c|
-            @intCast(@min(@as(usize, c.y), rows - 1))
-        else
-            0;
-        const cursor_col: u16 = if (cursor_vp) |c| col: {
-            const x = @min(@as(usize, c.x), cols - 1);
-            // On the tail half of a wide character, report the character's
-            // own cell so a reader lands on the glyph, not its spacer.
-            break :col @intCast(if (c.wide_tail and x > 0) x - 1 else x);
-        } else 0;
+        const cursor = cursorCell(state.cursor.viewport, rows, cols);
 
         result.* = .{
             .cells = out.ptr,
             .rows = @intCast(rows),
             .cols = @intCast(cols),
-            .cursor_row = cursor_row,
-            .cursor_col = cursor_col,
-            .cursor_in_viewport = cursor_vp != null,
+            .cursor_row = cursor.row,
+            .cursor_col = cursor.col,
+            .cursor_in_viewport = cursor.in_viewport,
         };
         return true;
+    }
+
+    /// Resolve the viewport cursor to the cell a reader should land on,
+    /// clamped into a grid of `rows` x `cols`. The caller indexes the emitted
+    /// cells with this, so it must never be out of range.
+    fn cursorCell(
+        viewport: ?terminal.RenderState.Cursor.Viewport,
+        rows: usize,
+        cols: usize,
+    ) struct { row: u16, col: u16, in_viewport: bool } {
+        const c = viewport orelse return .{ .row = 0, .col = 0, .in_viewport = false };
+        assert(rows > 0 and cols > 0);
+
+        const x = @min(@as(usize, c.x), cols - 1);
+        return .{
+            .row = @intCast(@min(@as(usize, c.y), rows - 1)),
+            // On the tail half of a wide character, report the character's own
+            // cell so a reader lands on the glyph and not its spacer.
+            .col = @intCast(if (c.wide_tail and x > 0) x - 1 else x),
+            .in_viewport = true,
+        };
     }
 
     export fn ghostty_surface_free_cells(_: *Surface, ptr: *Cells) void {

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1646,6 +1646,21 @@ pub const CAPI = struct {
         rows: u16 = 0,
         cols: u16 = 0,
 
+        /// Cursor position in VIEWPORT coordinates (0-based, y down).
+        /// Meaningful only when `cursor_in_viewport` is true.
+        ///
+        /// The cursor rides along with the cells rather than having its own
+        /// accessor so that both are resolved under a single hold of the
+        /// renderer mutex. A separate call would let a caller pair a cursor
+        /// from one frame with cells from another.
+        cursor_row: u16 = 0,
+        cursor_col: u16 = 0,
+
+        /// False when the cursor is not on screen. The viewport only ever
+        /// scrolls UP into scrollback and the cursor always lives in the
+        /// active area, so this means the cursor is BELOW the viewport.
+        cursor_in_viewport: bool = false,
+
         pub fn deinit(self: *Cells) void {
             if (self.cells) |ptr| {
                 const len: usize = @as(usize, self.rows) * @as(usize, self.cols);
@@ -2077,10 +2092,28 @@ pub const CAPI = struct {
             }
         }
 
+        // Clamp into the grid we just emitted: the render state and the row
+        // data are consistent here, but the consumer indexes `out` with these
+        // and must not be handed an out-of-range cell.
+        const cursor_vp = state.cursor.viewport;
+        const cursor_row: u16 = if (cursor_vp) |c|
+            @intCast(@min(@as(usize, c.y), rows - 1))
+        else
+            0;
+        const cursor_col: u16 = if (cursor_vp) |c| col: {
+            const x = @min(@as(usize, c.x), cols - 1);
+            // On the tail half of a wide character, report the character's
+            // own cell so a reader lands on the glyph, not its spacer.
+            break :col @intCast(if (c.wide_tail and x > 0) x - 1 else x);
+        } else 0;
+
         result.* = .{
             .cells = out.ptr,
             .rows = @intCast(rows),
             .cols = @intCast(cols),
+            .cursor_row = cursor_row,
+            .cursor_col = cursor_col,
+            .cursor_in_viewport = cursor_vp != null,
         };
         return true;
     }

--- a/windows/Ghostty.Core/Accessibility/ViewportAnchor.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportAnchor.cs
@@ -1,0 +1,95 @@
+using System;
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Aligns the viewport cell grid with the screen document. The two come from
+/// different reads (read_cells and read_text) and use different coordinate
+/// spaces, so everything that wants to cross between them needs the same
+/// anchor: the last grid row with content is the last document line with
+/// content, giving <c>docLine = gridRow + RowShift</c>.
+///
+/// The document is authoritative for text; the grid is viewport-only and may
+/// be a slightly different frame. Callers are expected to validate what they
+/// read and decline rather than report something wrong.
+/// </summary>
+internal readonly struct ViewportAnchor
+{
+    /// <summary>False when either side has no content, or the grid is
+    /// malformed. Nothing can be mapped in that case.</summary>
+    public bool HasContent { get; }
+
+    /// <summary><c>docLine = gridRow + RowShift</c>.</summary>
+    public int RowShift { get; }
+
+    private ViewportAnchor(bool hasContent, int rowShift)
+    {
+        HasContent = hasContent;
+        RowShift = rowShift;
+    }
+
+    public static ViewportAnchor Create(TerminalDocument doc, CellGrid cells)
+    {
+        // Decline a malformed or concurrently-torn grid (null backing array or a
+        // length that disagrees with rows*cols) instead of risking an out-of-range
+        // index in a caller. The grid comes from a 500ms cache read off the UI
+        // thread, and CellGrid is a multi-field struct, so a partially-published
+        // snapshot is possible; report "no content" rather than crash.
+        if (cells.Rows <= 0 || cells.Cols <= 0 ||
+            cells.Cells is null || cells.Cells.Length < (long)cells.Rows * cells.Cols)
+            return new ViewportAnchor(false, 0);
+
+        var lastContentRow = LastContentRow(cells);
+        var lastContentDocLine = LastContentDocLine(doc);
+        if (lastContentRow < 0 || lastContentDocLine < 0) return new ViewportAnchor(false, 0);
+
+        return new ViewportAnchor(true, lastContentDocLine - lastContentRow);
+    }
+
+    /// <summary>
+    /// Start offset of a document line, or -1 when the line does not exist.
+    /// Linear in the document, which is fine here: the document is a string and
+    /// callers are per-query, not per-cell.
+    /// </summary>
+    public static int LineStartOffset(TerminalDocument doc, int line)
+    {
+        if (line < 0) return -1;
+        if (line == 0) return 0;
+
+        var text = doc.Text;
+        var seen = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] != '\n') continue;
+            if (++seen == line) return i + 1;
+        }
+        return -1;
+    }
+
+    // Greatest document line index that contains a non-whitespace character, or -1.
+    // Mirrors LastContentRow's "blank" rule (which skips whitespace cells) so the two
+    // anchors agree: a trailing whitespace-only line would otherwise shift the anchor
+    // by a row and make every mapping off by one.
+    private static int LastContentDocLine(TerminalDocument doc)
+    {
+        var t = doc.Text;
+        for (var i = t.Length - 1; i >= 0; i--)
+            if (!char.IsWhiteSpace(t[i])) return doc.LineIndexForOffset(i);
+        return -1;
+    }
+
+    // Greatest grid row index that has a non-blank cell, or -1. A cell is blank
+    // when its codepoint is 0 (empty / spacer) or whitespace, matching how
+    // read_text trims trailing blank rows.
+    private static int LastContentRow(CellGrid cells)
+    {
+        for (var r = cells.Rows - 1; r >= 0; r--)
+            for (var c = 0; c < cells.Cols; c++)
+            {
+                var cp = cells.Cells[r * cells.Cols + c].Codepoint;
+                if (cp != 0 && !(cp <= 0xFFFF && char.IsWhiteSpace((char)cp))) return r;
+            }
+        return -1;
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/ViewportCaret.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportCaret.cs
@@ -1,0 +1,44 @@
+using System;
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Maps the terminal cursor to an offset in the screen document, for the UIA
+/// caret.
+///
+/// The column is NOT a document offset the way it would be over a padded grid:
+/// read_text trims trailing blanks, so a row that the grid reports as 80 cells
+/// wide may be a 12-character document line. The column is therefore clamped to
+/// the line it lands on, which parks the caret at end-of-line instead of
+/// running into the next one.
+/// </summary>
+internal static class ViewportCaret
+{
+    /// <summary>
+    /// Document offset for the cursor. Returns end-of-document when the cursor
+    /// is not in the viewport: the viewport only ever scrolls UP into
+    /// scrollback and the cursor lives in the active area, so "not visible"
+    /// means it is below what is on screen.
+    /// </summary>
+    public static int Offset(TerminalDocument doc, CellGrid cells)
+    {
+        if (!cells.CursorInViewport) return doc.Length;
+
+        var anchor = ViewportAnchor.Create(doc, cells);
+        if (!anchor.HasContent) return doc.Length;
+
+        var gridRow = Math.Clamp(cells.CursorRow, 0, cells.Rows - 1);
+        var lineStart = ViewportAnchor.LineStartOffset(doc, gridRow + anchor.RowShift);
+        if (lineStart < 0) return doc.Length;
+
+        // Clamp into the line, not the grid: the document line is trimmed and
+        // is usually shorter than Cols.
+        var bounds = doc.LineBounds(lineStart);
+        var lineEnd = bounds.End;
+        if (lineEnd > bounds.Start && doc.Text[lineEnd - 1] == '\n') lineEnd--;
+
+        var col = Math.Max(cells.CursorCol, 0);
+        return Math.Min(lineStart + col, lineEnd);
+    }
+}

--- a/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportColorMap.cs
@@ -35,21 +35,11 @@ internal sealed class ViewportColorMap
         _doc = doc;
         _cells = cells;
 
-        // Decline a malformed or concurrently-torn grid (null backing array or a
-        // length that disagrees with rows*cols) instead of risking an out-of-range
-        // index below. The grid comes from a 500ms cache read off the UI thread, and
-        // CellGrid is a multi-field struct, so a partially-published snapshot is
-        // possible; bail out and report NotMapped rather than crash.
-        if (cells.Rows <= 0 || cells.Cols <= 0 ||
-            cells.Cells is null || cells.Cells.Length < (long)cells.Rows * cells.Cols)
-            return; // _hasContent stays false
-
-        var lastContentRow = LastContentRow(cells);
-        var lastContentDocLine = LastContentDocLine(doc);
-        if (lastContentRow < 0 || lastContentDocLine < 0) return; // _hasContent = false
-
-        _hasContent = true;
-        _rowShift = lastContentDocLine - lastContentRow;
+        // Shared with the caret mapping so both cross between the grid and the
+        // document on exactly the same anchor.
+        var anchor = ViewportAnchor.Create(doc, cells);
+        _hasContent = anchor.HasContent;
+        _rowShift = anchor.RowShift;
     }
 
     public ColorResult Foreground(TextSpan span) => Reduce(span, fg: true);
@@ -113,31 +103,5 @@ internal sealed class ViewportColorMap
 
         var s = char.ConvertFromUtf32((int)codepoint);
         return offset + 1 < text.Length && text[offset] == s[0] && text[offset + 1] == s[1];
-    }
-
-    // Greatest document line index that contains a non-whitespace character, or -1.
-    // Mirrors LastContentRow's "blank" rule (which skips whitespace cells) so the two
-    // anchors agree: a trailing whitespace-only line would otherwise shift the anchor
-    // by a row and make every cell mis-map.
-    private static int LastContentDocLine(TerminalDocument doc)
-    {
-        var t = doc.Text;
-        for (var i = t.Length - 1; i >= 0; i--)
-            if (!char.IsWhiteSpace(t[i])) return doc.LineIndexForOffset(i);
-        return -1;
-    }
-
-    // Greatest grid row index that has a non-blank cell, or -1. A cell is blank
-    // when its codepoint is 0 (empty / spacer) or whitespace, matching how
-    // read_text trims trailing blank rows.
-    private static int LastContentRow(CellGrid cells)
-    {
-        for (var r = cells.Rows - 1; r >= 0; r--)
-            for (var c = 0; c < cells.Cols; c++)
-            {
-                var cp = cells.Cells[r * cells.Cols + c].Codepoint;
-                if (cp != 0 && !(cp <= 0xFFFF && char.IsWhiteSpace((char)cp))) return r;
-            }
-        return -1;
     }
 }

--- a/windows/Ghostty.Core/Tabs/CellGridFormatter.cs
+++ b/windows/Ghostty.Core/Tabs/CellGridFormatter.cs
@@ -7,8 +7,19 @@ namespace Ghostty.Core.Tabs;
 /// <summary>One resolved cell: codepoint (0 = empty) + 0x00RRGGBB fg/bg.</summary>
 internal readonly record struct Cell(uint Codepoint, uint Fg, uint Bg);
 
-/// <summary>The viewport as row-major cells. <c>Cells.Length == Rows*Cols</c>.</summary>
-internal readonly record struct CellGrid(Cell[] Cells, int Rows, int Cols);
+/// <summary>
+/// The viewport as row-major cells. <c>Cells.Length == Rows*Cols</c>.
+/// The cursor fields default to "no cursor" so callers that only want cells
+/// (the tab preview) keep constructing this with three arguments and do not
+/// accidentally claim a cursor sitting at the origin.
+/// </summary>
+internal readonly record struct CellGrid(
+    Cell[] Cells,
+    int Rows,
+    int Cols,
+    int CursorRow = 0,
+    int CursorCol = 0,
+    bool CursorInViewport = false);
 
 /// <summary>A run of same-colored text within a preview line.</summary>
 internal readonly record struct PreviewRun(string Text, uint Fg, uint Bg);

--- a/windows/Ghostty.Tests/Accessibility/ViewportCaretTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/ViewportCaretTests.cs
@@ -1,0 +1,111 @@
+using Ghostty.Core.Accessibility;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+/// <summary>
+/// The caret maps a viewport cell to a screen-document offset. The document is
+/// trimmed (read_text drops trailing blanks) while the grid is not, so the
+/// column cannot be treated as an offset within a fixed-width row.
+/// </summary>
+public class ViewportCaretTests
+{
+    // A grid whose rows carry the given text, left-aligned and blank-padded to
+    // Cols, which is what read_cells reports.
+    private static CellGrid Grid(string[] rows, int cols, int curRow, int curCol, bool inViewport)
+    {
+        var cells = new Cell[rows.Length * cols];
+        for (var r = 0; r < rows.Length; r++)
+            for (var c = 0; c < cols; c++)
+                cells[r * cols + c] = new Cell(c < rows[r].Length ? rows[r][c] : ' ', 0, 0);
+        return new CellGrid(cells, rows.Length, cols, curRow, curCol, inViewport);
+    }
+
+    [Fact]
+    public void MapsTheCursorCellToItsDocumentOffset()
+    {
+        var doc = new TerminalDocument("abc\ndefgh");
+        var grid = Grid(new[] { "abc", "defgh" }, 80, curRow: 1, curCol: 2, inViewport: true);
+
+        // Line 1 starts at offset 4 ("abc\n"), column 2 -> 6.
+        Assert.Equal(6, ViewportCaret.Offset(doc, grid));
+    }
+
+    [Fact]
+    public void ClampsTheColumnToTheTrimmedLineNotTheGridWidth()
+    {
+        // The grid says the row is 80 cells wide; the document line is 3 chars.
+        // Parking at column 40 must land at end-of-line, not inside the next line.
+        var doc = new TerminalDocument("abc\ndefgh");
+        var grid = Grid(new[] { "abc", "defgh" }, 80, curRow: 0, curCol: 40, inViewport: true);
+
+        Assert.Equal(3, ViewportCaret.Offset(doc, grid));
+    }
+
+    [Fact]
+    public void ReportsEndOfDocumentWhenTheCursorIsBelowTheViewport()
+    {
+        // The viewport only scrolls up into scrollback, so "not visible" means
+        // the cursor is below what is on screen.
+        var doc = new TerminalDocument("abc\ndefgh");
+        var grid = Grid(new[] { "abc", "defgh" }, 80, curRow: 0, curCol: 0, inViewport: false);
+
+        Assert.Equal(doc.Length, ViewportCaret.Offset(doc, grid));
+    }
+
+    [Fact]
+    public void ReportsTheOriginForACursorAtTheOrigin()
+    {
+        // Must not be confused with "no cursor".
+        var doc = new TerminalDocument("abc\ndefgh");
+        var grid = Grid(new[] { "abc", "defgh" }, 80, curRow: 0, curCol: 0, inViewport: true);
+
+        Assert.Equal(0, ViewportCaret.Offset(doc, grid));
+    }
+
+    [Fact]
+    public void ADefaultConstructedGridDoesNotClaimACursor()
+    {
+        // The tab-preview path builds a 3-arg CellGrid; it must not read as a
+        // cursor parked at the origin.
+        var doc = new TerminalDocument("abc\ndefgh");
+        var cells = new Cell[2 * 80];
+        var grid = new CellGrid(cells, 2, 80);
+
+        Assert.False(grid.CursorInViewport);
+        Assert.Equal(doc.Length, ViewportCaret.Offset(doc, grid));
+    }
+
+    [Fact]
+    public void AnchorsToTheLastContentRowWhenTheGridIsTallerThanTheDocument()
+    {
+        // Two content rows at the bottom of a 5-row viewport: the grid's blank
+        // leading rows have no document counterpart, so the anchor must come
+        // from the last row with content, not from row 0.
+        var doc = new TerminalDocument("abc\ndefgh");
+        var grid = Grid(new[] { "", "", "", "abc", "defgh" }, 80, curRow: 4, curCol: 1, inViewport: true);
+
+        // Row 4 -> document line 1, which starts at 4; column 1 -> 5.
+        Assert.Equal(5, ViewportCaret.Offset(doc, grid));
+    }
+
+    [Fact]
+    public void FallsBackToEndOfDocumentWhenNothingCanBeAnchored()
+    {
+        var doc = new TerminalDocument("");
+        var grid = Grid(new[] { "" }, 80, curRow: 0, curCol: 0, inViewport: true);
+
+        Assert.Equal(0, ViewportCaret.Offset(doc, grid));
+    }
+
+    [Fact]
+    public void DeclinesAMalformedGridInsteadOfThrowing()
+    {
+        var doc = new TerminalDocument("abc");
+        // Backing array shorter than Rows*Cols - a torn snapshot.
+        var grid = new CellGrid(new Cell[4], 2, 80, 0, 0, true);
+
+        Assert.Equal(doc.Length, ViewportCaret.Offset(doc, grid));
+    }
+}

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -28,8 +28,8 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     private readonly CachedValue<Ghostty.Core.Tabs.CellGrid?> _cells;
     private readonly TerminalOutputAnnouncer _announcer = new();
     private readonly DispatcherTimer _announceTimer;
-    // Last caret offset seen by the tick; null means "not observed yet".
-    private int? _lastCaretOffset;
+    // Last cursor cell seen by the tick; null means "not observed yet".
+    private (int Row, int Col, bool InViewport)? _lastCaretCell;
 
     internal TerminalAutomationPeer(TerminalControl owner) : base(owner)
     {
@@ -69,7 +69,7 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
             // Drop the remembered caret too, so returning to this surface
             // re-announces where the caret is rather than staying silent
             // because it happens to match where it was on the way out.
-            _lastCaretOffset = null;
+            _lastCaretCell = null;
             return;
         }
 
@@ -93,11 +93,15 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     {
         if (ViewportCells is not { } grid) return;
 
-        var offset = ViewportCaret.Offset(Document, grid);
-        if (_lastCaretOffset == offset) return;
+        // Compare the cursor CELL before mapping it. Resolving an offset walks
+        // the grid and the document, and the document is the whole screen
+        // including scrollback; doing that every 300ms to discover the caret
+        // has not moved is the expensive way to learn nothing.
+        var cell = (grid.CursorRow, grid.CursorCol, grid.CursorInViewport);
+        if (_lastCaretCell == cell) return;
 
-        var first = _lastCaretOffset is null;
-        _lastCaretOffset = offset;
+        var first = _lastCaretCell is null;
+        _lastCaretCell = cell;
 
         // The first observation establishes a baseline; there is no move yet.
         if (!first) RaiseSelectionChangedEvent();

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -14,7 +14,7 @@ namespace Ghostty.Accessibility;
 /// macOS VoiceOver model (textArea role, cached screen contents, read_selection
 /// offsets as the selected range). Read-only in this stage.
 /// </summary>
-internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomationPeer, ITextProvider
+internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomationPeer, ITextProvider, ITextProvider2
 {
     // Screen reads take the renderer mutex, so we serve a cached document for
     // this long between fetches. Matches the macOS surface's 500ms CachedValue.
@@ -28,6 +28,8 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     private readonly CachedValue<Ghostty.Core.Tabs.CellGrid?> _cells;
     private readonly TerminalOutputAnnouncer _announcer = new();
     private readonly DispatcherTimer _announceTimer;
+    // Last caret offset seen by the tick; null means "not observed yet".
+    private int? _lastCaretOffset;
 
     internal TerminalAutomationPeer(TerminalControl owner) : base(owner)
     {
@@ -64,6 +66,10 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
         if (!ScreenReaderDetector.IsRunning() || !_owner.IsActive)
         {
             _announcer.Reseed(Document.Text);
+            // Drop the remembered caret too, so returning to this surface
+            // re-announces where the caret is rather than staying silent
+            // because it happens to match where it was on the way out.
+            _lastCaretOffset = null;
             return;
         }
 
@@ -76,6 +82,25 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
                 text,
                 "terminal-output");
         }
+
+        RaiseCaretMovedIfChanged();
+    }
+
+    // Caret moves have no dedicated UIA event; the Text pattern's
+    // TextSelectionChanged is what tells a screen reader to re-read the caret,
+    // so a move and a selection change raise the same event.
+    private void RaiseCaretMovedIfChanged()
+    {
+        if (ViewportCells is not { } grid) return;
+
+        var offset = ViewportCaret.Offset(Document, grid);
+        if (_lastCaretOffset == offset) return;
+
+        var first = _lastCaretOffset is null;
+        _lastCaretOffset = offset;
+
+        // The first observation establishes a baseline; there is no move yet.
+        if (!first) RaiseSelectionChangedEvent();
     }
 
     /// <summary>
@@ -108,7 +133,9 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     protected override string GetNameCore() => "Terminal";
 
     protected override object GetPatternCore(PatternInterface patternInterface)
-        => patternInterface == PatternInterface.Text ? this : base.GetPatternCore(patternInterface);
+        => patternInterface is PatternInterface.Text or PatternInterface.Text2
+            ? this
+            : base.GetPatternCore(patternInterface);
 
     // ---- ITextProvider ----------------------------------------------------
 
@@ -133,4 +160,29 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     public ITextRangeProvider RangeFromPoint(global::Windows.Foundation.Point screenLocation) =>
         new TerminalTextRangeProvider(this, new TextSpan(0, 0));
+
+    // ---- ITextProvider2 ---------------------------------------------------
+
+    /// <summary>
+    /// The caret as a degenerate range. <paramref name="isActive"/> means "the
+    /// element holding this caret has keyboard focus": reporting a constant
+    /// true would tell a screen reader that a background pane's caret is the
+    /// live one.
+    /// </summary>
+    public ITextRangeProvider GetCaretRange(out bool isActive)
+    {
+        isActive = _owner.IsActive;
+
+        // Falls back to end-of-document when there are no cells to anchor
+        // against, which is also where an off-screen cursor maps to.
+        var cells = ViewportCells;
+        var offset = cells is { } grid
+            ? ViewportCaret.Offset(Document, grid)
+            : Document.Length;
+
+        return new TerminalTextRangeProvider(this, new TextSpan(offset, offset));
+    }
+
+    public ITextRangeProvider RangeFromAnnotation(IRawElementProviderSimple annotationElement) =>
+        DocumentRange;
 }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -920,7 +920,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     // events. We still dedupe on state change as a belt-and-braces
     // guard so libghostty never sees a redundant focus event.
 
-    private bool _focused;
+    // volatile because IsActive is read off the UI thread: UIA serves
+    // GetCaretRange on an RPC thread while the UI thread rewrites this on
+    // focus change, and a stale read would tell a screen reader that a
+    // background pane holds the live caret.
+    private volatile bool _focused;
 
     /// <summary>
     /// True only when this surface is focused AND its window is the OS

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -189,6 +189,13 @@ internal struct GhosttyCells
     public IntPtr Cells; // ghostty_cell_s* (rows*cols)
     public ushort Rows;
     public ushort Cols;
+    // Cursor in viewport coordinates, resolved under the same renderer-lock
+    // hold as the cells. Valid only when CursorInViewport is non-zero. Kept as
+    // a byte because the assembly sets DisableRuntimeMarshalling, so every
+    // interop field must be blittable and `bool` is not.
+    public ushort CursorRow;
+    public ushort CursorCol;
+    public byte CursorInViewport;
 }
 
 // Mirrors ghostty_point_tag_e.
@@ -585,7 +592,9 @@ internal static partial class NativeMethods
                     }
                 }
             }
-            return new Ghostty.Core.Tabs.CellGrid(managed, rows, cols);
+            return new Ghostty.Core.Tabs.CellGrid(
+                managed, rows, cols,
+                native.CursorRow, native.CursorCol, native.CursorInViewport != 0);
         }
         finally
         {


### PR DESCRIPTION
Screen readers can ask where the caret is now. The peer implements
ITextProvider2, and read_cells carries the cursor position so there is
something to answer with.

The cursor rides along with the cells rather than getting its own accessor,
so both resolve under a single hold of the renderer mutex. A separate call
would let a caller pair a cursor from one frame with cells from another.

The column is not a document offset. read_text trims trailing blanks, so a
row the grid reports as 80 cells wide can be a 12-character line. The column
is clamped to the line it lands on, which parks the caret at end-of-line
instead of running into the next one. ViewportColorMap already had the
anchor for crossing between the grid and the document, so it moves to
ViewportAnchor and both share it.

Caret moves reuse TextSelectionChanged, folded into the existing announce
tick, so nothing extra runs when no assistive tech is attached.

Verified with a UIA client against a running build: TextPattern2 is present
and GetCaretRange tracks the cursor exactly, one character per column
(END, then LEFT x3 and LEFT x2, gave deltas of 3 and 2).

1688 tests pass, 8 new.

Not done yet: no screen reader has been run against this.