### PR TITLE
windows: set the XAML brand surfaces from AppIdentity

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -30,8 +30,11 @@ internal static class AppIdentity
     /// <item>kernel object and window class names, which single-instance
     /// and the global hotkey key off.</item>
     /// </list>
-    /// A rebrand therefore touches this constant and the XAML literals
-    /// that cannot reach an internal type, not every "Wintty" in the tree.
+    /// A rebrand therefore touches this constant, the brand names written
+    /// into prose, and the Win32 version resource in <c>ghostty.rc</c>
+    /// that Explorer reads, not every "Wintty" in the tree. XAML surfaces
+    /// read it from code-behind, since this type is internal and x:Bind
+    /// would need it public.
     /// </summary>
     public const string ProductName = "Wintty";
 

--- a/windows/Ghostty.Core/Settings/SettingsIndex.cs
+++ b/windows/Ghostty.Core/Settings/SettingsIndex.cs
@@ -45,7 +45,7 @@ public static class SettingsIndex
 
         // ----- Appearance / Window Mode -----
         new("window-theme", "Window mode",
-            "Light, dark, or follow the system theme. Ghostty derives from terminal background.",
+            "Light, dark, or follow the system theme. Auto derives from terminal background.",
             "Appearance", "Window Mode",
             new[] { "theme", "dark", "light", "system", "chrome", "titlebar" },
             SettingType.Combo),

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -5,8 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:cmdpalette="using:Ghostty.Controls.CommandPalette"
     xmlns:notifications="using:Ghostty.Controls.Notifications"
-    xmlns:tabs="using:Ghostty.Tabs"
-    Title="Wintty">
+    xmlns:tabs="using:Ghostty.Tabs">
+    <!-- Title comes from AppIdentity.ProductName in the constructor. -->
+
 
     <!--
         Declarative layout for the dual tab-host shell.

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -8,7 +8,6 @@
     xmlns:tabs="using:Ghostty.Tabs">
     <!-- Title comes from AppIdentity.ProductName in the constructor. -->
 
-
     <!--
         Declarative layout for the dual tab-host shell.
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -457,6 +457,12 @@ public sealed partial class MainWindow : Window
         // the default title bar row.
         ExtendsContentIntoTitleBar = true;
 
+        // Set here rather than in XAML: AppIdentity is internal, and
+        // {x:Static} against an internal type is not reliable under the
+        // XAML compiler with AOT. This is the caption the shell shows in
+        // Alt+Tab and the taskbar before any tab reports a title.
+        Title = Ghostty.Core.AppIdentity.ProductName;
+
         // Apply window-theme from config. The manager resolves the
         // config value ("light"/"dark"/"system"/"auto") to a concrete
         // dark/light choice and sets both ElementTheme on the XAML root

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -457,10 +457,15 @@ public sealed partial class MainWindow : Window
         // the default title bar row.
         ExtendsContentIntoTitleBar = true;
 
-        // Set here rather than in XAML: AppIdentity is internal, and
-        // {x:Static} against an internal type is not reliable under the
-        // XAML compiler with AOT. This is the caption the shell shows in
-        // Alt+Tab and the taskbar before any tab reports a title.
+        // Set here rather than in XAML: Window is not a DependencyObject,
+        // so no markup extension can target Title at all, and AppIdentity
+        // is internal besides, which x:Bind's generated code would need
+        // public. Same constraint CommandPaletteControl documents.
+        //
+        // TitleBarCoordinator takes the caption over further down this
+        // constructor, from the active tab's EffectiveTitle, which falls
+        // back to this same constant. So this is the value only until
+        // then, and the two agree.
         Title = Ghostty.Core.AppIdentity.ProductName;
 
         // Apply window-theme from config. The manager resolves the

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -11,7 +11,7 @@
             <ctrl:SettingsGroup Header="Window Mode"
                                 Description="How the window chrome and title bar look.">
                 <ctrl:SettingsCard Header="Window mode"
-                                   Description="Auto derives from background luminosity. Ghostty colors the title bar from the terminal palette."
+                                   Description="Auto derives from background luminosity. Wintty colors the title bar from the terminal palette."
                                    ctrl:SettingsCard.ConfigKey="window-theme">
                     <ComboBox x:Name="WindowThemeCombo" MinWidth="260"
                               SelectionChanged="WindowTheme_SelectionChanged">

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -49,7 +49,9 @@
                         </ComboBoxItem>
                         <ComboBoxItem Tag="ghostty">
                             <StackPanel>
-                                <TextBlock Text="Wintty" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <!-- Text set in code-behind from AppIdentity.ProductName. -->
+                                <TextBlock x:Name="WindowThemeProductLabel"
+                                           Style="{StaticResource BodyStrongTextBlockStyle}" />
                                 <TextBlock Text="Color title bar from the terminal palette."
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -34,6 +34,12 @@ internal sealed partial class AppearancePage : Page
         _editor = editor;
         _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
+
+        // Set here rather than in XAML: AppIdentity is internal, and
+        // {x:Static} against an internal type is not reliable under the
+        // XAML compiler with AOT.
+        WindowThemeProductLabel.Text = Ghostty.Core.AppIdentity.ProductName;
+
         _fontList = new SearchableList(FontFamilySearch, chosen => OnValueChanged("font-family", chosen));
         OpacitySlider.Value = configService.BackgroundOpacity;
         SelectWindowTheme(configService.WindowTheme);

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -35,9 +35,9 @@ internal sealed partial class AppearancePage : Page
         _writer = new SettingsConfigWriter(configService, StaticLoggers.SettingsConfigWriter);
         InitializeComponent();
 
-        // Set here rather than in XAML: AppIdentity is internal, and
-        // {x:Static} against an internal type is not reliable under the
-        // XAML compiler with AOT.
+        // Set here rather than in XAML because AppIdentity is internal,
+        // and x:Bind's AOT-generated code would require the type to be
+        // public. Same constraint CommandPaletteControl documents.
         WindowThemeProductLabel.Text = Ghostty.Core.AppIdentity.ProductName;
 
         _fontList = new SearchableList(FontFamilySearch, chosen => OnValueChanged("font-family", chosen));


### PR DESCRIPTION
Finishes what # 584 left: the window caption and the window-theme option label were the last two brand literals in XAML, skipped there as XAML-only.

Neither has to be. `Window` is not a `DependencyObject`, so no markup extension can reach `Title` at all, and `AppIdentity` is `internal` besides, which `x:Bind`'s generated code would need public. Code-behind has neither constraint, so both values are assigned after `InitializeComponent`.

Review then found the same card describing its own option as "Ghostty" while the option below it now reads Wintty, and the settings-search entry for `window-theme` claiming Ghostty derives from the terminal background when that is what Auto does. Both corrected.

Left literal: the two `AppearancePage` descriptions that name the brand inside a sentence, and the `GeneralPage` / `TerminalPage` mentions of upstream Ghostty's default values, which mean upstream and not this fork. `Tag="ghostty"` stays too, being the libghostty config value rather than a brand.

`dotnet build` clean, `dotnet test` 1771 passed. Sampling the window title from launch shows Wintty before the shell's OSC title takes over, matching the old behaviour.