### PR TITLE
windows: route the user-visible brand surfaces through AppIdentity

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -16,9 +16,22 @@ internal static class AppIdentity
     public const string AumId = "com.deblasis.ghostty";
 
     /// <summary>
-    /// Brand name shown in user-facing surfaces (window titles, dialog
-    /// captions). Gated behind a single constant so rebrands (Ghostty →
-    /// Wintty → ...) only touch one file instead of scattering literals.
+    /// Brand name for what a user reads: window and tab titles, dialog
+    /// captions, the <c>+version</c> header, <see cref="LogTag"/>.
+    ///
+    /// Not the source for the other "Wintty" literals in the tree, which
+    /// track something a rebrand must not move:
+    /// <list type="bullet">
+    /// <item>paths under <c>%LOCALAPPDATA%</c>, where following the brand
+    /// would orphan a user's logs, session and window state with nothing
+    /// left to migrate them;</item>
+    /// <item>the assembly name, which <c>InternalsVisibleTo</c> and
+    /// <c>Process.GetProcessesByName</c> have to match;</item>
+    /// <item>kernel object and window class names, which single-instance
+    /// and the global hotkey key off.</item>
+    /// </list>
+    /// A rebrand therefore touches this constant and the XAML literals
+    /// that cannot reach an internal type, not every "Wintty" in the tree.
     /// </summary>
     public const string ProductName = "Wintty";
 

--- a/windows/Ghostty.Core/Panes/PaneNode.cs
+++ b/windows/Ghostty.Core/Panes/PaneNode.cs
@@ -1,8 +1,3 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Wintty")]
-[assembly: InternalsVisibleTo("Ghostty.Tests")]
-
 namespace Ghostty.Core.Panes;
 
 internal abstract class PaneNode { }

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -143,7 +143,7 @@ internal sealed class TabModel : INotifyPropertyChanged
     // Title precedence: explicit user override beats anything; then
     // the shell's OSC 0/2 reported title (which knows what the user
     // is actually running, e.g. "vim file.txt"); then the profile's
-    // display name (PR 4 - so a tab opened from the new-tab split
+    // display name (so a tab opened from the new-tab split
     // button reads its profile Name rather than the generic fallback
     // before the shell sends a title); then the product name for the
     // no-profile / pre-OSC-2 cold-start case.

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -145,10 +145,10 @@ internal sealed class TabModel : INotifyPropertyChanged
     // is actually running, e.g. "vim file.txt"); then the profile's
     // display name (PR 4 - so a tab opened from the new-tab split
     // button reads its profile Name rather than the generic fallback
-    // before the shell sends a title); then the hardcoded fallback
-    // for the no-profile / pre-OSC-2 cold-start case.
+    // before the shell sends a title); then the product name for the
+    // no-profile / pre-OSC-2 cold-start case.
     public string EffectiveTitle =>
