### PR TITLE
settings: fix gradient blend ConfigKey and pin card keys to the index

### DIFF
--- a/windows/Ghostty.Core/Settings/SettingsIndex.cs
+++ b/windows/Ghostty.Core/Settings/SettingsIndex.cs
@@ -29,7 +29,7 @@ public static class SettingsIndex
             SettingType.Number),
         new("vertical-tabs", "Vertical tab bar",
             "Render tabs in a vertical sidebar instead of the default horizontal strip.",
-            "General", "Tabs",
+            "General", "App Behavior",
             new[] { "tabs", "vertical", "sidebar", "layout", "orientation" },
             SettingType.Toggle),
         new("command-palette-background", "Command palette backdrop",

--- a/windows/Ghostty.Core/Settings/SettingsIndex.cs
+++ b/windows/Ghostty.Core/Settings/SettingsIndex.cs
@@ -21,6 +21,12 @@ public static class SettingsIndex
             "General", "App Behavior",
             new[] { "reload", "watch", "config" },
             SettingType.Toggle),
+        new("undo-timeout", "Undo timeout",
+            "How long a pane split, close, resize, or zoom can be undone, in " +
+            "milliseconds. Set to 0 to disable undo.",
+            "General", "App Behavior",
+            new[] { "undo", "redo", "timeout", "pane", "history" },
+            SettingType.Number),
         new("vertical-tabs", "Vertical tab bar",
             "Render tabs in a vertical sidebar instead of the default horizontal strip.",
             "General", "Tabs",
@@ -161,6 +167,12 @@ public static class SettingsIndex
             "Background color of selected text.",
             "Colors", "Terminal Colors",
             new[] { "color", "selection", "highlight" },
+            SettingType.Color),
+        new("accent-color", "Accent color",
+            "Color of the active tab background, focus border, and tab strip rail. " +
+            "When unset, the chrome follows cursor-color.",
+            "Colors", "Terminal Colors",
+            new[] { "color", "accent", "tab", "focus", "chrome" },
             SettingType.Color),
 
         // ----- Terminal -----

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -109,7 +109,9 @@
       rather than a file list: a page added later is picked up without anyone
       remembering this entry, which is the failure mode the other blocks above
       have. LogicalName is still spelled out per item, because deriving it from
-      Link makes the name depend on the host treating "\" as a separator.
+      Link makes the name depend on the host treating "\" as a separator. It
+      flattens away any subfolder, so two pages sharing a file name collide as
+      a CS1508 duplicate-resource error rather than as a silently dropped page.
     -->
     <EmbeddedResource Include="..\Ghostty\Settings\Pages\**\*.xaml"
                       Link="Settings\Pages\%(Filename)%(Extension)"

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -108,12 +108,12 @@
       Every settings page, for SettingsCardConfigKeyParityTests. A wildcard
       rather than a file list: a page added later is picked up without anyone
       remembering this entry, which is the failure mode the other blocks above
-      have. Link (not LogicalName) because LogicalName cannot be shared across
-      a glob; the default naming rule turns the link path into
-      Ghostty.Tests.Settings.Pages.<file>.xaml.
+      have. LogicalName is still spelled out per item, because deriving it from
+      Link makes the name depend on the host treating "\" as a separator.
     -->
-    <EmbeddedResource Include="..\Ghostty\Settings\Pages\*.xaml"
-                      Link="Settings\Pages\%(Filename)%(Extension)" />
+    <EmbeddedResource Include="..\Ghostty\Settings\Pages\**\*.xaml"
+                      Link="Settings\Pages\%(Filename)%(Extension)"
+                      LogicalName="Ghostty.Tests.Settings.Pages.%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -104,6 +104,16 @@
     <EmbeddedResource Include="..\..\src\cli\ghostty.zig"
                       Link="Cli\Actions\ghostty.zig"
                       LogicalName="Ghostty.Tests.Cli.Actions.ghostty.zig" />
