### PR TITLE
config: search the pre-rename themes directory, and unwind Reload safely

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -560,7 +560,12 @@ language: ?[:0]const u8 = null,
 /// configuration directory. This is `$XDG_CONFIG_HOME/wintty/themes` or
 /// `~/.config/wintty/themes`.
 ///
-/// The second directory is the `themes` subdirectory of the Ghostty resources
+/// The second directory is the same subdirectory under the pre-rename
+/// configuration directory, `ghostty` in place of `wintty`. It is searched
+/// so an install that predates the rename keeps its themes, matching how
+/// the configuration file itself is searched under both names.
+///
+/// The third directory is the `themes` subdirectory of the Ghostty resources
 /// directory. Ghostty ships with a multitude of themes that will be installed
 /// into this directory. On macOS, this list is in the
 /// `Ghostty.app/Contents/Resources/ghostty/themes` directory. On Linux, this

--- a/src/config/theme.zig
+++ b/src/config/theme.zig
@@ -50,7 +50,7 @@ pub const Location = enum {
         arena_alloc: Allocator,
         environ_map: *const std.process.Environ.Map,
         app_dir: []const u8,
-    ) error{ OutOfMemory, Unexpected }!?[]const u8 {
+    ) error{OutOfMemory}!?[]const u8 {
         const subdir = std.fs.path.join(arena_alloc, &.{
             app_dir, "themes",
         }) catch return error.OutOfMemory;
@@ -294,4 +294,14 @@ pub fn openAbsolute(
 
         return null;
     };
+}
+
+test "theme search order prefers the current config dir over the pre-rename one" {
+    const testing = std.testing;
+
+    // Priority is positional: LocationIterator walks the enum in
+    // declaration order, so an install that has migrated must reach its
+    // themes before one that has not, and both before the bundled ones.
+    try testing.expect(@intFromEnum(Location.user) < @intFromEnum(Location.user_ghostty));
+    try testing.expect(@intFromEnum(Location.user_ghostty) < @intFromEnum(Location.resources));
 }

--- a/src/config/theme.zig
+++ b/src/config/theme.zig
@@ -296,12 +296,15 @@ pub fn openAbsolute(
     };
 }
 
-test "theme search order prefers the current config dir over the pre-rename one" {
+test "theme: search order prefers the current config dir over the pre-rename one" {
     const testing = std.testing;
 
-    // Priority is positional: LocationIterator walks the enum in
-    // declaration order, so an install that has migrated must reach its
-    // themes before one that has not, and both before the bundled ones.
+    // A change detector, deliberately. LocationIterator walks the enum by
+    // ordinal, so the declaration order in this file *is* the priority,
+    // and a reorder that looked harmless would silently make an unmigrated
+    // install shadow a migrated one. Driving the iterator instead would
+    // only assert against whatever directories the test machine happens to
+    // have.
     try testing.expect(@intFromEnum(Location.user) < @intFromEnum(Location.user_ghostty));
     try testing.expect(@intFromEnum(Location.user_ghostty) < @intFromEnum(Location.resources));
 }

--- a/src/config/theme.zig
+++ b/src/config/theme.zig
@@ -9,6 +9,7 @@ const global = @import("../global.zig");
 /// defines the priority of theme search (from top to bottom).
 pub const Location = enum {
     user, // XDG config dir
+    user_ghostty, // XDG config dir from before the rename
     resources, // Ghostty resources dir
 
     /// Returns the directory for the given theme based on this location type.
@@ -27,41 +28,56 @@ pub const Location = enum {
         var environ_map = try global.environMap();
         defer environ_map.deinit();
         return switch (self) {
-            .user => user: {
-                const subdir = std.fs.path.join(arena_alloc, &.{
-                    "wintty", "themes",
-                }) catch return error.OutOfMemory;
-
-                break :user internal_os.xdg.config(
-                    global.io(),
-                    arena_alloc,
-                    &environ_map,
-                    .{ .subdir = subdir },
-                ) catch |err| {
-                    // We need to do some comptime tricks to get the right
-                    // error set since some platforms don't support some
-                    // error types.
-                    const Error = @TypeOf(err) || switch (builtin.os.tag) {
-                        .ios => error{BufferTooSmall},
-                        else => error{},
-                    };
-
-                    switch (@as(Error, err)) {
-                        error.OutOfMemory => return error.OutOfMemory,
-                        error.BufferTooSmall => return error.OutOfMemory,
-
-                        // Any other error we treat as the XDG directory not
-                        // existing. Windows in particularly can return a LOT
-                        // of errors here.
-                        else => return null,
-                    }
-                };
-            },
+            .user => try xdgThemesDir(arena_alloc, &environ_map, "wintty"),
+            .user_ghostty => try xdgThemesDir(arena_alloc, &environ_map, "ghostty"),
 
             .resources => try std.fs.path.join(arena_alloc, &.{
                 global.resourcesDir().app() orelse return null,
                 "themes",
             }),
+        };
+    }
+
+    /// The `themes` subdirectory of an XDG config directory, for the given
+    /// application directory name.
+    ///
+    /// Two names are searched because the config file itself is searched
+    /// under both (see config/file_load.zig): an install that predates the
+    /// rename keeps its config, and therefore its themes, under the old
+    /// name. Without the second name such an install silently falls back to
+    /// the built-in defaults for every theme it has.
+    fn xdgThemesDir(
+        arena_alloc: Allocator,
+        environ_map: *const std.process.Environ.Map,
+        app_dir: []const u8,
+    ) error{ OutOfMemory, Unexpected }!?[]const u8 {
+        const subdir = std.fs.path.join(arena_alloc, &.{
+            app_dir, "themes",
+        }) catch return error.OutOfMemory;
+
+        return internal_os.xdg.config(
+            global.io(),
+            arena_alloc,
+            environ_map,
+            .{ .subdir = subdir },
+        ) catch |err| {
+            // We need to do some comptime tricks to get the right
+            // error set since some platforms don't support some
+            // error types.
+            const Error = @TypeOf(err) || switch (builtin.os.tag) {
+                .ios => error{BufferTooSmall},
+                else => error{},
+            };
+
+            switch (@as(Error, err)) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.BufferTooSmall => return error.OutOfMemory,
+
+                // Any other error we treat as the XDG directory not
+                // existing. Windows in particularly can return a LOT
+                // of errors here.
+                else => return null,
+            }
         };
     }
 };

