### PR TITLE
config: re-resolve themed colours when the OS scheme flips

### DIFF
--- a/windows/Ghostty.Core/Config/ThemeParser.cs
+++ b/windows/Ghostty.Core/Config/ThemeParser.cs
@@ -29,6 +29,27 @@ public static class ThemeParser
     /// light: or only dark:) return (null, null) to match the Zig
     /// parser which treats those as InvalidValue errors.
     /// </summary>
+    /// <summary>
+    /// Resolve a theme config value to the name that applies under the
+    /// given OS colour scheme. A pair yields its light or dark side; a
+    /// single theme, a partial pair, or empty input yields the value
+    /// unchanged, since only a complete pair is scheme-dependent.
+    /// </summary>
+    /// <remarks>
+    /// Separated from the caller because which side is picked decides
+    /// which file the themed-colour caches are built from, and therefore
+    /// when those caches go stale.
+    /// </remarks>
+    public static string SelectForScheme(string theme, bool isOsDark)
+    {
+        if (string.IsNullOrEmpty(theme)) return theme;
+
+        var (light, dark) = ParseThemePair(theme);
+        if (light is null || dark is null) return theme;
+
+        return isOsDark ? dark : light;
+    }
+
     public static (string? light, string? dark) ParseThemePair(string theme)
     {
         if (string.IsNullOrWhiteSpace(theme))

--- a/windows/Ghostty.Core/Config/ThemeParser.cs
+++ b/windows/Ghostty.Core/Config/ThemeParser.cs
@@ -22,14 +22,6 @@ public static class ThemeParser
         SearchValues.Create(":=");
 
     /// <summary>
-    /// Parse a theme config value into light/dark components.
-    /// Handles single ("ThemeName") and pair ("light:X,dark:Y") forms.
-    /// Returns (null, null) for single themes or empty input. Both
-    /// light and dark must be present for a pair; partial pairs (only
-    /// light: or only dark:) return (null, null) to match the Zig
-    /// parser which treats those as InvalidValue errors.
-    /// </summary>
-    /// <summary>
     /// Resolve a theme config value to the name that applies under the
     /// given OS colour scheme. A pair yields its light or dark side; a
     /// single theme, a partial pair, or empty input yields the value
@@ -50,6 +42,14 @@ public static class ThemeParser
         return isOsDark ? dark : light;
     }
 
+    /// <summary>
+    /// Parse a theme config value into light/dark components.
+    /// Handles single ("ThemeName") and pair ("light:X,dark:Y") forms.
+    /// Returns (null, null) for single themes or empty input. Both
+    /// light and dark must be present for a pair; partial pairs (only
+    /// light: or only dark:) return (null, null) to match the Zig
+    /// parser which treats those as InvalidValue errors.
+    /// </summary>
     public static (string? light, string? dark) ParseThemePair(string theme)
     {
         if (string.IsNullOrWhiteSpace(theme))

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -11,11 +11,11 @@ internal static class LogEvents
     // 1000-1099: Config
     internal static class Config
     {
-        public const int ReloadFailed      = 1000; // reserved, populated in Phase 3 (ConfigService)
-        public const int WriteSchedulerErr = 1001;
-        public const int TimerDisposeSlow  = 1002;
-        public const int SeedFailed        = 1003;
-        public const int SettingsWriteErr  = 1004;
+        public const int ReloadFailed       = 1000;
+        public const int WriteSchedulerErr  = 1001;
+        public const int TimerDisposeSlow   = 1002;
+        public const int SeedFailed         = 1003;
+        public const int SettingsWriteErr   = 1004;
         public const int ThemeRefreshFailed = 1005;
     }
 

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -16,6 +16,7 @@ internal static class LogEvents
         public const int TimerDisposeSlow  = 1002;
         public const int SeedFailed        = 1003;
         public const int SettingsWriteErr  = 1004;
+        public const int ThemeRefreshFailed = 1005;
     }
 
     // 1100-1199: Frecency / command history

--- a/windows/Ghostty.Tests/Config/ThemeParserTests.cs
+++ b/windows/Ghostty.Tests/Config/ThemeParserTests.cs
@@ -292,4 +292,40 @@ public class ThemeParserTests
         Assert.False(ThemeParser.TryParseHexRgb("#xyz", out _));
         Assert.False(ThemeParser.TryParseHexRgb("#1234", out _)); // wrong length
     }
