### PR TITLE
panes: stop terminal content rendering under the pane chrome

### DIFF
--- a/windows/Ghostty.Core/Panes/PaneChrome.cs
+++ b/windows/Ghostty.Core/Panes/PaneChrome.cs
@@ -31,9 +31,9 @@ internal static class PaneChrome
     /// Gutter reserved between a pane's bounds and its terminal surface.
     ///
     /// Sized to the thickest chrome that can land on a single edge (the
-    /// divider rides the boundary between two leaves, so it draws into
-    /// one gutter or the other, never both), rounded up to a whole DIP so
-    /// the surface starts on a device-pixel boundary at 100% scale.
+    /// divider is pinned to the leading leaf's trailing edge, so it draws
+    /// into that leaf's gutter alone), rounded up to a whole DIP so the
+    /// surface starts on a device-pixel boundary at 100% scale.
     /// Derived rather than hardcoded so bumping a thickness above cannot
     /// silently reintroduce chrome drawing over terminal content.
     /// </summary>
@@ -50,8 +50,8 @@ internal static class PaneChrome
     /// backdrop and read as a differently tinted frame around every
     /// pane. The opacity has to be carried through rather than filled
     /// opaque because libghostty composites its own window padding the
-    /// same way; measured across a pane edge at opacity 0.75, gutter and
-    /// surface resolve to the same pixel.
+    /// same way, and the gutter's job is to be indistinguishable from
+    /// the surface it abuts.
     /// </remarks>
     /// <param name="backgroundRgb">Packed 0xRRGGBB background colour.</param>
     /// <param name="backgroundOpacity">Effective opacity, clamped to 0..1.</param>

--- a/windows/Ghostty.Core/Panes/PaneChrome.cs
+++ b/windows/Ghostty.Core/Panes/PaneChrome.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Ghostty.Core.Panes;
 
 /// <summary>
@@ -21,7 +19,7 @@ namespace Ghostty.Core.Panes;
 /// would resize the terminal grid -- and reflow the shell -- on every
 /// focus change.
 /// </summary>
