### PR TITLE
cli: report CLI argument errors instead of exiting silently

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -401,6 +401,45 @@ pub fn action() ?cli.ghostty.Action {
     return state.?.action;
 }
 
+/// Write a human-readable explanation of an `init` failure to stderr.
+///
+/// `init` reports a bad command line by returning an error, leaving `std.log`
+/// as the only other sink. libghostty silences that one: `Logging.stderr`
+/// above defaults to false whenever `app_runtime` is `none`, and it does so
+/// before the args are even parsed. An embedder that called us therefore had
+/// nothing to show for a typo but an exit code. Writing to the file directly
+/// skips the log sink so the message survives that default.
+///
+/// The exe has its own copy of this in `main_ghostty.zig`, where it runs
+/// before there is any global state to consult. Keep the wording in sync.
+///
+/// Only the argument-parsing errors get text here. Anything else stays with
+/// the caller's `std.log.err`, which reaches an embedder that registered a
+/// callback via `ghostty_log_set_callback`.
+pub fn reportInitError(err: anyerror) void {
+    const message = switch (err) {
+        error.MultipleActions =>
+            "Error: multiple CLI actions specified. You must specify only one\n" ++
+            "action starting with the `+` character.\n",
+
+        error.InvalidAction =>
+            "Error: unknown CLI action specified. CLI actions are specified with\n" ++
+            "the '+' character.\n\n" ++
+            "All valid CLI actions can be listed with `ghostty +help`\n",
+
+        else => return,
+    };
+
+    // Streaming, not the seekable `writer`: an embedder may have pointed
+    // stderr at a file it is also writing to itself, and a positional write
+    // would start at offset 0 and overwrite what is already there. Streaming
+    // writes go wherever the shared handle's file pointer sits.
+    std.Io.File.stderr().writeStreamingAll(
+        std.Io.Threaded.global_single_threaded.io(),
+        message,
+    ) catch return;
+}
+
 /// This represents the global process state. There should only
 /// be one of these at any given moment. This is extracted into a dedicated
 /// struct because it is reused by main and the static C lib.

--- a/src/global.zig
+++ b/src/global.zig
@@ -417,27 +417,58 @@ pub fn action() ?cli.ghostty.Action {
 /// the caller's `std.log.err`, which reaches an embedder that registered a
 /// callback via `ghostty_log_set_callback`.
 pub fn reportInitError(err: anyerror) void {
-    const message = switch (err) {
-        error.MultipleActions =>
-            "Error: multiple CLI actions specified. You must specify only one\n" ++
-            "action starting with the `+` character.\n",
-
-        error.InvalidAction =>
-            "Error: unknown CLI action specified. CLI actions are specified with\n" ++
-            "the '+' character.\n\n" ++
-            "All valid CLI actions can be listed with `ghostty +help`\n",
-
-        else => return,
-    };
+    const message = initErrorMessage(err) orelse return;
 
     // Streaming, not the seekable `writer`: an embedder may have pointed
     // stderr at a file it is also writing to itself, and a positional write
     // would start at offset 0 and overwrite what is already there. Streaming
     // writes go wherever the shared handle's file pointer sits.
+    //
+    // The global Io rather than `io()`: `init` can fail before it reaches
+    // `io_impl`, which `io()` asserts has been initialized.
     std.Io.File.stderr().writeStreamingAll(
         std.Io.Threaded.global_single_threaded.io(),
         message,
     ) catch return;
+}
+
+/// The text `reportInitError` writes for `err`, or null for errors with no
+/// user-facing explanation, which stay with the caller's `std.log.err`.
+///
+/// Split from the write so the mapping can be tested without capturing stderr.
+fn initErrorMessage(err: anyerror) ?[]const u8 {
+    return switch (err) {
+        error.MultipleActions => "Error: multiple CLI actions specified. You must specify only one\n" ++
+            "action starting with the `+` character.\n",
+
+        error.InvalidAction => "Error: unknown CLI action specified. CLI actions are specified with\n" ++
+            "the '+' character.\n\n" ++
+            "All valid CLI actions can be listed with `ghostty +help`\n",
+
+        else => null,
+    };
+}
+
+test "initErrorMessage explains the CLI argument errors" {
+    const testing = std.testing;
+
+    // The exe prints its own copy of these from main_ghostty.zig. If either
+    // side is reworded, both should say the same thing.
+    try testing.expectEqualStrings(
+        "Error: unknown CLI action specified. CLI actions are specified with\n" ++
+            "the '+' character.\n\n" ++
+            "All valid CLI actions can be listed with `ghostty +help`\n",
+        initErrorMessage(cli.action.DetectError.InvalidAction).?,
+    );
+    try testing.expectEqualStrings(
+        "Error: multiple CLI actions specified. You must specify only one\n" ++
+            "action starting with the `+` character.\n",
+        initErrorMessage(cli.action.DetectError.MultipleActions).?,
+    );
+}
+
+test "initErrorMessage leaves other errors to the log" {
+    try std.testing.expect(initErrorMessage(error.OutOfMemory) == null);
 }
 
 /// This represents the global process state. There should only

--- a/src/main_c.zig
+++ b/src/main_c.zig
@@ -133,6 +133,7 @@ pub export fn ghostty_init(argc: usize, argv: [*][*:0]u8) c_int {
         },
     }) catch |err| {
         std.log.err("failed to initialize ghostty error={}", .{err});
+        global.reportInitError(err);
         return 1;
     };
 