+
+    [Theory]
+    [InlineData("light:Day,dark:Night", false, "Day")]
+    [InlineData("light:Day,dark:Night", true, "Night")]
+    [InlineData("dark:Night,light:Day", true, "Night")]
+    public void Pair_theme_selects_the_side_for_the_scheme(
+        string theme, bool isOsDark, string expected)
+    {
+        Assert.Equal(expected, ThemeParser.SelectForScheme(theme, isOsDark));
+    }
+
+    [Theory]
+    [InlineData("Catppuccin Mocha")]
+    [InlineData("3024 Night")]
+    public void Single_theme_is_scheme_independent(string theme)
+    {
+        Assert.Equal(theme, ThemeParser.SelectForScheme(theme, isOsDark: false));
+        Assert.Equal(theme, ThemeParser.SelectForScheme(theme, isOsDark: true));
+    }
+
+    [Theory]
+    [InlineData("light:Day")]
+    [InlineData("dark:Night")]
+    public void Partial_pair_is_left_alone_for_the_zig_parser_to_reject(string theme)
+    {
+        // ParseThemePair reports (null, null) for these because Zig treats
+        // them as InvalidValue; selecting a side would invent a resolution
+        // libghostty never makes.
+        Assert.Equal(theme, ThemeParser.SelectForScheme(theme, isOsDark: true));
+    }
+
+    [Fact]
+    public void Empty_theme_stays_empty()
+    {
+        Assert.Equal("", ThemeParser.SelectForScheme("", isOsDark: true));
+    }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -441,6 +441,15 @@ public sealed partial class MainWindow : Window
                     : Ghostty.Interop.GhosttyColorScheme.Light;
                 Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, scheme);
                 _host.NotifyColorSchemeChanged(scheme);
+
+                // The two calls above move libghostty onto the new scheme,
+                // so the surfaces repaint. Anything the C# chrome derives
+                // from a conditional theme is still resolved against the
+                // outgoing one until this runs, which is what would leave
+                // window chrome on the old palette beside a repainted
+                // terminal. Self-guarding, so the per-window duplicates of
+                // this handler collapse to one refresh.
+                _configService.RefreshForOsColorScheme();
             });
         };
 

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -412,16 +412,21 @@ public sealed partial class MainWindow : Window
 
         // Detect initial system theme and notify libghostty so conditional
         // config blocks (e.g. palette dark/light) take effect immediately.
-        // UISettings.Foreground is white in dark mode and black in light mode,
-        // so R > 128 reliably distinguishes the two without needing the UWP
-        // ApplicationTheme enum (which isn't available outside a UWP package).
+        // The light/dark test itself lives in OsTheme so it cannot drift
+        // between the callers that depend on it.
         _systemUiSettings = new Windows.UI.ViewManagement.UISettings();
-        var initialFg = _systemUiSettings.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
-        var initialDark = initialFg.R > 128;
+        var initialDark = Ghostty.Services.OsTheme.IsDark(_systemUiSettings);
         var initialScheme = initialDark
             ? Ghostty.Interop.GhosttyColorScheme.Dark
             : Ghostty.Interop.GhosttyColorScheme.Light;
         Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, initialScheme);
+        // Closes the gap between ConfigService seeding its themed values in
+        // its constructor and this window reading the scheme: a flip in
+        // between would leave libghostty on the new scheme and the config
+        // caches on the old one, with nothing to reconcile them until the
+        // next flip. A no-op in the common case, since the service guards
+        // on the scheme actually having moved.
+        _configService.RefreshForOsColorScheme(initialDark);
         // NotifyColorSchemeChanged is not called here because no surfaces
         // exist yet at window construction time. Each surface picks up the
         // app-level scheme when it initializes. The runtime handler below