-public static class PaneChrome
+internal static class PaneChrome
 {
     /// <summary>Stroke thickness of the active-pane focus border.</summary>
     public const double ActiveBorderThickness = 1.5;
@@ -43,19 +41,6 @@ public static class PaneChrome
         Math.Ceiling(Math.Max(ActiveBorderThickness, DividerThickness));
 
     /// <summary>
-    /// The terminal surface extent along one axis for a pane of the given
-    /// extent, with the gutter removed from both edges.
-    /// </summary>
-    /// <remarks>
-    /// Clamped at zero: a pane briefly narrower than its two gutters
-    /// (mid-drag, or a split of an already tiny pane) would otherwise
-    /// yield a negative extent, which wraps to an enormous value once
-    /// cast to the unsigned pixel size libghostty takes.
-    /// </remarks>
-    public static double SurfaceExtent(double paneExtent)
-        => Math.Max(0.0, paneExtent - SurfaceInset * 2);
-
-    /// <summary>
     /// Packed ARGB to fill the gutter with: the terminal background at
     /// the effective background opacity.
     /// </summary>
@@ -63,10 +48,10 @@ public static class PaneChrome
     /// The gutter falls outside the terminal surface, so nothing paints
     /// it unless we do -- it would otherwise show the bare window
     /// backdrop and read as a differently tinted frame around every
-    /// pane. Carrying the opacity through (rather than filling opaque)
-    /// is what makes it match: libghostty composites its own window
-    /// padding the same way, so at any opacity the gutter and the
-    /// padding just inside it resolve to the same pixel.
+    /// pane. The opacity has to be carried through rather than filled
+    /// opaque because libghostty composites its own window padding the
+    /// same way; measured across a pane edge at opacity 0.75, gutter and
+    /// surface resolve to the same pixel.
     /// </remarks>
     /// <param name="backgroundRgb">Packed 0xRRGGBB background colour.</param>
     /// <param name="backgroundOpacity">Effective opacity, clamped to 0..1.</param>

--- a/windows/Ghostty.Core/Panes/PaneChrome.cs
+++ b/windows/Ghostty.Core/Panes/PaneChrome.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace Ghostty.Core.Panes;
+
+/// <summary>
+/// Thicknesses, in DIPs, of the chrome drawn around a pane, plus the
+/// gutter each pane reserves for it.
+///
+/// The chrome -- the active-pane focus stroke and the split divider --
+/// is drawn as an overlay above the split tree rather than as elements
+/// inside it, so it consumes no layout space of its own. On its own that
+/// makes the chrome paint over live terminal cells: the pane's full rect
+/// is what gets handed to libghostty, so it sizes its grid to the full
+/// rect and the renderer fills it edge to edge, right up under the
+/// stroke and the divider line.
+///
+/// <see cref="SurfaceInset"/> is the gutter every leaf keeps clear
+/// around its terminal surface so the chrome lands on empty pixels
+/// instead. It is uniform across all four edges and independent of which
+/// pane is focused on purpose: sizing the gutter to the active pane
+/// would resize the terminal grid -- and reflow the shell -- on every
+/// focus change.
+/// </summary>
+public static class PaneChrome
+{
+    /// <summary>Stroke thickness of the active-pane focus border.</summary>
+    public const double ActiveBorderThickness = 1.5;
+
+    /// <summary>Thickness of the divider line drawn between two panes.</summary>
+    public const double DividerThickness = 1.0;
+
+    /// <summary>
+    /// Gutter reserved between a pane's bounds and its terminal surface.
+    ///
+    /// Sized to the thickest chrome that can land on a single edge (the
+    /// divider rides the boundary between two leaves, so it draws into
+    /// one gutter or the other, never both), rounded up to a whole DIP so
+    /// the surface starts on a device-pixel boundary at 100% scale.
+    /// Derived rather than hardcoded so bumping a thickness above cannot
+    /// silently reintroduce chrome drawing over terminal content.
+    /// </summary>
+    public static readonly double SurfaceInset =
+        Math.Ceiling(Math.Max(ActiveBorderThickness, DividerThickness));
+
+    /// <summary>
+    /// The terminal surface extent along one axis for a pane of the given
+    /// extent, with the gutter removed from both edges.
+    /// </summary>
+    /// <remarks>
+    /// Clamped at zero: a pane briefly narrower than its two gutters
+    /// (mid-drag, or a split of an already tiny pane) would otherwise
+    /// yield a negative extent, which wraps to an enormous value once
+    /// cast to the unsigned pixel size libghostty takes.
+    /// </remarks>
+    public static double SurfaceExtent(double paneExtent)
+        => Math.Max(0.0, paneExtent - SurfaceInset * 2);
+
+    /// <summary>
+    /// Packed ARGB to fill the gutter with: the terminal background at
+    /// the effective background opacity.
+    /// </summary>
+    /// <remarks>
+    /// The gutter falls outside the terminal surface, so nothing paints
+    /// it unless we do -- it would otherwise show the bare window
+    /// backdrop and read as a differently tinted frame around every
+    /// pane. Carrying the opacity through (rather than filling opaque)
+    /// is what makes it match: libghostty composites its own window
+    /// padding the same way, so at any opacity the gutter and the
+    /// padding just inside it resolve to the same pixel.
+    /// </remarks>
+    /// <param name="backgroundRgb">Packed 0xRRGGBB background colour.</param>
+    /// <param name="backgroundOpacity">Effective opacity, clamped to 0..1.</param>
+    public static uint GutterArgb(uint backgroundRgb, double backgroundOpacity)
+    {
+        var alpha = (uint)Math.Round(Math.Clamp(backgroundOpacity, 0.0, 1.0) * 255.0);
+        return (alpha << 24) | (backgroundRgb & 0x00FFFFFFu);
+    }
+}

--- a/windows/Ghostty.Tests/Panes/PaneChromeTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneChromeTests.cs
@@ -1,0 +1,78 @@
+using Ghostty.Core.Panes;
+using Xunit;
+
+namespace Ghostty.Tests.Panes;
+
+public class PaneChromeTests
+{
+    [Fact]
+    public void Gutter_covers_the_active_border_stroke()
+    {
+        Assert.True(PaneChrome.SurfaceInset >= PaneChrome.ActiveBorderThickness);
+    }
+
+    [Fact]
+    public void Gutter_covers_the_divider_line()
+    {
+        // The divider rides the boundary between two leaves, so it draws
+        // over one gutter or the other -- never both at once.
+        Assert.True(PaneChrome.SurfaceInset >= PaneChrome.DividerThickness);
+    }
+
+    [Fact]
+    public void Gutter_is_a_whole_number_of_dips()
+    {
+        Assert.Equal(PaneChrome.SurfaceInset, System.Math.Floor(PaneChrome.SurfaceInset));
+    }
+
+    [Theory]
+    [InlineData(800.0, 600.0)]
+    [InlineData(120.0, 80.0)]
+    public void Surface_extent_leaves_a_gutter_on_both_edges(double w, double h)
+    {
+        Assert.Equal(w - PaneChrome.SurfaceInset * 2, PaneChrome.SurfaceExtent(w), 6);
+        Assert.Equal(h - PaneChrome.SurfaceInset * 2, PaneChrome.SurfaceExtent(h), 6);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(1.0)]
+    [InlineData(-5.0)]
+    public void Surface_extent_never_goes_negative_on_a_collapsed_pane(double extent)
+    {
+        // A pane narrower than the gutters would otherwise produce a
+        // negative extent, which becomes a huge value once cast to the
+        // unsigned width libghostty takes.
+        Assert.Equal(0.0, PaneChrome.SurfaceExtent(extent), 6);
+    }
+
+    [Fact]
+    public void Gutter_fill_is_opaque_background_at_full_opacity()
+    {
+        Assert.Equal(0xFF1E2430u, PaneChrome.GutterArgb(0x1E2430u, 1.0));
+    }
+
+    [Fact]
+    public void Gutter_fill_carries_the_background_opacity()
+    {
+        // Matches what libghostty composites into its own window padding,
+        // so the gutter cannot read as a differently tinted frame.
+        Assert.Equal(0x800C0C0Cu, PaneChrome.GutterArgb(0x0C0C0Cu,0.5));
+    }
+
+    [Theory]
+    [InlineData(-1.0, 0x00u)]
+    [InlineData(2.5, 0xFFu)]
+    public void Gutter_fill_clamps_out_of_range_opacity(double opacity, uint alpha)
+    {
+        Assert.Equal(alpha, PaneChrome.GutterArgb(0x0C0C0Cu,opacity) >> 24);
+    }
+
+    [Fact]
+    public void Gutter_fill_ignores_stray_high_bits_in_the_background()
+    {
+        // ConfigService hands back a packed RGB int; anything above the
+        // low 24 bits is not colour data and must not leak into alpha.
+        Assert.Equal(0xFF0C0C0Cu, PaneChrome.GutterArgb(0xAB0C0C0Cu, 1.0));
+    }
+}

--- a/windows/Ghostty.Tests/Panes/PaneChromeTests.cs
+++ b/windows/Ghostty.Tests/Panes/PaneChromeTests.cs
@@ -20,33 +20,6 @@ public class PaneChromeTests
     }
 
     [Fact]
