### PR TITLE
shell: show the app icon while the window loads

### DIFF
--- a/dist/windows/IconGen.Tests/PngWriterTests.cs
+++ b/dist/windows/IconGen.Tests/PngWriterTests.cs
@@ -52,10 +52,10 @@ public class PngWriterTests
     }
 
     [Theory]
-    [InlineData("SplashIcon.scale-100.png", 96)]
-    [InlineData("SplashIcon.scale-150.png", 144)]
-    [InlineData("SplashIcon.scale-200.png", 192)]
-    [InlineData("SplashIcon.scale-400.png", 384)]
+    [InlineData("SplashIcon.scale-100.png", 160)]
+    [InlineData("SplashIcon.scale-150.png", 240)]
+    [InlineData("SplashIcon.scale-200.png", 320)]
+    [InlineData("SplashIcon.scale-400.png", 640)]
     public void EachSplashPngHasExpectedDimensions(string fileName, int expectedPx)
     {
         using var tempDir = new TempDir();

--- a/dist/windows/IconGen.Tests/PngWriterTests.cs
+++ b/dist/windows/IconGen.Tests/PngWriterTests.cs
@@ -36,6 +36,37 @@ public class PngWriterTests
         Assert.Equal(expectedPx, img.Width);
         Assert.Equal(expectedPx, img.Height);
     }
+
+    [Fact]
+    public void WritesAllFourSplashPngs()
+    {
+        using var tempDir = new TempDir();
+        using var masters = MasterRasters.Load(TempDir.FindRepoRoot());
+
+        PngWriter.WriteScalePngs(masters, tempDir.Path);
+
+        Assert.True(File.Exists(Path.Combine(tempDir.Path, "SplashIcon.scale-100.png")));
+        Assert.True(File.Exists(Path.Combine(tempDir.Path, "SplashIcon.scale-150.png")));
+        Assert.True(File.Exists(Path.Combine(tempDir.Path, "SplashIcon.scale-200.png")));
+        Assert.True(File.Exists(Path.Combine(tempDir.Path, "SplashIcon.scale-400.png")));
+    }
+
+    [Theory]
+    [InlineData("SplashIcon.scale-100.png", 96)]
+    [InlineData("SplashIcon.scale-150.png", 144)]
+    [InlineData("SplashIcon.scale-200.png", 192)]
+    [InlineData("SplashIcon.scale-400.png", 384)]
+    public void EachSplashPngHasExpectedDimensions(string fileName, int expectedPx)
+    {
+        using var tempDir = new TempDir();
+        using var masters = MasterRasters.Load(TempDir.FindRepoRoot());
+
+        PngWriter.WriteScalePngs(masters, tempDir.Path);
+
+        using var img = new Bitmap(Path.Combine(tempDir.Path, fileName));
+        Assert.Equal(expectedPx, img.Width);
+        Assert.Equal(expectedPx, img.Height);
+    }
 }
 
 internal sealed class TempDir : IDisposable

--- a/dist/windows/IconGen/PngWriter.cs
+++ b/dist/windows/IconGen/PngWriter.cs
@@ -16,16 +16,18 @@ internal static class PngWriter
         ("AppIcon.scale-400.png", 160),
     };
 
-    // Second ladder for the launch icon the shell fades over a cold-start
-    // window. That one is painted at 96 DIP, so reusing the 40 DIP ladder
+    // Second ladder for the launch icon the shell shows over a cold-start
+    // window. Sized for the largest the icon ever draws at
+    // (LaunchIconMetrics.MaxSizeDips); smaller windows scale one of these
+    // rungs down, which stays sharp, whereas reusing the 40 DIP ladder
     // above would upscale even its largest rung and look soft. The masters
     // reach 2048 px, so every rung here is still a downsample.
     private static readonly (string Name, int Px)[] SplashTargets =
     {
-        ("SplashIcon.scale-100.png", 96),
-        ("SplashIcon.scale-150.png", 144),
-        ("SplashIcon.scale-200.png", 192),
-        ("SplashIcon.scale-400.png", 384),
+        ("SplashIcon.scale-100.png", 160),
+        ("SplashIcon.scale-150.png", 240),
+        ("SplashIcon.scale-200.png", 320),
+        ("SplashIcon.scale-400.png", 640),
     };
 
     public static void WriteScalePngs(MasterRasters masters, string outDir)

--- a/dist/windows/IconGen/PngWriter.cs
+++ b/dist/windows/IconGen/PngWriter.cs
@@ -16,10 +16,29 @@ internal static class PngWriter
         ("AppIcon.scale-400.png", 160),
     };
 