@@ -432,8 +437,9 @@ public sealed partial class MainWindow : Window
         // into libghostty (which expects UI-thread callers for App-level ops).
         _systemUiSettings.ColorValuesChanged += (s, _) =>
         {
-            var fg = s.GetColorValue(Windows.UI.ViewManagement.UIColorType.Foreground);
-            var dark = fg.R > 128;
+            // Classify the event's own sender rather than activating a
+            // second UISettings, which could answer for a later moment.
+            var dark = Ghostty.Services.OsTheme.IsDark(s);
             DispatcherQueue.TryEnqueue(() =>
             {
                 var scheme = dark

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -448,8 +448,10 @@ public sealed partial class MainWindow : Window
                 // outgoing one until this runs, which is what would leave
                 // window chrome on the old palette beside a repainted
                 // terminal. Self-guarding, so the per-window duplicates of
-                // this handler collapse to one refresh.
-                _configService.RefreshForOsColorScheme();
+                // this handler collapse to one refresh. Handed the same
+                // `dark` that drove the two calls above, so libghostty and
+                // the config caches cannot describe different schemes.
+                _configService.RefreshForOsColorScheme(dark);
             });
         };
 

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -549,9 +549,15 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
             // agree, so the palette is either wholly the old one or wholly
             // the new one and the next flip is still able to move it.
             StaticLoggers.ConfigService.LogThemeRefreshFailed(ex);
-            return;
         }
 
+        // Notified even when the read above threw. A failure partway can
+        // still leave the caches holding the incoming palette, and since
+        // the flag advances with them the guard would decline every retry
+        // -- so staying quiet here is what would strand the chrome, not
+        // what protects it. On the legs where nothing moved, subscribers
+        // re-read the values they already had.
+        //
         // Deferred rather than invoked inline so the fan-out does not run
         // on top of the ColorValuesChanged dispatcher frame, and to match
         // the shape Reload already uses. The caches have finished settling

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -24,9 +24,9 @@ internal readonly record struct GradientPoint(
 /// reload, and file-system watching (behind <c>auto-reload-config</c>).
 /// Fires <see cref="ConfigChanged"/> on the UI thread after every
 /// successful reload so consumers can re-read values they depend on, and
-/// also after an OS light/dark flip has moved the values a conditional
-/// theme resolves to (see <see cref="RefreshForOsColorScheme"/>) -- the
-/// file has not changed there, but what it resolves to has.
+/// again on an OS light/dark flip (see
+/// <see cref="RefreshForOsColorScheme"/>) -- the file has not changed
+/// there, but what a conditional theme resolves to may have.
 /// </summary>
 internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IProfileConfigSource
 {
@@ -276,7 +276,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
     /// <summary>
     /// Snapshot of the config file's key/value lines, populated at the
-    /// top of <see cref="ReadFlags"/> and replaced on each subsequent reload.
+    /// top of <see cref="ReadFlags(bool)"/> and replaced on each subsequent reload.
     /// Survives between reloads so live readers (IsConfiguredInFile,
     /// GetRawFileValue, GetFileValue) see the last-loaded state.
     /// Keys are case-insensitive; each maps to the list of raw values in
@@ -288,7 +288,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// Snapshot of the active theme file's key/value lines. The theme is
     /// resolved via ResolveActiveThemeName / ResolveThemePath, accounting
     /// for the light:X,dark:Y split on the OS color scheme. Populated at
-    /// the top of <see cref="ReadFlags"/> whenever a theme is active,
+    /// the top of <see cref="ReadFlags(bool)"/> whenever a theme is active,
     /// replaced on each subsequent reload, and survives between reloads so
     /// theme-color readers can consult it from any call into the service.
     /// Null when there is no active theme or the theme file is missing.
@@ -300,7 +300,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// A conditional <c>theme = light:X,dark:Y</c> picks its file from
     /// this at reload time, so every colour read out of
     /// <see cref="_activeThemeFileCache"/> is only valid while the OS
-    /// scheme still matches. Written by <see cref="ReadFlags"/>, compared
+    /// scheme still matches. Written by <see cref="ReadFlags(bool)"/>, compared
     /// by <see cref="RefreshForOsColorScheme"/>.
     /// </summary>
     private bool _themedValuesAreForDarkOs;
@@ -352,7 +352,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
         SeedConfigIfEmpty();
         CacheDiagnostics();
-        ReadFlags();
+        ReadFlags(OsTheme.IsDark());
     }
 
     /// <summary>
@@ -472,7 +472,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
         _config = newConfig;
         CacheDiagnostics();
-        ReadFlags();
+        ReadFlags(OsTheme.IsDark());
 
         if (oldConfig.Handle != IntPtr.Zero)
             NativeMethods.ConfigFree(oldConfig);
@@ -489,7 +489,10 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
 
     /// <summary>
     /// Re-resolve the config values that depend on the OS colour scheme,
-    /// and notify if any could have moved.
+    /// and notify. The guard is on the scheme itself, not on whether a
+    /// conditional theme is configured, so a plain theme refreshes to the
+    /// same values and notifies anyway -- a flip is rare enough that the
+    /// redundant fan-out is cheaper than a second thing to keep in sync.
     ///
     /// A conditional <c>theme = light:X,dark:Y</c> picks its file when the
     /// config is read, so an OS light/dark flip leaves every colour in the
@@ -515,10 +518,12 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// </param>
     public void RefreshForOsColorScheme(bool isOsDark)
     {
-        // Only the shutdown fence applies here. Unlike Reload this makes no
-        // native call, so there is no freed-app hazard to guard; what it
-        // does do is invoke ConfigChanged, and those subscribers touch XAML
-        // that does not survive teardown.
+        // Only the shutdown fence applies. Reload's second guard is about
+        // the pre-creation window before SetApp; by the time a window can
+        // observe a scheme change the app exists, so it would never fire.
+        // _shuttingDown is what actually matters: ReadFlagsCore reads the
+        // config handle, and ConfigChanged subscribers touch XAML, neither
+        // of which survives teardown.
         if (_shuttingDown) return;
 
         // Every window observes ColorValuesChanged, so this runs once per
@@ -534,19 +539,23 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         }
         catch (Exception ex)
         {
-            // ReadFlags reads two files. Windows fires this event
+            // ReadFlags reads three files (the config, the theme, and the
+            // config again for the profile pass). Windows fires this event
             // unattended on the auto light/dark schedule, and this runs
             // inside a dispatcher lambda, so letting an IO failure escape
-            // would take the process down with every session in it. The
-            // scheme flag is only advanced once the caches actually moved,
-            // so bailing here leaves the next flip able to retry.
-            StaticLoggers.ConfigService.LogReloadFailed(ex);
+            // would take the process down with every session in it.
+            //
+            // Whichever read failed, the scheme flag and the theme cache
+            // agree, so the palette is either wholly the old one or wholly
+            // the new one and the next flip is still able to move it.
+            StaticLoggers.ConfigService.LogThemeRefreshFailed(ex);
             return;
         }
 
-        // Deferred rather than invoked inline even though we are already on
-        // the UI thread: a subscriber that writes config would otherwise
-        // re-enter the service while these caches are still settling.
+        // Deferred rather than invoked inline so the fan-out does not run
+        // on top of the ColorValuesChanged dispatcher frame, and to match
+        // the shape Reload already uses. The caches have finished settling
+        // either way -- ReadFlags is synchronous and has returned.
         _dispatcher.TryEnqueue(() => ConfigChanged?.Invoke(this));
     }
 