-    public void Gutter_is_a_whole_number_of_dips()
-    {
-        Assert.Equal(PaneChrome.SurfaceInset, System.Math.Floor(PaneChrome.SurfaceInset));
-    }
-
-    [Theory]
-    [InlineData(800.0, 600.0)]
-    [InlineData(120.0, 80.0)]
-    public void Surface_extent_leaves_a_gutter_on_both_edges(double w, double h)
-    {
-        Assert.Equal(w - PaneChrome.SurfaceInset * 2, PaneChrome.SurfaceExtent(w), 6);
-        Assert.Equal(h - PaneChrome.SurfaceInset * 2, PaneChrome.SurfaceExtent(h), 6);
-    }
-
-    [Theory]
-    [InlineData(0.0)]
-    [InlineData(1.0)]
-    [InlineData(-5.0)]
-    public void Surface_extent_never_goes_negative_on_a_collapsed_pane(double extent)
-    {
-        // A pane narrower than the gutters would otherwise produce a
-        // negative extent, which becomes a huge value once cast to the
-        // unsigned width libghostty takes.
-        Assert.Equal(0.0, PaneChrome.SurfaceExtent(extent), 6);
-    }
-
-    [Fact]
     public void Gutter_fill_is_opaque_background_at_full_opacity()
     {
         Assert.Equal(0xFF1E2430u, PaneChrome.GutterArgb(0x1E2430u, 1.0));
@@ -57,7 +30,7 @@ public class PaneChromeTests
     {
         // Matches what libghostty composites into its own window padding,
         // so the gutter cannot read as a differently tinted frame.
-        Assert.Equal(0x800C0C0Cu, PaneChrome.GutterArgb(0x0C0C0Cu,0.5));
+        Assert.Equal(0x800C0C0Cu, PaneChrome.GutterArgb(0x0C0C0Cu, 0.5));
     }
 
     [Theory]
@@ -65,13 +38,13 @@ public class PaneChromeTests
     [InlineData(2.5, 0xFFu)]
     public void Gutter_fill_clamps_out_of_range_opacity(double opacity, uint alpha)
     {
-        Assert.Equal(alpha, PaneChrome.GutterArgb(0x0C0C0Cu,opacity) >> 24);
+        Assert.Equal(alpha, PaneChrome.GutterArgb(0x0C0C0Cu, opacity) >> 24);
     }
 
     [Fact]
     public void Gutter_fill_ignores_stray_high_bits_in_the_background()
     {
-        // ConfigService hands back a packed RGB int; anything above the
+        // ConfigService hands back a packed RGB value; anything above the
         // low 24 bits is not colour data and must not leak into alpha.
         Assert.Equal(0xFF0C0C0Cu, PaneChrome.GutterArgb(0xAB0C0C0Cu, 1.0));
     }

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -55,7 +55,14 @@
         hover/pointer-leave, so we get the native Windows 11 auto-fade
         for free without a custom Storyboard.
     -->
+    <!--
+        Root Background fills the gutter TerminalControl holds around the
+        SwapChainPanel for the pane chrome (see PaneChrome). Set from the
+        terminal background in code-behind rather than a ThemeResource so
+        it tracks the config theme, not the system one.
+    -->
     <Grid
+        x:Name="SurfaceRoot"
         HorizontalAlignment="Stretch"
         VerticalAlignment="Stretch">
         <SwapChainPanel

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -56,15 +56,15 @@
         for free without a custom Storyboard.
     -->
     <!--
-        SurfaceRoot Background fills the gutter this control holds around
-        the SwapChainPanel for the pane chrome (see PaneChrome). Set from
-        the terminal background in code-behind rather than a ThemeResource
-        so it tracks the config theme, not the system one.
+        SurfaceRoot fills the gutter this control holds around the
+        SwapChainPanel for the pane chrome (see PaneChrome). Its fill is
+        set from the terminal background in code-behind rather than a
+        ThemeResource so it tracks the config theme, not the system one.
 
         It repeats the panel's pointer handlers because the gutter sits
         outside the panel: without them the gutter band would swallow
         clicks, so clicking a pane's edge would neither focus it nor reach
-        libghostty. Each handler ignores the bubbled copy of an event a
+        libghostty. Each handler drops the bubbled copy of an event a
         child overlay already owns - the ScrollBar is a sibling of the
         panel, so its drags would otherwise reach the terminal too.
 
@@ -174,7 +174,6 @@
             VerticalAlignment="Top"
             HorizontalAlignment="Right"
             MaxWidth="480"
-            Margin="0,8,8,0"
             Visibility="Collapsed"
             Closed="OnSearchClosed" />
 

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -62,14 +62,21 @@
         so it tracks the config theme, not the system one.
 
         It repeats the panel's pointer handlers because the gutter sits
-        outside the panel: without them the outer 2 DIP would swallow
+        outside the panel: without them the gutter band would swallow
         clicks, so clicking a pane's edge would neither focus it nor reach
         libghostty. Each handler ignores the bubbled copy of an event a
         child overlay already owns - the ScrollBar is a sibling of the
         panel, so its drags would otherwise reach the terminal too.
+
+        Background="Transparent" is load-bearing, not decoration: a Grid
+        with a null Background is not hit-testable over its own area, so
+        without it those handlers are unreachable and the gutter is a dead
+        band again. The code-behind only ever recolours it, so the input
+        path never depends on the config path having produced a brush.
     -->
     <Grid
         x:Name="SurfaceRoot"
+        Background="Transparent"
         HorizontalAlignment="Stretch"
         VerticalAlignment="Stretch"
         PointerPressed="OnPointerPressed"

--- a/windows/Ghostty/Controls/TerminalControl.xaml
+++ b/windows/Ghostty/Controls/TerminalControl.xaml
@@ -56,15 +56,27 @@
         for free without a custom Storyboard.
     -->
     <!--
-        Root Background fills the gutter TerminalControl holds around the
-        SwapChainPanel for the pane chrome (see PaneChrome). Set from the
-        terminal background in code-behind rather than a ThemeResource so
-        it tracks the config theme, not the system one.
+        SurfaceRoot Background fills the gutter this control holds around
+        the SwapChainPanel for the pane chrome (see PaneChrome). Set from
+        the terminal background in code-behind rather than a ThemeResource
+        so it tracks the config theme, not the system one.
+
+        It repeats the panel's pointer handlers because the gutter sits
+        outside the panel: without them the outer 2 DIP would swallow
+        clicks, so clicking a pane's edge would neither focus it nor reach
+        libghostty. Each handler ignores the bubbled copy of an event a
+        child overlay already owns - the ScrollBar is a sibling of the
+        panel, so its drags would otherwise reach the terminal too.
     -->
     <Grid
         x:Name="SurfaceRoot"
         HorizontalAlignment="Stretch"
-        VerticalAlignment="Stretch">
+        VerticalAlignment="Stretch"
+        PointerPressed="OnPointerPressed"
+        PointerMoved="OnPointerMoved"
+        PointerReleased="OnPointerReleased"
+        PointerWheelChanged="OnPointerWheelChanged"
+        ContextRequested="OnContextRequested">
         <SwapChainPanel
             x:Name="Panel"
             IsTabStop="False"

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -565,16 +565,19 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// glow.</summary>
     public event EventHandler? FirstRender;
 
+    // Distance the search bar floats from the terminal's top-right, on
+    // top of whatever gutter the pane chrome reserves.
+    private const double SearchBarInset = 8;
+
     public TerminalControl()
     {
         InitializeComponent();
 
-        // Hold the terminal surface off the pane's edges by the width of
-        // the chrome PaneHost draws over it (the active-pane focus stroke
-        // and the split divider, both overlays that reserve no layout
-        // space of their own). Without this the surface fills the pane
-        // rect, PushSurfaceSize hands libghostty that full rect, and the
-        // outermost cells render underneath the chrome.
+        // Hold the terminal surface off the pane's edges so the chrome
+        // PaneHost overlays there does not paint over live cells -- see
+        // PaneChrome for why the gutter exists and how it is sized.
+        // PushSurfaceSize reads Panel.ActualWidth, so insetting the panel
+        // is also what keeps libghostty's grid matched to what is visible.
         //
         // Applied here rather than in XAML so PaneChrome stays the single
         // source of truth for the thicknesses, and set before the first
@@ -593,11 +596,21 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // both are pane-edge chrome themselves.
         VerticalScrollBar.Margin = gutter;
         ResizeOverlay.Margin = gutter;
+        // Assigned outright rather than added to a XAML margin: every
+        // other line here is idempotent, and this block is one refactor
+        // away from being re-run on attach the way ApplyGutterBrush now
+        // is. Accumulating would walk the search bar inward every time.
         SearchBar.Margin = new Thickness(
-            SearchBar.Margin.Left + gutter.Left,
-            SearchBar.Margin.Top + gutter.Top,
-            SearchBar.Margin.Right + gutter.Right,
-            SearchBar.Margin.Bottom + gutter.Bottom);
+            0,
+            SearchBarInset + gutter.Top,
+            SearchBarInset + gutter.Right,
+            0);
+
+        // Bell flash spans the pane bounds, so its stroke is what fills
+        // the gutter while it is up. Sized from the gutter for that
+        // reason -- a thicker chrome would otherwise leave it painting
+        // over live cells again.
+        BellOverlay.BorderThickness = gutter;
 
         ApplyGutterBrush();
     }
