### PR TITLE
webgen: reword a header line the rebrand inverted

### DIFF
--- a/src/build/webgen/main_config.zig
+++ b/src/build/webgen/main_config.zig
@@ -106,7 +106,7 @@ pub fn genConfig(writer: *std.Io.Writer) !void {
         \\for.
         \\
         \\Options Wintty cannot act on, including every macOS-only one,
-        \\are omitted. Options Ghostty does not have are listed separately
+        \\are omitted. Options unique to this build are listed
         \\under
         \\[Windows-Only Options](/docs/config/windows-only).
         \\


### PR DESCRIPTION
The reference header said "Options Ghostty does not have are listed separately
under Windows-Only Options". The website renames Ghostty to Wintty on the way
in, so the published page has been reading "Options Wintty does not have",
which is backwards - those are exactly the options Wintty has and Ghostty does
not.

Reworded to carry no project name at all, so the rename has nothing to catch.
Preserving the phrase in the sync script would have worked too, but that list
keeps growing (# 16, # 17) and a sentence that reads correctly either way does
not depend on the script.

Third instance of this class. Any generated sentence whose subject is a project
name is a candidate.
