### PR TITLE
shell: share the launch-icon ladder and widen the interop scan

### DIFF
--- a/dist/windows/IconGen.Tests/PngWriterTests.cs
+++ b/dist/windows/IconGen.Tests/PngWriterTests.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Drawing.Imaging;
+using Ghostty.Core.Shell;
 using Xunit;
 
 namespace Ghostty.IconGen.Tests;
@@ -66,6 +67,40 @@ public class PngWriterTests
         using var img = new Bitmap(Path.Combine(tempDir.Path, fileName));
         Assert.Equal(expectedPx, img.Width);
         Assert.Equal(expectedPx, img.Height);
+    }
+
+    // The two theories above pin the names and sizes this tool writes.
+    // This pins the shared table it writes them from, so moving
+    // LaunchIconMetrics.MaxSizeDips (which the rungs derive from) is a
+    // deliberate act with a failing test in front of it rather than a
+    // silent regeneration of every asset.
+    [Fact]
+    public void SharedLadderIsTheScaleAndPixelPairsWeShip()
+    {
+        var rungs = LaunchIconAssets.Rungs.Select(r => (r.Scale, r.Pixels)).ToArray();
+
+        Assert.Equal(new[] { (100, 160), (150, 240), (200, 320), (400, 640) }, rungs);
+    }
+
+    // Ties the output back to the table: every rung the splash window will
+    // ask for by name exists, at the size the table promises.
+    [Fact]
+    public void EverySharedRungIsWrittenAtItsDeclaredSize()
+    {
+        using var tempDir = new TempDir();
+        using var masters = MasterRasters.Load(TempDir.FindRepoRoot());
+
+        PngWriter.WriteScalePngs(masters, tempDir.Path);
+
+        foreach (var rung in LaunchIconAssets.Rungs)
+        {
+            var path = Path.Combine(tempDir.Path, rung.FileName);
+            Assert.True(File.Exists(path), $"IconGen did not write {rung.FileName}");
+
+            using var img = new Bitmap(path);
+            Assert.Equal(rung.Pixels, img.Width);
+            Assert.Equal(rung.Pixels, img.Height);
+        }
     }
 }
 

--- a/dist/windows/IconGen/IconGen.csproj
+++ b/dist/windows/IconGen/IconGen.csproj
@@ -30,6 +30,12 @@
       architecture-specific evaluation in front of icon generation.
       GenerateBrandingAssets in Ghostty.csproj lists both files as Inputs
       so editing the ladder still regenerates the icons.
+
+      Consequence to know about: these public types now exist in both
+      Ghostty.IconGen and Ghostty.Core. Nothing references both today. If
+      something ever needs to, the CS0433 ambiguity is the link, not a
+      stray package: give the referencing project an extern alias, or
+      promote the shared files to their own dependency-free assembly.
     -->
     <Compile Include="..\..\..\windows\Ghostty.Core\Shell\LaunchIconAssets.cs"
              Link="Shared\LaunchIconAssets.cs" />

--- a/dist/windows/IconGen/IconGen.csproj
+++ b/dist/windows/IconGen/IconGen.csproj
@@ -19,4 +19,21 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Ghostty.IconGen.Tests" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      The launch-icon ladder, owned by Ghostty.Core because the shell
+      reads it at runtime to find the PNGs this tool writes. Linked as
+      source rather than pulled in with a ProjectReference: Ghostty.csproj
+      runs this tool with `dotnet run` before it compiles, and referencing
+      Core would put Core's own prebake step, SkiaSharp, and an
+      architecture-specific evaluation in front of icon generation.
+      GenerateBrandingAssets in Ghostty.csproj lists both files as Inputs
+      so editing the ladder still regenerates the icons.
+    -->
+    <Compile Include="..\..\..\windows\Ghostty.Core\Shell\LaunchIconAssets.cs"
+             Link="Shared\LaunchIconAssets.cs" />
+    <Compile Include="..\..\..\windows\Ghostty.Core\Shell\LaunchIconMetrics.cs"
+             Link="Shared\LaunchIconMetrics.cs" />
+  </ItemGroup>
 </Project>

--- a/dist/windows/IconGen/PngWriter.cs
+++ b/dist/windows/IconGen/PngWriter.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
+using Ghostty.Core.Shell;
 
 namespace Ghostty.IconGen;
 
@@ -17,18 +18,14 @@ internal static class PngWriter
     };
 
     // Second ladder for the launch icon the shell shows over a cold-start
-    // window. Sized for the largest the icon ever draws at
-    // (LaunchIconMetrics.MaxSizeDips); smaller windows scale one of these
-    // rungs down, which stays sharp, whereas reusing the 40 DIP ladder
-    // above would upscale even its largest rung and look soft. The masters
-    // reach 2048 px, so every rung here is still a downsample.
+    // window. Read from the shared table rather than restated here: the
+    // splash window loads these files by name at runtime, so a rung this
+    // tool renames on its own leaves the shell with nothing to draw. The
+    // masters reach 2048 px, so every rung is still a downsample.
     private static readonly (string Name, int Px)[] SplashTargets =