+    // Second ladder for the launch icon the shell fades over a cold-start
+    // window. That one is painted at 96 DIP, so reusing the 40 DIP ladder
+    // above would upscale even its largest rung and look soft. The masters
+    // reach 2048 px, so every rung here is still a downsample.
+    private static readonly (string Name, int Px)[] SplashTargets =
+    {
+        ("SplashIcon.scale-100.png", 96),
+        ("SplashIcon.scale-150.png", 144),
+        ("SplashIcon.scale-200.png", 192),
+        ("SplashIcon.scale-400.png", 384),
+    };
+
     public static void WriteScalePngs(MasterRasters masters, string outDir)
     {
         Directory.CreateDirectory(outDir);
-        foreach (var (name, px) in ScaleTargets)
+        WriteLadder(masters, outDir, ScaleTargets);
+        WriteLadder(masters, outDir, SplashTargets);
+    }
+
+    private static void WriteLadder(
+        MasterRasters masters, string outDir, (string Name, int Px)[] targets)
+    {
+        foreach (var (name, px) in targets)
         {
             using var resized = Resize(masters, px);
             resized.Save(Path.Combine(outDir, name), ImageFormat.Png);

--- a/windows/Ghostty.Core/Shell/LaunchIconMetrics.cs
+++ b/windows/Ghostty.Core/Shell/LaunchIconMetrics.cs
@@ -1,0 +1,43 @@
+namespace Ghostty.Core.Shell;
+
+/// <summary>
+/// Picks the on-screen size of the launch icon for a given window size.
+/// Pure so the sizing curve is testable without a window.
+///
+/// The icon is a fraction of the window's smaller edge rather than a
+/// fixed size: a splash icon tuned for a full-screen terminal swamps a
+/// small one, and one tuned for a small window looks lost in a large
+/// one. The clamps stop it going comically large on an ultrawide or
+/// shrinking to an unreadable speck on a tiny quake window.
+/// </summary>
+public static class LaunchIconMetrics
+{
+    /// <summary>Upper clamp, in DIPs. Also the size used when the window size is unknown.</summary>
+    public const int MaxSizeDips = 160;
+
+    /// <summary>Lower clamp, in DIPs.</summary>
+    public const int MinSizeDips = 48;
+
+    /// <summary>Fraction of the window's smaller edge the icon aims for.</summary>
+    public const double WindowFraction = 0.25;
+
+    /// <param name="windowWidth">Window width in DIPs.</param>
+    /// <param name="windowHeight">Window height in DIPs.</param>
+    public static int Resolve(double windowWidth, double windowHeight)
+    {
+        // Math.Min rather than a ternary: every comparison against NaN is
+        // false, so `w < h ? w : h` would quietly return the other edge and
+        // skip the guard below. Math.Min propagates NaN.
+        var smallerEdge = System.Math.Min(windowWidth, windowHeight);
+
+        // No usable size yet (window not laid out, or a garbage value from
+        // a stale state file). Full size is the safer guess: too big reads
+        // as deliberate, too small reads as broken.
+        if (double.IsNaN(smallerEdge) || smallerEdge <= 0) return MaxSizeDips;
+
+        var target = smallerEdge * WindowFraction;
+        if (target >= MaxSizeDips) return MaxSizeDips;
+        if (target <= MinSizeDips) return MinSizeDips;
+        return (int)System.Math.Round(target);
+    }
+}

--- a/windows/Ghostty.Core/Shell/LaunchIconPolicy.cs
+++ b/windows/Ghostty.Core/Shell/LaunchIconPolicy.cs
@@ -1,0 +1,68 @@
+namespace Ghostty.Core.Shell;
+
+/// <summary>What the caller should do with the launch icon.</summary>
+public enum LaunchIconOutcome
+{
+    /// <summary>Already dismissed by an earlier signal. Do nothing.</summary>
+    Ignore,
+
+    /// <summary>Start the fade now.</summary>
+    FadeNow,
+
+    /// <summary>Start the fade after <see cref="LaunchIconDecision.DelayMs"/>.</summary>
+    FadeAfter,
+}
+
+/// <param name="Outcome">What to do.</param>
+/// <param name="DelayMs">Milliseconds to wait, zero unless <see cref="LaunchIconOutcome.FadeAfter"/>.</param>
+public readonly record struct LaunchIconDecision(LaunchIconOutcome Outcome, int DelayMs);
+
+/// <summary>
+/// Decides when the cold-start launch icon leaves the screen. Pure: the
+/// caller owns the clock and the timers and passes elapsed time in, so
+/// every branch here is directly testable.
+///
+/// Two signals can dismiss the icon -- the first surface reporting that
+/// it has rendered, and a watchdog for the case where it never does.
+/// Whichever arrives first latches, so the two can never both fade.
+/// </summary>
+public sealed class LaunchIconPolicy
+{
+    /// <summary>
+    /// Shortest time the icon stays up. On a warm disk the first render
+    /// can land in well under 100 ms; without a floor the icon would
+    /// flash for a frame or two and read as a glitch rather than a beat.
+    /// </summary>
+    public const int MinVisibleMs = 400;
+
+    /// <summary>
+    /// Longest the icon stays up with no first-render signal at all
+    /// (surface creation failed, the shell wedged). Without this the
+    /// window would sit behind the icon forever.
+    /// </summary>
+    public const int WatchdogMs = 3000;
+
+    private bool _dismissed;
+
+    /// <summary>The first surface reported that it has rendered.</summary>
+    /// <param name="elapsedMs">Milliseconds the icon has been on screen.</param>
+    public LaunchIconDecision Ready(int elapsedMs)
+    {
+        if (_dismissed) return new LaunchIconDecision(LaunchIconOutcome.Ignore, 0);
+        _dismissed = true;
+
+        var shown = elapsedMs < 0 ? 0 : elapsedMs;
+        if (shown >= MinVisibleMs)
+            return new LaunchIconDecision(LaunchIconOutcome.FadeNow, 0);
+
+        return new LaunchIconDecision(LaunchIconOutcome.FadeAfter, MinVisibleMs - shown);
+    }
+
+    /// <summary>The watchdog expired with no first-render signal.</summary>
+    public LaunchIconDecision Timeout()
+    {
+        if (_dismissed) return new LaunchIconDecision(LaunchIconOutcome.Ignore, 0);
+        _dismissed = true;
+        return new LaunchIconDecision(LaunchIconOutcome.FadeNow, 0);
+    }
+}

--- a/windows/Ghostty.Core/Shell/LaunchIconPolicy.cs
+++ b/windows/Ghostty.Core/Shell/LaunchIconPolicy.cs
@@ -18,34 +18,32 @@ public enum LaunchIconOutcome
 public readonly record struct LaunchIconDecision(LaunchIconOutcome Outcome, int DelayMs);
 
 /// <summary>
-/// Decides when the cold-start launch icon leaves the screen. Pure: the
-/// caller owns the clock and the timers and passes elapsed time in, so
-/// every branch here is directly testable.
+/// Decides when the cold-start launch splash leaves the screen. Pure:
+/// the caller owns the clock and the timers and passes elapsed time in,
+/// so every branch here is directly testable.
 ///
-/// Two signals can dismiss the icon -- the first surface reporting that
-/// it has rendered, and a watchdog for the case where it never does.
-/// Whichever arrives first latches, so the two can never both fade.
+/// The only thing this arbitrates is the minimum dwell. The hard
+/// timeout lives with the splash window itself, which is the thing that
+/// must never get stuck on screen, and so is the thing that should own
+/// its own escape hatch.
 /// </summary>
 public sealed class LaunchIconPolicy
 {
     /// <summary>
-    /// Shortest time the icon stays up. On a warm disk the first render
-    /// can land in well under 100 ms; without a floor the icon would
-    /// flash for a frame or two and read as a glitch rather than a beat.
+    /// Shortest time the splash stays up. On a fast start the window can
+    /// have content in well under 100 ms; without a floor the splash
+    /// would flash for a frame or two and read as a glitch rather than a
+    /// beat.
     /// </summary>
     public const int MinVisibleMs = 400;
 
-    /// <summary>
-    /// Longest the icon stays up with no first-render signal at all
-    /// (surface creation failed, the shell wedged). Without this the
-    /// window would sit behind the icon forever.
-    /// </summary>
-    public const int WatchdogMs = 3000;
-
     private bool _dismissed;
 
-    /// <summary>The first surface reported that it has rendered.</summary>
-    /// <param name="elapsedMs">Milliseconds the icon has been on screen.</param>
+    /// <summary>
+    /// The window has content worth revealing. Latches, so a second call
+    /// cannot start a second dismissal.
+    /// </summary>
+    /// <param name="elapsedMs">Milliseconds the splash has been on screen.</param>
     public LaunchIconDecision Ready(int elapsedMs)
     {
         if (_dismissed) return new LaunchIconDecision(LaunchIconOutcome.Ignore, 0);
@@ -56,13 +54,5 @@ public sealed class LaunchIconPolicy
             return new LaunchIconDecision(LaunchIconOutcome.FadeNow, 0);
 
         return new LaunchIconDecision(LaunchIconOutcome.FadeAfter, MinVisibleMs - shown);
-    }
-
-    /// <summary>The watchdog expired with no first-render signal.</summary>
-    public LaunchIconDecision Timeout()
-    {
-        if (_dismissed) return new LaunchIconDecision(LaunchIconOutcome.Ignore, 0);
-        _dismissed = true;
-        return new LaunchIconDecision(LaunchIconOutcome.FadeNow, 0);
     }
 }

--- a/windows/Ghostty.Tests/Shell/LaunchIconMetricsTests.cs
+++ b/windows/Ghostty.Tests/Shell/LaunchIconMetricsTests.cs
@@ -1,0 +1,63 @@
+using Ghostty.Core.Shell;
+using Xunit;
+
+namespace Ghostty.Tests.Shell;
+
+/// <summary>
+/// Unit tests for <see cref="LaunchIconMetrics"/>. The curve matters at
+/// its ends: a large window must not get an absurd icon, a small one
+/// must still get a legible icon, and a window whose size is not known
+/// yet must get something rather than zero.
+/// </summary>
+public sealed class LaunchIconMetricsTests
+{
+    [Theory]
+    [InlineData(1920, 1080)]
+    [InlineData(3440, 1440)]
+    [InlineData(1000, 800)]
+    public void Large_windows_clamp_to_the_maximum(double w, double h)
+    {
+        Assert.Equal(LaunchIconMetrics.MaxSizeDips, LaunchIconMetrics.Resolve(w, h));
+    }
+
+    [Theory]
+    [InlineData(300, 180)]
+    [InlineData(120, 120)]
+    public void Small_windows_clamp_to_the_minimum(double w, double h)
+    {
+        Assert.Equal(LaunchIconMetrics.MinSizeDips, LaunchIconMetrics.Resolve(w, h));
+    }
+
+    [Fact]
+    public void Mid_sized_windows_scale_with_the_smaller_edge()
+    {
+        // 500 * 0.25 = 125, between the two clamps.
+        Assert.Equal(125, LaunchIconMetrics.Resolve(900, 500));
+    }
+
+    [Fact]
+    public void Width_is_used_when_it_is_the_smaller_edge()
+    {
+        // A tall narrow window is driven by its width, not its height.
+        Assert.Equal(LaunchIconMetrics.Resolve(500, 900), LaunchIconMetrics.Resolve(900, 500));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(-1, 500)]
+    [InlineData(double.NaN, 500)]
+    public void Unknown_or_nonsense_sizes_fall_back_to_the_maximum(double w, double h)
+    {
+        Assert.Equal(LaunchIconMetrics.MaxSizeDips, LaunchIconMetrics.Resolve(w, h));
+    }
+
+    [Fact]
+    public void Result_is_always_within_the_clamps()
+    {
+        for (var edge = 1; edge <= 4000; edge += 7)
+        {
+            var size = LaunchIconMetrics.Resolve(edge, edge);
+            Assert.InRange(size, LaunchIconMetrics.MinSizeDips, LaunchIconMetrics.MaxSizeDips);
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Shell/LaunchIconPolicyTests.cs
+++ b/windows/Ghostty.Tests/Shell/LaunchIconPolicyTests.cs
@@ -56,39 +56,6 @@ public sealed class LaunchIconPolicyTests
     }
 
     [Fact]
-    public void Timeout_fades_immediately()
-    {
-        var policy = new LaunchIconPolicy();
-
-        var decision = policy.Timeout();
-
-        Assert.Equal(LaunchIconOutcome.FadeNow, decision.Outcome);
-        Assert.Equal(0, decision.DelayMs);
-    }
-
-    [Fact]
-    public void Ready_after_timeout_is_ignored()
-    {
-        var policy = new LaunchIconPolicy();
-        policy.Timeout();
-
-        var decision = policy.Ready(elapsedMs: 5000);
-
-        Assert.Equal(LaunchIconOutcome.Ignore, decision.Outcome);
-    }
-
-    [Fact]
-    public void Timeout_after_ready_is_ignored()
-    {
-        var policy = new LaunchIconPolicy();
-        policy.Ready(elapsedMs: 800);
-
-        var decision = policy.Timeout();
-
-        Assert.Equal(LaunchIconOutcome.Ignore, decision.Outcome);
-    }
-
-    [Fact]
     public void Second_ready_is_ignored()
     {
         var policy = new LaunchIconPolicy();
@@ -97,13 +64,5 @@ public sealed class LaunchIconPolicyTests
         var decision = policy.Ready(elapsedMs: 60);
 
         Assert.Equal(LaunchIconOutcome.Ignore, decision.Outcome);
-    }
-
-    [Fact]
-    public void Watchdog_is_longer_than_the_minimum_visible_time()
-    {
-        // Otherwise the watchdog could fire while the deferred fade is
-        // still pending and the two would race.
-        Assert.True(LaunchIconPolicy.WatchdogMs > LaunchIconPolicy.MinVisibleMs);
     }
 }

--- a/windows/Ghostty.Tests/Shell/LaunchIconPolicyTests.cs
+++ b/windows/Ghostty.Tests/Shell/LaunchIconPolicyTests.cs
@@ -1,0 +1,109 @@
+using Ghostty.Core.Shell;
+using Xunit;
+
+namespace Ghostty.Tests.Shell;
+
+/// <summary>
+/// Unit tests for <see cref="LaunchIconPolicy"/>, which decides when the
+/// cold-start launch icon leaves the screen. The interesting behaviour is
+/// all in the edges: a surface that renders faster than the minimum
+/// on-screen time, a surface that never renders at all, and the two
+/// orderings of ready-vs-watchdog.
+/// </summary>
+public sealed class LaunchIconPolicyTests
+{
+    [Fact]
+    public void Ready_after_the_minimum_fades_immediately()
+    {
+        var policy = new LaunchIconPolicy();
+
+        var decision = policy.Ready(elapsedMs: LaunchIconPolicy.MinVisibleMs + 1);
+
+        Assert.Equal(LaunchIconOutcome.FadeNow, decision.Outcome);
+        Assert.Equal(0, decision.DelayMs);
+    }
+
+    [Fact]
+    public void Ready_exactly_at_the_minimum_fades_immediately()
+    {
+        var policy = new LaunchIconPolicy();
+
+        var decision = policy.Ready(elapsedMs: LaunchIconPolicy.MinVisibleMs);
+
+        Assert.Equal(LaunchIconOutcome.FadeNow, decision.Outcome);
+    }
+
+    [Fact]
+    public void Ready_before_the_minimum_defers_by_the_remainder()
+    {
+        var policy = new LaunchIconPolicy();
+
+        var decision = policy.Ready(elapsedMs: 120);
+
+        Assert.Equal(LaunchIconOutcome.FadeAfter, decision.Outcome);
+        Assert.Equal(LaunchIconPolicy.MinVisibleMs - 120, decision.DelayMs);
+    }
+
+    [Fact]
+    public void Negative_elapsed_is_clamped_to_the_full_minimum()
+    {
+        var policy = new LaunchIconPolicy();
+
+        var decision = policy.Ready(elapsedMs: -50);
+
+        Assert.Equal(LaunchIconOutcome.FadeAfter, decision.Outcome);
+        Assert.Equal(LaunchIconPolicy.MinVisibleMs, decision.DelayMs);
+    }
+
+    [Fact]
+    public void Timeout_fades_immediately()
+    {
+        var policy = new LaunchIconPolicy();
+
+        var decision = policy.Timeout();
+
+        Assert.Equal(LaunchIconOutcome.FadeNow, decision.Outcome);
+        Assert.Equal(0, decision.DelayMs);
+    }
+
+    [Fact]
+    public void Ready_after_timeout_is_ignored()
+    {
+        var policy = new LaunchIconPolicy();
+        policy.Timeout();
+
+        var decision = policy.Ready(elapsedMs: 5000);
+
+        Assert.Equal(LaunchIconOutcome.Ignore, decision.Outcome);
+    }
+
+    [Fact]
+    public void Timeout_after_ready_is_ignored()
+    {
+        var policy = new LaunchIconPolicy();
+        policy.Ready(elapsedMs: 800);
+
+        var decision = policy.Timeout();
+
+        Assert.Equal(LaunchIconOutcome.Ignore, decision.Outcome);
+    }
+
+    [Fact]
+    public void Second_ready_is_ignored()
+    {
+        var policy = new LaunchIconPolicy();
+        policy.Ready(elapsedMs: 50);
+
+        var decision = policy.Ready(elapsedMs: 60);
+
+        Assert.Equal(LaunchIconOutcome.Ignore, decision.Outcome);
+    }
+
+    [Fact]
+    public void Watchdog_is_longer_than_the_minimum_visible_time()
+    {
+        // Otherwise the watchdog could fire while the deferred fade is
+        // still pending and the two would race.
+        Assert.True(LaunchIconPolicy.WatchdogMs > LaunchIconPolicy.MinVisibleMs);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -726,7 +726,8 @@ public partial class App : Application
             foreach (var ws in restoreState.Windows)
             {
                 var restored = new MainWindow(
-                    _configService, _bootstrapHost, _lifetimeSupervisor, factory, ws);
+                    _configService, _bootstrapHost, _lifetimeSupervisor, factory, ws,
+                    showLaunchIcon: true);
                 restored.Closed += OnAnyWindowClosedInternal;
                 _sessionManager.Track(restored);
                 restored.Activate();
@@ -734,7 +735,9 @@ public partial class App : Application
         }
         else
         {
-            var window = new MainWindow(_configService, _bootstrapHost, _lifetimeSupervisor, factory);
+            var window = new MainWindow(
+                _configService, _bootstrapHost, _lifetimeSupervisor, factory,
+                showLaunchIcon: true);
             window.Closed += OnAnyWindowClosedInternal;
             _sessionManager.Track(window);
             window.Activate();

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -723,11 +723,18 @@ public partial class App : Application
         var restoreState = _sessionManager.LoadForRestore();
         if (restoreState is { Windows.Count: > 0 })
         {
+            // Only the first restored window drives the splash. There is one
+            // splash per process, so arming every window would have them
+            // fight over it: each Track would drag it onto the newest
+            // window, uncovering the earlier ones, and whichever window
+            // rendered first would dismiss it for all of them.
+            var isFirstWindow = true;
             foreach (var ws in restoreState.Windows)
             {
                 var restored = new MainWindow(
                     _configService, _bootstrapHost, _lifetimeSupervisor, factory, ws,
-                    showLaunchIcon: true);
+                    showLaunchIcon: isFirstWindow);
+                isFirstWindow = false;
                 restored.Closed += OnAnyWindowClosedInternal;
                 _sessionManager.Track(restored);
                 restored.Activate();

--- a/windows/Ghostty/Branding/AppIconSource.cs
+++ b/windows/Ghostty/Branding/AppIconSource.cs
@@ -12,11 +12,8 @@ internal static class AppIconSource
     public static Uri Current { get; } =
         new Uri("ms-appx:///Assets/AppIcon.png");
 
-    /// <summary>
-    /// Launch icon (96 DIP ladder) faded over a cold-start window.
-    /// A separate asset because <see cref="Current"/> tops out at
-    /// 160 px and would upscale at this size.
-    /// </summary>
-    public static Uri Splash { get; } =
-        new Uri("ms-appx:///Assets/SplashIcon.png");
+    // The launch splash deliberately does NOT resolve its icon through
+    // here. It runs before WinUI is initialized, so ms-appx:/// cannot be
+    // resolved at all; SplashWindow loads the SplashIcon.scale-*.png
+    // assets from disk next to the executable instead.
 }

--- a/windows/Ghostty/Branding/AppIconSource.cs
+++ b/windows/Ghostty/Branding/AppIconSource.cs
@@ -1,13 +1,22 @@
 namespace Ghostty.Branding;
 
 /// <summary>
-/// Single source of truth for the Ghostty app icon URI. Anything that
-/// renders the icon inside the WinUI 3 shell binds to this. When we
-/// later add a vector source, a user-selectable icon set, or runtime
-/// channel detection, this is the one place that changes.
+/// Single source of truth for the Ghostty app icon URIs. Anything that
+/// renders the icon inside the WinUI 3 shell binds to one of these.
+/// When we later add a vector source, a user-selectable icon set, or
+/// runtime channel detection, this is the one place that changes.
 /// </summary>
 internal static class AppIconSource
 {
+    /// <summary>Chrome-sized icon (40 DIP ladder): title bar badge, menus.</summary>
     public static Uri Current { get; } =
         new Uri("ms-appx:///Assets/AppIcon.png");
+
+    /// <summary>
+    /// Launch icon (96 DIP ladder) faded over a cold-start window.
+    /// A separate asset because <see cref="Current"/> tops out at
+    /// 160 px and would upscale at this size.
+    /// </summary>
+    public static Uri Splash { get; } =
+        new Uri("ms-appx:///Assets/SplashIcon.png");
 }

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -496,7 +496,7 @@
       <Visible>false</Visible>
     </Content>
     <!--
-      Launch-icon ladder, sized for 96 DIP. Listed explicitly for the
+      Launch-icon ladder, sized for a 160 DIP icon. Listed explicitly for the
       same reason as the AppIcon rungs above: a wildcard evaluates
       before GenerateBrandingAssets produces the files. Keep in sync
       with PngWriter.SplashTargets in dist/windows/IconGen/PngWriter.cs.

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -496,6 +496,17 @@
       <Visible>false</Visible>
     </Content>
     <!--
+      Launch-icon ladder, sized for 96 DIP. Listed explicitly for the
+      same reason as the AppIcon rungs above: a wildcard evaluates
+      before GenerateBrandingAssets produces the files. Keep in sync
+      with PngWriter.SplashTargets in dist/windows/IconGen/PngWriter.cs.
+    -->
+    <Content Include="$(GeneratedBrandingDir)SplashIcon.scale-100.png;$(GeneratedBrandingDir)SplashIcon.scale-150.png;$(GeneratedBrandingDir)SplashIcon.scale-200.png;$(GeneratedBrandingDir)SplashIcon.scale-400.png">
+      <Link>Assets\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+    <!--
       Deploy the generated .ico alongside the runtime PNGs. ApplicationIcon
       already embeds this same file as the exe resource (which Explorer and
       the default-fallback path use), but AppWindow.SetIcon needs a real

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -190,34 +190,5 @@
                       FontSize="14"/>
         </ToggleButton>
 
-        <!--
-            Cold-start launch icon. Declared last so it paints above the
-            two tab hosts (which are inserted at ZIndex -1) and the rest
-            of the chrome, matching the way a packaged app's splash
-            covers the whole frame. Spans both rows and columns so it is
-            centred on the window, not on the terminal area.
-
-            No background of its own: RootGrid.Background is already
-            painted from the resolved theme and backdrop before the
-            window is activated, so a bare icon inherits the correct
-            surface, including Mica/Acrylic. An opaque scrim would
-            blank that out for the duration of the splash.
-
-            Source is assigned in code-behind (LaunchIconCoordinator.Arm)
-            rather than here, so a warm window never decodes the bitmap.
-            Raw accessibility view because it is pure decoration and is
-            gone within a second.
-        -->
-        <Image x:Name="LaunchIcon"
-               Grid.Row="0" Grid.RowSpan="2"
-               Grid.Column="0" Grid.ColumnSpan="2"
-               Width="96" Height="96"
-               HorizontalAlignment="Center"
-               VerticalAlignment="Center"
-               Opacity="0"
-               IsHitTestVisible="False"
-               Visibility="Collapsed"
-               AutomationProperties.AccessibilityView="Raw"/>
-
     </Grid>
 </Window>

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -190,5 +190,34 @@
                       FontSize="14"/>
         </ToggleButton>
 
+        <!--
+            Cold-start launch icon. Declared last so it paints above the
+            two tab hosts (which are inserted at ZIndex -1) and the rest
+            of the chrome, matching the way a packaged app's splash
+            covers the whole frame. Spans both rows and columns so it is
+            centred on the window, not on the terminal area.
+
+            No background of its own: RootGrid.Background is already
+            painted from the resolved theme and backdrop before the
+            window is activated, so a bare icon inherits the correct
+            surface, including Mica/Acrylic. An opaque scrim would
+            blank that out for the duration of the splash.
+
+            Source is assigned in code-behind (LaunchIconCoordinator.Arm)
+            rather than here, so a warm window never decodes the bitmap.
+            Raw accessibility view because it is pure decoration and is
+            gone within a second.
+        -->
+        <Image x:Name="LaunchIcon"
+               Grid.Row="0" Grid.RowSpan="2"
+               Grid.Column="0" Grid.ColumnSpan="2"
+               Width="96" Height="96"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"
+               Opacity="0"
+               IsHitTestVisible="False"
+               Visibility="Collapsed"
+               AutomationProperties.AccessibilityView="Raw"/>
+
     </Grid>
 </Window>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -609,8 +609,11 @@ public sealed partial class MainWindow : Window
             // drags or resizes the window before the splash comes down.
             Shell.SplashWindow.Track(WindowNative.GetWindowHandle(this));
 
-            if (_tabManager.Tabs.Count > 0
-                && _tabManager.Tabs[0].PaneHost is Panes.PaneHost seedHost)
+            // The active tab, not tab zero: a restored session can make any
+            // tab active, and a background tab never presents, so waiting on
+            // tab zero's surface would mean waiting for a first render that
+            // does not arrive until the user switches to it.
+            if (_tabManager.ActiveTab.PaneHost is Panes.PaneHost seedHost)
             {
                 seedHost.ActiveLeaf.Terminal().FirstRender += OnLaunchSurfaceFirstRender;
             }
@@ -1212,6 +1215,11 @@ public sealed partial class MainWindow : Window
         _configService.ConfigChanged -= OnConfigReloaded;
         _configService.ConfigChanged -= OnConfigReloadedChrome;
         _shellTheme.ThemeChanged -= OnShellThemeChanged;
+
+        // CompositionTarget.Rendering is static, so a window closed before
+        // its first composed frame would otherwise stay subscribed.
+        _launchIcon?.Cancel();
+        _launchIcon = null;
         if (Ghostty.App.PowerStateMonitor is { } powerMonitor)
         {
             powerMonitor.LowPowerChanged -= OnLowPowerChanged;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -603,6 +603,12 @@ public sealed partial class MainWindow : Window
             _launchIcon = new Shell.LaunchIconCoordinator(DispatcherQueue);
             _launchIcon.Arm();
 
+            // Let the splash follow this window. It was positioned from the
+            // saved window state before this window existed, so this both
+            // corrects any mismatch and keeps the two together if the user
+            // drags or resizes the window before the splash comes down.
+            Shell.SplashWindow.Track(WindowNative.GetWindowHandle(this));
+
             if (_tabManager.Tabs.Count > 0
                 && _tabManager.Tabs[0].PaneHost is Panes.PaneHost seedHost)
             {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -198,6 +198,10 @@ public sealed partial class MainWindow : Window
     private CommandPaletteViewModel? _commandPaletteVm;
     private FrecencyStore? _frecencyStore;
     private Controls.TerminalControl? _previousFocusSurface;
+    // Cold-start launch icon. Null on every window that was not opened
+    // by App.OnLaunched -- a warm-process window reaches first render
+    // fast enough that a splash would read as invented latency.
+    private Shell.LaunchIconCoordinator? _launchIcon;
 #if DEMO
     private Ghostty.Demo.DemoPlayer? _demoPlayer;
     private Ghostty.Demo.DemoOverlay? _demoOverlay;
@@ -271,8 +275,10 @@ public sealed partial class MainWindow : Window
         GhosttyHost bootstrapHost,
         HostLifetimeSupervisor supervisor,
         ILoggerFactory loggerFactory,
-        bool isQuickTerminal = false)
-        : this(configService, bootstrapHost, supervisor, loggerFactory, seedTab: null, isQuickTerminal)
+        bool isQuickTerminal = false,
+        bool showLaunchIcon = false)
+        : this(configService, bootstrapHost, supervisor, loggerFactory, seedTab: null,
+               isQuickTerminal, showLaunchIcon: showLaunchIcon)
     {
     }
 
@@ -286,9 +292,11 @@ public sealed partial class MainWindow : Window
         GhosttyHost bootstrapHost,
         HostLifetimeSupervisor supervisor,
         ILoggerFactory loggerFactory,
-        Ghostty.Core.Session.WindowSession restore)
+        Ghostty.Core.Session.WindowSession restore,
+        bool showLaunchIcon = false)
         : this(configService, bootstrapHost, supervisor, loggerFactory,
-               seedTab: null, isQuickTerminal: false, restore: restore)
+               seedTab: null, isQuickTerminal: false, restore: restore,
+               showLaunchIcon: showLaunchIcon)
     {
     }
 
@@ -312,7 +320,8 @@ public sealed partial class MainWindow : Window
         ILoggerFactory loggerFactory,
         TabModel? seedTab,
         bool isQuickTerminal = false,
-        Ghostty.Core.Session.WindowSession? restore = null)
+        Ghostty.Core.Session.WindowSession? restore = null,
+        bool showLaunchIcon = false)
     {
         InitializeComponent();
 
@@ -585,6 +594,23 @@ public sealed partial class MainWindow : Window
             AttachProcessTracking(t);
         }
         SwapActivePane();
