### PR TITLE
build: ship licence files for what we redistribute

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -286,6 +286,30 @@
   </ItemGroup>
 
   <!--
+    Ship the vendored third-party licences. These cover the binaries we
+    redistribute (ConPTY, Skia, HarfBuzz) and the fonts compiled into
+    ghostty.dll, none of which arrive with usable licence text: the NuGet
+    packages either ship none at all or ship only the C# binding's MIT,
+    which does not cover the native library inside the DLL.
+
+    Vendored rather than referenced from a package for exactly that reason -
+    there is no package path to point at. The DXC pair below is the
+    exception and stays package-referenced.
+
+    A glob rather than a per-file list: this set grows whenever we start
+    redistributing something new, and a list is one more place to forget.
+    licenses/README.md documents what covers what and is shipped with them
+    deliberately, so the payload explains itself.
+  -->
+  <ItemGroup>
+    <None Include="licenses\**\*">
+      <Link>licenses\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+
+  <!--
     Ship the licences that govern the redistributed binary. The LLVM/NCSA
     licence dxcompiler.dll is published under requires a binary redistributor
     to reproduce its copyright notice and disclaimer in the materials provided

--- a/windows/Ghostty/licenses/Fonts-BSD-2-Clause.txt
+++ b/windows/Ghostty/licenses/Fonts-BSD-2-Clause.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2018-2024, Frederic Cambus
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/windows/Ghostty/licenses/Fonts-MIT.txt
+++ b/windows/Ghostty/licenses/Fonts-MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/windows/Ghostty/licenses/Fonts-OFL-1.1.txt
+++ b/windows/Ghostty/licenses/Fonts-OFL-1.1.txt
@@ -1,0 +1,91 @@
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/windows/Ghostty/licenses/HarfBuzz-COPYING.txt
+++ b/windows/Ghostty/licenses/HarfBuzz-COPYING.txt
@@ -1,0 +1,42 @@
+HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.
+For parts of HarfBuzz that are licensed under different licenses see individual
+files names COPYING in subdirectories where applicable.
+
+Copyright © 2010-2022  Google, Inc.
+Copyright © 2015-2020  Ebrahim Byagowi
+Copyright © 2019,2020  Facebook, Inc.
+Copyright © 2012,2015  Mozilla Foundation
+Copyright © 2011  Codethink Limited
+Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)
+Copyright © 2009  Keith Stribley
+Copyright © 2011  Martin Hosken and SIL International
+Copyright © 2007  Chris Wilson
+Copyright © 2005,2006,2020,2021,2022,2023  Behdad Esfahbod
+Copyright © 2004,2007,2008,2009,2010,2013,2021,2022,2023  Red Hat, Inc.
+Copyright © 1998-2005  David Turner and Werner Lemberg
+Copyright © 2016  Igalia S.L.
+Copyright © 2022  Matthias Clasen
+Copyright © 2018,2021  Khaled Hosny
+Copyright © 2018,2019,2020  Adobe, Inc
+Copyright © 2013-2015  Alexei Podtelezhnikov
+
+For full copyright notices consult the individual files in the package.
+
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/windows/Ghostty/licenses/HarfBuzzSharp-LICENSE.txt
+++ b/windows/Ghostty/licenses/HarfBuzzSharp-LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2015-2016 Xamarin, Inc.
+Copyright (c) 2017-2018 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/windows/Ghostty/licenses/README.md
+++ b/windows/Ghostty/licenses/README.md
@@ -1,0 +1,57 @@
+# Third-party licences shipped with Wintty
+
+Every file in this directory is copied into the application payload next to
+`Wintty.exe`, under `licenses/`. The MSI harvest and the Velopack pack step
+both take the publish folder wholesale, so anything added here reaches users
+without a packaging change.
+
+This is a hand-maintained set, not a generated one. It covers the components
+we redistribute as binaries and the fonts compiled into `ghostty.dll`. It does
+**not** yet cover the full managed dependency graph — see "Known gaps" below.
+
+## What covers what
+
+| File | Component | Licence |
+|---|---|---|
+| `Wintty-LICENSE.txt` | Wintty itself, and Ghostty which it is based on | MIT |
+| `WindowsTerminal-LICENSE.txt` | `conpty.dll`, `OpenConsole.exe` | MIT |
+| `DirectXShaderCompiler-LICENSE-LLVM.txt` | `dxcompiler.dll` | LLVM / University of Illinois NCSA |
+| `DirectXShaderCompiler-LICENSE-MS.txt` | `dxcompiler.dll` redistribution grant | Microsoft |
+| `Skia-LICENSE.txt` | Skia, compiled into `libSkiaSharp.dll` | BSD-3-Clause |
+| `SkiaSharp-LICENSE.txt` | the SkiaSharp binding itself | MIT |
+| `HarfBuzz-COPYING.txt` | HarfBuzz, compiled into `libHarfBuzzSharp.dll` | "Old MIT" |
+| `HarfBuzzSharp-LICENSE.txt` | the HarfBuzzSharp binding itself | MIT |
+| `Fonts-OFL-1.1.txt` | JetBrains Mono, Nerd Fonts Symbols, Noto Emoji | SIL OFL 1.1 |
+| `Fonts-MIT.txt` | MIT-licensed embedded fonts | MIT |
+| `Fonts-BSD-2-Clause.txt` | BSD-licensed embedded fonts | BSD-2-Clause |
+
+The binding libraries and the native libraries inside them are listed
+separately on purpose. `SkiaSharp-LICENSE.txt` is the MIT text for the C#
+binding; it does not cover Skia, which is BSD-3-Clause and carries its own
+notice requirement. The same split applies to HarfBuzz. Shipping only the
+binding licence would under-report what is actually in the DLL.
+
+The two DXC files are staged directly from the pinned
+`Microsoft.Direct3D.DXC` package rather than checked in here, so they cannot
+drift from the binary they cover. Everything else is vendored, because the
+upstream package either ships no licence text at all or ships only the
+binding's.
+
+Fonts are grouped by licence rather than by font because the mapping from
+font to licence already lives in `src/font/res/README.md`, which names each
+embedded font with its copyright line. OFL 1.1 requires the licence travel
+with the font, and the upstream JetBrains Mono archive we fetch carries none,
+which is why these are vendored here.
+
+## Known gaps
+
+Managed dependencies resolved through NuGet are not covered yet. Most declare
+an SPDX expression and ship no licence text, so collecting them means pairing
+each package's `<copyright>` with the SPDX body — mechanical, but more than a
+file copy. The same applies to the C libraries statically linked into
+`ghostty.dll` (freetype, zlib, libpng, oniguruma, libxml2, simdutf, highway,
+fontconfig, wuffs) and to the Zig package graph.
+
+Adding a component here is the right move whenever we start redistributing a
+new binary. Adding one to the payload without a licence file is the failure
+mode this directory exists to prevent.

