### PR TITLE
termio: give the SPSC mailbox a stable wakeup pointer

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -765,7 +765,7 @@ pub fn init(
     // needs a stop-notify and a join rather than a plain errdefer, which is
     // a larger change than this.
     if (config.title) |title| {
-        setInitialTitle(rt_app, self, title);
+        setInitialTitle(self, title);
     } else if ((comptime builtin.os.tag == .linux) and
         config.@"_xdg-terminal-exec")
     xdg: {
@@ -781,12 +781,12 @@ pub fn init(
             break :xdg;
         };
         defer alloc.free(title);
-        setInitialTitle(rt_app, self, title);
+        setInitialTitle(self, title);
     } else if (command) |cmd| switch (cmd) {
         // If a user specifies a command it is appropriate to set the title as argv[0]
         // we know in the case of a direct command it has been supplied by the user
         .direct => |cmd_str| if (cmd_str.len != 0) {
-            setInitialTitle(rt_app, self, cmd_str[0]);
+            setInitialTitle(self, cmd_str[0]);
         },
 
         // We won't set the title in the case the shell expands the command

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -552,37 +552,12 @@ pub fn init(
         break :size size;
     };
 
-    // Create our terminal grid with the initial size
     const app_mailbox: App.Mailbox = .{ .rt_app = rt_app, .mailbox = &app.mailbox };
-    var renderer_impl = try Renderer.init(alloc, .{
-        .config = try .init(alloc, config),
-        .font_grid = font_grid,
-        .size = size,
-        .surface_mailbox = .{ .surface = self, .app = app_mailbox },
-        .rt_surface = rt_surface,
-        .thread = &self.renderer_thread,
-    });
-    errdefer renderer_impl.deinit();
 
     // The mutex used to protect our renderer state.
     const mutex = try alloc.create(std.Io.Mutex);
     mutex.* = .init;
     errdefer alloc.destroy(mutex);
-
-    // Create the renderer thread
-    var render_thread = try rendererpkg.Thread.init(
-        alloc,
-        config,
-        rt_surface,
-        &self.renderer,
-        &self.renderer_state,
-        app_mailbox,
-    );
-    errdefer render_thread.deinit();
-
-    // Create the IO thread
-    var io_thread = try termio.Thread.init(alloc);
-    errdefer io_thread.deinit();
 
     self.* = .{
         .id = id: {
@@ -604,8 +579,8 @@ pub fn init(
         .font_size = font_size,
         .font_size_adjusted = false,
         .font_metrics = font_grid.metrics,
-        .renderer = renderer_impl,
-        .renderer_thread = render_thread,
+        .renderer = undefined,
+        .renderer_thread = undefined,
         .renderer_state = .{
             .mutex = mutex,
             .terminal = &self.io.terminal,
@@ -614,7 +589,7 @@ pub fn init(
         .mouse = .{},
         .keyboard = .{},
         .io = undefined,
-        .io_thread = io_thread,
+        .io_thread = undefined,
         .io_thr = undefined,
         .size = size,
         .config = derived_config,
@@ -623,6 +598,33 @@ pub fn init(
         // lets us get the most likely correct color theme and so on.
         .config_conditional_state = app.config_conditional_state,
     };
+
+    // The renderer and both threads are built directly into their fields
+    // rather than into locals we copy in above. Constructing them into
+    // locals would leave the errdefers below pointing at stale copies once
+    // the assignment above moved the real values into `self`.
+    self.renderer = try Renderer.init(alloc, .{
+        .config = try .init(alloc, config),
+        .font_grid = font_grid,
+        .size = size,
+        .surface_mailbox = .{ .surface = self, .app = app_mailbox },
+        .rt_surface = rt_surface,
+        .thread = &self.renderer_thread,
+    });
+    errdefer self.renderer.deinit();
+
+    self.renderer_thread = try rendererpkg.Thread.init(
+        alloc,
+        config,
+        rt_surface,
+        &self.renderer,
+        &self.renderer_state,
+        app_mailbox,
+    );
+    errdefer self.renderer_thread.deinit();
+
+    self.io_thread = try termio.Thread.init(alloc);
+    errdefer self.io_thread.deinit();
 
     // The command we're going to execute
     const command: ?configpkg.Command = command: {
@@ -684,11 +686,10 @@ pub fn init(
             .backend = .{ .exec = io_exec },
             .mailbox = io_mailbox,
             .renderer_state = &self.renderer_state,
-            // Must be our own field, not `render_thread`: the renderer arms
-            // its wait on `self.renderer_thread.wakeup` and only that
-            // instance is notified.
+            // The renderer arms its wait on `self.renderer_thread.wakeup`,
+            // so only that instance may be notified.
             .renderer_wakeup = &self.renderer_thread.wakeup,
-            .renderer_mailbox = render_thread.mailbox,
+            .renderer_mailbox = self.renderer_thread.mailbox,
             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
         });
     }
@@ -724,7 +725,7 @@ pub fn init(
 
     // Give the renderer one more opportunity to finalize any surface
     // setup on the main thread prior to spinning up the rendering thread.
-    try renderer_impl.finalizeSurfaceInit(rt_surface);
+    try self.renderer.finalizeSurfaceInit(rt_surface);
 
     // Start our renderer thread
     self.renderer_thr = try std.Thread.spawn(
@@ -2590,7 +2591,6 @@ fn resize(self: *Surface, size: rendererpkg.ScreenSize) !void {
 
     // Mail the IO thread
     self.queueIo(.{ .resize = self.size }, .unlocked);
-
 }
 
 /// Recalculate the balanced padding if needed.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -599,10 +599,10 @@ pub fn init(
         .config_conditional_state = app.config_conditional_state,
     };
 
-    // The renderer and both threads are built directly into their fields
-    // rather than into locals we copy in above. Constructing them into
-    // locals would leave the errdefers below pointing at stale copies once
-    // the assignment above moved the real values into `self`.
+    // Assigned into their fields before anything can fail, so the errdefers
+    // below clean up the values `self` actually keeps rather than a copy,
+    // and so `&self.renderer` and `&self.renderer_state` are handed out
+    // pointing at initialized memory.
     self.renderer = try Renderer.init(alloc, .{
         .config = try .init(alloc, config),
         .font_grid = font_grid,
@@ -756,12 +756,16 @@ pub fn init(
         log.warn("unable to set initial window size: {}", .{err});
     };
 
+    // Both worker threads are running by now, so these must not propagate:
+    // unwinding past this point would deinit state the threads are still
+    // reading. Failing to set a title shouldn't stop the terminal working,
+    // same reasoning as the initial size above.
+    //
+    // The io thread spawn above is the one remaining exception. Handling it
+    // needs a stop-notify and a join rather than a plain errdefer, which is
+    // a larger change than this.
     if (config.title) |title| {
-        _ = try rt_app.performAction(
-            .{ .surface = self },
-            .set_title,
-            .{ .title = title },
-        );
+        setInitialTitle(rt_app, self, title);
     } else if ((comptime builtin.os.tag == .linux) and
         config.@"_xdg-terminal-exec")
     xdg: {
@@ -777,20 +781,12 @@ pub fn init(
             break :xdg;
         };
         defer alloc.free(title);
-        _ = try rt_app.performAction(
-            .{ .surface = self },
-            .set_title,
-            .{ .title = title },
-        );
+        setInitialTitle(rt_app, self, title);
     } else if (command) |cmd| switch (cmd) {
         // If a user specifies a command it is appropriate to set the title as argv[0]
         // we know in the case of a direct command it has been supplied by the user
         .direct => |cmd_str| if (cmd_str.len != 0) {
-            _ = try rt_app.performAction(
-                .{ .surface = self },
-                .set_title,
-                .{ .title = cmd_str[0] },
-            );
+            setInitialTitle(rt_app, self, cmd_str[0]);
         },
 
         // We won't set the title in the case the shell expands the command
@@ -801,6 +797,20 @@ pub fn init(
 
     // We are no longer the first surface
     app.first = false;
+}
+
+/// Set the title a surface starts with. Errors are logged rather than
+/// returned: this runs after the render and IO threads are spawned, where
+/// unwinding would tear down state those threads are still using.
+fn setInitialTitle(self: *Surface, title: [:0]const u8) void {
+    _ = self.rt_app.performAction(
+        .{ .surface = self },
+        .set_title,
+        .{ .title = title },
+    ) catch |err| {
+        log.warn("error setting initial title err={}", .{err});
+        return;
+    };
 }
 
 pub fn deinit(self: *Surface) void {

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -30,16 +30,24 @@ pub const Mailbox = union(enum) {
     /// Write messages to a SPSC queue for multi-threaded applications.
     spsc: struct {
         queue: *Queue,
-        wakeup: xev.Async,
+
+        /// Heap-allocated so that copying this union never forks the
+        /// wakeup. Several libxev backends (IOCP, wasi_poll) store the
+        /// wait registration inside the Async itself, so arming a wait on
+        /// one instance and notifying another silently drops the wakeup.
+        /// This value travels from Surface.init through termio.Options
+        /// into Termio, so it is copied more than once.
+        wakeup: *xev.Async,
     },
 
     /// Init the SPSC writer.
     pub fn initSPSC(alloc: Allocator) !Mailbox {
-        var queue = try Queue.create(alloc);
+        const queue = try Queue.create(alloc);
         errdefer queue.destroy(alloc);
 
-        var wakeup = try xev.Async.init();
-        errdefer wakeup.deinit();
+        const wakeup = try alloc.create(xev.Async);
+        errdefer alloc.destroy(wakeup);
+        wakeup.* = try .init();
 
         return .{ .spsc = .{ .queue = queue, .wakeup = wakeup } };
     }
@@ -50,6 +58,7 @@ pub const Mailbox = union(enum) {
                 while (v.queue.pop(global.io())) |msg| msg.deinit();
                 v.queue.destroy(alloc);
                 v.wakeup.deinit();
+                alloc.destroy(v.wakeup);
             },
         }
     }
@@ -107,3 +116,17 @@ pub const Mailbox = union(enum) {
         }
     }
 };
+
+test "spsc copies share one wakeup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var mailbox = try Mailbox.initSPSC(alloc);
+    defer mailbox.deinit(alloc);
+
+    // termio.Thread arms its wait on whichever copy reached Termio, while
+    // producers notify through their own. Both must name one Async.
+    const copy = mailbox;
+    try testing.expectEqual(mailbox.spsc.wakeup, copy.spsc.wakeup);
+    try testing.expectEqual(mailbox.spsc.queue, copy.spsc.queue);
+}

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -31,12 +31,12 @@ pub const Mailbox = union(enum) {
     spsc: struct {
         queue: *Queue,
 
-        /// Heap-allocated so that copying this union never forks the
-        /// wakeup. Several libxev backends (IOCP, wasi_poll) store the
-        /// wait registration inside the Async itself, so arming a wait on
-        /// one instance and notifying another silently drops the wakeup.
-        /// This value travels from Surface.init through termio.Options
-        /// into Termio, so it is copied more than once.
+        /// There must be exactly one Async per mailbox. This union is a
+        /// value type that gets copied on its way to its owner (Surface.init
+        /// builds it, termio.Options carries it, Termio takes it), and the
+        /// IOCP backend keeps its wait registration and a mutex inline in
+        /// the Async, so it cannot survive living here by value. Boxing it
+        /// makes an accidental copy harmless rather than silent.
         wakeup: *xev.Async,
     },
 
@@ -48,6 +48,7 @@ pub const Mailbox = union(enum) {
         const wakeup = try alloc.create(xev.Async);
         errdefer alloc.destroy(wakeup);
         wakeup.* = try .init();
+        errdefer wakeup.deinit();
 
         return .{ .spsc = .{ .queue = queue, .wakeup = wakeup } };
     }
@@ -61,6 +62,11 @@ pub const Mailbox = union(enum) {
                 alloc.destroy(v.wakeup);
             },
         }
+
+        // Poison in safe builds so a second deinit crashes near the fault
+        // instead of silently double-freeing. This does not protect the
+        // other copies of the union, only the one being torn down.
+        self.* = undefined;
     }
 
     /// Sends the given message without notifying there are messages.
@@ -117,16 +123,44 @@ pub const Mailbox = union(enum) {
     }
 };
 
-test "spsc copies share one wakeup" {
+test "Mailbox: spsc wakeup survives copying the union" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
     var mailbox = try Mailbox.initSPSC(alloc);
     defer mailbox.deinit(alloc);
 
-    // termio.Thread arms its wait on whichever copy reached Termio, while
-    // producers notify through their own. Both must name one Async.
-    const copy = mailbox;
-    try testing.expectEqual(mailbox.spsc.wakeup, copy.spsc.wakeup);
-    try testing.expectEqual(mailbox.spsc.queue, copy.spsc.queue);
+    // This assert is what actually guards the invariant: boxing makes the
+    // wait/notify below share one Async by construction, so only a revert
+    // to a by-value field can fail, and it fails here rather than hanging
+    // on a notify that went to a different instance.
+    try testing.expectEqual(*xev.Async, @TypeOf(mailbox.spsc.wakeup));
+
+    var loop = try xev.Loop.init(.{});
+    defer loop.deinit();
+
+    // Exercise the wiring end to end. Only meaningful on backends that keep
+    // the registration inline in the Async; the test backend on Linux is
+    // epoll, whose Async is a bare eventfd and is copy-safe either way.
+    var consumer = mailbox;
+    var producer = mailbox;
+
+    var fired: bool = false;
+    var c: xev.Completion = .{};
+    consumer.spsc.wakeup.wait(&loop, &c, bool, &fired, (struct {
+        fn callback(
+            ud: ?*bool,
+            _: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Async.WaitError!void,
+        ) xev.CallbackAction {
+            _ = r catch return .disarm;
+            ud.?.* = true;
+            return .disarm;
+        }
+    }).callback);
+
+    producer.notify();
+    try loop.run(.until_done);
+    try testing.expect(fired);
 }


### PR DESCRIPTION
The SPSC mailbox declared its wakeup by value:

    spsc: struct {
        queue: *Queue,
        wakeup: xev.Async,
    },

That Async gets copied twice before it comes to rest: `Surface.init` builds it, copies it into `termio.Options`, and that is copied into `Termio`. It works today only because `termio.Thread` arms its wait on `io.mailbox`, the final copy, and every notifier happens to reach that same instance. Correct by ordering, not by design.

This is the shape that caused the blank restored panes in b18a7eddb425. libxev's IOCP backend keeps the wait registration, and a mutex, inline in the Async, so a notify on a copy is silently dropped.

Heap-allocating the wakeup beside the queue makes every copy of the union name one Async.

To be clear about what this is: no live path notifies a copy today, so this is hardening rather than a bug fix with a reproduction. It removes the reorder-fragility, which is what bit us the last time.

## Audit

Every other `xev.Async` in `src/` is already safe:

- `renderer/Thread.zig` and `termio/Thread.zig` are copied by value into `self.*`, but no wait is armed until `threadMain` runs on `&self.renderer_thread` / `&self.io_thread`, and all notifiers go through `self`.
- `terminal/search/Thread.zig` assigns straight into `self.search` with a comment saying why.
- `os/cf_release_thread.zig` is heap-allocated and only ever touched through the pointer.

## Second commit

`Surface.init` built the renderer and both threads into locals and copied them into `self`, leaving three errdefers pointing at the stale copies. They now initialize directly into their fields.

That surfaced a hazard the errdefer retargeting made worse rather than better. `Renderer.deinit` ends with `self.* = undefined`; before, that scribbled a dead stack local, but afterwards it scribbles `self.renderer`, which the render thread reads through `Thread.renderer`. So the three post-spawn `set_title` calls are now routed through a helper that logs instead of returning an error. This is a behaviour change: a failed title no longer aborts surface creation, matching what `recomputeInitialSize` already does immediately above.

The io thread spawn is the one remaining call that propagates with the renderer thread live. Closing it needs a stop-notify and a join rather than an errdefer, tracked in # 624 along with three adjacent pre-existing leaks review found in the same function.

## Review

Three reviewers over two rounds. Findings applied:

- The original regression test was vacuous: it asserted that copying a struct preserves a pointer, which the pre-fix by-value field satisfied identically, so it could not fail on the code it guarded. Now asserts the field type first, then exercises arm-through-one-copy notify-through-another against a real loop.
- The field comment claimed a live dropped wakeup and named `wasi_poll` as a second affected backend. `AsyncLoopState` is `struct {}` when threaded, so that claim did not hold as stated; the comment now states the invariant and names only IOCP.
- Restored `errdefer wakeup.deinit()`, which matters on `AsyncEventFd` where the Async owns an fd.

Declined: boxing the whole `spsc` payload as `*SPSC`. `queue` is already a stable pointer, and `*xev.Async` matches the house pattern in `renderer/generic.zig` and `termio/Options.zig`, which keeps this portable upstream.

Also included: a one-line `zig fmt` fix in `resize`. It is unrelated churn, but the formatter removes that blank line on any `zig fmt` run, so keeping it out would leave the branch failing `zig fmt --check`.

## Testing

Three platforms, all against the final commit:

| Platform | Steps | Tests |
|---|---|---|
| Windows (IOCP) | 83/83 | 3757/3834, 77 skipped |
| Linux (eventfd) | 78/78 | 3588/3697, 109 skipped |
| macOS (kqueue) | 199/201 | 3607/3701, 94 skipped |

The macOS step failure is `xcodebuild test` aborting on `childPID > 0`, which the base branch does identically; that host has no codesigning certificate. Zig test failures on macOS: zero. The base measures 3606/3700 there, so the +1 is this PR's new test.

Cross-platform was worth running. An earlier revision of this branch compiled and passed on both Windows and Linux while containing a hard compile error in `Surface.init`, because that function is only semantically analysed when an apprt references it and neither of those test configurations does. macOS reaches it through `apprt/embedded.zig` and caught it.

Also verified: the new test isolated with `-Dtest-filter` to confirm it is discovered and does not hang, `zig fmt --check` clean on both files, and a two-pane session on the real Windows app where output repaints an unfocused pane. That last one is a non-regression check; the base passes it too.

Upstream candidate: `main` has the same by-value declaration, and the change is a no-op on eventfd and kqueue.