+
+        // Cold start: cover the frame with the app icon until the seed
+        // surface has something on screen. Armed before the surface is
+        // created so the icon is up for the whole wait, and dismissed
+        // from libghostty's first_render via the seed tab's terminal.
+        if (showLaunchIcon)
+        {
+            _launchIcon = new Shell.LaunchIconCoordinator(LaunchIcon, DispatcherQueue);
+            _launchIcon.Arm();
+
+            if (_tabManager.Tabs.Count > 0
+                && _tabManager.Tabs[0].PaneHost is Panes.PaneHost seedHost)
+            {
+                seedHost.ActiveLeaf.Terminal().FirstRender += OnLaunchSurfaceFirstRender;
+            }
+        }
+
         _tabManager.TabAdded += (_, t) =>
         {
             AddPaneHost(t);
@@ -2755,6 +2781,18 @@ public sealed partial class MainWindow : Window
             else
                 control.SetUserTitleOverride(result);
         }
+    }
+
+    /// <summary>
+    /// The cold-start seed surface has rendered its first frame, so the
+    /// launch icon can go. One-shot: later renders in the same surface
+    /// are irrelevant, and the policy latches anyway.
+    /// </summary>
+    private void OnLaunchSurfaceFirstRender(object? sender, EventArgs e)
+    {
+        if (sender is Controls.TerminalControl terminal)
+            terminal.FirstRender -= OnLaunchSurfaceFirstRender;
+        _launchIcon?.NotifyReady();
     }
 
     /// <summary>

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -595,19 +595,30 @@ public sealed partial class MainWindow : Window
         }
         SwapActivePane();
 
-        // Cold start: cover the frame with the app icon until the seed
-        // surface has something on screen. Armed before the surface is
-        // created so the icon is up for the whole wait, and dismissed
-        // from libghostty's first_render via the seed tab's terminal.
+        // Cold start: the pre-XAML splash is already covering this window's
+        // rect. It comes down on our first composed frame, which is when
+        // this window stops painting black and has something real to show.
         if (showLaunchIcon)
         {
-            _launchIcon = new Shell.LaunchIconCoordinator(LaunchIcon, DispatcherQueue);
+            _launchIcon = new Shell.LaunchIconCoordinator(DispatcherQueue);
             _launchIcon.Arm();
 
             if (_tabManager.Tabs.Count > 0
                 && _tabManager.Tabs[0].PaneHost is Panes.PaneHost seedHost)
             {
                 seedHost.ActiveLeaf.Terminal().FirstRender += OnLaunchSurfaceFirstRender;
+            }
+
+            // Record the resolved background for the next launch's splash
+            // now, rather than only on close. A session that is force-killed
+            // or crashes never runs the close path, and the splash would
+            // then keep falling back to the built-in default and flash a
+            // mismatched colour on every subsequent start.
+            var splashBackground = _configService.BackgroundColor & 0x00FFFFFFu;
+            if (_windowState.BackgroundRgb != splashBackground)
+            {
+                _windowState.BackgroundRgb = splashBackground;
+                _windowState.Save();
             }
         }
 
@@ -1227,6 +1238,10 @@ public sealed partial class MainWindow : Window
             _windowState.WindowY = g.Y;
             _windowState.WindowWidth = g.Width;
             _windowState.WindowHeight = g.Height;
+            // Carried purely for the next cold start's splash, which runs
+            // before any theme has been resolved and would otherwise have
+            // to guess this colour.
+            _windowState.BackgroundRgb = _configService.BackgroundColor & 0x00FFFFFFu;
             _windowState.Save();
         }
 
@@ -2784,9 +2799,9 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
-    /// The cold-start seed surface has rendered its first frame, so the
-    /// launch icon can go. One-shot: later renders in the same surface
-    /// are irrelevant, and the policy latches anyway.
+    /// The cold-start seed surface has presented its first frame, so the
+    /// splash can go once WinUI has also composed. One-shot: later renders
+    /// are irrelevant, and the coordinator latches anyway.
     /// </summary>
     private void OnLaunchSurfaceFirstRender(object? sender, EventArgs e)
     {

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -246,6 +246,14 @@ public static partial class Program
     private static void WriteStderr(string message) => WriteConsole(Console.Error, message);
 
     /// <summary>
+    /// Report a diagnostic from code that runs before the logger exists.
+    /// Startup work that happens ahead of the logging bootstrap has nowhere
+    /// else to report a failure, and stays silent in the field otherwise.
+    /// </summary>
+    internal static void WriteStartupDiagnostic(string message) =>
+        WriteStderr($"{AppIdentity.LogTag} {message}");
+
+    /// <summary>
     /// Write to a console stream, tolerating a handle that refuses the write.
     /// </summary>
     /// <remarks>
@@ -856,7 +864,10 @@ public static partial class Program
             // HWND exists and paints black. The splash covers that rect
             // until there is real content to reveal. It runs on its own
             // thread, so none of that work delays it.
-            Ghostty.Shell.SplashWindow.Show();
+            if (!AnotherInstanceOwnsTheSession())
+            {
+                Ghostty.Shell.SplashWindow.Show();
+            }
 
             Microsoft.UI.Xaml.Application.Start(p =>
             {
@@ -877,9 +888,51 @@ public static partial class Program
         }
         catch (Exception ex)
         {
+            // Take the splash down before reporting. Startup that dies before
+            // any window exists leaves nothing else to dismiss it, and an
+            // opaque topmost rectangle sitting over the desktop is the worst
+            // possible time to be hiding a crash report.
+            Ghostty.Shell.SplashWindow.Dismiss();
+
             // Same reporting as an escape from MainImpl, so the GUI path also
             // gets the terminal tee instead of only the log.
             return ReportFatal(ex);
+        }
+    }
+
+    /// <summary>
+    /// True when a single-instance primary is already running, so this
+    /// process is about to forward its launch and exit.
+    /// </summary>
+    /// <remarks>
+    /// The mutex is only ever created when <c>windows-single-instance</c> is
+    /// on, so its presence answers both questions at once: the feature is
+    /// enabled and somebody already owns the session. Without this check the
+    /// secondary paints a full-size opaque splash over the primary's window
+    /// -- the user's actual terminal -- for as long as it takes to reach the
+    /// gate, and is then killed by Environment.Exit mid-GDI+.
+    ///
+    /// Opened, never acquired: taking ownership here would make this process
+    /// look like the primary to the real gate in App.OnLaunched.
+    /// </remarks>
+    private static bool AnotherInstanceOwnsTheSession()
+    {
+        try
+        {
+            var names = Ghostty.Core.SingleInstance.SingleInstanceNames.For(
+                Environment.ProcessPath ?? string.Empty);
+            if (!System.Threading.Mutex.TryOpenExisting(names.Mutex, out var existing))
+            {
+                return false;
+            }
+            existing.Dispose();
+            return true;
+        }
+        catch
+        {
+            // Probing is best effort. A splash we should have skipped is a
+            // far smaller problem than a launch we blocked.
+            return false;
         }
     }
 }

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -849,6 +849,15 @@ public static partial class Program
             WinRT.ComWrappersSupport.InitializeComWrappers();
             WriteStderr($"{AppIdentity.LogTag} ComWrappers initialized");
 
