### PR TITLE
a11y: give the peer geometry, hit-testing and identity

### DIFF
--- a/windows/Ghostty.Core/Accessibility/ViewportGeometry.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportGeometry.cs
@@ -1,0 +1,23 @@
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Where the terminal grid sits on screen, in PHYSICAL pixels, which is the
+/// unit UIA reports rectangles and receives hit-test points in.
+/// </summary>
+/// <param name="OriginX">Screen x of the grid's top-left corner.</param>
+/// <param name="OriginY">Screen y of the grid's top-left corner.</param>
+/// <param name="Width">Grid width on screen.</param>
+/// <param name="Height">Grid height on screen.</param>
+public readonly record struct ViewportGeometry(
+    double OriginX,
+    double OriginY,
+    double Width,
+    double Height)
+{
+    /// <summary>
+    /// A grid too small to be worth reporting. A control that has never been
+    /// laid out measures 0x0, and a split mid-layout can report a couple of
+    /// pixels for one pass before it settles.
+    /// </summary>
+    public bool IsUsable => Width >= 32 && Height >= 32;
+}

--- a/windows/Ghostty.Core/Accessibility/ViewportHitTest.cs
+++ b/windows/Ghostty.Core/Accessibility/ViewportHitTest.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// Maps between screen pixels and document offsets, for the two UIA text
+/// operations that are geometric rather than textual: hit-testing a point and
+/// reporting a range's bounding rectangles.
+///
+/// Both cross the same seam as <see cref="ViewportCaret"/>: the grid is padded
+/// to <c>Cols</c> while the document comes from read_text, which trims trailing
+/// blanks. Columns are therefore always clamped to the line they land on, and
+/// anything the viewport cannot show reports nothing rather than guessing.
+/// </summary>
+internal static class ViewportHitTest
+{
+    /// <summary>
+    /// Document offset under a screen point, or -1 when the point is outside
+    /// the grid or nothing can be mapped. Callers should treat -1 as "no
+    /// range here" rather than substituting offset 0, which would silently
+    /// send a screen reader to the top of the screen.
+    /// </summary>
+    public static int OffsetFromPoint(
+        TerminalDocument doc, CellGrid cells, ViewportGeometry geom, double screenX, double screenY)
+    {
+        if (!geom.IsUsable) return -1;
+
+        var anchor = ViewportAnchor.Create(doc, cells);
+        if (!anchor.HasContent) return -1;
+
+        var cellW = geom.Width / cells.Cols;
+        var cellH = geom.Height / cells.Rows;
+        if (cellW <= 0 || cellH <= 0) return -1;
+
+        var col = (int)Math.Floor((screenX - geom.OriginX) / cellW);
+        var row = (int)Math.Floor((screenY - geom.OriginY) / cellH);
+        if (col < 0 || col >= cells.Cols || row < 0 || row >= cells.Rows) return -1;
+
+        return OffsetOfCell(doc, anchor, row, col);
+    }
+
+    /// <summary>
+    /// UIA bounding rectangles for <paramref name="span"/>, as a flat
+    /// [x, y, width, height, ...] array with one rectangle per visual line.
+    /// Empty for a degenerate span, for unusable geometry, and for lines that
+    /// have scrolled out of the viewport - a rectangle for something not on
+    /// screen would point a screen reader at the wrong pixels.
+    /// </summary>
+    public static double[] Rects(
+        TerminalDocument doc, CellGrid cells, ViewportGeometry geom, TextSpan span)
+    {
+        if (span.IsDegenerate || !geom.IsUsable) return Array.Empty<double>();
+
+        var anchor = ViewportAnchor.Create(doc, cells);
+        if (!anchor.HasContent) return Array.Empty<double>();
+
+        var cellW = geom.Width / cells.Cols;
+        var cellH = geom.Height / cells.Rows;
+        if (cellW <= 0 || cellH <= 0) return Array.Empty<double>();
+
+        var start = doc.ClampOffset(span.Start);
+        var end = doc.ClampOffset(span.End);
+        if (end <= start) return Array.Empty<double>();
+
+        var rects = new List<double>();
+        var offset = start;
+        while (offset < end)
+        {
+            var bounds = doc.LineBounds(offset);
+            var lineStart = bounds.Start;
+            // The newline itself is not a drawn cell; a span that runs through
+            // it should not stretch the rectangle one column past the text.
+            var lineEnd = bounds.End;
+            if (lineEnd > lineStart && doc.Text[lineEnd - 1] == '\n') lineEnd--;
+
+            var segStart = offset;
+            var segEnd = Math.Min(end, lineEnd);
+
+            // Row this document line occupies on screen. Lines above the
+            // viewport map to a negative row and are skipped, not clamped.
+            var gridRow = doc.LineIndexForOffset(lineStart) - anchor.RowShift;
+            if (gridRow >= 0 && gridRow < cells.Rows && segEnd > segStart)
+            {
+                var startCol = Math.Min(segStart - lineStart, cells.Cols);
+                var endCol = Math.Min(segEnd - lineStart, cells.Cols);
+                if (endCol > startCol)
+                {
+                    rects.Add(geom.OriginX + startCol * cellW);
+                    rects.Add(geom.OriginY + gridRow * cellH);
+                    rects.Add((endCol - startCol) * cellW);
+                    rects.Add(cellH);
+                }
+            }
+
+            // Step past the newline; bounds.End already includes it.
+            offset = bounds.End > offset ? bounds.End : offset + 1;
+        }
+
+        return rects.ToArray();
+    }
+
+    // Document offset of a grid cell, clamped into the line it lands on. Mirrors
+    // ViewportCaret.Offset - a row that the grid reports as Cols wide is usually
+    // a much shorter document line, so a raw lineStart + col would run into the
+    // next line's text.
+    private static int OffsetOfCell(TerminalDocument doc, ViewportAnchor anchor, int gridRow, int col)
+    {
+        var lineStart = ViewportAnchor.LineStartOffset(doc, gridRow + anchor.RowShift);
+        if (lineStart < 0) return -1;
+
+        var bounds = doc.LineBounds(lineStart);
+        var lineEnd = bounds.End;
+        if (lineEnd > bounds.Start && doc.Text[lineEnd - 1] == '\n') lineEnd--;
+
+        return Math.Min(lineStart + Math.Max(col, 0), lineEnd);
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/ViewportHitTestTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/ViewportHitTestTests.cs
@@ -1,0 +1,152 @@
+using Ghostty.Core.Accessibility;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+/// <summary>
+/// Screen-point-to-offset and span-to-rectangle mapping. Both cross between
+/// the trimmed screen document and the padded cell grid, so they share
+/// <see cref="ViewportAnchor"/> with the caret and carry the same hazard:
+/// a document line is usually SHORTER than Cols.
+/// </summary>
+public class ViewportHitTestTests
+{
+    // 10x3 grid, 100px wide and 60px tall => 10px per column, 20px per row,
+    // anchored at screen (1000, 500) so an origin mistake cannot look like a
+    // correct answer.
+    private const int Cols = 10;
+    private const int Rows = 3;
+    private static readonly ViewportGeometry Geom = new(1000, 500, 100, 60);
+
+    /// <summary>Grid whose rows carry <paramref name="lines"/>, space-padded to Cols.</summary>
+    private static CellGrid GridOf(params string[] lines)
+    {
+        var cells = new Cell[Rows * Cols];
+        for (var r = 0; r < Rows; r++)
+        {
+            var line = r < lines.Length ? lines[r] : "";
+            for (var c = 0; c < Cols; c++)
+                cells[r * Cols + c] = new Cell(c < line.Length ? line[c] : 0u, 0, 0);
+        }
+        return new CellGrid(cells, Rows, Cols);
+    }
+
+    // read_text trims trailing blanks, so the document is the lines joined by
+    // newlines with no padding - deliberately unlike the grid.
+    private static TerminalDocument DocOf(params string[] lines) =>
+        new(string.Join("\n", lines));
+
+    [Fact]
+    public void PointInTheFirstCellMapsToOffsetZero()
+    {
+        var doc = DocOf("hello", "world");
+        var offset = ViewportHitTest.OffsetFromPoint(doc, GridOf("hello", "world"), Geom, 1001, 501);
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void PointPicksTheColumnItLandsIn()
+    {
+        var doc = DocOf("hello", "world");
+        // Column 3 of row 0 spans x 1030..1040.
+        var offset = ViewportHitTest.OffsetFromPoint(doc, GridOf("hello", "world"), Geom, 1035, 505);
+        Assert.Equal(3, offset);
+    }
+
+    [Fact]
+    public void PointOnTheSecondRowLandsAfterTheNewline()
+    {
+        var doc = DocOf("hello", "world");
+        // Row 1 spans y 520..540; column 0.
+        var offset = ViewportHitTest.OffsetFromPoint(doc, GridOf("hello", "world"), Geom, 1001, 525);
+        Assert.Equal("hello\n".Length, offset);
+    }
+
+    [Fact]
+    public void PointPastTheEndOfAShortLineClampsToThatLineNotTheNext()
+    {
+        var doc = DocOf("hi", "world");
+        // Column 8 exists in the grid but "hi" is 2 characters. Landing past it
+        // must park at end-of-line, not run into "world".
+        var offset = ViewportHitTest.OffsetFromPoint(doc, GridOf("hi", "world"), Geom, 1085, 505);
+        Assert.Equal(2, offset);
+    }
+
+    [Fact]
+    public void PointOutsideTheGridReturnsMinusOne()
+    {
+        var doc = DocOf("hello", "world");
+        var cells = GridOf("hello", "world");
+        Assert.Equal(-1, ViewportHitTest.OffsetFromPoint(doc, cells, Geom, 999, 505));
+        Assert.Equal(-1, ViewportHitTest.OffsetFromPoint(doc, cells, Geom, 1105, 505));
+        Assert.Equal(-1, ViewportHitTest.OffsetFromPoint(doc, cells, Geom, 1050, 499));
+        Assert.Equal(-1, ViewportHitTest.OffsetFromPoint(doc, cells, Geom, 1050, 565));
+    }
+
+    [Fact]
+    public void UnusableGeometryYieldsNoRectangles()
+    {
+        var doc = DocOf("hello");
+        var rects = ViewportHitTest.Rects(doc, GridOf("hello"), new ViewportGeometry(0, 0, 4, 4), new TextSpan(0, 5));
+        Assert.Empty(rects);
+    }
+
+    [Fact]
+    public void SingleLineSpanYieldsOneRectangleOfTheRightCells()
+    {
+        var doc = DocOf("hello", "world");
+        // "ell" = offsets 1..4 on row 0 => x 1010, width 30.
+        var rects = ViewportHitTest.Rects(doc, GridOf("hello", "world"), Geom, new TextSpan(1, 4));
+        Assert.Equal(4, rects.Length);
+        Assert.Equal(1010, rects[0]);
+        Assert.Equal(500, rects[1]);
+        Assert.Equal(30, rects[2]);
+        Assert.Equal(20, rects[3]);
+    }
+
+    [Fact]
+    public void SpanCrossingLinesYieldsOneRectanglePerLine()
+    {
+        var doc = DocOf("hello", "world");
+        // From "llo" on row 0 through "wo" on row 1.
+        var rects = ViewportHitTest.Rects(doc, GridOf("hello", "world"), Geom, new TextSpan(2, 8));
+        Assert.Equal(8, rects.Length);
+        Assert.Equal(1020, rects[0]);   // row 0 starts at column 2
+        Assert.Equal(500, rects[1]);
+        Assert.Equal(30, rects[2]);     // columns 2..4
+        Assert.Equal(1000, rects[4]);   // row 1 starts at column 0
+        Assert.Equal(520, rects[5]);
+        Assert.Equal(20, rects[6]);     // columns 0..1
+    }
+
+    [Fact]
+    public void DegenerateSpanYieldsNoRectangles()
+    {
+        var doc = DocOf("hello");
+        var rects = ViewportHitTest.Rects(doc, GridOf("hello"), Geom, new TextSpan(2, 2));
+        Assert.Empty(rects);
+    }
+
+    [Fact]
+    public void RectanglesAreOmittedForLinesOutsideTheViewport()
+    {
+        // Document has scrollback the 3-row grid cannot show; the span covers a
+        // line above the viewport, which has no on-screen rectangle.
+        var doc = DocOf("scrolled", "away", "hello", "world");
+        var rects = ViewportHitTest.Rects(doc, GridOf("hello", "world"), Geom, new TextSpan(0, 8));
+        Assert.Empty(rects);
+    }
+
+    [Fact]
+    public void RoundTripsAPointThroughItsOwnRectangle()
+    {
+        var doc = DocOf("hello", "world");
+        var cells = GridOf("hello", "world");
+        var offset = ViewportHitTest.OffsetFromPoint(doc, cells, Geom, 1035, 505);
+        var rects = ViewportHitTest.Rects(doc, cells, Geom, new TextSpan(offset, offset + 1));
+        Assert.Equal(4, rects.Length);
+        Assert.True(rects[0] <= 1035 && 1035 <= rects[0] + rects[2]);
+        Assert.True(rects[1] <= 505 && 505 <= rects[1] + rects[3]);
+    }
+}

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -14,7 +14,8 @@ namespace Ghostty.Accessibility;
 /// macOS VoiceOver model (textArea role, cached screen contents, read_selection
 /// offsets as the selected range). Read-only in this stage.
 /// </summary>
-internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomationPeer, ITextProvider, ITextProvider2
+internal sealed partial class TerminalAutomationPeer
+    : FrameworkElementAutomationPeer, ITextProvider, ITextProvider2, IValueProvider
 {
     // Screen reads take the renderer mutex, so we serve a cached document for
     // this long between fetches. Matches the macOS surface's 500ms CachedValue.
@@ -82,6 +83,19 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
                 AutomationNotificationProcessing.All,
                 text,
                 "terminal-output");
+
+            // Notification carries the words; TextChanged tells a client that
+            // tracks the document to re-read rather than rely on the
+            // announcement alone.
+            //
+            // LiveRegionChanged is deliberately NOT raised, even though
+            // GetLiveSettingCore reports Polite. NVDA answers it by
+            // re-announcing the element's name, so every burst of output ended
+            // with a spoken "Terminal" on top of the text we just sent
+            // (measured: it disappears the moment the event is dropped, and the
+            // caret behaviour is unchanged either way). The property is still
+            // honest about what this control is; the event only added noise.
+            RaiseIfListening(AutomationEvents.TextPatternOnTextChanged);
         }
 
         RaiseCaretMovedIfChanged();
@@ -115,9 +129,13 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
     /// is inert when no AT client is attached.
     /// </summary>
     internal void RaiseSelectionChangedEvent()
+        => RaiseIfListening(AutomationEvents.TextPatternOnTextSelectionChanged);
+
+    // Raising an event with no client attached still crosses the UIA boundary,
+    // so every raise is gated. On a non-AT machine this reduces to one check.
+    private void RaiseIfListening(AutomationEvents which)
     {
-        if (AutomationPeer.ListenerExists(AutomationEvents.TextPatternOnTextSelectionChanged))
-            RaiseAutomationEvent(AutomationEvents.TextPatternOnTextSelectionChanged);
+        if (AutomationPeer.ListenerExists(which)) RaiseAutomationEvent(which);
     }
 
     /// <summary>Current cached screen document. Refreshed at most every 500ms.</summary>
@@ -137,8 +155,23 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     protected override string GetNameCore() => "Terminal";
 
+    /// <summary>
+    /// Stable identity for this pane. Without one, every terminal in a split
+    /// or a tab set is indistinguishable to an automation client, which can
+    /// then only address them positionally.
+    /// </summary>
+    protected override string GetAutomationIdCore() => _owner.AccessibilityAutomationId;
+
+    /// <summary>
+    /// The terminal is a live region: content arrives on its own rather than
+    /// in response to the user. Polite so a screen reader finishes what it is
+    /// saying first - Assertive would interrupt the user mid-sentence on every
+    /// line of build output.
+    /// </summary>
+    protected override AutomationLiveSetting GetLiveSettingCore() => AutomationLiveSetting.Polite;
+
     protected override object GetPatternCore(PatternInterface patternInterface)
-        => patternInterface is PatternInterface.Text or PatternInterface.Text2
+        => patternInterface is PatternInterface.Text or PatternInterface.Text2 or PatternInterface.Value
             ? this
             : base.GetPatternCore(patternInterface);
 
@@ -172,8 +205,23 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     public ITextRangeProvider RangeFromChild(IRawElementProviderSimple childElement) => DocumentRange;
 
-    public ITextRangeProvider RangeFromPoint(global::Windows.Foundation.Point screenLocation) =>
-        new TerminalTextRangeProvider(this, new TextSpan(0, 0));
+    /// <summary>
+    /// The character under a screen point, as a degenerate range. This is what
+    /// backs screen-reader mouse and touch exploration, so an unmappable point
+    /// collapses to the start of the document rather than inventing a
+    /// plausible-looking offset somewhere in the middle.
+    /// </summary>
+    public ITextRangeProvider RangeFromPoint(global::Windows.Foundation.Point screenLocation)
+    {
+        var offset = 0;
+        if (ViewportCells is { } grid && _owner.AccessibilityViewportGeometry() is { } geom)
+        {
+            var hit = ViewportHitTest.OffsetFromPoint(
+                Document, grid, geom, screenLocation.X, screenLocation.Y);
+            if (hit >= 0) offset = hit;
+        }
+        return new TerminalTextRangeProvider(this, Degenerate(offset));
+    }
 
     // ---- ITextProvider2 ---------------------------------------------------
 
@@ -191,6 +239,34 @@ internal sealed partial class TerminalAutomationPeer : FrameworkElementAutomatio
 
     public ITextRangeProvider RangeFromAnnotation(IRawElementProviderSimple annotationElement) =>
         DocumentRange;
+
+    // ---- IValueProvider ---------------------------------------------------
+
+    /// <summary>
+    /// The screen contents as one string. Redundant with the Text pattern, but
+    /// some clients read Value first and never reach TextPattern; it is the
+    /// same document, so the two cannot disagree.
+    /// </summary>
+    public string Value => Document.Text;
+
+    public bool IsReadOnly => true;
+
+    public void SetValue(string value)
+        => throw new InvalidOperationException("The terminal grid is not editable through UIA.");
+
+    // ---- geometry ---------------------------------------------------------
+
+    /// <summary>
+    /// Screen rectangles for a range, one per visual line, or empty when the
+    /// text is not on screen. Used for braille routing and for the visual
+    /// highlight a screen reader draws around what it is reading.
+    /// </summary>
+    internal double[] BoundingRectangles(TextSpan span)
+    {
+        if (ViewportCells is not { } grid) return Array.Empty<double>();
+        if (_owner.AccessibilityViewportGeometry() is not { } geom) return Array.Empty<double>();
+        return ViewportHitTest.Rects(Document, grid, geom, span);
+    }
 
     // ---- helpers ----------------------------------------------------------
 

--- a/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/TerminalAutomationPeer.cs
@@ -260,6 +260,12 @@ internal sealed partial class TerminalAutomationPeer
     /// Screen rectangles for a range, one per visual line, or empty when the
     /// text is not on screen. Used for braille routing and for the visual
     /// highlight a screen reader draws around what it is reading.
+    ///
+    /// Reads the CACHED grid, unlike the caret. A caret query follows the
+    /// keystroke that moved it, so a stale answer is wrong by a whole
+    /// character; a rectangle query follows the pointer or a braille cursor
+    /// over text that is already on screen, where 500ms of staleness is not
+    /// observable and the fresh reads would land on every mouse move.
     /// </summary>
     internal double[] BoundingRectangles(TextSpan span)
     {

--- a/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
+++ b/windows/Ghostty/Accessibility/TerminalTextRangeProvider.cs
@@ -95,7 +95,7 @@ internal sealed partial class TerminalTextRangeProvider : ITextRangeProvider
             : UiaReservedValues.NotSupported()!;
     }
 
-    public void GetBoundingRectangles(out double[] rectangles) => rectangles = Array.Empty<double>();
+    public void GetBoundingRectangles(out double[] rectangles) => rectangles = _peer.BoundingRectangles(_span);
 
     public IRawElementProviderSimple GetEnclosingElement() => _peer.Provider;
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -167,12 +167,12 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// teardown can't touch freed native state. Takes the renderer mutex; the
     /// automation peer caches the result for 500ms.
     ///
-    /// UIA calls arrive on a UIA/RPC thread, so there is a narrow race between
-    /// this guard and the native read if the surface is disposed concurrently.
-    /// libghostty serializes the read on its renderer mutex and the guard makes
-    /// the window small; macOS accepts the same race for the same reason. An
-    /// empty string on a transient/teardown miss is the intended graceful
-    /// degradation (a screen reader must not crash on a momentary read failure).
+    /// WinUI marshals automation-peer calls onto the UI thread, which is also
+    /// where _surfaceDisposed is written, so the guard and the read are not
+    /// racing. Feed can run on another thread for a mux pane, but libghostty
+    /// serializes reads on its renderer mutex. An empty string on a
+    /// transient/teardown miss is the intended graceful degradation (a screen
+    /// reader must not crash on a momentary read failure).
     /// </summary>
     internal string AccessibilityReadScreenText()
     {
@@ -201,6 +201,61 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         if (_surfaceDisposed || _surface.Handle == IntPtr.Zero) return null;
         return NativeMethods.SurfaceReadCells(_surface);
     }
+
+    /// <summary>
+    /// Where this pane's grid sits on screen, in physical pixels, or null when
+    /// the control has no usable layout (never measured, collapsed in a
+    /// background tab, or detached mid-reparent). Backs UIA bounding
+    /// rectangles and hit-testing.
+    ///
+    /// Computed on demand rather than cached on a layout pass: WinUI marshals
+    /// automation-peer calls onto the UI thread, so live XAML is legal here,
+    /// and a cache would only add a way for the reported rectangle to describe
+    /// a frame that is no longer on screen.
+    /// </summary>
+    internal Ghostty.Core.Accessibility.ViewportGeometry? AccessibilityViewportGeometry()
+    {
+        try
+        {
+            if (XamlRoot is not { Content: { } root } xamlRoot) return null;
+            var env = xamlRoot.ContentIslandEnvironment;
+            if (env is null) return null;
+            nint hwnd = Microsoft.UI.Win32Interop.GetWindowFromWindowId(env.AppWindowId);
+            if (hwnd == 0) return null;
+
+            // The panel's offset is in DIPs relative to the window content; the
+            // window's client origin is already in physical screen pixels, so
+            // only the former is scaled.
+            var client = new System.Drawing.Point(0, 0);
+            PInvoke.ClientToScreen(new Windows.Win32.Foundation.HWND(hwnd), ref client);
+            var scale = xamlRoot.RasterizationScale;
+            var offset = Panel.TransformToVisual(root)
+                .TransformPoint(new Windows.Foundation.Point(0, 0));
+
+            var geom = new Ghostty.Core.Accessibility.ViewportGeometry(
+                client.X + offset.X * scale,
+                client.Y + offset.Y * scale,
+                Panel.ActualWidth * scale,
+                Panel.ActualHeight * scale);
+            return geom.IsUsable ? geom : null;
+        }
+        catch
+        {
+            // TransformToVisual throws for an element that is not in the tree,
+            // which is exactly a pane that should not be reporting geometry.
+            return null;
+        }
+    }
+
+    // Stable identity for this pane in the automation tree. Assigned once and
+    // kept for the control's lifetime so a client that bound to a pane still
+    // finds it after the pane is backgrounded and shown again.
+    private static int _nextAutomationId;
+    private readonly string _automationId =
+        "TerminalGrid-" + System.Threading.Interlocked.Increment(ref _nextAutomationId)
+            .ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    internal string AccessibilityAutomationId => _automationId;
 
     private Ghostty.Accessibility.TerminalAutomationPeer? _automationPeer;
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -239,10 +239,13 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
                 Panel.ActualHeight * scale);
             return geom.IsUsable ? geom : null;
         }