@@ -655,12 +664,14 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         }
     }
 
-    private void ReadFlags() => ReadFlags(IsOsDark());
-
+    /// <summary>
+    /// Rebuild the file-derived caches and re-read every flag from them.
+    /// </summary>
     /// <param name="isOsDark">
-    /// Scheme to resolve a conditional theme against. Sampled once by the
-    /// caller and threaded through, so the theme file that gets loaded and
-    /// the scheme recorded for it cannot come from two different reads.
+    /// Scheme to resolve a conditional theme against. Taken as a parameter
+    /// rather than sampled here so each caller names where its value came
+    /// from, and so the theme file that gets loaded and the scheme recorded
+    /// for it cannot come from two different reads.
     /// </param>
     private void ReadFlags(bool isOsDark)
     {
@@ -674,6 +685,16 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         var themePath = string.IsNullOrEmpty(activeTheme) ? null : ResolveThemePath(activeTheme);
         _activeThemeFileCache = themePath is null ? null : LoadIniFile(themePath);
 
+        // Immediately after the assignment it certifies, so the two cannot
+        // disagree. Both failure legs then stay consistent: a throw from
+        // either LoadIniFile above leaves stale flag and stale caches, which
+        // the next flip retries; a throw from ReadFlagsCore below leaves
+        // fresh flag and fresh caches, which is the right palette. Recording
+        // it at either end of this method instead lets one leg strand the
+        // service claiming a scheme its caches do not hold, and the guard in
+        // RefreshForOsColorScheme would then decline every retry.
+        _themedValuesAreForDarkOs = isOsDark;
+
         // _configFileCache and _activeThemeFileCache deliberately survive
         // past ReadFlagsCore. Live readers (IsConfiguredInFile, GetRawFileValue,
         // GetFileValue) are consulted from UI page constructors and event
@@ -682,13 +703,6 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // fallback. Each reload overwrites both fields at the top of ReadFlags,
         // so memory cost stays bounded (~few KB per reload, no accumulation).
         ReadFlagsCore();
-
-        // Last, so it certifies work that actually happened. Recording it
-        // up front would mean a throw from either LoadIniFile above left
-        // the service claiming to be resolved for a scheme whose theme it
-        // never loaded -- and RefreshForOsColorScheme would then decline
-        // every retry, making a transient file error permanent.
-        _themedValuesAreForDarkOs = isOsDark;
     }
 
     private void ReadFlagsCore()
