### PR TITLE
global: keep the redundant state check in the init guard

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -90,11 +90,18 @@ pub fn init(opts: InitOpts) !void {
     // (Both of those are no-ops on Windows.) Tripping that sentry assert is a
     // panic in Debug and ReleaseSafe, and illegal behavior in ReleaseFast.
     //
-    // Latched rather than derived from `state`, because the errdefer below
-    // clears that on failure and a failed init must not look retryable.
+    // The latch, not `state`, is what carries this: the errdefer below clears
+    // the state on failure, and a failed init must not look retryable.
     // Returning before the errdefer is armed leaves any live state untouched.
-    assert(state == null or init_attempted);
-    if (init_attempted) return error.AlreadyInitialized;
+    //
+    // `state != null` is redundant with the latch, which is set below before
+    // the state is ever assigned and is never cleared. It stays as a cheap
+    // guard rather than an assertion because the consequence of being wrong is
+    // the leak described above, and an assertion buys nothing where it would
+    // matter: `quirks.inlineAssert` is `unreachable`, which ReleaseFast does
+    // not check, so it would fall through and overwrite the live state in
+    // exactly the build where that is hardest to diagnose.
+    if (state != null or init_attempted) return error.AlreadyInitialized;
     init_attempted = true;
 
     // Initialize ourself to nothing so we don't have any extra state.


### PR DESCRIPTION
Partial revert of # 587.

# 587 replaced the `state != null` half of the re-entrancy guard with an assertion, on the grounds that it was dead: `init_attempted` is set before the state is assigned and never cleared, so a non-null state always implies the latch. The reasoning was right and the trade was not.

`quirks.inlineAssert` is `std.debug.assert` in Debug and `if (!ok) unreachable` everywhere else. ReleaseSafe checks that; ReleaseFast and ReleaseSmall do not. So where the invariant held the assertion was free, and where it did not, the shipping build fell through and overwrote a live `GlobalState` - leaking the GPA, the I/O instance and the resources dir, and orphaning the WTF-16 command line the args iterator borrows. That is the leak the guard exists to prevent, and the graceful `error.AlreadyInitialized` costs one comparison.

The check is back, with a comment on why it stays despite being redundant, so it does not get tidied away again.

The rest of # 587 stands. In particular the test still pins the latch rather than this branch: it sets `init_attempted` and leaves `state` null, so dropping the latch from the guard still crashes it with `reached unreachable code`. Confirmed by reverting.

Tested on Windows (`zig build` 103/103; `zig build test` 3748 pass, 77 skip, 0 fail) and Linux `-Dapp-runtime=none`.
