### PR TITLE
init: refuse re-entrant global.init and use one init call site

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -66,8 +66,18 @@ pub const InitOpts = union(enum) {
     },
 };
 
-/// Initialize the global state.
+/// Initialize the global state. This may only be called once per process;
+/// a second call returns `error.AlreadyInitialized` and leaves the existing
+/// state untouched.
 pub fn init(opts: InitOpts) !void {
+    // The assignment below is unconditional, so re-initializing would leak
+    // the previous GPA, I/O instance, tmp dir and resources dir, and orphan
+    // the command line the args iterator borrows. Embedders reach here
+    // through the C API (`ghostty_init`, `ghostty_init_wide`), which already
+    // has a status channel for this, so refuse rather than assert: an
+    // assertion compiles out of exactly the release builds we ship.
+    if (state != null) return error.AlreadyInitialized;
+
     // Initialize ourself to nothing so we don't have any extra state.
     // IMPORTANT: this MUST be initialized before any log output because
     // the log function uses the global state.

--- a/src/global.zig
+++ b/src/global.zig
@@ -66,16 +66,14 @@ pub const InitOpts = union(enum) {
     },
 };
 
-/// Initialize the global state. This may only be called once per process;
-/// a second call returns `error.AlreadyInitialized` and leaves the existing
-/// state untouched.
+/// Initialize the global state. This may only be called once per process,
+/// including after `deinit`, which does not reset it. A second call returns
+/// `error.AlreadyInitialized` without touching the state already there.
 pub fn init(opts: InitOpts) !void {
     // The assignment below is unconditional, so re-initializing would leak
-    // the previous GPA, I/O instance, tmp dir and resources dir, and orphan
-    // the command line the args iterator borrows. Embedders reach here
-    // through the C API (`ghostty_init`, `ghostty_init_wide`), which already
-    // has a status channel for this, so refuse rather than assert: an
-    // assertion compiles out of exactly the release builds we ship.
+    // the previous GPA, I/O instance and resources dir, and orphan the
+    // command line the args iterator borrows. Returning before the errdefer
+    // below is armed leaves a live state usable by whoever owns it.
     if (state != null) return error.AlreadyInitialized;
 
     // Initialize ourself to nothing so we don't have any extra state.
@@ -553,3 +551,18 @@ pub const ResourceLimits = struct {
         if (self.nofile) |lim| internal_os.restoreMaxFiles(lim);
     }
 };
+
+test "init refuses a second call" {
+    // Both values are undefined because the re-entrancy check returns before
+    // it reads either one, so the test needs no real global state. Restore
+    // whatever was there so the rest of the suite is unaffected.
+    const prev = state;
+    defer state = prev;
+    const dummy: GlobalState = undefined;
+    state = dummy;
+
+    try std.testing.expectError(
+        error.AlreadyInitialized,
+        init(.{ .tool = undefined }),
+    );
+}

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -249,6 +249,7 @@ test {
     _ = @import("termio.zig");
     _ = @import("input.zig");
     _ = @import("cli.zig");
+    _ = @import("global.zig");
     _ = @import("surface_mouse.zig");
 
     // Libraries

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -335,13 +335,18 @@ public static partial class Program
     }
 
     /// <summary>
-    /// Initialize libghostty from this process's command line.
+    /// Initialize libghostty from this process's command line, exiting the
+    /// process if it fails.
+    ///
+    /// This is the single init entry point for both startup paths (the CLI
+    /// branch above and <see cref="Services.ConfigService"/> for the GUI).
+    /// It must run exactly once, before any other libghostty export.
     ///
     /// The marshalled buffer is intentionally not freed: libghostty keeps a
     /// reference to it and ghostty_cli_run_action reads the args later. The
     /// OS reclaims it on process exit.
     /// </summary>
