### PR TITLE
build: package the DirectX shader compiler

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -134,6 +134,43 @@
                       Version="1.25.260427001-preview"
                       GeneratePathProperty="true"
                       ExcludeAssets="all" />
+
+    <!--
+      DirectX Shader Compiler redistributable. The DX12 renderer compiles
+      user custom shaders at runtime via LoadLibraryW("dxcompiler.dll")
+      (src/renderer/directx12/d3d12.zig, DxcLibrary.load). Without it the
+      custom-shader setting silently does nothing, which is what shipped
+      until now: the DLL is not an in-box Windows component, so the feature
+      only ever worked for people who happened to have a copy on PATH from
+      an unrelated install.
+
+      We deliberately ship dxcompiler.dll ALONE, without the dxil.dll
+      validator that older guidance pairs with it. DXC 1.8.2502 stopped
+      requiring the external validator to sign shaders and 1.8.2505 stopped
+      looking for it at all, using an internal validator that writes a real
+      hash every D3D12 runtime accepts. This pin is past both, and a custom
+      shader was verified to compile and render with dxil.dll absent from
+      the app directory and from PATH. Shipping it would add 1.5 MB of dead
+      weight, and it is the one closed-source binary in the package.
+
+      Pinned to 1.9.2602.24 rather than the newer 1.9.2607.13 because
+      1.9.2602.24 still carries distributable_files.txt, the in-package
+      manifest that LICENSE-MS.txt's redistribution grant refers to by name,
+      and that manifest names dxcompiler.dll. 1.9.2607.13 dropped the
+      manifest while still shipping the license that points at it, which
+      leaves the grant referring to a list that is not there.
+
+      ExcludeAssets="all" is load-bearing: the package's own
+      build/native/Microsoft.Direct3D.DXC.targets copies dxcompiler.pdb and
+      dxil.pdb alongside the DLLs, and those symbols are 34 MB on x64, more
+      than the binaries themselves. We stage the one DLL we need explicitly
+      below. GeneratePathProperty exposes $(PkgMicrosoft_Direct3D_DXC).
+    -->
+    <PackageReference Include="Microsoft.Direct3D.DXC"
+                      Version="1.9.2602.24"
+                      GeneratePathProperty="true"
+                      ExcludeAssets="all"
+                      Condition="'$(WinttyShipDxc)' != 'false'" />
   </ItemGroup>
 
   <!--
@@ -212,6 +249,86 @@
            Text="Bundled conpty.dll missing for x86 from the Microsoft.Windows.Console.ConPTY package." />
     <Error Condition="'$(Platform)' == 'x86' and !Exists('$(PkgMicrosoft_Windows_Console_ConPTY)\build\native\runtimes\x86\OpenConsole.exe')"
            Text="Bundled OpenConsole.exe missing for x86 from the Microsoft.Windows.Console.ConPTY package; without it conpty.dll silently falls back to in-box conhost." />
+  </Target>
+
+  <!--
+    Deploy dxcompiler.dll for the build platform alongside Wintty.exe.
+    NOT into native\: LoadLibraryW with a bare name searches the directory
+    the *application* loaded from, never the directory of the calling DLL.
+    In Release the DX12 code is statically linked into Wintty.exe anyway
+    (DirectPInvoke + ghostty-static.lib); in Debug it lives in
+    native\ghostty.dll. The exe folder is the one location that works for
+    both.
+
+    Same longhand-per-RID shape as the ConPTY block above, and for the same
+    MSBuild reason. Package arch folders are lowercase x86/x64/arm64 while
+    $(Platform) is x86/x64/ARM64.
+  -->
+  <ItemGroup Condition="'$(WinttyShipDxc)' != 'false'">
+    <None Include="$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\x64\dxcompiler.dll"
+          Condition="'$(Platform)' == 'x64' and Exists('$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\x64\dxcompiler.dll')">
+      <Link>dxcompiler.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\arm64\dxcompiler.dll"
+          Condition="'$(Platform)' == 'ARM64' and Exists('$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\arm64\dxcompiler.dll')">
+      <Link>dxcompiler.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\x86\dxcompiler.dll"
+          Condition="'$(Platform)' == 'x86' and Exists('$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\x86\dxcompiler.dll')">
+      <Link>dxcompiler.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+
+  <!--
+    Ship the licences that govern the redistributed binary. The LLVM/NCSA
+    licence dxcompiler.dll is published under requires a binary redistributor
+    to reproduce its copyright notice and disclaimer in the materials provided
+    with the distribution, so this is an obligation rather than a courtesy.
+    LICENSE-MS.txt is the Microsoft redistribution grant that permits shipping
+    the binary at all. Both are referenced from the pinned package rather than
+    vendored into the repo, so they cannot drift from the binary they cover.
+
+    LICENCE-MIT.txt from the package is deliberately not shipped: it covers
+    d3d12shader.h, a header we do not redistribute.
+
+    These land in licenses/ in the publish output, which the MSI harvest
+    (Files Include="$(var.PublishDir)\**") and the Velopack pack step both
+    pick up with no packaging change.
+  -->
+  <ItemGroup Condition="'$(WinttyShipDxc)' != 'false'">
+    <None Include="$(PkgMicrosoft_Direct3D_DXC)\LICENSE-LLVM.txt"
+          Condition="Exists('$(PkgMicrosoft_Direct3D_DXC)\LICENSE-LLVM.txt')">
+      <Link>licenses\DirectXShaderCompiler-LICENSE-LLVM.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(PkgMicrosoft_Direct3D_DXC)\LICENSE-MS.txt"
+          Condition="Exists('$(PkgMicrosoft_Direct3D_DXC)\LICENSE-MS.txt')">
+      <Link>licenses\DirectXShaderCompiler-LICENSE-MS.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+
+  <!--
+    Fail the build if dxcompiler.dll is missing. Its absence is invisible in
+    a build log and only shows up as the custom-shader setting quietly doing
+    nothing at runtime, which is the failure this whole change exists to
+    remove. One Error per platform (the project Platforms are x86;x64;ARM64).
+  -->
+  <Target Name="ErrorIfDxcRedistMissing" BeforeTargets="Build" Condition="'$(WinttyShipDxc)' != 'false'">
+    <Error Condition="'$(Platform)' == 'x64' and !Exists('$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\x64\dxcompiler.dll')"
+           Text="dxcompiler.dll missing for x64 from the Microsoft.Direct3D.DXC package. Custom shaders cannot compile without it, so the custom-shader setting would be silently ignored. Restore the package or fix the version pin." />
+    <Error Condition="'$(Platform)' == 'ARM64' and !Exists('$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\arm64\dxcompiler.dll')"
+           Text="dxcompiler.dll missing for ARM64 from the Microsoft.Direct3D.DXC package. Custom shaders cannot compile without it, so the custom-shader setting would be silently ignored. Restore the package or fix the version pin." />
+    <Error Condition="'$(Platform)' == 'x86' and !Exists('$(PkgMicrosoft_Direct3D_DXC)\build\native\bin\x86\dxcompiler.dll')"
+           Text="dxcompiler.dll missing for x86 from the Microsoft.Direct3D.DXC package. Custom shaders cannot compile without it, so the custom-shader setting would be silently ignored. Restore the package or fix the version pin." />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Stages `dxcompiler.dll` next to `Wintty.exe`, following the shape already used for `conpty.dll`: a pinned `PackageReference` with `GeneratePathProperty`, explicit per-platform copies, and a build-time error if it is missing. Adds ~18 MB per arch on x64.