--- a/windows/Ghostty.Core/Config/ThemeSearchPath.cs
+++ b/windows/Ghostty.Core/Config/ThemeSearchPath.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -24,50 +25,58 @@ public static class ThemeSearchPath
     /// Directories to search, most current first, without duplicates.
     /// </summary>
     /// <param name="configDirectory">
-    /// Directory holding the config file libghostty actually loaded.
-    /// Probed first because libghostty resolved it, so it already accounts
-    /// for XDG_CONFIG_HOME and for an APPDATA that a portable launcher has
-    /// redirected -- neither of which the fallbacks below can see.
+    /// Directory holding the config file libghostty resolved for editing.
+    /// Its parent is the config root, which is where the sibling names
+    /// below are looked for -- that root already accounts for
+    /// XDG_CONFIG_HOME and for an APPDATA a portable launcher redirected,
+    /// neither of which <paramref name="appData"/> can see.
     /// </param>
-    /// <param name="appData">Roaming application data directory.</param>
+    /// <param name="appData">
+    /// Roaming application data directory, used only when there is no
+    /// config directory to derive a root from.
+    /// </param>
     public static IEnumerable<string> UserDirectories(string? configDirectory, string? appData)
     {
-        var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        string? configRoot = null;
         if (!string.IsNullOrEmpty(configDirectory))
         {
-            var fromConfig = Path.Combine(configDirectory, "themes");
+            var trimmed = Path.TrimEndingDirectorySeparator(configDirectory);
+            configRoot = Path.GetDirectoryName(trimmed);
+
+            var fromConfig = Path.Combine(trimmed, "themes");
             if (seen.Add(fromConfig)) yield return fromConfig;
         }
 
-        if (string.IsNullOrEmpty(appData)) yield break;
+        // Both application directory names under the config root, current
+        // first, matching theme.zig's two xdgThemesDir calls. An install
+        // can hold its config under one name and its themes under the
+        // other, so the sibling is not reachable from configDirectory
+        // alone. Falling back to appData only when there is no root to
+        // derive keeps this from probing directories libghostty would
+        // never look at.
+        var root = configRoot ?? appData;
+        if (string.IsNullOrEmpty(root)) yield break;
 
-        // The two application directory names, current first, matching the
-        // `user` and `user_ghostty` entries of theme.zig's Location enum.
-        // An install can hold its config under one name and its themes
-        // under the other, so neither is reachable from configDirectory
-        // alone.
-        foreach (var app in new[] { "wintty", "ghostty" })
+        foreach (var app in AppDirectoryNames)
         {
-            var dir = Path.Combine(appData, app, "themes");
+            var dir = Path.Combine(root, app, "themes");
             if (seen.Add(dir)) yield return dir;
         }
     }
 
+    private static readonly string[] AppDirectoryNames = ["wintty", "ghostty"];
+
     /// <summary>
-    /// True when a theme value names a file to look up in the search
-    /// directories, rather than an absolute path or something with a
-    /// directory component.
+    /// True when a theme value is a bare file name to look up in the
+    /// search directories. False for an absolute path, which is used
+    /// as-is, and for a relative name with a directory component, which
+    /// theme.zig refuses outright with a diagnostic -- resolving one here
+    /// would load a theme the terminal never applied.
     /// </summary>
-    /// <remarks>
-    /// theme.zig rejects a relative name containing a path separator
-    /// outright, with a diagnostic. Accepting one here would resolve a
-    /// theme libghostty refuses, which is the same disagreement by another
-    /// route -- the terminal falls back to defaults while the chrome loads
-    /// whatever the traversal reached.
-    /// </remarks>
     public static bool IsSearchableName(string themeName)
         => !string.IsNullOrEmpty(themeName)
            && !Path.IsPathRooted(themeName)
-           && string.Equals(themeName, Path.GetFileName(themeName), System.StringComparison.Ordinal);
+           && string.Equals(themeName, Path.GetFileName(themeName), StringComparison.Ordinal);
 }