@@ -606,14 +619,14 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     // resolves to the same value neither allocates a brush nor dirties
     // the pane's visual. Reloads are frequent (Ctrl+Shift+Wheel walks
     // background-opacity one step per notch) and every leaf of every tab
-    // is repainted on each one. Mirrors ApplyRootGridBackground.
+    // is repainted on each one, plus every leaf repaints on attach.
     private uint? _lastGutterArgb;
 
     /// <summary>
-    /// Repaint the gutter to match the terminal background. Called at
-    /// construction, and by MainWindow whenever the backdrop is recomputed,
-    /// so a theme change or a power-saver transition does not strand a
-    /// stale frame around each pane.
+    /// Repaint the gutter to match the terminal background. Called when
+    /// the control is built, on every attach, and by MainWindow on a
+    /// config reload -- the three ways this leaf's fill can fall behind
+    /// the surface it abuts.
     /// </summary>
     internal void ApplyGutterBrush()
     {
@@ -631,11 +644,14 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
             cfg.BackgroundColor, cfg.BackgroundOpacity);
         if (_lastGutterArgb == argb) return;
 
-        // Commit the cache only after the write lands. XAML property sets
-        // on this path can throw against a tearing-down visual tree (see
-        // the catch in MainWindow.OnLowPowerChanged); recording first
-        // would leave the leaf believing it had painted a colour it never
-        // did, and every later repaint of that value would early-out.
+        // Commit the cache only after the write lands. A config reload
+        // can reach a leaf whose visual tree is tearing down, and the
+        // property set throws there; recording first would leave the leaf
+        // believing it had painted a colour it never did, and every later
+        // repaint of that value would early-out. PaneHost.RefreshGutterBrush
+        // swallows that throw per leaf, so without this ordering the miss
+        // would also be silent. Note ApplyRootGridBackground commits
+        // first -- same hazard, not yet addressed there.
         SurfaceRoot.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
             Microsoft.UI.ColorHelper.FromArgb(
                 (byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb));
@@ -1187,29 +1203,27 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         UrlHoverBanner.Visibility = Visibility.Visible;
     }
 
-    // The pointer handlers are attached to both Panel and SurfaceRoot so
-    // the chrome gutter around the panel still routes into the terminal.
-    // On the SurfaceRoot copy, take only events that landed on the gutter
-    // itself: the ScrollBar and SearchBar are siblings of the panel, so
-    // their pointer events bubble through here and must stay theirs.
+    // True for the SurfaceRoot copy of an event that started somewhere
+    // below it -- on the panel, or on a sibling overlay that owns it. See
+    // the dual-attachment rationale in the XAML.
     //
     // Source-based rather than Handled-based on purpose, so it holds for
     // the handlers that return early without marking the event (the
     // motion threshold in OnPointerMoved, the null-surface guards).
     //
-    // Events that do come from the gutter carry Panel-relative
-    // coordinates slightly outside the surface. That is intended:
-    // libghostty clamps them to the edge cell, which is what makes a
-    // click on a pane's edge behave as a click on its outermost cell.
-    // It does mean an app running mouse=a sees button reports attributed
-    // to the edge cell for clicks a few DIPs outside the grid.
-    private bool NotOurs(object sender, RoutedEventArgs e)
+    // Events that survive it came from the gutter and carry Panel-relative
+    // coordinates just outside the surface. That is intended: libghostty
+    // clamps them to the edge cell, which is what makes a click on a
+    // pane's edge behave as a click on its outermost cell. It does mean
+    // an app running mouse=a sees button reports attributed to the edge
+    // cell for clicks a few DIPs outside the grid.
+    private bool BubbledFromChild(object sender, RoutedEventArgs e)
         => ReferenceEquals(sender, SurfaceRoot)
            && !ReferenceEquals(e.OriginalSource, SurfaceRoot);
 
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
-        if (NotOurs(sender, e)) return;
+        if (BubbledFromChild(sender, e)) return;
 
         // Take focus on the UserControl, not the panel. Guard with the
         // current focus state to avoid generating a Lost+Got pair when
