### PR TITLE
build: flush webgen stdout and add a webdata step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -98,6 +98,7 @@ pub fn build(b: *std.Build) !void {
 
     // Ghostty webdata
     const webdata = try buildpkg.GhosttyWebdata.init(b, &deps);
+    webdata.addStep();
     if (config.emit_webdata) webdata.install();
 
     // Ghostty bench tools

--- a/build.zig
+++ b/build.zig
@@ -98,7 +98,13 @@ pub fn build(b: *std.Build) !void {
 
     // Ghostty webdata
     const webdata = try buildpkg.GhosttyWebdata.init(b, &deps);
-    webdata.addStep();
+    {
+        // The website only needs these .mdx files, but the install step drags
+        // in the whole app build to get them. This lets the docs be
+        // regenerated on their own.
+        const step = b.step("webdata", "Generate website reference data");
+        for (webdata.steps) |s| step.dependOn(s);
+    }
     if (config.emit_webdata) webdata.install();
 
     // Ghostty bench tools

--- a/src/build/GhosttyWebdata.zig
+++ b/src/build/GhosttyWebdata.zig
@@ -117,13 +117,3 @@ pub fn install(self: *const GhosttyWebdata) void {
     const b = self.steps[0].owner;
     for (self.steps) |step| b.getInstallStep().dependOn(step);
 }
-
-/// Expose the webdata generation as its own top-level step. The website only
-/// needs these three .mdx files, and depending on the full install step drags
-/// in the whole app build (libghostty, harfbuzz, the GUI) just to regenerate
-/// documentation. `zig build webdata` builds only the generators.
-pub fn addStep(self: *const GhosttyWebdata) void {
-    const b = self.steps[0].owner;
-    const webdata_step = b.step("webdata", "Generate website reference data");
-    for (self.steps) |s| webdata_step.dependOn(s);
-}

--- a/src/build/GhosttyWebdata.zig
+++ b/src/build/GhosttyWebdata.zig
@@ -117,3 +117,13 @@ pub fn install(self: *const GhosttyWebdata) void {
     const b = self.steps[0].owner;
     for (self.steps) |step| b.getInstallStep().dependOn(step);
 }
+
+/// Expose the webdata generation as its own top-level step. The website only
+/// needs these three .mdx files, and depending on the full install step drags
+/// in the whole app build (libghostty, harfbuzz, the GUI) just to regenerate
+/// documentation. `zig build webdata` builds only the generators.
+pub fn addStep(self: *const GhosttyWebdata) void {
+    const b = self.steps[0].owner;
+    const webdata_step = b.step("webdata", "Generate website reference data");
+    for (self.steps) |s| webdata_step.dependOn(s);
+}

--- a/src/build/webgen/main_actions.zig
+++ b/src/build/webgen/main_actions.zig
@@ -6,4 +6,5 @@ pub fn main(init: std.process.Init) !void {
     var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
     const stdout = &stdout_writer.interface;
     try helpgen_actions.generate(stdout, .markdown, true, std.heap.page_allocator);
+    try stdout.flush();
 }

--- a/src/build/webgen/main_commands.zig
+++ b/src/build/webgen/main_commands.zig
@@ -7,6 +7,7 @@ pub fn main(init: std.process.Init) !void {
     var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
     const stdout = &stdout_writer.interface;
     try genActions(stdout);
+    try stdout.flush();
 }
 
 // Note: as a shortcut for defining inline editOnGithubLinks per cli action the user

--- a/src/build/webgen/main_config.zig
+++ b/src/build/webgen/main_config.zig
@@ -7,6 +7,7 @@ pub fn main(init: std.process.Init) !void {
     var stdout_writer = std.Io.File.stdout().writer(init.io, &buffer);
     const stdout = &stdout_writer.interface;
     try genConfig(stdout);
+    try stdout.flush();
 }
 
 pub fn genConfig(writer: *std.Io.Writer) !void {


### PR DESCRIPTION
The webgen entrypoints buffer stdout and never flush, so the tail of each
generated file is lost. `config.mdx` ended mid-sentence and `actions.mdx`
stopped at the `crash` header with no body, so the website had no anchor to
link to. Every other CLI entrypoint already flushes.

Second change: webdata gets its own top-level step. `-Demit-webdata` hangs it
off install, so regenerating three .mdx files built libghostty, harfbuzz and
the GUI. On Windows that fails in harfbuzz translate-c before the files land.
`zig build webdata` now builds only the generators.

Verified by regenerating: both files grew by just under one buffer and the
`crash` action came back complete.