### PR TITLE
global: remove redundant errdefer in init

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -247,7 +247,6 @@ pub fn init(opts: InitOpts) !void {
     // Find our resources directory once for the app so every launch
     // hereafter can use this cached value.
     self.resources_dir = try apprt.runtime.resourcesDir(self.alloc);
-    errdefer self.resources_dir.deinit(self.alloc);
 
     // Setup i18n
     if (self.resources_dir.app()) |v| internal_os.i18n.init(v) catch |err| {


### PR DESCRIPTION
`init` arms `errdefer deinit()` right after `state` is assigned, and `deinit()` frees `resources_dir` as its first statement. Errdefers unwind in reverse order, so the extra `errdefer self.resources_dir.deinit(self.alloc)` after the assignment frees it first and `deinit()` then frees it again. `ResourcesDir.deinit` frees `app_path`/`host_path` without nulling them, so it is not idempotent and the second free is a real double-free.

It is unreachable today. The only statement after it is the `internal_os.i18n.init` call, whose error is swallowed by `catch`, so no error can return through both errdefers. Deleting it removes a trap for whoever adds the next fallible call to the end of `init`.

Checked the other two fields that `deinit()` frees: neither `tmp_dir_path` nor `io_impl` has its own errdefer, so this was the only overlap.

No test: `init` mutates process-global state and the error path is unreachable, so there is nothing to exercise from `zig build test`.

Local: `zig build` clean, `zig build test` 3743 pass / 77 skip / 0 fail.
