### PR TITLE
app: enforce the init precondition in the build that ships

### DIFF
--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -529,8 +529,8 @@ public static partial class Program
 
     /// <summary>
     /// Whether <see cref="InitGhostty"/> has completed. Callers that depend on
-    /// libghostty global state assert on this rather than initializing it
-    /// themselves; <see cref="MainImpl"/> owns that decision.
+    /// libghostty global state check this and throw rather than initializing
+    /// it themselves; <see cref="MainImpl"/> owns that decision.
     /// </summary>
     internal static bool IsGhosttyInitialized => _ghosttyInitialized;
 
@@ -570,9 +570,11 @@ public static partial class Program
         if (result != 0)
         {
             // ghostty_init failed (e.g. invalid action). There is no degraded
-            // mode to continue in: the failure leaves the global state tagged
-            // unavailable, so every later export that reaches for the
-            // allocator or the I/O instance traps instead of returning.
+            // mode to continue in: the failure tears the global state down but
+            // leaves it in place, so every later export that reaches for the
+            // allocator or the I/O instance gets a deinitialized one. Exiting
+            // here is what makes that unreachable, the same way macOS and iOS
+            // exit from their own ghostty_init call sites.
             //
             // libghostty explains the argument-parsing errors itself, via
             // global.reportInitError writing straight to stderr. This line

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -303,23 +302,28 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     {
         _dispatcher = dispatcher;
 
-        // A failed ghostty_init leaves the global state tagged unavailable,
-        // and the accessors trip on that tag rather than reading through it.
-        // ConfigNew allocates from the global allocator, so reaching here
-        // without a successful init is a native trap in Debug and ReleaseSafe
-        // and undefined behavior in ReleaseFast, which is the build where it
-        // would surface as a crash with no managed stack.
+        // ConfigNew allocates from libghostty's global allocator. A failed
+        // ghostty_init leaves the global state in place but torn down, so the
+        // allocator reached here would be a deinitialized one: no trap, in any
+        // build mode, just a corrupted heap and a crash somewhere later with
+        // no managed stack and nothing pointing back here.
         //
-        // Program.MainImpl owns that call and makes it before starting WinUI,
-        // so by the time this constructor runs the decision is already made
-        // and this only has to state the precondition. Initializing from here
-        // would put a process-lifetime decision partway down the object graph,
-        // and its exit-on-failure would run inside Application.Start's
-        // initialization callback where StartGui's catch cannot see it.
-        Debug.Assert(
-            Program.IsGhosttyInitialized,
-            "ghostty_init must run at the composition root before any " +
-            "libghostty export that touches global state.");
+        // That makes this check the only one there is, which is why it throws
+        // rather than asserting. Debug.Assert compiles out of Release, and
+        // Release is where an unexplained native crash costs the most.
+        //
+        // Program.MainImpl owns the init call and makes it before starting
+        // WinUI, so this states a precondition rather than enforcing a policy.
+        // Initializing from here would put a process-lifetime decision partway
+        // down the object graph, and its exit-on-failure would run inside
+        // Application.Start's initialization callback where StartGui's catch
+        // cannot see it.
+        if (!Program.IsGhosttyInitialized)
+        {
+            throw new InvalidOperationException(
+                "ghostty_init must run at the composition root before any " +
+                "libghostty export that touches global state.");
+        }
 
         _config = NativeMethods.ConfigNew();
         NativeMethods.ConfigLoadDefaultFiles(_config);


### PR DESCRIPTION
Looked at how macOS and iOS handle a failed `ghostty_init`, to see where our
embedder actually differs.

`macos/Sources/App/macOS/main.swift:8` calls `ghostty_init` as the first
statement of the process and calls `exit(1)` on a non-zero return, in both
launch-source branches. `iOSApp.swift:9` calls `preconditionFailure`. Nothing
runs between the call and the exit. The state a failed init leaves behind is
therefore unreachable there, which is why it has never been a defect for them.

Our composition root exits the same way. The gap was one level down:
`ConfigService` stated its precondition with `Debug.Assert`, which compiles
out of Release. And a failed init leaves the global state torn down but in
place, so the native side does not trap either - `ConfigNew` would allocate
from a deinitialized allocator and corrupt the heap, surfacing later with no
managed stack and nothing pointing back at this line.

So in the build that ships there was no check on either side of the boundary. It throws now. A managed exception with a stack
beats a native crash without one, and it lands in `ReportFatal` rather than
corrupting the process.

Nothing in the tree can trigger it. `ConfigService` has one construction site,
`App.OnLaunched`, which runs after `MainImpl` has already initialized or
exited, and no test constructs one.

`dotnet build -p:Platform=x64` clean, 1771 passed / 0 failed / 1 skipped.