+    <!--
+      Every settings page, for SettingsCardConfigKeyParityTests. A wildcard
+      rather than a file list: a page added later is picked up without anyone
+      remembering this entry, which is the failure mode the other blocks above
+      have. Link (not LogicalName) because LogicalName cannot be shared across
+      a glob; the default naming rule turns the link path into
+      Ghostty.Tests.Settings.Pages.<file>.xaml.
+    -->
+    <EmbeddedResource Include="..\Ghostty\Settings\Pages\*.xaml"
+                      Link="Settings\Pages\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Tests/Settings/SettingsCardConfigKeyParityTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsCardConfigKeyParityTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+// Pins the SettingsCard.ConfigKey attached properties in the settings page
+// XAML against SettingsIndex.
+//
+// Search results are routed by key: SettingsWindow navigates to the entry's
+// page and then asks SettingsCardLocator.FindByConfigKey for the matching
+// card. A key that exists on only one side of that handshake fails silently
+// -- the page opens, nothing scrolls, nothing pulses, no error anywhere. A
+// typo'd ConfigKey (background-gradient-blend-mode for
+// background-gradient-blend) shipped exactly that way.
+//
+// The XAML is embedded by Ghostty.Tests.csproj rather than read from disk, so
+// the test does not depend on where the assembly runs from, and does not need
+// a project reference to Ghostty.csproj.
+public class SettingsCardConfigKeyParityTests
+{
+    private const string PagePrefix = "Ghostty.Tests.Settings.Pages.";
+
+    // ctrl: is the only prefix the pages bind to Ghostty.Controls.Settings,
+    // but match any prefix so a renamed namespace alias shows up as a parity
+    // failure rather than as an unscanned card. The prefix is optional: on a
+    // SettingsCard element itself the attached property can be set unqualified.
+    private static readonly Regex ConfigKeyPattern = new(
+        @"(?:(?:[A-Za-z_][\w.]*:)?SettingsCard\.)?ConfigKey\s*=\s*""(?<key>[^""]*)""",
+        RegexOptions.Compiled);
+
+    // Indexed so search can surface them, but not editable from a settings
+    // card yet. Search hits for these navigate to the page without scrolling
+    // to anything, which is a gap in the UI, not a broken key. Delete an
+    // entry here when its card lands.
+    private static readonly string[] KeysWithNoCardYet =
+    {
+        "command-palette-background",
+        "command-palette-group-commands",
+    };
+
+    [Fact]
+    public void EveryConfigKeyInXamlIsIndexed()
+    {
+        var indexed = SettingsIndex.All.Select(e => e.Key).ToHashSet(StringComparer.Ordinal);
+
+        var unindexed = ConfigKeysByPage()
+            .SelectMany(page => page.Value.Select(key => (Page: page.Key, Key: key)))
+            .Where(c => !indexed.Contains(c.Key))
+            .OrderBy(c => c.Page, StringComparer.Ordinal)
+            .ThenBy(c => c.Key, StringComparer.Ordinal)
+            .ToList();
+
+        if (unindexed.Count > 0)
+        {
+            Assert.Fail(
+                "SettingsCard.ConfigKey values with no SettingsIndex entry. Either " +
+                "the key is a typo (compare against the key ConfigService reads and " +
+                "the page's OnValueChanged writes), or the setting needs an entry in " +
+                "SettingsIndex.All so search can find it:\n" +
+                string.Join("\n", unindexed.Select(c => $"  {c.Key}  ({c.Page})")));
+        }
+    }
+
+    [Fact]
+    public void EveryIndexedKeyHasACard()
+    {
+        var inXaml = ConfigKeysByPage().Values
+            .SelectMany(keys => keys)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var cardless = SettingsIndex.All
+            .Select(e => e.Key)
+            .Where(k => !inXaml.Contains(k))
+            .Except(KeysWithNoCardYet, StringComparer.Ordinal)
+            .OrderBy(k => k, StringComparer.Ordinal)
+            .ToList();
+
+        if (cardless.Count > 0)
+        {
+            Assert.Fail(
+                "SettingsIndex entries with no SettingsCard.ConfigKey in any settings " +
+                "page. Choosing one of these in search navigates to the page but never " +
+                "scrolls to or pulses the card. Add the attached property to the card, " +
+                "or list the key in KeysWithNoCardYet if the setting has no card:\n" +
+                string.Join("\n", cardless.Select(k => $"  {k}")));
+        }
+    }
+
+    // KeysWithNoCardYet is only honest while it stays a list of keys that
+    // genuinely have no card. Without this, a card added later would leave a
+    // stale entry that permanently exempts a real key from the check above.
+    [Fact]
+    public void KeysWithNoCardYetIsNotStale()
+    {
+        var inXaml = ConfigKeysByPage().Values
+            .SelectMany(keys => keys)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var landed = KeysWithNoCardYet.Where(inXaml.Contains).ToList();
+
+        Assert.True(
+            landed.Count == 0,
+            "These keys now have a SettingsCard, so remove them from " +
+            $"KeysWithNoCardYet: {string.Join(", ", landed)}");
+    }
+
+    // Without this, a ConfigKey written in a spelling the regex does not match
+    // would be absent from the scanned set, and the checks above would report
+    // it as a setting with no card -- or, if the index has no entry for it
+    // either, not report it at all.
+    [Fact]
+    public void EveryConfigKeyOccurrenceIsMatched()
+    {
+        foreach (var (page, source) in PageSources())
+        {
+            var occurrences = Regex.Matches(source, @"\bConfigKey\b").Count;
+            var matched = ConfigKeyPattern.Matches(source).Count;
+
+            Assert.True(
+                occurrences == matched,
+                $"{page} mentions ConfigKey {occurrences} time(s) but the scan " +
+                $"pattern in {nameof(SettingsCardConfigKeyParityTests)} matched " +
+                $"{matched}. The pattern no longer describes how the pages set " +
+                "the attached property, so the parity checks cannot see every card.");
+        }
+    }
+
+    // Guards the csproj wildcard. Losing it, or moving the pages, would make
+    // every check above scan an empty corpus and pass. Pages that hold no
+    // cards at all (keybindings, profiles, the raw editor) legitimately
+    // contribute no keys, so this pins the page with the most of them.
+    [Fact]
+    public void SettingsPagesAreEmbedded()
+    {
+        var pages = ConfigKeysByPage();
+
+        Assert.NotEmpty(pages);
+        Assert.NotEmpty(pages["AppearancePage.xaml"]);
+    }
+
+    private static Dictionary<string, HashSet<string>> ConfigKeysByPage()
+        => PageSources().ToDictionary(
+            p => p.Page,
+            p => ConfigKeyPattern.Matches(p.Source)
+                .Select(m => m.Groups["key"].Value)
+                .ToHashSet(StringComparer.Ordinal),
+            StringComparer.Ordinal);
+
+    private static List<(string Page, string Source)> PageSources()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var pages = new List<(string, string)>();
+
+        foreach (var resource in assembly.GetManifestResourceNames()
+                     .Where(n => n.StartsWith(PagePrefix, StringComparison.Ordinal)
+                                 && n.EndsWith(".xaml", StringComparison.Ordinal)))
+        {
+            using var stream = assembly.GetManifestResourceStream(resource);
+            Assert.NotNull(stream);
+            using var reader = new StreamReader(stream);
+
+            pages.Add((resource[PagePrefix.Length..], reader.ReadToEnd()));
+        }
+
+        return pages;
+    }
+}

