### PR TITLE
global: give every init failure a user-facing explanation

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -228,10 +228,10 @@ pub fn init(opts: InitOpts) !void {
     // this. Env vars are useful for logging too because they are
     // easy to set.
     logging: {
-        const v = self.environ.getAlloc(self.alloc, "GHOSTTY_LOG") catch |err| switch (err) {
-            error.EnvironmentVariableMissing => break :logging,
-            else => return err,
-        };
+        // Any read failure leaves the defaults, rather than aborting startup
+        // over a logging knob. The parse below is already tolerant, so a
+        // malformed value could not stop init while an unreadable one could.
+        const v = self.environ.getAlloc(self.alloc, "GHOSTTY_LOG") catch break :logging;
         defer self.alloc.free(v);
         self.logging = cli.args.parsePackedStruct(GlobalState.Logging, v) catch .{};
     }
@@ -480,11 +480,15 @@ pub fn action() ?cli.ghostty.Action {
 /// design: `init` can fail before `io_impl` exists, so the caller may
 /// have nothing initialized to consult.
 ///
-/// Only the argument-parsing errors get text here. Anything else stays with
-/// the caller's `std.log.err`, which reaches an embedder that registered a
-/// callback via `ghostty_log_set_callback`.
+/// Every failure gets text, not just the argument-parsing ones. The rest were
+/// previously left to the caller's `std.log.err`, which in the lib artifact
+/// reaches only an embedder that already registered a callback via
+/// `ghostty_log_set_callback` - and that registration typically happens after
+/// init, since init is what the embedder is trying to get through. Eight of
+/// the ten ways `init` can fail produced no bytes anywhere as a result.
 pub fn reportInitError(err: anyerror) void {
-    const message = initErrorMessage(err) orelse return;
+    var buf: [256]u8 = undefined;
+    const message = initErrorText(err, &buf);
 
     // Streaming, not the seekable `writer`: an embedder may have pointed
     // stderr at a file it is also writing to itself, and a positional write
@@ -499,12 +503,27 @@ pub fn reportInitError(err: anyerror) void {
     ) catch return;
 }
 
-/// The text `reportInitError` writes for `err`, or null for errors with no
-/// user-facing explanation, which stay with the caller's `std.log.err`.
+/// The exact text `reportInitError` writes for `err`: the bespoke wording
+/// where there is one, and otherwise a generic line naming the error, so no
+/// failure leaves a caller with a status and nothing to print.
+///
+/// `buf` backs the generic line; the returned slice may point into it.
+///
+/// Split from the write, for the same reason as `initErrorMessage`.
+fn initErrorText(err: anyerror, buf: []u8) []const u8 {
+    return initErrorMessage(err) orelse std.fmt.bufPrint(
+        buf,
+        "Error: ghostty failed to initialize err={t}\n",
+        .{err},
+    ) catch "Error: ghostty failed to initialize.\n";
+}
+
+/// The bespoke text for `err`, or null for errors with no wording of their
+/// own, which `initErrorText` covers with a generic line.
 ///
 /// Split from the write so the mapping can be tested without capturing
-/// stderr, and so `main_ghostty` can ask whether an error explains itself
-/// before falling back to the log.
+/// stderr. It is no longer a question about whether an error explains
+/// itself - every error does now - only about which wording it gets.
 pub fn initErrorMessage(err: anyerror) ?[]const u8 {
     return switch (err) {
         error.MultipleActions => "Error: multiple CLI actions specified. You must specify only one\n" ++
@@ -538,8 +557,34 @@ test "initErrorMessage explains the CLI argument errors" {
     );
 }
 
-test "initErrorMessage leaves other errors to the log" {
+test "initErrorMessage has no bespoke wording for the rest" {
     try std.testing.expect(initErrorMessage(error.OutOfMemory) == null);
+    try std.testing.expect(initErrorMessage(error.AlreadyInitialized) == null);
+}
+
+test "initErrorText still explains an error with no wording of its own" {
+    // The point of the change: these used to produce no bytes at all through
+    // the C API. `OutOfMemory` alone can come from `allocTmpDir`,
+    // `detectArgs`, `ensureLocale`, `oni.init` and `resourcesDir`.
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "Error: ghostty failed to initialize err=OutOfMemory\n",
+        initErrorText(error.OutOfMemory, &buf),
+    );
+
+    // A bespoke message still wins, and does not touch the buffer.
+    try std.testing.expectEqualStrings(
+        initErrorMessage(error.InvalidAction).?,
+        initErrorText(error.InvalidAction, &buf),
+    );
+
+    // Degrades rather than truncating into nonsense when the buffer cannot
+    // hold the formatted line.
+    var tiny: [4]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "Error: ghostty failed to initialize.\n",
+        initErrorText(error.OutOfMemory, &tiny),
+    );
 }
 
 test "a failed init clears the state and is not retryable" {

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -32,31 +32,17 @@ pub fn main(minimal: std.process.Init.Minimal) !MainReturn {
     global.init(.{ .main = minimal }) catch |err| {
         defer std.process.exit(1);
 
-        // The argument-error text comes from `global` rather than a second
-        // copy here. The two were hand-synced before, with nothing to fail
-        // when they drifted.
+        // All of it comes from `global` now, including the catch-all for
+        // errors with no bespoke text. This used to be a second copy here,
+        // which is why the C API had no catch-all at all: the exe had one and
+        // `ghostty_init` did not.
         //
-        // Neither branch may use `std.log`. `init` leaves the state null
-        // on the way out, so a log call gets the default `Logging`, whose
-        // `stderr` is false whenever `app_runtime` is `none` - and that
-        // artifact calls `main` for its CLI actions. The report would be
-        // dropped in exactly the build that has no other sink. Writing to
-        // the handle is what `reportInitError` does, and for the same
-        // reason.
-        if (global.initErrorMessage(err)) |_| {
-            global.reportInitError(err);
-        } else {
-            var buf: [256]u8 = undefined;
-            const line = std.fmt.bufPrint(
-                &buf,
-                "invalid CLI invocation err={}\n",
-                .{err},
-            ) catch "invalid CLI invocation\n";
-            std.Io.File.stderr().writeStreamingAll(
-                std.Io.Threaded.global_single_threaded.io(),
-                line,
-            ) catch {};
-        }
+        // It may not use `std.log`. `init` leaves the state null on the way
+        // out, so a log call gets the default `Logging`, whose `stderr` is
+        // false whenever `app_runtime` is `none` - and that artifact calls
+        // `main` for its CLI actions. The report would be dropped in exactly
+        // the build that has no other sink.
+        global.reportInitError(err);
     };
     defer global.deinit();
     const alloc = global.alloc();


### PR DESCRIPTION
Follow-up to # 591, from a `ghostty-reviewer` pass over the init/stderr seam.

`reportInitError` returned early for any error `initErrorMessage` had no wording for, and `main_ghostty` carried its own catch-all for those. So the exe explained itself and the C API did not: `ghostty_init` emitted `std.log.err` and returned 1.

In the lib artifact that log line reaches nobody on the failure path. `Logging.stderr` is false when `app_runtime` is `none`, and an embedder's log callback is typically registered *after* init, since init is what it is trying to get through. Eight of the ten ways `init` can fail therefore produced no bytes anywhere:

- `AlreadyInitialized`
- `OutOfMemory` from `allocTmpDir`, `detectArgs`, `ensureLocale`, `oni.init`, `resourcesDir`
- non-missing errors reading `GHOSTTY_LOG`
- `environ.createMap` under `-Dsentry`

A caller was left with an exit code and nothing to print - which is exactly what # 590 and # 591 built a reporting path to avoid. The tee added there says "See gpu.log for details" and for those eight there were none.

Move the fallback into `reportInitError` so both callers inherit it, and collapse `main_ghostty`'s branch to the single call it now needs (a net deletion). The wording lives in `initErrorText`, split from the write for the same reason `initErrorMessage` already was: so it can be tested without capturing stderr.

Also stop a `GHOSTTY_LOG` read failure from aborting startup. The parse immediately below is already tolerant (`catch .{}`), so a malformed value could not stop init while an unreadable one could.

Verified on Windows: `zig build` 103/103; `zig build test` 3749 pass, 77 skip, 0 fail. Rebuilt the native dll and re-ran the embedder to confirm the bespoke wording still reaches both sinks - `wintty +definitely-not-an-action` prints libghostty's own text plus the FATAL line, and with `WINTTY_GPU_LOG` set the log keeps libghostty's text while the terminal gets the tee. `+version` and `--help` unaffected.

Not included, deliberately: giving `AlreadyInitialized` a distinct C status. Today it and a real failure both return 1, which is why the embedder needs a lock rather than being able to tell them apart. That changes `include/ghostty.h` and the macOS callers, so it wants its own PR.