--- a/windows/Ghostty.Core/Config/ThemeSearchPath.cs
+++ b/windows/Ghostty.Core/Config/ThemeSearchPath.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Where to look for a user theme file, and which names are allowed.
+///
+/// This mirrors src/config/theme.zig. The two read the same theme for
+/// different halves of one window -- libghostty renders the terminal from
+/// it, the Windows shell reads it for the chrome around it -- so any
+/// disagreement shows as a pane framed in a different palette than it is
+/// filled with. Kept as a separate, testable piece because the rule has
+/// drifted between the two sides before.
+/// </summary>
+/// <remarks>
+/// Duplicated rather than shared: libghostty exports no theme-path call
+/// today. An export wrapping theme.zig's own lookup would remove this
+/// file and the whole class of drift with it.
+/// </remarks>
+public static class ThemeSearchPath
+{
+    /// <summary>
+    /// Directories to search, most current first, without duplicates.
+    /// </summary>
+    /// <param name="configDirectory">
+    /// Directory holding the config file libghostty actually loaded.
+    /// Probed first because libghostty resolved it, so it already accounts
+    /// for XDG_CONFIG_HOME and for an APPDATA that a portable launcher has
+    /// redirected -- neither of which the fallbacks below can see.
+    /// </param>
+    /// <param name="appData">Roaming application data directory.</param>
+    public static IEnumerable<string> UserDirectories(string? configDirectory, string? appData)
+    {
+        var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrEmpty(configDirectory))
+        {
+            var fromConfig = Path.Combine(configDirectory, "themes");
+            if (seen.Add(fromConfig)) yield return fromConfig;
+        }
+
+        if (string.IsNullOrEmpty(appData)) yield break;
+
+        // The two application directory names, current first, matching the
+        // `user` and `user_ghostty` entries of theme.zig's Location enum.
+        // An install can hold its config under one name and its themes
+        // under the other, so neither is reachable from configDirectory
+        // alone.
+        foreach (var app in new[] { "wintty", "ghostty" })
+        {
+            var dir = Path.Combine(appData, app, "themes");
+            if (seen.Add(dir)) yield return dir;
+        }
+    }
+
+    /// <summary>
+    /// True when a theme value names a file to look up in the search
+    /// directories, rather than an absolute path or something with a
+    /// directory component.
+    /// </summary>
+    /// <remarks>
+    /// theme.zig rejects a relative name containing a path separator
+    /// outright, with a diagnostic. Accepting one here would resolve a
+    /// theme libghostty refuses, which is the same disagreement by another
+    /// route -- the terminal falls back to defaults while the chrome loads
+    /// whatever the traversal reached.
+    /// </remarks>
+    public static bool IsSearchableName(string themeName)
+        => !string.IsNullOrEmpty(themeName)
+           && !Path.IsPathRooted(themeName)
+           && string.Equals(themeName, Path.GetFileName(themeName), System.StringComparison.Ordinal);
+}

--- a/windows/Ghostty.Core/Config/ThemeSearchPath.cs
+++ b/windows/Ghostty.Core/Config/ThemeSearchPath.cs
@@ -56,7 +56,9 @@ public static class ThemeSearchPath
         // alone. Falling back to appData only when there is no root to
         // derive keeps this from probing directories libghostty would
         // never look at.
-        var root = configRoot ?? appData;
+        // GetDirectoryName gives null for a root and "" for a bare
+        // segment; neither is a usable root, so both fall back.
+        var root = string.IsNullOrEmpty(configRoot) ? appData : configRoot;
         if (string.IsNullOrEmpty(root)) yield break;
 
         foreach (var app in AppDirectoryNames)
@@ -77,6 +79,25 @@ public static class ThemeSearchPath
     /// </summary>
     public static bool IsSearchableName(string themeName)
         => !string.IsNullOrEmpty(themeName)
-           && !Path.IsPathRooted(themeName)
+           && !IsAbsolute(themeName)
            && string.Equals(themeName, Path.GetFileName(themeName), StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when a theme value is an absolute path, by the same rule
+    /// std.fs.path.isAbsoluteWindows uses: a leading separator, or a drive
+    /// letter followed by one.
+    /// </summary>
+    /// <remarks>
+    /// Path.IsPathRooted alone is wider than that rule. It also accepts
+    /// the drive-relative form with no separator, <c>C:mocha</c>, which
+    /// libghostty treats as a plain name, finds a directory component in,
+    /// and rejects. Taking it as absolute here would theme the chrome from
+    /// a file the terminal refused.
+    /// </remarks>
+    public static bool IsAbsolute(string themeName)
+    {
+        if (string.IsNullOrEmpty(themeName)) return false;
+        if (themeName[0] is '\\' or '/') return true;
+        return Path.IsPathFullyQualified(themeName);
+    }
 }

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -11,11 +11,11 @@ internal static class LogEvents
     // 1000-1099: Config
     internal static class Config
     {
-        public const int ReloadFailed       = 1000;
-        public const int WriteSchedulerErr  = 1001;
-        public const int TimerDisposeSlow   = 1002;
-        public const int SeedFailed         = 1003;
-        public const int SettingsWriteErr   = 1004;
+        public const int ReloadFailed          = 1000;
+        public const int WriteSchedulerErr     = 1001;
+        public const int TimerDisposeSlow      = 1002;
+        public const int SeedFailed            = 1003;
+        public const int SettingsWriteErr      = 1004;
         public const int ThemeRefreshFailed    = 1005;
         public const int SnapshotRefreshFailed = 1006;
     }

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -16,7 +16,7 @@ internal static class LogEvents
         public const int TimerDisposeSlow   = 1002;
         public const int SeedFailed         = 1003;
         public const int SettingsWriteErr   = 1004;