+            // Put the launch splash up before WinUI starts. Everything
+            // below this line -- Application.Start, App's ctor, config
+            // load, libghostty init, the first XAML frame -- is seconds of
+            // dead time on a cold start during which the main window's
+            // HWND exists and paints black. The splash covers that rect
+            // until there is real content to reveal. It runs on its own
+            // thread, so none of that work delays it.
+            Ghostty.Shell.SplashWindow.Show();
+
             Microsoft.UI.Xaml.Application.Start(p =>
             {
                 WriteStderr($"{AppIdentity.LogTag} Application.Start callback entered");

--- a/windows/Ghostty/Settings/WindowState.cs
+++ b/windows/Ghostty/Settings/WindowState.cs
@@ -36,6 +36,14 @@ internal sealed class WindowState
     public int? WindowHeight { get; set; }
     public bool WindowMaximized { get; set; }
 
+    // Last resolved terminal background, RGB. Written on close purely so
+    // the next cold start's pre-XAML splash can fill the window rect with
+    // the right colour. The splash runs before libghostty is initialized
+    // and so before any theme has been resolved, and reading it back from
+    // here is what stops the launch flashing a mismatched surface. Null
+    // until the first close; the splash falls back to the config default.
+    public uint? BackgroundRgb { get; set; }
+
     // User-resized height of the quake / drop-down window, remembered
     // per-user so a manual resize survives restarts. Null until the user
     // first resizes. Distinct from WindowHeight (regular window placement);

--- a/windows/Ghostty/Shell/LaunchIconCoordinator.cs
+++ b/windows/Ghostty/Shell/LaunchIconCoordinator.cs
@@ -1,114 +1,106 @@
 using System;
-using System.Diagnostics;
 using Ghostty.Core.Shell;
 using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Animation;
-using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace Ghostty.Shell;
 
 /// <summary>
-/// Owns the cold-start launch icon: the bitmap assignment, the
-/// minimum-on-screen stopwatch, the watchdog timer, and the fade
-/// Storyboard. <see cref="LaunchIconPolicy"/> makes every timing
-/// decision; this type only carries them out.
+/// Decides when the pre-XAML <see cref="SplashWindow"/> may be taken
+/// down, and takes it down.
 ///
-/// Lifted out of MainWindow for the same reason as
+/// <para>Two things must both be true before the splash can go, and
+/// neither alone is enough:</para>
+///
+/// <list type="number">
+/// <item>WinUI has composed a frame. Before this the window is not
+/// drawing at all.</item>
+/// <item>The terminal's swap chain has presented. WinUI composes for
+/// roughly two seconds before the DX12 surface presents anything, and
+/// the surface reads as pure black for that whole stretch -- so
+/// dismissing on composition alone uncovers exactly the black gap the
+/// splash exists to hide.</item>
+/// </list>
+///
+/// <para>The second condition arrives as libghostty's
+/// <c>first_render</c>. That signal is gated on the terminal having
+/// produced content, so a surface whose shell never writes anything
+/// will never raise it. Hence the grace period: once composition has
+/// happened, the splash waits a bounded time for the surface and then
+/// gives up rather than outstaying its welcome.</para>
+///
+/// <para>Lifted out of MainWindow for the same reason as
 /// <see cref="LayoutCoordinator"/>: the window is a composition root,
-/// not an animation host.
+/// not a scheduler.</para>
 /// </summary>
 internal sealed class LaunchIconCoordinator
 {
-    public const int FadeDurationMs = 250;
+    /// <summary>
+    /// How long to wait for the surface to present after WinUI has
+    /// composed. Sized to cover the observed compose-to-present gap with
+    /// headroom; past this the splash comes down regardless, on the
+    /// assumption the surface has nothing to draw.
+    /// </summary>
+    private const int SurfaceGraceMs = 2500;
 
-    // The icon grows slightly as it dissolves. A straight opacity fade
-    // reads as the icon being switched off; the drift outward reads as
-    // it giving way to the content behind it, which is the Windows 11
-    // splash-to-content feel we are copying.
-    private const double ExitScale = 1.08;
-
-    private readonly Microsoft.UI.Xaml.Controls.Image _icon;
     private readonly DispatcherQueue _dispatcher;
     private readonly LaunchIconPolicy _policy = new();
-    private readonly Stopwatch _onScreen = new();
 
-    private DispatcherQueueTimer? _watchdog;
-    private DispatcherQueueTimer? _deferred;
-    private Storyboard? _fade;
+    private DispatcherQueueTimer? _timer;
     private bool _armed;
-    // True once the compositor has produced a frame, which is the first
-    // moment the icon is actually on screen. Until then the clocks are
-    // not running and a ready signal is held rather than acted on.
-    private bool _onScreenYet;
-    private bool _readyWhileHidden;
+    private bool _composed;
+    private bool _surfacePresented;
 
-    public LaunchIconCoordinator(
-        Microsoft.UI.Xaml.Controls.Image icon, DispatcherQueue dispatcher)
+    public LaunchIconCoordinator(DispatcherQueue dispatcher)
     {
-        _icon = icon;
         _dispatcher = dispatcher;
     }
 
     /// <summary>
-    /// Show the icon and wait for the compositor to put it on screen.
-    /// Idempotent: a second call is ignored, so re-entrancy during
-    /// window construction cannot restart the timing.
+    /// Start watching for the first composed frame. Idempotent, so
+    /// re-entrancy during window construction cannot subscribe twice.
     /// </summary>
     public void Arm()
     {
         if (_armed) return;
         _armed = true;
-
-        // Decoded here rather than in XAML so warm windows, which never
-        // arm, never pay for the bitmap.
-        _icon.Source = new BitmapImage(Ghostty.Branding.AppIconSource.Splash);
-
-        // Full opacity from the first frame. The window itself is
-        // appearing at this moment, so fading the icon in would only
-        // soften the window's own entrance.
-        _icon.Opacity = 1;
-        _icon.Visibility = Visibility.Visible;
-
-        // Arm() runs during the window constructor, and WinUI shows the
-        // HWND well before it composes a first XAML frame -- measured at
-        // roughly two seconds on a cold Debug start. Counting the dwell
-        // and the watchdog from here would spend most of both budgets
-        // while the icon is not yet on screen, so the icon could fade
-        // out before the user ever saw it. Start the clocks on the first
-        // composed frame instead, which is the first moment the icon is
-        // genuinely visible.
         CompositionTarget.Rendering += OnFirstComposedFrame;
     }
 
     /// <summary>
-    /// The first surface reported that it has rendered. Safe to call
-    /// before <see cref="Arm"/> (does nothing), before the icon is on
-    /// screen (held until it is), and more than once (the policy
-    /// latches).
+    /// The seed surface reported its first render. Safe before
+    /// <see cref="Arm"/>, safe before composition, and safe more than
+    /// once.
     /// </summary>
     public void NotifyReady()
     {
         if (!_armed) return;
-        if (!_onScreenYet)
-        {
-            _readyWhileHidden = true;
-            return;
-        }
-        Apply(_policy.Ready((int)_onScreen.ElapsedMilliseconds));
+        _surfacePresented = true;
+        if (_composed) DismissNow();
     }
 
     private void OnFirstComposedFrame(object? sender, object e)
     {
         CompositionTarget.Rendering -= OnFirstComposedFrame;
-        _onScreenYet = true;
-        _onScreen.Start();
-        _watchdog = RunAfter(LaunchIconPolicy.WatchdogMs, () => Apply(_policy.Timeout()));
+        _composed = true;
 
-        // The surface beat us to the compositor. Zero elapsed, so the
-        // policy grants the full minimum dwell from this frame.
-        if (_readyWhileHidden) Apply(_policy.Ready(0));
+        if (_surfacePresented)
+        {
+            DismissNow();
+            return;
+        }
+
+        _timer = RunAfter(SurfaceGraceMs, DismissNow);
+    }
+
+    private void DismissNow()
+    {
+        // Elapsed is measured from when the splash went up, not from this
+        // window's construction. On a cold start it has been on screen for
+        // seconds by now, so the minimum-dwell clause is already satisfied
+        // and dismissal is immediate. That clause only bites on a startup
+        // fast enough that the splash would otherwise flash.
+        Apply(_policy.Ready(SplashWindow.VisibleForMs));
     }
 
     private void Apply(LaunchIconDecision decision)
@@ -116,11 +108,11 @@ internal sealed class LaunchIconCoordinator
         switch (decision.Outcome)
         {
             case LaunchIconOutcome.FadeNow:
-                StartFade();
+                Dismiss();
                 break;
             case LaunchIconOutcome.FadeAfter:
-                StopTimers();
-                _deferred = RunAfter(decision.DelayMs, StartFade);
+                StopTimer();
+                _timer = RunAfter(decision.DelayMs, Dismiss);
                 break;
             case LaunchIconOutcome.Ignore:
             default:
@@ -128,39 +120,16 @@ internal sealed class LaunchIconCoordinator
         }
     }
 
-    private void StartFade()
+    private void Dismiss()
     {
-        StopTimers();
-        _onScreen.Stop();
-
-        var scale = EnsureScale(_icon);
-        var sb = new Storyboard();
-        sb.Children.Add(Tween(_icon, "Opacity", 1, 0));
-        sb.Children.Add(Tween(scale, "ScaleX", 1, ExitScale));
-        sb.Children.Add(Tween(scale, "ScaleY", 1, ExitScale));
-
-        sb.Completed += (_, _) =>
-        {
-            // Collapse rather than leaving a transparent element in the
-            // tree: the icon is never shown again for this window's
-            // lifetime, and a collapsed element costs nothing in layout.
-            _icon.Visibility = Visibility.Collapsed;
-            _icon.Opacity = 0;
-            scale.ScaleX = 1;
-            scale.ScaleY = 1;
-            _fade = null;
-        };
-
-        _fade = sb;
-        sb.Begin();
+        StopTimer();
+        SplashWindow.Dismiss();
     }
 
-    private void StopTimers()
+    private void StopTimer()
     {
-        _watchdog?.Stop();
-        _watchdog = null;
-        _deferred?.Stop();
-        _deferred = null;
+        _timer?.Stop();
+        _timer = null;
     }
 
     private DispatcherQueueTimer RunAfter(int delayMs, Action action)
@@ -171,30 +140,5 @@ internal sealed class LaunchIconCoordinator
         timer.Tick += (t, _) => { t.Stop(); action(); };
         timer.Start();
         return timer;
-    }
-
-    // Scale about the centre so the icon grows in place instead of
-    // drifting toward the bottom-right.
-    private static ScaleTransform EnsureScale(FrameworkElement fe)
-    {
-        if (fe.RenderTransform is ScaleTransform existing) return existing;
-        var scale = new ScaleTransform();
-        fe.RenderTransform = scale;
-        fe.RenderTransformOrigin = new Windows.Foundation.Point(0.5, 0.5);
-        return scale;
-    }
-
-    private static DoubleAnimation Tween(DependencyObject target, string path, double from, double to)
-    {
-        var anim = new DoubleAnimation
-        {
-            From = from,
-            To = to,
-            Duration = new Duration(TimeSpan.FromMilliseconds(FadeDurationMs)),
-            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
-        };
-        Storyboard.SetTarget(anim, target);
-        Storyboard.SetTargetProperty(anim, path);
-        return anim;
     }
 }

--- a/windows/Ghostty/Shell/LaunchIconCoordinator.cs
+++ b/windows/Ghostty/Shell/LaunchIconCoordinator.cs
@@ -68,18 +68,27 @@ internal sealed class LaunchIconCoordinator
     }
 
     /// <summary>
-    /// Stop watching, without dismissing. For a window that closes before
-    /// it ever composed a frame: <see cref="CompositionTarget.Rendering"/>
-    /// is a static event, so an armed coordinator that is never torn down
-    /// keeps this object and its window alive, and later fires against some
-    /// other window's frame and schedules work on a dead dispatcher.
+    /// Stop watching, because the window this was arming for is going away.
     /// </summary>
+    /// <remarks>
+    /// Unsubscribing matters because <see cref="CompositionTarget.Rendering"/>
+    /// is a static event: an armed coordinator that is never torn down keeps
+    /// this object and its window alive, later fires against some other
+    /// window's frame, and schedules work on a dead dispatcher.
+    ///
+    /// It dismisses on the way out rather than just unsubscribing. This
+    /// coordinator is the only thing that can take the splash down, so
+    /// dropping a pending dismissal without taking it down would strand an
+    /// opaque topmost window over the remaining windows until the watchdog
+    /// fires seconds later.
+    /// </remarks>
     public void Cancel()
     {
         if (!_armed) return;
         _armed = false;
         CompositionTarget.Rendering -= OnFirstComposedFrame;
         StopTimer();
+        Dismiss();
     }
 
     /// <summary>

--- a/windows/Ghostty/Shell/LaunchIconCoordinator.cs
+++ b/windows/Ghostty/Shell/LaunchIconCoordinator.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Diagnostics;
+using Ghostty.Core.Shell;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Ghostty.Shell;
+
+/// <summary>
+/// Owns the cold-start launch icon: the bitmap assignment, the
+/// minimum-on-screen stopwatch, the watchdog timer, and the fade
+/// Storyboard. <see cref="LaunchIconPolicy"/> makes every timing
+/// decision; this type only carries them out.
+///
+/// Lifted out of MainWindow for the same reason as
+/// <see cref="LayoutCoordinator"/>: the window is a composition root,
+/// not an animation host.
+/// </summary>
+internal sealed class LaunchIconCoordinator
+{
+    public const int FadeDurationMs = 250;
+
+    // The icon grows slightly as it dissolves. A straight opacity fade
+    // reads as the icon being switched off; the drift outward reads as
+    // it giving way to the content behind it, which is the Windows 11
+    // splash-to-content feel we are copying.
+    private const double ExitScale = 1.08;
+
+    private readonly Microsoft.UI.Xaml.Controls.Image _icon;
+    private readonly DispatcherQueue _dispatcher;
+    private readonly LaunchIconPolicy _policy = new();
+    private readonly Stopwatch _onScreen = new();
+
+    private DispatcherQueueTimer? _watchdog;
+    private DispatcherQueueTimer? _deferred;
+    private Storyboard? _fade;
+    private bool _armed;
+
+    public LaunchIconCoordinator(
+        Microsoft.UI.Xaml.Controls.Image icon, DispatcherQueue dispatcher)
+    {
+        _icon = icon;
+        _dispatcher = dispatcher;
+    }
+
+    /// <summary>
+    /// Show the icon and start both clocks. Idempotent: a second call is
+    /// ignored, so re-entrancy during window construction cannot restart
+    /// the minimum-visible window.
+    /// </summary>
+    public void Arm()
+    {
+        if (_armed) return;
+        _armed = true;
+
+        // Decoded here rather than in XAML so warm windows, which never
+        // arm, never pay for the bitmap.
+        _icon.Source = new BitmapImage(Ghostty.Branding.AppIconSource.Splash);
+
+        // Full opacity from the first frame. The window itself is
+        // appearing at this moment, so fading the icon in would only
+        // soften the window's own entrance.
+        _icon.Opacity = 1;
+        _icon.Visibility = Visibility.Visible;
+        _onScreen.Start();
+
+        _watchdog = RunAfter(LaunchIconPolicy.WatchdogMs, () => Apply(_policy.Timeout()));
+    }
+
+    /// <summary>
+    /// The first surface reported that it has rendered. Safe to call
+    /// before <see cref="Arm"/> (does nothing) and more than once (the
+    /// policy latches).
+    /// </summary>
+    public void NotifyReady()
+    {
+        if (!_armed) return;
+        Apply(_policy.Ready((int)_onScreen.ElapsedMilliseconds));
+    }
+
+    private void Apply(LaunchIconDecision decision)
+    {
+        switch (decision.Outcome)
+        {
+            case LaunchIconOutcome.FadeNow:
+                StartFade();
+                break;
+            case LaunchIconOutcome.FadeAfter:
+                StopTimers();
+                _deferred = RunAfter(decision.DelayMs, StartFade);
+                break;
+            case LaunchIconOutcome.Ignore:
+            default:
+                break;
+        }
+    }
+
+    private void StartFade()
+    {
+        StopTimers();
+        _onScreen.Stop();
+
+        var scale = EnsureScale(_icon);
+        var sb = new Storyboard();
+        sb.Children.Add(Tween(_icon, "Opacity", 1, 0));
+        sb.Children.Add(Tween(scale, "ScaleX", 1, ExitScale));
+        sb.Children.Add(Tween(scale, "ScaleY", 1, ExitScale));
+
+        sb.Completed += (_, _) =>
+        {
+            // Collapse rather than leaving a transparent element in the
+            // tree: the icon is never shown again for this window's
+            // lifetime, and a collapsed element costs nothing in layout.
+            _icon.Visibility = Visibility.Collapsed;
+            _icon.Opacity = 0;
+            scale.ScaleX = 1;
+            scale.ScaleY = 1;
+            _fade = null;
+        };
+
+        _fade = sb;
+        sb.Begin();
+    }
+
+    private void StopTimers()
+    {
+        _watchdog?.Stop();
+        _watchdog = null;
+        _deferred?.Stop();
+        _deferred = null;
+    }
+
+    private DispatcherQueueTimer RunAfter(int delayMs, Action action)
+    {
+        var timer = _dispatcher.CreateTimer();
+        timer.Interval = TimeSpan.FromMilliseconds(delayMs);
+        timer.IsRepeating = false;
+        timer.Tick += (t, _) => { t.Stop(); action(); };
+        timer.Start();
+        return timer;
+    }
+
+    // Scale about the centre so the icon grows in place instead of
+    // drifting toward the bottom-right.
+    private static ScaleTransform EnsureScale(FrameworkElement fe)
+    {
+        if (fe.RenderTransform is ScaleTransform existing) return existing;
+        var scale = new ScaleTransform();
+        fe.RenderTransform = scale;
+        fe.RenderTransformOrigin = new Windows.Foundation.Point(0.5, 0.5);
+        return scale;
+    }
+
+    private static DoubleAnimation Tween(DependencyObject target, string path, double from, double to)
+    {
+        var anim = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = new Duration(TimeSpan.FromMilliseconds(FadeDurationMs)),
+            EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(anim, target);
+        Storyboard.SetTargetProperty(anim, path);
+        return anim;
+    }
+}

--- a/windows/Ghostty/Shell/LaunchIconCoordinator.cs
+++ b/windows/Ghostty/Shell/LaunchIconCoordinator.cs
@@ -38,6 +38,11 @@ internal sealed class LaunchIconCoordinator
     private DispatcherQueueTimer? _deferred;
     private Storyboard? _fade;
     private bool _armed;
+    // True once the compositor has produced a frame, which is the first
+    // moment the icon is actually on screen. Until then the clocks are
+    // not running and a ready signal is held rather than acted on.
+    private bool _onScreenYet;
+    private bool _readyWhileHidden;
 
     public LaunchIconCoordinator(
         Microsoft.UI.Xaml.Controls.Image icon, DispatcherQueue dispatcher)
@@ -47,9 +52,9 @@ internal sealed class LaunchIconCoordinator
     }
 
     /// <summary>
-    /// Show the icon and start both clocks. Idempotent: a second call is
-    /// ignored, so re-entrancy during window construction cannot restart
-    /// the minimum-visible window.
+    /// Show the icon and wait for the compositor to put it on screen.
+    /// Idempotent: a second call is ignored, so re-entrancy during
+    /// window construction cannot restart the timing.
     /// </summary>
     public void Arm()
     {
@@ -65,20 +70,45 @@ internal sealed class LaunchIconCoordinator
         // soften the window's own entrance.
         _icon.Opacity = 1;
         _icon.Visibility = Visibility.Visible;
-        _onScreen.Start();
 
-        _watchdog = RunAfter(LaunchIconPolicy.WatchdogMs, () => Apply(_policy.Timeout()));
+        // Arm() runs during the window constructor, and WinUI shows the
+        // HWND well before it composes a first XAML frame -- measured at
+        // roughly two seconds on a cold Debug start. Counting the dwell
+        // and the watchdog from here would spend most of both budgets
+        // while the icon is not yet on screen, so the icon could fade
+        // out before the user ever saw it. Start the clocks on the first
+        // composed frame instead, which is the first moment the icon is
+        // genuinely visible.
+        CompositionTarget.Rendering += OnFirstComposedFrame;
     }
 
     /// <summary>
     /// The first surface reported that it has rendered. Safe to call