@@ -164,6 +165,7 @@ fn ghosttyInitWide(cmdline: [*]const u16, len: usize) callconv(.c) c_int {
         },
     }) catch |err| {
         std.log.err("failed to initialize ghostty error={}", .{err});
+        global.reportInitError(err);
         return 1;
     };
 

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -85,19 +85,38 @@ public static partial class Program
     /// <summary>
     /// Persistent GPU diagnostic log path.  Survives reboot so we can
     /// read crash details after a GPU driver crash takes down the machine.
-    /// Located next to the executable so it's easy to find.
     /// </summary>
     private static readonly string GpuLogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Wintty", "gpu.log");
 
     /// <summary>
+    /// Set to any value to force the <see cref="GpuLogPath"/> redirect on for
+    /// a CLI action, which otherwise keeps the terminal's stderr. This is an
+    /// environment variable rather than a command line flag because
+    /// libghostty parses the process command line itself and rejects any
+    /// option it does not recognize.
+    /// </summary>
+    private const string GpuLogEnvVar = "WINTTY_GPU_LOG";
+
+    private static bool _stderrRedirected;
+
+    /// <summary>
     /// Redirect stderr to a file so all diagnostic output (Zig std.log,
     /// C# Console.Error, DX12 debug layer via OutputDebugString) is
     /// persisted to disk.  Called before any native GPU code runs.
