### PR TITLE
global: clear the state when init fails

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -109,7 +109,20 @@ pub fn init(opts: InitOpts) !void {
         .resources_dir = .{},
     };
     const self = &state.?;
-    errdefer deinit();
+
+    // Clear the state on the way out, not just tear it down. The accessors
+    // below assert on `state`, and those assertions are meant to catch use
+    // before init - but they cannot fire while a failed init leaves behind a
+    // `GlobalState` full of dead pointers, which is how an embedder that
+    // ignored our error ended up allocating from a deinitialized GPA.
+    //
+    // One block rather than two `errdefer` statements: those unwind in reverse
+    // declaration order, so a separate `errdefer state = null;` would run
+    // first and `deinit` would then read through a null optional.
+    errdefer {
+        deinit();
+        state = null;
+    }
 
     // Don't let the narrow-entry-point fallback above be silent: a caller
     // that passed argv on Windows is not getting the args it asked for.
@@ -265,6 +278,11 @@ pub fn init(opts: InitOpts) !void {
 /// Cleans up the global state. This doesn't _need_ to be called but
 /// doing so in dev modes will check for memory leaks.
 ///
+/// This deliberately leaves `state` populated, which is what makes `init`
+/// refuse a second call after a `deinit`. A failed `init` is the one case
+/// that does clear it, and it does that in its own `errdefer` rather than
+/// here, so that the once-per-process guard keeps holding for everyone else.
+///
 /// Asserts that the state exists.
 pub fn deinit() void {
     const self = &state.?;
@@ -394,11 +412,24 @@ pub fn rlimits() ResourceLimits {
     return state.?.rlimits;
 }
 
-/// Returns the global state logging configuration.
+/// Returns the global state logging configuration, or the defaults if there
+/// is no state.
 ///
-/// Asserts that the global state is initialized.
+/// Unlike the accessors above this one tolerates a missing state rather than
+/// asserting on it. `logFn` reads it on every single log call, including the
+/// `std.log.err` that `ghostty_init` writes to report an `init` failure - and
+/// by then `init`'s `errdefer` has already torn the state back down. Asserting
+/// here would panic inside the code trying to explain the failure.
+///
+/// The defaults are the same values `init` starts from, so a log emitted
+/// before or after a state exists goes wherever a log emitted at the very
+/// start of `init` would have gone.
+///
+/// Captured by pointer: `logFn` runs this on every log call, and a by-value
+/// capture would copy the whole `GlobalState` (`io_impl` included) just to
+/// read two bits out of it.
 pub fn logging() GlobalState.Logging {
-    return state.?.logging;
+    return if (state) |*s| s.logging else .{};
 }
 
 /// Returns the global state action.
@@ -476,6 +507,44 @@ test "initErrorMessage explains the CLI argument errors" {
 
 test "initErrorMessage leaves other errors to the log" {
     try std.testing.expect(initErrorMessage(error.OutOfMemory) == null);
+}
+
+test "a failed init leaves no state behind" {
+    // An unknown `+action` fails in `detectArgs`, the earliest error `init`
+    // can return. That keeps this to the allocator, the I/O impl and the tmp
+    // dir rather than standing up (and tearing back down) signal handlers,
+    // oniguruma and the resources dir.
+    //
+    // The args vector is platform-typed - a WTF-16 command line on Windows,
+    // an argv elsewhere - so build it the same way `init` does for the `.c`
+    // prong, with a comptime `if` that leaves the other branch unanalyzed.
+    const vector: std.process.Args.Vector = if (comptime builtin.os.tag == .windows)
+        std.unicode.utf8ToUtf16LeStringLiteral("ghostty +definitely-not-an-action")
+    else
+        &.{ "ghostty", "+definitely-not-an-action" };
+
+    try std.testing.expectError(error.InvalidAction, init(.{ .main = .{
+        .environ = std.testing.environ,
+        .args = .{ .vector = vector },
+    } }));
+
+    // The whole point. Every accessor asserts on this, and a failed init that
+    // left the state populated would hand out a dead allocator and a
+    // deinitialized I/O impl instead of tripping those assertions.
+    try std.testing.expect(state == null);
+}
+
+test "logging tolerates an absent state" {
+    // The failure path above logs through `logFn` after `init`'s `errdefer`
+    // has run, so this accessor has to survive what the others assert on.
+    try std.testing.expect(state == null);
+
+    // Compared field by field: `Logging` is a packed struct and the point is
+    // the values, not the backing integer.
+    const expected: GlobalState.Logging = .{};
+    const actual = logging();
+    try std.testing.expectEqual(expected.stderr, actual.stderr);
+    try std.testing.expectEqual(expected.macos, actual.macos);
 }
 
 /// This represents the global process state. There should only


### PR DESCRIPTION
`deinit` tears the `GlobalState` down but leaves `state` pointing at it, by design: that is what makes `init` refuse a second call (# 575). A failed `init` calls `deinit` from its `errdefer` and inherited that, so it left behind a non-null state holding a deinitialized GPA, a released I/O impl and a freed resources dir.

Every accessor asserts with `state.?`. Those assertions are there to catch use before init, but they cannot fire once a failed init leaves the state populated, so `ghostty_config_new` allocated from the dead GPA instead of tripping one. # 578 made the GUI path exit on a non-zero init status, but libghostty is a library and any embedder that ignores the status still gets the dead allocator.

Clear it in `init`'s `errdefer` rather than in `deinit`, so the once-per-process guard keeps holding for the normal teardown path and only the failure path resets. One block rather than two `errdefer` statements: those unwind in reverse declaration order, so a separate `errdefer state = null;` would run first and `deinit` would then read through a null optional.

`logging` has to tolerate an absent state for this to be safe. `logFn` reads it on every log call, including the `std.log.err` that `ghostty_init` writes to report the failure, which runs after the errdefer. Asserting there turned the failure report itself into a null-unwrap panic. It returns the same defaults `init` starts from, and captures by pointer so the hot path does not copy the whole `GlobalState` to read two bits. The other accessors keep asserting, which is the behavior being restored.

One visible change: an exe that fails init after detecting an action used to report `stderr = false` and stay silent. It now uses the default, so the error reaches stderr.

Both new tests were checked against a reverted fix rather than only against the fix:

- reverting the combined `errdefer` to plain `errdefer deinit();` fails `a failed init leaves no state behind` at the assert
- reverting `logging` to `state.?.logging` crashes `logging tolerates an absent state` with `panic: attempt to use null value`

Tested on Windows (`zig build` 103/103; `zig build test` 3748 pass, 77 skip, 0 fail) and Linux `-Dapp-runtime=none` (3581 pass, 109 skip, 0 fail).
