### PR TITLE
renderer: bind the DX12 SRV table to the pixel stage only

### DIFF
--- a/src/renderer/directx12/Pipeline.zig
+++ b/src/renderer/directx12/Pipeline.zig
@@ -105,13 +105,20 @@ pub fn createRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSignat
             .ShaderVisibility = .ALL,
         },
         // [1] Descriptor table for SRVs.
+        //
+        // PIXEL, not ALL: visibility is what decides the resource state the
+        // debug layer demands at bind. ALL means any stage could read the
+        // table, so it requires NON_PIXEL_SHADER_RESOURCE |
+        // PIXEL_SHADER_RESOURCE, while these textures are only sampled from a
+        // pixel shader (CellTextPS, ImagePS, BgImagePS) and so sit in
+        // PIXEL_SHADER_RESOURCE alone.
         .{
             .ParameterType = .DESCRIPTOR_TABLE,
             .u = .{ .DescriptorTable = .{
                 .NumDescriptorRanges = 1,
                 .pDescriptorRanges = @ptrCast(&srv_range),
             } },
-            .ShaderVisibility = .ALL,
+            .ShaderVisibility = .PIXEL,
         },
         // [2] Descriptor table for samplers.
         .{
@@ -223,13 +230,15 @@ pub fn createPostRootSignature(device: *d3d12.ID3D12Device) !*d3d12.ID3D12RootSi
             .ShaderVisibility = .ALL,
         },
         // [1] Descriptor table: 1 SRV at t0 (source texture).
+        // PIXEL for the same reason: only the post shader's pixel stage
+        // samples t0, which endPass leaves in PIXEL_SHADER_RESOURCE.
         .{
             .ParameterType = .DESCRIPTOR_TABLE,
             .u = .{ .DescriptorTable = .{
                 .NumDescriptorRanges = 1,
                 .pDescriptorRanges = @ptrCast(&srv_range),
             } },
-            .ShaderVisibility = .ALL,
+            .ShaderVisibility = .PIXEL,
         },
         // [2] Descriptor table: 1 sampler at s0.
         .{


### PR DESCRIPTION
Every `SetGraphicsRootDescriptorTable` in a Debug build logged `INVALID_SUBRESOURCE_STATE` (#538), 36 to 117 per run:

```
Resource state (0x80: PIXEL_SHADER_RESOURCE) ... is invalid for use as a
NON_PIXEL_SHADER_RESOURCE|PIXEL_SHADER_RESOURCE ... Missing State: 0x40
```

Both root signatures declared their SRV descriptor table with `ShaderVisibility` `ALL`. D3D12 validates a bound resource against what the root signature says can read it, not against what the shaders actually do, so `ALL` required every texture in that table to carry `NON_PIXEL_SHADER_RESOURCE` as well.

Nothing in that table is read outside a pixel shader: `shaders.hlsl` samples `t0`/`t1` in `CellTextPS`, `ImagePS` and `BgImagePS`, and the post pipeline's `t0` is the offscreen target `RenderPass.endPass` leaves in `PIXEL_SHADER_RESOURCE`. The state was right; the declaration was wider than the truth.

Narrowing to `PIXEL` rather than widening the state to 0xC0: adding `NON_PIXEL_SHADER_RESOURCE` would buy a bit no stage reads through, and it would keep the root signature claiming an access the renderer never makes.

Release builds skip validation and said nothing, but the binding is invalid either way and a driver is entitled to act on the declaration.

Verified by capturing `OutputDebugString` off the DBWIN buffer while the app ran for 25s, filtering to the launched PID: 36+ before, 0 after, window up and rendering. `INVALID_DESCRIPTOR_HANDLE` (#646) still fires around 11 times per run and is untouched here: the SRV range declares `NumDescriptors = 3` while `RenderPass.zig` binds one texture's handle as the table base, leaving the other two slots uninitialized. Separate fix.
