### PR TITLE
config: register quick-terminal-key and the log keys as Windows-only

### DIFF
--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -59,6 +59,12 @@ public static class WindowsOnlyKeys
             "When true, a second launch is routed into the already-running instance (opens a new window) instead of starting a separate process."),
         new("windows-high-contrast",
             "When true (default), the terminal surface follows the Windows High Contrast theme automatically; set false to keep your configured colors even in High Contrast mode."),
+        new("quick-terminal-key",
+            "Global hotkey chord that toggles the quick terminal (default ctrl+backquote). Unparseable values fall back to the default chord."),
+        new("log-level",
+            "Minimum severity written to the app log: trace, debug, info (default), warn, error, or off."),
+        new("log-filter",
+            "Comma-separated CATEGORY=LEVEL pairs overriding log-level per component (longest matching category prefix wins)."),
     ];
 
     public static readonly FrozenSet<string> Set =

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -62,9 +62,9 @@ public static class WindowsOnlyKeys
         new("quick-terminal-key",
             "Global hotkey chord that toggles the quick terminal (default ctrl+backquote). Unparseable values fall back to the default chord."),
         new("log-level",
-            "Minimum severity written to the app log: trace, debug, info (default), warn, error, or off."),
+            "Minimum severity written to the app log: trace, debug, info (default), warn, error, or off. An unrecognized value falls back to info silently."),
         new("log-filter",
-            "Comma-separated CATEGORY=LEVEL pairs overriding log-level per component (longest matching category prefix wins)."),
+            "Comma-separated CATEGORY=LEVEL pairs overriding log-level per component (longest matching category prefix wins). Malformed pairs and unknown levels are skipped silently."),
     ];
 
     public static readonly FrozenSet<string> Set =

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -64,10 +64,14 @@ public class WindowsOnlyKeysTests
     [Fact]
     public void All_HasNoDuplicateOrCaseCollidingKeys()
     {
-        // ByKey's ToFrozenDictionary throws on a duplicate, which surfaces as
-        // a TypeInitializationException from whichever test touches the class
-        // first. Comparing against the deduping Set names the real cause.
-        Assert.Equal(WindowsOnlyKeys.All.Count, WindowsOnlyKeys.Set.Count);
+        // A duplicate makes ByKey's ToFrozenDictionary throw during static
+        // init, which otherwise kills whichever test touches the class first
+        // with an opaque TypeInitializationException. Catching it here
+        // surfaces the inner ArgumentException, which names the bad key.
+        // Asserting on Set.Count instead would not work: Set is initialized
+        // by the same type initializer, so the comparison never runs.
+        var ex = Record.Exception(() => _ = WindowsOnlyKeys.ByKey.Count);
+        Assert.True(ex is null, ex?.InnerException?.Message ?? ex?.Message ?? "");
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -23,6 +23,12 @@ public class WindowsOnlyKeysTests
     [InlineData("default-profile")]
     [InlineData("profile-order")]
     [InlineData("no-color-override")]
+    [InlineData("accent-color")]
+    [InlineData("windows-single-instance")]
+    [InlineData("windows-high-contrast")]
+    [InlineData("quick-terminal-key")]
+    [InlineData("log-level")]
+    [InlineData("log-filter")]
     public void Contains_KnownKey(string key)
     {
         Assert.True(WindowsOnlyKeys.Contains(key));
@@ -36,6 +42,15 @@ public class WindowsOnlyKeysTests
         Assert.False(WindowsOnlyKeys.Contains("font-size"));
         Assert.False(WindowsOnlyKeys.Contains("theme"));
         Assert.False(WindowsOnlyKeys.Contains("windows-settings-ui"));
+        // ConfigService reads these from the file cache too, but they are
+        // real Zig fields, so libghostty never calls them unknown.
+        Assert.False(WindowsOnlyKeys.Contains("quick-terminal-autohide"));
+        Assert.False(WindowsOnlyKeys.Contains("bell-audio-path"));
+        // scrollback-limit is an upstream compatibility rename to
+        // scrollback-limit-bytes. A valid value parses silently; an invalid
+        // one reports "unknown field" from the rename handler. Registering
+        // it would swallow that genuine value error, so it stays out.
+        Assert.False(WindowsOnlyKeys.Contains("scrollback-limit"));
     }
 
     [Fact]
@@ -152,6 +167,24 @@ public class WindowsOnlyKeysTests
     public void IsAgentDetectKey_Expected(string key, bool expected)
     {
         Assert.Equal(expected, Ghostty.Core.Config.WindowsOnlyKeys.IsAgentDetectKey(key));
+    }
+
+    [Theory]
+    [InlineData("quick-terminal-key")]
+    [InlineData("log-level")]
+    [InlineData("log-filter")]
+    public void FileReadKeyDiagnostic_ExtractsKey_AndIsSuppressed(string configKey)
+    {
+        // Verbatim shape emitted by `wintty +validate-config` for these keys:
+        // ConfigService reads them from the raw config file, so libghostty's
+        // parser sees an unknown field and the filter must absorb it into
+        // WindowsOnlyKeysUsed instead of the error list.
+        var message =
+            $"C:\\Users\\alex\\AppData\\Roaming\\com.mitchellh.ghostty\\config:3:{configKey}: unknown field";
+
+        Assert.True(WindowsOnlyKeys.TryExtractUnknownFieldKey(message, out var key));
+        Assert.Equal(configKey, key);
+        Assert.True(WindowsOnlyKeys.Contains(key));
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
+++ b/windows/Ghostty.Tests/Config/WindowsOnlyKeysTests.cs
@@ -37,7 +37,8 @@ public class WindowsOnlyKeysTests
     [Fact]
     public void Contains_UpstreamKey_IsFalse()
     {
-        // These are all in upstream Zig Config, not Windows-only.
+        // These are all declared in the Zig config schema (upstream or
+        // fork-added), so libghostty parses them normally.
         Assert.False(WindowsOnlyKeys.Contains("background-opacity"));
         Assert.False(WindowsOnlyKeys.Contains("font-size"));
         Assert.False(WindowsOnlyKeys.Contains("theme"));
@@ -58,6 +59,15 @@ public class WindowsOnlyKeysTests
     {
         Assert.True(WindowsOnlyKeys.Contains("Background-Style"));
         Assert.True(WindowsOnlyKeys.Contains("BACKGROUND-STYLE"));
+    }
+
+    [Fact]
+    public void All_HasNoDuplicateOrCaseCollidingKeys()
+    {
+        // ByKey's ToFrozenDictionary throws on a duplicate, which surfaces as
+        // a TypeInitializationException from whichever test touches the class
+        // first. Comparing against the deduping Set names the real cause.
+        Assert.Equal(WindowsOnlyKeys.All.Count, WindowsOnlyKeys.Set.Count);
     }
 
     [Fact]
@@ -173,12 +183,13 @@ public class WindowsOnlyKeysTests
     [InlineData("quick-terminal-key")]
     [InlineData("log-level")]
     [InlineData("log-filter")]
-    public void FileReadKeyDiagnostic_ExtractsKey_AndIsSuppressed(string configKey)
+    public void FileReadKeyDiagnostic_ExtractsKey_AndClassifiesAsWindowsOnly(string configKey)
     {
-        // Verbatim shape emitted by `wintty +validate-config` for these keys:
-        // ConfigService reads them from the raw config file, so libghostty's
-        // parser sees an unknown field and the filter must absorb it into
-        // WindowsOnlyKeysUsed instead of the error list.
+        // Shape of the precomputed diagnostic message (src/cli/diagnostics.zig
+        // Diagnostic.format). ConfigService reads these keys from the raw
+        // config file, so libghostty's parser sees an unknown field and the
+        // filter must absorb it into WindowsOnlyKeysUsed instead of the error
+        // list.
         var message =
             $"C:\\Users\\alex\\AppData\\Roaming\\com.mitchellh.ghostty\\config:3:{configKey}: unknown field";
 

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -583,8 +583,11 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     private void ReadFlagsCore()
     {
         AutoReloadEnabled = GetBool("auto-reload-config");
-        // windows-settings-ui is a Windows-only key not in the Zig
-        // config schema, so read it from the config file directly.
+        // windows-settings-ui is a fork-added Zig field, so libghostty
+        // parses it fine, but it's a bool and reads more cheaply from
+        // the file cache alongside the other Windows-only flags below.
+        // It is deliberately absent from WindowsOnlyKeys: the parser
+        // knows it, so there is no unknown-field diagnostic to suppress.
         SettingsUiEnabled = string.Equals(
             GetFileValue("windows-settings-ui", "false"),
             "true", StringComparison.OrdinalIgnoreCase);
@@ -1024,6 +1027,13 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// cannot be read via <c>ghostty_config_get</c>, so we parse the
     /// file ourselves.
     /// </summary>
+    /// <remarks>
+    /// Any key read here that libghostty's parser doesn't know about
+    /// must also be listed in <see cref="WindowsOnlyKeys.All"/>.
+    /// Otherwise its "unknown field" diagnostic reaches
+    /// <see cref="CacheDiagnostics"/> unfiltered and the settings UI
+    /// shows the user a config error for a setting the app honors.
+    /// </remarks>
     private string GetFileValue(string key, string defaultValue)
         => _configFileCache is not null
             && _configFileCache.TryGetValue(key, out var list)

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -163,7 +163,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// Raw pane undo/redo <c>undo-timeout</c> value, in milliseconds. Read
     /// live from the libghostty <c>Duration</c> config handle (not the file
     /// cache, which can be stale outside ReadFlags). Returned verbatim,
-    /// including <c>0</c> (upstream's "disable undo" sentinel) — the policy
+    /// including <c>0</c> (upstream's "disable undo" sentinel) -- the policy
     /// interpretation lives in
     /// <see cref="Ghostty.Core.Panes.UndoPolicy.FromConfigMilliseconds"/>.
     /// Falls back to upstream Ghostty's 5s default window when the key isn't
@@ -584,10 +584,11 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     {
         AutoReloadEnabled = GetBool("auto-reload-config");
         // windows-settings-ui is a fork-added Zig field, so libghostty
-        // parses it fine, but it's a bool and reads more cheaply from
-        // the file cache alongside the other Windows-only flags below.
-        // It is deliberately absent from WindowsOnlyKeys: the parser
-        // knows it, so there is no unknown-field diagnostic to suppress.
+        // parses it and there is no unknown-field diagnostic to suppress;
+        // that is why it is deliberately absent from WindowsOnlyKeys. It
+        // is still read from the file cache here, which only covers the
+        // top-level config file: a value set in an included file or a
+        // conditional block won't be seen.
         SettingsUiEnabled = string.Equals(
             GetFileValue("windows-settings-ui", "false"),
             "true", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
`ConfigService` reads `quick-terminal-key`, `log-level` and `log-filter` straight
from the config file, but none of them were listed in `WindowsOnlyKeys`. So
libghostty's "unknown field" diagnostic for each one landed in the Raw Editor
error list, even though the app honours the setting.

Setting `quick-terminal-key = alt+space` shows a red "1 issue" in Settings ->
Raw Editor while the hotkey works fine.

Checked every key ConfigService reads from the file cache against
`+validate-config`. Three came back as unknown fields and were missing:
`quick-terminal-key`, `log-level`, `log-filter`. `quick-terminal-autohide`,
`bell-audio-path` and `windows-settings-ui` are real Zig fields and stay quiet.
None of the 23 registry entries has been adopted upstream, so nothing in there
is silently swallowing real diagnostics.

`scrollback-limit` is deliberately left out. It is an upstream compatibility
rename to `scrollback-limit-bytes`: a valid value parses silently, and only an
invalid one reports "unknown field" from the rename handler. Registering it
would swallow a genuine value error.

To stop this recurring, `GetFileValue` now documents that any key it reads which
libghostty doesn't know must also be registered here.

Tests cover the three new keys plus the three registered-but-untested ones
(`accent-color`, `windows-single-instance`, `windows-high-contrast`), pin the
diagnostic shape through extract-then-classify, and add a duplicate-key guard
(a collision otherwise blows up as an opaque TypeInitializationException in
whichever test touches the class first).

Two comments in the area said the wrong thing about which keys the Zig parser
knows, including one about `windows-settings-ui`, so they are corrected here too.