### PR TITLE
windows: move the AUMID to com.deblasis.wintty

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -12,29 +12,48 @@ internal static class AppIdentity
     /// Explicit AppUserModelID for the process. Must be set before any
     /// Shell interop call (jump list, taskbar, toasts) — the Shell
     /// caches the process-to-AUMID association on first use.
+    ///
+    /// This is the Shell's identity key, not a display string. Changing
+    /// it detaches existing pinned taskbar entries, jump lists and
+    /// already-scheduled toasts from the app, and Windows offers no
+    /// migration for that, so treat a change as a one-off break rather
+    /// than a rename that follows the brand.
     /// </summary>
-    public const string AumId = "com.deblasis.ghostty";
+    public const string AumId = "com.deblasis.wintty";
 
     /// <summary>
     /// Brand name for what a user reads: window and tab titles, dialog
-    /// captions, the <c>+version</c> header, <see cref="LogTag"/>.
+    /// captions, the <c>+version</c> header, <see cref="LogTag"/>. It is
+    /// not the source for the other "Wintty" literals in the tree, and
+    /// those split two ways.
     ///
-    /// Not the source for the other "Wintty" literals in the tree, which
-    /// track something a rebrand must not move:
+    /// Following the brand, and already moved with it: the Win32 version
+    /// resource in <c>ghostty.rc</c> that Explorer reads; the config file,
+    /// now <c>%APPDATA%\wintty\config.wintty</c>, still falling back to
+    /// <c>ghostty\config.ghostty</c> and to the Ghostty &lt;1.3.0
+    /// <c>ghostty\config</c> so an existing install keeps working; themes
+    /// under <c>%APPDATA%\wintty</c>; and libghostty's crash, sentry, ssh
+    /// terminfo cache and WSL terminfo cache directories under
+    /// <c>%LOCALAPPDATA%\wintty</c>, which moved with no fallback because
+    /// that data regenerates.
+    ///
+    /// Not following the brand, and a rebrand must not move them:
     /// <list type="bullet">
-    /// <item>paths under <c>%LOCALAPPDATA%</c>, where following the brand
-    /// would orphan a user's logs, session and window state with nothing
-    /// left to migrate them;</item>
+    /// <item>the shell's own <c>%APPDATA%\Wintty</c> (session, window
+    /// state, command frecency) and <c>%LOCALAPPDATA%\Wintty</c> (logs,
+    /// crash.log, gpu.log, icon cache), spelled out at each call site
+    /// rather than read from here. Unlike the libghostty caches above
+    /// this is state the user would notice losing, with nothing left to
+    /// migrate it;</item>
     /// <item>the assembly name, which <c>InternalsVisibleTo</c> and
     /// <c>Process.GetProcessesByName</c> have to match;</item>
     /// <item>kernel object and window class names, which single-instance
-    /// and the global hotkey key off.</item>
+    /// and the global hotkey key off;</item>
+    /// <item><see cref="AumId"/>, which the Shell keys taskbar pins and
+    /// toasts off. See its own remarks.</item>
     /// </list>
-    /// A rebrand therefore touches this constant, the brand names written
-    /// into prose, and the Win32 version resource in <c>ghostty.rc</c>
-    /// that Explorer reads, not every "Wintty" in the tree. XAML surfaces
-    /// read it from code-behind, since this type is internal and x:Bind
-    /// would need it public.
+    /// XAML surfaces read this constant from code-behind, since this type
+    /// is internal and x:Bind would need it public.
     /// </summary>
     public const string ProductName = "Wintty";
 

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -8,7 +8,7 @@ namespace Ghostty.Tests.JumpList;
 public class JumpListBuilderTests
 {
     private const string TestExe = @"C:\fake\Wintty.exe";
-    private const string TestAppId = "com.deblasis.ghostty";
+    private const string TestAppId = "com.deblasis.wintty";
 
     [Fact]
     public void Build_sets_app_id()

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -367,7 +367,7 @@ public partial class App : Application
         // Set the explicit AppUserModelID. This MUST happen before
         // any shell interop call (jump list registration, taskbar
         // icon operations, toast notifications).
-        const string AppUserModelId = "com.deblasis.ghostty";
+        const string AppUserModelId = Ghostty.Core.AppIdentity.AumId;
         try
         {
             Windows.Win32.PInvoke.SetCurrentProcessExplicitAppUserModelID(AppUserModelId)


### PR DESCRIPTION
The AppUserModelID still said `com.deblasis.ghostty`. This moves it to `com.deblasis.wintty`.

This is a break, not a rename. The AUMID is what Windows keys taskbar pins, jump lists and toasts off, so anyone with Wintty pinned today will find the pin no longer tracks the running app, and already scheduled toasts lose their association. There is no migration path. The constant now says so in its doc comment.

`App.xaml.cs` had its own copy of the literal rather than using `AppIdentity.AumId` - exactly the drift the constant exists to prevent - so it now reads the constant. The jump list test keeps a literal because that is test input, not the shipped identity.

Second half of the change refreshes the `AppIdentity.ProductName` policy comment, which went stale after # 600. Config and libghostty state did follow the brand: config is `%APPDATA%\wintty\config.wintty` with a fallback to `ghostty\config.ghostty` and the Ghostty <1.3.0 path, themes moved, and the crash, sentry, ssh terminfo cache and WSL terminfo cache directories moved with no fallback since that data regenerates. The shell's own `%APPDATA%\Wintty` and `%LOCALAPPDATA%\Wintty` directories did not move. The old comment drew the line at `%LOCALAPPDATA%`, which was never right: some `%LOCALAPPDATA%` paths did move, and the session and window state it meant to protect actually live under `%APPDATA%`.

Verified: `dotnet build -p:Platform=x64` on Ghostty.Core and Ghostty compiles clean (the Ghostty project then fails on a post-build step that wants a zig-built `ghostty.dll`, unrelated). Full Ghostty.Tests suite passes, 1771 passed / 0 failed. `git grep com.deblasis.ghostty` returns nothing.