-        public const int ThemeRefreshFailed = 1005;
+        public const int ThemeRefreshFailed    = 1005;
         public const int SnapshotRefreshFailed = 1006;
     }
 

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -17,6 +17,7 @@ internal static class LogEvents
         public const int SeedFailed         = 1003;
         public const int SettingsWriteErr   = 1004;
         public const int ThemeRefreshFailed = 1005;
+        public const int SnapshotRefreshFailed = 1006;
     }
 
     // 1100-1199: Frecency / command history

--- a/windows/Ghostty.Tests/Config/ThemeSearchPathTests.cs
+++ b/windows/Ghostty.Tests/Config/ThemeSearchPathTests.cs
@@ -10,14 +10,6 @@ public class ThemeSearchPathTests
     private const string AppData = @"C:\Users\u\AppData\Roaming";
 
     [Fact]
-    public void Config_directory_is_searched_first()
-    {
-        var dirs = ThemeSearchPath.UserDirectories(@"D:\dotfiles\wintty", AppData).ToList();
-
-        Assert.Equal(Path.Combine(@"D:\dotfiles\wintty", "themes"), dirs[0]);
-    }
-
-    [Fact]
     public void Sibling_name_is_searched_under_the_config_root_not_app_data()
     {
         // With XDG_CONFIG_HOME set, libghostty's two user locations are both
@@ -35,7 +27,6 @@ public class ThemeSearchPathTests
                 Path.Combine(@"D:\dotfiles", "ghostty", "themes"),
             },
             dirs);
-        Assert.DoesNotContain(dirs, d => d.Contains("AppData"));
     }
 
     [Fact]
@@ -109,7 +100,6 @@ public class ThemeSearchPathTests
     [InlineData(@"..\..\secrets.ini")]
     [InlineData("sub/theme")]
     [InlineData(@"sub\theme")]
-    [InlineData("")]
     public void Relative_names_with_a_directory_component_are_not_searchable(string name)
     {
         // theme.zig rejects these outright, so resolving one here would
@@ -118,11 +108,41 @@ public class ThemeSearchPathTests
     }
 
     [Fact]
-    public void Absolute_names_are_not_searched_because_they_are_used_as_is()
+    public void Empty_name_is_not_searchable()
     {
-        // theme.zig routes an absolute theme through openAbsolute rather
-        // than the search directories, and so does the caller here. This
-        // is not a rejection.
-        Assert.False(ThemeSearchPath.IsSearchableName(@"C:\themes\Mocha"));
+        Assert.False(ThemeSearchPath.IsSearchableName(""));
+    }
+
+    [Theory]
+    [InlineData(@"C:\themes\Mocha")]
+    [InlineData(@"\themes\Mocha")]
+    [InlineData("/themes/Mocha")]
+    [InlineData(@"\\server\share\Mocha")]
+    public void Absolute_names_are_used_as_is_not_searched(string name)
+    {
+        // theme.zig routes these through openAbsolute rather than the
+        // search directories, and so does ResolveThemePath.
+        Assert.True(ThemeSearchPath.IsAbsolute(name));
+        Assert.False(ThemeSearchPath.IsSearchableName(name));
+    }
+
+    [Theory]
+    [InlineData("C:mocha")]
+    [InlineData("C:")]
+    public void Drive_relative_names_are_not_absolute(string name)
+    {
+        // Path.IsPathRooted accepts these, std.fs.path.isAbsoluteWindows
+        // does not. Treating them as absolute would theme the chrome from
+        // a file resolved against the drive's working directory, while
+        // libghostty finds a directory component and refuses the theme.
+        Assert.False(ThemeSearchPath.IsAbsolute(name));
+    }
+
+    [Theory]
+    [InlineData("Catppuccin Mocha")]
+    [InlineData("3024 Night")]
+    public void Plain_names_are_not_absolute(string name)
+    {
+        Assert.False(ThemeSearchPath.IsAbsolute(name));
     }
 }

--- a/windows/Ghostty.Tests/Config/ThemeSearchPathTests.cs
+++ b/windows/Ghostty.Tests/Config/ThemeSearchPathTests.cs
@@ -10,14 +10,32 @@ public class ThemeSearchPathTests
     private const string AppData = @"C:\Users\u\AppData\Roaming";
 
     [Fact]
-    public void Config_directory_is_searched_before_the_fallbacks()
+    public void Config_directory_is_searched_first()
     {
-        // It is the only entry that reflects XDG_CONFIG_HOME or a
-        // redirected APPDATA, because libghostty resolved it.
         var dirs = ThemeSearchPath.UserDirectories(@"D:\dotfiles\wintty", AppData).ToList();
 
         Assert.Equal(Path.Combine(@"D:\dotfiles\wintty", "themes"), dirs[0]);
-        Assert.Equal(3, dirs.Count);
+    }
+
+    [Fact]
+    public void Sibling_name_is_searched_under_the_config_root_not_app_data()
+    {
+        // With XDG_CONFIG_HOME set, libghostty's two user locations are both
+        // under that root. Probing %APPDATA% instead would miss the sibling
+        // and probe directories libghostty never looks at.
+        var dirs = ThemeSearchPath.UserDirectories(@"D:\dotfiles\wintty", AppData).ToList();
+
+        // Only two: the config directory's own themes dir and the sibling
+        // under the same root are the same path when the config already
+        // lives under the current name, so the dedupe collapses them.
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine(@"D:\dotfiles", "wintty", "themes"),
+                Path.Combine(@"D:\dotfiles", "ghostty", "themes"),
+            },
+            dirs);
+        Assert.DoesNotContain(dirs, d => d.Contains("AppData"));
     }
 
     [Fact]
