### PR TITLE
renderer: tell the user when a custom shader is not applied

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -812,6 +812,14 @@ typedef enum {
   GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
 } ghostty_action_renderer_health_e;
 
+// renderer.CustomShaderFailure
+typedef enum {
+  GHOSTTY_CUSTOM_SHADER_FAILURE_LOAD_FAILED,
+  GHOSTTY_CUSTOM_SHADER_FAILURE_COMPILER_UNAVAILABLE,
+  GHOSTTY_CUSTOM_SHADER_FAILURE_COMPILE_FAILED,
+  GHOSTTY_CUSTOM_SHADER_FAILURE_PIPELINE_FAILED,
+} ghostty_action_custom_shader_failure_e;
+
 // apprt.action.KeySequence
 typedef struct {
   bool active;
@@ -1011,6 +1019,7 @@ typedef enum {
   GHOSTTY_ACTION_MOVE_TAB_TO_NEW_WINDOW,
   GHOSTTY_ACTION_PROMPT_READY,
   GHOSTTY_ACTION_FIRST_RENDER,
+  GHOSTTY_ACTION_CUSTOM_SHADER_FAILED,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -1036,6 +1045,7 @@ typedef union {
   ghostty_action_mouse_visibility_e mouse_visibility;
   ghostty_action_mouse_over_link_s mouse_over_link;
   ghostty_action_renderer_health_e renderer_health;
+  ghostty_action_custom_shader_failure_e custom_shader_failed;
   ghostty_action_quit_timer_e quit_timer;
   ghostty_action_float_window_e float_window;
   ghostty_action_secure_input_e secure_input;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1218,6 +1218,16 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
             };
         },
 
+        .custom_shader_failed => |reason| {
+            _ = self.rt_app.performAction(
+                .{ .surface = self },
+                .custom_shader_failed,
+                reason,
+            ) catch |err| {
+                log.warn("apprt failed to notify custom shader failure={}", .{err});
+            };
+        },
+
         .search_total => |v| {
             _ = try self.rt_app.performAction(
                 .{ .surface = self },

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -364,6 +364,12 @@ pub const Action = union(Key) {
     /// apprt consumers.
     first_render,
 
+    /// A configured `custom-shader` is not being applied because the
+    /// renderer could not load, compile, or build a pipeline for it. The
+    /// terminal keeps rendering normally without the shader, so this is
+    /// the only signal that the setting silently did nothing.
+    custom_shader_failed: renderer.CustomShaderFailure,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -436,6 +442,7 @@ pub const Action = union(Key) {
         move_tab_to_new_window,
         prompt_ready,
         first_render,
+        custom_shader_failed,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");

--- a/src/apprt/surface.zig
+++ b/src/apprt/surface.zig
@@ -108,6 +108,10 @@ pub const Message = union(enum) {
     /// `first_render` action.
     first_render,
 
+    /// The renderer could not apply the configured `custom-shader`.
+    /// Forwarded to the apprt as the `custom_shader_failed` action.
+    custom_shader_failed: renderer.CustomShaderFailure,
+
     /// The scrollbar state changed for the surface.
     scrollbar: terminal.Scrollbar,
 

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -55,6 +55,37 @@ pub const Health = enum(c_int) {
     }
 };
 
+/// Why a configured `custom-shader` is not being applied. Like `Health`,
+/// this is shared across all renderers even though not every variant is
+/// reachable on every one, so API users get a single enum.
+///
+/// A failure here is not fatal: the renderer falls back to drawing straight
+/// to the target, so the terminal looks entirely normal and the user has no
+/// way to tell their shader silently did nothing. That is what this reason
+/// exists to report.
+pub const CustomShaderFailure = enum(c_int) {
+    /// The shader file could not be read, or could not be translated into
+    /// the backend's shading language.
+    load_failed,
+
+    /// The backend has no shader compiler available at runtime. On DX12
+    /// this means dxcompiler.dll was not found next to the executable.
+    compiler_unavailable,
+
+    /// The compiler ran and rejected the shader source.
+    compile_failed,
+
+    /// The shader compiled but no GPU pipeline could be built from it.
+    pipeline_failed,
+
+    test "ghostty.h CustomShaderFailure" {
+        try lib.checkGhosttyHEnum(
+            CustomShaderFailure,
+            "GHOSTTY_CUSTOM_SHADER_FAILURE_",
+        );
+    }
+};
+
 test {
     // Our comptime-chosen renderer
     _ = Renderer;

--- a/src/renderer/directx12/shaders.zig
+++ b/src/renderer/directx12/shaders.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 const com = @import("com.zig");
 
 const d3d12 = @import("d3d12.zig");
+const renderer = @import("../../renderer.zig");
 const gpu_data = @import("gpu_data.zig");
 const Pipeline = @import("Pipeline.zig");
 
@@ -351,6 +352,14 @@ pub const Shaders = struct {
     post_root_signature: ?*d3d12.ID3D12RootSignature = null,
     pipelines: Pipelines = .{},
     post_pipelines: []const Pipeline = &.{},
+    /// Why `post_pipelines` is empty despite shaders having been requested.
+    /// Null when none were requested, or when at least one built.
+    ///
+    /// An empty slice on its own cannot distinguish "the user configured no
+    /// shaders" from "every shader the user configured failed to build",
+    /// which is exactly what made this failure silent. The generic renderer
+    /// reads this to raise a user-facing notice.
+    post_failure: ?renderer.CustomShaderFailure = null,
     defunct: bool = false,
 
     pub const Pipelines = struct {
@@ -451,6 +460,28 @@ pub const Shaders = struct {
             return .{
                 .root_signature = root_sig,
                 .pipelines = pipelines,
+                // Reaching here with shaders requested means the post root
+                // signature failed to serialize, which is a pipeline-object
+                // failure rather than anything to do with the shader source.
+                .post_failure = if (custom_shaders.len > 0) .pipeline_failed else null,
+            };
+        }
+
+        // Probe for the compiler once, up front. `compileHlslToDxil` loads
+        // the DLL itself per shader, but the reason the post pipelines come
+        // out empty has to be distinguishable: "this build cannot compile
+        // shaders at all" is a packaging defect we own, while "your shader
+        // did not compile" is something the user can fix. Both produce an
+        // identical empty slice.
+        if (d3d12.DxcLibrary.load()) |probe| {
+            probe.deinit();
+        } else {
+            log.warn("dxcompiler.dll not found, cannot compile custom shader", .{});
+            return .{
+                .root_signature = root_sig,
+                .post_root_signature = post_root_sig,
+                .pipelines = pipelines,
+                .post_failure = .compiler_unavailable,
             };
         }
 
@@ -463,14 +494,26 @@ pub const Shaders = struct {
                 .post_root_signature = post_root_sig,
                 .pipelines = pipelines,
                 .post_pipelines = &.{},
+                .post_failure = .compile_failed,
             };
         };
         defer std.heap.c_allocator.free(entry_point_w);
 
         const custom_root_sig = post_root_sig orelse root_sig;
 
+        // Why individual shaders dropped out, so an all-empty result can name
+        // a cause. First failure wins: the notice names one reason and the
+        // per-shader detail is already in the log.
+        var loop_failure: ?renderer.CustomShaderFailure = null;
+
         for (custom_shaders) |source| {
-            const dxil = compileHlslToDxil(alloc, source, entry_point_w) catch continue orelse continue;
+            const dxil = compileHlslToDxil(alloc, source, entry_point_w) catch {
+                if (loop_failure == null) loop_failure = .compile_failed;
+                continue;
+            } orelse {
+                if (loop_failure == null) loop_failure = .compile_failed;
+                continue;
+            };
             // D3D12 copies bytecode into the PSO during CreateGraphicsPipelineState,
             // so the allocation can be freed immediately after PSO creation.
             defer alloc.free(dxil);
@@ -483,6 +526,7 @@ pub const Shaders = struct {
                 .blend = .none,
             }) catch |err| {
                 log.warn("custom shader PSO creation failed: {}", .{err});
+                if (loop_failure == null) loop_failure = .pipeline_failed;
                 continue;
             };
 
@@ -496,6 +540,10 @@ pub const Shaders = struct {
             .post_root_signature = post_root_sig,
             .pipelines = pipelines,
             .post_pipelines = post_pipelines,
+            // Only report a failure when nothing built at all. If some
+            // shaders compiled the chain still runs, so a partial failure
+            // belongs in the log rather than in a banner.
+            .post_failure = if (post_pipelines.len == 0) loop_failure else null,
         };
     }
 
@@ -570,6 +618,20 @@ test "Shaders.init returns default on null device" {
     try std.testing.expect(s.root_signature == null);
     try std.testing.expect(s.pipelines.bg_color.pso == null);
     try std.testing.expect(s.pipelines.cell_text.pso == null);
+}
+
+test "Shaders default reports no custom shader failure" {
+    const s: Shaders = .{};
+    try std.testing.expect(s.post_failure == null);
+}
+
+test "Shaders.init reports no failure when no shaders were requested" {
+    // "Nothing configured" must never look like a failure -- that is the
+    // distinction post_failure exists to draw, and an empty post_pipelines
+    // slice alone cannot make it.
+    const s = try Shaders.init(null, std.testing.allocator, &.{});
+    try std.testing.expect(s.post_pipelines.len == 0);
+    try std.testing.expect(s.post_failure == null);
 }
 
 test "Pipelines has all 5 fields" {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1778,8 +1778,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // The resource/PSO null checks are DX12-specific (descriptor heaps
             // can be exhausted, PSOs can be defunct after re-init); Metal and
             // OpenGL fail at allocation so any state we reach here is valid.
-            const use_custom_shader = use_custom_shader: {
-                const state = frame.custom_shader_state orelse break :use_custom_shader false;
+            //
+            // This block only answers "are the resources we have valid"; it
+            // says nothing about whether we have any pipelines at all, because
+            // the loop below has nothing to reject when the list is empty.
+            // `customShaderUsable` owns that half of the decision.
+            const resources_valid = resources_valid: {
+                const state = frame.custom_shader_state orelse break :resources_valid false;
                 if (comptime @hasField(Texture, "resource")) {
                     if (state.front_texture.resource == null or
                         state.back_texture.resource == null or
@@ -1788,7 +1793,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         state.front_texture.srv.gpu.ptr == 0 or
                         state.back_texture.srv.gpu.ptr == 0)
                     {
-                        break :use_custom_shader false;
+                        break :resources_valid false;
                     }
                 }
                 // Verify post-process pipelines have valid PSOs (DX12-only
@@ -1797,12 +1802,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     for (self.shaders.post_pipelines, 0..) |pipeline, i| {
                         if (pipeline.pso == null or pipeline.root_signature == null) {
                             log.warn("post-process pipeline {} has null PSO/root_sig, falling back", .{i});
-                            break :use_custom_shader false;
+                            break :resources_valid false;
                         }
                     }
                 }
-                break :use_custom_shader true;
+                break :resources_valid true;
             };
+            const use_custom_shader = customShaderUsable(
+                frame.custom_shader_state != null,
+                resources_valid,
+                self.shaders.post_pipelines.len,
+            );
 
             {
                 var pass = frame_ctx.renderPass(&.{.{
@@ -3625,4 +3635,67 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
         }
     };
+}
+
+/// Whether the post-process custom shader path can be used for a frame.
+///
+/// `resources_valid` carries the backend-specific texture/PSO null checks
+/// done at the call site (they need the concrete `Texture` / `Pipeline`
+/// types, so they can't move in here). What this function owns is the
+/// backend-independent precondition that has to hold for the retarget to
+/// be safe at all.
+///
+/// `post_pipeline_count` is the load-bearing one, and it is easy to miss:
+/// taking this path retargets the frame to `custom_shader_state.back_texture`,
+/// and the only code that blits back to `frame.target` is the loop over
+/// `post_pipelines`. With an empty list the retarget still happens but the
+/// blit loop never runs, so `frame.target` is presented having never been
+/// written -- the terminal renders as a transparent hole instead of falling
+/// back to an unshaded terminal. An empty list is therefore "cannot use",
+/// not "nothing to validate".
+///
+/// That list is empty whenever every configured shader failed to build: on
+/// DX12, dxcompiler.dll missing at runtime, DXC rejecting the generated
+/// HLSL, or pipeline creation failing. All are recoverable -- the terminal
+/// just renders unshaded -- but only if we refuse the path here.
+fn customShaderUsable(
+    has_state: bool,
+    resources_valid: bool,
+    post_pipeline_count: usize,
+) bool {
+    if (!has_state) return false;
+    if (post_pipeline_count == 0) return false;
+    return resources_valid;
+}
+
+test "customShaderUsable: no custom shader state means no custom shader path" {
+    try std.testing.expect(!customShaderUsable(false, true, 1));
+}
+
+test "customShaderUsable: empty post_pipelines must not take the path" {
+    // Regression: an empty pipeline list used to pass validation
+    // vacuously (the validity loop had nothing to reject), the frame was
+    // retargeted to the offscreen texture, and the blit loop that would
+    // have copied it back never ran -- presenting an unwritten surface.
+    try std.testing.expect(!customShaderUsable(true, true, 0));
+}
+
+test "customShaderUsable: invalid resources fall back even with pipelines" {
+    try std.testing.expect(!customShaderUsable(true, false, 1));
+}
+
+test "customShaderUsable: valid state, resources and pipelines uses the path" {
+    try std.testing.expect(customShaderUsable(true, true, 1));
+    try std.testing.expect(customShaderUsable(true, true, 3));
+}
+
+test "customShaderUsable: empty pipelines lose to every other input" {
+    // The empty-list guard must not be reachable-around: no combination
+    // of the other two inputs may re-enable the path when there is
+    // nothing to blit the offscreen texture back with.
+    for ([_]bool{ true, false }) |has_state| {
+        for ([_]bool{ true, false }) |resources_valid| {
+            try std.testing.expect(!customShaderUsable(has_state, resources_valid, 0));
+        }
+    }
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -169,6 +169,16 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// only after a frame that actually paints content is presented.
         first_render_sent: bool = false,
 
+        /// A custom-shader failure waiting to be pushed to the surface. Set
+        /// by `initShaders` when the user configured a shader the backend
+        /// could not apply, cleared once `drawFrame` has pushed it.
+        ///
+        /// Pushed from the draw path rather than from `initShaders` itself
+        /// because at renderer-init time the apprt has not necessarily
+        /// registered the surface yet, so an action raised there can be
+        /// dropped. `.first_render` above takes the same route.
+        custom_shader_failure: ?renderer.CustomShaderFailure = null,
+
         /// The current GPU uniform values.
         uniforms: shaderpkg.Uniforms,
 
@@ -869,7 +879,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 .swap_chain = swap_chain,
             };
 
-            try result.initShaders();
+            try result.initShaders(.startup);
 
             // Ensure our undefined values above are correctly initialized.
             result.updateFontGridUniforms();
@@ -927,10 +937,23 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             self.shaders.deinit(self.alloc);
         }
 
-        fn initShaders(self: *Self) !void {
+        /// Why shaders are being (re)built. Only `startup` and
+        /// `config_reload` arm the user-facing custom-shader notice: a
+        /// display realize rebuilds GPU resources for something the user did
+        /// not ask for, and must not re-raise a failure they have already
+        /// been told about.
+        const ShaderInitCause = enum { startup, config_reload, display_realized };
+
+        fn initShaders(self: *Self, cause: ShaderInitCause) !void {
             var arena = ArenaAllocator.init(self.alloc);
             defer arena.deinit();
             const arena_alloc = arena.allocator();
+
+            // Whether the user asked for post-process shaders at all. Read
+            // from config rather than from the load result below, because the
+            // whole point is to tell "configured but not applied" apart from
+            // "not configured" -- `has_custom_shaders` is false in both.
+            const configured = self.config.custom_shaders.value.items.len > 0;
 
             // Load our custom shaders
             const custom_shaders: []const [:0]const u8 = shadertoy.loadFromFiles(
@@ -952,6 +975,29 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             self.shaders = shaders;
             self.has_custom_shaders = has_custom_shaders;
+
+            // Arm the notice if the user configured a shader that ended up
+            // doing nothing. Two distinct silent paths land here: the load or
+            // translation above failing, and the backend building zero post
+            // pipelines. Both leave the terminal rendering normally, so a
+            // `log.warn` nobody reads is otherwise the only trace.
+            if (cause != .display_realized and configured) {
+                if (!has_custom_shaders) {
+                    self.custom_shader_failure = .load_failed;
+                } else if (shaders.post_pipelines.len == 0) {
+                    // Backends that can say why record it on their Shaders
+                    // struct; everyone else gets the generic pipeline
+                    // failure. Same comptime-probe idiom as the
+                    // `@hasField(Pipeline, "pso")` guard in drawFrame.
+                    self.custom_shader_failure = if (comptime @hasField(
+                        @TypeOf(shaders),
+                        "post_failure",
+                    ))
+                        shaders.post_failure orelse .pipeline_failed
+                    else
+                        .pipeline_failed;
+                }
+            }
         }
 
         /// This is called early right after surface creation.
@@ -1046,7 +1092,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             assert(self.swap_chain.defunct);
 
             // We reinitialize our shaders and our swap chain.
-            try self.initShaders();
+            try self.initShaders(.display_realized);
             self.swap_chain = try SwapChain.init(
                 self.alloc,
                 self.api,
@@ -1623,6 +1669,20 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     self.first_render_sent = true;
             };
 
+            // Emit any pending custom-shader failure on the same mailbox path
+            // as `.first_render` above. A defer so it also catches a failure
+            // armed by the shader re-init further down this same frame.
+            // `.instant` so a momentarily full mailbox delays the signal to
+            // the next frame rather than blocking the render thread; clearing
+            // the field only on a successful push is what makes this fire
+            // exactly once per shader initialization.
+            defer if (self.custom_shader_failure) |reason| {
+                if (self.surface_mailbox.push(
+                    .{ .custom_shader_failed = reason },
+                    .instant,
+                ) > 0) self.custom_shader_failure = null;
+            };
+
             // Let our graphics API do any bookkeeping, etc.
             // that it needs to do before / after `drawFrame`.
             self.api.drawFrameStart();
@@ -1674,7 +1734,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.reinitialize_shaders = false;
                 self.api.waitGpu();
                 self.shaders.deinit(self.alloc);
-                try self.initShaders();
+                try self.initShaders(.config_reload);
             }
 
             // Our shaders should not be defunct at this point.

--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -63,6 +63,7 @@ internal enum GhosttyActionTag
     SearchSelected = 64,
     PromptReady    = 68,
     FirstRender    = 69,
+    CustomShaderFailed = 70,
 }
 
 // ghostty_action_scrollbar_s:

--- a/windows/Ghostty.Core/Renderer/CustomShaderFailure.cs
+++ b/windows/Ghostty.Core/Renderer/CustomShaderFailure.cs
@@ -1,0 +1,20 @@
+namespace Ghostty.Core.Renderer;
+
+/// <summary>
+/// Why a configured <c>custom-shader</c> is not being applied. Mirrors
+/// <c>ghostty_action_custom_shader_failure_e</c> in include/ghostty.h
+/// (renderer.CustomShaderFailure in src/renderer.zig).
+/// </summary>
+/// <remarks>
+/// The ordinals are ABI, not an implementation detail — they arrive as a raw
+/// int in the action payload. GhosttyActionsLayoutTests pins them against the
+/// header so a reordering upstream fails a test rather than silently showing
+/// the user the wrong reason.
+/// </remarks>
+public enum CustomShaderFailure
+{
+    LoadFailed = 0,
+    CompilerUnavailable = 1,
+    CompileFailed = 2,
+    PipelineFailed = 3,
+}

--- a/windows/Ghostty.Core/Renderer/CustomShaderNoticeSource.cs
+++ b/windows/Ghostty.Core/Renderer/CustomShaderNoticeSource.cs
@@ -1,0 +1,97 @@
+using System;
+using Ghostty.Core.Notifications;
+
+namespace Ghostty.Core.Renderer;
+
+/// <summary>
+/// Turns a renderer <see cref="CustomShaderFailure"/> into the one-time
+/// <see cref="Notice"/> explaining why the user's <c>custom-shader</c> is not
+/// being applied.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The failure is otherwise invisible. The renderer falls back to drawing
+/// straight to the target, so the terminal looks completely normal and the
+/// only trace is a Zig <c>log.warn</c> in a file nobody opens.
+/// </para>
+/// <para>
+/// Stateful because the signal repeats: libghostty raises the action once per
+/// surface per shader initialization, so one config reload with three panes
+/// open produces three actions. <see cref="Notice.DedupKey"/> collapses those
+/// into a single banner while one is on screen; this gate is what stops the
+/// banner returning after the user dismissed it and later reloaded config for
+/// an unrelated reason.
+/// </para>
+/// <para>
+/// The gate keys on the reason alone, deliberately. Re-arming when the reason
+/// changes (a syntax error becoming a pipeline failure) is new information
+/// worth showing; the same reason again is not, whatever else changed. Keying
+/// on the configured shader path as well was considered and dropped — the only
+/// getter for it returns the first entry of a repeatable option, so it would
+/// have been wrong for anyone with two shaders configured.
+/// </para>
+/// <para>
+/// UI-free and dependency-free so the gating and the copy unit-test without a
+/// WinUI runtime, mirroring <c>NoColorStartup</c>. Not thread-safe: call it on
+/// the UI thread like everything else touching
+/// <see cref="INotificationService"/>.
+/// </para>
+/// </remarks>
+public sealed class CustomShaderNoticeSource
+{
+    /// <summary>
+    /// One key for every variant, so several surfaces failing at once show a
+    /// single banner rather than one per pane.
+    /// </summary>
+    public const string DedupKey = "custom-shader";
+
+    // The reason behind the last notice we returned; null until the first one.
+    private CustomShaderFailure? _lastNotified;
+
+    /// <param name="failure">The reason reported by the renderer.</param>
+    /// <returns>
+    /// The notice to show, or null when it would just repeat the last one.
+    /// </returns>
+    public Notice? Resolve(CustomShaderFailure failure)
+    {
+        if (_lastNotified == failure) return null;
+        _lastNotified = failure;
+
+        return new Notice
+        {
+            Title = "Custom shader not applied",
+            Message = MessageFor(failure),
+            // Warning, not Informational: something the user explicitly
+            // configured is doing nothing. Not Error -- nothing is broken,
+            // the terminal renders normally without the shader.
+            Severity = NoticeSeverity.Warning,
+            DedupKey = DedupKey,
+            // No actions, deliberately. We cannot retry a compile the driver
+            // already rejected, we will not silently rewrite the user's
+            // config, and an "Open settings" button would land on a page that
+            // cannot show what the compiler objected to. NO_COLOR earns its
+            // buttons because there is a real reversible choice behind them;
+            // here there is only information.
+        };
+    }
+
+    private static string MessageFor(CustomShaderFailure failure) => failure switch
+    {
+        CustomShaderFailure.LoadFailed =>
+            "Wintty could not read or translate the shader file in your custom-shader "
+            + "setting, so it is being skipped. Check the path; the terminal renders "
+            + "normally without it.",
+        CustomShaderFailure.CompilerUnavailable =>
+            "Wintty could not load the DirectX shader compiler (dxcompiler.dll), so "
+            + "custom-shader has no effect in this build. The terminal renders normally "
+            + "without it.",
+        CustomShaderFailure.CompileFailed =>
+            "Your custom-shader did not compile, so it is being skipped. The compiler's "
+            + "errors are in the Wintty log; the terminal renders normally without it.",
+        // PipelineFailed, and any future variant an older build does not know:
+        // the shader was readable and compilable but the GPU would not take it.
+        _ =>
+            "Your custom-shader compiled but the graphics pipeline for it could not be "
+            + "created, so it is being skipped. The terminal renders normally without it.",
+    };
+}

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Ghostty.Core.Interop;
+using Ghostty.Core.Renderer;
 using Xunit;
 
 namespace Ghostty.Tests.Interop;
@@ -40,6 +41,7 @@ public class GhosttyActionsLayoutTests
     [InlineData((int)GhosttyActionTag.SearchSelected, 64)]
     [InlineData((int)GhosttyActionTag.PromptReady, 68)]
     [InlineData((int)GhosttyActionTag.FirstRender, 69)]
+    [InlineData((int)GhosttyActionTag.CustomShaderFailed, 70)]
     [InlineData((int)GhosttyActionTag.ToggleVisibility, 12)]
     [InlineData((int)GhosttyActionTag.ToggleBackgroundOpacity, 13)]
     [InlineData((int)GhosttyActionTag.GotoWindow, 17)]
@@ -64,6 +66,19 @@ public class GhosttyActionsLayoutTests
     public void ProgressState_Ordinal_Matches_Upstream(int state, int expected)
     {
         Assert.Equal(expected, state);
+    }
+
+    // ghostty_action_custom_shader_failure_e. These ordinals arrive as a raw
+    // int in the action payload, so a reorder upstream would silently show the
+    // user the wrong reason rather than failing to compile.
+    [Theory]
+    [InlineData((int)CustomShaderFailure.LoadFailed, 0)]
+    [InlineData((int)CustomShaderFailure.CompilerUnavailable, 1)]
+    [InlineData((int)CustomShaderFailure.CompileFailed, 2)]
+    [InlineData((int)CustomShaderFailure.PipelineFailed, 3)]
+    public void CustomShaderFailure_Ordinal_Matches_Upstream(int failure, int expected)
+    {
+        Assert.Equal(expected, failure);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Renderer/CustomShaderNoticeSourceTests.cs
+++ b/windows/Ghostty.Tests/Renderer/CustomShaderNoticeSourceTests.cs
@@ -1,0 +1,83 @@
+using Ghostty.Core.Notifications;
+using Ghostty.Core.Renderer;
+using Xunit;
+
+namespace Ghostty.Tests.Renderer;
+
+public class CustomShaderNoticeSourceTests
+{
+    [Fact]
+    public void First_failure_returns_a_closable_warning_with_no_actions()
+    {
+        var notice = new CustomShaderNoticeSource().Resolve(CustomShaderFailure.CompilerUnavailable);
+
+        Assert.NotNull(notice);
+        Assert.Equal("Custom shader not applied", notice!.Title);
+        Assert.Equal(NoticeSeverity.Warning, notice.Severity);
+        Assert.Equal(CustomShaderNoticeSource.DedupKey, notice.DedupKey);
+        Assert.Empty(notice.Actions);
+        Assert.True(notice.IsClosable);
+    }
+
+    [Theory]
+    [InlineData(CustomShaderFailure.LoadFailed)]
+    [InlineData(CustomShaderFailure.CompilerUnavailable)]
+    [InlineData(CustomShaderFailure.CompileFailed)]
+    [InlineData(CustomShaderFailure.PipelineFailed)]
+    public void Every_failure_has_its_own_copy(CustomShaderFailure failure)
+    {
+        var notice = new CustomShaderNoticeSource().Resolve(failure);
+
+        Assert.NotNull(notice);
+        Assert.NotEqual(string.Empty, notice!.Message);
+    }
+
+    [Theory]
+    [InlineData(CustomShaderFailure.LoadFailed)]
+    [InlineData(CustomShaderFailure.CompilerUnavailable)]
+    [InlineData(CustomShaderFailure.CompileFailed)]
+    [InlineData(CustomShaderFailure.PipelineFailed)]
+    public void Copy_never_claims_the_shader_is_working(CustomShaderFailure failure)
+    {
+        // The notice must describe a shader that did nothing and a terminal
+        // that is otherwise fine. Promising more than that is the one thing
+        // this copy cannot do.
+        var notice = new CustomShaderNoticeSource().Resolve(failure);
+
+        Assert.Contains("renders normally without it", notice!.Message);
+        Assert.True(
+            notice.Message.Contains("skipped") || notice.Message.Contains("no effect"),
+            $"copy should say the shader is not being applied: {notice.Message}");
+    }
+
+    [Fact]
+    public void CompilerUnavailable_names_the_missing_dll_so_a_bug_report_can_use_it()
+    {
+        var notice = new CustomShaderNoticeSource().Resolve(CustomShaderFailure.CompilerUnavailable);
+
+        Assert.Contains("dxcompiler.dll", notice!.Message);
+    }
+
+    [Fact]
+    public void Repeat_of_the_same_failure_is_suppressed()
+    {
+        // One config reload re-inits every surface's shaders, so N panes
+        // produce N actions for a single user-visible event.
+        var source = new CustomShaderNoticeSource();
+
+        Assert.NotNull(source.Resolve(CustomShaderFailure.CompileFailed));
+        Assert.Null(source.Resolve(CustomShaderFailure.CompileFailed));
+        Assert.Null(source.Resolve(CustomShaderFailure.CompileFailed));
+    }
+
+    [Fact]
+    public void A_different_failure_re_arms_the_notice()
+    {
+        // The user fixed a syntax error and now hits a pipeline failure: that
+        // is new information, not a repeat.
+        var source = new CustomShaderNoticeSource();
+
+        Assert.NotNull(source.Resolve(CustomShaderFailure.CompileFailed));
+        Assert.NotNull(source.Resolve(CustomShaderFailure.PipelineFailed));
+    }
+}

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -155,6 +155,12 @@ internal sealed class GhosttyHost : IDisposable
     // focus-regain clear forwarded by their controls.
     private readonly Ghostty.Core.Notifications.IToastNotifier _toasts;
 
+    // One-time gate plus copy for the "custom-shader configured but not
+    // applied" notice. Lives on the host because that is the singleton every
+    // surface's action lands on, so one gate sees the whole process rather
+    // than one banner per pane. Only touched from the UI-thread lambda below.
+    private readonly Ghostty.Core.Renderer.CustomShaderNoticeSource _customShaderNotices = new();
+
     public GhosttyApp App => _app;
 
     /// <summary>
@@ -909,6 +915,25 @@ internal sealed class GhosttyHost : IDisposable
                     {
                         if (TryResolveControl(surfaceHandle, out var c) && c is not null)
                             c.RaiseFirstRender();
+                    });
+                    return 1;
+                }
+
+                case GhosttyActionTag.CustomShaderFailed:
+                {
+                    // The renderer has already fallen back to drawing straight
+                    // to the target, so nothing here is a recovery step -- this
+                    // is purely the signal that the user's shader silently did
+                    // nothing. Raised app-level rather than per-surface because
+                    // it explains a config problem, not something about this
+                    // one pane.
+                    var failure = (Ghostty.Core.Renderer.CustomShaderFailure)
+                        Marshal.ReadInt32(actionPtr, 8);
+                    _dispatcher.TryEnqueue(() =>
+                    {
+                        if (Ghostty.App.NotificationService is not { } notifications) return;
+                        if (_customShaderNotices.Resolve(failure) is { } notice)
+                            notifications.Show(notice);
                     });
                     return 1;
                 }


### PR DESCRIPTION
## Summary

Adds a `custom_shader_failed` apprt action carrying a reason, and surfaces it through the existing `NotificationService` as a warning banner: *"Custom shader not applied — Wintty could not load the DirectX shader compiler (dxcompiler.dll), so custom-shader has no effect in this build. The terminal renders normally without it."*

The reason matters because the causes are not equally the user's problem. A missing `dxcompiler.dll` means this build cannot compile custom shaders at all; a shader the compiler rejected is something the user can fix. Both produce an identical empty pipeline list, so DX12 records which one happened on its `Shaders` struct, including an up-front probe for the compiler.

The banner is informational, with no action buttons. We cannot retry a compile the driver rejected, we will not rewrite the user's config, and a settings link would land on a page that cannot show what the compiler objected to. The copy never claims the feature works.

## Why

Stacked on #610. With that fix a custom shader that fails to build degrades to an unshaded terminal — the right behaviour, but completely silent: the terminal looks normal and the only trace is a `log.warn` in a file nobody opens. A user who set `custom-shader` and sees no shader cannot tell whether they made a mistake or the build cannot compile shaders at all.

The action is pushed from the draw path rather than from `initShaders`, because at renderer-init time the apprt has not necessarily registered the surface yet and the action can be dropped. A display realize does not arm it: that rebuilds GPU resources for something the user did not ask for.

## Test plan

- [x] `zig build test` — 83/83 steps, 3756 passed, 77 skipped; the `ghostty.h` enum-sync tests pin the new ABI
- [x] `dotnet test Ghostty.Tests -p:Platform=x64` — 1793 passed, 0 failed
- [x] Real app with `custom-shader` set and no DXC on the DLL search path: banner appears naming dxcompiler.dll, stacked below the NO_COLOR notice, terminal rendering normally