### PR TITLE
config: check ghostty_init result on the GUI path

### DIFF
--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -23,7 +23,7 @@ public static partial class Program
     /// return whatever the native action produced via
     /// <c>Environment.Exit(exitCode)</c>.
     /// </summary>
-    private enum ExitCode
+    internal enum ExitCode
     {
         /// <summary>WinUI message loop returned cleanly, or a CLI
         /// action completed with exit code 0.</summary>

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -303,19 +303,24 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         _dispatcher = dispatcher;
 
         // A failed ghostty_init runs its own errdefer cleanup but leaves the
-        // global state readable: deinit does not null it, and it frees
-        // resources_dir and tmp_dir_path without nulling those either. So
-        // ConfigNew below would allocate through an already-deinit'd
-        // allocator and later hand back dangling resource paths, surfacing
-        // as a native crash with no managed stack. Program.InitGhostty
-        // checks this on the CLI path; the GUI path comes through here.
+        // global state readable: deinit never nulls it, deinits io_impl
+        // unconditionally, and frees resources_dir and tmp_dir_path without
+        // nulling them. ConfigNew and the loads below would then run against
+        // a dead I/O implementation and freed resource paths, surfacing as a
+        // native crash with no managed stack. Program.InitGhostty checks this
+        // on the CLI path; a GUI launch comes through here instead.
         //
-        // Console.Error rather than a logger: the logging factory is built
-        // from this service's own config, so it does not exist yet.
+        // Console.Error, not a logger: the logging factory is built from this
+        // service's own config, and the libghostty log bridge is installed
+        // later still. MainImpl has already pointed stderr at gpu.log, so the
+        // line lands there. Name the log rather than promise a reason --
+        // libghostty is silent on this path, because lib builds disable
+        // stderr logging and its init-error text only covers the two CLI
+        // action errors that a GUI launch cannot produce.
         if (NativeMethods.InitWideFromProcess() != 0)
         {
             Console.Error.WriteLine(
-                "[Ghostty] ghostty_init failed; libghostty logged the reason above");
+                @"[Ghostty] ghostty_init failed; see %LOCALAPPDATA%\Wintty\gpu.log");
             Console.Error.Flush();
             Environment.Exit((int)Program.ExitCode.InitFailed);
         }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -302,7 +302,23 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     {
         _dispatcher = dispatcher;
 
-        NativeMethods.InitWideFromProcess();
+        // A failed ghostty_init runs its own errdefer cleanup but leaves the
+        // global state readable: deinit does not null it, and it frees
+        // resources_dir and tmp_dir_path without nulling those either. So
+        // ConfigNew below would allocate through an already-deinit'd
+        // allocator and later hand back dangling resource paths, surfacing
+        // as a native crash with no managed stack. Program.InitGhostty
+        // checks this on the CLI path; the GUI path comes through here.
+        //
+        // Console.Error rather than a logger: the logging factory is built
+        // from this service's own config, so it does not exist yet.
+        if (NativeMethods.InitWideFromProcess() != 0)
+        {
+            Console.Error.WriteLine(
+                "[Ghostty] ghostty_init failed; libghostty logged the reason above");
+            Console.Error.Flush();
+            Environment.Exit((int)Program.ExitCode.InitFailed);
+        }
 
         _config = NativeMethods.ConfigNew();
         NativeMethods.ConfigLoadDefaultFiles(_config);


### PR DESCRIPTION
`ConfigService`'s constructor called `ghostty_init_wide` and discarded the return value. `Program.InitGhostty` checks it on the CLI path, but a GUI launch never goes through there, so a failed init fell straight into `ghostty_config_new`.

That is not benign. `global.deinit` never nulls the state, deinits `io_impl` unconditionally, and frees `resources_dir` and `tmp_dir_path` without nulling them. So after a failed init the state still reads as valid while the I/O implementation behind it is dead and the resource paths are freed, which surfaces as a native crash with no managed stack.

Now checks the result and exits with `ExitCode.InitFailed`, matching the CLI path. `ExitCode` widens from `private` to `internal` for the second call site.

The failure message names `%LOCALAPPDATA%\Wintty\gpu.log` rather than claiming libghostty logged a reason. It does not on this path: lib builds disable stderr logging, `reportInitError` only has text for the two CLI action errors a GUI launch cannot reach, and the libghostty log bridge is installed after this constructor runs. `MainImpl` has already redirected stderr to that file, so the line lands there.

No test: `Ghostty.Tests` references `Ghostty.Core` and the Bench projects, not the app project where `ConfigService` lives, so the ctor is not reachable from the suite.

Local: build 0 errors, `dotnet test` 1754 passed / 0 failed / 1 skipped.
