### PR TITLE
windows: tag startup diagnostics with the product name

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -21,4 +21,12 @@ internal static class AppIdentity
     /// Wintty → ...) only touch one file instead of scattering literals.
     /// </summary>
     public const string ProductName = "Wintty";
+
+    /// <summary>
+    /// Prefix on diagnostics we write to stderr, gpu.log and the crash
+    /// log, so a line is attributable at a glance when it lands in a
+    /// shared console alongside shell and libghostty output. Built from
+    /// <see cref="ProductName"/> so it cannot drift from the brand.
+    /// </summary>
+    public const string LogTag = $"[{ProductName}]";
 }

--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -23,9 +23,9 @@ internal static class AppIdentity
     public const string ProductName = "Wintty";
 
     /// <summary>
-    /// Prefix on the startup diagnostics, so a line stays attributable
-    /// when it lands in a console shared with shell and libghostty
-    /// output. Reaches gpu.log through the stderr redirect and
+    /// Prefix on the diagnostics we write ourselves, so a line stays
+    /// attributable when it lands in a console shared with shell and
+    /// libghostty output. Reaches gpu.log through the stderr redirect and
     /// ghostty-crash.log through the fatal-startup message; the
     /// App-level crash.log tags its entries by handler name instead.
     /// Built from <see cref="ProductName"/> so it cannot drift from the

--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -23,10 +23,13 @@ internal static class AppIdentity
     public const string ProductName = "Wintty";
 
     /// <summary>
-    /// Prefix on diagnostics we write to stderr, gpu.log and the crash
-    /// log, so a line is attributable at a glance when it lands in a
-    /// shared console alongside shell and libghostty output. Built from
-    /// <see cref="ProductName"/> so it cannot drift from the brand.
+    /// Prefix on the startup diagnostics, so a line stays attributable
+    /// when it lands in a console shared with shell and libghostty
+    /// output. Reaches gpu.log through the stderr redirect and
+    /// ghostty-crash.log through the fatal-startup message; the
+    /// App-level crash.log tags its entries by handler name instead.
+    /// Built from <see cref="ProductName"/> so it cannot drift from the
+    /// brand.
     /// </summary>
     public const string LogTag = $"[{ProductName}]";
 }

--- a/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
+++ b/windows/Ghostty.Core/Logging/FileLoggerOptions.cs
@@ -2,7 +2,7 @@ namespace Ghostty.Core.Logging;
 
 /// <summary>
 /// Knobs for <see cref="FileLoggerProvider"/>. Path defaults to
-/// <c>%LOCALAPPDATA%\Ghostty\logs</c>; size cap to 16 MB; retention to
+/// <c>%LOCALAPPDATA%\Wintty\logs</c>; size cap to 16 MB; retention to
 /// 14 days. Tests inject narrower values and a temp dir.
 /// </summary>
 internal sealed record FileLoggerOptions

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -304,7 +304,7 @@ public partial class App : Application
         InitializeComponent();
 
         // Surface unhandled exceptions to stderr AND to a file under
-        // %LOCALAPPDATA%\Ghostty\ before the process dies. Without
+        // %LOCALAPPDATA%\Wintty\ before the process dies. Without
         // this, a managed exception on the UI thread silently exits
         // with a non-descriptive code and we have nothing to debug
         // from -- especially in Release, where WER captures a dump
@@ -440,7 +440,7 @@ public partial class App : Application
         ConfigService = _configService;
 
         // build the factory from Ghostty config before any other service constructs an
-        // ILogger<T>. Log directory under the same %LOCALAPPDATA%\Ghostty root that
+        // ILogger<T>. Log directory under the same %LOCALAPPDATA%\Wintty root that
         // App.LogUnhandled already uses for crash.log, so a user reporting a bug only has
         // one folder to attach.
         var logDir = System.IO.Path.Combine(

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Ghostty.Controls;
+using Ghostty.Core;
 using Ghostty.Core.Config;
 using Ghostty.Core.Hosting;
 using Ghostty.Core.Power;
@@ -296,7 +297,7 @@ public partial class App : Application
             // down. A packaged Release launch will lose this — that's
             // acceptable for a one-frame cosmetic flash.
             System.Diagnostics.Debug.WriteLine(
-                $"[Ghostty] OsTheme.IsDark() threw during App ctor; falling back to Dark. {ex.GetType().Name}: {ex.Message}");
+                $"{AppIdentity.LogTag} OsTheme.IsDark() threw during App ctor; falling back to Dark. {ex.GetType().Name}: {ex.Message}");
             RequestedTheme = ApplicationTheme.Dark;
         }
 
@@ -335,7 +336,7 @@ public partial class App : Application
         // FreeConsole gate keeps the console attached in that case).
         try
         {
-            Console.Error.WriteLine($"[Ghostty] {tag}:");
+            Console.Error.WriteLine($"{AppIdentity.LogTag} {tag}:");
             Console.Error.WriteLine(detail);
             Console.Error.Flush();
         }

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Ghostty.Core;
 using Ghostty.Core.Input;
 using Ghostty.Core.ResizeOverlay;
 using Ghostty.Core.Windows;