@@ -1075,18 +1089,11 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// <summary>
     /// Resolve the active theme name from the config file. For a
     /// conditional theme (light:X,dark:Y), picks X or Y based on the
-    /// current OS color scheme. For a single theme, returns it as-is.
+    /// supplied scheme. For a single theme, returns it as-is.
     /// </summary>
+    /// <param name="isOsDark">Scheme to pick the dark side for.</param>
     private string ResolveActiveThemeName(bool isOsDark)
-    {
-        var raw = GetFileValue("theme", "");
-        if (string.IsNullOrEmpty(raw)) return "";
-
-        var (light, dark) = ThemeParser.ParseThemePair(raw);
-        if (light is null || dark is null) return raw;
-
-        return isOsDark ? dark : light;
-    }
+        => ThemeParser.SelectForScheme(GetFileValue("theme", ""), isOsDark);
 
     /// <summary>
     /// Find the theme file on disk by name. Looks in the user themes
@@ -1126,16 +1133,9 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     }
 
     /// <summary>
-    /// Detect OS dark mode via the shared <see cref="OsTheme"/> helper
-    /// so this and <see cref="WindowThemeManager"/> can't drift on the
-    /// "which byte means dark" heuristic.
-    /// </summary>
-    private static bool IsOsDark() => OsTheme.IsDark();
-
-    /// <summary>
     /// Read the first non-empty value for a Windows-only config key
     /// from the cached snapshot of the config file populated by
-    /// <see cref="ReadFlags"/>. Keys not in the Zig config schema
+    /// <see cref="ReadFlags(bool)"/>. Keys not in the Zig config schema
     /// cannot be read via <c>ghostty_config_get</c>, so we parse the
     /// file ourselves.
     /// </summary>
@@ -1447,6 +1447,15 @@ internal static partial class ConfigServiceLogExtensions
                    Level = LogLevel.Warning,
                    Message = "[ConfigService] Could not seed comment header into empty config file")]
     internal static partial void LogSeedFailed(
+        this ILogger<ConfigService> logger, System.Exception ex);
+
+    // Error, matching LogReloadFailed: the themed values keep resolving
+    // against the outgoing scheme, so window chrome stays on the wrong
+    // palette until something else moves it.
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Config.ThemeRefreshFailed,
+                   Level = LogLevel.Error,
+                   Message = "[ConfigService] Failed to re-resolve themed values after an OS colour scheme change")]
+    internal static partial void LogThemeRefreshFailed(
         this ILogger<ConfigService> logger, System.Exception ex);
 
     // Surfaces each warning string returned by

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -293,6 +293,16 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     private Dictionary<string, List<string>>? _activeThemeFileCache;
 
     /// <summary>
+    /// OS colour scheme the cached themed values were resolved against.
+    /// A conditional <c>theme = light:X,dark:Y</c> picks its file from
+    /// this at reload time, so every colour read out of
+    /// <see cref="_activeThemeFileCache"/> is only valid while the OS
+    /// scheme still matches. Written by <see cref="ReadFlags"/>, compared
+    /// by <see cref="RefreshForOsColorScheme"/>.
+    /// </summary>
+    private bool _themedValuesAreForDarkOs;
+
+    /// <summary>
     /// The current config handle. Passed to <see cref="GhosttyHost"/>
     /// so it can create the app with the loaded config.
     /// </summary>