-    private static void InitGhostty()
+    internal static void InitGhostty()
     {
         // Pass the real WTF-16 command line rather than rebuilding a UTF-8
         // argv. ghostty_init's char** cannot represent WTF-16, so it would
@@ -350,9 +355,20 @@ public static partial class Program
         var result = NativeMethods.InitWideFromProcess();
         if (result != 0)
         {
-            // ghostty_init failed (e.g. invalid action). The Zig
-            // code logs to stderr. Distinct exit code per the
-            // ExitCode enum above.
+            // ghostty_init failed (e.g. invalid action). There is no
+            // degraded mode to continue in: a failed init already ran
+            // global.init's errdefer, which deinits the allocator and the
+            // I/O instance every later export depends on.
+            //
+            // We write the reason ourselves because libghostty won't: the
+            // lib artifact builds with app_runtime == none, so global
+            // logging defaults to stderr = false and its own "failed to
+            // initialize" line goes nowhere unless GHOSTTY_LOG is set.
+            // Without this, a failed init is a silent exit 2.
+            Console.Error.WriteLine(
+                "[Ghostty] FATAL: ghostty_init failed, exiting with " +
+                $"{(int)ExitCode.InitFailed} ({nameof(ExitCode.InitFailed)})");
+            Console.Error.Flush();
             Environment.Exit((int)ExitCode.InitFailed);
         }
     }

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -23,7 +23,7 @@ public static partial class Program
     /// return whatever the native action produced via
     /// <c>Environment.Exit(exitCode)</c>.
     /// </summary>
-    internal enum ExitCode
+    private enum ExitCode
     {
         /// <summary>WinUI message loop returned cleanly, or a CLI
         /// action completed with exit code 0.</summary>
@@ -36,9 +36,9 @@ public static partial class Program
         /// <c>%LOCALAPPDATA%\CrashDumps\</c>.</summary>
         NativeCrash = 1,
 
-        /// <summary><c>ghostty_init</c> failed. The native library
-        /// already wrote the reason to stderr; no config means no
-        /// app.</summary>
+        /// <summary><c>ghostty_init</c> failed; no config means no app.
+        /// libghostty explains argument errors itself; the status and this
+        /// exit code come from <see cref="InitGhostty"/>.</summary>
         InitFailed = 2,
 
         /// <summary>Unhandled managed exception in the GUI startup
@@ -335,12 +335,26 @@ public static partial class Program
     }
 
     /// <summary>
+    /// Whether <see cref="InitGhostty"/> has already initialized libghostty.
+    /// </summary>
+    /// <remarks>
+    /// Both startup paths call it and both run on the thread <see cref="Main"/>
+    /// creates, which goes on to become the UI thread, so a plain field is
+    /// enough. libghostty refuses a second init, and it reports that refusal
+    /// with the same status as a real failure, so without this gate a
+    /// double-init would be indistinguishable from a fatal one.
+    /// </remarks>
+    private static bool _ghosttyInitialized;
+
+    /// <summary>
     /// Initialize libghostty from this process's command line, exiting the
-    /// process if it fails.
+    /// process if it fails. A second call is a no-op.
     ///
     /// This is the single init entry point for both startup paths (the CLI
     /// branch above and <see cref="Services.ConfigService"/> for the GUI).
-    /// It must run exactly once, before any other libghostty export.
+    /// It must run before any export that touches global state (config, app,
+    /// surface). Exports that only read static build data, such as
+    /// ghostty_build_info behind +version, do not need it.
     ///
     /// The marshalled buffer is intentionally not freed: libghostty keeps a
     /// reference to it and ghostty_cli_run_action reads the args later. The
