### PR TITLE
cli: stop explaining the + prefix on an unknown action

### DIFF
--- a/macos/Sources/App/macOS/main.swift
+++ b/macos/Sources/App/macOS/main.swift
@@ -15,8 +15,7 @@ if ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) != GHOSTTY_SUCCE
         stderrHandle.write(
             "Ghostty failed to initialize! If you're executing Ghostty from the command line\n" +
             "then this is usually because an invalid action or multiple actions were specified.\n" +
-            "Actions start with the `+` character.\n\n" +
-            "View all available actions by running `ghostty +help`.\n")
+            "ghostty_init explains the argument errors itself, above this line.\n")
         exit(1)
 
     case .app:

--- a/src/global.zig
+++ b/src/global.zig
@@ -448,8 +448,9 @@ pub fn action() ?cli.ghostty.Action {
 /// nothing to show for a typo but an exit code. Writing to the file directly
 /// skips the log sink so the message survives that default.
 ///
-/// The exe has its own copy of this in `main_ghostty.zig`, where it runs
-/// before there is any global state to consult. Keep the wording in sync.
+/// The exe routes through here too. It touches no global state, by
+/// design: `init` can fail before `io_impl` exists, so the caller may
+/// have nothing initialized to consult.
 ///
 /// Only the argument-parsing errors get text here. Anything else stays with
 /// the caller's `std.log.err`, which reaches an embedder that registered a
@@ -495,8 +496,8 @@ pub fn initErrorMessage(err: anyerror) ?[]const u8 {
 test "initErrorMessage explains the CLI argument errors" {
     const testing = std.testing;
 
-    // The exe prints its own copy of these from main_ghostty.zig. If either
-    // side is reworded, both should say the same thing.
+    // The exe and the C API both print these, so a reword lands in every
+    // surface at once. Pinning the text keeps that deliberate.
     try testing.expectEqualStrings(
         "Error: unknown CLI action specified.\n\n" ++
             "All valid CLI actions can be listed with the `+help` action.\n",

--- a/src/global.zig
+++ b/src/global.zig
@@ -473,8 +473,10 @@ pub fn reportInitError(err: anyerror) void {
 /// The text `reportInitError` writes for `err`, or null for errors with no
 /// user-facing explanation, which stay with the caller's `std.log.err`.
 ///
-/// Split from the write so the mapping can be tested without capturing stderr.
-fn initErrorMessage(err: anyerror) ?[]const u8 {
+/// Split from the write so the mapping can be tested without capturing
+/// stderr, and so `main_ghostty` can ask whether an error explains itself
+/// before falling back to the log.
+pub fn initErrorMessage(err: anyerror) ?[]const u8 {
     return switch (err) {
         error.MultipleActions => "Error: multiple CLI actions specified. You must specify only one\n" ++
             "action starting with the `+` character.\n",

--- a/src/global.zig
+++ b/src/global.zig
@@ -479,9 +479,14 @@ fn initErrorMessage(err: anyerror) ?[]const u8 {
         error.MultipleActions => "Error: multiple CLI actions specified. You must specify only one\n" ++
             "action starting with the `+` character.\n",
 
-        error.InvalidAction => "Error: unknown CLI action specified. CLI actions are specified with\n" ++
-            "the '+' character.\n\n" ++
-            "All valid CLI actions can be listed with `ghostty +help`\n",
+        // Deliberately silent about the `+` convention. `detectIter` skips
+        // every argument that does not start with `+`, so this error can
+        // only mean the name after the `+` is not an action: explaining the
+        // prefix sends the reader looking for a mistake they did not make.
+        // Naming the action rather than a binary keeps it true for `wintty`
+        // as well as `ghostty`.
+        error.InvalidAction => "Error: unknown CLI action specified.\n\n" ++
+            "All valid CLI actions can be listed with the `+help` action.\n",
 
         else => null,
     };
@@ -493,9 +498,8 @@ test "initErrorMessage explains the CLI argument errors" {
     // The exe prints its own copy of these from main_ghostty.zig. If either
     // side is reworded, both should say the same thing.
     try testing.expectEqualStrings(
-        "Error: unknown CLI action specified. CLI actions are specified with\n" ++
-            "the '+' character.\n\n" ++
-            "All valid CLI actions can be listed with `ghostty +help`\n",
+        "Error: unknown CLI action specified.\n\n" ++
+            "All valid CLI actions can be listed with the `+help` action.\n",
         initErrorMessage(cli.action.DetectError.InvalidAction).?,
     );
     try testing.expectEqualStrings(

--- a/src/global.zig
+++ b/src/global.zig
@@ -479,12 +479,10 @@ fn initErrorMessage(err: anyerror) ?[]const u8 {
         error.MultipleActions => "Error: multiple CLI actions specified. You must specify only one\n" ++
             "action starting with the `+` character.\n",
 
-        // Deliberately silent about the `+` convention. `detectIter` skips
-        // every argument that does not start with `+`, so this error can
-        // only mean the name after the `+` is not an action: explaining the
-        // prefix sends the reader looking for a mistake they did not make.
-        // Naming the action rather than a binary keeps it true for `wintty`
-        // as well as `ghostty`.
+        // Deliberately silent about the `+` convention. The only path to
+        // this error is a `+` argument whose name is not in the action
+        // enum, so explaining the prefix sends the reader hunting for a
+        // mistake they did not make.
         error.InvalidAction => "Error: unknown CLI action specified.\n\n" ++
             "All valid CLI actions can be listed with the `+help` action.\n",
 

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -46,9 +46,8 @@ pub fn main(minimal: std.process.Init.Minimal) !MainReturn {
             ),
 
             error.InvalidAction => try stderr.print(
-                "Error: unknown CLI action specified. CLI actions are specified with\n" ++
-                    "the '+' character.\n\n" ++
-                    "All valid CLI actions can be listed with `ghostty +help`\n",
+                "Error: unknown CLI action specified.\n\n" ++
+                    "All valid CLI actions can be listed with the `+help` action.\n",
                 .{},
             ),
 

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -45,6 +45,8 @@ pub fn main(minimal: std.process.Init.Minimal) !MainReturn {
                 .{},
             ),
 
+            // Keep in sync with `global.initErrorMessage`, which carries
+            // the reasoning for what this text does and does not say.
             error.InvalidAction => try stderr.print(
                 "Error: unknown CLI action specified.\n\n" ++
                     "All valid CLI actions can be listed with the `+help` action.\n",

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -30,32 +30,17 @@ pub fn main(minimal: std.process.Init.Minimal) !MainReturn {
     // a global is because the C API needs to be able to access this state;
     // no other Zig code should EVER access the global state.
     global.init(.{ .main = minimal }) catch |err| {
-        var buffer: [1024]u8 = undefined;
-        var stderr_writer = std.Io.File.stderr().writer(
-            std.Io.Threaded.global_single_threaded.io(),
-            &buffer,
-        );
-        const stderr = &stderr_writer.interface;
         defer std.process.exit(1);
-        const ErrSet = @TypeOf(err) || error{Unknown};
-        switch (@as(ErrSet, @errorCast(err))) {
-            error.MultipleActions => try stderr.print(
-                "Error: multiple CLI actions specified. You must specify only one\n" ++
-                    "action starting with the `+` character.\n",
-                .{},
-            ),
 
-            // Keep in sync with `global.initErrorMessage`, which carries
-            // the reasoning for what this text does and does not say.
-            error.InvalidAction => try stderr.print(
-                "Error: unknown CLI action specified.\n\n" ++
-                    "All valid CLI actions can be listed with the `+help` action.\n",
-                .{},
-            ),
-
-            else => try stderr.print("invalid CLI invocation err={}\n", .{err}),
+        // The argument-error text comes from `global` rather than a second
+        // copy here. The two were hand-synced before, with nothing to fail
+        // when they drifted. Errors it has no text for fall back to the
+        // log, which is all the old branch for them did.
+        if (global.initErrorMessage(err)) |_| {
+            global.reportInitError(err);
+        } else {
+            std.log.err("invalid CLI invocation err={}", .{err});
         }
-        try stderr.flush();
     };
     defer global.deinit();
     const alloc = global.alloc();

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -34,12 +34,28 @@ pub fn main(minimal: std.process.Init.Minimal) !MainReturn {
 
         // The argument-error text comes from `global` rather than a second
         // copy here. The two were hand-synced before, with nothing to fail
-        // when they drifted. Errors it has no text for fall back to the
-        // log, which is all the old branch for them did.
+        // when they drifted.
+        //
+        // Neither branch may use `std.log`. `init` leaves the state null
+        // on the way out, so a log call gets the default `Logging`, whose
+        // `stderr` is false whenever `app_runtime` is `none` - and that
+        // artifact calls `main` for its CLI actions. The report would be
+        // dropped in exactly the build that has no other sink. Writing to
+        // the handle is what `reportInitError` does, and for the same
+        // reason.
         if (global.initErrorMessage(err)) |_| {
             global.reportInitError(err);
         } else {
-            std.log.err("invalid CLI invocation err={}", .{err});
+            var buf: [256]u8 = undefined;
+            const line = std.fmt.bufPrint(
+                &buf,
+                "invalid CLI invocation err={}\n",
+                .{err},
+            ) catch "invalid CLI invocation\n";
+            std.Io.File.stderr().writeStreamingAll(
+                std.Io.Threaded.global_single_threaded.io(),
+                line,
+            ) catch {};
         }
     };
     defer global.deinit();


### PR DESCRIPTION
`wintty +definitelyNotAnAction` answered with "CLI actions are specified with the '+' character", which reads as a complaint about the character it had just accepted.

`InvalidAction` can only mean the name after the `+` is not an action: the only path to it is a `+` argument whose name is not in the enum. The prefix advice was unreachable and sent the reader hunting for a mistake they did not make. The suggestion also named `ghostty`, which is not the binary on Windows, so it points at the `+help` action instead.

macOS reprints its own init-failure block after `ghostty_init` has already reported, so the same advice survived one line below the new message. That block now points at what libghostty already said.

While in here, `main_ghostty` kept its own copy of both argument-error strings, synced to `global.initErrorMessage` by a comment and nothing else, which is why a one-string reword had to touch two files. It asks `global` for the text now, which also deletes the stderr writer, its buffer and the `errorCast` switch that existed only to carry the duplicate. The fallback for errors with no text keeps writing to the handle rather than `std.log`: a failed init leaves the state null, so a log call gets the default `Logging`, whose `stderr` is false whenever `app_runtime` is `none` - the one artifact with no other sink.

Not done: echoing the offending argument. Zig error sets carry no payload, so `detectIter` would need an out-parameter, and that is upstream code with 13 call sites. Re-scanning argv in `global` instead would duplicate the parser and could disagree with it.

Verified `zig build test` on Windows (3748/3825) and Linux (3581/3690), and ran `Wintty.exe +definitelyNotAnAction` against the rebuilt dll. Mac is unverified: that host's zig is 0.15.2 against the repo's required 0.16.0.