@@ -475,6 +485,47 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     }
 
     /// <summary>
+    /// Re-resolve the config values that depend on the OS colour scheme,
+    /// and notify if any could have moved.
+    ///
+    /// A conditional <c>theme = light:X,dark:Y</c> picks its file when the
+    /// config is read, so an OS light/dark flip leaves every colour in the
+    /// theme cache pointing at the wrong palette. libghostty handles its
+    /// own side of the flip -- <c>AppSetColorScheme</c> moves the
+    /// conditional state and the surfaces repaint -- but the C# chrome
+    /// reads these cached values, so without this it keeps painting the
+    /// outgoing palette next to freshly repainted terminals.
+    ///
+    /// Deliberately not a <see cref="Reload"/>: the config file has not
+    /// changed, so re-parsing it would push a redundant AppUpdateConfig
+    /// through to the renderer. Only the file-derived caches are rebuilt.
+    /// </summary>
+    /// <returns>True when the scheme moved and subscribers were notified.</returns>
+    public bool RefreshForOsColorScheme()
+    {
+        // Same teardown fences as Reload: ConfigChanged subscribers touch
+        // XAML and libghostty surfaces, neither of which survives shutdown.
+        if (_shuttingDown) return false;
+        if (_app.Handle == IntPtr.Zero) return false;
+
+        // Every window observes ColorValuesChanged, so this runs once per
+        // window per flip. Only the first call finds a difference; the
+        // rest are a bool compare. Also filters the ColorValuesChanged
+        // firings that carry no scheme change at all -- accent colour
+        // edits and High Contrast toggles raise the same event.
+        if (_themedValuesAreForDarkOs == IsOsDark()) return false;
+
+        ReadFlags();
+
+        _dispatcher.TryEnqueue(() =>
+        {
+            ConfigChanged?.Invoke(this);
+            ProfileConfigChanged?.Invoke();
+        });
+        return true;
+    }
+
+    /// <summary>
     /// Enumerate the compiled default keybinds only (no user config files),
     /// for the default-vs-user source diff in the keybindings settings page.
     /// Deliberately skips <c>ConfigLoadDefaultFiles</c> so the user's file
@@ -587,6 +638,9 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // these caches, so the whole reload is bounded by at most two
         // File.ReadLines calls regardless of how many keys we probe.
         _configFileCache = LoadIniFile(ConfigFilePath);
