### PR TITLE
termio: notify the renderer thread's own wakeup, not a copy

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -684,7 +684,10 @@ pub fn init(
             .backend = .{ .exec = io_exec },
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,
-            .renderer_wakeup = render_thread.wakeup,
+            // Must be our own field, not `render_thread`: the renderer arms
+            // its wait on `self.renderer_thread.wakeup` and only that
+            // instance is notified.
+            .renderer_wakeup = &self.renderer_thread.wakeup,
             .renderer_mailbox = render_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
         });

--- a/src/termio/Options.zig
+++ b/src/termio/Options.zig
@@ -32,7 +32,11 @@ renderer_state: *renderer.State,
 
 /// A handle to wake up the renderer. This hints to the renderer that
 /// a repaint should happen.
-renderer_wakeup: xev.Async,
+///
+/// This must point to the exact instance the renderer thread waits on.
+/// Some xev backends (IOCP) store the wait registration in the struct
+/// itself, so notifying a copy does nothing.
+renderer_wakeup: *xev.Async,
 
 /// The mailbox for renderer messages.
 renderer_mailbox: *renderer.Thread.Mailbox,

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -46,8 +46,8 @@ terminal: terminalpkg.Terminal,
 renderer_state: *renderer.State,
 
 /// A handle to wake up the renderer. This hints to the renderer that
-/// a repaint should happen.
-renderer_wakeup: xev.Async,
+/// a repaint should happen. See termio.Options for why this is a pointer.
+renderer_wakeup: *xev.Async,
 
 /// The mailbox for notifying the renderer of things.
 renderer_mailbox: *renderer.Thread.Mailbox,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -46,8 +46,8 @@ pub const StreamHandler = struct {
     renderer_mailbox: *renderer.Thread.Mailbox,
 
     /// A handle to wake up the renderer. This hints to the renderer that
-    /// a repaint should happen.
-    renderer_wakeup: xev.Async,
+    /// a repaint should happen. See termio.Options for why this is a pointer.
+    renderer_wakeup: *xev.Async,
 
     /// The response to use for ENQ requests. The memory is owned by
     /// whoever owns StreamHandler.


### PR DESCRIPTION
Restored multi-pane tabs rendered blank until clicked: the focused pane came up,
the others showed a bare cursor and only revealed their content on a click or a
window resize.

`Surface.init` passed `render_thread.wakeup` by value into termio, so Termio and
StreamHandler notified a copy of the renderer's `xev.Async`. On Linux (eventfd)
and macOS (mach port) the Async wraps a kernel handle, so a copy still signals
the same object. libxev's IOCP Async carries the wait registration itself, so on
Windows the copy's waiter is permanently null and every notification was
dropped. Terminal output never woke a renderer. Focused panes repainted anyway
off the cursor-blink timer, which is why only the unfocused ones looked broken.

Pass a pointer to the thread's own wakeup instead.

Verified with address probes (termio now notifies the same async the loop waits
on, and renderers that were stuck at 4 wakeups get full counts) and 16
screenshot-checked restore runs across Debug and Release, including output that
arrives 25s after startup repainting an unfocused pane.