--- a/windows/Ghostty/licenses/Skia-LICENSE.txt
+++ b/windows/Ghostty/licenses/Skia-LICENSE.txt
@@ -1,0 +1,29 @@
+Copyright (c) 2011 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/windows/Ghostty/licenses/SkiaSharp-LICENSE.txt
+++ b/windows/Ghostty/licenses/SkiaSharp-LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2015-2016 Xamarin, Inc.
+Copyright (c) 2017-2018 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/windows/Ghostty/licenses/WindowsTerminal-LICENSE.txt
+++ b/windows/Ghostty/licenses/WindowsTerminal-LICENSE.txt
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/windows/Ghostty/licenses/Wintty-LICENSE.txt
+++ b/windows/Ghostty/licenses/Wintty-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Vendors the licence texts we can obtain today and stages them into `licenses/` next to `Wintty.exe`, alongside the DXC pair from #612. Covers ConPTY and OpenConsole, Skia and HarfBuzz, the fonts compiled into `ghostty.dll`, and Wintty's own MIT. A `README.md` ships with them documenting what covers what.

Native libraries are listed separately from their C# bindings on purpose. SkiaSharp and HarfBuzzSharp ship a byte-identical MIT text covering the binding and no notice for the library inside the DLL — Skia is BSD-3-Clause, HarfBuzz is "Old MIT", both with their own notice requirements. Shipping only what the packages carry would under-report what we actually redistribute.

Staged with a glob rather than a per-file list, because this set grows whenever we ship something new and a list is one more place to forget.

## Why

Nothing in the payload told a user what they had received. The two attribution files that exist — `THIRD_PARTY_NOTICES.md` and the tier overlay's `licenses/` — sit at the repo root, are never copied into the publish folder, and cover SVG icons only. The About box says "MIT License" and nothing else.

Fonts are grouped by licence rather than by font because `src/font/res` already maps each embedded font to its licence and copyright. OFL 1.1 requires the licence travel with the font and the JetBrains Mono archive we fetch carries none, so vendoring is the only way to satisfy it.

This is deliberately not the whole dependency graph. Managed NuGet packages, the C libraries statically linked into `ghostty.dll`, and the Zig package graph are not covered — those need collection tooling rather than a file copy. The shipped README says so rather than implying the set is complete.

## Test plan

- [x] `dotnet build windows/Ghostty.sln /p:Platform=x64` — all 11 files land in `licenses/` in the payload
- [x] Both DXC files still staged from the pinned package, so they cannot drift from the binary