+        // Record the scheme the theme file is chosen against, so an OS
+        // flip afterwards is detectable without re-reading the files.
+        _themedValuesAreForDarkOs = IsOsDark();
         var activeTheme = ResolveActiveThemeName();
         var themePath = string.IsNullOrEmpty(activeTheme) ? null : ResolveThemePath(activeTheme);
         _activeThemeFileCache = themePath is null ? null : LoadIniFile(themePath);

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -23,7 +23,10 @@ internal readonly record struct GradientPoint(
 /// Owns the libghostty config lifecycle: init, load from disk,
 /// reload, and file-system watching (behind <c>auto-reload-config</c>).
 /// Fires <see cref="ConfigChanged"/> on the UI thread after every
-/// successful reload so consumers can re-read values they depend on.
+/// successful reload so consumers can re-read values they depend on, and
+/// also after an OS light/dark flip has moved the values a conditional
+/// theme resolves to (see <see cref="RefreshForOsColorScheme"/>) -- the
+/// file has not changed there, but what it resolves to has.
 /// </summary>
 internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IProfileConfigSource
 {
@@ -496,33 +499,55 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// reads these cached values, so without this it keeps painting the
     /// outgoing palette next to freshly repainted terminals.
     ///
-    /// Deliberately not a <see cref="Reload"/>: the config file has not
-    /// changed, so re-parsing it would push a redundant AppUpdateConfig
-    /// through to the renderer. Only the file-derived caches are rebuilt.
+    /// This itself does no reloading: the config file has not changed, so
+    /// re-parsing it would push a redundant AppUpdateConfig through to the
+    /// renderer, and only the file-derived caches are rebuilt. Note that a
+    /// subscriber can still reload downstream -- under High Contrast,
+    /// HighContrastMonitor rebuilds its override from system colours,
+    /// which do move on a flip, and hands it back through
+    /// SetHighContrastOverride.
     /// </summary>
-    /// <returns>True when the scheme moved and subscribers were notified.</returns>
-    public bool RefreshForOsColorScheme()
+    /// <param name="isOsDark">
+    /// The scheme the caller observed. Passed in rather than sampled here
+    /// so the value that drove <c>AppSetColorScheme</c> is the same one
+    /// the caches are rebuilt against; sampling again could disagree with
+    /// it and leave the two sides describing different schemes.
+    /// </param>
+    public void RefreshForOsColorScheme(bool isOsDark)
     {
-        // Same teardown fences as Reload: ConfigChanged subscribers touch
-        // XAML and libghostty surfaces, neither of which survives shutdown.
-        if (_shuttingDown) return false;
-        if (_app.Handle == IntPtr.Zero) return false;
+        // Only the shutdown fence applies here. Unlike Reload this makes no
+        // native call, so there is no freed-app hazard to guard; what it
+        // does do is invoke ConfigChanged, and those subscribers touch XAML
+        // that does not survive teardown.
+        if (_shuttingDown) return;
 
         // Every window observes ColorValuesChanged, so this runs once per
-        // window per flip. Only the first call finds a difference; the
-        // rest are a bool compare. Also filters the ColorValuesChanged
-        // firings that carry no scheme change at all -- accent colour
-        // edits and High Contrast toggles raise the same event.
-        if (_themedValuesAreForDarkOs == IsOsDark()) return false;
+        // window per flip and only the first call finds a difference. Also
+        // filters the ColorValuesChanged firings that carry no scheme
+        // change at all -- accent colour edits and High Contrast toggles
+        // raise the same event.
+        if (_themedValuesAreForDarkOs == isOsDark) return;
 
-        ReadFlags();
-
-        _dispatcher.TryEnqueue(() =>
+        try
         {
-            ConfigChanged?.Invoke(this);
-            ProfileConfigChanged?.Invoke();
-        });
-        return true;
+            ReadFlags(isOsDark);
+        }
+        catch (Exception ex)
+        {
+            // ReadFlags reads two files. Windows fires this event
+            // unattended on the auto light/dark schedule, and this runs
+            // inside a dispatcher lambda, so letting an IO failure escape
+            // would take the process down with every session in it. The
+            // scheme flag is only advanced once the caches actually moved,
+            // so bailing here leaves the next flip able to retry.
+            StaticLoggers.ConfigService.LogReloadFailed(ex);
+            return;
+        }
+
+        // Deferred rather than invoked inline even though we are already on
+        // the UI thread: a subscriber that writes config would otherwise
+        // re-enter the service while these caches are still settling.
+        _dispatcher.TryEnqueue(() => ConfigChanged?.Invoke(this));
     }
 
     /// <summary>
@@ -630,7 +655,14 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         }
     }
 
-    private void ReadFlags()
+    private void ReadFlags() => ReadFlags(IsOsDark());
+
+    /// <param name="isOsDark">
+    /// Scheme to resolve a conditional theme against. Sampled once by the
+    /// caller and threaded through, so the theme file that gets loaded and
+    /// the scheme recorded for it cannot come from two different reads.
+    /// </param>
+    private void ReadFlags(bool isOsDark)
     {
         // Snapshot the config file once up front, and the active theme
         // file once after we know which one to read. Everything below
@@ -638,10 +670,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // these caches, so the whole reload is bounded by at most two
         // File.ReadLines calls regardless of how many keys we probe.
         _configFileCache = LoadIniFile(ConfigFilePath);
-        // Record the scheme the theme file is chosen against, so an OS
-        // flip afterwards is detectable without re-reading the files.
-        _themedValuesAreForDarkOs = IsOsDark();
-        var activeTheme = ResolveActiveThemeName();
+        var activeTheme = ResolveActiveThemeName(isOsDark);
         var themePath = string.IsNullOrEmpty(activeTheme) ? null : ResolveThemePath(activeTheme);
         _activeThemeFileCache = themePath is null ? null : LoadIniFile(themePath);
 
@@ -653,6 +682,13 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // fallback. Each reload overwrites both fields at the top of ReadFlags,
         // so memory cost stays bounded (~few KB per reload, no accumulation).
         ReadFlagsCore();
+
+        // Last, so it certifies work that actually happened. Recording it
+        // up front would mean a throw from either LoadIniFile above left
+        // the service claiming to be resolved for a scheme whose theme it
+        // never loaded -- and RefreshForOsColorScheme would then decline
+        // every retry, making a transient file error permanent.
+        _themedValuesAreForDarkOs = isOsDark;
     }
 
     private void ReadFlagsCore()