@@ -35,23 +53,42 @@ public class ThemeSearchPathTests
     }
 
     [Fact]
-    public void Config_directory_matching_a_fallback_is_not_searched_twice()
+    public void Config_directory_matching_a_sibling_is_not_searched_twice()
     {
         var dirs = ThemeSearchPath.UserDirectories(Path.Combine(AppData, "ghostty"), AppData).ToList();
 
-        Assert.Equal(3 - 1, dirs.Count);
+        Assert.Equal(2, dirs.Count);
         Assert.Equal(Path.Combine(AppData, "ghostty", "themes"), dirs[0]);
         Assert.Equal(Path.Combine(AppData, "wintty", "themes"), dirs[1]);
+    }
+
+    [Fact]
+    public void Dedupe_ignores_case_because_the_two_sources_are_cased_differently()
+    {
+        // The config directory arrives via GetFullPath of a Zig-produced
+        // path; app data via the shell. They can differ only in case.
+        var dirs = ThemeSearchPath.UserDirectories(@"C:\Users\u\AppData\Roaming\GHOSTTY", AppData).ToList();
+
+        Assert.Equal(2, dirs.Count);
+    }
+
+    [Fact]
+    public void Trailing_separator_on_the_config_directory_does_not_defeat_dedupe()
+    {
+        var dirs = ThemeSearchPath.UserDirectories(Path.Combine(AppData, "ghostty") + @"\", AppData).ToList();
+
+        Assert.Equal(2, dirs.Count);
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void Missing_app_data_still_yields_the_config_directory(string? appData)
+    public void Missing_app_data_still_yields_from_the_config_directory(string? appData)
     {
-        var dirs = ThemeSearchPath.UserDirectories(@"D:\cfg", appData).ToList();
+        var dirs = ThemeSearchPath.UserDirectories(@"D:\cfg\wintty", appData).ToList();
 
-        Assert.Equal(Path.Combine(@"D:\cfg", "themes"), Assert.Single(dirs));
+        Assert.Equal(Path.Combine(@"D:\cfg\wintty", "themes"), dirs[0]);
+        Assert.Contains(Path.Combine(@"D:\cfg", "ghostty", "themes"), dirs);
     }
 
     [Fact]
@@ -72,13 +109,20 @@ public class ThemeSearchPathTests
     [InlineData(@"..\..\secrets.ini")]
     [InlineData("sub/theme")]
     [InlineData(@"sub\theme")]
-    [InlineData(@"C:\themes\Mocha")]
     [InlineData("")]
-    public void Names_libghostty_refuses_are_not_searchable(string name)
+    public void Relative_names_with_a_directory_component_are_not_searchable(string name)
     {
-        // theme.zig rejects a relative name with a separator, and routes an
-        // absolute one down a different path entirely. Resolving either
-        // here would load a theme the terminal never applied.
+        // theme.zig rejects these outright, so resolving one here would
+        // load a theme the terminal never applied.
         Assert.False(ThemeSearchPath.IsSearchableName(name));
+    }
+
+    [Fact]
+    public void Absolute_names_are_not_searched_because_they_are_used_as_is()
+    {
+        // theme.zig routes an absolute theme through openAbsolute rather
+        // than the search directories, and so does the caller here. This
+        // is not a rejection.
+        Assert.False(ThemeSearchPath.IsSearchableName(@"C:\themes\Mocha"));
     }
 }

--- a/windows/Ghostty.Tests/Config/ThemeSearchPathTests.cs
+++ b/windows/Ghostty.Tests/Config/ThemeSearchPathTests.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using System.Linq;
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public class ThemeSearchPathTests
+{
+    private const string AppData = @"C:\Users\u\AppData\Roaming";
+
+    [Fact]
+    public void Config_directory_is_searched_before_the_fallbacks()
+    {
+        // It is the only entry that reflects XDG_CONFIG_HOME or a
+        // redirected APPDATA, because libghostty resolved it.
+        var dirs = ThemeSearchPath.UserDirectories(@"D:\dotfiles\wintty", AppData).ToList();
+
+        Assert.Equal(Path.Combine(@"D:\dotfiles\wintty", "themes"), dirs[0]);
+        Assert.Equal(3, dirs.Count);
+    }
+
+    [Fact]
+    public void Current_application_name_is_searched_before_the_pre_rename_one()
+    {
+        var dirs = ThemeSearchPath.UserDirectories(null, AppData).ToList();
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine(AppData, "wintty", "themes"),
+                Path.Combine(AppData, "ghostty", "themes"),
+            },
+            dirs);
+    }
+
+    [Fact]
+    public void Config_directory_matching_a_fallback_is_not_searched_twice()
+    {
+        var dirs = ThemeSearchPath.UserDirectories(Path.Combine(AppData, "ghostty"), AppData).ToList();
+
+        Assert.Equal(3 - 1, dirs.Count);
+        Assert.Equal(Path.Combine(AppData, "ghostty", "themes"), dirs[0]);
+        Assert.Equal(Path.Combine(AppData, "wintty", "themes"), dirs[1]);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Missing_app_data_still_yields_the_config_directory(string? appData)
+    {
+        var dirs = ThemeSearchPath.UserDirectories(@"D:\cfg", appData).ToList();
+
+        Assert.Equal(Path.Combine(@"D:\cfg", "themes"), Assert.Single(dirs));
+    }
+
+    [Fact]
+    public void No_directories_at_all_yields_nothing()
+    {
+        Assert.Empty(ThemeSearchPath.UserDirectories(null, null));
+    }
+
+    [Theory]
+    [InlineData("Catppuccin Mocha")]
+    [InlineData("3024 Night")]
+    public void Plain_names_are_searchable(string name)
+    {
+        Assert.True(ThemeSearchPath.IsSearchableName(name));
+    }
+
+    [Theory]
+    [InlineData(@"..\..\secrets.ini")]
+    [InlineData("sub/theme")]
+    [InlineData(@"sub\theme")]
+    [InlineData(@"C:\themes\Mocha")]
+    [InlineData("")]
+    public void Names_libghostty_refuses_are_not_searchable(string name)
+    {
+        // theme.zig rejects a relative name with a separator, and routes an
+        // absolute one down a different path entirely. Resolving either
+        // here would load a theme the terminal never applied.
+        Assert.False(ThemeSearchPath.IsSearchableName(name));
+    }
+}

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -1158,7 +1158,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         // An absolute theme is used as-is, mirroring theme.zig's own
         // openAbsolute branch. Dropping it here would leave the terminal
         // themed and the chrome on defaults.