@@ -1265,7 +1279,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
     {
-        if (NotOurs(sender, e)) return;
+        if (BubbledFromChild(sender, e)) return;
 
         // Complete the suppressed right-click on its matching right-release,
         // opening the menu so it feels like a normal Windows right-click. We
@@ -1289,7 +1303,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnContextRequested(UIElement sender, ContextRequestedEventArgs args)
     {
-        if (NotOurs(sender, args)) return;
+        if (BubbledFromChild(sender, args)) return;
 
         // ContextRequested fires for both right-click and keyboard. The
         // pointer path (OnPointerPressed/Released) already handles right-click
@@ -1304,7 +1318,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
     {
-        if (NotOurs(sender, e)) return;
+        if (BubbledFromChild(sender, e)) return;
         if (_surface.Handle == IntPtr.Zero) return;
         // ghostty_surface_mouse_pos expects unscaled coordinates (DIPs):
         // src/apprt/embedded.zig cursorPosCallback runs the input through
@@ -1342,7 +1356,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
-        if (NotOurs(sender, e)) return;
+        if (BubbledFromChild(sender, e)) return;
         if (_surface.Handle == IntPtr.Zero) return;
         var pt = e.GetCurrentPoint(Panel);
         var rawDelta = pt.Properties.MouseWheelDelta;

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -584,14 +584,20 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         Panel.Margin = gutter;
 
         // Overlays that read as part of the terminal content follow the
-        // surface into the gutter. The scrollbar tracks the grid's right
-        // edge and the resize pill positions itself within the grid, so
-        // leaving either on the pane bounds would float it over the
-        // border stroke. The other three stay on the pane bounds: the
-        // bell flash and the URL banner are pane-edge chrome themselves,
-        // and the SearchBar already floats on its own inset margin.
+        // surface into the gutter: the scrollbar tracks the grid's right
+        // edge, the resize pill positions itself within the grid, and the
+        // search bar floats over it. Leaving any of them on the pane
+        // bounds would sit them over the border stroke, and for the
+        // search bar would quietly shrink its own inset by the gutter.
+        // The bell flash and the URL banner stay on the pane bounds --
+        // both are pane-edge chrome themselves.
         VerticalScrollBar.Margin = gutter;
         ResizeOverlay.Margin = gutter;
+        SearchBar.Margin = new Thickness(
+            SearchBar.Margin.Left + gutter.Left,
+            SearchBar.Margin.Top + gutter.Top,
+            SearchBar.Margin.Right + gutter.Right,
+            SearchBar.Margin.Bottom + gutter.Bottom);
 
         ApplyGutterBrush();
     }
@@ -614,19 +620,26 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         var cfg = App.ConfigService;
         if (cfg is null) return;
 
-        // Mirror ApplyBackdropStyle: low power flattens opacity to 1.0,
-        // and the gutter has to follow or it goes translucent over an
-        // already-opaque backdrop.
-        var lowPower = Ghostty.App.PowerStateMonitor?.IsLowPowerActive ?? false;
-        var opacity = lowPower ? 1.0 : cfg.BackgroundOpacity;
-
-        var argb = Core.Panes.PaneChrome.GutterArgb(cfg.BackgroundColor, opacity);
+        // Deliberately NOT flattened under low power the way
+        // ApplyBackdropStyle flattens the window backdrop. The gutter's
+        // peer is the surface it abuts, not the backdrop behind it, and
+        // nothing pushes a power-state opacity override into libghostty --
+        // the surface keeps clearing at background-opacity whatever the
+        // power state. Following the backdrop here would produce the
+        // saturated frame this fill exists to avoid.
+        var argb = Core.Panes.PaneChrome.GutterArgb(
+            cfg.BackgroundColor, cfg.BackgroundOpacity);
         if (_lastGutterArgb == argb) return;
-        _lastGutterArgb = argb;
 
+        // Commit the cache only after the write lands. XAML property sets
+        // on this path can throw against a tearing-down visual tree (see
+        // the catch in MainWindow.OnLowPowerChanged); recording first
+        // would leave the leaf believing it had painted a colour it never
+        // did, and every later repaint of that value would early-out.
         SurfaceRoot.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
             Microsoft.UI.ColorHelper.FromArgb(
                 (byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb));
+        _lastGutterArgb = argb;
     }
 
     // Lifecycle ----------------------------------------------------------
@@ -640,6 +653,14 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         Panel.LayoutUpdated -= OnFirstLayoutUpdated;
         Panel.LayoutUpdated += OnFirstLayoutUpdated;
         DisableAncestorScrollViewerTabStop();
+
+        // Repaint the gutter on every attach, not just at construction.
+        // A leaf can be off the tree while the config changes -- retained
+        // by the undo stack after a soft close, or mid-flight in a
+        // cross-window tab detach -- and would otherwise come back
+        // wearing the pre-change fill. Cheap: the colour cache makes the
+        // steady-state call a comparison.
+        ApplyGutterBrush();
 
         // SearchBar lifetime matches the control's; wiring `this` as the
         // host is idempotent so doing it on every Loaded is safe and
@@ -1171,6 +1192,17 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     // On the SurfaceRoot copy, take only events that landed on the gutter
     // itself: the ScrollBar and SearchBar are siblings of the panel, so
     // their pointer events bubble through here and must stay theirs.
+    //
+    // Source-based rather than Handled-based on purpose, so it holds for
+    // the handlers that return early without marking the event (the
+    // motion threshold in OnPointerMoved, the null-surface guards).
+    //
+    // Events that do come from the gutter carry Panel-relative
+    // coordinates slightly outside the surface. That is intended:
+    // libghostty clamps them to the edge cell, which is what makes a
+    // click on a pane's edge behave as a click on its outermost cell.
+    // It does mean an app running mouse=a sees button reports attributed
+    // to the edge cell for clicks a few DIPs outside the grid.
     private bool NotOurs(object sender, RoutedEventArgs e)
         => ReferenceEquals(sender, SurfaceRoot)
            && !ReferenceEquals(e.OriginalSource, SurfaceRoot);

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -587,18 +587,27 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         // surface into the gutter. The scrollbar tracks the grid's right
         // edge and the resize pill positions itself within the grid, so
         // leaving either on the pane bounds would float it over the
-        // border stroke. The bell flash and the URL banner deliberately
-        // stay on the pane bounds -- both are pane-edge chrome.
+        // border stroke. The other three stay on the pane bounds: the
+        // bell flash and the URL banner are pane-edge chrome themselves,
+        // and the SearchBar already floats on its own inset margin.
         VerticalScrollBar.Margin = gutter;
         ResizeOverlay.Margin = gutter;
 
         ApplyGutterBrush();
     }
 
+    // Last gutter colour written to SurfaceRoot, so a repaint that
+    // resolves to the same value neither allocates a brush nor dirties
+    // the pane's visual. Reloads are frequent (Ctrl+Shift+Wheel walks
+    // background-opacity one step per notch) and every leaf of every tab
+    // is repainted on each one. Mirrors ApplyRootGridBackground.
+    private uint? _lastGutterArgb;
+
     /// <summary>
     /// Repaint the gutter to match the terminal background. Called at