**`dxil.dll` is deliberately not shipped.** DXC 1.8.2502 stopped requiring the external validator to sign shaders and 1.8.2505 stopped looking for it at all, using an internal validator that writes a real hash every D3D12 runtime accepts. This pin is past both, and a custom shader was verified to compile and render with `dxil.dll` absent from the app directory and from PATH. Omitting it drops 1.5 MB and avoids redistributing the one closed-source binary in the package.

The DLL goes next to the executable rather than into `native/` because `LoadLibraryW` with a bare name searches the directory the application loaded from, never the directory of the calling DLL. That location also works for both configurations: in Release the DX12 code is statically linked into `Wintty.exe`, while in Debug it lives in `native/ghostty.dll`.

`LICENSE-LLVM.txt` and `LICENSE-MS.txt` ship into `licenses/` in the payload. The LLVM/NCSA license `dxcompiler.dll` is published under requires a binary redistributor to reproduce its copyright notice and disclaimer in the materials provided with the distribution, so this is an obligation rather than a courtesy. Both are referenced from the pinned package rather than vendored, so they cannot drift from the binary they cover.

## Why

The DX12 renderer compiles custom shaders at runtime via `LoadLibraryW("dxcompiler.dll")`, but nothing ever staged that DLL into a shipped artifact, and it is not an in-box Windows DLL. `custom-shader` has therefore never worked for anyone who did not happen to have a copy on their PATH from an unrelated install. It went unnoticed because the Vulkan SDK and Cursor both put one there, so it resolves on a typical dev machine and not on a user's.

Pinned to 1.9.2602.24 rather than the newer 1.9.2607.13 because that version still carries `distributable_files.txt`, the in-package manifest that `LICENSE-MS.txt`'s redistribution grant refers to by name, and which names `dxcompiler.dll`. 1.9.2607.13 dropped the manifest while still shipping the license that points at it, leaving the grant referring to a list that is not there.

`ExcludeAssets="all"` is not boilerplate copied from the ConPTY reference: the package's own targets also copy `dxcompiler.pdb` and `dxil.pdb`, which are 34 MB on x64, larger than the binary itself.

The payload is gated on a `WinttyShipDxc` property so the DX11 tier, whose renderer discards custom shaders unconditionally, can opt out of ~18 MB it can never use. Nothing sets it yet; wiring that up is a change in the tier repo.

## Test plan

- [x] `dotnet build windows/Ghostty.sln /p:Platform=x64` — `dxcompiler.dll` lands next to `Wintty.exe` at exactly the package size, with the two licence texts in `licenses/` and no `.pdb`, `dxil.dll`, `dxc.exe` or `dxv.exe` alongside
- [x] `/p:WinttyShipDxc=false` omits the payload; rebuilding without it restores it
- [x] `dotnet test Ghostty.Tests -p:Platform=x64` — 1776 passed, 0 failed
- [x] Real app with `custom-shader` set and **no DXC anywhere on PATH**: the shader renders, resolving the compiler purely from the app directory
- [x] Same, with `dxil.dll` additionally absent from the app directory: the shader still renders, confirming the external validator is not needed at this pin