-    {
-        ("SplashIcon.scale-100.png", 160),
-        ("SplashIcon.scale-150.png", 240),
-        ("SplashIcon.scale-200.png", 320),
-        ("SplashIcon.scale-400.png", 640),
-    };
+        LaunchIconAssets.Rungs
+            .Select(rung => (Name: rung.FileName, Px: rung.Pixels))
+            .ToArray();
 
     public static void WriteScalePngs(MasterRasters masters, string outDir)
     {

--- a/windows/Ghostty.Core/Shell/LaunchIconAssets.cs
+++ b/windows/Ghostty.Core/Shell/LaunchIconAssets.cs
@@ -1,0 +1,47 @@
+namespace Ghostty.Core.Shell;
+
+/// <summary>
+/// One rung of the launch-icon ladder: a WinUI asset scale and the pixel
+/// size the PNG for it is generated at.
+/// </summary>
+/// <param name="Scale">The number in the <c>.scale-xxx</c> file suffix.</param>
+/// <param name="Pixels">Edge length of the generated PNG, in pixels.</param>
+public readonly record struct LaunchIconRung(int Scale, int Pixels)
+{
+    /// <summary>Name this rung ships under in the app's Assets folder.</summary>
+    public string FileName => $"SplashIcon.scale-{Scale}.png";
+}
+
+/// <summary>
+/// The launch-icon ladder the cold-start splash draws from.
+///
+/// <para>Two sides have to agree on it: the icon generator that writes
+/// the PNGs (<c>dist/windows/IconGen</c>, which links this file rather
+/// than referencing this assembly) and the splash window that picks one
+/// to draw. They used to hold a copy each, kept in step by a comment.
+/// Renaming or renumbering a rung on one side left the other asking for
+/// files that no longer existed, and the splash's answer to a missing
+/// file is to paint a bare coloured rectangle -- a silent failure with
+/// no build error in front of it.</para>
+/// </summary>
+public static class LaunchIconAssets
+{
+    // Sized off the largest the icon ever draws at
+    // (LaunchIconMetrics.MaxSizeDips) so every on-screen size is a
+    // downsample, which stays sharp; the 40 DIP AppIcon ladder would
+    // have to upscale even its largest rung. Derived rather than
+    // listed so the ladder follows if that clamp ever moves.
+    private static readonly int[] ScalePercents = [100, 150, 200, 400];
+
+    /// <summary>
+    /// The rungs, ascending by pixel size. Both consumers rely on that
+    /// order: the splash takes the first rung at least as large as the
+    /// size it is drawing, and falls back to the last as the largest
+    /// shipped.
+    /// </summary>
+    public static IReadOnlyList<LaunchIconRung> Rungs { get; } =
+    [
+        .. ScalePercents.Select(scale =>
+            new LaunchIconRung(scale, LaunchIconMetrics.MaxSizeDips * scale / 100)),
+    ];
+}

--- a/windows/Ghostty.Core/Shell/LaunchIconAssets.cs
+++ b/windows/Ghostty.Core/Shell/LaunchIconAssets.cs
@@ -30,7 +30,9 @@ public static class LaunchIconAssets
     // (LaunchIconMetrics.MaxSizeDips) so every on-screen size is a
     // downsample, which stays sharp; the 40 DIP AppIcon ladder would
     // have to upscale even its largest rung. Derived rather than
-    // listed so the ladder follows if that clamp ever moves.
+    // listed so the ladder follows if that clamp ever moves -- pick a
+    // clamp every scale divides cleanly, since the truncation here is
+    // silent and only the tests' expected pixel sizes would notice.
     private static readonly int[] ScalePercents = [100, 150, 200, 400];
 
     /// <summary>

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -116,6 +116,42 @@
     <EmbeddedResource Include="..\Ghostty\Settings\Pages\**\*.xaml"
                       Link="Settings\Pages\%(Filename)%(Extension)"
                       LogicalName="Ghostty.Tests.Settings.Pages.%(Filename)%(Extension)" />
+    <!--
+      The shell project file, for LaunchIconAssetsTests. It carries the one
+      copy of the launch-icon ladder that no C# type can share: an explicit
+      <Content Include> list of the generated PNG rungs.
+    -->
+    <EmbeddedResource Include="..\Ghostty\Ghostty.csproj"
+                      Link="Shell\Ghostty.csproj"
+                      LogicalName="Ghostty.Tests.Shell.Ghostty.csproj" />
+    <!--
+      Every C# source in the two assemblies that set
+      [assembly: DisableRuntimeMarshalling], for MarshalComplianceTests.
+      A wildcard rather than a file list, because the interop surface is
+      not confined to Interop\: it also lives in Shell\, Hosting\,
+      Accessibility\ and Program.cs, and a hand-maintained list is exactly
+      how a new P/Invoke file escapes the scan. The test picks the files
+      that declare a native import out of this corpus.
+
+      LogicalName keeps %(RecursiveDir) so two files sharing a name in
+      different folders (Ghostty.Core has two IFileSystem.cs) stay
+      distinct instead of colliding as a duplicate resource. The test
+      treats the tail as an opaque label, so the path separator the host
+      substitutes does not matter.
+
+      The two files already embedded under Interop\Imports above are
+      excluded here: the same file twice is a duplicate-item error, not
+      two resources. MarshalComplianceTests reads both prefixes, so they
+      are still scanned.
+    -->
+    <EmbeddedResource Include="..\Ghostty\**\*.cs"
+                      Exclude="..\Ghostty\obj\**\*.cs;..\Ghostty\bin\**\*.cs;..\Ghostty\Interop\NativeMethods.cs"
+                      Link="Interop\Sources\Ghostty\%(RecursiveDir)%(Filename)%(Extension)"
+                      LogicalName="Ghostty.Tests.Interop.Sources.Ghostty.%(RecursiveDir)%(Filename)%(Extension)" />
+    <EmbeddedResource Include="..\Ghostty.Core\**\*.cs"
+                      Exclude="..\Ghostty.Core\obj\**\*.cs;..\Ghostty.Core\bin\**\*.cs;..\Ghostty.Core\Version\LibGhosttyBuildInfo.cs"
+                      Link="Interop\Sources\Ghostty.Core\%(RecursiveDir)%(Filename)%(Extension)"
+                      LogicalName="Ghostty.Tests.Interop.Sources.Ghostty.Core.%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -125,13 +125,18 @@
                       Link="Shell\Ghostty.csproj"
                       LogicalName="Ghostty.Tests.Shell.Ghostty.csproj" />
     <!--
-      Every C# source in the two assemblies that set
+      Every C# source under the two project directories that set
       [assembly: DisableRuntimeMarshalling], for MarshalComplianceTests.
       A wildcard rather than a file list, because the interop surface is
       not confined to Interop\: it also lives in Shell\, Hosting\,
       Accessibility\ and Program.cs, and a hand-maintained list is exactly
       how a new P/Invoke file escapes the scan. The test picks the files
-      that declare a native import out of this corpus.
+      that declare a native import or an interop struct out of this corpus.
+
+      Directories, not assemblies: Ghostty\Demo is <Compile Remove>d from
+      non-demo builds but is embedded and scanned unconditionally. It is
+      real code in every Debug build, so scanning it always is the cheaper
+      side of that mismatch.
 
       LogicalName keeps %(RecursiveDir) so two files sharing a name in
       different folders (Ghostty.Core has two IFileSystem.cs) stay

--- a/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
+++ b/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -13,18 +14,27 @@ namespace Ghostty.Tests.Interop;
 //
 // Two scopes, because the rules are not the same everywhere. The libghostty
 // boundary in NativeMethods.cs bans [MarshalAs] outright: that surface is
-// hand-written against a C header and its shape is the convention. The
-// struct rules below apply to every source in the two assemblies that set
-// DisableRuntimeMarshalling, because a non-blittable interop struct is not a
-// style question -- runtime marshalling is off, so field marshalling is not
-// honored, and the mistake surfaces as a failed call rather than a build
-// error. That corpus comes from a wildcard in Ghostty.Tests.csproj, so a new
-// interop file is scanned without anyone remembering to add it here.
+// hand-written against a C header and its shape is the convention.
+//
+// The struct rules apply to every [StructLayout] struct in the corpus, which
+// is every source under windows/Ghostty and windows/Ghostty.Core that
+// declares a native import or an interop struct. A non-blittable field there
+// is not a style question: runtime marshalling is off, so field marshalling
+// is not honored, and the mistake surfaces as a failed call rather than a
+// build error. [StructLayout] is what scopes it -- it is how this codebase
+// marks a struct that crosses the boundary, so a managed struct sitting in
+// the same file cannot be flagged for a rule that does not apply to it.
+//
+// The corpus comes from a wildcard in Ghostty.Tests.csproj, so a new interop
+// file is scanned without anyone remembering to add it here. It is the two
+// project directories rather than the two assemblies: windows/Ghostty/Demo
+// is compiled only into demo builds but is scanned always, which costs
+// nothing since it is real code in the Debug binary.
 public class MarshalComplianceTests
 {
     private const string ResourceName = "Ghostty.Tests.Interop.Imports.NativeMethods.cs";
 
-    // Every C# source of the two DisableRuntimeMarshalling assemblies.
+    // Every C# source of the two DisableRuntimeMarshalling projects.
     // Covers both the wildcard corpus under Sources\ and the two files
     // embedded separately under Imports\ for the entry-point parity test:
     // the same file cannot be embedded twice, and the .zig exports under
@@ -44,31 +54,61 @@ public class MarshalComplianceTests
         "UnmanagedType.I1",
     };
 
-    // A file is interop if it declares a native import. [DllImport] is in
-    // here as well as [LibraryImport] so the older form cannot slip a
-    // surface past the scan by being the thing nobody looks for.
-    private static readonly string[] InteropMarkers = new[]
+    // A file is interop if it declares a native import or an interop
+    // struct. [DllImport] is in here as well as [LibraryImport] so the
+    // older form cannot slip a surface past the scan by being the thing
+    // nobody looks for, and the layout attributes because this codebase
+    // keeps several ABI structs in files that import nothing themselves
+    // (Ghostty.Core/Interop/*.cs) -- exactly where a non-blittable field
+    // would be introduced.
+    // What marks a struct as one the runtime hands to native code.
+    // [InlineArray] is here alongside [StructLayout] because an inline
+    // array is a layout even without one: KeybindInterop's TriggerSteps
+    // carries no [StructLayout] and is a by-value field of a struct that
+    // a P/Invoke returns.
+    private static readonly string[] LayoutAttributes = new[]
     {
-        "[LibraryImport",
-        "[DllImport",
+        "[StructLayout",
+        "[InlineArray",
     };
 
-    // `struct Name`, in any of the modifier orders C# allows. Only the
-    // keyword and the name are matched; the modifiers in front vary and
-    // none of them change whether a body follows.
+    private static readonly string[] InteropMarkers =
+        new[] { "[LibraryImport", "[DllImport" }.Concat(LayoutAttributes).ToArray();
+
+    // `struct Name`, in any of the modifier orders C# allows. `record
+    // struct` is excluded: it is the managed idiom in this codebase (handle
+    // wrappers and value tuples), never a layout the runtime hands to
+    // native code.
     private static readonly Regex StructDeclaration = new(
-        @"\bstruct\s+[A-Za-z_]\w*",
+        @"(?<!\brecord\s)\bstruct\s+[A-Za-z_]\w*",
         RegexOptions.Compiled);
 
-    // A plain field of a type runtime marshalling would have had to
-    // convert. Deliberately narrow: an access modifier, the type, one or
-    // more names, a semicolon, end of line. Anything with `=>` or a call
-    // in it is a property or a local, which are not part of the struct's
-    // memory layout and are fine. `char*` does not match, because the
-    // pointer is what makes it blittable.
+    // A field or auto-property of a type runtime marshalling would have had
+    // to convert. Leading attributes are allowed, so a field sharing a line
+    // with [MarshalAs] is still seen, and the access modifier is optional,
+    // since a field without one is private and still part of the layout.
+    // `char*` does not match: the pointer is what makes it blittable.
+    private const string FieldModifiers =
+        @"^\s*(?:\[[^\]]*\]\s*)*(?:(?:public|internal|private|protected|readonly|volatile|required|new|unsafe)\s+)*";
+    private const string NonBlittableTypes =
+        @"(?<type>(?:System\.)?(?:bool|Boolean|char|Char|string|String))(?:\?|\[\])?";
+
+    // `= value` is allowed (a struct field initializer), `=> expr` is not:
+    // an expression-bodied property is computed, not stored.
     private static readonly Regex NonBlittableField = new(
-        @"^\s*(?:public|internal|private|protected)\s+(?:readonly\s+|volatile\s+)*"
-            + @"(?<type>bool|char|string)\??\s+\w+(?:\s*,\s*\w+)*\s*;\s*$",
+        FieldModifiers + NonBlittableTypes + @"\s+\w+(?:\s*,\s*\w+)*\s*(?:=(?!>)[^;]*)?;\s*$",
+        RegexOptions.Compiled);
+
+    // An auto-property has a compiler-generated backing field, so it is
+    // part of the layout even though it does not look like a field.
+    private static readonly Regex NonBlittableAutoProperty = new(
+        FieldModifiers + NonBlittableTypes + @"\s+\w+\s*\{\s*get\s*;",
+        RegexOptions.Compiled);
+
+    // Neither rule applies to these: a `fixed` buffer is blittable by
+    // construction, and const/static members are not part of the layout.
+    private static readonly Regex NotLayoutMember = new(
+        @"\b(?:fixed|const|static)\b",
         RegexOptions.Compiled);
 
     [Fact]
@@ -100,15 +140,24 @@ public class MarshalComplianceTests
 
     // The corpus guard. Without it a wildcard that stopped matching, or a
     // marker that stopped being recognized, would leave every scan below
-    // passing over nothing.
+    // passing over nothing. Each half of the corpus needs its own anchor:
+    // NativeMethods.cs is hand-listed in the csproj, so it proves nothing
+    // about the wildcards, and two anchors from the same project would not
+    // notice the other project's glob going dead.
     [Fact]
-    public void InteropCorpus_CoversTheHandWrittenSurfaces()
+    public void InteropCorpus_CoversBothProjects()
     {
         var scanned = InteropSources().Select(s => s.Name).ToList();
 
         Assert.NotEmpty(scanned);
         Assert.Contains(scanned, n => n.EndsWith("NativeMethods.cs", StringComparison.Ordinal));
+
+        // From the windows\Ghostty wildcard.
         Assert.Contains(scanned, n => n.EndsWith("SplashWindow.cs", StringComparison.Ordinal));
+        // From the windows\Ghostty.Core wildcard.
+        Assert.Contains(scanned, n => n.EndsWith("NtProcessInterop.cs", StringComparison.Ordinal));
+        // The ABI structs that declare no import of their own.
+        Assert.Contains(scanned, n => n.EndsWith("GhosttySharedTexture.cs", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -143,10 +192,10 @@ public class MarshalComplianceTests
 
         Assert.True(
             offending.Count == 0,
-            "bool, char and string are not blittable, so a struct carrying " +
-            "one cannot cross the boundary with runtime marshalling " +
-            "disabled. Use byte for a C99 _Bool, int for a Win32 BOOL, and " +
-            "a char* or IntPtr for a string. Offending lines:\n" +
+            "bool, char and string are not blittable, so an interop layout " +
+            "struct carrying one cannot cross the boundary with runtime " +
+            "marshalling disabled. Use byte for a C99 _Bool, int for a Win32 " +
+            "BOOL, and a char* or IntPtr for a string. Offending lines:\n" +
             string.Join("\n", offending));
     }
 
@@ -212,11 +261,13 @@ public class MarshalComplianceTests
         Assert.Contains("Flagged", tokenHits[0].Text);
     }
 
-    // Unit test: the struct-scoped rules must see struct bodies and
-    // nothing else. A [return: MarshalAs] on an import, and a bool local
-    // or expression-bodied property, are all legal and must stay quiet.
+    // Unit test: the struct rules must see every shape that ends up in the
+    // layout, and nothing else. A [return: MarshalAs] on an import, an
+    // expression-bodied property, a char pointer and a fixed buffer are all
+    // legal and must stay quiet; a field sharing its line with an attribute
+    // and an auto-property must not.
     [Fact]
-    public void StructScanner_SeparatesStructFieldsFromEverythingElse()
+    public void StructScanner_SeparatesLayoutMembersFromEverythingElse()
     {
         const string sample =
             "internal static partial class Fake\n" +
@@ -225,46 +276,142 @@ public class MarshalComplianceTests
             "    [return: MarshalAs(UnmanagedType.Bool)]\n" +
             "    private static partial bool IsWindow(nint hwnd);\n" +
             "\n" +
-            "    private struct Blittable\n" +
+            "    [StructLayout(LayoutKind.Sequential)]\n" +
+            "    private unsafe struct Blittable\n" +
             "    {\n" +
             "        public byte Composing;\n" +
             "        public char* Name;\n" +
+            "        public fixed char Buffer[8];\n" +
+            "        public const string Sentinel = \"x\";\n" +
             "        public bool IsComposing => Composing != 0;\n" +
             "    }\n" +
             "\n" +
+            "    [StructLayout(LayoutKind.Sequential)]\n" +
             "    private struct Broken\n" +
             "    {\n" +
             "        [MarshalAs(UnmanagedType.I1)]\n" +
             "        public bool Enabled;\n" +
+            "        [FieldOffset(4)] public bool Packed;\n" +
+            "        public string Name { get; set; }\n" +
+            "        bool NoModifier;\n" +
             "    }\n" +
             "\n" +
+            "    [StructLayout(LayoutKind.Sequential)]\n" +
             "    private struct OneLiner { public string Label; }\n" +
             "}\n";
 
         var attrHits = ScanStructFieldsForBannedAttribute(sample);
         var fieldHits = ScanStructFieldsForNonBlittableTypes(sample);
 
+        // Only the [MarshalAs]: [FieldOffset] is layout, not marshalling,
+        // and the [return:] one belongs to the import above the structs.
         Assert.Single(attrHits);
         Assert.Contains("UnmanagedType.I1", attrHits[0].Text);
 
-        Assert.Equal(2, fieldHits.Count);
-        Assert.Contains(fieldHits, l => l.Text.Contains("Enabled", StringComparison.Ordinal));
-        Assert.Contains(fieldHits, l => l.Text.Contains("Label", StringComparison.Ordinal));
+        Assert.Equal(5, fieldHits.Count);
+        foreach (var expected in new[] { "Enabled", "Packed", "Name { get;", "NoModifier", "Label" })
+        {
+            Assert.Contains(fieldHits, l => l.Text.Contains(expected, StringComparison.Ordinal));
+        }
+    }
+
+    // Unit test: a struct with no [StructLayout] is managed, and the rules
+    // are about what crosses the boundary. Flagging it would fail the build
+    // over a string field that never reaches native code.
+    [Fact]
+    public void StructScanner_IgnoresStructsThatAreNotInteropLayouts()
+    {
+        const string sample =
+            "internal static partial class Fake\n" +
+            "{\n" +
+            "    [LibraryImport(\"user32.dll\")]\n" +
+            "    private static partial int GetSystemMetrics(int index);\n" +
+            "\n" +
+            "    private struct Managed\n" +
+            "    {\n" +
+            "        public string Path;\n" +
+            "    }\n" +
+            "\n" +
+            "    private readonly record struct Handle(string Name)\n" +
+            "    {\n" +
+            "        public string Label;\n" +
+            "    }\n" +
+            "}\n";
+
+        Assert.Empty(ScanStructFieldsForNonBlittableTypes(sample));
+    }
+
+    // Unit test: a local inside a method the struct declares is not part
+    // of the layout, and a member whose body starts on the next line is
+    // still a property. Both would otherwise fail the build over code that
+    // never crosses the boundary.
+    [Fact]
+    public void StructScanner_IgnoresLocalsAndMultiLineProperties()
+    {
+        const string sample =
+            "[StructLayout(LayoutKind.Sequential)]\n" +
+            "internal struct Handle\n" +
+            "{\n" +
+            "    public IntPtr Ptr;\n" +
+            "\n" +
+            "    public bool IsEmpty\n" +
+            "        => Ptr == IntPtr.Zero;\n" +
+            "\n" +
+            "    public string Describe()\n" +
+            "    {\n" +
+            "        string text = Ptr.ToString();\n" +
+            "        bool empty = text.Length == 0;\n" +
+            "        return empty ? string.Empty : text;\n" +
+            "    }\n" +
+            "}\n";
+
+        Assert.Empty(ScanStructFieldsForNonBlittableTypes(sample));
+    }
+
+    // Unit test: braces inside literals and block comments must not move
+    // the struct bookkeeping. A dropped brace closes a struct early and
+    // silences the rest of it; an extra one leaves it open and flags plain
+    // managed fields further down the file.
+    [Fact]
+    public void StructScanner_IgnoresBracesInsideLiteralsAndBlockComments()
+    {
+        const string sample =
+            "[StructLayout(LayoutKind.Sequential)]\n" +
+            "internal struct Config\n" +
+            "{\n" +
+            "    public byte Ready;\n" +
+            "    /* struct Old { public bool Legacy; */\n" +
+            "    public const string Close = \"}\";\n" +
+            "    public char Brace;\n" +
+            "    public string Trailing;\n" +
+            "}\n" +
+            "\n" +
+            "internal sealed class After\n" +
+            "{\n" +
+            "    public bool Shown;\n" +
+            "}\n";
+
+        var hits = ScanStructFieldsForNonBlittableTypes(sample);
+
+        // The two real fields inside the struct, and nothing from the class
+        // that follows it.
+        Assert.Equal(2, hits.Count);
+        Assert.Contains(hits, l => l.Text.Contains("Brace", StringComparison.Ordinal));
+        Assert.Contains(hits, l => l.Text.Contains("Trailing", StringComparison.Ordinal));
     }
 
     // Allowlist: lines referencing Windows.Win32.* (CsWin32 boundary, marshalling
     // already enforced upstream).
-    private static bool IsCsWin32Boundary(string strippedLine)
-        => strippedLine.Contains("Windows.Win32.", StringComparison.Ordinal);
+    private static bool IsCsWin32Boundary(string codeLine)
+        => codeLine.Contains("Windows.Win32.", StringComparison.Ordinal);
 
     private static List<Line> ScanForBannedAttribute(string source, string banned)
     {
         var hits = new List<Line>();
         foreach (var line in EnumerateLines(source))
         {
-            var stripped = StripLineComment(line.Text);
-            if (IsCsWin32Boundary(stripped)) continue;
-            if (stripped.Contains(banned, StringComparison.Ordinal))
+            if (IsCsWin32Boundary(line.Code)) continue;
+            if (line.Code.Contains(banned, StringComparison.Ordinal))
             {
                 hits.Add(line);
             }
@@ -277,9 +424,8 @@ public class MarshalComplianceTests
         var hits = new List<Line>();
         foreach (var line in EnumerateLines(source))
         {
-            var stripped = StripLineComment(line.Text);
-            if (IsCsWin32Boundary(stripped)) continue;
-            if (bannedTokens.Any(bt => stripped.Contains(bt, StringComparison.Ordinal)))
+            if (IsCsWin32Boundary(line.Code)) continue;
+            if (bannedTokens.Any(bt => line.Code.Contains(bt, StringComparison.Ordinal)))
             {
                 hits.Add(line);
             }
@@ -292,13 +438,12 @@ public class MarshalComplianceTests
         var hits = new List<Line>();
         foreach (var line in EnumerateLines(source))
         {
-            if (!line.InStruct) continue;
-            var stripped = StripLineComment(line.Text);
-            if (IsCsWin32Boundary(stripped)) continue;
+            if (!line.InInteropStruct) continue;
+            if (IsCsWin32Boundary(line.Code)) continue;
             // A [return:] attribute belongs to an import declared beside
             // the fields, not to the layout.
-            if (stripped.Contains("[return:", StringComparison.Ordinal)) continue;
-            if (stripped.Contains(BannedAttribute, StringComparison.Ordinal))
+            if (line.Code.Contains("[return:", StringComparison.Ordinal)) continue;
+            if (line.Code.Contains(BannedAttribute, StringComparison.Ordinal))
             {
                 hits.Add(line);
             }
@@ -311,18 +456,17 @@ public class MarshalComplianceTests
         var hits = new List<Line>();
         foreach (var line in EnumerateLines(source))
         {
-            if (!line.InStruct) continue;
-            var stripped = StripLineComment(line.Text);
-            if (IsCsWin32Boundary(stripped)) continue;
-            // One-liner struct bodies carry the declaration and the fields
-            // on the same line, so scan the body rather than the whole line.
-            var body = stripped;
-            var brace = body.IndexOf('{');
-            if (brace >= 0 && StructDeclaration.IsMatch(body)) body = body[(brace + 1)..];
+            if (!line.InInteropStruct) continue;
+            if (IsCsWin32Boundary(line.Code)) continue;
+            // A declaration that ends on a later line: `public bool X` with
+            // its `=> expr` or `{ get; }` below it. Judging it here would
+            // read a property as a field.
+            if (!line.Code.Contains(';') && !line.Code.Contains('{')) continue;
 
-            foreach (var field in body.Split(';'))
+            foreach (var member in SplitMembers(line.Code))
             {
-                if (NonBlittableField.IsMatch(field + ";"))
+                if (NotLayoutMember.IsMatch(member)) continue;
+                if (NonBlittableField.IsMatch(member) || NonBlittableAutoProperty.IsMatch(member))
                 {
                     hits.Add(line);
                     break;
@@ -332,10 +476,23 @@ public class MarshalComplianceTests
         return hits;
     }
 
-    private static string StripLineComment(string rawLine)
+    /// <summary>
+    /// The declarations on one line of a struct body. Usually one, but a
+    /// one-liner struct carries its declaration and every field on the same
+    /// line, and the fields there are still layout.
+    /// </summary>
+    private static IEnumerable<string> SplitMembers(string codeLine)
     {
-        var commentIdx = rawLine.IndexOf("//", StringComparison.Ordinal);
-        return commentIdx >= 0 ? rawLine.Substring(0, commentIdx) : rawLine;
+        var body = codeLine;
+        var brace = body.IndexOf('{');
+        if (brace >= 0 && StructDeclaration.IsMatch(body)) body = body[(brace + 1)..];
+
+        foreach (var part in body.Split(';'))
+        {
+            // Split drops the terminator the field patterns anchor on, and
+            // the auto-property pattern needs the `{ get;` that split ate.
+            yield return part + ";";
+        }
     }
 
     private static string ReadEmbeddedSource()
@@ -348,8 +505,8 @@ public class MarshalComplianceTests
     }
 
     /// <summary>
-    /// Every embedded source that declares a native import, by resource
-    /// name and content.
+    /// Every embedded source that declares a native import or an interop
+    /// struct, by resource name and content.
     /// </summary>
     private static List<(string Name, string Source)> InteropSources()
     {
@@ -374,61 +531,183 @@ public class MarshalComplianceTests
         return sources;
     }
 
-    private readonly record struct Line(int Number, string Text, bool InStruct);
+    private readonly record struct Line(int Number, string Text, string Code, bool InInteropStruct);
 
     /// <summary>
-    /// The source's lines, each tagged with whether it sits inside a
+    /// The source's lines, each paired with its code (comments and literal
+    /// contents removed) and whether it sits inside a <c>[StructLayout]</c>
     /// struct body. Brace counting rather than parsing: enough to tell a
-    /// layout field from a method local, which is the only distinction
-    /// the rules above need.
+    /// layout member from a method local, which is the only distinction the
+    /// rules above need. Raw string literals are the one gap: the
+    /// delimiter line is dropped whole rather than guessed at, but the
+    /// body between delimiters is still read as code.
     /// </summary>
     private static IEnumerable<Line> EnumerateLines(string source)
     {
         var lines = source.Split('\n');
         var depth = 0;
-        var structDepths = new Stack<int>();
+        // Open struct bodies, each with the brace depth it opened at and
+        // whether it is an interop layout.
+        var structs = new Stack<(int Depth, bool Layout)>();
         var pendingStruct = false;
+        var pendingLayout = false;
+        var sawStructLayout = false;
+        var inBlockComment = false;
 
         for (int i = 0; i < lines.Length; i++)
         {
-            var stripped = StripLineComment(lines[i]);
-            var opensStruct = StructDeclaration.IsMatch(stripped);
+            var code = StripCommentsAndLiterals(lines[i], ref inBlockComment);
+            if (LayoutAttributes.Any(a => code.Contains(a, StringComparison.Ordinal)))
+            {
+                sawStructLayout = true;
+            }
 
-            // A one-liner declares the struct and its fields on the same
-            // line, so the line that opens a body counts as inside it.
-            yield return new Line(
-                i + 1,
-                lines[i],
-                structDepths.Count > 0 || (opensStruct && stripped.Contains('{')));
+            var opensStruct = StructDeclaration.IsMatch(code);
 
-            if (opensStruct) pendingStruct = true;
-            foreach (var c in stripped)
+            // Only the struct's own body, not deeper: a member sits at the
+            // depth the opening brace reached, while anything inside a
+            // method the struct declares is one deeper and is a local, not
+            // layout. A one-liner declares the struct and its members on
+            // the same line, so the line that opens a body counts too.
+            var insideLayout = structs.Count > 0
+                ? structs.Peek().Layout && structs.Peek().Depth == depth
+                : opensStruct && sawStructLayout && code.Contains('{');
+
+            yield return new Line(i + 1, lines[i], code, insideLayout);
+
+            if (opensStruct)
+            {
+                pendingStruct = true;
+                pendingLayout = sawStructLayout;
+            }
+
+            foreach (var c in code)
             {
                 if (c == '{')
                 {
                     depth++;
                     if (pendingStruct)
                     {
-                        structDepths.Push(depth);
+                        structs.Push((depth, pendingLayout));
                         pendingStruct = false;
                     }
                 }
                 else if (c == '}')
                 {
-                    if (structDepths.Count > 0 && structDepths.Peek() == depth)
-                    {
-                        structDepths.Pop();
-                    }
+                    if (structs.Count > 0 && structs.Peek().Depth == depth) structs.Pop();
                     depth--;
                 }
                 else if (c == ';')
                 {
                     // A bodyless declaration: `record struct Point(int X);`.
                     // Without this the pending open would latch onto the
-                    // next unrelated brace in the file.
+                    // next unrelated brace in the file. It also ends the
+                    // reach of a [StructLayout] that decorated something
+                    // other than a struct.
                     pendingStruct = false;
+                    sawStructLayout = false;
                 }
             }
+
+            // An attribute applies to the next declaration, so it survives
+            // blank lines and further attributes and nothing else.
+            if (opensStruct || (code.Contains('{') && !pendingStruct)) sawStructLayout = false;
         }
+    }
+
+    /// <summary>
+    /// One line with its comments and its string and char literal contents
+    /// removed, so that a brace or a keyword inside either cannot move the
+    /// scanner's bookkeeping.
+    /// </summary>
+    private static string StripCommentsAndLiterals(string rawLine, ref bool inBlockComment)
+    {
+        // Raw string literals can span lines and carry anything at all.
+        // Nothing in this codebase declares interop inside one, so drop the
+        // line rather than pretend to parse it.
+        if (!inBlockComment && rawLine.Contains("\"\"\"", StringComparison.Ordinal)) return string.Empty;
+
+        var code = new StringBuilder(rawLine.Length);
+        var i = 0;
+        while (i < rawLine.Length)
+        {
+            if (inBlockComment)
+            {
+                if (rawLine[i] == '*' && i + 1 < rawLine.Length && rawLine[i + 1] == '/')
+                {
+                    inBlockComment = false;
+                    i += 2;
+                }
+                else i++;
+                continue;
+            }
+
+            var c = rawLine[i];
+            if (c == '/' && i + 1 < rawLine.Length && rawLine[i + 1] == '/') break;
+            if (c == '/' && i + 1 < rawLine.Length && rawLine[i + 1] == '*')
+            {
+                inBlockComment = true;
+                i += 2;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                // @", $@" and @$" are all verbatim; the interpolation
+                // marker can sit on either side of the @.
+                var verbatim = (i > 0 && rawLine[i - 1] == '@')
+                    || (i > 1 && rawLine[i - 2] == '@');
+                i = SkipStringLiteral(rawLine, i, verbatim);
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                i = SkipCharLiteral(rawLine, i);
+                continue;
+            }
+
+            code.Append(c);
+            i++;
+        }
+
+        return code.ToString();
+    }
+
+    /// <summary>Index just past the closing quote, or end of line if unterminated.</summary>
+    private static int SkipStringLiteral(string line, int openIndex, bool verbatim)
+    {
+        var i = openIndex + 1;
+        while (i < line.Length)
+        {
+            if (verbatim)
+            {
+                // "" is an escaped quote in a verbatim string.
+                if (line[i] == '"')
+                {
+                    if (i + 1 < line.Length && line[i + 1] == '"') { i += 2; continue; }
+                    return i + 1;
+                }
+                i++;
+                continue;
+            }
+
+            if (line[i] == '\\') { i += 2; continue; }
+            if (line[i] == '"') return i + 1;
+            i++;
+        }
+        return i;
+    }
+
+    private static int SkipCharLiteral(string line, int openIndex)
+    {
+        var i = openIndex + 1;
+        while (i < line.Length)
+        {
+            if (line[i] == '\\') { i += 2; continue; }
+            if (line[i] == '\'') return i + 1;
+            i++;
+        }
+        return i;
     }
 }

--- a/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
+++ b/windows/Ghostty.Tests/Interop/MarshalComplianceTests.cs
@@ -3,15 +3,33 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Ghostty.Tests.Interop;
 
 // Pins that every P/Invoke surface honors [assembly: DisableRuntimeMarshalling]
 // (no [MarshalAs], two-BOOL-shape: byte for libghostty _Bool, int for Win32 BOOL).
+//
+// Two scopes, because the rules are not the same everywhere. The libghostty
+// boundary in NativeMethods.cs bans [MarshalAs] outright: that surface is
+// hand-written against a C header and its shape is the convention. The
+// struct rules below apply to every source in the two assemblies that set
+// DisableRuntimeMarshalling, because a non-blittable interop struct is not a
+// style question -- runtime marshalling is off, so field marshalling is not
+// honored, and the mistake surfaces as a failed call rather than a build
+// error. That corpus comes from a wildcard in Ghostty.Tests.csproj, so a new
+// interop file is scanned without anyone remembering to add it here.
 public class MarshalComplianceTests
 {
     private const string ResourceName = "Ghostty.Tests.Interop.Imports.NativeMethods.cs";
+
+    // Every C# source of the two DisableRuntimeMarshalling assemblies.
+    // Covers both the wildcard corpus under Sources\ and the two files
+    // embedded separately under Imports\ for the entry-point parity test:
+    // the same file cannot be embedded twice, and the .zig exports under
+    // this prefix are filtered out by extension below.
+    private const string SourcePrefix = "Ghostty.Tests.Interop.";
 
     // Note: `StringMarshalling = StringMarshalling.Utf8` is a separate,
     // supported mechanism and is NOT what this test scans for. Only the
@@ -25,6 +43,33 @@ public class MarshalComplianceTests
         "UnmanagedType.Bool",
         "UnmanagedType.I1",
     };
+
+    // A file is interop if it declares a native import. [DllImport] is in
+    // here as well as [LibraryImport] so the older form cannot slip a
+    // surface past the scan by being the thing nobody looks for.
+    private static readonly string[] InteropMarkers = new[]
+    {
+        "[LibraryImport",
+        "[DllImport",
+    };
+
+    // `struct Name`, in any of the modifier orders C# allows. Only the
+    // keyword and the name are matched; the modifiers in front vary and
+    // none of them change whether a body follows.
+    private static readonly Regex StructDeclaration = new(
+        @"\bstruct\s+[A-Za-z_]\w*",
+        RegexOptions.Compiled);
+
+    // A plain field of a type runtime marshalling would have had to
+    // convert. Deliberately narrow: an access modifier, the type, one or
+    // more names, a semicolon, end of line. Anything with `=>` or a call
+    // in it is a property or a local, which are not part of the struct's
+    // memory layout and are fine. `char*` does not match, because the
+    // pointer is what makes it blittable.
+    private static readonly Regex NonBlittableField = new(
+        @"^\s*(?:public|internal|private|protected)\s+(?:readonly\s+|volatile\s+)*"
+            + @"(?<type>bool|char|string)\??\s+\w+(?:\s*,\s*\w+)*\s*;\s*$",
+        RegexOptions.Compiled);
 
     [Fact]
     public void NativeMethods_HasNoMarshalAsAttributes()
@@ -51,6 +96,58 @@ public class MarshalComplianceTests
             "UnmanagedType.I1. Two-BOOL-shape convention: byte for " +
             "libghostty C99 _Bool, int for Win32 BOOL. Offending lines:\n" +
             string.Join("\n", offending.Select(l => $"  line {l.Number}: {l.Text.Trim()}")));
+    }
+
+    // The corpus guard. Without it a wildcard that stopped matching, or a
+    // marker that stopped being recognized, would leave every scan below
+    // passing over nothing.
+    [Fact]
+    public void InteropCorpus_CoversTheHandWrittenSurfaces()
+    {
+        var scanned = InteropSources().Select(s => s.Name).ToList();
+
+        Assert.NotEmpty(scanned);
+        Assert.Contains(scanned, n => n.EndsWith("NativeMethods.cs", StringComparison.Ordinal));
+        Assert.Contains(scanned, n => n.EndsWith("SplashWindow.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void InteropSources_HaveNoMarshalAsOnStructFields()
+    {
+        var offending = new List<string>();
+        foreach (var (name, source) in InteropSources())
+        {
+            offending.AddRange(
+                ScanStructFieldsForBannedAttribute(source)
+                    .Select(l => $"  {name} line {l.Number}: {l.Text.Trim()}"));
+        }
+
+        Assert.True(
+            offending.Count == 0,
+            "[MarshalAs] on an interop struct field does nothing under " +
+            "[assembly: DisableRuntimeMarshalling]: the struct is passed as " +
+            "laid out, so the field has to be blittable already. Offending " +
+            "lines:\n" + string.Join("\n", offending));
+    }
+
+    [Fact]
+    public void InteropSources_HaveNoNonBlittableStructFields()
+    {
+        var offending = new List<string>();
+        foreach (var (name, source) in InteropSources())
+        {
+            offending.AddRange(
+                ScanStructFieldsForNonBlittableTypes(source)
+                    .Select(l => $"  {name} line {l.Number}: {l.Text.Trim()}"));
+        }
+
+        Assert.True(
+            offending.Count == 0,
+            "bool, char and string are not blittable, so a struct carrying " +
+            "one cannot cross the boundary with runtime marshalling " +
+            "disabled. Use byte for a C99 _Bool, int for a Win32 BOOL, and " +
+            "a char* or IntPtr for a string. Offending lines:\n" +
+            string.Join("\n", offending));
     }
 
     // Unit test: comment-only mention must not false-positive.
@@ -115,36 +212,121 @@ public class MarshalComplianceTests
         Assert.Contains("Flagged", tokenHits[0].Text);
     }
 
+    // Unit test: the struct-scoped rules must see struct bodies and
+    // nothing else. A [return: MarshalAs] on an import, and a bool local
+    // or expression-bodied property, are all legal and must stay quiet.
+    [Fact]
+    public void StructScanner_SeparatesStructFieldsFromEverythingElse()
+    {
+        const string sample =
+            "internal static partial class Fake\n" +
+            "{\n" +
+            "    [LibraryImport(\"user32.dll\")]\n" +
+            "    [return: MarshalAs(UnmanagedType.Bool)]\n" +
+            "    private static partial bool IsWindow(nint hwnd);\n" +
+            "\n" +
+            "    private struct Blittable\n" +
+            "    {\n" +
+            "        public byte Composing;\n" +
+            "        public char* Name;\n" +
+            "        public bool IsComposing => Composing != 0;\n" +
+            "    }\n" +
+            "\n" +
+            "    private struct Broken\n" +
+            "    {\n" +
+            "        [MarshalAs(UnmanagedType.I1)]\n" +
+            "        public bool Enabled;\n" +
+            "    }\n" +
+            "\n" +
+            "    private struct OneLiner { public string Label; }\n" +
+            "}\n";
+
+        var attrHits = ScanStructFieldsForBannedAttribute(sample);
+        var fieldHits = ScanStructFieldsForNonBlittableTypes(sample);
+
+        Assert.Single(attrHits);
+        Assert.Contains("UnmanagedType.I1", attrHits[0].Text);
+
+        Assert.Equal(2, fieldHits.Count);
+        Assert.Contains(fieldHits, l => l.Text.Contains("Enabled", StringComparison.Ordinal));
+        Assert.Contains(fieldHits, l => l.Text.Contains("Label", StringComparison.Ordinal));
+    }
+
     // Allowlist: lines referencing Windows.Win32.* (CsWin32 boundary, marshalling
     // already enforced upstream).
     private static bool IsCsWin32Boundary(string strippedLine)
         => strippedLine.Contains("Windows.Win32.", StringComparison.Ordinal);
 
-    private static List<(int Number, string Text)> ScanForBannedAttribute(string source, string banned)
+    private static List<Line> ScanForBannedAttribute(string source, string banned)
     {
-        var hits = new List<(int Number, string Text)>();
-        foreach (var pair in EnumerateLines(source))
+        var hits = new List<Line>();
+        foreach (var line in EnumerateLines(source))
         {
-            var stripped = StripLineComment(pair.Text);
+            var stripped = StripLineComment(line.Text);
             if (IsCsWin32Boundary(stripped)) continue;
             if (stripped.Contains(banned, StringComparison.Ordinal))
             {
-                hits.Add(pair);
+                hits.Add(line);
             }
         }
         return hits;
     }
 
-    private static List<(int Number, string Text)> ScanForBannedTokens(string source, string[] bannedTokens)
+    private static List<Line> ScanForBannedTokens(string source, string[] bannedTokens)
     {
-        var hits = new List<(int Number, string Text)>();
-        foreach (var pair in EnumerateLines(source))
+        var hits = new List<Line>();
+        foreach (var line in EnumerateLines(source))
         {
-            var stripped = StripLineComment(pair.Text);
+            var stripped = StripLineComment(line.Text);
             if (IsCsWin32Boundary(stripped)) continue;
             if (bannedTokens.Any(bt => stripped.Contains(bt, StringComparison.Ordinal)))
             {
-                hits.Add(pair);
+                hits.Add(line);
+            }
+        }
+        return hits;
+    }
+
+    private static List<Line> ScanStructFieldsForBannedAttribute(string source)
+    {
+        var hits = new List<Line>();
+        foreach (var line in EnumerateLines(source))
+        {
+            if (!line.InStruct) continue;
+            var stripped = StripLineComment(line.Text);
+            if (IsCsWin32Boundary(stripped)) continue;
+            // A [return:] attribute belongs to an import declared beside
+            // the fields, not to the layout.
+            if (stripped.Contains("[return:", StringComparison.Ordinal)) continue;
+            if (stripped.Contains(BannedAttribute, StringComparison.Ordinal))
+            {
+                hits.Add(line);
+            }
+        }
+        return hits;
+    }
+
+    private static List<Line> ScanStructFieldsForNonBlittableTypes(string source)
+    {
+        var hits = new List<Line>();
+        foreach (var line in EnumerateLines(source))
+        {
+            if (!line.InStruct) continue;
+            var stripped = StripLineComment(line.Text);
+            if (IsCsWin32Boundary(stripped)) continue;
+            // One-liner struct bodies carry the declaration and the fields
+            // on the same line, so scan the body rather than the whole line.
+            var body = stripped;
+            var brace = body.IndexOf('{');
+            if (brace >= 0 && StructDeclaration.IsMatch(body)) body = body[(brace + 1)..];
+
+            foreach (var field in body.Split(';'))
+            {
+                if (NonBlittableField.IsMatch(field + ";"))
+                {
+                    hits.Add(line);
+                    break;
+                }
             }
         }
         return hits;
@@ -165,12 +347,88 @@ public class MarshalComplianceTests
         return reader.ReadToEnd();
     }
 
-    private static IEnumerable<(int Number, string Text)> EnumerateLines(string source)
+    /// <summary>
+    /// Every embedded source that declares a native import, by resource
+    /// name and content.
+    /// </summary>
+    private static List<(string Name, string Source)> InteropSources()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var sources = new List<(string, string)>();
+
+        foreach (var name in asm.GetManifestResourceNames()
+                     .Where(n => n.StartsWith(SourcePrefix, StringComparison.Ordinal)
+                         && n.EndsWith(".cs", StringComparison.Ordinal))
+                     .OrderBy(n => n, StringComparer.Ordinal))
+        {
+            using var stream = asm.GetManifestResourceStream(name);
+            if (stream is null) continue;
+            using var reader = new StreamReader(stream);
+            var source = reader.ReadToEnd();
+            if (InteropMarkers.Any(m => source.Contains(m, StringComparison.Ordinal)))
+            {
+                sources.Add((name[SourcePrefix.Length..], source));
+            }
+        }
+
+        return sources;
+    }
+
+    private readonly record struct Line(int Number, string Text, bool InStruct);
+
+    /// <summary>
+    /// The source's lines, each tagged with whether it sits inside a
+    /// struct body. Brace counting rather than parsing: enough to tell a
+    /// layout field from a method local, which is the only distinction
+    /// the rules above need.
+    /// </summary>
+    private static IEnumerable<Line> EnumerateLines(string source)
     {
         var lines = source.Split('\n');
+        var depth = 0;
+        var structDepths = new Stack<int>();
+        var pendingStruct = false;
+
         for (int i = 0; i < lines.Length; i++)
         {
-            yield return (i + 1, lines[i]);
+            var stripped = StripLineComment(lines[i]);
+            var opensStruct = StructDeclaration.IsMatch(stripped);
+
+            // A one-liner declares the struct and its fields on the same
+            // line, so the line that opens a body counts as inside it.
+            yield return new Line(
+                i + 1,
+                lines[i],
+                structDepths.Count > 0 || (opensStruct && stripped.Contains('{')));
+
+            if (opensStruct) pendingStruct = true;
+            foreach (var c in stripped)
+            {
+                if (c == '{')
+                {
+                    depth++;
+                    if (pendingStruct)
+                    {
+                        structDepths.Push(depth);
+                        pendingStruct = false;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (structDepths.Count > 0 && structDepths.Peek() == depth)
+                    {
+                        structDepths.Pop();
+                    }
+                    depth--;
+                }
+                else if (c == ';')
+                {
+                    // A bodyless declaration: `record struct Point(int X);`.
+                    // Without this the pending open would latch onto the
+                    // next unrelated brace in the file.
+                    pendingStruct = false;
+                }
+            }
         }
     }
 }

--- a/windows/Ghostty.Tests/Shell/LaunchIconAssetsTests.cs
+++ b/windows/Ghostty.Tests/Shell/LaunchIconAssetsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -15,11 +16,26 @@ public class LaunchIconAssetsTests
     // drag the WinAppSDK MRT/PRI targets into a plain net10.0 assembly.
     private const string ProjectResourceName = "Ghostty.Tests.Shell.Ghostty.csproj";
 
+    // SplashWindow.cs, from the interop source corpus embedded for
+    // MarshalComplianceTests. Located by suffix because the resource name
+    // carries the folder path with whatever separator the build host used.
+    private const string SplashWindowResourceSuffix = "SplashWindow.cs";
+
     // Spelled out rather than built from LaunchIconRung.FileName: this is
     // the check that a rename of that pattern leaves nothing behind in the
     // project file, so it has to know the old shape independently.
-    private static readonly Regex SplashAssetPattern = new(
-        @"SplashIcon\.scale-\d+\.png",
+    private const string SplashAssetPattern = @"SplashIcon\.scale-\d+\.png";
+
+    // The two places the project file names generated icons: the copy list
+    // that puts them in bin\Assets, and the up-to-date check that decides
+    // whether they get generated at all. Both have to agree with the shared
+    // ladder, and each has to be read on its own -- a scan of the whole file
+    // is satisfied by either one, which is how a missing copy item hides.
+    private static readonly Regex ContentIncludeAttribute = new(
+        @"<Content\s+Include=""(?<items>[^""]*)""",
+        RegexOptions.Compiled);
+    private static readonly Regex OutputsAttribute = new(
+        @"Outputs=""(?<items>[^""]*)""",
         RegexOptions.Compiled);
 
     [Fact]
@@ -51,52 +67,108 @@ public class LaunchIconAssetsTests
         }
     }
 
-    // The csproj holds the one copy of the ladder that cannot read the
-    // shared table: <Content Include> is evaluated by MSBuild, and it has
-    // to be an explicit list because a wildcard expands before the icons
-    // are generated. A rung listed there but not shipped is an MSB3030
-    // build failure; a rung shipped but not listed never reaches
-    // bin\Assets, and the splash then paints a bare rectangle.
+    // The copy list is the one that decides whether the PNGs reach
+    // bin\Assets. A rung missing from it is generated and then left behind,
+    // and the splash paints a bare rectangle at runtime.
     [Fact]
-    public void ProjectFileCopiesEverySharedRung()
+    public void ProjectFileCopiesExactlyTheSharedRungs()
     {
-        var project = ReadEmbeddedProject();
-
-        foreach (var rung in LaunchIconAssets.Rungs)
-        {
-            Assert.True(
-                project.Contains(rung.FileName, StringComparison.Ordinal),
-                $"Ghostty.csproj does not copy {rung.FileName}. Add it to the " +
-                "SplashIcon <Content Include> list and to GenerateBrandingAssets' " +
-                "Outputs.");
-        }
+        AssertNamesExactlyTheSharedRungs(
+            SplashAssetsIn(ContentIncludeAttribute),
+            "the SplashIcon <Content Include> list");
     }
 
-    // The other direction: a rung dropped or renumbered leaves the copy
-    // item pointing at a file IconGen no longer writes, which fails the
-    // build with MSB3030 rather than skipping quietly.
+    // The up-to-date check is the one that decides whether they are
+    // generated. A rung missing from it lets MSBuild skip the target with
+    // the file absent, which the unconditional copy item turns into an
+    // MSB3030 build failure.
     [Fact]
-    public void ProjectFileCopiesNothingButTheSharedRungs()
+    public void GenerationOutputsNameExactlyTheSharedRungs()
     {
-        var project = ReadEmbeddedProject();
-        var shipped = LaunchIconAssets.Rungs.Select(r => r.FileName).ToHashSet(StringComparer.Ordinal);
+        AssertNamesExactlyTheSharedRungs(
+            SplashAssetsIn(OutputsAttribute),
+            "GenerateBrandingAssets' Outputs");
+    }
 
-        var stale = SplashAssetPattern.Matches(project)
-            .Select(m => m.Value)
-            .Distinct(StringComparer.Ordinal)
-            .Where(name => !shipped.Contains(name))
+    // The AppIcon ladder has no shared table to compare against (nothing in
+    // C# resolves those files by name), but its two lists still have to
+    // agree with each other for the same two reasons as above.
+    [Fact]
+    public void AppIconCopyListAndGenerationOutputsAgree()
+    {
+        var copied = AssetsIn(ContentIncludeAttribute, @"AppIcon\.scale-\d+\.png");
+        var generated = AssetsIn(OutputsAttribute, @"AppIcon\.scale-\d+\.png");
+
+        Assert.NotEmpty(copied);
+        Assert.Equal(
+            generated.OrderBy(n => n, StringComparer.Ordinal),
+            copied.OrderBy(n => n, StringComparer.Ordinal));
+    }
+
+    // Nothing else can pin this: SplashWindow lives in Ghostty.csproj, which
+    // this project does not reference. Without the check, reverting
+    // IconPathForSize to its own hardcoded rung table leaves every test
+    // above green while the consumer drifts away from the shared one again.
+    [Fact]
+    public void SplashWindowResolvesIconsThroughTheSharedLadder()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var names = asm.GetManifestResourceNames()
+            .Where(n => n.StartsWith("Ghostty.Tests.Interop.Sources.", StringComparison.Ordinal)
+                && n.EndsWith(SplashWindowResourceSuffix, StringComparison.Ordinal))
             .ToArray();
 
         Assert.True(
-            stale.Length == 0,
-            "Ghostty.csproj names launch icons that are not shipped rungs: "
-                + string.Join(", ", stale));
+            names.Length == 1,
+            $"Expected exactly one embedded {SplashWindowResourceSuffix}, found "
+                + $"[{string.Join(", ", names)}].");
+
+        var source = ReadEmbeddedText(names[0]);
+
+        Assert.Contains("LaunchIconAssets.Rungs", source, StringComparison.Ordinal);
+        // The prefix alone, not the full file name: a revert that rebuilds
+        // the name with the same interpolation the shared rung uses would
+        // slip past a pattern that insists on the digits and extension.
+        Assert.DoesNotContain("SplashIcon.scale-", source, StringComparison.Ordinal);
     }
 
-    private static string ReadEmbeddedProject()
+    private static void AssertNamesExactlyTheSharedRungs(
+        IReadOnlyCollection<string> named, string what)
+    {
+        var shipped = LaunchIconAssets.Rungs
+            .Select(r => r.FileName)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            shipped.SequenceEqual(named.OrderBy(n => n, StringComparer.Ordinal)),
+            $"Ghostty.csproj: {what} names [{string.Join(", ", named)}], but the "
+                + $"shared ladder ships [{string.Join(", ", shipped)}].");
+    }
+
+    private static IReadOnlyCollection<string> SplashAssetsIn(Regex attribute)
+        => AssetsIn(attribute, SplashAssetPattern);
+
+    /// <summary>
+    /// File names matching <paramref name="assetPattern"/> that appear
+    /// inside an <paramref name="attribute"/> value, so that a mention in a
+    /// comment or in the other list cannot stand in for the real entry.
+    /// </summary>
+    private static IReadOnlyCollection<string> AssetsIn(Regex attribute, string assetPattern)
+    {
+        var project = ReadEmbeddedText(ProjectResourceName);
+        var asset = new Regex(assetPattern);
+
+        return attribute.Matches(project)
+            .SelectMany(m => asset.Matches(m.Groups["items"].Value).Select(a => a.Value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string ReadEmbeddedText(string resourceName)
     {
         var asm = Assembly.GetExecutingAssembly();
-        using var stream = asm.GetManifestResourceStream(ProjectResourceName);
+        using var stream = asm.GetManifestResourceStream(resourceName);
         Assert.NotNull(stream);
         using var reader = new StreamReader(stream!);
         return reader.ReadToEnd();

--- a/windows/Ghostty.Tests/Shell/LaunchIconAssetsTests.cs
+++ b/windows/Ghostty.Tests/Shell/LaunchIconAssetsTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Shell;
+using Xunit;
+
+namespace Ghostty.Tests.Shell;
+
+public class LaunchIconAssetsTests
+{
+    // Ghostty.csproj, embedded by Ghostty.Tests.csproj. Read as text: this
+    // project deliberately does not reference Ghostty.csproj, which would
+    // drag the WinAppSDK MRT/PRI targets into a plain net10.0 assembly.
+    private const string ProjectResourceName = "Ghostty.Tests.Shell.Ghostty.csproj";
+
+    // Spelled out rather than built from LaunchIconRung.FileName: this is
+    // the check that a rename of that pattern leaves nothing behind in the
+    // project file, so it has to know the old shape independently.
+    private static readonly Regex SplashAssetPattern = new(
+        @"SplashIcon\.scale-\d+\.png",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void RungsAreTheLadderWeShip()
+    {
+        var rungs = LaunchIconAssets.Rungs.Select(r => (r.Scale, r.Pixels)).ToArray();
+
+        Assert.Equal(new[] { (100, 160), (150, 240), (200, 320), (400, 640) }, rungs);
+    }
+
+    [Fact]
+    public void RungsAscendByPixelSize()
+    {
+        // SplashWindow.IconPathForSize takes the first rung at least as
+        // large as the size it needs and treats the last as the largest
+        // shipped. Out of order, it would pick a rung it has to upscale
+        // and fall back to one that is not the biggest.
+        var pixels = LaunchIconAssets.Rungs.Select(r => r.Pixels).ToArray();
+
+        Assert.Equal(pixels.OrderBy(p => p).ToArray(), pixels);
+    }
+
+    [Fact]
+    public void FileNamesFollowTheWinuiScaleSuffix()
+    {
+        foreach (var rung in LaunchIconAssets.Rungs)
+        {
+            Assert.Equal($"SplashIcon.scale-{rung.Scale}.png", rung.FileName);
+        }
+    }
+
+    // The csproj holds the one copy of the ladder that cannot read the
+    // shared table: <Content Include> is evaluated by MSBuild, and it has
+    // to be an explicit list because a wildcard expands before the icons
+    // are generated. A rung listed there but not shipped is an MSB3030
+    // build failure; a rung shipped but not listed never reaches
+    // bin\Assets, and the splash then paints a bare rectangle.
+    [Fact]
+    public void ProjectFileCopiesEverySharedRung()
+    {
+        var project = ReadEmbeddedProject();
+
+        foreach (var rung in LaunchIconAssets.Rungs)
+        {
+            Assert.True(
+                project.Contains(rung.FileName, StringComparison.Ordinal),
+                $"Ghostty.csproj does not copy {rung.FileName}. Add it to the " +
+                "SplashIcon <Content Include> list and to GenerateBrandingAssets' " +
+                "Outputs.");
+        }
+    }
+
+    // The other direction: a rung dropped or renumbered leaves the copy
+    // item pointing at a file IconGen no longer writes, which fails the
+    // build with MSB3030 rather than skipping quietly.
+    [Fact]
+    public void ProjectFileCopiesNothingButTheSharedRungs()
+    {
+        var project = ReadEmbeddedProject();
+        var shipped = LaunchIconAssets.Rungs.Select(r => r.FileName).ToHashSet(StringComparer.Ordinal);
+
+        var stale = SplashAssetPattern.Matches(project)
+            .Select(m => m.Value)
+            .Distinct(StringComparer.Ordinal)
+            .Where(name => !shipped.Contains(name))
+            .ToArray();
+
+        Assert.True(
+            stale.Length == 0,
+            "Ghostty.csproj names launch icons that are not shipped rungs: "
+                + string.Join(", ", stale));
+    }
+
+    private static string ReadEmbeddedProject()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(ProjectResourceName);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -467,10 +467,19 @@
     ms-appx:///Assets/AppIcon.scale-xxx.png at runtime. The .ico is
     embedded in the exe automatically via <ApplicationIcon>.
   -->
+  <!--
+    Outputs names every file the tool writes, not just the .icos. The
+    PNG rungs are copied by unconditional <Content> items below, so a
+    state where MSBuild thinks this target is up to date while a PNG is
+    absent is not a graceful skip: it is an MSB3030 copy failure that
+    fails the build. The linked ladder files from Ghostty.Core are
+    Inputs for the same reason as IconGen's own sources: IconGen
+    compiles them, so editing one changes what it writes.
+  -->
   <Target Name="GenerateBrandingAssets"
           BeforeTargets="BeforeBuild"
-          Inputs="..\..\dist\windows\IconGen\**\*.cs;..\..\images\icons\icon_*.png"
-          Outputs="$(GeneratedBrandingDir)wintty.ico;$(GeneratedBrandingDir)wintty-settings.ico;$(GeneratedBrandingDir)wintty-inspector.ico">
+          Inputs="..\..\dist\windows\IconGen\**\*.cs;..\Ghostty.Core\Shell\LaunchIconAssets.cs;..\Ghostty.Core\Shell\LaunchIconMetrics.cs;..\..\images\icons\icon_*.png"
+          Outputs="$(GeneratedBrandingDir)wintty.ico;$(GeneratedBrandingDir)wintty-settings.ico;$(GeneratedBrandingDir)wintty-inspector.ico;$(GeneratedBrandingDir)AppIcon.scale-100.png;$(GeneratedBrandingDir)AppIcon.scale-150.png;$(GeneratedBrandingDir)AppIcon.scale-200.png;$(GeneratedBrandingDir)AppIcon.scale-400.png;$(GeneratedBrandingDir)SplashIcon.scale-100.png;$(GeneratedBrandingDir)SplashIcon.scale-150.png;$(GeneratedBrandingDir)SplashIcon.scale-200.png;$(GeneratedBrandingDir)SplashIcon.scale-400.png">
     <MakeDir Directories="$(GeneratedBrandingDir)" />
     <Exec Command="dotnet run --project ..\..\dist\windows\IconGen --no-launch-profile -c Release -- --channel $(Channel) --out &quot;$(GeneratedBrandingDir.TrimEnd('\'))&quot;"
           WorkingDirectory="$(MSBuildThisFileDirectory)" />
@@ -498,8 +507,10 @@
     <!--
       Launch-icon ladder, sized for a 160 DIP icon. Listed explicitly for the
       same reason as the AppIcon rungs above: a wildcard evaluates
-      before GenerateBrandingAssets produces the files. Keep in sync
-      with PngWriter.SplashTargets in dist/windows/IconGen/PngWriter.cs.
+      before GenerateBrandingAssets produces the files. MSBuild cannot read
+      the shared ladder in Ghostty.Core.Shell.LaunchIconAssets, so this list
+      is a third copy of it; LaunchIconAssetsTests scans this file and fails
+      if the two disagree.
     -->
     <Content Include="$(GeneratedBrandingDir)SplashIcon.scale-100.png;$(GeneratedBrandingDir)SplashIcon.scale-150.png;$(GeneratedBrandingDir)SplashIcon.scale-200.png;$(GeneratedBrandingDir)SplashIcon.scale-400.png">
       <Link>Assets\%(Filename)%(Extension)</Link>

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -589,20 +589,16 @@ internal static unsafe partial class SplashWindow
     private static string? IconPathForSize(int iconPx)
     {
         var dir = Path.Combine(AppContext.BaseDirectory, "Assets");
+        var rungs = LaunchIconAssets.Rungs;
 
-        // Pixel size of each rung paired with the scale suffix it ships
-        // under. Keep in sync with PngWriter.SplashTargets.
-        ReadOnlySpan<int> rungPixels = [160, 240, 320, 640];
-        ReadOnlySpan<int> rungScales = [100, 150, 200, 400];
-
-        for (var i = 0; i < rungPixels.Length; i++)
+        for (var i = 0; i < rungs.Count; i++)
         {
-            if (rungPixels[i] < iconPx) continue;
-            var candidate = Path.Combine(dir, $"SplashIcon.scale-{rungScales[i]}.png");
+            if (rungs[i].Pixels < iconPx) continue;
+            var candidate = Path.Combine(dir, rungs[i].FileName);
             if (File.Exists(candidate)) return candidate;
         }
 
-        var largest = Path.Combine(dir, "SplashIcon.scale-400.png");
+        var largest = Path.Combine(dir, rungs[^1].FileName);
         return File.Exists(largest) ? largest : null;
     }
 


### PR DESCRIPTION
Three build-level gaps left over from # 619. None is a live bug; each is a way the splash can break silently later.

**One ladder, not three.** The splash rung table was duplicated between `PngWriter.SplashTargets` and `SplashWindow.IconPathForSize`, kept in step by a comment, with only the generator side tested. `Ghostty.Core.Shell.LaunchIconAssets` now owns it, derived from `LaunchIconMetrics.MaxSizeDips`. IconGen links the file rather than referencing Ghostty.Core, which would put Core's prebake step and SkiaSharp in front of icon generation. The third copy lives in `Ghostty.csproj`'s `<Content Include>` list, which MSBuild cannot read from C#, so `LaunchIconAssetsTests` scans the project file both ways: every rung is copied, and nothing else is.

**The interop scan follows the code.** `MarshalComplianceTests` read one embedded file, so SplashWindow's P/Invokes and interop structs were outside it. The corpus is now every source in the two `DisableRuntimeMarshalling` assemblies that declares a `[LibraryImport]` or `[DllImport]`, taken from a wildcard rather than a list. The existing no-`[MarshalAs]` rule still applies to the libghostty boundary only, since the Win32 files legitimately use `[return: MarshalAs(UnmanagedType.Bool)]` on a `[LibraryImport]`. What applies everywhere are the struct rules: no `[MarshalAs]` on a field, no `bool`/`char`/`string` field. Those are the ones that fail at call time rather than at build time.

**Outputs names what the target writes.** `GenerateBrandingAssets` declared three .icos while also producing eight PNGs that `<Content>` items copy unconditionally, so a skip with a PNG absent is an MSB3030 failure, not a graceful no-op. All eight are listed now, along with the two linked ladder files as Inputs.

## Verification

`dotnet test` on both suites: 1833 passed in Ghostty.Tests, 27 in IconGen.Tests. Breaking a rung locally in three ways was caught before reverting:

- renumbering scale-400 to scale-500: 3 failures in Ghostty.Tests, 3 in IconGen.Tests
- renaming the file prefix to `LaunchIcon`: caught by `ProjectFileCopiesEverySharedRung`
- adding `public bool Broken;` to SplashWindow's `SIZE` struct: `InteropSources_HaveNoNonBlittableStructFields` reports it as `Sources.Ghostty.Shell\SplashWindow.cs line 817`

## Noted, not fixed

`GenerateBrandingAssets` never actually skips: MSBuild does not expand the `**` wildcard in `Inputs`, reports `Input file "..\..\dist\windows\IconGen\**\*.cs" does not exist`, and rebuilds completely every time. That is why the stale Outputs were harmless, and it means the shell pays a `dotnet run` icon regeneration on every build. Worth a follow-up; the Outputs fix here is what has to land first.