### PR TITLE
a11y: return the caret from GetSelection, uncached

### DIFF
--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -22,9 +22,10 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     private readonly TerminalControl _owner;
     private readonly CachedValue<TerminalDocument> _document;
-    // Viewport cells for color attributes. Fetched lazily (only when a color
-    // attribute is queried) and cached for the same 500ms window as the
-    // document, since read_cells is expensive and takes the renderer mutex.
+    // Viewport cells, for color attributes and for locating the cursor. Fetched
+    // lazily and cached for the same 500ms window as the document, since
+    // read_cells is expensive and takes the renderer mutex. The caret path is
+    // the exception and refreshes both - see CaretOffset.
     private readonly CachedValue<Ghostty.Core.Tabs.CellGrid?> _cells;
     private readonly TerminalOutputAnnouncer _announcer = new();
     private readonly DispatcherTimer _announceTimer;
@@ -148,11 +149,20 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     public SupportedTextSelection SupportedTextSelection => SupportedTextSelection.Single;
 
+    /// <summary>
+    /// The selection, or the caret as a degenerate range when nothing is
+    /// selected. Never empty: <see cref="SupportedTextSelection"/> is
+    /// <c>Single</c>, which promises a range here, and screen readers resolve
+    /// the caret through this method rather than through
+    /// <see cref="GetCaretRange"/>. Returning an empty array makes NVDA fail to
+    /// construct a text position at all ("UIAutomationTextRangeArray is
+    /// empty"), which silences every caret-move announcement.
+    /// </summary>
     public ITextRangeProvider[] GetSelection()
     {
-        var offsets = _owner.AccessibilitySelectionOffsets();
-        if (offsets is not { } o) return Array.Empty<ITextRangeProvider>();
-        var span = SelectionRange.FromOffsets(o.OffsetStart, o.OffsetLen, Document.Length);
+        var span = _owner.AccessibilitySelectionOffsets() is { } o
+            ? SelectionRange.FromOffsets(o.OffsetStart, o.OffsetLen, Document.Length)
+            : Degenerate(CaretOffset());
         return new ITextRangeProvider[] { new TerminalTextRangeProvider(this, span) };
     }
 
@@ -176,17 +186,35 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     public ITextRangeProvider GetCaretRange(out bool isActive)
     {
         isActive = _owner.IsActive;
-
-        // Falls back to end-of-document when there are no cells to anchor
-        // against, which is also where an off-screen cursor maps to.
-        var cells = ViewportCells;
-        var offset = cells is { } grid
-            ? ViewportCaret.Offset(Document, grid)
-            : Document.Length;
-
-        return new TerminalTextRangeProvider(this, new TextSpan(offset, offset));
+        return new TerminalTextRangeProvider(this, Degenerate(CaretOffset()));
     }
 
     public ITextRangeProvider RangeFromAnnotation(IRawElementProviderSimple annotationElement) =>
         DocumentRange;
+
+    // ---- helpers ----------------------------------------------------------
+
+    /// <summary>
+    /// Document offset of the terminal cursor. Falls back to end-of-document
+    /// when there are no cells to anchor against, which is also where an
+    /// off-screen cursor maps to.
+    ///
+    /// Deliberately uncached. A screen reader asks for the caret immediately
+    /// after the keystroke that moved it, so any time-boxed window can hand
+    /// back a value captured before that keystroke and make the caret trail
+    /// input by one key; shortening the window narrows the race without
+    /// closing it. Both caches are dropped rather than bypassed so the range
+    /// this offset is handed to reads the same snapshot the offset came from.
+    /// Only assistive tech reaches this path, and it costs a few reads per
+    /// second there (measured against NVDA: ~4/s while navigating, peaking at
+    /// 28 in the burst that follows a keypress).
+    /// </summary>
+    private int CaretOffset()
+    {
+        _document.Invalidate();
+        _cells.Invalidate();
+        return ViewportCells is { } grid ? ViewportCaret.Offset(Document, grid) : Document.Length;
+    }
+
+    private static TextSpan Degenerate(int offset) => new(offset, offset);
 }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -920,11 +920,14 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     // events. We still dedupe on state change as a belt-and-braces
     // guard so libghostty never sees a redundant focus event.
 
-    // volatile because IsActive is read off the UI thread: UIA serves
-    // GetCaretRange on an RPC thread while the UI thread rewrites this on
-    // focus change, and a stale read would tell a screen reader that a
-    // background pane holds the live caret.
-    private volatile bool _focused;
+    // Written and read on the UI thread only. UIA looked like a second reader
+    // on an RPC thread, but WinUI marshals provider calls onto the UI thread
+    // (measured under Narrator and NVDA: every GetSelection landed on the same
+    // managed thread as the DispatcherTimer tick), and the toast paths read
+    // IsActive from inside DispatcherQueue.TryEnqueue. IsActive also walks
+    // XamlRoot, which is thread-affine, so an off-thread caller would fault
+    // rather than merely read this stale.
+    private bool _focused;
 
     /// <summary>
     /// True only when this surface is focused AND its window is the OS


### PR DESCRIPTION
Follow-up to # 567. A screen-reader pass against the merged caret work found two defects that only show once a real screen reader drives the provider. Both are in `TerminalAutomationPeer`.

**`GetSelection` returned an empty array when nothing was selected.** That contradicts `SupportedTextSelection.Single`, which promises a range, and it is how screen readers actually ask for the caret - `GetCaretRange` is the newer `ITextProvider2` entry point, but NVDA resolves the caret through `GetSelection`. NVDA could not build a text position at all:

```
NotImplementedError: UIAutomationTextRangeArray is empty
  File "NVDAObjects\UIA\__init__.pyc", line 490, in __init__
```

Every caret move was announced as silence. With no selection we now hand back the caret as a degenerate range.

**The caret was served from the 500ms cache shared with the screen document.** A screen reader asks for the caret immediately after the keystroke that moved it, so the cached value predates that keystroke. Walking back through `abcdefg` from the end, NVDA said `g, f, e, d` - correct characters, one key behind, all the way. Shortening the window narrows the race without closing it, so the caret path drops both caches and reads fresh. Only assistive tech reaches it; measured against NVDA it costs ~4 reads/sec while navigating, peaking at 28 in the burst after a keypress.

## Verification

No unit test: the peer lives in the app project, which `Ghostty.Tests` cannot see, and the pure mapping it calls (`ViewportCaret`) is already covered. The evidence is live.

NVDA 2026.1.1, silent synth, `-l 10` debug log, keys driven with SendInput. Expected vs spoken, walking left through `echo abcdefg`:

| step | expect | before | after |
|---|---|---|---|
| left | g | (silence) | g |
| left | f | (silence) | f |
| left | e | (silence) | e |
| left | d | (silence) | d |
| home | e | (silence) | e |
| right | c | (silence) | c |

The intermediate state with only the `GetSelection` fix spoke `space, g, f, e, d, e` - right characters, one key behind - which is what isolated the cache. The `UIATextInfo` error no longer appears in the log.

Narrator plus a managed UIA client, same keys: exactly one `TerminalControl` element, `SupportedTextSelection=Single`, `GetSelection` never empty, caret offsets 122, 121, 120, 119, then 110 on Home and 111 on Right. Narrator and Wintty both responding at the end.

1713 tests pass.