--- a/windows/Ghostty.Tests/Settings/SettingsCardConfigKeyParityTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsCardConfigKeyParityTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Ghostty.Core.Settings;
 using Xunit;
 
@@ -12,33 +12,33 @@ namespace Ghostty.Tests.Settings;
 // Pins the SettingsCard.ConfigKey attached properties in the settings page
 // XAML against SettingsIndex.
 //
-// Search results are routed by key: SettingsWindow navigates to the entry's
-// page and then asks SettingsCardLocator.FindByConfigKey for the matching
-// card. A key that exists on only one side of that handshake fails silently
-// -- the page opens, nothing scrolls, nothing pulses, no error anywhere. A
-// typo'd ConfigKey (background-gradient-blend-mode for
+// Search results are routed by key in two legs: SettingsWindow navigates to
+// the entry's Page, and only then does SettingsCardLocator.FindByConfigKey
+// walk THAT page's visual tree for the key. A key that exists on only one
+// side of the handshake, or that sits on a different page than the index
+// claims, fails silently -- the page opens, nothing scrolls, nothing pulses,
+// no error anywhere. A typo'd ConfigKey (background-gradient-blend-mode for
 // background-gradient-blend) shipped exactly that way.
 //
-// The XAML is embedded by Ghostty.Tests.csproj rather than read from disk, so
-// the test does not depend on where the assembly runs from, and does not need
-// a project reference to Ghostty.csproj.
+// The pages are parsed as XML rather than text-scanned so that a key inside
+// an XML comment does not count as a live one. The XAML is embedded by
+// Ghostty.Tests.csproj rather than read from disk, so the test does not
+// depend on where the assembly runs from, and does not need a project
+// reference to Ghostty.csproj.
 public class SettingsCardConfigKeyParityTests
 {
     private const string PagePrefix = "Ghostty.Tests.Settings.Pages.";
 
-    // ctrl: is the only prefix the pages bind to Ghostty.Controls.Settings,
-    // but match any prefix so a renamed namespace alias shows up as a parity
-    // failure rather than as an unscanned card. The prefix is optional: on a
-    // SettingsCard element itself the attached property can be set unqualified.
-    private static readonly Regex ConfigKeyPattern = new(
-        @"(?:(?:[A-Za-z_][\w.]*:)?SettingsCard\.)?ConfigKey\s*=\s*""(?<key>[^""]*)""",
-        RegexOptions.Compiled);
+    // The XAML prefix is an alias (ctrl:), but the namespace it resolves to
+    // is what identifies the property, so a renamed alias changes nothing.
+    private static readonly XNamespace ControlsNamespace = "using:Ghostty.Controls.Settings";
+    private const string AttachedName = "SettingsCard.ConfigKey";
 
-    // Indexed so search can surface them, but not editable from a settings
-    // card yet. Search hits for these navigate to the page without scrolling
+    // Indexed so search can surface them, but not editable from any settings
+    // page yet. Search hits for these navigate to the page without scrolling
     // to anything, which is a gap in the UI, not a broken key. Delete an
-    // entry here when its card lands.
-    private static readonly string[] KeysWithNoCardYet =
+    // entry here when its control lands.
+    private static readonly string[] KeysWithNoControlYet =
     {
         "command-palette-background",
         "command-palette-group-commands",
@@ -67,95 +67,168 @@ public class SettingsCardConfigKeyParityTests
         }
     }
 