-        if (Path.IsPathRooted(themeName))
+        if (ThemeSearchPath.IsAbsolute(themeName))
             return File.Exists(themeName) ? themeName : null;
 
         if (!ThemeSearchPath.IsSearchableName(themeName)) return null;

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -471,13 +471,38 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         NativeMethods.AppUpdateConfig(_app, newConfig);
 
         _config = newConfig;
-        CacheDiagnostics();
-        ReadFlags(OsTheme.IsDark());
+        try
+        {
+            CacheDiagnostics();
+            ReadFlags(OsTheme.IsDark());
+        }
+        catch (Exception ex)
+        {
+            // ReadFlags reads files, so this is reachable on a locked or
+            // half-written config. Reload runs inside a dispatcher lambda
+            // (the watcher marshals through one), where an escape is an
+            // unhandled UI-thread exception rather than a failed reload.
+            //
+            // Swallowed rather than rethrown because the native swap above
+            // already succeeded: libghostty is on the new config and the
+            // surfaces will repaint from it. What is left stale is the C#
+            // snapshot, which the next reload rebuilds. Bailing out here
+            // would leave those two disagreeing with no way back.
+            StaticLoggers.ConfigService.LogReloadFailed(ex);
+        }
+        finally
+        {
+            // Both of these have to happen even on the throw path. Leaking
+            // oldConfig leaks the libghostty config for the process
+            // lifetime, and leaving _suppressWatcher latched would make
+            // OnFileChanged return early on every subsequent edit --
+            // auto-reload-config would silently stop working for the rest
+            // of the session, with nothing logged.
+            if (oldConfig.Handle != IntPtr.Zero)
+                NativeMethods.ConfigFree(oldConfig);
 
-        if (oldConfig.Handle != IntPtr.Zero)
-            NativeMethods.ConfigFree(oldConfig);
-
-        _suppressWatcher = wasSuppressed;
+            _suppressWatcher = wasSuppressed;
+        }
 
         _dispatcher.TryEnqueue(() =>
         {
@@ -1102,15 +1127,43 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         => ThemeParser.SelectForScheme(GetFileValue("theme", ""), isOsDark);
 
     /// <summary>
-    /// Find the theme file on disk by name. Looks in the user themes
-    /// directory next to the config file. Returns null if not found.
+    /// Find the theme file on disk by name, searching the same directories
+    /// in the same order as libghostty. Returns null if not found.
     /// </summary>
+    /// <remarks>
+    /// This has to agree with src/config/theme.zig, because the two read
+    /// the same theme for different purposes: libghostty renders the
+    /// terminal from it, this reads it for the window chrome. Where they
+    /// disagree, a themed pane ends up framed in chrome from a different
+    /// palette. Deriving the directory from the config file's own location
+    /// is what used to make them disagree -- an install can hold its
+    /// config under the pre-rename name and its themes under the current
+    /// one, or the reverse.
+    /// </remarks>
     private string? ResolveThemePath(string themeName)
     {
-        var configDir = Path.GetDirectoryName(ConfigFilePath);
-        if (string.IsNullOrEmpty(configDir)) return null;
-        var themePath = Path.Combine(configDir, "themes", themeName);
-        return File.Exists(themePath) ? themePath : null;
+        foreach (var dir in UserThemeDirectories())
+        {
+            var themePath = Path.Combine(dir, themeName);
+            if (File.Exists(themePath)) return themePath;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// User theme directories, most current first. Mirrors the `user` and
+    /// `user_ghostty` entries of theme.zig's Location enum; the resources
+    /// directory it searches last has no chrome-visible values, so it is
+    /// deliberately not probed here.
+    /// </summary>
+    private static IEnumerable<string> UserThemeDirectories()
+    {
+        // xdg.config resolves to %APPDATA% on Windows (src/os/xdg.zig).
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        if (string.IsNullOrEmpty(appData)) yield break;
+
+        yield return Path.Combine(appData, "wintty", "themes");
+        yield return Path.Combine(appData, "ghostty", "themes");
     }
 
     /// <summary>

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -471,7 +471,6 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         NativeMethods.AppUpdateConfig(_app, newConfig);
 
         _config = newConfig;
-        var snapshotRefreshed = true;
         try
         {
             CacheDiagnostics();
@@ -489,9 +488,15 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
             // Swallowed rather than rethrown because the native swap above
             // already succeeded: libghostty is on the new config and the
             // surfaces will repaint from it. What is left stale, or torn
-            // partway, is the C# snapshot -- so the caller is told the
-            // reload did not complete even though the terminal moved.
-            snapshotRefreshed = false;
+            // partway, is the C# snapshot, which the next reload rebuilds.
+            //
+            // Deliberately not reported through the return value. Callers
+            // read that as "a reload happened, so expect the ConfigChanged
+            // echo" -- AppearancePage counts on it to skip re-seeding its
+            // own editors, and every other false leg returns before the
+            // event fires. Returning false here while still firing would
+            // tear an open picker down mid-drag. The distinct log message
+            // is where this failure is reported.
             StaticLoggers.ConfigService.LogSnapshotRefreshFailed(ex);
         }
         finally
@@ -516,7 +521,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
             ConfigChanged?.Invoke(this);
             ProfileConfigChanged?.Invoke();
         });
-        return snapshotRefreshed;
+        return true;
     }
 
     /// <summary>
@@ -1150,6 +1155,12 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// </remarks>
     private string? ResolveThemePath(string themeName)
     {
+        // An absolute theme is used as-is, mirroring theme.zig's own
+        // openAbsolute branch. Dropping it here would leave the terminal
+        // themed and the chrome on defaults.
+        if (Path.IsPathRooted(themeName))
+            return File.Exists(themeName) ? themeName : null;
+
         if (!ThemeSearchPath.IsSearchableName(themeName)) return null;
 
         var dirs = ThemeSearchPath.UserDirectories(

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -471,6 +471,7 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         NativeMethods.AppUpdateConfig(_app, newConfig);
 
         _config = newConfig;
+        var snapshotRefreshed = true;
         try
         {
             CacheDiagnostics();
@@ -479,37 +480,43 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         catch (Exception ex)
         {
             // ReadFlags reads files, so this is reachable on a locked or
-            // half-written config. Reload runs inside a dispatcher lambda
-            // (the watcher marshals through one), where an escape is an
-            // unhandled UI-thread exception rather than a failed reload.
+            // half-written config -- most likely right after a save, while
+            // the editor still holds the file. Reload runs inside a
+            // dispatcher lambda (the watcher marshals through one), where
+            // an escape is an unhandled UI-thread exception rather than a
+            // failed reload, so it is caught broadly rather than by type.
             //
             // Swallowed rather than rethrown because the native swap above
             // already succeeded: libghostty is on the new config and the
-            // surfaces will repaint from it. What is left stale is the C#
-            // snapshot, which the next reload rebuilds. Bailing out here
-            // would leave those two disagreeing with no way back.
-            StaticLoggers.ConfigService.LogReloadFailed(ex);
+            // surfaces will repaint from it. What is left stale, or torn
+            // partway, is the C# snapshot -- so the caller is told the
+            // reload did not complete even though the terminal moved.
+            snapshotRefreshed = false;
+            StaticLoggers.ConfigService.LogSnapshotRefreshFailed(ex);
         }
         finally
         {
-            // Both of these have to happen even on the throw path. Leaking
-            // oldConfig leaks the libghostty config for the process
-            // lifetime, and leaving _suppressWatcher latched would make
-            // OnFileChanged return early on every subsequent edit --
-            // auto-reload-config would silently stop working for the rest
-            // of the session, with nothing logged.
+            // Restored first: leaving _suppressWatcher latched makes
+            // OnFileChanged return early on every subsequent edit, so
+            // auto-reload-config silently stops working for the rest of
+            // the session with nothing logged. Freeing oldConfig matters
+            // too -- it is leaked for the process lifetime otherwise --
+            // but a fault there must not cost us the latch.
+            _suppressWatcher = wasSuppressed;
+
             if (oldConfig.Handle != IntPtr.Zero)
                 NativeMethods.ConfigFree(oldConfig);
-
-            _suppressWatcher = wasSuppressed;
         }
 
+        // Fired even when the snapshot failed: libghostty has moved, so
+        // suppressing this would leave the chrome painting against a
+        // terminal that already repainted.
         _dispatcher.TryEnqueue(() =>
         {
             ConfigChanged?.Invoke(this);
             ProfileConfigChanged?.Invoke();
         });
-        return true;
+        return snapshotRefreshed;
     }
 
     /// <summary>
@@ -1131,39 +1138,30 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     /// in the same order as libghostty. Returns null if not found.
     /// </summary>
     /// <remarks>
-    /// This has to agree with src/config/theme.zig, because the two read
-    /// the same theme for different purposes: libghostty renders the
-    /// terminal from it, this reads it for the window chrome. Where they
-    /// disagree, a themed pane ends up framed in chrome from a different
-    /// palette. Deriving the directory from the config file's own location
-    /// is what used to make them disagree -- an install can hold its
-    /// config under the pre-rename name and its themes under the current
-    /// one, or the reverse.
+    /// Search order and name rules live in
+    /// <see cref="ThemeSearchPath"/>, which documents why they have to
+    /// track theme.zig. The resources directory theme.zig searches last is
+    /// not probed: those themes reach the chrome through libghostty's own
+    /// resolved values instead. The one case that would miss -- a
+    /// conditional light:/dark: pair in dark mode, where libghostty's
+    /// handle is finalized light -- is unreachable while the Windows build
+    /// ships no resources themes (emit_themes defaults off), and would
+    /// need this list extended if that changes.
     /// </remarks>
     private string? ResolveThemePath(string themeName)
     {
-        foreach (var dir in UserThemeDirectories())
+        if (!ThemeSearchPath.IsSearchableName(themeName)) return null;
+
+        var dirs = ThemeSearchPath.UserDirectories(
+            Path.GetDirectoryName(ConfigFilePath),
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+
+        foreach (var dir in dirs)
         {
             var themePath = Path.Combine(dir, themeName);
             if (File.Exists(themePath)) return themePath;
         }
         return null;
-    }
-
-    /// <summary>
-    /// User theme directories, most current first. Mirrors the `user` and
-    /// `user_ghostty` entries of theme.zig's Location enum; the resources
-    /// directory it searches last has no chrome-visible values, so it is
-    /// deliberately not probed here.
-    /// </summary>
-    private static IEnumerable<string> UserThemeDirectories()
-    {
-        // xdg.config resolves to %APPDATA% on Windows (src/os/xdg.zig).
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        if (string.IsNullOrEmpty(appData)) yield break;
-
-        yield return Path.Combine(appData, "wintty", "themes");
-        yield return Path.Combine(appData, "ghostty", "themes");
     }
 
     /// <summary>
@@ -1515,6 +1513,16 @@ internal static partial class ConfigServiceLogExtensions
                    Level = LogLevel.Error,
                    Message = "[ConfigService] Failed to re-resolve themed values after an OS colour scheme change")]
     internal static partial void LogThemeRefreshFailed(
+        this ILogger<ConfigService> logger, System.Exception ex);
+
+    // Distinct from LogReloadFailed: there the config was never built and
+    // nothing changed, here it was built and pushed and only the C#
+    // snapshot is behind. The two want opposite triage, so they must not
+    // share a message.
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Config.SnapshotRefreshFailed,
+                   Level = LogLevel.Error,
+                   Message = "[ConfigService] Config applied natively but the C# snapshot failed to refresh")]
+    internal static partial void LogSnapshotRefreshFailed(
         this ILogger<ConfigService> logger, System.Exception ex);
 
     // Surfaces each warning string returned by