-    /// before <see cref="Arm"/> (does nothing) and more than once (the
-    /// policy latches).
+    /// before <see cref="Arm"/> (does nothing), before the icon is on
+    /// screen (held until it is), and more than once (the policy
+    /// latches).
     /// </summary>
     public void NotifyReady()
     {
         if (!_armed) return;
+        if (!_onScreenYet)
+        {
+            _readyWhileHidden = true;
+            return;
+        }
         Apply(_policy.Ready((int)_onScreen.ElapsedMilliseconds));
+    }
+
+    private void OnFirstComposedFrame(object? sender, object e)
+    {
+        CompositionTarget.Rendering -= OnFirstComposedFrame;
+        _onScreenYet = true;
+        _onScreen.Start();
+        _watchdog = RunAfter(LaunchIconPolicy.WatchdogMs, () => Apply(_policy.Timeout()));
+
+        // The surface beat us to the compositor. Zero elapsed, so the
+        // policy grants the full minimum dwell from this frame.
+        if (_readyWhileHidden) Apply(_policy.Ready(0));
     }
 
     private void Apply(LaunchIconDecision decision)

--- a/windows/Ghostty/Shell/LaunchIconCoordinator.cs
+++ b/windows/Ghostty/Shell/LaunchIconCoordinator.cs
@@ -68,6 +68,21 @@ internal sealed class LaunchIconCoordinator
     }
 
     /// <summary>
+    /// Stop watching, without dismissing. For a window that closes before
+    /// it ever composed a frame: <see cref="CompositionTarget.Rendering"/>
+    /// is a static event, so an armed coordinator that is never torn down
+    /// keeps this object and its window alive, and later fires against some
+    /// other window's frame and schedules work on a dead dispatcher.
+    /// </summary>
+    public void Cancel()
+    {
+        if (!_armed) return;
+        _armed = false;
+        CompositionTarget.Rendering -= OnFirstComposedFrame;
+        StopTimer();
+    }
+
+    /// <summary>
     /// The seed surface reported its first render. Safe before
     /// <see cref="Arm"/>, safe before composition, and safe more than
     /// once.

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -161,8 +161,19 @@ internal static unsafe partial class SplashWindow
     /// silently does nothing -- or paints a bare rectangle because its
     /// icon is missing -- is otherwise invisible in the field.
     /// </summary>
-    private static void Diag(string message) =>
-        Program.WriteStartupDiagnostic($"splash: {message}");
+    private static void Diag(string message)
+    {
+        try
+        {
+            Program.WriteStartupDiagnostic($"splash: {message}");
+        }
+        catch
+        {
+            // A last-chance reporter that can throw is worse than one that
+            // says nothing: this runs on a background thread, where an
+            // escape would take the process down over a decoration.
+        }
+    }
 
     private static void ThreadMain()
     {
@@ -222,7 +233,11 @@ internal static unsafe partial class SplashWindow
             if (dpi == 0) dpi = 96;
             _scale = dpi / 96.0;
 
-            if (!Paint(255)) return;
+            if (!Paint(255))
+            {
+                Diag("first paint failed; no splash this launch");
+                return;
+            }
             ShowWindow(_hwnd, SW_SHOWNA);
             Volatile.Write(ref _shownAtTicks, Environment.TickCount64);
 
@@ -270,7 +285,7 @@ internal static unsafe partial class SplashWindow
                 if (CoversForegroundWindow())
                 {
                     SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
-                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS);
+                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
                 }
                 nextTopmostNudge = now + TopmostNudgeIntervalMs;
             }
@@ -343,8 +358,7 @@ internal static unsafe partial class SplashWindow
         _width = width;
         _height = height;
 
-        SetWindowPos(_hwnd, HWND_TOPMOST, r.left, r.top, width, height,
-            SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS);
+        SetWindowPos(_hwnd, HWND_TOPMOST, r.left, r.top, width, height, SWP_NOACTIVATE);
 
         // A move alone keeps the existing layered bitmap; a resize needs a
         // new one, both because the surface is a different size and
@@ -457,15 +471,21 @@ internal static unsafe partial class SplashWindow
             return false;
         }
 
-        _surfaceOldBitmap = SelectObject(memDc, dib);
-        FillOpaque(bits, width, height, background);
-        DrawIcon(memDc, width, height, iconPx);
+        var oldBitmap = SelectObject(memDc, dib);
 
+        // Publish all of it or none of it. ReleaseSurface only frees what
+        // these fields point at, so committing the bitmap handle before the
+        // compose below could leak both DCs and the DIB if anything in it
+        // threw.
         _surfaceScreenDc = screenDc;
         _surfaceMemDc = memDc;
         _surfaceDib = dib;
+        _surfaceOldBitmap = oldBitmap;
         _surfaceWidth = width;
         _surfaceHeight = height;
+
+        FillOpaque(bits, width, height, background);
+        DrawIcon(memDc, width, height, iconPx);
         return true;
     }
 
@@ -529,12 +549,23 @@ internal static unsafe partial class SplashWindow
             nint image;
             fixed (char* file = path)
             {
-                if (GdipCreateBitmapFromFile(file, out image) != 0 || image == 0) return;
+                if (GdipCreateBitmapFromFile(file, out image) != 0 || image == 0)
+                {
+                    // Present but unreadable: truncated, corrupt, or locked.
+                    // Same bare-rectangle result as a missing file, so it
+                    // needs the same signal.
+                    Diag($"could not decode {path}; drawing without the icon");
+                    return;
+                }
             }
 
             try
             {
-                if (GdipCreateFromHDC(memDc, out var graphics) != 0 || graphics == 0) return;
+                if (GdipCreateFromHDC(memDc, out var graphics) != 0 || graphics == 0)
+                {
+                    Diag("GdipCreateFromHDC failed; drawing without the icon");
+                    return;
+                }
                 try
                 {
                     GdipSetInterpolationMode(graphics, InterpolationModeHighQualityBicubic);
@@ -616,7 +647,7 @@ internal static unsafe partial class SplashWindow
             && state.WindowHeight is int h and >= MinPlausibleHeight
             && state.WindowX is int x
             && state.WindowY is int y
-            && IntersectsVirtualScreen(x, y, w, h))
+            && IntersectsLiveMonitor(x, y, w, h))
         {
             // A maximized window comes up filling its monitor's work area,
             // not the restored rect that was saved alongside the flag.
@@ -637,16 +668,14 @@ internal static unsafe partial class SplashWindow
     /// <summary>
     /// True when any part of the rect lands on a live monitor. Guards
     /// against a saved position on a display that is no longer attached.
+    /// Asks the window manager rather than testing the virtual-screen
+    /// bounding box, which on an L-shaped arrangement contains dead space
+    /// that belongs to no monitor.
     /// </summary>
-    private static bool IntersectsVirtualScreen(int x, int y, int w, int h)
+    private static bool IntersectsLiveMonitor(int x, int y, int w, int h)
     {
-        var vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
-        var vy = GetSystemMetrics(SM_YVIRTUALSCREEN);
-        var vw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-        var vh = GetSystemMetrics(SM_CYVIRTUALSCREEN);
-        if (vw <= 0 || vh <= 0) return true; // Nothing to check against.
-
-        return x < vx + vw && x + w > vx && y < vy + vh && y + h > vy;
+        var rect = new RECT { left = x, top = y, right = x + w, bottom = y + h };
+        return MonitorFromRect(ref rect, MONITOR_DEFAULTTONULL) != 0;
     }
 
     /// <summary>
@@ -664,11 +693,17 @@ internal static unsafe partial class SplashWindow
         var info = new MONITORINFO { cbSize = (uint)sizeof(MONITORINFO) };
         if (GetMonitorInfoW(monitor, ref info) == 0) return false;
 
-        var width = info.rcWork.right - info.rcWork.left;
-        var height = info.rcWork.bottom - info.rcWork.top;
+        // A maximized window's rect is the work area grown by the invisible
+        // resize border, not the work area itself. Matching it exactly keeps
+        // a black frame from showing around the splash for the whole gap.
+        var border = GetSystemMetrics(SM_CXSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER);
+        var left = info.rcWork.left - border;
+        var top = info.rcWork.top - border;
+        var width = (info.rcWork.right - info.rcWork.left) + (border * 2);
+        var height = (info.rcWork.bottom - info.rcWork.top) + (border * 2);
         if (width <= 0 || height <= 0) return false;
 
-        area = (info.rcWork.left, info.rcWork.top, width, height);
+        area = (left, top, width, height);
         return true;
     }
 
@@ -728,21 +763,14 @@ internal static unsafe partial class SplashWindow
     private const uint ULW_ALPHA = 0x00000002;
     private const int SM_CXSCREEN = 0;
     private const int SM_CYSCREEN = 1;
-    private const int SM_XVIRTUALSCREEN = 76;
-    private const int SM_YVIRTUALSCREEN = 77;
-    private const int SM_CXVIRTUALSCREEN = 78;
-    private const int SM_CYVIRTUALSCREEN = 79;
+    private const int SM_CXSIZEFRAME = 32;
+    private const int SM_CXPADDEDBORDER = 92;
+    private const uint MONITOR_DEFAULTTONULL = 0x00000000;
     private const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
     private static readonly nint HWND_TOPMOST = -1;
     private const uint SWP_NOSIZE = 0x0001;
     private const uint SWP_NOMOVE = 0x0002;
     private const uint SWP_NOACTIVATE = 0x0010;
-
-    // Post the z-order change instead of waiting on it. SetWindowPos
-    // otherwise notifies other top-level windows synchronously, and the
-    // thread it would be waiting on is the UI thread that is busy doing
-    // the startup work this splash exists to cover.
-    private const uint SWP_ASYNCWINDOWPOS = 0x4000;
     private static readonly nint IDC_ARROW = 32512;
     private const int InterpolationModeHighQualityBicubic = 7;
     private const int PixelOffsetModeHighQuality = 4;
@@ -881,6 +909,9 @@ internal static unsafe partial class SplashWindow
 
     [LibraryImport("user32.dll")]
     private static partial nint MonitorFromPoint(POINT pt, uint flags);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint MonitorFromRect(ref RECT rect, uint flags);
 
     [LibraryImport("user32.dll")]
     private static partial int GetMonitorInfoW(nint monitor, ref MONITORINFO info);

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -53,6 +53,11 @@ internal static unsafe partial class SplashWindow
     private const int FadeDurationMs = 220;
     private const int FadeStepMs = 16;
 
+    // How often to re-assert topmost while waiting. Frequent enough that a
+    // main window appearing underneath is covered again within a frame or
+    // two, rare enough not to load the window manager during startup.
+    private const int TopmostNudgeIntervalMs = 250;
+
     // Hard stop. If the main window never reports content the splash must
     // still go away rather than sit on top of the user's desktop forever.
     private const int WatchdogMs = 10_000;