+    // Checks the key AND the page it lives on. Asserting only that the key
+    // exists somewhere would let an entry point search at the wrong page,
+    // where the tree walk cannot see the control.
     [Fact]
-    public void EveryIndexedKeyHasACard()
+    public void EveryIndexedKeyHasAControlOnItsOwnPage()
     {
-        var inXaml = ConfigKeysByPage().Values
-            .SelectMany(keys => keys)
-            .ToHashSet(StringComparer.Ordinal);
+        var pages = ConfigKeysByPage();
+        var problems = new List<string>();
 
-        var cardless = SettingsIndex.All
-            .Select(e => e.Key)
-            .Where(k => !inXaml.Contains(k))
-            .Except(KeysWithNoCardYet, StringComparer.Ordinal)
-            .OrderBy(k => k, StringComparer.Ordinal)
-            .ToList();
+        foreach (var entry in SettingsIndex.All)
+        {
+            if (KeysWithNoControlYet.Contains(entry.Key, StringComparer.Ordinal)) continue;
 
-        if (cardless.Count > 0)
+            var expectedPage = PageFileFor(entry.Page);
+            if (!pages.TryGetValue(expectedPage, out var keys))
+            {
+                problems.Add(
+                    $"  {entry.Key}: Page \"{entry.Page}\" has no {expectedPage} in the " +
+                    "scanned corpus");
+                continue;
+            }
+
+            if (keys.Contains(entry.Key)) continue;
+
+            var elsewhere = pages.Where(p => p.Value.Contains(entry.Key))
+                .Select(p => p.Key).ToList();
+            problems.Add(elsewhere.Count > 0
+                ? $"  {entry.Key}: indexed under \"{entry.Page}\" but tagged in " +
+                  string.Join(", ", elsewhere)
+                : $"  {entry.Key}: no ConfigKey anywhere in {expectedPage}");
+        }
+
+        if (problems.Count > 0)
         {
             Assert.Fail(
-                "SettingsIndex entries with no SettingsCard.ConfigKey in any settings " +
-                "page. Choosing one of these in search navigates to the page but never " +
-                "scrolls to or pulses the card. Add the attached property to the card, " +
-                "or list the key in KeysWithNoCardYet if the setting has no card:\n" +
-                string.Join("\n", cardless.Select(k => $"  {k}")));
+                "SettingsIndex entries whose control search cannot reach. Choosing one " +
+                "of these in search navigates to the page but never scrolls to or " +
+                "pulses anything. Add the attached property to the control on that " +
+                "page, correct the entry's Page, or list the key in " +
+                $"{nameof(KeysWithNoControlYet)} if the setting has no control:\n" +
+                string.Join("\n", problems));
         }
     }
 
-    // KeysWithNoCardYet is only honest while it stays a list of keys that
-    // genuinely have no card. Without this, a card added later would leave a
-    // stale entry that permanently exempts a real key from the check above.
+    // The scan only recognizes the qualified attribute form. Without this, a
+    // ConfigKey written any other way would be absent from the scanned set,
+    // and the checks above would report a real key as missing -- or, if the
+    // index has no entry for it either, not report it at all.
     [Fact]