### PR DESCRIPTION
Two fixes, both in the config layer.

## Themes are not found under the pre-rename directory

`config/file_load.zig` searches the config file under `wintty/config.wintty`, then `ghostty/config.ghostty`, then `ghostty/config`, so an install that predates the rename keeps loading -- its own comment says as much. `config/theme.zig` had no equivalent fallback: it looked only under `wintty/themes`. So an install whose config lives under the old name keeps its config and silently loses every theme, falling back to the built-in defaults with no diagnostic.

`Location` gains a `user_ghostty` entry between `user` and `resources`. `LocationIterator` walks the enum, so `+list-themes` and the inline picker pick it up unchanged.

The C# side had drifted in the other direction: `ResolveThemePath` derived the directory from wherever the config file happened to load. That is a third rule, and it means the two sides can resolve different files for the same theme name -- libghostty renders the terminal from it and `ConfigService` reads it for the chrome around it, so disagreement shows up as a pane framed in the wrong palette. It now probes the same ordered list.

## Reload leaks and latches on a throw

`Reload` did:

```
_suppressWatcher = true;
...
ReadFlags(...);                       // reads files, can throw
ConfigFree(oldConfig);                // skipped
_suppressWatcher = wasSuppressed;     // skipped
```

`ReadFlags` reads files, and `Reload` reaches the UI through a dispatcher lambda, so a throw escaped as an unhandled UI-thread exception. It also skipped both following lines: the old `GhosttyConfig` was never freed, and `_suppressWatcher` stayed latched, so `OnFileChanged` returns early on every subsequent edit -- `auto-reload-config` silently stops working for the rest of the session with nothing logged.

The tail now runs in a `finally`. The failure is logged and swallowed rather than rethrown, because the native swap has already succeeded by that point: libghostty is on the new config and the surfaces repaint from it. What is left stale is the C# snapshot, which the next reload rebuilds.

## Verification

Against this machine's install, which holds 486 themes under `ghostty/themes` and has no `wintty/themes` at all, with `theme = Catppuccin Mocha`:

- before: surface `#282C34` (Ghostty's built-in default)
- after: surface `#1E1E2E` (Catppuccin Mocha)

and with a split open, the C# chrome gutter and the Zig surface beside it both read `#171724` (that theme under the inactive-pane dim), i.e. the two sides now resolve the same file.

1808 and 13 tests pass. `zig fmt --check` clean.

## Note on migration

This does not move any files. A fallback keeps existing installs working without touching user data, and matches what the config file already does. If you would rather have the old directory actively migrated into the new one, that is a separate change and a destructive one, so I have not assumed it.