@@ -637,7 +638,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine(
-                $"[Ghostty] SurfaceNew failed: {ex.Message}\n{ex.StackTrace}");
+                $"{AppIdentity.LogTag} SurfaceNew failed: {ex.Message}\n{ex.StackTrace}");
             throw;
         }
         // Drop our ref: libghostty does not retain the panel pointer.

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -46,7 +46,7 @@ public static partial class Program
         /// path. <see cref="StartGui"/>'s catch block writes
         /// <c>ghostty-crash.log</c> in <c>AppContext.BaseDirectory</c>.
         /// (A future PR should converge this with the
-        /// <c>%LOCALAPPDATA%\Ghostty\crash.log</c> path used by the
+        /// <c>%LOCALAPPDATA%\Wintty\crash.log</c> path used by the
         /// App-level unhandled-exception handlers.)</summary>
         ManagedUnhandled = 3,
     }
@@ -144,7 +144,8 @@ public static partial class Program
             var writer = new StreamWriter(fs, System.Text.Encoding.UTF8) { AutoFlush = true };
             Console.SetError(writer);
 
-            Console.Error.WriteLine($"=== Wintty GPU log started {DateTime.UtcNow:O} ===");
+            Console.Error.WriteLine(
+                $"=== {AppIdentity.ProductName} GPU log started {DateTime.UtcNow:O} ===");
             Console.Error.WriteLine($"Log file: {GpuLogPath}");
             Console.Error.Flush();
         }

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Ghostty.Core;
 using Ghostty.Interop;
 
 namespace Ghostty;
@@ -328,7 +329,7 @@ public static partial class Program
     private static string ProgramName()
     {
         var name = Path.GetFileNameWithoutExtension(Environment.ProcessPath ?? string.Empty);
-        if (string.IsNullOrEmpty(name)) name = Ghostty.Core.AppIdentity.ProductName;
+        if (string.IsNullOrEmpty(name)) name = AppIdentity.ProductName;
         // Lowercased because that is how the command gets typed, and
         // Windows does not care either way.
         return name.ToLowerInvariant();
@@ -488,28 +489,28 @@ public static partial class Program
     {
         try
         {
-            Console.Error.WriteLine("[Ghostty] Program.Main entered");
+            Console.Error.WriteLine($"{AppIdentity.LogTag} Program.Main entered");
             Console.Error.Flush();
 
             WinRT.ComWrappersSupport.InitializeComWrappers();
-            Console.Error.WriteLine("[Ghostty] ComWrappers initialized");
+            Console.Error.WriteLine($"{AppIdentity.LogTag} ComWrappers initialized");
             Console.Error.Flush();
 
             Microsoft.UI.Xaml.Application.Start(p =>
             {
-                Console.Error.WriteLine("[Ghostty] Application.Start callback entered");
+                Console.Error.WriteLine($"{AppIdentity.LogTag} Application.Start callback entered");
                 Console.Error.Flush();
 
                 var context = new Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext(
                     Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());
                 System.Threading.SynchronizationContext.SetSynchronizationContext(context);
 
-                Console.Error.WriteLine("[Ghostty] Creating App instance");
+                Console.Error.WriteLine($"{AppIdentity.LogTag} Creating App instance");
                 Console.Error.Flush();
 
                 new App();
 
-                Console.Error.WriteLine("[Ghostty] App instance created");
+                Console.Error.WriteLine($"{AppIdentity.LogTag} App instance created");
                 Console.Error.Flush();
             });
 
@@ -517,7 +518,7 @@ public static partial class Program
         }
         catch (Exception ex)
         {
-            var msg = $"[Ghostty] FATAL: {ex}";
+            var msg = $"{AppIdentity.LogTag} FATAL: {ex}";
             Console.Error.WriteLine(msg);
             Console.Error.Flush();
 

--- a/windows/docs/logging.md
+++ b/windows/docs/logging.md
@@ -24,7 +24,7 @@ The same provider is visible in PerfView and Windows Performance Analyzer.
 
 ### Rolling file
 
-`%LOCALAPPDATA%\Ghostty\logs\ghostty-YYYYMMDD.log`. One file per UTC day.
+`%LOCALAPPDATA%\Wintty\logs\ghostty-YYYYMMDD.log`. One file per UTC day.
 Each file caps at 16 MB; when full, the writer rolls to
 `ghostty-YYYYMMDD-1.log`, `-2.log`, and so on. Files older than 14 days
 are deleted at startup and again whenever the writer crosses a UTC-day


### PR DESCRIPTION
The startup diagnostics in Program.cs, App.xaml.cs and TerminalControl.xaml.cs were prefixed `[Ghostty]`. The binary is Wintty.

Renames the prefix to `[Wintty]` through a new `AppIdentity.LogTag` constant, built from `ProductName`, so the tag cannot drift from the name every other user-visible surface already uses. Line format is otherwise unchanged since gpu.log and ghostty-crash.log get read by hand when startup fails.

`ProgramName()` was the other candidate but it lowercases, so it would render `[wintty]`.

Not touched: `ghostty_init`, `ghostty_config_*` and the Zig log scopes are API and symbol names, and the `[Ghostty](https://ghostty.org)` in `include/ghostty/vt.h` is a markdown link in upstream doc text.

Verified with `dotnet build`, `dotnet test` (1754 passed), and by reading `%LOCALAPPDATA%\Wintty\gpu.log` after a GUI launch.