-    public void KeysWithNoCardYetIsNotStale()
+    public void ConfigKeyIsAlwaysWrittenAsTheAttachedProperty()
     {
-        var inXaml = ConfigKeysByPage().Values
+        var problems = new List<string>();
+
+        foreach (var (page, document) in PageDocuments())
+        {
+            foreach (var element in document.Descendants())
+            {
+                // Property-element syntax: <ctrl:SettingsCard.ConfigKey>key</...>.
+                if (element.Name.LocalName == AttachedName)
+                    problems.Add($"  {page}: {AttachedName} set as a property element");
+
+                foreach (var attribute in element.Attributes())
+                {
+                    var local = attribute.Name.LocalName;
+
+                    if (local == "ConfigKey")
+                    {
+                        problems.Add(
+                            $"  {page}: unqualified ConfigKey on <{element.Name.LocalName}>; " +
+                            $"write it as the attached property, {AttachedName}");
+                        continue;
+                    }
+
+                    if (local != AttachedName) continue;
+
+                    if (attribute.Name.Namespace != ControlsNamespace)
+                    {
+                        problems.Add(
+                            $"  {page}: {AttachedName} resolves to " +
+                            $"\"{attribute.Name.Namespace}\", not \"{ControlsNamespace}\"");
+                    }
+                    else if (string.IsNullOrWhiteSpace(attribute.Value))
+                    {
+                        problems.Add(
+                            $"  {page}: empty {AttachedName} on <{element.Name.LocalName}>");
+                    }
+                }
+            }
+        }
+
+        if (problems.Count > 0)
+        {
+            Assert.Fail(
+                "ConfigKey written in a form the parity checks above cannot see:\n" +
+                string.Join("\n", problems));
+        }
+    }
+
+    // KeysWithNoControlYet is only honest while both halves hold: the keys
+    // still exist in the index, and they still have no control. Otherwise a
+    // stale entry permanently exempts a real key from the check above.
+    [Fact]
+    public void KeysWithNoControlYetIsNotStale()
+    {
+        var tagged = ConfigKeysByPage().Values
             .SelectMany(keys => keys)
             .ToHashSet(StringComparer.Ordinal);
+        var indexed = SettingsIndex.All.Select(e => e.Key).ToHashSet(StringComparer.Ordinal);
 
-        var landed = KeysWithNoCardYet.Where(inXaml.Contains).ToList();
+        var landed = KeysWithNoControlYet.Where(tagged.Contains).ToList();
+        var dropped = KeysWithNoControlYet.Where(k => !indexed.Contains(k)).ToList();
 
         Assert.True(
             landed.Count == 0,
-            "These keys now have a SettingsCard, so remove them from " +
-            $"KeysWithNoCardYet: {string.Join(", ", landed)}");
-    }
-
-    // Without this, a ConfigKey written in a spelling the regex does not match
-    // would be absent from the scanned set, and the checks above would report
-    // it as a setting with no card -- or, if the index has no entry for it
-    // either, not report it at all.
-    [Fact]
-    public void EveryConfigKeyOccurrenceIsMatched()
-    {
-        foreach (var (page, source) in PageSources())
-        {
-            var occurrences = Regex.Matches(source, @"\bConfigKey\b").Count;
-            var matched = ConfigKeyPattern.Matches(source).Count;
-
-            Assert.True(
-                occurrences == matched,
-                $"{page} mentions ConfigKey {occurrences} time(s) but the scan " +
-                $"pattern in {nameof(SettingsCardConfigKeyParityTests)} matched " +
-                $"{matched}. The pattern no longer describes how the pages set " +
-                "the attached property, so the parity checks cannot see every card.");
-        }
+            "These keys now have a tagged control, so remove them from " +
+            $"{nameof(KeysWithNoControlYet)}: {string.Join(", ", landed)}");
+        Assert.True(
+            dropped.Count == 0,
+            "These keys are no longer in SettingsIndex, so remove them from " +
+            $"{nameof(KeysWithNoControlYet)}: {string.Join(", ", dropped)}");
     }
 
     // Guards the csproj wildcard. Losing it, or moving the pages, would make
-    // every check above scan an empty corpus and pass. Pages that hold no
-    // cards at all (keybindings, profiles, the raw editor) legitimately
-    // contribute no keys, so this pins the page with the most of them.
+    // the checks above scan an empty corpus. EveryIndexedKeyHasAControlOnItsOwnPage
+    // already fails loudly in that case; this names the cause.
     [Fact]
     public void SettingsPagesAreEmbedded()
     {
         var pages = ConfigKeysByPage();
 
-        Assert.NotEmpty(pages);
-        Assert.NotEmpty(pages["AppearancePage.xaml"]);
+        var missing = SettingsIndex.All
+            .Select(e => PageFileFor(e.Page))
+            .Distinct(StringComparer.Ordinal)
+            .Where(f => !pages.ContainsKey(f))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "Settings pages named by SettingsIndex are not embedded in the test " +
+            "assembly. Check the EmbeddedResource wildcard in Ghostty.Tests.csproj: " +
+            $"{string.Join(", ", missing)}");
     }
 