-        UserOverrideTitle ?? ShellReportedTitle ?? ProfileSnapshot?.DisplayName ?? "Wintty";
+        UserOverrideTitle ?? ShellReportedTitle ?? ProfileSnapshot?.DisplayName ?? AppIdentity.ProductName;
 
     public TabModel(IPaneHost paneHost)
     {

--- a/windows/Ghostty.Core/Version/AboutContent.cs
+++ b/windows/Ghostty.Core/Version/AboutContent.cs
@@ -20,7 +20,7 @@ public static class AboutContent
     // The embedded '\n' is intentional: the About TextBlock renders it as a
     // line break, keeping this value UI-free and unit-testable here in Core.
     public const string Copyright =
-        "Wintty (c) 2026 Alessandro De Blasis\n" +
+        AppIdentity.ProductName + " (c) 2026 Alessandro De Blasis\n" +
         "Based on Ghostty (c) 2024 Mitchell Hashimoto, Ghostty contributors";
 
     public const string GitHubUrl = "https://github.com/deblasis/wintty";

--- a/windows/Ghostty.Core/Version/VersionRenderer.cs
+++ b/windows/Ghostty.Core/Version/VersionRenderer.cs
@@ -88,13 +88,13 @@ public static class VersionRenderer
         if (ansi && hasCommit)
         {
             sb.Append(Osc8Open).Append(CommitUrlPrefix).Append(info.WinttyCommit).Append(St);
-            sb.Append("Wintty ").Append(info.WinttyVersionString);
+            sb.Append(AppIdentity.ProductName).Append(' ').Append(info.WinttyVersionString);
             sb.Append(Osc8Close);
             sb.Append('\n');
         }
         else
         {
-            sb.Append("Wintty ").Append(info.WinttyVersionString).Append('\n');
+            sb.Append(AppIdentity.ProductName).Append(' ').Append(info.WinttyVersionString).Append('\n');
         }
         if (hasCommit)
         {

--- a/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
+++ b/windows/Ghostty/Dialogs/VersionDialog.xaml.cs
@@ -33,7 +33,7 @@ internal sealed partial class VersionDialog : ContentDialog
         // Title bar: app icon + "Wintty <version>". Icon URI is the
         // canonical AppIconSource so packaging changes propagate here.
         TitleIcon.Source = new BitmapImage(AppIconSource.Current);
-        TitleText.Text = $"Wintty {info.WinttyVersionString}";
+        TitleText.Text = $"{Ghostty.Core.AppIdentity.ProductName} {info.WinttyVersionString}";
 
         var commitUrl = VersionRenderer.CommitUrl(info);
         if (commitUrl is null)

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -397,7 +397,7 @@ public static partial class Program
             // terminal's stderr, while the GUI has already pointed stderr at
             // the log file by the time ConfigService calls in.
             Console.Error.WriteLine(
-                $"[{Ghostty.Core.AppIdentity.ProductName}] FATAL: " +
+                $"{AppIdentity.LogTag} FATAL: " +
                 $"ghostty_init failed (status {result}), exiting with " +
                 $"{(int)ExitCode.InitFailed} ({nameof(ExitCode.InitFailed)})");
             Console.Error.Flush();

--- a/windows/Ghostty/Shell/TitleBarCoordinator.cs
+++ b/windows/Ghostty/Shell/TitleBarCoordinator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using Ghostty.Controls;
+using Ghostty.Core;
 using Ghostty.Core.Panes;
 using Ghostty.Core.Tabs;
 using Ghostty.Panes;
@@ -156,7 +157,8 @@ internal sealed class TitleBarCoordinator
     }
 
     private void UpdateVerticalTitleText()
-        => _verticalTitleText.Text = _boundTab?.EffectiveTitle ?? "Wintty";
+        => _verticalTitleText.Text = _boundTab?.EffectiveTitle
+            ?? AppIdentity.ProductName;
 
     /// <summary>
     /// Subscribe the active tab's active leaf to live title-change

--- a/windows/Ghostty/Shell/TitleBarCoordinator.cs
+++ b/windows/Ghostty/Shell/TitleBarCoordinator.cs
@@ -157,8 +157,7 @@ internal sealed class TitleBarCoordinator
     }
 
     private void UpdateVerticalTitleText()
-        => _verticalTitleText.Text = _boundTab?.EffectiveTitle
-            ?? AppIdentity.ProductName;
+        => _verticalTitleText.Text = _boundTab?.EffectiveTitle ?? AppIdentity.ProductName;
 
     /// <summary>
     /// Subscribe the active tab's active leaf to live title-change


### PR DESCRIPTION
Follow-ups from the review of # 579.

`InitGhostty` rebuilt the bracketed log tag out of `ProductName` instead of using `LogTag`, which is the drift that constant exists to prevent. The vertical title bar, `TabModel.EffectiveTitle`, the Version dialog caption, the `+version` header on both the plain and ANSI paths, and the About copyright line all spelled the brand themselves, while About, Settings and Inspector already went through `ProductName`.

`ProductName` now says what it is not the source for. The old wording promised a rebrand touches one file, which invites routing three other families of `"Wintty"` literal through it, and each tracks something a rebrand must not move:

- paths under `%LOCALAPPDATA%`, where following the brand would strand a user's logs, session and window state with nothing to migrate them
- the assembly name, which `InternalsVisibleTo` and `Process.GetProcessesByName` have to match
- kernel object and window class names behind single-instance and the global hotkey

Left alone: `MainWindow.xaml` `Title="Wintty"` and the other XAML literals. `AppIdentity` is `internal`, and `{x:Static}` against an internal type is not reliable under the XAML compiler with AOT, so those need code-behind rather than a constant. `TabModelProfileSnapshotTests` keeps asserting the bare literal on purpose, so a rebrand regression fails a test instead of passing tautologically.

Also drops the duplicate `InternalsVisibleTo` pair from `PaneNode.cs`; `AssemblyAttributes.cs` already declares a superset.

`dotnet build` clean, `dotnet test` 1771 passed, and `wintty +version` renders a byte-identical header.