### PR TITLE
webgen: omit macOS-only options from the config reference

### DIFF
--- a/src/build/webgen/main_config.zig
+++ b/src/build/webgen/main_config.zig
@@ -10,6 +10,24 @@ pub fn main(init: std.process.Init) !void {
     try stdout.flush();
 }
 
+/// Whether an option only applies to macOS, and so has no place in the
+/// Wintty reference.
+///
+/// The `macos-` name prefix is the only signal used, because it is the only
+/// exact one. Matching prose like "only supported on macOS" looks tempting
+/// and is wrong: that sentence describes *upstream's* platform support, not
+/// this fork's. `window-save-state` and `undo-timeout` both carry it, and
+/// the Windows app implements both -- filtering on prose would have hidden
+/// options Windows users actually set.
+///
+/// Options that merely mention macOS while working everywhere are also left
+/// alone. Rewriting their prose to drop the macOS clause is not something a
+/// generator can do safely, since the surrounding sentence usually depends
+/// on it.
+fn isMacOSOnly(comptime name: []const u8) bool {
+    return std.mem.startsWith(u8, name, "macos-");
+}
+
 pub fn genConfig(writer: *std.Io.Writer) !void {
     // Write the header
     try writer.writeAll(
@@ -19,11 +37,15 @@ pub fn genConfig(writer: *std.Io.Writer) !void {
         \\editOnGithubLink: https://github.com/ghostty-org/ghostty/edit/main/src/config/Config.zig
         \\---
         \\
-        \\This is a reference of all Ghostty configuration options. These
+        \\This is a reference of the Ghostty configuration options. These
         \\options are ordered roughly by how common they are to be used
         \\and grouped with related options. I recommend utilizing your
         \\browser's search functionality to find the option you're looking
         \\for.
+        \\
+        \\Options that only apply to macOS are omitted. Options Ghostty
+        \\does not have are listed separately under
+        \\[Windows-Only Options](/docs/config/windows-only).
         \\
         \\In the future, we'll have a more user-friendly way to view and
         \\organize these options.
@@ -31,11 +53,16 @@ pub fn genConfig(writer: *std.Io.Writer) !void {
         \\
     );
 
-    @setEvalBranchQuota(50_000);
+    @setEvalBranchQuota(200_000);
     const fields = @typeInfo(Config).@"struct".fields;
     inline for (fields, 0..) |field, i| {
         if (field.name[0] == '_') continue;
         if (!@hasDecl(help_strings.Config, field.name)) continue;
+
+        // Skipping a documented field also drops the undocumented fields
+        // grouped under it, since those are only reachable through the
+        // inner loop below.
+        if (comptime isMacOSOnly(field.name)) continue;
 
         // Write the field name.
         try writer.writeAll("## `");
@@ -48,6 +75,10 @@ pub fn genConfig(writer: *std.Io.Writer) !void {
             inline for (fields[i + 1 ..]) |next_field| {
                 if (next_field.name[0] == '_') break;
                 if (@hasDecl(help_strings.Config, next_field.name)) break;
+
+                // A macOS-only field can be grouped under an option we are
+                // keeping. Drop its header without ending the group.
+                if (comptime isMacOSOnly(next_field.name)) continue;
 
                 try writer.writeAll("## `");
                 try writer.writeAll(next_field.name);


### PR DESCRIPTION
Wintty is a Windows application, so the 17 `macos-*` options are noise in its
config reference.

The filter keys on the `macos-` name prefix and nothing else. Matching prose
like "only supported on macOS" catches another six options and looked like the
obvious second signal, but it is wrong: that sentence describes *upstream's*
platform support, not this fork's. `window-save-state` and `undo-timeout` both
carry it, and the Windows app implements both - `ConfigService.cs:686` reads
`window-save-state`, and `PaneHost.cs` drives undo from `undo-timeout`. A prose
filter would have hidden options Windows users actually set, so it is out.

Options that merely mention macOS keep their text. Removing the clause usually
breaks the sentence around it, which a generator cannot do safely.

Grouping is handled: skipping a documented field also drops the undocumented
fields grouped under it, and the inner loop filters by name so a `macos-` field
grouped under a kept option does not slip through.

Verified by regenerating: exactly the 17 `macos-*` options disappear, 213 ->
196, and `window-save-state`, `undo-timeout`, `window-position-x`,
`font-thicken` and `window-theme` all survive. The website builds green and all
176 reference anchors still resolve.