### PR TITLE
config: read config and state from wintty, not ghostty

### DIFF
--- a/src/cli/ssh-cache/DiskCache.zig
+++ b/src/cli/ssh-cache/DiskCache.zig
@@ -451,7 +451,7 @@ test "disk cache default path" {
     const testing = std.testing;
     const alloc = std.testing.allocator;
 
-    const path = try DiskCache.defaultPath(alloc, "ghostty");
+    const path = try DiskCache.defaultPath(alloc, "wintty");
     defer alloc.free(path);
     try testing.expect(path.len > 0);
 }

--- a/src/cli/ssh.zig
+++ b/src/cli/ssh.zig
@@ -244,7 +244,7 @@ fn runInner(
         };
 
         const cache: ?DiskCache = if (opts.cache) cache: {
-            const path = DiskCache.defaultPath(alloc, "ghostty") catch |err| {
+            const path = DiskCache.defaultPath(alloc, "wintty") catch |err| {
                 warnPrint(stderr, "ghostty terminfo cache unavailable: {t}", .{err});
                 break :session .{ .term = "xterm-256color" };
             };

--- a/src/cli/ssh_cache.zig
+++ b/src/cli/ssh_cache.zig
@@ -134,7 +134,7 @@ pub fn run(alloc_gpa: Allocator) !u8 {
     }
 
     // Setup our disk cache to the standard location
-    const cache_path = DiskCache.defaultPath(alloc, "ghostty") catch |err| {
+    const cache_path = DiskCache.defaultPath(alloc, "wintty") catch |err| {
         try stderr.print(
             "Error: unable to determine the cache path: {t}\n",
             .{err},

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -557,8 +557,8 @@ language: ?[:0]const u8 = null,
 /// include path separators unless it is an absolute pathname.
 ///
 /// The first directory is the `themes` subdirectory of your Ghostty
-/// configuration directory. This is `$XDG_CONFIG_HOME/ghostty/themes` or
-/// `~/.config/ghostty/themes`.
+/// configuration directory. This is `$XDG_CONFIG_HOME/wintty/themes` or
+/// `~/.config/wintty/themes`.
 ///
 /// The second directory is the `themes` subdirectory of the Ghostty resources
 /// directory. Ghostty ships with a multitude of themes that will be installed
@@ -2605,7 +2605,7 @@ keybind: Keybinds = .{},
 
 /// When this is true, the default configuration file paths will be loaded.
 /// The default configuration file paths are currently only the XDG
-/// config path ($XDG_CONFIG_HOME/ghostty/config.ghostty).
+/// config path ($XDG_CONFIG_HOME/wintty/config.wintty).
 ///
 /// If this is false, the default configuration paths will not be loaded.
 /// This is targeted directly at using Ghostty from the CLI in a way
@@ -3566,7 +3566,7 @@ keybind: Keybinds = .{},
 /// The absolute path to the custom icon file.
 /// Supported formats include PNG, JPEG, and ICNS.
 ///
-/// Defaults to `~/.config/ghostty/Ghostty.icns`
+/// Defaults to `~/.config/wintty/Wintty.icns`
 @"macos-custom-icon": ?[:0]const u8 = null,
 
 /// The material to use for the frame of the macOS app icon.
@@ -4201,67 +4201,93 @@ fn writeConfigTemplate(path: []const u8) !void {
 }
 
 /// Load configurations from the default configuration files. The default
-/// configuration file is at `$XDG_CONFIG_HOME/ghostty/config.ghostty`.
+/// configuration file is at `$XDG_CONFIG_HOME/wintty/config.wintty`.
 ///
 /// On macOS, `$HOME/Library/Application Support/$CFBundleIdentifier/`
 /// is also loaded.
 ///
-/// The legacy `config` file (without extension) is first loaded,
-/// then `config.ghostty`.
+/// Older locations are loaded first so a newer file wins on conflict:
+/// the Ghostty <1.3.0 `config` file (without extension), then
+/// `ghostty/config.ghostty` from before the Wintty rename, then
+/// `wintty/config.wintty`.
 pub fn loadDefaultFiles(self: *Config, alloc: Allocator) !void {
     // Load XDG first
     const legacy_xdg_path = try file_load.legacyDefaultXdgPath(alloc);
     defer alloc.free(legacy_xdg_path);
+    const ghostty_xdg_path = try file_load.ghosttyXdgPath(alloc);
+    defer alloc.free(ghostty_xdg_path);
     const xdg_path = try file_load.defaultXdgPath(alloc);
     defer alloc.free(xdg_path);
     const xdg_loaded: bool = xdg_loaded: {
+        // Oldest first, so a newer file overrides an older one.
         const legacy_xdg_action = self.loadOptionalFile(alloc, legacy_xdg_path);
+        const ghostty_xdg_action = self.loadOptionalFile(alloc, ghostty_xdg_path);
         const xdg_action = self.loadOptionalFile(alloc, xdg_path);
-        if (xdg_action != .not_found and legacy_xdg_action != .not_found) {
-            log.warn("both config files `{s}` and `{s}` exist.", .{ legacy_xdg_path, xdg_path });
-            log.warn("loading them both in that order", .{});
-            break :xdg_loaded true;
+
+        var found: usize = 0;
+        for ([_]OptionalFileAction{
+            legacy_xdg_action,
+            ghostty_xdg_action,
+            xdg_action,
+        }) |action| {
+            if (action != .not_found) found += 1;
         }
 
-        break :xdg_loaded xdg_action != .not_found or
-            legacy_xdg_action != .not_found;
+        if (found > 1) {
+            log.warn("multiple config files exist: `{s}`, `{s}`, `{s}`", .{
+                legacy_xdg_path,
+                ghostty_xdg_path,
+                xdg_path,
+            });
+            log.warn("loading the ones that exist, oldest first", .{});
+        }
+
+        break :xdg_loaded found > 0;
     };
 
     // On macOS load the app support directory as well
     if (comptime builtin.os.tag == .macos) {
         const legacy_app_support_path = try file_load.legacyDefaultAppSupportPath(alloc);
         defer alloc.free(legacy_app_support_path);
-        const app_support_path = try file_load.preferredAppSupportPath(alloc);
+        const ghostty_app_support_path = try file_load.ghosttyAppSupportPath(alloc);
+        defer alloc.free(ghostty_app_support_path);
+        const app_support_path = try file_load.defaultAppSupportPath(alloc);
         defer alloc.free(app_support_path);
         const app_support_loaded: bool = loaded: {
+            // All three names differ, so unlike the previous two-path version
+            // there is no way to double-load the same file.
             const legacy_app_support_action = self.loadOptionalFile(
                 alloc,
                 legacy_app_support_path,
             );
-
-            // The app support path and legacy may be the same, since we
-            // use the `preferred` call above. If its the same, avoid
-            // a double-load.
-            const app_support_action: OptionalFileAction = if (!std.mem.eql(
-                u8,
-                legacy_app_support_path,
-                app_support_path,
-            )) self.loadOptionalFile(
+            const ghostty_app_support_action = self.loadOptionalFile(
+                alloc,
+                ghostty_app_support_path,
+            );
+            const app_support_action = self.loadOptionalFile(
                 alloc,
                 app_support_path,
-            ) else .not_found;
+            );
 
-            if (app_support_action != .not_found and legacy_app_support_action != .not_found) {
-                log.warn(
-                    "both config files `{s}` and `{s}` exist.",
-                    .{ legacy_app_support_path, app_support_path },
-                );
-                log.warn("loading them both in that order", .{});
-                break :loaded true;
+            var found: usize = 0;
+            for ([_]OptionalFileAction{
+                legacy_app_support_action,
+                ghostty_app_support_action,
+                app_support_action,
+            }) |action| {
+                if (action != .not_found) found += 1;
             }
 
-            break :loaded app_support_action != .not_found or
-                legacy_app_support_action != .not_found;
+            if (found > 1) {
+                log.warn("multiple config files exist: `{s}`, `{s}`, `{s}`", .{
+                    legacy_app_support_path,
+                    ghostty_app_support_path,
+                    app_support_path,
+                });
+                log.warn("loading the ones that exist, oldest first", .{});
+            }
+
+            break :loaded found > 0;
         };
 
         // If both files are not found, then we create a template file.

--- a/src/config/edit.zig
+++ b/src/config/edit.zig
@@ -91,15 +91,19 @@ fn configPath(alloc_arena: Allocator) ![]const u8 {
 /// Returns a const list of possible paths the main config file could be
 /// in for the current OS.
 fn configPathCandidates(alloc_arena: Allocator) ![]const []const u8 {
-    var paths: std.ArrayList([]const u8) = try .initCapacity(alloc_arena, 4);
+    // Three names per location: the current one, the pre-rename Ghostty one,
+    // and the Ghostty <1.3.0 one.
+    var paths: std.ArrayList([]const u8) = try .initCapacity(alloc_arena, 6);
     errdefer paths.deinit(alloc_arena);
 
     if (comptime builtin.os.tag == .macos) {
         paths.appendAssumeCapacity(try file_load.defaultAppSupportPath(alloc_arena));
+        paths.appendAssumeCapacity(try file_load.ghosttyAppSupportPath(alloc_arena));
         paths.appendAssumeCapacity(try file_load.legacyDefaultAppSupportPath(alloc_arena));
     }
 
     paths.appendAssumeCapacity(try file_load.defaultXdgPath(alloc_arena));
+    paths.appendAssumeCapacity(try file_load.ghosttyXdgPath(alloc_arena));
     paths.appendAssumeCapacity(try file_load.legacyDefaultXdgPath(alloc_arena));
 
     return paths.items;

--- a/src/config/file_load.zig
+++ b/src/config/file_load.zig
@@ -7,60 +7,73 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.config);
 
-/// Default path for the XDG home configuration file. Returned value
-/// must be freed by the caller.
-pub fn defaultXdgPath(alloc: Allocator) ![]const u8 {
+fn xdgPath(alloc: Allocator, subdir: []const u8) ![]const u8 {
     var environ_map = try global.environMap();
     defer environ_map.deinit();
     return try internal_os.xdg.config(
         global.io(),
         alloc,
         &environ_map,
-        .{ .subdir = "ghostty/config.ghostty" },
+        .{ .subdir = subdir },
     );
+}
+
+/// Default path for the XDG home configuration file. Returned value
+/// must be freed by the caller.
+pub fn defaultXdgPath(alloc: Allocator) ![]const u8 {
+    return try xdgPath(alloc, "wintty/config.wintty");
+}
+
+/// Path used before Wintty renamed its configuration directory. Kept so an
+/// existing install keeps loading rather than silently starting on defaults.
+/// Returned value must be freed by the caller.
+pub fn ghosttyXdgPath(alloc: Allocator) ![]const u8 {
+    return try xdgPath(alloc, "ghostty/config.ghostty");
 }
 
 /// Ghostty <1.3.0 default path for the XDG home configuration file.
 /// Returned value must be freed by the caller.
 pub fn legacyDefaultXdgPath(alloc: Allocator) ![]const u8 {
-    var environ_map = try global.environMap();
-    defer environ_map.deinit();
-    return try internal_os.xdg.config(
-        global.io(),
-        alloc,
-        &environ_map,
-        .{ .subdir = "ghostty/config" },
-    );
+    return try xdgPath(alloc, "ghostty/config");
 }
 
 /// Preferred default path for the XDG home configuration file.
 /// Returned value must be freed by the caller.
 pub fn preferredXdgPath(alloc: Allocator) ![]const u8 {
-    // If the XDG path exists, use that.
-    const xdg_path = try defaultXdgPath(alloc);
-    if (open(global.io(), xdg_path)) |f| {
-        f.close(global.io());
-        return xdg_path;
-    } else |_| {}
+    // Newest first. The first entry is also what we return when nothing
+    // exists yet, so a fresh install writes to the current path.
+    const candidates = [_]*const fn (Allocator) anyerror![]const u8{
+        defaultXdgPath,
+        ghosttyXdgPath,
+        legacyDefaultXdgPath,
+    };
 
-    // Try the legacy path
-    errdefer alloc.free(xdg_path);
-    const legacy_xdg_path = try legacyDefaultXdgPath(alloc);
-    if (open(global.io(), legacy_xdg_path)) |f| {
-        f.close(global.io());
-        alloc.free(xdg_path);
-        return legacy_xdg_path;
-    } else |_| {}
+    var preferred: ?[]const u8 = null;
+    errdefer if (preferred) |p| alloc.free(p);
+    for (candidates, 0..) |candidate, i| {
+        const path = try candidate(alloc);
+        if (open(global.io(), path)) |f| {
+            f.close(global.io());
+            if (preferred) |p| alloc.free(p);
+            return path;
+        } else |_| {}
 
-    // Legacy path and XDG path both don't exist. Return the
-    // new one.
-    alloc.free(legacy_xdg_path);
-    return xdg_path;
+        if (i == 0) preferred = path else alloc.free(path);
+    }
+
+    // Nothing exists. Return the current path.
+    return preferred.?;
 }
 
 /// Default path for the macOS Application Support configuration file.
 /// Returned value must be freed by the caller.
 pub fn defaultAppSupportPath(alloc: Allocator) ![]const u8 {
+    return try internal_os.macos.appSupportDir(alloc, "config.wintty");
+}
+
+/// Path used before Wintty renamed its configuration file. Returned value
+/// must be freed by the caller.
+pub fn ghosttyAppSupportPath(alloc: Allocator) ![]const u8 {
     return try internal_os.macos.appSupportDir(alloc, "config.ghostty");
 }
 
@@ -73,26 +86,28 @@ pub fn legacyDefaultAppSupportPath(alloc: Allocator) ![]const u8 {
 /// Preferred default path for the macOS Application Support configuration file.
 /// Returned value must be freed by the caller.
 pub fn preferredAppSupportPath(alloc: Allocator) ![]const u8 {
-    // If the app support path exists, use that.
-    const app_support_path = try defaultAppSupportPath(alloc);
-    if (open(global.io(), app_support_path)) |f| {
-        f.close(global.io());
-        return app_support_path;
-    } else |_| {}
+    // Newest first, same ordering rule as preferredXdgPath.
+    const candidates = [_]*const fn (Allocator) anyerror![]const u8{
+        defaultAppSupportPath,
+        ghosttyAppSupportPath,
+        legacyDefaultAppSupportPath,
+    };
 
-    // Try the legacy path
-    errdefer alloc.free(app_support_path);
-    const legacy_app_support_path = try legacyDefaultAppSupportPath(alloc);
-    if (open(global.io(), legacy_app_support_path)) |f| {
-        f.close(global.io());
-        alloc.free(app_support_path);
-        return legacy_app_support_path;
-    } else |_| {}
+    var preferred: ?[]const u8 = null;
+    errdefer if (preferred) |p| alloc.free(p);
+    for (candidates, 0..) |candidate, i| {
+        const path = try candidate(alloc);
+        if (open(global.io(), path)) |f| {
+            f.close(global.io());
+            if (preferred) |p| alloc.free(p);
+            return path;
+        } else |_| {}
 
-    // Legacy path and app support path both don't exist. Return the
-    // new one.
-    alloc.free(legacy_app_support_path);
-    return app_support_path;
+        if (i == 0) preferred = path else alloc.free(path);
+    }
+
+    // Nothing exists. Return the current path.
+    return preferred.?;
 }
 
 /// Returns the path to the preferred default configuration file.

--- a/src/config/theme.zig
+++ b/src/config/theme.zig
@@ -29,7 +29,7 @@ pub const Location = enum {
         return switch (self) {
             .user => user: {
                 const subdir = std.fs.path.join(arena_alloc, &.{
-                    "ghostty", "themes",
+                    "wintty", "themes",
                 }) catch return error.OutOfMemory;
 
                 break :user internal_os.xdg.config(

--- a/src/crash/dir.zig
+++ b/src/crash/dir.zig
@@ -5,7 +5,7 @@ const internal_os = @import("../os/main.zig");
 /// Returns a Dir for the default directory. The Dir.path field must be
 /// freed with the given allocator.
 pub fn defaultDir(io: std.Io, alloc: Allocator, environ_map: *const std.process.Environ.Map) !Dir {
-    const crash_dir = try internal_os.xdg.state(io, alloc, environ_map, .{ .subdir = "ghostty/crash" });
+    const crash_dir = try internal_os.xdg.state(io, alloc, environ_map, .{ .subdir = "wintty/crash" });
     errdefer alloc.free(crash_dir);
     return .{ .path = crash_dir };
 }

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -203,7 +203,7 @@ fn cacheDir(io: std.Io, alloc: Allocator, environ_map: *const std.process.Enviro
         io,
         alloc,
         environ_map,
-        .{ .subdir = "ghostty/sentry" },
+        .{ .subdir = "wintty/sentry" },
     );
 }
 

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -2523,7 +2523,7 @@ fn maybeProvisionWslTerminfo(
             global.io(),
             alloc,
             &environ_map,
-            .{ .subdir = "ghostty" },
+            .{ .subdir = "wintty" },
         ) catch break :cache null;
         defer alloc.free(state_dir);
         const path = std.fs.path.join(


### PR DESCRIPTION
The website has been documenting `$XDG_CONFIG_HOME/wintty/config.wintty` and
`~/.config/wintty/themes` for a while. The code still read the ghostty paths,
so the published guidance was wrong. This moves the code rather than the docs
- regenerating the reference pages after this change produces no diff at all,
because the docs already said wintty.

Existing installs keep working. `preferredXdgPath` and
`preferredAppSupportPath` walk newest-first through `wintty/config.wintty`,
`ghostty/config.ghostty` and the Ghostty <1.3.0 `config`, returning the
current path when none exist so a fresh install writes the new name.
`loadDefaultFiles` loads them oldest-first so a newer file wins, extending the
ordering that was already there.

One bug fixed on the way: the macOS branch used `preferredAppSupportPath` plus
a same-path dedup, which with three tiers would have silently skipped the
middle one. It now loads all three explicitly.

State and cache directories move with no fallback - crash reports, sentry, the
WSL terminfo cache and the ssh cache all regenerate. Session and window state
under `%LOCALAPPDATA%` is deliberately untouched, per the note in
`AppIdentity.cs`.

`zig build webdata` compiles clean and `zig build test -Dtest-filter=config`
passes. I could not get a clean signal from the full `zig build test` on this
host - it fails in harfbuzz `translate-c`, but it does that on an unmodified
tree too.

Two things deliberately left for follow-ups: `window-theme = ghostty` is a
real enum value and `x11-instance-name` defaults to `ghostty`, both of which
the docs already claim are wintty. Renaming those means accepting both
spellings so existing configs keep parsing. `AppIdentity.cs` also still
documents the old policy that a rebrand must not move paths, which this
contradicts.