-    /// construction and again by MainWindow on every config reload, so a
-    /// theme change does not strand a stale frame around each pane.
+    /// construction, and by MainWindow whenever the backdrop is recomputed,
+    /// so a theme change or a power-saver transition does not strand a
+    /// stale frame around each pane.
     /// </summary>
     internal void ApplyGutterBrush()
     {
@@ -612,6 +621,9 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         var opacity = lowPower ? 1.0 : cfg.BackgroundOpacity;
 
         var argb = Core.Panes.PaneChrome.GutterArgb(cfg.BackgroundColor, opacity);
+        if (_lastGutterArgb == argb) return;
+        _lastGutterArgb = argb;
+
         SurfaceRoot.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
             Microsoft.UI.ColorHelper.FromArgb(
                 (byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb));
@@ -1154,8 +1166,19 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         UrlHoverBanner.Visibility = Visibility.Visible;
     }
 
+    // The pointer handlers are attached to both Panel and SurfaceRoot so
+    // the chrome gutter around the panel still routes into the terminal.
+    // On the SurfaceRoot copy, take only events that landed on the gutter
+    // itself: the ScrollBar and SearchBar are siblings of the panel, so
+    // their pointer events bubble through here and must stay theirs.
+    private bool NotOurs(object sender, RoutedEventArgs e)
+        => ReferenceEquals(sender, SurfaceRoot)
+           && !ReferenceEquals(e.OriginalSource, SurfaceRoot);
+
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
+        if (NotOurs(sender, e)) return;
+
         // Take focus on the UserControl, not the panel. Guard with the
         // current focus state to avoid generating a Lost+Got pair when
         // we already have focus.
