### PR TITLE
cli: accept Windows-native subcommands alongside +action

### DIFF
--- a/windows/Ghostty.Core/Cli/CliAliases.cs
+++ b/windows/Ghostty.Core/Cli/CliAliases.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ghostty.Core.Cli;
+
+/// <summary>
+/// Windows-native subcommand spellings for the <c>+action</c> CLI
+/// convention Wintty inherits from Ghostty.
+///
+/// `wintty +list-themes` is a Ghostty-ism. On Windows a verb is a bare
+/// subcommand (`winget install`, `dotnet build`), so `wintty list-themes`
+/// has to work too. Both forms are supported; neither is deprecated.
+///
+/// libghostty stays the authority on action detection. This type answers
+/// only the one question libghostty cannot answer for itself - whether the
+/// first argument is a bare alias that needs a <c>+</c> spliced in before
+/// <c>ghostty_init_wide</c> parses the command line - and defers
+/// everything else, including every error case, to
+/// <c>src/cli/action.zig</c>.
+///
+/// Pure (no I/O, no P/Invoke) so it is unit-testable and so the drift
+/// guard in Ghostty.Tests can exercise the real type.
+/// </summary>
+internal static class CliAliases
+{
+    /// <summary>
+    /// Canonical action names, without the <c>+</c>. One entry per field
+    /// of the <c>Action</c> enum in <c>src/cli/ghostty.zig</c>; a parity
+    /// test fails the build when the two sets diverge.
+    ///
+    /// Ordinal by construction, not by default: Ghostty.csproj sets
+    /// InvariantGlobalization and Ghostty.Core.csproj does not, and that
+    /// property is process-wide. Culture-sensitive comparison would
+    /// therefore behave one way in Wintty.exe and another under
+    /// `dotnet test`, where ICU collapses ignorable characters.
+    /// </summary>
+    public static readonly FrozenSet<string> Actions = new[]
+    {
+        "boo",
+        "crash-report",
+        "edit-config",
+        "explain-config",
+        "help",
+        "list-actions",
+        "list-colors",
+        "list-fonts",
+        "list-keybinds",
+        "list-themes",
+        "list-themes-tui",
+        "new-window",
+        "show-config",
+        "show-face",
+        "ssh",
+        "ssh-cache",
+        "toggle-quick-terminal",
+        "validate-config",
+        "version",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Windows argument separators. Exactly space and tab - not
+    /// <see cref="char.IsWhiteSpace"/>, which also returns true for CR,
+    /// LF, VT, FF, U+00A0 and U+3000. Windows tokenization treats those
+    /// as ordinary argument characters, so counting one as a separator
+    /// would splice into the middle of what the OS considers a single
+    /// argument and corrupt argv[0].
+    /// </summary>
+    private static bool IsSeparator(char c) => c is ' ' or '\t';
+
+    /// <summary>
+    /// Rewrite <paramref name="commandLine"/> so libghostty sees a bare
+    /// leading subcommand as its <c>+action</c> form, e.g.
+    /// <c>wintty.exe list-themes</c> to <c>wintty.exe +list-themes</c>.
+    /// Returns false and leaves the command line untouched when the first
+    /// argument is not a bare alias.
+    /// </summary>
+    /// <remarks>
+    /// The tokenizer mirrors <c>std.process.Args.Iterator.Windows</c>
+    /// (zig 0.16.0, <c>lib/std/process/Args.zig</c>), because that is what
+    /// libghostty runs on the string handed back. Divergence here would
+    /// mean splicing at an offset the real parser reads differently.
+    ///
+    /// Scanning is index-based over <c>char</c> on purpose. The command
+    /// line is WTF-16 and may hold unpaired surrogates, which
+    /// <c>Rune.DecodeFromUtf16</c> rejects. Index-based scanning is also
+    /// what makes the insertion point provably safe: the code unit before
+    /// it is always a separator, so the <c>+</c> can never land between a
+    /// high and a low surrogate.
+    /// </remarks>
+    public static bool TryRewrite(string commandLine, out string rewritten, out string? action)
+    {
+        rewritten = commandLine;
+        action = null;
+
+        // An empty command line, or one starting with NUL, yields zero
+        // arguments: the iterator completes before argv[0].
+        if (string.IsNullOrEmpty(commandLine) || commandLine[0] == '\0') return false;
+
+        // argv[0] plays by its own rules: quotes toggle and are dropped,
+        // backslash escaping does not apply, and there is no leading
+        // separator skip. A command line starting with a separator
+        // therefore has an empty argv[0] and the exe path becomes the
+        // first argument, which is what both zig and the .NET host do.
+        var i = 0;
+        var insideQuotes = false;
+        while (i < commandLine.Length)
+        {
+            var c = commandLine[i];
+            if (c == '\0') return false;
+            i++;
+            if (c == '"') insideQuotes = !insideQuotes;
+            else if (IsSeparator(c) && !insideQuotes) break;
+        }
+
+        // Ran to the end of the string without an unquoted separator, or
+        // the separator was the last character: no arguments follow.
+        if (i >= commandLine.Length) return false;
+
+        while (i < commandLine.Length && IsSeparator(commandLine[i])) i++;
+        if (i >= commandLine.Length || commandLine[i] == '\0') return false;
+
+        var start = i;
+        while (i < commandLine.Length &&
+               commandLine[i] != '\0' &&
+               !IsSeparator(commandLine[i]))
+        {
+            i++;
+        }
+
+        var span = commandLine.AsSpan(start, i - start);
+
+        // Decline anything carrying a quote or a backslash. Full
+        // escaping (2n vs 2n+1 backslashes before a quote, doubled quotes
+        // inside quotes) is real, but no action name needs any of it, so
+        // declining keeps `wintty "list-themes"` behaving exactly as it
+        // does today instead of requiring those rules to be reimplemented
+        // correctly. With neither character present, this span is
+        // byte-for-byte what zig's tokenizer produces.
+        if (span.IndexOfAny('"', '\\') >= 0) return false;
+
+        var candidate = span.ToString();
+        if (!Actions.Contains(candidate)) return false;
+
+        action = candidate;
+        rewritten = string.Concat(commandLine.AsSpan(0, start), "+", commandLine.AsSpan(start));
+        return true;
+    }
+
+    /// <summary>
+    /// True when <paramref name="arg"/> looks like a bare subcommand the
+    /// user got wrong, rather than a flag, a path, or an <c>-e</c>
+    /// payload. Used to turn an unknown verb into an error instead of a
+    /// silently ignored argument.
+    /// </summary>
+    public static bool LooksLikeCommand(string arg)
+    {
+        if (arg.Length == 0 || arg[0] is < 'a' or > 'z') return false;
+        foreach (var c in arg)
+        {
+            if (c is (>= 'a' and <= 'z') or (>= '0' and <= '9') or '-') continue;
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Windows-native usage text. Replaces libghostty's <c>+help</c>
+    /// output, which names `ghostty`, points the reader at
+    /// <c>src/config/Config.zig</c>, and explains
+    /// <c>open -na Ghostty.app</c> - all wrong on Windows.
+    ///
+    /// One command per line, rendered from <see cref="Actions"/>, so a
+    /// new upstream action appears here the moment the parity test forces
+    /// it into the set. Upstream prints names without descriptions too,
+    /// so there is no description text to drift.
+    /// </summary>
+    public static string RenderHelp(string programName)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"Usage: {programName} [command] [options]\n\n");
+        sb.Append($"Run the {AppIdentity.ProductName} terminal emulator, or a specific helper\n");
+        sb.Append("command.\n\n");
+        sb.Append(
+            "If no command is given, run the terminal emulator. All configuration\n" +
+            "keys are available as command line options in `--<key>=<value>` form,\n" +
+            "using the same syntax as the config file, for example `--font-size=12`\n" +
+            "or `--font-family=\"Fira Code\"`.\n\n");
+        sb.Append($"`{programName} -e <command>` runs a command inside the terminal, for\n");
+        sb.Append($"example `{programName} -e pwsh`.\n\n");
+        sb.Append("Commands:\n\n");
+
+        foreach (var name in Actions.OrderBy(static n => n, StringComparer.Ordinal))
+            sb.Append($"  {name}\n");
+
+        sb.Append("\nEach command also accepts the `+command` spelling inherited from\n");
+        sb.Append($"Ghostty, for example `{programName} +list-themes`. Both forms work.\n\n");
+        sb.Append($"Run `{programName} +<command> --help` for help on a single command.\n");
+
+        return sb.ToString();
+    }
+}

--- a/windows/Ghostty.Core/Cli/CliAliases.cs
+++ b/windows/Ghostty.Core/Cli/CliAliases.cs
@@ -181,8 +181,7 @@ internal static class CliAliases
     {
         var sb = new StringBuilder();
         sb.Append($"Usage: {programName} [command] [options]\n\n");
-        sb.Append($"Run the {AppIdentity.ProductName} terminal emulator, or a specific helper\n");
-        sb.Append("command.\n\n");
+        sb.Append($"Run the {AppIdentity.ProductName} terminal emulator, or a helper command.\n\n");
         sb.Append(
             "If no command is given, run the terminal emulator. All configuration\n" +
             "keys are available as command line options in `--<key>=<value>` form,\n" +

--- a/windows/Ghostty.Core/Cli/CliAliases.cs
+++ b/windows/Ghostty.Core/Cli/CliAliases.cs
@@ -47,6 +47,7 @@ internal static class CliAliases
         "list-keybinds",
         "list-themes",
         "list-themes-tui",
+        "new-tab",
         "new-window",
         "show-config",
         "show-face",

--- a/windows/Ghostty.Core/Cli/CliAliases.cs
+++ b/windows/Ghostty.Core/Cli/CliAliases.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Ghostty.Core.Cli;
@@ -31,13 +29,12 @@ internal static class CliAliases
     /// of the <c>Action</c> enum in <c>src/cli/ghostty.zig</c>; a parity
     /// test fails the build when the two sets diverge.
     ///
-    /// Ordinal by construction, not by default: Ghostty.csproj sets
-    /// InvariantGlobalization and Ghostty.Core.csproj does not, and that
-    /// property is process-wide. Culture-sensitive comparison would
-    /// therefore behave one way in Wintty.exe and another under
-    /// `dotnet test`, where ICU collapses ignorable characters.
+    /// Kept in sorted order because <see cref="RenderHelp"/> prints it
+    /// as-is, which is cheaper and more predictable than sorting a set
+    /// whose enumeration order is unspecified. A test asserts the help
+    /// output is ordered, so an entry added in the wrong place fails.
     /// </summary>
-    public static readonly FrozenSet<string> Actions = new[]
+    private static readonly string[] Sorted =
     {
         "boo",
         "crash-report",
@@ -58,7 +55,19 @@ internal static class CliAliases
         "toggle-quick-terminal",
         "validate-config",
         "version",
-    }.ToFrozenSet(StringComparer.Ordinal);
+    };
+
+    /// <summary>
+    /// Lookup form of <see cref="Sorted"/>.
+    ///
+    /// Ordinal by construction, not by default: Ghostty.csproj sets
+    /// InvariantGlobalization and Ghostty.Core.csproj does not, and that
+    /// property is process-wide. Culture-sensitive comparison would
+    /// therefore behave one way in Wintty.exe and another under
+    /// `dotnet test`, where ICU collapses ignorable characters.
+    /// </summary>
+    public static readonly FrozenSet<string> Actions =
+        FrozenSet.ToFrozenSet(Sorted, StringComparer.Ordinal);
 
     /// <summary>
     /// Windows argument separators. Exactly space and tab - not
@@ -167,12 +176,43 @@ internal static class CliAliases
     }
 
     /// <summary>
+    /// Whether to print <see cref="RenderHelp"/> instead of running an
+    /// action or starting the GUI. <paramref name="isAlias"/> is the
+    /// result of <see cref="TryRewrite"/> over the same invocation.
+    /// </summary>
+    public static bool IsHelpRequest(string[] args, bool isAlias)
+    {
+        if (args.Length == 0) return false;
+
+        // An explicit help command in the first position, either spelling.
+        if (args[0] == "help" || args[0] == "+help") return true;
+
+        // Any other action owns --help: it prints that action's own help,
+        // which only libghostty can render.
+        if (args[0].StartsWith('+') || isAlias) return false;
+
+        // -e hands the rest of the line to the child command, so a help
+        // flag anywhere on it is the child's, not ours. Checked before the
+        // help flags rather than alongside them: detectSpecialCase in
+        // src/cli/action.zig returns abort_if_no_action on -e regardless of
+        // whether a help fallback was already recorded, so `--help -e foo`
+        // has to run foo too, not just `-e foo --help`.
+        foreach (var arg in args)
+            if (arg == "-e") return false;
+
+        foreach (var arg in args)
+            if (arg == "--help" || arg == "-h" || arg == "/?") return true;
+
+        return false;
+    }
+
+    /// <summary>
     /// Windows-native usage text. Replaces libghostty's <c>+help</c>
     /// output, which names `ghostty`, points the reader at
     /// <c>src/config/Config.zig</c>, and explains
     /// <c>open -na Ghostty.app</c> - all wrong on Windows.
     ///
-    /// One command per line, rendered from <see cref="Actions"/>, so a
+    /// One command per line, rendered from <see cref="Sorted"/>, so a
     /// new upstream action appears here the moment the parity test forces
     /// it into the set. Upstream prints names without descriptions too,
     /// so there is no description text to drift.
@@ -191,7 +231,7 @@ internal static class CliAliases
         sb.Append($"example `{programName} -e pwsh`.\n\n");
         sb.Append("Commands:\n\n");
 
-        foreach (var name in Actions.OrderBy(static n => n, StringComparer.Ordinal))
+        foreach (var name in Sorted)
             sb.Append($"  {name}\n");
 
         sb.Append("\nEach command also accepts the `+command` spelling inherited from\n");

--- a/windows/Ghostty.Tests/Cli/CliAliasParityTests.cs
+++ b/windows/Ghostty.Tests/Cli/CliAliasParityTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Cli;
+using Xunit;
+
+namespace Ghostty.Tests.Cli;
+
+// Pins CliAliases.Actions to the Action enum in src/cli/ghostty.zig.
+//
+// The Windows subcommand aliases are upstream divergence, and the alias
+// table is the part that rots: upstream adds an action, nobody notices,
+// and `wintty <new-action>` silently opens a terminal window instead of
+// running it. This fails the build instead.
+//
+// Same technique as EntryPointParityTests, which pins [LibraryImport]
+// entry points against zig `export fn` sites. The zig source is embedded
+// by Ghostty.Tests.csproj rather than read from disk, so the test does not
+// depend on where the assembly runs from.
+public class CliAliasParityTests
+{
+    private const string ActionResource = "Ghostty.Tests.Cli.Actions.ghostty.zig";
+
+    // `pub const Action = enum {` opens the block; the first four-space
+    // `pub fn` (detectSpecialCase) closes it. Slicing rather than scanning
+    // the whole file keeps runMain's `.@"list-themes" =>` switch prongs,
+    // which look exactly like field declarations, out of the corpus.
+    private const string EnumOpen = "pub const Action = enum {";
+    private static readonly Regex DeclStart = new(
+        @"^    pub fn ", RegexOptions.Compiled | RegexOptions.Multiline);
+
+    // Both spellings zig permits for these names: bare `ssh,` and quoted
+    // `@"list-themes",`. Anchored to end of line so nothing longer can
+    // masquerade as a field.
+    private static readonly Regex FieldPattern = new(
+        @"^\s*(?:@""(?<name>[^""]+)""|(?<name>[A-Za-z_][A-Za-z0-9_]*)),\s*$",
+        RegexOptions.Compiled);
+
+    // Lines that legitimately appear between fields.
+    private static readonly Regex IgnorablePattern = new(
+        @"^\s*(?://.*)?$", RegexOptions.Compiled);
+
+    [Fact]
+    public void EveryLibghosttyActionHasAnAlias()
+    {
+        var declared = ReadActionFields();
+
+        Assert.NotEmpty(declared);
+
+        var missing = declared.Except(CliAliases.Actions, StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal).ToList();
+        var stale = CliAliases.Actions.Except(declared, StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal).ToList();
+
+        if (missing.Count > 0 || stale.Count > 0)
+        {
+            Assert.Fail(
+                "CliAliases.Actions is out of sync with the Action enum in " +
+                "src/cli/ghostty.zig.\n" +
+                (missing.Count > 0
+                    ? "Actions libghostty exposes with no Windows alias (add them " +
+                      "to CliAliases.Actions):\n" +
+                      string.Join("\n", missing.Select(n => $"  {n}")) + "\n"
+                    : string.Empty) +
+                (stale.Count > 0
+                    ? "Aliases with no matching action (upstream removed them; " +
+                      "delete them from CliAliases.Actions):\n" +
+                      string.Join("\n", stale.Select(n => $"  {n}"))
+                    : string.Empty));
+        }
+    }
+
+    // Without this, an upstream action declared in a syntax FieldPattern
+    // does not match would be absent from BOTH sets, set equality would
+    // hold, and a missing alias would ship on a green build.
+    [Fact]
+    public void EveryLineInTheEnumBlockIsAccountedFor()
+    {
+        var unrecognized = EnumBlockLines()
+            .Where(line => !FieldPattern.IsMatch(line) && !IgnorablePattern.IsMatch(line))
+            .ToList();
+
+        if (unrecognized.Count > 0)
+        {
+            Assert.Fail(
+                "Unrecognized lines inside the Action enum block in " +
+                "src/cli/ghostty.zig. The field regex in CliAliasParityTests no " +
+                "longer describes how upstream declares actions, so the parity " +
+                "check above can no longer see them:\n" +
+                string.Join("\n", unrecognized.Select(l => $"  {l}")));
+        }
+    }
+
+    // Guards the csproj resource entry. Losing it would make both tests
+    // above scan an empty string.
+    [Fact]
+    public void ActionSourceIsEmbedded()
+    {
+        Assert.Contains(
+            ActionResource,
+            Assembly.GetExecutingAssembly().GetManifestResourceNames());
+    }
+
+    // Program.IsHelpRequest and the version check mirror three comparisons
+    // from Action.detectSpecialCase. The name list above cannot see a
+    // change to those, so pin their text directly.
+    [Fact]
+    public void SpecialCaseHandlingIsUnchanged()
+    {
+        var source = ReadActionSource();
+        var start = source.IndexOf("pub fn detectSpecialCase", StringComparison.Ordinal);
+        Assert.True(start >= 0, "detectSpecialCase is gone from src/cli/ghostty.zig.");
+        var body = source[start..];
+
+        foreach (var expected in new[]
+                 {
+                     @"std.mem.eql(u8, arg, ""-e"")",
+                     @"std.mem.eql(u8, arg, ""--version"")",
+                     @"std.mem.eql(u8, arg, ""--help"")",
+                     @"std.mem.eql(u8, arg, ""-h"")",
+                 })
+        {
+            Assert.True(
+                body.Contains(expected, StringComparison.Ordinal),
+                $"Upstream changed CLI special-case handling: {expected} is gone " +
+                "from Action.detectSpecialCase. Re-check Program.IsHelpRequest and " +
+                "the version interception in Program.MainImpl.");
+        }
+    }
+
+    private static HashSet<string> ReadActionFields()
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var line in EnumBlockLines())
+        {
+            var match = FieldPattern.Match(line);
+            if (match.Success) names.Add(match.Groups["name"].Value);
+        }
+        return names;
+    }
+
+    private static IEnumerable<string> EnumBlockLines()
+    {
+        var source = ReadActionSource();
+
+        var open = source.IndexOf(EnumOpen, StringComparison.Ordinal);
+        Assert.True(open >= 0, $"'{EnumOpen}' not found in src/cli/ghostty.zig.");
+        var bodyStart = open + EnumOpen.Length;
+
+        var decl = DeclStart.Match(source, bodyStart);
+        Assert.True(decl.Success, "No `pub fn` closes the Action enum field block.");
+
+        return source[bodyStart..decl.Index]
+            .Split('\n')
+            .Select(l => l.TrimEnd('\r'));
+    }
+
+    private static string ReadActionSource()
+    {
+        using var stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream(ActionResource);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty.Tests/Cli/CliAliasTests.cs
+++ b/windows/Ghostty.Tests/Cli/CliAliasTests.cs
@@ -1,0 +1,147 @@
+using System.Linq;
+using Ghostty.Core.Cli;
+using Xunit;
+
+namespace Ghostty.Tests.Cli;
+
+// Behaviour of the bare-subcommand rewrite. The tokenizer under test
+// mirrors std.process.Args.Iterator.Windows, so the cases that matter are
+// the ones where a naive "split on whitespace" would disagree with what
+// libghostty actually parses out of the same string.
+public class CliAliasTests
+{
+    [Theory]
+    // The point of the feature.
+    [InlineData(@"wintty.exe list-themes", @"wintty.exe +list-themes")]
+    [InlineData(@"wintty.exe ssh user@host", @"wintty.exe +ssh user@host")]
+    // argv[0] quoting: the space inside the path is not a separator.
+    [InlineData(@"""C:\Program Files\Wintty\wintty.exe"" list-themes",
+                @"""C:\Program Files\Wintty\wintty.exe"" +list-themes")]
+    // Tab is a separator; the run of spaces is preserved verbatim.
+    [InlineData("wintty.exe\tlist-themes", "wintty.exe\t+list-themes")]
+    [InlineData(@"wintty.exe   list-themes", @"wintty.exe   +list-themes")]
+    // Everything past the first argument is untouched.
+    [InlineData(@"wintty.exe show-config --font-size=12 ""a b""",
+                @"wintty.exe +show-config --font-size=12 ""a b""")]
+    public void RewritesBareSubcommand(string commandLine, string expected)
+    {
+        Assert.True(CliAliases.TryRewrite(commandLine, out var rewritten, out var action));
+        Assert.Equal(expected, rewritten);
+        Assert.NotNull(action);
+    }
+
+    [Theory]
+    // Already in +action form.
+    [InlineData(@"wintty.exe +list-themes")]
+    // -e hands the line to a child command.
+    [InlineData(@"wintty.exe -e ssh myhost")]
+    [InlineData(@"wintty.exe notacommand")]
+    // Quote or backslash in the token: declined rather than guessed at.
+    [InlineData(@"wintty.exe ""list-themes""")]
+    [InlineData(@"wintty.exe \""list-themes\""")]
+    // No unquoted separator at all, so this is a single argv[0].
+    [InlineData(@"""wintty.exe""list-themes")]
+    // No arguments.
+    [InlineData(@"wintty.exe")]
+    [InlineData(@"wintty.exe ")]
+    [InlineData("")]
+    [InlineData("   ")]
+    // Only space and tab separate arguments on Windows. VT, LF and CR are
+    // ordinary characters, so these are all one argv[0].
+    [InlineData("wintty.exe\vlist-themes")]
+    [InlineData("wintty.exe\nlist-themes")]
+    [InlineData("wintty.exe\rlist-themes")]
+    // NUL terminates the command line before any argument.
+    [InlineData("wintty.exe\0list-themes")]
+    // A leading separator makes argv[0] empty, so the exe path becomes the
+    // first argument and is not an action.
+    [InlineData(@" wintty.exe list-themes")]
+    public void LeavesEverythingElseAlone(string commandLine)
+    {
+        Assert.False(CliAliases.TryRewrite(commandLine, out var rewritten, out var action));
+        Assert.Equal(commandLine, rewritten);
+        Assert.Null(action);
+    }
+
+    [Fact]
+    public void PreservesUnpairedSurrogatesInLaterArguments()
+    {
+        // A lone high surrogate is representable in a Windows command line
+        // and in a .NET string, and libghostty round-trips it through
+        // WTF-8. Splicing must not disturb it.
+        var commandLine = "wintty.exe show-config --config-file=\ud800tail";
+
+        Assert.True(CliAliases.TryRewrite(commandLine, out var rewritten, out _));
+        Assert.Equal("wintty.exe +show-config --config-file=\ud800tail", rewritten);
+    }
+
+    // The invariant the dispatch gate in Program.MainImpl depends on: if
+    // TryRewrite reports an alias, libghostty is guaranteed to receive the
+    // +action form. A future action name the tokenizer declines to splice
+    // would fail here rather than gating a command open that does nothing.
+    [Fact]
+    public void EveryActionRewritesFromABareFirstArgument()
+    {
+        foreach (var name in CliAliases.Actions)
+        {
+            Assert.True(
+                CliAliases.TryRewrite($"wintty.exe {name}", out var rewritten, out var action),
+                $"'{name}' is in Actions but does not rewrite from a bare first argument.");
+            Assert.Equal($"wintty.exe +{name}", rewritten);
+            Assert.Equal(name, action);
+        }
+    }
+
+    [Theory]
+    [InlineData("list-themes", true)]
+    [InlineData("boo", true)]
+    [InlineData("notacommand", true)]
+    [InlineData("list-theme", true)]
+    // Flags, paths and anything capitalised are not mistyped verbs.
+    [InlineData("--font-size=12", false)]
+    [InlineData("-e", false)]
+    [InlineData("/?", false)]
+    [InlineData(@"C:\tmp\a.txt", false)]
+    [InlineData("List-Themes", false)]
+    [InlineData("list_themes", false)]
+    [InlineData("2fast", false)]
+    [InlineData("", false)]
+    public void LooksLikeCommandMatchesBareVerbsOnly(string arg, bool expected)
+        => Assert.Equal(expected, CliAliases.LooksLikeCommand(arg));
+
+    [Fact]
+    public void HelpListsEveryActionAndBothSpellings()
+    {
+        var help = CliAliases.RenderHelp("wintty");
+
+        foreach (var name in CliAliases.Actions)
+            Assert.Contains($"  {name}\n", help);
+
+        // The whole point is telling the reader both forms exist.
+        Assert.Contains("+command", help);
+        Assert.Contains("wintty +list-themes", help);
+
+        // Upstream's help text is wrong on Windows in these three specific
+        // ways; regressing to it would be silent otherwise.
+        Assert.DoesNotContain("ghostty [", help);
+        Assert.DoesNotContain("open -na", help);
+        Assert.DoesNotContain("src/config/Config.zig", help);
+    }
+
+    [Fact]
+    public void HelpUsesTheProgramNameItIsGiven()
+        => Assert.Contains("Usage: wt [command]", CliAliases.RenderHelp("wt"));
+
+    [Fact]
+    public void ActionsAreSortedInHelp()
+    {
+        var help = CliAliases.RenderHelp("wintty");
+        var offsets = CliAliases.Actions
+            .OrderBy(static n => n, System.StringComparer.Ordinal)
+            .Select(n => help.IndexOf($"  {n}\n", System.StringComparison.Ordinal))
+            .ToList();
+
+        Assert.DoesNotContain(-1, offsets);
+        Assert.Equal(offsets.OrderBy(static o => o), offsets);
+    }
+}

--- a/windows/Ghostty.Tests/Cli/CliAliasTests.cs
+++ b/windows/Ghostty.Tests/Cli/CliAliasTests.cs
@@ -109,6 +109,37 @@ public class CliAliasTests
     public void LooksLikeCommandMatchesBareVerbsOnly(string arg, bool expected)
         => Assert.Equal(expected, CliAliases.LooksLikeCommand(arg));
 
+    [Theory]
+    // Bare and + spellings of the help command itself.
+    [InlineData(true, "help")]
+    [InlineData(true, "+help")]
+    // Fallback flags, with no action present.
+    [InlineData(true, "--help")]
+    [InlineData(true, "-h")]
+    [InlineData(true, "/?")]
+    [InlineData(true, "--font-size=12", "--help")]
+    // An action owns --help: only libghostty can render per-action help.
+    [InlineData(false, "+list-themes", "--help")]
+    [InlineData(false, "list-themes", "--help")]
+    // -e hands the line to a child command, so the flag is the child's.
+    // The second case is the ordering that matters: upstream's
+    // abort_if_no_action fires on -e even though --help came first.
+    [InlineData(false, "-e", "pwsh", "--help")]
+    [InlineData(false, "--help", "-e", "pwsh")]
+    [InlineData(false, "-e", "pwsh")]
+    [InlineData(false, "notacommand")]
+    public void IsHelpRequestMatchesUpstreamFallbackRules(bool expected, params string[] args)
+    {
+        // Mirrors what Program.MainImpl passes: the alias flag comes from
+        // TryRewrite over the same invocation.
+        var isAlias = args.Length > 0 && CliAliases.Actions.Contains(args[0]);
+        Assert.Equal(expected, CliAliases.IsHelpRequest(args, isAlias));
+    }
+
+    [Fact]
+    public void IsHelpRequestIgnoresEmptyArgs()
+        => Assert.False(CliAliases.IsHelpRequest([], false));
+
     [Fact]
     public void HelpListsEveryActionAndBothSpellings()
     {

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -96,6 +96,14 @@
     <EmbeddedResource Include="..\..\src\main_c.zig"
                       Link="Interop\Exports\main_c.zig"
                       LogicalName="Ghostty.Tests.Interop.Exports.main_c.zig" />
+    <!--
+      The CLI Action enum, for CliAliasParityTests. Deliberately NOT under
+      the Interop.Exports prefix: EntryPointParityTests selects its corpus
+      by that prefix and would silently absorb this file.
+    -->
+    <EmbeddedResource Include="..\..\src\cli\ghostty.zig"
+                      Link="Cli\Actions\ghostty.zig"
+                      LogicalName="Ghostty.Tests.Cli.Actions.ghostty.zig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -396,11 +396,23 @@ internal static partial class NativeMethods
     /// <remarks>
     /// The marshalled buffer is intentionally never freed: libghostty keeps
     /// a reference to it for as long as the args are readable, which is the
-    /// life of the process. The OS reclaims it on exit.
+    /// life of the process. The OS reclaims it on exit. That unmanaged copy
+    /// is what discharges the borrow, so the managed string it came from may
+    /// be a temporary. Do not "optimize" this into a <c>fixed</c> pointer or
+    /// a pinned handle over a local: libghostty reads the buffer long after
+    /// this method returns.
+    ///
+    /// This is also the choke point where a bare Windows subcommand becomes
+    /// its <c>+action</c> form, so no caller can forget it. The rewrite is
+    /// assigned back through <c>cmdline</c> on purpose: the string that gets
+    /// marshalled and the string that gets measured must be the same object,
+    /// or libghostty is handed a buffer longer than the length it is told and
+    /// silently drops the last character of the last argument.
     /// </remarks>
     internal static int InitWideFromProcess()
     {
         var cmdline = Environment.CommandLine;
+        Ghostty.Core.Cli.CliAliases.TryRewrite(cmdline, out cmdline, out _);
         var buf = Marshal.StringToHGlobalUni(cmdline);
         return InitWide(buf, (UIntPtr)cmdline.Length);
     }

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -192,7 +192,7 @@ public static partial class Program
         // Help is rendered Windows-side for every spelling, including
         // +help. libghostty's help text names `ghostty`, points at
         // src/config/Config.zig, and explains `open -na Ghostty.app`.
-        if (IsHelpRequest(args, isAlias))
+        if (Ghostty.Core.Cli.CliAliases.IsHelpRequest(args, isAlias))
         {
             Console.Out.Write(Ghostty.Core.Cli.CliAliases.RenderHelp(ProgramName()));
             Console.Out.Flush();
@@ -301,33 +301,6 @@ public static partial class Program
         // Lowercased because that is how the command gets typed, and
         // Windows does not care either way.
         return name.ToLowerInvariant();
-    }
-
-    /// <summary>
-    /// Whether to print the Windows-native usage text instead of running
-    /// an action or starting the GUI.
-    /// </summary>
-    private static bool IsHelpRequest(string[] args, bool isAlias)
-    {
-        if (args.Length == 0) return false;
-
-        // An explicit help command in the first position, either spelling.
-        if (args[0] == "help" || args[0] == "+help") return true;
-
-        // Any other action owns --help: it prints that action's own help,
-        // which only libghostty can render.
-        if (args[0].StartsWith('+') || isAlias) return false;
-
-        foreach (var arg in args)
-        {
-            // -e hands the rest of the line to the child command, so a
-            // --help after it is the child's flag, not ours. Matches
-            // abort_if_no_action in src/cli/action.zig.
-            if (arg == "-e") return false;
-            if (arg == "--help" || arg == "-h" || arg == "/?") return true;
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -253,10 +253,14 @@ public static partial class Program
             !args[0].StartsWith('+') &&
             Ghostty.Core.Cli.CliAliases.LooksLikeCommand(args[0]))
         {
-            Console.Error.WriteLine(
+            // stdout, not stderr: RedirectStderrToFile above has already
+            // pointed STD_ERROR_HANDLE at %LOCALAPPDATA%\Wintty\gpu.log, so
+            // anything written to stderr from here is invisible to the user.
+            // The exit code carries the error for scripts.
+            Console.Out.WriteLine(
                 $"unknown command '{args[0]}'. " +
                 $"Run '{ProgramName()} --help' for a list of commands.");
-            Console.Error.Flush();
+            Console.Out.Flush();
             Environment.Exit(1);
         }
 

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -167,11 +167,36 @@ public static partial class Program
         // +version is intercepted here, before the libghostty CLI
         // dispatcher. The renderer lives in C# so it can also drive the
         // Version palette dialog with the same output.
+        //
+        // Still first-argument only. libghostty treats --version as
+        // unconditional, so `wintty --font-size=12 --version` detects the
+        // action and never runs it, which also silences stderr logging for
+        // the session. That is a pre-existing bug and widening the check
+        // here would only paper over half of it.
         if (args.Length > 0 &&
-            (args[0] == "+version" || args[0] == "--version" || args[0] == "-v"))
+            (args[0] == "+version" || args[0] == "--version" ||
+             args[0] == "-v" || args[0] == "version"))
         {
             RegisterNativeResolver();
             Environment.Exit(Cli.CliActions.PrintVersion());
+        }
+
+        // Does the command line lead with a bare Windows subcommand, e.g.
+        // `wintty list-themes`? This is the same call InitWideFromProcess
+        // makes to perform the rewrite, over the same input, so the gate
+        // below can never open on something the rewrite would then fail to
+        // deliver to libghostty.
+        var isAlias = Ghostty.Core.Cli.CliAliases.TryRewrite(
+            Environment.CommandLine, out _, out _);
+
+        // Help is rendered Windows-side for every spelling, including
+        // +help. libghostty's help text names `ghostty`, points at
+        // src/config/Config.zig, and explains `open -na Ghostty.app`.
+        if (IsHelpRequest(args, isAlias))
+        {
+            Console.Out.Write(Ghostty.Core.Cli.CliAliases.RenderHelp(ProgramName()));
+            Console.Out.Flush();
+            Environment.Exit(0);
         }
 
         // CLI actions are delegated to libghostty, matching the macOS
@@ -182,12 +207,27 @@ public static partial class Program
         // inherit the terminal's console handles natively. This lets
         // Zig's isTty() return true and the Vaxis interactive TUI work.
         // For GUI mode we detach from the console immediately.
-        if (args.Length > 0 && args[0].StartsWith('+'))
+        //
+        // The StartsWith('+') half of the gate is deliberately unchanged
+        // and deliberately not narrowed to known actions: `+bogus` and
+        // `+a +b` have to keep reaching libghostty so it can reject them
+        // and we can exit with InitFailed, rather than silently opening a
+        // window on a typo.
+        if (args.Length > 0 && (args[0].StartsWith('+') || isAlias))
         {
-            // +list-themes (without -tui): try the in-process picker first
+            // list-themes (without -tui): try the in-process picker first
             // by sending LIST_THEMES to a running Ghostty app's pipe.
-            if (args[0] == "+list-themes" && TrySendListThemesMessage())
+            //
+            // Only for a lone argument. The picker cannot honour flags, so
+            // `+list-themes --help` used to reach it and exit 0 having
+            // printed nothing - and the help text above now sends readers
+            // straight at that.
+            if (args.Length == 1 &&
+                (args[0] == "+list-themes" || args[0] == "list-themes") &&
+                TrySendListThemesMessage())
+            {
                 Environment.Exit(0);
+            }
 
             RegisterNativeResolver();
             InitGhostty();
@@ -196,6 +236,28 @@ public static partial class Program
             CleanupThemeCallback();
             if (exitCode >= 0)
                 Environment.Exit(exitCode);
+        }
+
+        // A bare word that is not a command is a typo, not a config key.
+        // libghostty records it as an "invalid field" diagnostic and opens
+        // a window anyway; once we tell users wintty takes subcommands,
+        // that silence is the wrong answer. Narrow on purpose: paths,
+        // flags and -e payloads never match.
+        //
+        // The isAlias / '+' guard keeps this quiet on the one path that
+        // reaches here with a real action: libghostty returning -1 from
+        // CliRunAction. Falling through to the GUI is what that did before,
+        // and "unknown command 'list-themes'" would be a lie.
+        if (args.Length > 0 &&
+            !isAlias &&
+            !args[0].StartsWith('+') &&
+            Ghostty.Core.Cli.CliAliases.LooksLikeCommand(args[0]))
+        {
+            Console.Error.WriteLine(
+                $"unknown command '{args[0]}'. " +
+                $"Run '{ProgramName()} --help' for a list of commands.");
+            Console.Error.Flush();
+            Environment.Exit(1);
         }
 
         // Detach from the console before starting WinUI, but ONLY
@@ -221,6 +283,47 @@ public static partial class Program
             FreeConsole();
 
         return StartGui();
+    }
+
+    /// <summary>
+    /// Name to print in usage and error text. Derived from the running
+    /// binary rather than hardcoded so a rebrand does not leave the CLI
+    /// telling users to run a command that no longer exists.
+    /// </summary>
+    private static string ProgramName()
+    {
+        var name = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? string.Empty);
+        if (string.IsNullOrEmpty(name)) name = Ghostty.Core.AppIdentity.ProductName;
+        // Lowercased because that is how the command gets typed, and
+        // Windows does not care either way.
+        return name.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Whether to print the Windows-native usage text instead of running
+    /// an action or starting the GUI.
+    /// </summary>
+    private static bool IsHelpRequest(string[] args, bool isAlias)
+    {
+        if (args.Length == 0) return false;
+
+        // An explicit help command in the first position, either spelling.
+        if (args[0] == "help" || args[0] == "+help") return true;
+
+        // Any other action owns --help: it prints that action's own help,
+        // which only libghostty can render.
+        if (args[0].StartsWith('+') || isAlias) return false;
+
+        foreach (var arg in args)
+        {
+            // -e hands the rest of the line to the child command, so a
+            // --help after it is the child's flag, not ours. Matches
+            // abort_if_no_action in src/cli/action.zig.
+            if (arg == "-e") return false;
+            if (arg == "--help" || arg == "-h" || arg == "/?") return true;
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
`wintty +list-themes` is a Ghostty-ism. On Windows a verb is a bare subcommand (`winget install`, `dotnet build`), and nothing told a Windows user the `+` form existed, because `wintty --help` just launched the GUI.

So `wintty list-themes` works now, and `--help` prints a usage block listing the commands. `+action` keeps working; nothing is removed or deprecated.

## How

libghostty parses the raw WTF-16 command line, not our argv, so the alias has to be spliced into that string before `ghostty_init_wide` sees it. `CliAliases.TryRewrite` inserts one `+` at the first argument's offset. Finding that offset means mirroring `std.process.Args.Iterator.Windows` exactly: quote-toggling `argv[0]`, no leading-separator skip, space and tab as the only separators. It declines on a quote or backslash in the token, so `wintty "list-themes"` behaves as it does today instead of needing the escaping rules reimplemented correctly.

The rewrite lives in `InitWideFromProcess`, the single call site, so no caller can forget it. `Program.MainImpl` calls the same function over the same input to decide whether to take the CLI path, so the gate cannot open on something the rewrite would then fail to deliver.

libghostty stays the authority on action detection. An earlier draft ported `detectIter` into C# and that was wrong: it collapsed `InvalidAction` and `MultipleActions` to "no action", which would have turned `wintty +list-themse` from "exit 2 with a message" into "a terminal window opens". The gate still opens for anything starting with `+`.

## Drift guard

The alias table is upstream divergence, so `CliAliasParityTests` pins it to the `Action` enum in `src/cli/ghostty.zig`, embedded as a resource the way `EntryPointParityTests` does for export sites.

Set equality alone is not enough: if upstream adds an action in a syntax the field regex misses, the name is absent from both sets, equality holds, and a missing alias ships green. So a second test fails on any line inside the enum block matching neither a field nor a comment. Both failure modes were provoked deliberately and observed to fail.

## Behaviour changes

Everything else is additive, including `+bogus`, `+a +b`, `wintty -e python --version` and every working `+action` invocation.

| input | before | after |
| --- | --- | --- |
| `--help`, `-h`, `/?` | GUI launches | usage, exit 0 |
| `+help` | libghostty help | same usage, exit 0 |
| `--font-size=12 --help` | GUI launches | usage, exit 0 |
| `+list-themes --help` | picker, exit 0, no output | per-action help |
| `list-theme` (typo) | GUI launches | message, exit 1 |

`+help` is the biggest one. Upstream's text says `ghostty`, points at `src/config/Config.zig`, and explains `open -na Ghostty.app`; all three are wrong here.

The typo case goes beyond "add aliases" and is easy to drop if you disagree. The argument for it: once wintty advertises subcommands, typos become the common case, and silently ignoring an unknown verb is what makes a subcommand CLI feel broken. It is guarded to `^[a-z][a-z0-9-]*$`, so paths, flags and `-e` payloads never match, and nothing wintty invokes itself with is affected.

## Verification

1741 tests pass. Ran against a real build: `list-themes`, `show-config`, `list-fonts`, `validate-config`, `version`, `help`, `+help`, `-h`, `/?` all behave; `+bogus` and `+list-themes +show-config` still exit 2; `list-theme` exits 1 with the message; `-e pwsh --help` launches the GUI; `list-themes` and `+list-themes` both reach the in-process picker identically. `show-config` and `+show-config` produce byte-identical output.

The second commit fixes something the runtime pass caught: `RedirectStderrToFile` had been sending the typo message to `gpu.log` instead of the terminal. That redirect also hides libghostty's own CLI errors, which is why `+bogus` exits 2 silently. Pre-existing, tracked separately.

One `show-config` run returned exit -1 with no output and did not reproduce across six subsequent runs. Not Page Heap (no IFEO entry). Recording it rather than dismissing it.