+    ///
+    /// Idempotent: the GUI path and the <see cref="GpuLogEnvVar"/> opt-in can
+    /// both reach it, and re-opening would truncate the log we just wrote.
     /// </summary>
     private static void RedirectStderrToFile()
     {
+        if (_stderrRedirected) return;
+
+        // Set before the attempt, not after: a redirect that failed once is
+        // not going to succeed on a retry, and reopening would truncate.
+        _stderrRedirected = true;
+
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(GpuLogPath)!);
@@ -159,11 +178,6 @@ public static partial class Program
 
     static int MainImpl(string[] args)
     {
-        // Persist GPU diagnostics to disk before any native code runs.
-        // After a GPU driver crash, the log at %LOCALAPPDATA%\Ghostty\gpu.log
-        // survives reboot and tells us exactly what went wrong.
-        RedirectStderrToFile();
-
         // +version is intercepted here, before the libghostty CLI
         // dispatcher. The renderer lives in C# so it can also drive the
         // Version palette dialog with the same output.
@@ -215,6 +229,18 @@ public static partial class Program
         // window on a typo.
         if (args.Length > 0 && (args[0].StartsWith('+') || isAlias))
         {
+            // A CLI action keeps the terminal's stderr, so that libghostty's
+            // own argument errors reach the user: `wintty +bogus` reports
+            // InvalidAction, `wintty +list-themes +show-config` reports
+            // MultipleActions. Redirecting first turned both into a bare exit
+            // code with the reason buried in a log file.
+            //
+            // WINTTY_GPU_LOG opts back into the file, which is how you capture
+            // diagnostics from a CLI run that has no console to print to (a
+            // scheduled task, a Start Menu launch).
+            if (Environment.GetEnvironmentVariable(GpuLogEnvVar) is not null)
+                RedirectStderrToFile();
+
             // list-themes (without -tui): try the in-process picker first
             // by sending LIST_THEMES to a running Ghostty app's pipe.
             //
@@ -253,16 +279,21 @@ public static partial class Program
             !args[0].StartsWith('+') &&
             Ghostty.Core.Cli.CliAliases.LooksLikeCommand(args[0]))
         {
-            // stdout, not stderr: RedirectStderrToFile above has already
-            // pointed STD_ERROR_HANDLE at %LOCALAPPDATA%\Wintty\gpu.log, so
-            // anything written to stderr from here is invisible to the user.
-            // The exit code carries the error for scripts.
-            Console.Out.WriteLine(
+            Console.Error.WriteLine(
                 $"unknown command '{args[0]}'. " +
                 $"Run '{ProgramName()} --help' for a list of commands.");
-            Console.Out.Flush();
+            Console.Error.Flush();
             Environment.Exit(1);
         }
+
+        // Persist GPU diagnostics to disk before any native code runs. After
+        // a GPU driver crash the log at %LOCALAPPDATA%\Wintty\gpu.log survives
+        // reboot and tells us exactly what went wrong. Nothing above this line
+        // touches the GPU, so starting here costs the GUI no coverage.
+        //
+        // Also covers the case where the block above found no action to run
+        // and fell through to the GUI; the call is idempotent.
+        RedirectStderrToFile();
 
         // Detach from the console before starting WinUI, but ONLY
         // when we are the console's sole owner. Explorer / Start


### PR DESCRIPTION
`wintty +bogus` exited 2 and printed nothing. So did `wintty +list-themes +show-config`. A typo got you a bare exit code.

Two separate causes.

**The message was never written.** The `InvalidAction` and `MultipleActions` text lives in `main_ghostty.zig`'s `main()`, which the exe runs and the C ABI does not. `ghostty_init` and `ghostty_init_wide` only had a `std.log.err`, and libghostty silences that one: `Logging.stderr` defaults to false whenever `app_runtime` is `none`, set before the args are even parsed. Nothing reached any sink. This adds `reportInitError` next to that default and calls it from both entry points. It writes to the file directly rather than through `std.log`, so the silenced sink doesn't apply.

**Even once written, it went to a log file.** `RedirectStderrToFile` was `MainImpl`'s first statement, pointing `STD_ERROR_HANDLE` at `%LOCALAPPDATA%\Wintty\gpu.log` before the CLI dispatch. That log exists to persist GPU driver crash details across a reboot, which only the GUI needs. The call moves below the dispatch so CLI actions keep the terminal's stderr. Nothing above it touches the GPU, so the GUI loses no coverage.

That gave up one case: a CLI action with no console used to have its output captured in the log and would now have nowhere to send it. `WINTTY_GPU_LOG` opts back in. It's an environment variable rather than a flag because libghostty parses the process command line itself and rejects options it doesn't recognize, and the Windows entry point passes that command line straight through, so there's no point at which a wintty-only flag could be stripped.

Since 573 landed first, this also retires the workaround it needed: `unknown command '...'` went to stdout because stderr was already pointed at the log file by then. That path now runs before the redirect, so it goes back to `Console.Error` where it belongs.

## Verified

| | |
|---|---|
| `wintty +bogus` | exit 2, InvalidAction text on stderr, no gpu.log |
| `wintty +list-themes +show-config` | exit 2, MultipleActions text on stderr |
| `wintty list-theme` | exit 1, unknown-command text on stderr (was stdout) |
| `+show-config` / `show-config` / `+version` / `version` / `--help` / `list-themes` | exit 0, stdout only, clean stderr |
| `WINTTY_GPU_LOG=1 wintty +bogus` | terminal silent, message appended to gpu.log after the header |
| GUI launch | window opens, gpu.log written as before |
| `zig build test -Dapp-runtime=none` | 83/83 steps, 3520/3576 passed, 56 skipped |
| Cross-compile linux-gnu / aarch64-macos | exit 0 |

## Notes

`reportInitError` writes streaming rather than positionally. The seekable writer starts at offset 0, which overwrote the header the C# side had already written to the same handle when both were logging to the file.

The exe keeps its own copy of the two strings, since it runs before there is global state to consult. `initErrorMessage` is split out so the mapping is unit tested against the exact text, which is what keeps the two copies honest.

The text still says `` `ghostty +help` ``, matching the exe's copy. There's no exe-name constant to key off, so rebranding it belongs with the rest of that work rather than diverging the two copies here.