@@ -1210,6 +1233,8 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
     {
+        if (NotOurs(sender, e)) return;
+
         // Complete the suppressed right-click on its matching right-release,
         // opening the menu so it feels like a normal Windows right-click. We
         // consume the flag ONLY on the right-release: an unrelated release (or
@@ -1232,6 +1257,8 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnContextRequested(UIElement sender, ContextRequestedEventArgs args)
     {
+        if (NotOurs(sender, args)) return;
+
         // ContextRequested fires for both right-click and keyboard. The
         // pointer path (OnPointerPressed/Released) already handles right-click
         // with the mouse-capture gate, so here we only act on keyboard
@@ -1245,6 +1272,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
     {
+        if (NotOurs(sender, e)) return;
         if (_surface.Handle == IntPtr.Zero) return;
         // ghostty_surface_mouse_pos expects unscaled coordinates (DIPs):
         // src/apprt/embedded.zig cursorPosCallback runs the input through
@@ -1282,6 +1310,7 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
+        if (NotOurs(sender, e)) return;
         if (_surface.Handle == IntPtr.Zero) return;
         var pt = e.GetCurrentPoint(Panel);
         var rawDelta = pt.Properties.MouseWheelDelta;

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -568,6 +568,53 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     public TerminalControl()
     {
         InitializeComponent();
+
+        // Hold the terminal surface off the pane's edges by the width of
+        // the chrome PaneHost draws over it (the active-pane focus stroke
+        // and the split divider, both overlays that reserve no layout
+        // space of their own). Without this the surface fills the pane
+        // rect, PushSurfaceSize hands libghostty that full rect, and the
+        // outermost cells render underneath the chrome.
+        //
+        // Applied here rather than in XAML so PaneChrome stays the single
+        // source of truth for the thicknesses, and set before the first
+        // measure so the surface is never sized to the full rect even for
+        // one layout pass.
+        var gutter = new Thickness(Core.Panes.PaneChrome.SurfaceInset);
+        Panel.Margin = gutter;
+
+        // Overlays that read as part of the terminal content follow the
+        // surface into the gutter. The scrollbar tracks the grid's right
+        // edge and the resize pill positions itself within the grid, so
+        // leaving either on the pane bounds would float it over the
+        // border stroke. The bell flash and the URL banner deliberately
+        // stay on the pane bounds -- both are pane-edge chrome.
+        VerticalScrollBar.Margin = gutter;
+        ResizeOverlay.Margin = gutter;
+
+        ApplyGutterBrush();
+    }
+
+    /// <summary>
+    /// Repaint the gutter to match the terminal background. Called at
+    /// construction and again by MainWindow on every config reload, so a
+    /// theme change does not strand a stale frame around each pane.
+    /// </summary>
+    internal void ApplyGutterBrush()
+    {
+        var cfg = App.ConfigService;
+        if (cfg is null) return;
+
+        // Mirror ApplyBackdropStyle: low power flattens opacity to 1.0,
+        // and the gutter has to follow or it goes translucent over an
+        // already-opaque backdrop.
+        var lowPower = Ghostty.App.PowerStateMonitor?.IsLowPowerActive ?? false;
+        var opacity = lowPower ? 1.0 : cfg.BackgroundOpacity;
+
+        var argb = Core.Panes.PaneChrome.GutterArgb(cfg.BackgroundColor, opacity);
+        SurfaceRoot.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+            Microsoft.UI.ColorHelper.FromArgb(
+                (byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb));
     }
 
     // Lifecycle ----------------------------------------------------------

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1807,7 +1807,10 @@ public sealed partial class MainWindow : Window
         var brush = new SolidColorBrush(muiColor);
 
         foreach (var t in _tabManager.Tabs)
+        {
             ((PaneHost)t.PaneHost).SetActiveBorderBrush(brush);
+            ((PaneHost)t.PaneHost).RefreshGutterBrush();
+        }
 
         var bg = _configService.BackgroundColor;
         var fg = _configService.ForegroundColor;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1807,10 +1807,7 @@ public sealed partial class MainWindow : Window
         var brush = new SolidColorBrush(muiColor);
 
         foreach (var t in _tabManager.Tabs)
-        {
             ((PaneHost)t.PaneHost).SetActiveBorderBrush(brush);
-            ((PaneHost)t.PaneHost).RefreshGutterBrush();
-        }
 
         var bg = _configService.BackgroundColor;
         var fg = _configService.ForegroundColor;
@@ -1943,6 +1940,7 @@ public sealed partial class MainWindow : Window
                 UpdateAcrylicTuning();
                 ApplyGradientTint();
                 ApplyRootGridBackground();
+                RefreshPaneGutters();
                 RefreshPowerSaverIcon();
             }
             catch (Exception ex) when (ex is System.Runtime.InteropServices.COMException
@@ -2116,6 +2114,21 @@ public sealed partial class MainWindow : Window
         UpdateCursorAccentColors();
         ApplyShellTheme();
         ApplyRootGridBackground();
+        RefreshPaneGutters();
+    }
+
+    /// <summary>
+    /// Repaint the chrome gutter around every pane. Owns exactly that one
+    /// piece of chrome state, and sits alongside ApplyRootGridBackground
+    /// on both paths that recompute the backdrop: the gutter is filled
+    /// from the background colour and the effective opacity, so a reload
+    /// or a power-saver transition that flattens one has to flatten the
+    /// other or the panes keep a mismatched frame.
+    /// </summary>
+    private void RefreshPaneGutters()
+    {
+        foreach (var t in _tabManager.Tabs)
+            ((PaneHost)t.PaneHost).RefreshGutterBrush();
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1940,7 +1940,6 @@ public sealed partial class MainWindow : Window
                 UpdateAcrylicTuning();
                 ApplyGradientTint();
                 ApplyRootGridBackground();
-                RefreshPaneGutters();
                 RefreshPowerSaverIcon();
             }
             catch (Exception ex) when (ex is System.Runtime.InteropServices.COMException
@@ -2119,11 +2118,13 @@ public sealed partial class MainWindow : Window
 
     /// <summary>
     /// Repaint the chrome gutter around every pane. Owns exactly that one
-    /// piece of chrome state, and sits alongside ApplyRootGridBackground
-    /// on both paths that recompute the backdrop: the gutter is filled
-    /// from the background colour and the effective opacity, so a reload
-    /// or a power-saver transition that flattens one has to flatten the
-    /// other or the panes keep a mismatched frame.
+    /// piece of chrome state.
+    ///
+    /// Belongs on the config-reload path only: the gutter is filled from
+    /// background and background-opacity, both of which change only on a
+    /// reload. It deliberately does not ride the power-saver path, which
+    /// reworks the window backdrop without touching what libghostty
+    /// renders -- the gutter tracks the surface, not the backdrop.
     /// </summary>
     private void RefreshPaneGutters()
     {

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -52,8 +52,8 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     // Pane highlight system, rendered as an overlay Canvas above the
     // split tree. Two layers of chrome:
     //
-    //   - _activeBorderRect: a 1.5px accent-colored border tracking
-    //     the active leaf's bounds. Positioned via TransformToVisual.
+    //   - _activeBorderRect: an accent-colored border tracking the
+    //     active leaf's bounds. Positioned via TransformToVisual.
     //   - _dimRects: one semi-transparent dark rectangle per INACTIVE
     //     leaf, positioned over each inactive leaf's bounds. Gives
     //     the visual effect of the active pane being "brighter" than
@@ -64,6 +64,13 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     // a parent Grid is not a sibling of a leaf's chrome and cannot
     // be defeated with Canvas.ZIndex. The overlay sits above
     // everything and is tracked via TransformToVisual on each layout.
+    //
+    // Because it is an overlay it reserves no layout space, so each
+    // leaf holds its own terminal surface off its edges by
+    // PaneChrome.SurfaceInset (applied inside TerminalControl, below
+    // the leaf root, so the layout-slot chain this overlay walks is
+    // unaffected). That gutter is what keeps this chrome from painting
+    // over live cells.
     // Assigned once in BuildChrome() (called from every ctor), never
     // reassigned. Not readonly because BuildChrome is a shared helper
     // rather than the ctor body itself.
@@ -248,6 +255,17 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         _activeBorderRect.Stroke = brush ?? DefaultActiveBorderBrush;
     }
 
+    /// <summary>
+    /// Repaint every leaf's chrome gutter after a config reload. New
+    /// leaves pick the brush up themselves at construction, so this only
+    /// has to catch the ones already mounted.
+    /// </summary>
+    public void RefreshGutterBrush()
+    {
+        foreach (var leaf in PaneTree.Leaves(_root))
+            leaf.Terminal().ApplyGutterBrush();
+    }
+
     public int PaneCount
     {
         get
@@ -391,7 +409,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         _activeBorderRect = new Rectangle
         {
             Stroke = DefaultActiveBorderBrush,
-            StrokeThickness = 1.5,
+            StrokeThickness = Core.Panes.PaneChrome.ActiveBorderThickness,
             Fill = null,
             IsHitTestVisible = false,
         };
@@ -1337,9 +1355,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         }
         var bounds = new Rect(bx, by, ctl.ActualWidth, ctl.ActualHeight);
         // For the stroked active border, inset by half the stroke
-        // thickness so the 1.5px stroke draws entirely INSIDE the
-        // leaf bounds. For dim fills, use the full rect.
-        var inset = insetForStroke ? 0.75 : 0.0;
+        // thickness so the stroke draws entirely INSIDE the leaf bounds
+        // (and so within the gutter each leaf reserves for it -- see
+        // PaneChrome). For dim fills, use the full rect.
+        var inset = insetForStroke ? Core.Panes.PaneChrome.ActiveBorderThickness / 2 : 0.0;
         Canvas.SetLeft(rect, bounds.X + inset);
         Canvas.SetTop(rect, bounds.Y + inset);
         rect.Width = Math.Max(0, bounds.Width - inset * 2);
@@ -1462,7 +1481,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             Grid.SetColumn(splitter, 0);
             splitter.HorizontalAlignment = HorizontalAlignment.Right;
             splitter.VerticalAlignment = VerticalAlignment.Stretch;
-            splitter.Width = 1;
+            splitter.Width = Core.Panes.PaneChrome.DividerThickness;
             // Keep the splitter above the panes regardless of later child
             // order. Operations that re-add a leaf via Children.Add -- unzoom
             // (ToggleSplitZoom) splicing the floated leaf back, and an in-place
@@ -1494,7 +1513,7 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             Grid.SetRow(splitter, 0);
             splitter.VerticalAlignment = VerticalAlignment.Bottom;
             splitter.HorizontalAlignment = HorizontalAlignment.Stretch;
-            splitter.Height = 1;
+            splitter.Height = Core.Panes.PaneChrome.DividerThickness;
             // Pin above the panes so a later Children.Add (unzoom / cell-0
             // split) can't occlude the divider. See the vertical case above.
             Canvas.SetZIndex(splitter, 1);

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -256,13 +256,18 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     }
 
     /// <summary>
-    /// Repaint every leaf's chrome gutter after a config reload. New
-    /// leaves pick the brush up themselves at construction, so this only
-    /// has to catch the ones already mounted.
+    /// Repaint every leaf's chrome gutter after the backdrop is
+    /// recomputed. New leaves pick the brush up themselves at
+    /// construction, so this only has to catch the ones already mounted.
     /// </summary>
     public void RefreshGutterBrush()
     {
-        foreach (var leaf in PaneTree.Leaves(_root))
+        // Once the last leaf is closed _root still references it, and
+        // walking it here would touch a terminal that CloseLeaf has
+        // already torn down. Same invariant DisposeAllLeaves honors.
+        if (_allLeavesClosed) return;
+
+        foreach (var leaf in Core.Panes.PaneTree.Leaves(_root))
             leaf.Terminal().ApplyGutterBrush();
     }
 

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -256,9 +256,10 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
     }
 
     /// <summary>
-    /// Repaint every leaf's chrome gutter after the backdrop is
-    /// recomputed. New leaves pick the brush up themselves at
-    /// construction, so this only has to catch the ones already mounted.
+    /// Repaint every mounted leaf's chrome gutter for the current
+    /// terminal background. Leaves repaint themselves when constructed
+    /// and on every attach, so this only has to catch the ones already
+    /// sitting in the tree when the config changes.
     /// </summary>
     public void RefreshGutterBrush()
     {
@@ -268,7 +269,24 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
         if (_allLeavesClosed) return;
 
         foreach (var leaf in Core.Panes.PaneTree.Leaves(_root))
-            leaf.Terminal().ApplyGutterBrush();
+        {
+            // Per leaf, not around the loop: a config reload can land
+            // while a window is tearing down or a tab is mid-detach, and
+            // a XAML write against a dying leaf must not strand the rest
+            // of the tree on the old fill. Letting it escape would be
+            // worse still -- this runs from OnConfigReloadedChrome, one
+            // subscriber of many on ConfigChanged, so a throw here stops
+            // every later subscriber from seeing the reload at all.
+            try
+            {
+                leaf.Terminal().ApplyGutterBrush();
+            }
+            catch (Exception ex) when (ex is System.Runtime.InteropServices.COMException
+                                    or InvalidOperationException
+                                    or NullReferenceException)
+            {
+            }
+        }
     }
 
     public int PaneCount

--- a/windows/Ghostty/Panes/Splitter.cs
+++ b/windows/Ghostty/Panes/Splitter.cs
@@ -15,7 +15,7 @@ namespace Ghostty.Panes;
 ///
 /// Why hand-rolled and not the CommunityToolkit GridSplitter:
 ///   - Avoids pulling a NuGet dependency for ~80 lines of behavior.
-///   - We can size it as a true 1px line; GridSplitter has a minimum
+///   - We can size it as a true hairline; GridSplitter has a minimum
 ///     hit-test thickness that looks heavy on a terminal.
 ///   - We can route the ratio change directly to our model without an
 ///     intermediate VisualState/Behavior abstraction.
@@ -44,7 +44,7 @@ internal sealed partial class Splitter : Grid
         _split = split;
         _onRatioChanged = onRatioChanged;
 
-        // 1px line in a neutral terminal-chrome color. The dark grey
+        // Hairline in a neutral terminal-chrome color. The dark grey
         // matches typical terminal panel chrome and stays visible
         // against both #0C0C0C backgrounds and Mica. TODO: source from
         // a theme resource once the config layer exists.

--- a/windows/Ghostty/Panes/Splitter.cs
+++ b/windows/Ghostty/Panes/Splitter.cs
@@ -10,7 +10,7 @@ using Windows.Foundation;
 namespace Ghostty.Panes;
 
 /// <summary>
-/// A 1-pixel draggable Grid that updates a <see cref="SplitPane.Ratio"/>
+/// A hairline draggable Grid that updates a <see cref="SplitPane.Ratio"/>
 /// from pointer drag deltas relative to its parent's rendered size.
 ///
 /// Why hand-rolled and not the CommunityToolkit GridSplitter:
@@ -53,14 +53,14 @@ internal sealed partial class Splitter : Grid
         if (split.Orientation == PaneOrientation.Vertical)
         {
             // Vertical splitter LINE between left/right panes.
-            Width = 1;
+            Width = PaneChrome.DividerThickness;
             HorizontalAlignment = HorizontalAlignment.Stretch;
             VerticalAlignment = VerticalAlignment.Stretch;
             ChangeCursor(InputSystemCursorShape.SizeWestEast);
         }
         else
         {
-            Height = 1;
+            Height = PaneChrome.DividerThickness;
             HorizontalAlignment = HorizontalAlignment.Stretch;
             VerticalAlignment = VerticalAlignment.Stretch;
             ChangeCursor(InputSystemCursorShape.SizeNorthSouth);


### PR DESCRIPTION
The active-pane border and the split divider are drawn on an overlay Canvas above the split tree, so neither reserves layout space. Each leaf got the full pane rect, `PushSurfaceSize` handed that rect to libghostty, and the renderer filled it edge to edge, putting the outermost row and column of cells underneath the chrome.

This reserves a gutter inside each leaf. The margin goes on the SwapChainPanel rather than the leaf root, so `PushSurfaceSize` picks the reduced size up from `Panel.ActualWidth` with no change at the call site, and the layout-slot chain the overlay walks stays intact. The gutter is uniform across every leaf rather than sized to the focused one: making it track focus would resize the grid, and reflow the shell, on every focus change.

`PaneChrome` derives the gutter from the chrome thicknesses instead of hardcoding it, so raising a stroke cannot silently put content back under the border. It also owns the gutter fill, since the gutter sits outside the surface and would otherwise show the bare window backdrop as a differently tinted frame.

The scrollbar and resize pill follow the surface into the gutter. The bell flash and URL banner stay on the pane bounds, both being pane-edge chrome themselves.

## Verification

Built and driven with three panes open. Sampling pixels across the active pane's left edge at `background-opacity = 0.75`:

- x=549-552: divider and focus stroke
- x=553-554: gutter, `#414650`
- x=555-700: terminal surface, `#414650`

Gutter and surface are identical, and the first glyph column now starts inside the stroke instead of under it.

13 new tests in `PaneChromeTests`; 1806 and 13 passing in the two existing suites.

Not covered: DPI other than 100%.