-        catch
+        catch (Exception ex) when (ex is COMException or InvalidOperationException or ArgumentException)
         {
             // TransformToVisual throws for an element that is not in the tree,
-            // which is exactly a pane that should not be reporting geometry.
+            // which is exactly a pane that should not be reporting geometry, and
+            // the island interop can fail the same way mid-teardown. Narrow
+            // rather than bare: anything else here is a bug, and swallowing it
+            // would leave a screen reader silently pointed at nothing.
             return null;
         }
     }


### PR DESCRIPTION
The XAML automation peer could describe the terminal's text but not where any of it was. A screen reader could not route braille, draw a highlight, or explore by mouse, and an automation client could not name a pane. These are the gaps that block retiring Pro's satellite provider.

## What changed

- **`GetBoundingRectangles` returned an empty array.** Now one rectangle per visual line, in physical screen pixels.
- **`RangeFromPoint` was a stub pinned at offset 0**, so every hit-test answered "top-left of the screen". Now resolves the character under the point.
- **No `AutomationId`**, so panes were only addressable positionally. Each control now carries a stable `TerminalGrid-N` for its lifetime.
- **Added ValuePattern** (read-only, backed by the same document as the Text pattern so the two cannot disagree) and **`LiveSetting = Polite`**.
- **TextChanged** is raised alongside the existing notification when output settles.