@@ -1041,7 +1077,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// conditional theme (light:X,dark:Y), picks X or Y based on the
     /// current OS color scheme. For a single theme, returns it as-is.
     /// </summary>
-    private string ResolveActiveThemeName()
+    private string ResolveActiveThemeName(bool isOsDark)
     {
         var raw = GetFileValue("theme", "");
         if (string.IsNullOrEmpty(raw)) return "";
@@ -1049,7 +1085,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         var (light, dark) = ThemeParser.ParseThemePair(raw);
         if (light is null || dark is null) return raw;
 
-        return IsOsDark() ? dark : light;
+        return isOsDark ? dark : light;
     }
 
     /// <summary>

--- a/windows/Ghostty/Services/OsTheme.cs
+++ b/windows/Ghostty/Services/OsTheme.cs
@@ -11,14 +11,22 @@ namespace Ghostty.Services;
 internal static class OsTheme
 {
     /// <summary>
-    /// True when the OS is currently in dark mode.
+    /// True when the OS is currently in dark mode. Activates a
+    /// <see cref="UISettings"/> to ask; callers holding one already
+    /// should use the overload.
+    /// </summary>
+    public static bool IsDark() => IsDark(new UISettings());
+
+    /// <summary>
+    /// True when the given settings snapshot reports dark mode.
     /// UISettings.Foreground is white (R greater than 128) in dark
     /// mode (light text on dark background) and black in light mode.
     /// </summary>
-    public static bool IsDark()
-    {
-        var ui = new UISettings();
-        var fg = ui.GetColorValue(UIColorType.Foreground);
-        return fg.R > 128;
-    }
+    /// <remarks>
+    /// Takes the instance so a ColorValuesChanged handler can classify
+    /// the event's own sender rather than activating a second one, which
+    /// could answer for a different moment.
+    /// </remarks>
+    public static bool IsDark(UISettings settings)
+        => settings.GetColorValue(UIColorType.Foreground).R > 128;
 }


### PR DESCRIPTION
A conditional `theme = light:X,dark:Y` picks its file when the config is read, so every colour cached out of that file is only valid while the OS scheme still matches. libghostty already handles its own side of a flip -- `AppSetColorScheme` moves the conditional state and the surfaces repaint -- but nothing re-resolved the C# copy, so window chrome kept painting the outgoing palette next to freshly repainted terminals.

`RefreshForOsColorScheme` rebuilds the file-derived caches when the scheme actually moves and notifies the usual reload subscribers, so every applier re-runs. It is deliberately not a full `Reload`: the config file has not changed, so re-parsing it would push a redundant `AppUpdateConfig` through to the renderer.

The guard is on the resolved scheme rather than on the event. Every window observes `ColorValuesChanged`, so the handler fires once per window per flip, and the event also fires for accent-colour edits and High Contrast toggles, none of which move the theme.

## Verification

Measured on `theme = light:3024 Day,dark:3024 Night` across a real OS light/dark flip, sampling the pane gutter against the terminal surface beside it:

| | gutter | surface |
| --- | --- | --- |
| dark (`#090300`) | `#070200` | `#070200` |
| light (`#F7F7F7`) | `#C1C1C1` | `#C1C1C1` |

Both are the theme background under the 22% inactive-pane dim. Before this, the gutter stayed on the outgoing palette.

1800 and 13 tests pass. No new tests: the logic lives in `ConfigService`, which needs a live libghostty app, and the test project sees Core only.

## Unrelated issue found while testing

The Zig and C# sides disagree on where user themes live. `src/config/theme.zig` looks in `<XDG config>/wintty/themes`, while `ConfigService.ResolveThemePath` uses `<config-dir>/themes`, which resolves to `.../ghostty/themes`. On a machine with themes in the latter, a debug build silently renders Ghostty's default instead of the configured theme. Not touched here.
