### PR TITLE
deps: bump zioshade to v0.5.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -92,13 +92,22 @@
         // HLSL/MSL/GLSL cross compiler. It replaces the glslang and
         // spirv-cross C++ packages, so custom shader compilation is
         // in-process with no C++ dependencies.
-        // Pinned to the v0.4.0 tag (cut past PR #492, which carries the Zig 0.16
-        // build + packaging fix this pin depends on; the older v0.3.0 tag
-        // hard-errored on 0.16). v0.4.0 also completes the float-comparison
-        // NaN-correctness campaign and a fully-clean compile-validity matrix.
+        // Pinned to the v0.5.0 tag. It carries a broad silent-wrong hunt across
+        // all four backends (~17 bug classes), honest errors instead of
+        // placeholder output for unknown types, self-loop lowering, and a C ABI
+        // fix that matters here: caller-owned buffers now come from a
+        // process-global mutex-guarded allocator, so they may be freed from any
+        // thread. Previously they came from a threadlocal allocator, so
+        // compiling on a worker and freeing on the main thread handed an
+        // allocator a pointer it never produced.
+        // Note for anyone diffing generated shader text: v0.5.0 mangles
+        // identifiers that used to collide, so output for unchanged input can
+        // differ from v0.4.0. That is a correctness fix, not a regression.
+        // `zioshade_status_t` also gained ZIOSHADE_ERR_UNSUPPORTED (8), an
+        // additive change; keep a default branch when switching over it.
         .zioshade = .{
-            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.4.0.tar.gz",
-            .hash = "zioshade-0.4.0-8s3a2sRrRACbnWG3W-IvO9Z2s2X4jsvBaO0aU3gd8bbo",
+            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.5.0.tar.gz",
+            .hash = "zioshade-0.5.0-8s3a2t1NSAALg56PbAKbTaDxBDPyUOQ-VR3zKsnPDmky",
             .lazy = true,
         },
 


### PR DESCRIPTION
Advances the zioshade pin from `v0.4.0` to `v0.5.0`.

**Why it matters here.** The C ABI fix is the headline for an in-process consumer: caller-owned buffers now come from a process-global mutex-guarded allocator rather than a threadlocal one, so they can be freed from any thread. Under the old contract, compiling on a worker thread and freeing on the main thread handed an allocator a pointer it never produced.

Also in this release: a broad silent-wrong hunt across MSL/GLSL/HLSL/WGSL (~17 bug classes), honest errors instead of placeholder output for unknown types, self-loop lowering, and `emitWhileLoop` recursion bounded to an honest error instead of a stack-overflow crash.

**Two things to be aware of:**

- `zioshade_status_t` gained `ZIOSHADE_ERR_UNSUPPORTED` (value 8). Existing values are unchanged, so this is additive, but a consumer switching exhaustively over the enum needs a default branch.
- Generated shader text can differ from v0.4.0, because identifiers that previously collided are now mangled. This is a correctness fix, not a regression, but it will show up in any output diff.

Verified locally: `zig build --fetch` resolves and hash-checks clean against `zioshade-0.5.0-8s3a2t1NSAALg56PbAKbTaDxBDPyUOQ-VR3zKsnPDmky`.