### PR TITLE
config: prefer wintty spelling over ghostty

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -957,8 +957,8 @@ pub const Application = extern struct {
         const headerbar_background = config.@"window-titlebar-background" orelse config.background;
         const headerbar_foreground = config.@"window-titlebar-foreground" orelse config.foreground;
 
-        switch (window_theme) {
-            .ghostty => try writer.print(
+        if (window_theme.usesTerminalColors()) {
+            try writer.print(
                 \\windowhandle {{
                 \\  background-color: rgb({d},{d},{d});
                 \\  color: rgb({d},{d},{d});
@@ -977,8 +977,7 @@ pub const Application = extern struct {
                 headerbar_background.r,
                 headerbar_background.g,
                 headerbar_background.b,
-            }),
-            else => {},
+            });
         }
     }
 
@@ -1080,8 +1079,8 @@ pub const Application = extern struct {
             \\
         );
 
-        switch (window_theme) {
-            .ghostty => try writer.print(
+        if (window_theme.usesTerminalColors()) {
+            try writer.print(
                 \\:root {{
                 \\  --ghostty-fg: rgb({d},{d},{d});
                 \\  --ghostty-bg: rgb({d},{d},{d});
@@ -1109,8 +1108,7 @@ pub const Application = extern struct {
                 headerbar_background.r,
                 headerbar_background.g,
                 headerbar_background.b,
-            }),
-            else => {},
+            });
         }
     }
 
@@ -1431,7 +1429,7 @@ pub const Application = extern struct {
         // Setup our initial light/dark
         const style = self.as(adw.Application).getStyleManager();
         style.setColorScheme(switch (config.@"window-theme") {
-            .auto, .ghostty => auto: {
+            .auto, .wintty, .ghostty => auto: {
                 const lum = config.background.toTerminalRGB().perceivedLuminance();
                 break :auto if (lum > 0.5)
                     .prefer_light

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -720,13 +720,13 @@ pub const Window = extern struct {
             config.@"background-opacity" >= 1,
         );
 
-        // Apply class to color headerbar if window-theme is set to `ghostty` and
-        // GTK version is before 4.16. The conditional is because above 4.16
-        // we use GTK CSS color variables.
+        // Apply class to color headerbar if window-theme is set to `wintty`
+        // (or its `ghostty` alias) and GTK version is before 4.16. The
+        // conditional is because above 4.16 we use GTK CSS color variables.
         self.toggleCssClass(
             "window-theme-ghostty",
             !gtk_version.atLeast(4, 16, 0) and
-                config.@"window-theme" == .ghostty,
+                config.@"window-theme".usesTerminalColors(),
         );
 
         // Move the tab bar to the proper location.

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -46,9 +46,9 @@ pub const App = struct {
         const x11_program_name: [:0]const u8 = if (config.@"x11-instance-name") |pn|
             pn
         else if (builtin.mode == .Debug)
-            "ghostty-debug"
+            "wintty-debug"
         else
-            "ghostty";
+            "wintty";
 
         // Set the X11 window class property (WM_CLASS) if we are on an X11
         // display.
@@ -63,7 +63,7 @@ pub const App = struct {
         //
         // This makes the property show up like so when using xprop:
         //
-        //     WM_CLASS(STRING) = "ghostty", "com.mitchellh.ghostty"
+        //     WM_CLASS(STRING) = "wintty", "com.mitchellh.ghostty"
         //
         // Append "-debug" on both when using the debug build.
         glib.setPrgname(x11_program_name);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1581,7 +1581,7 @@ class: ?[:0]const u8 = null,
 /// This controls the instance name field of the `WM_CLASS` X11 property when
 /// running under X11. It has no effect otherwise.
 ///
-/// The default is `ghostty`.
+/// The default is `wintty`.
 ///
 /// This only affects GTK builds.
 @"x11-instance-name": ?[:0]const u8 = null,
@@ -2204,8 +2204,10 @@ keybind: Keybinds = .{},
 ///   * `system` - Use the system theme.
 ///   * `light` - Use the light theme regardless of system theme.
 ///   * `dark` - Use the dark theme regardless of system theme.
-///   * `ghostty` - Use the background and foreground colors specified in the
-///     Ghostty configuration. This is only supported on Linux builds.
+///   * `wintty` - Use the background and foreground colors specified in the
+///     Wintty configuration. This is only supported on Linux builds.
+///   * `ghostty` - Deprecated alias for `wintty`, kept so configurations
+///     written for upstream Ghostty keep working. Prefer `wintty`.
 ///
 /// On macOS, if `macos-titlebar-style` is `tabs` or `transparent`, the window theme will be
 /// automatically set based on the luminosity of the terminal background color.
@@ -2352,14 +2354,14 @@ keybind: Keybinds = .{},
 @"window-show-tab-bar": WindowShowTabBar = .auto,
 
 /// Background color for the window titlebar. This only takes effect if
-/// window-theme is set to ghostty. Currently only supported in the GTK app
+/// window-theme is set to wintty. Currently only supported in the GTK app
 /// runtime.
 ///
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
 @"window-titlebar-background": ?Color = null,
 
 /// Foreground color for the window titlebar. This only takes effect if
-/// window-theme is set to ghostty. Currently only supported in the GTK app
+/// window-theme is set to wintty. Currently only supported in the GTK app
 /// runtime.
 ///
 /// Specified as either hex (`#RRGGBB` or `RRGGBB`) or a named X11 color.
@@ -9407,7 +9409,27 @@ pub const WindowTheme = enum {
     system,
     light,
     dark,
+    wintty,
+
+    /// Deprecated alias for `wintty`. Kept as a real tag rather than
+    /// canonicalized at parse time so that a config written against upstream
+    /// Ghostty keeps round-tripping through `+show-config` and the C API
+    /// unchanged. Never compare against this tag directly; use
+    /// `usesTerminalColors` so both spellings stay in lockstep.
     ghostty,
+
+    /// True when the window chrome takes its colors from the configured
+    /// terminal background/foreground instead of a light/dark system theme.
+    ///
+    /// This exists so the `wintty`/`ghostty` pair is spelled out in exactly
+    /// one exhaustive switch. Call sites that compared against a single tag
+    /// would silently stop matching the other spelling.
+    pub fn usesTerminalColors(self: WindowTheme) bool {
+        return switch (self) {
+            .wintty, .ghostty => true,
+            .auto, .system, .light, .dark => false,
+        };
+    }
 };
 
 /// See window-colorspace
@@ -11308,6 +11330,36 @@ test "theme loading correct light/dark" {
             .g = 0xEE,
             .b = 0xEE,
         }, new.background);
+    }
+}
+
+test "window-theme accepts ghostty as an alias for wintty" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        var it: TestIterator = .{ .data = &.{"--window-theme=wintty"} };
+        try cfg.loadIter(alloc, &it);
+        try cfg.finalize();
+
+        try testing.expect(cfg.@"window-theme" == .wintty);
+        try testing.expect(cfg.@"window-theme".usesTerminalColors());
+    }
+
+    // The pre-rename spelling has to keep parsing and has to drive the same
+    // palette-derived chrome, otherwise upgrading silently changes the theme
+    // of anyone still carrying an upstream Ghostty config.
+    {
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        var it: TestIterator = .{ .data = &.{"--window-theme=ghostty"} };
+        try cfg.loadIter(alloc, &it);
+        try cfg.finalize();
+
+        try testing.expect(cfg.@"window-theme" == .ghostty);
+        try testing.expect(cfg.@"window-theme".usesTerminalColors());
     }
 }
 

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -100,8 +100,9 @@ public interface IConfigService : IDisposable
 
     /// <summary>
     /// Window theme from config: "light", "dark", "system", "auto", or
-    /// "ghostty" (palette-derived chrome). Controls both the XAML
-    /// ElementTheme and the DWM title bar chrome.
+    /// "wintty" (palette-derived chrome; "ghostty" is a deprecated alias
+    /// libghostty still accepts). Controls both the XAML ElementTheme and
+    /// the DWM title bar chrome.
     /// </summary>
     string WindowTheme { get; }
 

--- a/windows/Ghostty/Services/ShellThemeService.cs
+++ b/windows/Ghostty/Services/ShellThemeService.cs
@@ -22,7 +22,13 @@ internal sealed class ShellThemeService
     public Windows.UI.Color ScrollbarTrack { get; private set; }
     public Windows.UI.Color ScrollbarThumb { get; private set; }
 
-    public bool IsEnabled => string.Equals(_configService.WindowTheme, "ghostty", StringComparison.OrdinalIgnoreCase);
+    // "wintty" is the preferred spelling; "ghostty" is the deprecated alias
+    // libghostty still parses, and it comes back through the C API verbatim,
+    // so both have to enable palette-derived chrome or an unmigrated config
+    // would silently lose it.
+    public bool IsEnabled =>
+        string.Equals(_configService.WindowTheme, "wintty", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(_configService.WindowTheme, "ghostty", StringComparison.OrdinalIgnoreCase);
 
     private bool _wasEnabled;
 

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml
@@ -47,7 +47,7 @@
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>
                         </ComboBoxItem>
-                        <ComboBoxItem Tag="ghostty">
+                        <ComboBoxItem Tag="wintty">
                             <StackPanel>
                                 <!-- Text set in code-behind from AppIdentity.ProductName. -->
                                 <TextBlock x:Name="WindowThemeProductLabel"

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -157,9 +157,17 @@ internal sealed partial class AppearancePage : Page
 
     private void SelectWindowTheme(string theme)
     {
+        // libghostty still accepts the pre-rename "ghostty" spelling and hands
+        // it back verbatim, but the combo only carries the preferred "wintty"
+        // tag. Fold the alias here so an unmigrated config selects the right
+        // item instead of falling through to "auto" below.
+        var wanted = string.Equals(theme, "ghostty", StringComparison.OrdinalIgnoreCase)
+            ? "wintty"
+            : theme;
+
         foreach (ComboBoxItem item in WindowThemeCombo.Items)
         {
-            if (string.Equals(item.Tag?.ToString(), theme, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(item.Tag?.ToString(), wanted, StringComparison.OrdinalIgnoreCase))
             {
                 WindowThemeCombo.SelectedItem = item;
                 return;


### PR DESCRIPTION
The docs say wintty, but two config surfaces still only understood the
ghostty spelling.

`window-theme` now has a `wintty` value. The old `ghostty` value stays as a
real enum tag, so existing configs keep parsing and keep round-tripping
through `+show-config` and the C API unchanged. Since both spellings have to
behave identically, `WindowTheme` grows a `usesTerminalColors` helper that
names them in one exhaustive switch, and the GTK call sites go through it.
Two of those call sites were switches with an `else` arm, so adding a value
would have silently fallen through instead of failing to compile.

The Windows app reads `window-theme` back as a string, so `ShellThemeService`
and the Appearance settings combo also learned the new spelling. The settings
page maps a stored `ghostty` value onto the `wintty` item so an unmigrated
config does not show up as `auto`.

`x11-instance-name` now defaults to `wintty`, matching what its doc comment
claims. GTK/X11 only.

Verified with `zig build webdata` (exit 0) and `zig build test -Dtest-filter=config`
(267 pass, 4 skip, 0 fail). The GTK apprt does not compile on this host, so
those edits were reviewed by hand rather than by the compiler.