@@ -133,8 +138,16 @@ internal static unsafe partial class SplashWindow
 
         fixed (char* className = ClassName)
         {
+            // WS_EX_TRANSPARENT is what keeps the app usable underneath.
+            // Without it this window is a solid input target sitting over
+            // the whole main window, so every click during the splash --
+            // including any spent waiting for a surface that is already
+            // ready -- lands here and does nothing, which reads as the app
+            // being frozen. With it, hit-testing skips this window
+            // entirely and input goes straight to the real one.
             _hwnd = CreateWindowExW(
-                WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TOPMOST,
+                WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW
+                    | WS_EX_NOACTIVATE | WS_EX_TOPMOST,
                 className, null, WS_POPUP,
                 x, y, width, height,
                 0, 0, GetModuleHandleW(0), 0);
@@ -173,17 +186,27 @@ internal static unsafe partial class SplashWindow
     private static void PumpUntilDismissed()
     {
         var deadline = Environment.TickCount64 + WatchdogMs;
+        var nextTopmostNudge = 0L;
+
         while (!_dismissed.IsSet && Environment.TickCount64 < deadline)
         {
             // Re-assert topmost. Creating the window with WS_EX_TOPMOST is
             // not enough: when WinUI shows and activates the main window,
             // the splash ends up behind it and the black gap it is meant
-            // to be covering shows through. Nudging the z-order on every
-            // tick is cheap and keeps the splash on top for the handful of
-            // seconds it exists. SWP_NOACTIVATE so this never steals focus
-            // from the window coming up behind it.
-            SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
-                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+            // to be covering shows through. SWP_NOACTIVATE so this never
+            // steals focus from the window coming up behind it.
+            //
+            // Throttled rather than done every pump tick. At tick rate this
+            // reorders the z-order sixty times a second while the main
+            // thread is still initializing, and the resulting window-manager
+            // and DWM work slows down the very startup we are waiting on.
+            var now = Environment.TickCount64;
+            if (now >= nextTopmostNudge)
+            {
+                SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+                nextTopmostNudge = now + TopmostNudgeIntervalMs;
+            }
 
             while (PeekMessageW(out var msg, 0, 0, 0, PM_REMOVE) != 0)
             {
@@ -396,6 +419,13 @@ internal static unsafe partial class SplashWindow
                 cbSize = (uint)sizeof(WNDCLASSEXW),
                 lpfnWndProc = &WndProc,
                 hInstance = GetModuleHandleW(0),
+                // A class with no cursor leaves whatever the OS was last
+                // showing in place, which during process start is the
+                // app-starting hourglass. WS_EX_TRANSPARENT means
+                // hit-testing should never reach us, so this is belt and
+                // braces -- but a null class cursor is a latent defect
+                // rather than a deliberate choice.
+                hCursor = LoadCursorW(0, IDC_ARROW),
                 lpszClassName = name,
             };
             // Show() guarantees one registration per process, so a zero
@@ -420,6 +450,7 @@ internal static unsafe partial class SplashWindow
 
     private const uint WS_POPUP = 0x80000000;
     private const uint WS_EX_LAYERED = 0x00080000;
+    private const uint WS_EX_TRANSPARENT = 0x00000020;
     private const uint WS_EX_TOOLWINDOW = 0x00000080;
     private const uint WS_EX_NOACTIVATE = 0x08000000;
     private const uint WS_EX_TOPMOST = 0x00000008;
@@ -433,6 +464,7 @@ internal static unsafe partial class SplashWindow
     private const uint SWP_NOSIZE = 0x0001;
     private const uint SWP_NOMOVE = 0x0002;
     private const uint SWP_NOACTIVATE = 0x0010;
+    private static readonly nint IDC_ARROW = 32512;
     private const int InterpolationModeHighQualityBicubic = 7;
     private const int PixelOffsetModeHighQuality = 4;
 
@@ -537,6 +569,9 @@ internal static unsafe partial class SplashWindow
 
     [LibraryImport("user32.dll")]
     private static partial void PostQuitMessage(int exitCode);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint LoadCursorW(nint instance, nint cursorName);
 
     [LibraryImport("user32.dll")]
     private static partial nint GetDC(nint hwnd);

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -1,0 +1,605 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Ghostty.Core.Shell;
+
+namespace Ghostty.Shell;
+
+/// <summary>
+/// Pre-XAML launch splash: a layered Win32 window showing the app icon,
+/// created before <c>Application.Start</c> and torn down once the main
+/// window has real content on screen.
+///
+/// <para>Why this is not XAML. WinUI 3 shows the main window's HWND
+/// well before it composes a first XAML frame -- around two seconds on
+/// a cold start -- and paints black for that whole gap. Nothing
+/// declared in XAML can cover it, because XAML is precisely what is not
+/// running yet. So the splash is a plain Win32 window on its own thread
+/// with its own message pump, up within a few hundred milliseconds of
+/// process start and owing nothing to the WinUI stack.</para>
+///
+/// <para>It covers the rect the main window is about to restore to (from
+/// <see cref="Ghostty.Settings.WindowState"/>) and fills it with the
+/// terminal background colour, so the black gap is never visible. When
+/// the main window reports content, the splash fades and closes,
+/// revealing the real window underneath.</para>
+///
+/// <para>Interop here is hand-written rather than CsWin32-generated for
+/// the same reason <c>NativeMethods.txt</c> already documents for
+/// CreateSolidBrush and SetClassLongPtr: several of these entry points
+/// are absent from the CsWin32 metadata for this target. It follows the
+/// project's <c>DisableRuntimeMarshalling</c> conventions -- Win32 BOOL
+/// as <see cref="int"/>, strings as <see cref="char"/> pointers, every
+/// struct blittable. The window procedure is an
+/// <see cref="UnmanagedCallersOnlyAttribute"/> function pointer rather
+/// than a delegate so there is no managed callback to keep alive; a
+/// collected WNDPROC delegate is the classic way this kind of window
+/// crashes.</para>
+/// </summary>
+internal static unsafe partial class SplashWindow
+{
+    // Fallback background when no colour has been persisted yet (first
+    // ever launch). Matches ConfigService's default background so the
+    // handoff to the real window is not a visible colour jump.
+    private const uint DefaultBackgroundRgb = 0x1E1E2E;
+
+    // Fallback rect when there is no saved window state, in physical
+    // pixels. Close enough to the app's default window that the splash
+    // lands where the window will.
+    private const int FallbackWidth = 1200;
+    private const int FallbackHeight = 800;
+
+    private const int FadeDurationMs = 220;
+    private const int FadeStepMs = 16;
+
+    // Hard stop. If the main window never reports content the splash must
+    // still go away rather than sit on top of the user's desktop forever.
+    private const int WatchdogMs = 10_000;
+
+    private const string ClassName = "WinttySplash";
+
+    private static nint _hwnd;
+    private static readonly ManualResetEventSlim _dismissed = new(false);
+    private static int _started;
+    private static long _shownAtTicks;
+
+    /// <summary>
+    /// Milliseconds the splash has been on screen, or 0 if it was never
+    /// shown. The dwell clause in <see cref="LaunchIconPolicy"/> is
+    /// measured against this rather than against main-window
+    /// construction, which happens seconds later.
+    /// </summary>
+    public static int VisibleForMs
+    {
+        get
+        {
+            var shown = Volatile.Read(ref _shownAtTicks);
+            if (shown == 0) return 0;
+            var elapsed = Environment.TickCount64 - shown;
+            if (elapsed <= 0) return 0;
+            return elapsed > int.MaxValue ? int.MaxValue : (int)elapsed;
+        }
+    }
+
+    /// <summary>
+    /// Put the splash on screen. Returns immediately; the window lives on
+    /// its own background thread. Only the first call per process does
+    /// anything.
+    /// </summary>
+    public static void Show()
+    {
+        if (Interlocked.Exchange(ref _started, 1) != 0) return;
+
+        var thread = new Thread(ThreadMain)
+        {
+            IsBackground = true,
+            Name = "wintty-splash",
+        };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+    }
+
+    /// <summary>
+    /// The main window has content. Fade the splash out and close it.
+    /// Safe when no splash was ever shown, and safe to call repeatedly.
+    /// </summary>
+    public static void Dismiss()
+    {
+        if (Volatile.Read(ref _started) == 0) return;
+        _dismissed.Set();
+    }
+
+    private static void ThreadMain()
+    {
+        try
+        {
+            RunSplash();
+        }
+        catch
+        {
+            // A splash is decoration. Nothing it can do is worth taking the
+            // process down before the real window exists, and there is no
+            // logger wired up this early in startup.
+        }
+    }
+
+    private static void RunSplash()
+    {
+        var (x, y, width, height) = ResolveRect();
+        var background = ResolveBackgroundRgb();
+
+        if (!RegisterWindowClass()) return;
+
+        fixed (char* className = ClassName)
+        {
+            _hwnd = CreateWindowExW(
+                WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TOPMOST,
+                className, null, WS_POPUP,
+                x, y, width, height,
+                0, 0, GetModuleHandleW(0), 0);
+        }
+        if (_hwnd == 0) return;
+
+        try
+        {
+            // DPI is only knowable once the window exists and the OS has
+            // assigned it to a monitor.
+            var dpi = GetDpiForWindow(_hwnd);
+            if (dpi == 0) dpi = 96;
+            var scale = dpi / 96.0;
+            var iconPx = (int)Math.Round(
+                LaunchIconMetrics.Resolve(width / scale, height / scale) * scale);
+
+            if (!Paint(width, height, background, iconPx, 255)) return;
+            ShowWindow(_hwnd, SW_SHOWNA);
+            Volatile.Write(ref _shownAtTicks, Environment.TickCount64);
+
+            PumpUntilDismissed();
+            FadeOut(width, height, background, iconPx);
+        }
+        finally
+        {
+            DestroyWindow(_hwnd);
+            _hwnd = 0;
+        }
+    }
+
+    /// <summary>
+    /// Service the message queue until dismissal or the watchdog. A
+    /// window with no pump is marked unresponsive by the OS and painted
+    /// as a ghost.
+    /// </summary>
+    private static void PumpUntilDismissed()
+    {
+        var deadline = Environment.TickCount64 + WatchdogMs;
+        while (!_dismissed.IsSet && Environment.TickCount64 < deadline)
+        {
+            // Re-assert topmost. Creating the window with WS_EX_TOPMOST is
+            // not enough: when WinUI shows and activates the main window,
+            // the splash ends up behind it and the black gap it is meant
+            // to be covering shows through. Nudging the z-order on every
+            // tick is cheap and keeps the splash on top for the handful of
+            // seconds it exists. SWP_NOACTIVATE so this never steals focus
+            // from the window coming up behind it.
+            SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+
+            while (PeekMessageW(out var msg, 0, 0, 0, PM_REMOVE) != 0)
+            {
+                TranslateMessage(ref msg);
+                DispatchMessageW(ref msg);
+            }
+            // Waits on the dismiss signal rather than sleeping blindly, so
+            // the fade starts the moment the window reports content.
+            _dismissed.Wait(FadeStepMs);
+        }
+    }
+
+    private static void FadeOut(int width, int height, uint background, int iconPx)
+    {
+        var steps = Math.Max(1, FadeDurationMs / FadeStepMs);
+        for (var i = steps - 1; i >= 0; i--)
+        {
+            var alpha = (byte)(255 * i / steps);
+            if (!Paint(width, height, background, iconPx, alpha)) break;
+            Thread.Sleep(FadeStepMs);
+        }
+    }
+
+    /// <summary>
+    /// Render the splash into a 32bpp DIB and hand it to
+    /// UpdateLayeredWindow. The content is fully opaque, so
+    /// <paramref name="alpha"/> alone drives the fade and there is no
+    /// premultiplied alpha to get wrong.
+    /// </summary>
+    private static bool Paint(int width, int height, uint background, int iconPx, byte alpha)
+    {
+        var screenDc = GetDC(0);
+        if (screenDc == 0) return false;
+
+        var memDc = CreateCompatibleDC(screenDc);
+        if (memDc == 0)
+        {
+            ReleaseDC(0, screenDc);
+            return false;
+        }
+
+        var header = new BITMAPINFOHEADER
+        {
+            biSize = (uint)sizeof(BITMAPINFOHEADER),
+            biWidth = width,
+            // Negative height means top-down, so row 0 is the top row and
+            // the GDI+ draw below lands the right way up.
+            biHeight = -height,
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0, // BI_RGB
+        };
+
+        var dib = CreateDIBSection(memDc, ref header, 0, out var bits, 0, 0);
+        if (dib == 0)
+        {
+            DeleteDC(memDc);
+            ReleaseDC(0, screenDc);
+            return false;
+        }
+
+        var oldBitmap = SelectObject(memDc, dib);
+        FillOpaque(bits, width, height, background);
+        DrawIcon(memDc, width, height, iconPx);
+
+        var size = new SIZE { cx = width, cy = height };
+        var srcPoint = new POINT { x = 0, y = 0 };
+        var blend = new BLENDFUNCTION
+        {
+            BlendOp = 0,                      // AC_SRC_OVER
+            BlendFlags = 0,
+            SourceConstantAlpha = alpha,
+            AlphaFormat = 0,                  // opaque source, constant alpha only
+        };
+
+        var ok = UpdateLayeredWindow(
+            _hwnd, screenDc, 0, ref size, memDc, ref srcPoint, 0, ref blend, ULW_ALPHA) != 0;
+
+        SelectObject(memDc, oldBitmap);
+        DeleteObject(dib);
+        DeleteDC(memDc);
+        ReleaseDC(0, screenDc);
+        return ok;
+    }
+
+    /// <summary>
+    /// Fill the DIB with the background colour at full alpha. Written
+    /// directly rather than with FillRect because a GDI brush fill leaves
+    /// the alpha channel at zero, which UpdateLayeredWindow then treats
+    /// as fully transparent -- an invisible splash.
+    /// </summary>
+    private static void FillOpaque(nint bits, int width, int height, uint rgb)
+    {
+        var pixel = 0xFF000000u | (rgb & 0x00FFFFFFu);
+        var p = (uint*)bits;
+        var count = (long)width * height;
+        for (long i = 0; i < count; i++) p[i] = pixel;
+    }
+
+    private static void DrawIcon(nint memDc, int width, int height, int iconPx)
+    {
+        var path = IconPathForSize(iconPx);
+        if (path is null) return;
+
+        var startup = new GdiplusStartupInput { GdiplusVersion = 1 };
+        if (GdiplusStartup(out var token, ref startup, 0) != 0) return;
+
+        try
+        {
+            nint image;
+            fixed (char* file = path)
+            {
+                if (GdipCreateBitmapFromFile(file, out image) != 0 || image == 0) return;
+            }
+
+            try
+            {
+                if (GdipCreateFromHDC(memDc, out var graphics) != 0 || graphics == 0) return;
+                try
+                {
+                    GdipSetInterpolationMode(graphics, InterpolationModeHighQualityBicubic);
+                    GdipSetPixelOffsetMode(graphics, PixelOffsetModeHighQuality);
+                    GdipDrawImageRectI(
+                        graphics, image,
+                        (width - iconPx) / 2, (height - iconPx) / 2, iconPx, iconPx);
+                }
+                finally { GdipDeleteGraphics(graphics); }
+            }
+            finally { GdipDisposeImage(image); }
+        }
+        finally { GdiplusShutdown(token); }
+    }
+
+    /// <summary>
+    /// Pick the smallest shipped rung at least as large as the size being
+    /// drawn, so GDI+ downsamples rather than upsamples. Falls back to the
+    /// largest rung when the request exceeds everything we ship.
+    /// </summary>
+    private static string? IconPathForSize(int iconPx)
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Assets");
+
+        // Pixel size of each rung paired with the scale suffix it ships
+        // under. Keep in sync with PngWriter.SplashTargets.
+        ReadOnlySpan<int> rungPixels = [160, 240, 320, 640];
+        ReadOnlySpan<int> rungScales = [100, 150, 200, 400];
+
+        for (var i = 0; i < rungPixels.Length; i++)
+        {
+            if (rungPixels[i] < iconPx) continue;
+            var candidate = Path.Combine(dir, $"SplashIcon.scale-{rungScales[i]}.png");
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        var largest = Path.Combine(dir, "SplashIcon.scale-400.png");
+        return File.Exists(largest) ? largest : null;
+    }
+
+    /// <summary>
+    /// Where the main window is about to appear, in physical pixels. Read
+    /// straight from the saved window state because that is what the
+    /// window itself restores from; anything else would put the splash
+    /// somewhere the black gap is not.
+    /// </summary>
+    private static (int X, int Y, int Width, int Height) ResolveRect()
+    {
+        try
+        {
+            var state = Ghostty.Settings.WindowState.Load();
+            if (state.WindowWidth is int w and > 0
+                && state.WindowHeight is int h and > 0
+                && state.WindowX is int x
+                && state.WindowY is int y)
+            {
+                return (x, y, w, h);
+            }
+        }
+        catch
+        {
+            // Unreadable state file. Fall through to the centred default.
+        }
+
+        var screenWidth = GetSystemMetrics(SM_CXSCREEN);
+        var screenHeight = GetSystemMetrics(SM_CYSCREEN);
+        var width = Math.Min(FallbackWidth, screenWidth);
+        var height = Math.Min(FallbackHeight, screenHeight);
+        return ((screenWidth - width) / 2, (screenHeight - height) / 2, width, height);
+    }
+
+    private static uint ResolveBackgroundRgb()
+    {
+        try
+        {
+            if (Ghostty.Settings.WindowState.Load().BackgroundRgb is uint saved)
+                return saved & 0x00FFFFFFu;
+        }
+        catch
+        {
+            // Unreadable state file. Fall through to the default.
+        }
+        return DefaultBackgroundRgb;
+    }
+
+    private static bool RegisterWindowClass()
+    {
+        fixed (char* name = ClassName)
+        {
+            var wc = new WNDCLASSEXW
+            {
+                cbSize = (uint)sizeof(WNDCLASSEXW),
+                lpfnWndProc = &WndProc,
+                hInstance = GetModuleHandleW(0),
+                lpszClassName = name,
+            };
+            // Show() guarantees one registration per process, so a zero
+            // atom here is a genuine failure rather than "already
+            // registered".
+            return RegisterClassExW(ref wc) != 0;
+        }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static nint WndProc(nint hwnd, uint msg, nint wParam, nint lParam)
+    {
+        // Layered content is supplied wholesale by UpdateLayeredWindow, so
+        // there is no WM_PAINT work and no background to erase.
+        if (msg == WM_DESTROY)
+        {
+            PostQuitMessage(0);
+            return 0;
+        }
+        return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+
+    private const uint WS_POPUP = 0x80000000;
+    private const uint WS_EX_LAYERED = 0x00080000;
+    private const uint WS_EX_TOOLWINDOW = 0x00000080;
+    private const uint WS_EX_NOACTIVATE = 0x08000000;
+    private const uint WS_EX_TOPMOST = 0x00000008;
+    private const int SW_SHOWNA = 8;
+    private const uint PM_REMOVE = 0x0001;
+    private const uint WM_DESTROY = 0x0002;
+    private const uint ULW_ALPHA = 0x00000002;
+    private const int SM_CXSCREEN = 0;
+    private const int SM_CYSCREEN = 1;
+    private static readonly nint HWND_TOPMOST = -1;
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const int InterpolationModeHighQualityBicubic = 7;
+    private const int PixelOffsetModeHighQuality = 4;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WNDCLASSEXW
+    {
+        public uint cbSize;
+        public uint style;
+        public delegate* unmanaged[Stdcall]<nint, uint, nint, nint, nint> lpfnWndProc;
+        public int cbClsExtra;
+        public int cbWndExtra;
+        public nint hInstance;
+        public nint hIcon;
+        public nint hCursor;
+        public nint hbrBackground;
+        public char* lpszMenuName;
+        public char* lpszClassName;
+        public nint hIconSm;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BITMAPINFOHEADER
+    {
+        public uint biSize;
+        public int biWidth;
+        public int biHeight;
+        public ushort biPlanes;
+        public ushort biBitCount;
+        public uint biCompression;
+        public uint biSizeImage;
+        public int biXPelsPerMeter;
+        public int biYPelsPerMeter;
+        public uint biClrUsed;
+        public uint biClrImportant;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BLENDFUNCTION
+    {
+        public byte BlendOp;
+        public byte BlendFlags;
+        public byte SourceConstantAlpha;
+        public byte AlphaFormat;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SIZE { public int cx; public int cy; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT { public int x; public int y; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MSG
+    {
+        public nint hwnd;
+        public uint message;
+        public nint wParam;
+        public nint lParam;
+        public uint time;
+        public POINT pt;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct GdiplusStartupInput
+    {
+        public uint GdiplusVersion;
+        public nint DebugEventCallback;
+        public int SuppressBackgroundThread;
+        public int SuppressExternalCodecs;
+    }
+
+    [LibraryImport("user32.dll")]
+    private static partial ushort RegisterClassExW(ref WNDCLASSEXW wc);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint CreateWindowExW(
+        uint exStyle, char* className, char* windowName, uint style,
+        int x, int y, int width, int height,
+        nint parent, nint menu, nint instance, nint param);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint DefWindowProcW(nint hwnd, uint msg, nint wParam, nint lParam);
+
+    [LibraryImport("user32.dll")]
+    private static partial int DestroyWindow(nint hwnd);
+
+    [LibraryImport("user32.dll")]
+    private static partial int ShowWindow(nint hwnd, int cmdShow);
+
+    [LibraryImport("user32.dll")]
+    private static partial int SetWindowPos(
+        nint hwnd, nint insertAfter, int x, int y, int cx, int cy, uint flags);
+
+    [LibraryImport("user32.dll")]
+    private static partial int PeekMessageW(out MSG msg, nint hwnd, uint min, uint max, uint remove);
+
+    [LibraryImport("user32.dll")]
+    private static partial int TranslateMessage(ref MSG msg);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint DispatchMessageW(ref MSG msg);
+
+    [LibraryImport("user32.dll")]
+    private static partial void PostQuitMessage(int exitCode);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint GetDC(nint hwnd);
+
+    [LibraryImport("user32.dll")]
+    private static partial int ReleaseDC(nint hwnd, nint dc);
+
+    [LibraryImport("user32.dll")]
+    private static partial uint GetDpiForWindow(nint hwnd);
+
+    [LibraryImport("user32.dll")]
+    private static partial int GetSystemMetrics(int index);
+
+    [LibraryImport("user32.dll")]
+    private static partial int UpdateLayeredWindow(
+        nint hwnd, nint destDc, nint destPoint, ref SIZE size,
+        nint srcDc, ref POINT srcPoint, uint colorKey, ref BLENDFUNCTION blend, uint flags);
+
+    [LibraryImport("gdi32.dll")]
+    private static partial nint CreateCompatibleDC(nint dc);
+
+    [LibraryImport("gdi32.dll")]
+    private static partial int DeleteDC(nint dc);
+
+    [LibraryImport("gdi32.dll")]
+    private static partial nint SelectObject(nint dc, nint obj);
+
+    [LibraryImport("gdi32.dll")]
+    private static partial int DeleteObject(nint obj);
+
+    [LibraryImport("gdi32.dll")]
+    private static partial nint CreateDIBSection(
+        nint dc, ref BITMAPINFOHEADER header, uint usage,
+        out nint bits, nint section, uint offset);
+
+    [LibraryImport("kernel32.dll")]
+    private static partial nint GetModuleHandleW(nint moduleName);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdiplusStartup(out nint token, ref GdiplusStartupInput input, nint output);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial void GdiplusShutdown(nint token);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdipCreateBitmapFromFile(char* filename, out nint bitmap);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdipDisposeImage(nint image);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdipCreateFromHDC(nint dc, out nint graphics);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdipDeleteGraphics(nint graphics);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdipSetInterpolationMode(nint graphics, int mode);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdipSetPixelOffsetMode(nint graphics, int mode);
+
+    [LibraryImport("gdiplus.dll")]
+    private static partial int GdipDrawImageRectI(
+        nint graphics, nint image, int x, int y, int width, int height);
+}

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -50,6 +50,12 @@ internal static unsafe partial class SplashWindow
     private const int FallbackWidth = 1200;
     private const int FallbackHeight = 800;
 
+    // Smallest saved rect worth believing. Matches MainWindow.ApplyGeometry,
+    // which discards anything smaller, so the splash and the window agree on
+    // when saved geometry is junk.
+    private const int MinPlausibleWidth = 200;
+    private const int MinPlausibleHeight = 150;
+
     private const int FadeDurationMs = 220;
     private const int FadeStepMs = 16;
 
@@ -77,6 +83,18 @@ internal static unsafe partial class SplashWindow
     private static int _height;
     private static uint _background;
     private static double _scale = 1.0;
+
+    // The composed splash bitmap, kept alive between blends. Building it
+    // costs a full-window DIB, a per-pixel fill and a PNG decode, none of
+    // which change while only the alpha does, so the fade re-blends this
+    // instead of rebuilding it every frame. Owned by the splash thread and
+    // released in RunSplash's finally.
+    private static nint _surfaceScreenDc;
+    private static nint _surfaceMemDc;
+    private static nint _surfaceDib;
+    private static nint _surfaceOldBitmap;
+    private static int _surfaceWidth;
+    private static int _surfaceHeight;
 
     /// <summary>
     /// Follow <paramref name="hwnd"/> from now on. Called once the main
@@ -130,9 +148,21 @@ internal static unsafe partial class SplashWindow
     /// </summary>
     public static void Dismiss()
     {
-        if (Volatile.Read(ref _started) == 0) return;
+        // Set unconditionally rather than bailing when nothing has started
+        // yet. RunSplash handles an already-signalled event correctly, so
+        // latching here means a dismissal that races Show can never be
+        // dropped and leave the splash up until the watchdog.
         _dismissed.Set();
     }
+
+    /// <summary>
+    /// Report a splash failure on the only channel that exists this early.
+    /// Nothing here is worth failing the launch over, but a splash that
+    /// silently does nothing -- or paints a bare rectangle because its
+    /// icon is missing -- is otherwise invisible in the field.
+    /// </summary>
+    private static void Diag(string message) =>
+        Program.WriteStartupDiagnostic($"splash: {message}");
 
     private static void ThreadMain()
     {
@@ -140,22 +170,27 @@ internal static unsafe partial class SplashWindow
         {
             RunSplash();
         }
-        catch
+        catch (Exception ex)
         {
             // A splash is decoration. Nothing it can do is worth taking the
-            // process down before the real window exists, and there is no
-            // logger wired up this early in startup.
+            // process down before the real window exists.
+            Diag($"aborted: {ex}");
         }
     }
 
     private static void RunSplash()
     {
-        var (x, y, width, height) = ResolveRect();
+        var state = LoadState();
+        var (x, y, width, height) = ResolveRect(state);
         _width = width;
         _height = height;
-        _background = ResolveBackgroundRgb();
+        _background = ResolveBackgroundRgb(state);
 
-        if (!RegisterWindowClass()) return;
+        if (!RegisterWindowClass())
+        {
+            Diag("could not register the window class");
+            return;
+        }
 
         fixed (char* className = ClassName)
         {
@@ -173,7 +208,11 @@ internal static unsafe partial class SplashWindow
                 x, y, width, height,
                 0, 0, GetModuleHandleW(0), 0);
         }
-        if (_hwnd == 0) return;
+        if (_hwnd == 0)
+        {
+            Diag($"CreateWindowExW failed for {width}x{height} at ({x},{y})");
+            return;
+        }
 
         try
         {
@@ -192,6 +231,7 @@ internal static unsafe partial class SplashWindow
         }
         finally
         {
+            ReleaseSurface();
             DestroyWindow(_hwnd);
             _hwnd = 0;
         }
@@ -219,11 +259,19 @@ internal static unsafe partial class SplashWindow
             // reorders the z-order sixty times a second while the main
             // thread is still initializing, and the resulting window-manager
             // and DWM work slows down the very startup we are waiting on.
+            //
+            // Skipped once the user has switched to another app. The splash
+            // has no taskbar button, no Alt-Tab entry and no close affordance,
+            // so re-asserting topmost over whatever they switched to would
+            // leave them looking at something they cannot dismiss.
             var now = Environment.TickCount64;
             if (now >= nextTopmostNudge)
             {
-                SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
-                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+                if (CoversForegroundWindow())
+                {
+                    SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS);
+                }
                 nextTopmostNudge = now + TopmostNudgeIntervalMs;
             }
 
@@ -233,15 +281,39 @@ internal static unsafe partial class SplashWindow
             // change, a SetWindowPos.
             FollowTrackedWindow();
 
-            while (PeekMessageW(out var msg, 0, 0, 0, PM_REMOVE) != 0)
-            {
-                TranslateMessage(ref msg);
-                DispatchMessageW(ref msg);
-            }
+            PumpMessages();
             // Waits on the dismiss signal rather than sleeping blindly, so
             // the fade starts the moment the window reports content.
             _dismissed.Wait(FadeStepMs);
         }
+    }
+
+    /// <summary>
+    /// Drain the message queue. A window whose thread stops pumping is
+    /// marked unresponsive by the OS and painted as a ghost.
+    /// </summary>
+    private static void PumpMessages()
+    {
+        while (PeekMessageW(out var msg, 0, 0, 0, PM_REMOVE) != 0)
+        {
+            TranslateMessage(ref msg);
+            DispatchMessageW(ref msg);
+        }
+    }
+
+    /// <summary>
+    /// True while the splash is still covering for this app rather than
+    /// sitting over something the user deliberately switched to. Treats an
+    /// untracked splash as ours, since before the main window exists there
+    /// is nothing else it could be covering.
+    /// </summary>
+    private static bool CoversForegroundWindow()
+    {
+        var tracked = Volatile.Read(ref _trackedHwnd);
+        if (tracked == 0) return true;
+
+        var foreground = GetForegroundWindow();
+        return foreground == 0 || foreground == tracked || foreground == _hwnd;
     }
 
     /// <summary>
@@ -271,7 +343,8 @@ internal static unsafe partial class SplashWindow
         _width = width;
         _height = height;
 
-        SetWindowPos(_hwnd, HWND_TOPMOST, r.left, r.top, width, height, SWP_NOACTIVATE);
+        SetWindowPos(_hwnd, HWND_TOPMOST, r.left, r.top, width, height,
+            SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS);
 
         // A move alone keeps the existing layered bitmap; a resize needs a
         // new one, both because the surface is a different size and
@@ -279,37 +352,86 @@ internal static unsafe partial class SplashWindow
         if (resized) Paint(255);
     }
 
+    /// <summary>
+    /// Fade the splash out. Keeps servicing the message queue and tracking
+    /// the window while it does: this is a top-level window, so a thread
+    /// that stops pumping stalls any process broadcasting a message to it,
+    /// and a drag during the fade would otherwise detach the splash.
+    /// </summary>
     private static void FadeOut()
     {
         var steps = Math.Max(1, FadeDurationMs / FadeStepMs);
         for (var i = steps - 1; i >= 0; i--)
         {
             var alpha = (byte)(255 * i / steps);
+            FollowTrackedWindow();
             if (!Paint(alpha)) break;
+            PumpMessages();
             Thread.Sleep(FadeStepMs);
         }
     }
 
     /// <summary>
-    /// Render the splash into a 32bpp DIB and hand it to
-    /// UpdateLayeredWindow. The content is fully opaque, so
-    /// <paramref name="alpha"/> alone drives the fade and there is no
-    /// premultiplied alpha to get wrong.
+    /// Show the splash at <paramref name="alpha"/>, composing the bitmap
+    /// first if there is not already one at the current size. The content
+    /// is fully opaque, so <paramref name="alpha"/> alone drives the fade
+    /// and there is no premultiplied alpha to get wrong.
     /// </summary>
     private static bool Paint(byte alpha)
     {
+        if (!EnsureSurface()) return false;
+
+        var size = new SIZE { cx = _surfaceWidth, cy = _surfaceHeight };
+        var srcPoint = new POINT { x = 0, y = 0 };
+        var blend = new BLENDFUNCTION
+        {
+            BlendOp = 0,                      // AC_SRC_OVER
+            BlendFlags = 0,
+            SourceConstantAlpha = alpha,
+            AlphaFormat = 0,                  // opaque source, constant alpha only
+        };
+
+        return UpdateLayeredWindow(
+            _hwnd, _surfaceScreenDc, 0, ref size, _surfaceMemDc,
+            ref srcPoint, 0, ref blend, ULW_ALPHA) != 0;
+    }
+
+    /// <summary>
+    /// Compose the splash bitmap into a 32bpp DIB, reusing the existing one
+    /// when it already matches the current size. Kept apart from the blend
+    /// because composing costs a full-window allocation, a per-pixel fill
+    /// and a PNG decode, and the fade changes only the alpha: rebuilding it
+    /// per frame turned a 220ms fade into a stutter that delayed the very
+    /// reveal it was smoothing.
+    /// </summary>
+    private static bool EnsureSurface()
+    {
         var width = _width;
         var height = _height;
+        if (width <= 0 || height <= 0) return false;
+
+        if (_surfaceDib != 0 && _surfaceWidth == width && _surfaceHeight == height)
+        {
+            return true;
+        }
+
+        ReleaseSurface();
+
         var background = _background;
         var iconPx = (int)Math.Round(
             LaunchIconMetrics.Resolve(width / _scale, height / _scale) * _scale);
 
         var screenDc = GetDC(0);
-        if (screenDc == 0) return false;
+        if (screenDc == 0)
+        {
+            Diag("GetDC failed; no splash this launch");
+            return false;
+        }
 
         var memDc = CreateCompatibleDC(screenDc);
         if (memDc == 0)
         {
+            Diag("CreateCompatibleDC failed; no splash this launch");
             ReleaseDC(0, screenDc);
             return false;
         }
@@ -329,33 +451,44 @@ internal static unsafe partial class SplashWindow
         var dib = CreateDIBSection(memDc, ref header, 0, out var bits, 0, 0);
         if (dib == 0)
         {
+            Diag($"CreateDIBSection failed for {width}x{height}; no splash this launch");
             DeleteDC(memDc);
             ReleaseDC(0, screenDc);
             return false;
         }
 
-        var oldBitmap = SelectObject(memDc, dib);
+        _surfaceOldBitmap = SelectObject(memDc, dib);
         FillOpaque(bits, width, height, background);
         DrawIcon(memDc, width, height, iconPx);
 
-        var size = new SIZE { cx = width, cy = height };
-        var srcPoint = new POINT { x = 0, y = 0 };
-        var blend = new BLENDFUNCTION
+        _surfaceScreenDc = screenDc;
+        _surfaceMemDc = memDc;
+        _surfaceDib = dib;
+        _surfaceWidth = width;
+        _surfaceHeight = height;
+        return true;
+    }
+
+    /// <summary>
+    /// Drop the composed bitmap and every GDI object behind it. Safe to
+    /// call when there is nothing to release.
+    /// </summary>
+    private static void ReleaseSurface()
+    {
+        if (_surfaceMemDc != 0)
         {
-            BlendOp = 0,                      // AC_SRC_OVER
-            BlendFlags = 0,
-            SourceConstantAlpha = alpha,
-            AlphaFormat = 0,                  // opaque source, constant alpha only
-        };
+            if (_surfaceOldBitmap != 0) SelectObject(_surfaceMemDc, _surfaceOldBitmap);
+            DeleteDC(_surfaceMemDc);
+        }
+        if (_surfaceDib != 0) DeleteObject(_surfaceDib);
+        if (_surfaceScreenDc != 0) ReleaseDC(0, _surfaceScreenDc);
 
-        var ok = UpdateLayeredWindow(
-            _hwnd, screenDc, 0, ref size, memDc, ref srcPoint, 0, ref blend, ULW_ALPHA) != 0;
-
-        SelectObject(memDc, oldBitmap);
-        DeleteObject(dib);
-        DeleteDC(memDc);
-        ReleaseDC(0, screenDc);
-        return ok;
+        _surfaceScreenDc = 0;
+        _surfaceMemDc = 0;
+        _surfaceDib = 0;
+        _surfaceOldBitmap = 0;
+        _surfaceWidth = 0;
+        _surfaceHeight = 0;
     }
 
     /// <summary>
@@ -375,10 +508,21 @@ internal static unsafe partial class SplashWindow
     private static void DrawIcon(nint memDc, int width, int height, int iconPx)
     {
         var path = IconPathForSize(iconPx);
-        if (path is null) return;
+        if (path is null)
+        {
+            // Without this the splash still paints, as a bare rectangle in
+            // the terminal background colour, which reads as a rendering
+            // bug rather than as missing assets.
+            Diag($"no SplashIcon asset for {iconPx}px in {AppContext.BaseDirectory}Assets");
+            return;
+        }
 
         var startup = new GdiplusStartupInput { GdiplusVersion = 1 };
-        if (GdiplusStartup(out var token, ref startup, 0) != 0) return;
+        if (GdiplusStartup(out var token, ref startup, 0) != 0)
+        {
+            Diag("GdiplusStartup failed; drawing without the icon");
+            return;
+        }
 
         try
         {
@@ -432,27 +576,55 @@ internal static unsafe partial class SplashWindow
     }
 
     /// <summary>
-    /// Where the main window is about to appear, in physical pixels. Read
-    /// straight from the saved window state because that is what the
-    /// window itself restores from; anything else would put the splash
-    /// somewhere the black gap is not.
+    /// Read the saved window state once, or null if there is none to read.
+    /// Loaded once and shared: each call is a directory create plus a file
+    /// read plus a deserialize, on the path whose whole purpose is to get
+    /// something on screen quickly, and two reads can disagree because the
+    /// main window rewrites this file while it is starting up.
     /// </summary>
-    private static (int X, int Y, int Width, int Height) ResolveRect()
+    private static Ghostty.Settings.WindowState? LoadState()
     {
         try
         {
-            var state = Ghostty.Settings.WindowState.Load();
-            if (state.WindowWidth is int w and > 0
-                && state.WindowHeight is int h and > 0
-                && state.WindowX is int x
-                && state.WindowY is int y)
-            {
-                return (x, y, w, h);
-            }
+            return Ghostty.Settings.WindowState.Load();
         }
-        catch
+        catch (Exception ex)
         {
-            // Unreadable state file. Fall through to the centred default.
+            Diag($"could not read the saved window state: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Where the main window is about to appear, in physical pixels.
+    /// </summary>
+    /// <remarks>
+    /// Applies the same plausibility rules as
+    /// <c>MainWindow.ApplyGeometry</c>, which decides where the window
+    /// really goes. A saved rect the window would reject is one the splash
+    /// must reject too: closing while minimized saves a 160x31 rect at
+    /// (-32000,-32000), and honouring that puts the splash off-screen for
+    /// the whole cold start, which is a silent no-op of the feature.
+    /// The window's own check uses WinUI's DisplayArea, which does not
+    /// exist yet on this thread, so this uses the virtual screen instead.
+    /// </remarks>
+    private static (int X, int Y, int Width, int Height) ResolveRect(
+        Ghostty.Settings.WindowState? state)
+    {
+        if (state is not null
+            && state.WindowWidth is int w and >= MinPlausibleWidth
+            && state.WindowHeight is int h and >= MinPlausibleHeight
+            && state.WindowX is int x
+            && state.WindowY is int y
+            && IntersectsVirtualScreen(x, y, w, h))
+        {
+            // A maximized window comes up filling its monitor's work area,
+            // not the restored rect that was saved alongside the flag.
+            if (state.WindowMaximized && TryGetWorkArea(x, y, w, h, out var work))
+            {
+                return work;
+            }
+            return (x, y, w, h);
         }
 
         var screenWidth = GetSystemMetrics(SM_CXSCREEN);
@@ -462,17 +634,47 @@ internal static unsafe partial class SplashWindow
         return ((screenWidth - width) / 2, (screenHeight - height) / 2, width, height);
     }
 
-    private static uint ResolveBackgroundRgb()
+    /// <summary>
+    /// True when any part of the rect lands on a live monitor. Guards
+    /// against a saved position on a display that is no longer attached.
+    /// </summary>
+    private static bool IntersectsVirtualScreen(int x, int y, int w, int h)
     {
-        try
-        {
-            if (Ghostty.Settings.WindowState.Load().BackgroundRgb is uint saved)
-                return saved & 0x00FFFFFFu;
-        }
-        catch
-        {
-            // Unreadable state file. Fall through to the default.
-        }
+        var vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        var vy = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        var vw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        var vh = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        if (vw <= 0 || vh <= 0) return true; // Nothing to check against.
+
+        return x < vx + vw && x + w > vx && y < vy + vh && y + h > vy;
+    }
+
+    /// <summary>
+    /// Work area of the monitor holding the centre of the given rect.
+    /// </summary>
+    private static bool TryGetWorkArea(
+        int x, int y, int w, int h, out (int X, int Y, int Width, int Height) area)
+    {
+        area = default;
+
+        var centre = new POINT { x = x + (w / 2), y = y + (h / 2) };
+        var monitor = MonitorFromPoint(centre, MONITOR_DEFAULTTONEAREST);
+        if (monitor == 0) return false;
+
+        var info = new MONITORINFO { cbSize = (uint)sizeof(MONITORINFO) };
+        if (GetMonitorInfoW(monitor, ref info) == 0) return false;
+
+        var width = info.rcWork.right - info.rcWork.left;
+        var height = info.rcWork.bottom - info.rcWork.top;
+        if (width <= 0 || height <= 0) return false;
+
+        area = (info.rcWork.left, info.rcWork.top, width, height);
+        return true;
+    }
+
+    private static uint ResolveBackgroundRgb(Ghostty.Settings.WindowState? state)
+    {
+        if (state?.BackgroundRgb is uint saved) return saved & 0x00FFFFFFu;
         return DefaultBackgroundRgb;
     }
 
@@ -526,10 +728,21 @@ internal static unsafe partial class SplashWindow
     private const uint ULW_ALPHA = 0x00000002;
     private const int SM_CXSCREEN = 0;
     private const int SM_CYSCREEN = 1;
+    private const int SM_XVIRTUALSCREEN = 76;
+    private const int SM_YVIRTUALSCREEN = 77;
+    private const int SM_CXVIRTUALSCREEN = 78;
+    private const int SM_CYVIRTUALSCREEN = 79;
+    private const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
     private static readonly nint HWND_TOPMOST = -1;
     private const uint SWP_NOSIZE = 0x0001;
     private const uint SWP_NOMOVE = 0x0002;
     private const uint SWP_NOACTIVATE = 0x0010;
+
+    // Post the z-order change instead of waiting on it. SetWindowPos
+    // otherwise notifies other top-level windows synchronously, and the
+    // thread it would be waiting on is the UI thread that is busy doing
+    // the startup work this splash exists to cover.
+    private const uint SWP_ASYNCWINDOWPOS = 0x4000;
     private static readonly nint IDC_ARROW = 32512;
     private const int InterpolationModeHighQualityBicubic = 7;
     private const int PixelOffsetModeHighQuality = 4;
@@ -584,6 +797,15 @@ internal static unsafe partial class SplashWindow
 
     [StructLayout(LayoutKind.Sequential)]
     private struct POINT { public int x; public int y; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MONITORINFO
+    {
+        public uint cbSize;
+        public RECT rcMonitor;
+        public RECT rcWork;
+        public uint dwFlags;
+    }
 
     [StructLayout(LayoutKind.Sequential)]
     private struct MSG
@@ -653,6 +875,15 @@ internal static unsafe partial class SplashWindow
 
     [LibraryImport("user32.dll")]
     private static partial uint GetDpiForWindow(nint hwnd);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint GetForegroundWindow();
+
+    [LibraryImport("user32.dll")]
+    private static partial nint MonitorFromPoint(POINT pt, uint flags);
+
+    [LibraryImport("user32.dll")]
+    private static partial int GetMonitorInfoW(nint monitor, ref MONITORINFO info);
 
     [LibraryImport("user32.dll")]
     private static partial int GetSystemMetrics(int index);

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -68,6 +68,25 @@ internal static unsafe partial class SplashWindow
     private static readonly ManualResetEventSlim _dismissed = new(false);
     private static int _started;
     private static long _shownAtTicks;
+    private static nint _trackedHwnd;
+
+    // Current splash geometry, owned by the splash thread. Mutable
+    // because the splash follows the main window, which the user can move
+    // or resize while it is still up.
+    private static int _width;
+    private static int _height;
+    private static uint _background;
+    private static double _scale = 1.0;
+
+    /// <summary>
+    /// Follow <paramref name="hwnd"/> from now on. Called once the main
+    /// window exists, so that moving or resizing it while the splash is
+    /// still up keeps the two together instead of leaving the icon
+    /// stranded where the window used to be. The alternative -- pinning
+    /// the window in place until the splash goes -- would take a
+    /// legitimate action away from the user to keep a decoration tidy.
+    /// </summary>
+    public static void Track(nint hwnd) => Volatile.Write(ref _trackedHwnd, hwnd);
 
     /// <summary>
     /// Milliseconds the splash has been on screen, or 0 if it was never
@@ -132,7 +151,9 @@ internal static unsafe partial class SplashWindow
     private static void RunSplash()
     {
         var (x, y, width, height) = ResolveRect();
-        var background = ResolveBackgroundRgb();
+        _width = width;
+        _height = height;
+        _background = ResolveBackgroundRgb();
 
         if (!RegisterWindowClass()) return;
 
@@ -160,16 +181,14 @@ internal static unsafe partial class SplashWindow
             // assigned it to a monitor.
             var dpi = GetDpiForWindow(_hwnd);
             if (dpi == 0) dpi = 96;
-            var scale = dpi / 96.0;
-            var iconPx = (int)Math.Round(
-                LaunchIconMetrics.Resolve(width / scale, height / scale) * scale);
+            _scale = dpi / 96.0;
 
-            if (!Paint(width, height, background, iconPx, 255)) return;
+            if (!Paint(255)) return;
             ShowWindow(_hwnd, SW_SHOWNA);
             Volatile.Write(ref _shownAtTicks, Environment.TickCount64);
 
             PumpUntilDismissed();
-            FadeOut(width, height, background, iconPx);
+            FadeOut();
         }
         finally
         {
@@ -208,6 +227,12 @@ internal static unsafe partial class SplashWindow
                 nextTopmostNudge = now + TopmostNudgeIntervalMs;
             }
 
+            // Checked every tick, not throttled: this one tracks a drag,
+            // so anything slower shows the splash lagging behind the
+            // window. It is a GetWindowRect and, only on an actual
+            // change, a SetWindowPos.
+            FollowTrackedWindow();
+
             while (PeekMessageW(out var msg, 0, 0, 0, PM_REMOVE) != 0)
             {
                 TranslateMessage(ref msg);
@@ -219,13 +244,48 @@ internal static unsafe partial class SplashWindow
         }
     }
 
-    private static void FadeOut(int width, int height, uint background, int iconPx)
+    /// <summary>
+    /// Keep the splash glued to the window it is covering. Without this,
+    /// moving the window during startup slides it out from under the
+    /// splash, leaving the icon floating over the desktop and the black
+    /// gap exposed.
+    /// </summary>
+    private static void FollowTrackedWindow()
+    {
+        var tracked = Volatile.Read(ref _trackedHwnd);
+        if (tracked == 0) return;
+        if (GetWindowRect(tracked, out var r) == 0) return;
+
+        var width = r.right - r.left;
+        var height = r.bottom - r.top;
+        if (width <= 0 || height <= 0) return;
+
+        if (GetWindowRect(_hwnd, out var mine) != 0
+            && mine.left == r.left && mine.top == r.top
+            && mine.right - mine.left == width && mine.bottom - mine.top == height)
+        {
+            return;
+        }
+
+        var resized = width != _width || height != _height;
+        _width = width;
+        _height = height;
+
+        SetWindowPos(_hwnd, HWND_TOPMOST, r.left, r.top, width, height, SWP_NOACTIVATE);
+
+        // A move alone keeps the existing layered bitmap; a resize needs a
+        // new one, both because the surface is a different size and
+        // because the icon rescales with the window.
+        if (resized) Paint(255);
+    }
+
+    private static void FadeOut()
     {
         var steps = Math.Max(1, FadeDurationMs / FadeStepMs);
         for (var i = steps - 1; i >= 0; i--)
         {
             var alpha = (byte)(255 * i / steps);
-            if (!Paint(width, height, background, iconPx, alpha)) break;
+            if (!Paint(alpha)) break;
             Thread.Sleep(FadeStepMs);
         }
     }
@@ -236,8 +296,14 @@ internal static unsafe partial class SplashWindow
     /// <paramref name="alpha"/> alone drives the fade and there is no
     /// premultiplied alpha to get wrong.
     /// </summary>
-    private static bool Paint(int width, int height, uint background, int iconPx, byte alpha)
+    private static bool Paint(byte alpha)
     {
+        var width = _width;
+        var height = _height;
+        var background = _background;
+        var iconPx = (int)Math.Round(
+            LaunchIconMetrics.Resolve(width / _scale, height / _scale) * _scale);
+
         var screenDc = GetDC(0);
         if (screenDc == 0) return false;
 
@@ -514,6 +580,9 @@ internal static unsafe partial class SplashWindow
     private struct SIZE { public int cx; public int cy; }
 
     [StructLayout(LayoutKind.Sequential)]
+    private struct RECT { public int left; public int top; public int right; public int bottom; }
+
+    [StructLayout(LayoutKind.Sequential)]
     private struct POINT { public int x; public int y; }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -569,6 +638,9 @@ internal static unsafe partial class SplashWindow
 
     [LibraryImport("user32.dll")]
     private static partial void PostQuitMessage(int exitCode);
+
+    [LibraryImport("user32.dll")]
+    private static partial int GetWindowRect(nint hwnd, out RECT rect);
 
     [LibraryImport("user32.dll")]
     private static partial nint LoadCursorW(nint instance, nint cursorName);


### PR DESCRIPTION
A cold start shows a black window for several seconds while WinUI starts, the
config loads, libghostty initialises and the first surface renders. This covers
that gap with the app icon, the way the Windows Clock app does.

A Win32 layered window puts the icon up before WinUI starts, on its own thread,
so none of the startup work delays it. It follows the main window's position and
size, passes clicks and hit-testing through to whatever is underneath, and fades
out once the first surface has actually rendered.

The icon is sized to the window (a quarter of the shorter edge, clamped to
48-160 DIP) so a small window gets a smaller icon. Assets ship at four scale
factors.

Measured on a cold start: the icon is on screen at 0.8-1.4s against 6.8s before,
and sampling every 150ms no longer catches a black frame.

The last commit is review fixes, the ones worth calling out being: only the
first restored window drives the splash (all of them armed it before, so they
fought over the single instance and the first to render dismissed it for the
rest); dismissal waits on the active tab's surface rather than tab zero's, which
never presents when a restored session makes another tab active; and the fade
re-blends one composed bitmap instead of rebuilding it, with a PNG decode, on
each of its 13 frames.

Known gaps, none of them new to this change and none blocking: the splash does
not react to WM_DPICHANGED, so dragging across monitors of different scale
during startup leaves the icon at the launch monitor's size; the icon rung table
is duplicated between the generator and the consumer with only the generator
side tested; and SplashWindow itself has no unit tests, being almost entirely
Win32 calls.