The geometry lives in `ViewportHitTest` in Core, next to `ViewportCaret`, and crosses the same seam: the grid is padded to `Cols` while `read_text` trims, so columns clamp to the line they land on, and anything scrolled out of the viewport reports no rectangle rather than a wrong one.

`TerminalControl` computes geometry **on demand** rather than caching it on a layout pass, which is what the satellite has to do. Automation-peer calls are marshalled onto the UI thread, so live XAML is legal here and a cache could only ever describe a frame that is no longer on screen. The stale comment claiming a UIA/RPC-thread race on the screen-text read goes with it.

## One deliberate divergence

**`LiveRegionChanged` is not raised**, even though `LiveSetting` reports Polite. NVDA answers that event by re-announcing the element's *name*, so every burst of output ended with a spoken "Terminal" on top of the text we had just sent:

```
Speaking [... 'echo abcdefg\nabcdefg']
Speaking [... 'Terminal']          <- the event
Speaking [... '252 new lines']
Speaking [... 'Terminal']          <- the event
```

It disappears the moment the event is dropped, and the caret behaves identically either way. The property still describes what this control is; the event only added noise. Pro's `uiatest` asserts the event fires - that assertion encodes the satellite's design and should be revisited rather than followed here.

## Verification

11 new unit tests on the pure mapping. The trimmed-line clamp is pinned by a mutation: replacing it with `lineStart + col` fails exactly `PointPastTheEndOfAShortLineClampsToThatLineNotTheNext` and nothing else. 1724 tests pass overall (up from 1713).

Live UIA client against a running build, 13 of 13:

```
PASS  no satellite provider in a base build  (0)
PASS  exposes a stable AutomationId  ('TerminalGrid-1')
PASS  supports ValuePattern  (True)
PASS  ValuePattern exposes the live grid  (133 chars)
PASS  ValuePattern is read-only  (True)
PASS  match yields exactly one bounding rect  (1 rect)
PASS  bounding rect has plausible cell metrics  (cellW=10.0 h=19.0)
PASS  bounding rect lies inside the terminal
PASS  RangeFromPoint lands on the first character of the match  (got 'P')
PASS  RangeFromPoint tracks x across the match  (got 'R')
```

NVDA 2026.1.1 still announces six of six caret positions, so none of this regressed # 568.