+    // SettingsWindow maps an entry's Page to a page instance by its own table;
+    // the file names follow the same "<Page>Page.xaml" convention throughout.
+    private static string PageFileFor(string page) => $"{page}Page.xaml";
+
     private static Dictionary<string, HashSet<string>> ConfigKeysByPage()
-        => PageSources().ToDictionary(
+        => PageDocuments().ToDictionary(
             p => p.Page,
-            p => ConfigKeyPattern.Matches(p.Source)
-                .Select(m => m.Groups["key"].Value)
+            p => p.Document.Descendants()
+                .SelectMany(e => e.Attributes())
+                .Where(a => a.Name == ControlsNamespace + AttachedName)
+                .Select(a => a.Value)
                 .ToHashSet(StringComparer.Ordinal),
             StringComparer.Ordinal);
 
-    private static List<(string Page, string Source)> PageSources()
+    private static List<(string Page, XDocument Document)> PageDocuments()
     {
         var assembly = Assembly.GetExecutingAssembly();
-        var pages = new List<(string, string)>();
+        var pages = new List<(string, XDocument)>();
 
         foreach (var resource in assembly.GetManifestResourceNames()
                      .Where(n => n.StartsWith(PagePrefix, StringComparison.Ordinal)
@@ -163,9 +236,8 @@ public class SettingsCardConfigKeyParityTests
         {
             using var stream = assembly.GetManifestResourceStream(resource);
             Assert.NotNull(stream);
-            using var reader = new StreamReader(stream);
 
-            pages.Add((resource[PagePrefix.Length..], reader.ReadToEnd()));
+            pages.Add((resource[PagePrefix.Length..], XDocument.Load(stream)));
         }
 
         return pages;

--- a/windows/Ghostty.Tests/Settings/SettingsCardConfigKeyParityTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsCardConfigKeyParityTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Xml;
 using System.Xml.Linq;
 using Ghostty.Core.Settings;
 using Xunit;
@@ -25,6 +26,10 @@ namespace Ghostty.Tests.Settings;
 // Ghostty.Tests.csproj rather than read from disk, so the test does not
 // depend on where the assembly runs from, and does not need a project
 // reference to Ghostty.csproj.
+//
+// This pins the markup, not the running visual tree: a key on a control
+// inside a collapsed panel reads as present here, while the search hit still
+// lands on nothing until the page reveals it.
 public class SettingsCardConfigKeyParityTests
 {
     private const string PagePrefix = "Ghostty.Tests.Settings.Pages.";
@@ -189,6 +194,51 @@ public class SettingsCardConfigKeyParityTests
             $"{nameof(KeysWithNoControlYet)}: {string.Join(", ", dropped)}");
     }
 
+    // The breadcrumb in the results pane reads "<Page> > <Section>", and the
+    // tree walk stops at the first match, so a Section naming a group the card
+    // does not live in sends the user looking under the wrong heading.
+    [Fact]
+    public void EveryIndexedSectionNamesTheGroupItsControlLivesIn()
+    {
+        var controls = TaggedControls()
+            .GroupBy(c => c.Key, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+        var mismatched = SettingsIndex.All
+            .Where(e => controls.TryGetValue(e.Key, out var c) && c.Group != e.Section)
+            .Select(e => $"  {e.Key}: indexed under \"{e.Section}\", but its control " +
+                         $"sits in \"{controls[e.Key].Group ?? "no SettingsGroup"}\"")
+            .ToList();
+
+        if (mismatched.Count > 0)
+        {
+            Assert.Fail(
+                "SettingsIndex sections that name a group their control does not " +
+                "live in. Correct the entry's Section, or move the control:\n" +
+                string.Join("\n", mismatched));
+        }
+    }
+
+    // FindByConfigKey returns the first match in visual-tree order, so a key
+    // used twice silently picks one control and strands the other.
+    [Fact]
+    public void NoConfigKeyIsUsedTwice()
+    {
+        var duplicates = TaggedControls()
+            .GroupBy(c => c.Key, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => $"  {g.Key}: {string.Join(", ", g.Select(c => c.Page))}")
+            .OrderBy(line => line, StringComparer.Ordinal)
+            .ToList();
+
+        if (duplicates.Count > 0)
+        {
+            Assert.Fail(
+                "The same ConfigKey tags more than one control. Search reaches only " +
+                "the first one found:\n" + string.Join("\n", duplicates));
+        }
+    }
+
     // Guards the csproj wildcard. Losing it, or moving the pages, would make
     // the checks above scan an empty corpus. EveryIndexedKeyHasAControlOnItsOwnPage
     // already fails loudly in that case; this names the cause.
@@ -216,14 +266,27 @@ public class SettingsCardConfigKeyParityTests
     private static string PageFileFor(string page) => $"{page}Page.xaml";
 
     private static Dictionary<string, HashSet<string>> ConfigKeysByPage()
-        => PageDocuments().ToDictionary(
-            p => p.Page,
-            p => p.Document.Descendants()
-                .SelectMany(e => e.Attributes())
-                .Where(a => a.Name == ControlsNamespace + AttachedName)
-                .Select(a => a.Value)
-                .ToHashSet(StringComparer.Ordinal),
-            StringComparer.Ordinal);
+        => TaggedControls()
+            .GroupBy(c => c.Page, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(c => c.Key).ToHashSet(StringComparer.Ordinal),
+                StringComparer.Ordinal);
+
+    private static List<(string Page, string Key, string? Group)> TaggedControls()
+        => PageDocuments()
+            .SelectMany(p => p.Document.Descendants()
+                .SelectMany(e => e.Attributes()
+                    .Where(a => a.Name == ControlsNamespace + AttachedName)
+                    .Select(a => (p.Page, Key: a.Value, Group: EnclosingGroupHeader(e)))))
+            .ToList();
+
+    // Cards are grouped visually by SettingsGroup, and its Header is what an
+    // entry's Section has to name for the search breadcrumb to be followable.
+    private static string? EnclosingGroupHeader(XElement element)
+        => element.AncestorsAndSelf()
+            .FirstOrDefault(a => a.Name == ControlsNamespace + "SettingsGroup")
+            ?.Attribute("Header")?.Value;
 
     private static List<(string Page, XDocument Document)> PageDocuments()
     {
@@ -237,7 +300,17 @@ public class SettingsCardConfigKeyParityTests
             using var stream = assembly.GetManifestResourceStream(resource);
             Assert.NotNull(stream);
 
-            pages.Add((resource[PagePrefix.Length..], XDocument.Load(stream)));
+            var page = resource[PagePrefix.Length..];
+            try
+            {
+                pages.Add((page, XDocument.Load(stream)));
+            }
+            catch (XmlException ex)
+            {
+                // XDocument.Load has no base URI here, so its message names a
+                // line but not a file, and every test in this class reports it.
+                Assert.Fail($"{page} is not well-formed XML: {ex.Message}");
+            }
         }
 
         return pages;

--- a/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsIndexTests.cs
@@ -12,6 +12,7 @@ public class SettingsIndexTests
     {
         // General
         "auto-reload-config",
+        "undo-timeout",
         "vertical-tabs",
         "command-palette-background",
         "command-palette-group-commands",
@@ -39,6 +40,7 @@ public class SettingsIndexTests
         "background",
         "cursor-color",
         "selection-background",
+        "accent-color",
         // Terminal
         "scrollback-limit",
         "cursor-style",

--- a/windows/Ghostty/Controls/Settings/SettingsCard.xaml
+++ b/windows/Ghostty/Controls/Settings/SettingsCard.xaml
@@ -9,8 +9,8 @@
       control slot on the right. Height and spacing are hard-coded here
       so every row on every page aligns the same way, eliminating the
       drift we had before where each page used ad-hoc StackPanel Spacing
-      values. The ConfigKey attached property is reserved for Phase 3
-      (search) to scroll to + pulse a specific card.
+      values. The ConfigKey attached property lets settings search scroll
+      to + pulse a specific card.
     -->
     <Border
         Padding="16,10"

--- a/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
@@ -12,8 +12,9 @@ namespace Ghostty.Controls.Settings;
 ///
 /// Header and Description are exposed as dependency properties so
 /// XAML consumers can write Header="Font size" without touching
-/// code-behind. ConfigKey is reserved for Phase 3 (search overlay) --
-/// it tags the card for scroll-to and pulse animation.
+/// code-behind. ConfigKey tags the card for the settings search, which
+/// scrolls to and pulses it; it is attached rather than a plain property
+/// because settings too large for a card row carry it on their own control.
 /// </summary>
 [ContentProperty(Name = nameof(Control))]
 public sealed partial class SettingsCard : UserControl

--- a/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/SettingsCard.xaml.cs
@@ -88,8 +88,6 @@ public sealed partial class SettingsCard : UserControl
         card.ControlPresenter.Content = e.NewValue;
     }
 
-    // Reserved for Phase 3: search scroll + pulse animation targets
-    // this attached property to find the card for a given config key.
     public static readonly DependencyProperty ConfigKeyProperty =
         DependencyProperty.RegisterAttached(
             "ConfigKey",

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -161,7 +161,7 @@
                 <StackPanel x:Name="GradientSettingsPanel" Spacing="8" Visibility="Collapsed">
 
                     <ctrl:SettingsCard Header="Blend mode"
-                                       ctrl:SettingsCard.ConfigKey="background-gradient-blend-mode">
+                                       ctrl:SettingsCard.ConfigKey="background-gradient-blend">
                         <ComboBox x:Name="GradientBlendCombo"
                                   SelectionChanged="GradientBlend_SelectionChanged">
                             <ComboBoxItem Content="Overlay (on top of content)" Tag="overlay" />

--- a/windows/Ghostty/Settings/Pages/GeneralPage.xaml
+++ b/windows/Ghostty/Settings/Pages/GeneralPage.xaml
@@ -22,7 +22,8 @@
 
                 <ctrl:SettingsCard
                     Header="Vertical tabs"
-                    Description="Arrange tabs in a sidebar instead of a horizontal bar.">
+                    Description="Arrange tabs in a sidebar instead of a horizontal bar."
+                    ctrl:SettingsCard.ConfigKey="vertical-tabs">
                     <ToggleSwitch
                         x:Name="VerticalTabsToggle"
                         OffContent="Horizontal tab bar"

--- a/windows/Ghostty/Settings/SettingsCardLocator.cs
+++ b/windows/Ghostty/Settings/SettingsCardLocator.cs
@@ -26,6 +26,10 @@ internal static class SettingsCardLocator
     /// </summary>
     public static FrameworkElement? FindByConfigKey(DependencyObject root, string key)
     {
+        // Untagged elements read back the property default, so an empty key
+        // would match the first element walked rather than nothing.
+        if (string.IsNullOrEmpty(key)) return null;
+
         int childCount = VisualTreeHelper.GetChildrenCount(root);
         for (int i = 0; i < childCount; i++)
         {

--- a/windows/Ghostty/Settings/SettingsCardLocator.cs
+++ b/windows/Ghostty/Settings/SettingsCardLocator.cs
@@ -17,14 +17,21 @@ namespace Ghostty.Settings;
 /// </summary>
 internal static class SettingsCardLocator
 {
-    public static SettingsCard? FindByConfigKey(DependencyObject root, string key)
+    /// <summary>
+    /// Finds the element tagged with <paramref name="key"/>. Matches any
+    /// FrameworkElement rather than only SettingsCard: ConfigKey is an
+    /// attached property, and settings that are too large for a card row
+    /// (the gradient points canvas) carry it on the control itself. Both
+    /// ScrollIntoView and Pulse only need a FrameworkElement.
+    /// </summary>
+    public static FrameworkElement? FindByConfigKey(DependencyObject root, string key)
     {
         int childCount = VisualTreeHelper.GetChildrenCount(root);
         for (int i = 0; i < childCount; i++)
         {
             var child = VisualTreeHelper.GetChild(root, i);
-            if (child is SettingsCard card && SettingsCard.GetConfigKey(card) == key)
-                return card;
+            if (child is FrameworkElement element && SettingsCard.GetConfigKey(element) == key)
+                return element;
             var nested = FindByConfigKey(child, key);
             if (nested != null) return nested;
         }


### PR DESCRIPTION
The blend-mode card carried `ConfigKey="background-gradient-blend-mode"`, but the key ConfigService reads, AppearancePage writes, and SettingsIndex indexes is `background-gradient-blend`. Choosing the "Gradient blend mode" search hit navigated to Appearance and then did nothing: the lookup returned null, so nothing scrolled and nothing pulsed, with no error anywhere.

The parity test pins the settings page XAML against SettingsIndex in both directions, plus the page an entry claims, its section breadcrumb, and that no key tags two controls. Pages are parsed as XML so a key inside a comment does not count as live. They are embedded as manifest resources because Ghostty.Tests cannot reference Ghostty.csproj without dragging the WinAppSDK targets into a plain net10.0 assembly, same approach as CliAliasParityTests. Each check was verified to fail on the defect it describes before being kept.

It found three more instances of the same silent failure:

- the gradient points editor carried the key on a UserControl, and the locator type-tested for SettingsCard before comparing, so it was unreachable. The locator now matches any FrameworkElement, which is what the attached property was for
- the `vertical-tabs` card had no ConfigKey at all, and its index section named a group it does not sit in
- `accent-color` and `undo-timeout` had cards but no SettingsIndex entry, so search never surfaced them

Two gaps this does not close. `command-palette-background` and `command-palette-group-commands` are indexed with no control anywhere, so they sit in a documented allowlist guarded by a staleness test; those settings are not editable from the settings UI at all. And the five gradient keys live inside a panel that is collapsed until gradients are enabled, so their search hits still land on nothing in the default state. The test reads markup, not the running visual tree, and says so.