@@ -348,6 +362,8 @@ public static partial class Program
     /// </summary>
     internal static void InitGhostty()
     {
+        if (_ghosttyInitialized) return;
+
         // Pass the real WTF-16 command line rather than rebuilding a UTF-8
         // argv. ghostty_init's char** cannot represent WTF-16, so it would
         // ignore what we passed and use the process command line anyway,
@@ -356,21 +372,30 @@ public static partial class Program
         if (result != 0)
         {
             // ghostty_init failed (e.g. invalid action). There is no
-            // degraded mode to continue in: a failed init already ran
-            // global.init's errdefer, which deinits the allocator and the
-            // I/O instance every later export depends on.
+            // degraded mode to continue in: global.init runs its errdefer on
+            // the way out, which deinits the allocator and the I/O instance
+            // every later export depends on.
             //
-            // We write the reason ourselves because libghostty won't: the
-            // lib artifact builds with app_runtime == none, so global
-            // logging defaults to stderr = false and its own "failed to
-            // initialize" line goes nowhere unless GHOSTTY_LOG is set.
-            // Without this, a failed init is a silent exit 2.
+            // libghostty explains the argument-parsing errors itself, via
+            // global.reportInitError writing straight to stderr. This line
+            // adds what that cannot: the native status, the exit code about
+            // to be used, and some signal for the errors it has no text for
+            // (global logging defaults to stderr = false in the lib
+            // artifact, so their std.log.err reaches only an embedder that
+            // registered a log callback).
+            //
+            // Where it surfaces depends on the path: a CLI action keeps the
+            // terminal's stderr, while the GUI has already pointed stderr at
+            // the log file by the time ConfigService calls in.
             Console.Error.WriteLine(
-                "[Ghostty] FATAL: ghostty_init failed, exiting with " +
+                $"[{Ghostty.Core.AppIdentity.ProductName}] FATAL: " +
+                $"ghostty_init failed (status {result}), exiting with " +
                 $"{(int)ExitCode.InitFailed} ({nameof(ExitCode.InitFailed)})");
             Console.Error.Flush();
             Environment.Exit((int)ExitCode.InitFailed);
         }
+
+        _ghosttyInitialized = true;
     }
 
     private static System.IO.Pipes.NamedPipeClientStream? _themePipe;

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -307,23 +307,13 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // unconditionally, and frees resources_dir and tmp_dir_path without
         // nulling them. ConfigNew and the loads below would then run against
         // a dead I/O implementation and freed resource paths, surfacing as a
-        // native crash with no managed stack. Program.InitGhostty checks this
-        // on the CLI path; a GUI launch comes through here instead.
+        // native crash with no managed stack.
         //
-        // Console.Error, not a logger: the logging factory is built from this
-        // service's own config, and the libghostty log bridge is installed
-        // later still. MainImpl has already pointed stderr at gpu.log, so the
-        // line lands there. Name the log rather than promise a reason --
-        // libghostty is silent on this path, because lib builds disable
-        // stderr logging and its init-error text only covers the two CLI
-        // action errors that a GUI launch cannot produce.
-        if (NativeMethods.InitWideFromProcess() != 0)
-        {
-            Console.Error.WriteLine(
-                @"[Ghostty] ghostty_init failed; see %LOCALAPPDATA%\Wintty\gpu.log");
-            Console.Error.Flush();
-            Environment.Exit((int)Program.ExitCode.InitFailed);
-        }
+        // Program.InitGhostty is the one init entry point for both startup
+        // paths: it checks the status, reports it, exits on failure, and is a
+        // no-op once init has run. A GUI launch reaches init only from here,
+        // since it never goes through Program's CLI branch.
+        Program.InitGhostty();
 
         _config = NativeMethods.ConfigNew();
         NativeMethods.ConfigLoadDefaultFiles(_config);


### PR DESCRIPTION
Follow-on to 578, which landed the GUI-path status check. This covers what
that left open.

global.init assigned the state unconditionally, so a second call leaked the
previous GPA, I/O instance and resources dir, and orphaned the command line
the args iterator borrows. It now returns error.AlreadyInitialized and
leaves the existing state alone. Nothing calls init twice today, so this is
a guard rather than a fix. The check sits before the errdefer is armed, so
refusing cannot disturb a live state.

Both startup paths now go through Program.InitGhostty instead of repeating
the status check, and it is a no-op once init has run. libghostty reports a
refused second init with the same status as a real failure, so a duplicated
check would turn a benign double init into exit 2. The fatal line also
carries the native status now, because AlreadyInitialized and a bad CLI
action are otherwise indistinguishable at the ABI.

ExitCode.InitFailed still claimed the native library writes the reason to
stderr. It does not on this path: lib builds default Logging.stderr to
false, and 574's init-error text only covers the two CLI action errors.

global.zig was missing from the test allowlist in main_ghostty.zig, so any
test in it was silently never run. Added the import and a test for the
guard, confirmed to fail when the expectation is wrong.

Testing: Windows `zig build test` 3746 pass / 77 skip, Ghostty.Tests 1764
pass, Linux (ubuntinovm, -Dapp-runtime=none) 3579 pass / 109 skip. By hand:
`+badaction` exits 2 with the reason, the `list-themes` alias still runs,
and a GUI launch reaches a live shell.