### PR TITLE
shell: elect single-instance before the splash, not after

### DIFF
--- a/justfile
+++ b/justfile
@@ -112,6 +112,22 @@ build-win:
 run-win: build-dll build-win
     ./windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe
 
+# Run the C# test suites. Ghostty.Tests is pure logic and cross-platform;
+# Ghostty.Tests.Windows holds the tests that need real Windows semantics
+# (named mutexes, file sharing, the registry).
+[windows]
+test-win:
+    dotnet test windows/Ghostty.Tests/Ghostty.Tests.csproj
+    dotnet test windows/Ghostty.Tests.Windows/Ghostty.Tests.Windows.csproj /p:Platform=x64
+
+# Launch two instances a few hundred ms apart and watch for a launch splash
+# owned by the one that should be forwarding itself to the other. Opens real
+# windows, so it needs an interactive desktop and no Wintty already running.
+# Pass extra args through, e.g. `just splash-race "-SecondaryFeatureOff"`.
+[windows]
+splash-race args="": build-win
+    pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}
+
 # === Upstream Sync ===
 
 # Pinned to bash via shebang so the POSIX `[` branch test below works

--- a/windows/Ghostty.Core/Config/ConfigIniFile.cs
+++ b/windows/Ghostty.Core/Config/ConfigIniFile.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Reader for a ghostty-style ini file. Keys that libghostty's parser does
+/// not know about (see <see cref="WindowsOnlyKeys"/>) cannot be read through
+/// <c>ghostty_config_get</c>, so the Windows side parses the file itself.
+/// </summary>
+/// <remarks>
+/// Shared rather than private to the config service because one of these keys
+/// is read before that service can exist: the single-instance election runs
+/// ahead of <c>Application.Start</c>.
+/// </remarks>
+public static class ConfigIniFile
+{
+    /// <summary>
+    /// Load <paramref name="path"/> into a key/value dictionary. Empty lines
+    /// and #-prefixed comments are skipped, empty values are ignored entirely,
+    /// and keys are matched case-insensitively. Values may themselves contain
+    /// <c>=</c>; only the first one separates.
+    /// </summary>
+    /// <remarks>
+    /// Returns an empty dictionary for a path that does not exist -- and for
+    /// one whose existence cannot be established, since the probe reports a
+    /// denied file as missing. A file that exists but cannot be read, an
+    /// editor holding it exclusively being the usual case, propagates the I/O
+    /// failure instead. Callers decide what that means: the config service
+    /// lets it escape (a half-read config is worse than none), the pre-startup
+    /// election degrades to the default.
+    /// </remarks>
+    public static Dictionary<string, List<string>> Load(string? path)
+    {
+        var dict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            return dict;
+
+        foreach (var line in File.ReadLines(path))
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#')) continue;
+            var eqIndex = trimmed.IndexOf('=');
+            if (eqIndex < 0) continue;
+            var k = trimmed[..eqIndex].Trim();
+            if (k.Length == 0) continue;
+            var v = trimmed[(eqIndex + 1)..].Trim();
+            if (v.Length == 0) continue;
+            if (!dict.TryGetValue(k, out var list))
+            {
+                list = new List<string>(1);
+                dict[k] = list;
+            }
+            list.Add(v);
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// First value recorded for <paramref name="key"/>, or
+    /// <paramref name="defaultValue"/> when the file does not set it.
+    /// </summary>
+    public static string First(
+        IReadOnlyDictionary<string, List<string>>? file,
+        string key,
+        string defaultValue = "")
+        => file is not null
+            && file.TryGetValue(key, out var list)
+            && list.Count > 0
+            ? list[0]
+            : defaultValue;
+}

--- a/windows/Ghostty.Core/Config/IConfigService.cs
+++ b/windows/Ghostty.Core/Config/IConfigService.cs
@@ -42,14 +42,6 @@ public interface IConfigService : IDisposable
     bool CommandPaletteGroupCommands { get; }
 
     /// <summary>
-    /// Windows-only: true when opt-in single-instance mode is active. A
-    /// second launch forwards its working directory and argv to the
-    /// already-running instance (which opens a new window) and then exits.
-    /// Default false. Backed by the "windows-single-instance" key.
-    /// </summary>
-    bool WindowsSingleInstance { get; }
-
-    /// <summary>
     /// Windows-only: default true. Backed by the "windows-high-contrast"
     /// key. When true, the terminal surface follows the OS High Contrast
     /// theme; false keeps the user's configured colors regardless of OS
@@ -74,7 +66,7 @@ public interface IConfigService : IDisposable
 
     /// <summary>
     /// Windows-only: how Wintty reacts to a <c>NO_COLOR</c> value inherited
-    /// from the launching environment. One of "notify" (default — honor
+    /// from the launching environment. One of "notify" (default -- honor
     /// NO_COLOR but show a one-time notice offering to enable color), "strip"
     /// (enable color by removing NO_COLOR from spawned shells), or "keep"
     /// (honor NO_COLOR silently). Backed by the "no-color-override" key.

--- a/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
+++ b/windows/Ghostty.Core/Config/WindowsOnlyKeys.cs
@@ -56,7 +56,7 @@ public static class WindowsOnlyKeys
         new("no-color-override",
             "How Wintty reacts to a NO_COLOR value inherited from the environment: notify (default -- honor NO_COLOR but show a one-time notice offering to enable color), strip (enable color by removing NO_COLOR from spawned shells), or keep (honor NO_COLOR silently)."),
         new("windows-single-instance",
-            "When true, a second launch is routed into the already-running instance (opens a new window) instead of starting a separate process."),
+            "When true, a second launch is routed into the already-running instance (opens a new window) instead of starting a separate process. Read once at startup, so a change takes effect on the next launch."),
         new("windows-high-contrast",
             "When true (default), the terminal surface follows the Windows High Contrast theme automatically; set false to keep your configured colors even in High Contrast mode."),
         new("quick-terminal-key",

--- a/windows/Ghostty.Core/SingleInstance/SingleInstanceElection.cs
+++ b/windows/Ghostty.Core/SingleInstance/SingleInstanceElection.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Runtime.Versioning;
+using System.Threading;
+
+namespace Ghostty.Core.SingleInstance;
+
+/// <summary>
+/// What a launch turned out to be, once the election has been held.
+/// </summary>
+public enum SingleInstanceRole
+{
+    /// <summary><c>windows-single-instance</c> is off; nothing was created.</summary>
+    Disabled,
+
+    /// <summary>This process owns the session and serves forwarded launches.</summary>
+    Primary,
+
+    /// <summary>A primary already exists; this launch is forwarded to it.</summary>
+    Secondary,
+
+    /// <summary>The election could not be held. See <see cref="SingleInstanceElection.Failure"/>.</summary>
+    Failed,
+}
+
+/// <summary>
+/// The single-instance decision, made once per process.
+/// </summary>
+/// <remarks>
+/// Creating the mutex IS the decision: <c>CreateMutex</c> is atomic, so exactly
+/// one of any number of racing processes sees <c>createdNew</c>. Asking whether
+/// the mutex exists and then acting on the answer decides twice, and the answer
+/// can change in between.
+///
+/// Held before the app runtime exists, so there is no logger to report to; a
+/// failure is carried in <see cref="Failure"/> for the caller to log later. A
+/// failed election is not a blocked launch - the process continues as an
+/// ordinary independent window.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+public sealed class SingleInstanceElection : IDisposable
+{
+    private SingleInstanceElection(
+        SingleInstanceRole role,
+        Mutex? mutex,
+        SingleInstanceNames.Names names,
+        Exception? failure)
+    {
+        Role = role;
+        Mutex = mutex;
+        Names = names;
+        Failure = failure;
+    }
+
+    /// <summary>What this launch turned out to be.</summary>
+    public SingleInstanceRole Role { get; }
+
+    /// <summary>
+    /// The mutex, on a <see cref="SingleInstanceRole.Primary"/> only. Must stay
+    /// reachable for the process lifetime: a collected handle releases the name
+    /// and lets a later launch elect itself primary alongside this one.
+    /// </summary>
+    public Mutex? Mutex { get; }
+
+    /// <summary>The mutex and pipe names this election was held under.</summary>
+    public SingleInstanceNames.Names Names { get; }
+
+    /// <summary>Why the election could not be held, on a
+    /// <see cref="SingleInstanceRole.Failed"/> only.</summary>
+    public Exception? Failure { get; }
+
+    /// <summary>
+    /// Whether this launch should put the splash up.
+    /// </summary>
+    /// <remarks>
+    /// A secondary must not, even for the moment before it forwards: the splash
+    /// is full-size, opaque and topmost, and the window it would cover is the
+    /// primary's. Every other role goes on to open a window of its own.
+    /// </remarks>
+    public bool ShouldShowLaunchSplash => Role != SingleInstanceRole.Secondary;
+
+    /// <summary>
+    /// Hold the election. Creates nothing when <paramref name="enabled"/> is
+    /// false, so a process with the feature off never leaves a mutex behind for
+    /// one with it on to misread.
+    /// </summary>
+    public static SingleInstanceElection Run(bool enabled, string exePath)
+    {
+        var names = SingleInstanceNames.For(exePath);
+
+        if (!enabled)
+            return new SingleInstanceElection(SingleInstanceRole.Disabled, null, names, null);
+
+        try
+        {
+            var mutex = new Mutex(initiallyOwned: true, name: names.Mutex, out var createdNew);
+            if (createdNew)
+                return new SingleInstanceElection(SingleInstanceRole.Primary, mutex, names, null);
+
+            // Close the loser's handle here rather than carrying it. A named
+            // mutex outlives its owner for as long as ANY handle is open, so
+            // holding this one across startup would keep the name alive after
+            // the primary exits - and the next launch would elect itself
+            // secondary with nobody left to forward to.
+            mutex.Dispose();
+            return new SingleInstanceElection(SingleInstanceRole.Secondary, null, names, null);
+        }
+        catch (Exception ex)
+        {
+            return new SingleInstanceElection(SingleInstanceRole.Failed, null, names, ex);
+        }
+    }
+
+    /// <summary>
+    /// Release the mutex, so a relaunch can become the new primary immediately.
+    /// A no-op on any role but <see cref="SingleInstanceRole.Primary"/>.
+    /// </summary>
+    public void Dispose() => Mutex?.Dispose();
+}

--- a/windows/Ghostty.Tests.Windows/Config/ConfigIniFileSharingTests.cs
+++ b/windows/Ghostty.Tests.Windows/Config/ConfigIniFileSharingTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Windows.Config;
+
+/// <summary>
+/// The rest of the parser's behaviour is pure logic and lives in the
+/// cross-platform test project. This one asserts a sharing rule, which is
+/// Windows-native: elsewhere .NET emulates FileShare with advisory locks and
+/// the guarantee is not the same.
+/// </summary>
+public sealed class ConfigIniFileSharingTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), $"wintty-ini-share-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void FileLockedAgainstReaders_Throws()
+    {
+        // The doc promises propagation rather than an empty dictionary, and the
+        // config service relies on it: a half-read config is worse than none,
+        // so it lets the throw escape rather than starting on defaults.
+        Directory.CreateDirectory(_dir);
+        var path = Path.Combine(_dir, "config.wintty");
+        File.WriteAllText(path, "windows-single-instance = true\n");
+
+        using var exclusive = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        Assert.ThrowsAny<IOException>(() => ConfigIniFile.Load(path));
+    }
+}

--- a/windows/Ghostty.Tests.Windows/SingleInstance/SingleInstanceElectionTests.cs
+++ b/windows/Ghostty.Tests.Windows/SingleInstance/SingleInstanceElectionTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Ghostty.Core.SingleInstance;
+using Xunit;
+
+namespace Ghostty.Tests.Windows.SingleInstance;
+
+/// <summary>
+/// Exercises the real named mutex, which is the whole point: the guarantee
+/// under test is one the OS provides and a fake would only restate.
+/// </summary>
+public sealed class SingleInstanceElectionTests
+{
+    /// <summary>
+    /// A path no other test (or leftover process) can be holding. The names are
+    /// a hash of the path, so a fresh path is a fresh election.
+    /// </summary>
+    private static string UniqueExePath()
+        => $@"C:\wintty-tests\{Guid.NewGuid():N}\Wintty.exe";
+
+    [Fact]
+    public void Disabled_CreatesNothingAndElectsNobody()
+    {
+        var path = UniqueExePath();
+
+        using var election = SingleInstanceElection.Run(enabled: false, path);
+
+        Assert.Equal(SingleInstanceRole.Disabled, election.Role);
+        Assert.Null(election.Mutex);
+        Assert.Null(election.Failure);
+
+        // The mutex must not exist. A process running with the feature off that
+        // left one behind would make the next process with it on read a primary
+        // that is not there.
+        Assert.False(Mutex.TryOpenExisting(election.Names.Mutex, out var leaked));
+        leaked?.Dispose();
+    }
+
+    [Fact]
+    public void FirstElection_IsPrimary()
+    {
+        var path = UniqueExePath();
+
+        using var election = SingleInstanceElection.Run(enabled: true, path);
+
+        Assert.Equal(SingleInstanceRole.Primary, election.Role);
+        Assert.NotNull(election.Mutex);
+        Assert.Null(election.Failure);
+    }
+
+    [Fact]
+    public void SecondElectionWhilePrimaryLives_IsSecondary()
+    {
+        var path = UniqueExePath();
+
+        using var primary = SingleInstanceElection.Run(enabled: true, path);
+        using var secondary = SingleInstanceElection.Run(enabled: true, path);
+
+        Assert.Equal(SingleInstanceRole.Primary, primary.Role);
+        Assert.Equal(SingleInstanceRole.Secondary, secondary.Role);
+    }
+
+    [Fact]
+    public void AfterPrimaryReleases_NextElectionIsPrimaryAgain()
+    {
+        var path = UniqueExePath();
+
+        var first = SingleInstanceElection.Run(enabled: true, path);
+        Assert.Equal(SingleInstanceRole.Primary, first.Role);
+        first.Dispose();
+
+        using var second = SingleInstanceElection.Run(enabled: true, path);
+        Assert.Equal(SingleInstanceRole.Primary, second.Role);
+    }
+
+    /// <summary>
+    /// A named mutex outlives its owner for as long as any handle is open, so a
+    /// secondary that kept its losing handle would keep the name alive after
+    /// the primary exited - and the next launch would elect itself secondary
+    /// with nobody left to forward to.
+    /// </summary>
+    [Fact]
+    public void SecondarysHandleDoesNotOutlivePrimary()
+    {
+        var path = UniqueExePath();
+
+        var primary = SingleInstanceElection.Run(enabled: true, path);
+        using var secondary = SingleInstanceElection.Run(enabled: true, path);
+        Assert.Equal(SingleInstanceRole.Secondary, secondary.Role);
+        Assert.Null(secondary.Mutex);
+
+        primary.Dispose();
+
+        using var third = SingleInstanceElection.Run(enabled: true, path);
+        Assert.Equal(SingleInstanceRole.Primary, third.Role);
+    }
+
+    /// <summary>
+    /// The property the whole change rests on. A probe ("does the mutex
+    /// exist?") followed by an election is two decisions with a gap between
+    /// them, and racing launches can both read "no primary" in that gap.
+    /// Creating the mutex IS the decision, so no spacing produces two primaries.
+    /// </summary>
+    [Fact]
+    public void ConcurrentElections_ProduceExactlyOnePrimary()
+    {
+        var path = UniqueExePath();
+        const int racers = 16;
+
+        // Dedicated threads, not Parallel.For. The barrier requires all 16 to
+        // be running at once, and Parallel.For grows its replica count only as
+        // replicas start work - so blocked racers never free a pool thread for
+        // the next one, and the run stalls (or hangs outright on a pool capped
+        // below 16) waiting on the starvation heuristic.
+        using var ready = new Barrier(racers);
+        var elections = new SingleInstanceElection[racers];
+        var threads = new Thread[racers];
+
+        for (var i = 0; i < racers; i++)
+        {
+            var index = i;
+            threads[i] = new Thread(() =>
+            {
+                // Release them together, so they contend rather than queue.
+                ready.SignalAndWait();
+                elections[index] = SingleInstanceElection.Run(enabled: true, path);
+            })
+            { IsBackground = true };
+        }
+
+        foreach (var thread in threads) thread.Start();
+
+        try
+        {
+            foreach (var thread in threads)
+                Assert.True(thread.Join(TimeSpan.FromSeconds(30)), "a racer never finished");
+
+            Assert.Equal(1, elections.Count(e => e.Role == SingleInstanceRole.Primary));
+            Assert.Equal(racers - 1, elections.Count(e => e.Role == SingleInstanceRole.Secondary));
+        }
+        finally
+        {
+            foreach (var e in elections) e?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The election asks whether single-instance is on for THIS process, not
+    /// whether a mutex happens to exist. A primary started with the setting on
+    /// holds its mutex for its whole lifetime regardless of later config edits,
+    /// so a launch with the setting off must be unaffected by it.
+    /// </summary>
+    [Fact]
+    public void FeatureOff_IsUnaffectedByALivePrimary()
+    {
+        var path = UniqueExePath();
+
+        using var primary = SingleInstanceElection.Run(enabled: true, path);
+        using var later = SingleInstanceElection.Run(enabled: false, path);
+
+        Assert.Equal(SingleInstanceRole.Primary, primary.Role);
+        Assert.Equal(SingleInstanceRole.Disabled, later.Role);
+    }
+
+    [Fact]
+    public void DifferentExePaths_DoNotContend()
+    {
+        using var a = SingleInstanceElection.Run(enabled: true, UniqueExePath());
+        using var b = SingleInstanceElection.Run(enabled: true, UniqueExePath());
+
+        Assert.Equal(SingleInstanceRole.Primary, a.Role);
+        Assert.Equal(SingleInstanceRole.Primary, b.Role);
+    }
+
+    /// <summary>
+    /// An unusable name is the one input that makes the mutex throw. The
+    /// election must carry the failure rather than raise it: it runs before
+    /// there is a logger, and a launch must not be lost over a coordination
+    /// primitive.
+    /// </summary>
+    [Fact]
+    public void ElectionFailure_IsCarriedNotThrown()
+    {
+        // SingleInstanceNames hashes the path, so no path can produce a bad
+        // name. Contend against a name already taken by an object of another
+        // type instead: Windows keeps mutexes, semaphores and events in one
+        // namespace, and CreateMutexEx reports ERROR_INVALID_HANDLE for a kind
+        // mismatch, which .NET surfaces as WaitHandleCannotBeOpenedException.
+        var path = UniqueExePath();
+        var names = SingleInstanceNames.For(path);
+        using var blocker = new Semaphore(1, 1, names.Mutex);
+
+        using var election = SingleInstanceElection.Run(enabled: true, path);
+
+        Assert.Equal(SingleInstanceRole.Failed, election.Role);
+        Assert.IsType<WaitHandleCannotBeOpenedException>(election.Failure);
+        Assert.Null(election.Mutex);
+    }
+
+    /// <summary>
+    /// Pins the splash gate's semantics. The defect this replaced lived at the
+    /// call site rather than in the election, and the call site is in the WinUI
+    /// assembly where no test can reach it - so the decision is a property here
+    /// and this is what would fail if it drifted.
+    /// </summary>
+    [Theory]
+    [InlineData(SingleInstanceRole.Disabled, true)]
+    [InlineData(SingleInstanceRole.Primary, true)]
+    [InlineData(SingleInstanceRole.Failed, true)]
+    [InlineData(SingleInstanceRole.Secondary, false)]
+    public void OnlyASecondarySuppressesTheSplash(SingleInstanceRole role, bool expected)
+    {
+        var (election, incumbent) = ElectionWithRole(role);
+        try
+        {
+            Assert.Equal(role, election.Role);
+            Assert.Equal(expected, election.ShouldShowLaunchSplash);
+        }
+        finally
+        {
+            election.Dispose();
+            incumbent?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A role added without updating the theory above would get no coverage
+    /// and no failure, and would also fall through the gate in App silently.
+    /// </summary>
+    [Fact]
+    public void EveryRoleIsCoveredByTheSplashTheory()
+    {
+        Assert.Equal(4, Enum.GetValues<SingleInstanceRole>().Length);
+    }
+
+    /// <summary>
+    /// Drive a real election into <paramref name="role"/>, so the theory above
+    /// tests reachable states rather than a hand-built object.
+    /// </summary>
+    /// <returns>
+    /// The election, plus whatever has to stay reachable to hold it in that
+    /// role. Returned rather than discarded: an unrooted incumbent can be
+    /// collected between the two calls, its handle finalized, the name
+    /// released - and the election under test comes back Primary instead.
+    /// </returns>
+    private static (SingleInstanceElection Election, IDisposable? Incumbent) ElectionWithRole(
+        SingleInstanceRole role)
+    {
+        var path = UniqueExePath();
+        switch (role)
+        {
+            case SingleInstanceRole.Disabled:
+                return (SingleInstanceElection.Run(enabled: false, path), null);
+
+            case SingleInstanceRole.Primary:
+                return (SingleInstanceElection.Run(enabled: true, path), null);
+
+            case SingleInstanceRole.Secondary:
+                var incumbent = SingleInstanceElection.Run(enabled: true, path);
+                return (SingleInstanceElection.Run(enabled: true, path), incumbent);
+
+            case SingleInstanceRole.Failed:
+                // A kind mismatch on the name is what makes the mutex throw.
+                var blocker = new Semaphore(1, 1, SingleInstanceNames.For(path).Mutex);
+                return (SingleInstanceElection.Run(enabled: true, path), blocker);
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(role));
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Config/ConfigIniFileTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigIniFileTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+public sealed class ConfigIniFileTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), $"wintty-ini-{Guid.NewGuid():N}");
+
+    private string Write(string contents)
+    {
+        Directory.CreateDirectory(_dir);
+        var path = Path.Combine(_dir, "config.wintty");
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void MissingFile_LoadsEmpty()
+    {
+        var file = ConfigIniFile.Load(Path.Combine(_dir, "does-not-exist"));
+        Assert.Empty(file);
+        Assert.Equal("fallback", ConfigIniFile.First(file, "anything", "fallback"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NoPath_LoadsEmpty(string? path)
+    {
+        Assert.Empty(ConfigIniFile.Load(path));
+    }
+
+    [Fact]
+    public void SkipsCommentsAndBlankLines()
+    {
+        var path = Write("""
+            # windows-single-instance = true
+
+              # indented comment
+            windows-single-instance = false
+            """);
+
+        Assert.Equal("false", ConfigIniFile.First(ConfigIniFile.Load(path), "windows-single-instance"));
+    }
+
+    [Fact]
+    public void EmptyValue_IsIgnoredEntirely()
+    {
+        // An empty value must not shadow the default, or clearing a key in
+        // the file would read as a value rather than as "unset".
+        var path = Write("windows-single-instance =\n");
+        var file = ConfigIniFile.Load(path);
+
+        Assert.Empty(file);
+        Assert.Equal("", ConfigIniFile.First(file, "windows-single-instance"));
+    }
+
+    [Theory]
+    [InlineData("windows-single-instance=true")]
+    [InlineData("windows-single-instance =true")]
+    [InlineData("windows-single-instance= true")]
+    [InlineData("  windows-single-instance  =  true  ")]
+    public void SpacingAroundTheSeparatorDoesNotMatter(string line)
+    {
+        var path = Write(line + "\n");
+        Assert.Equal("true", ConfigIniFile.First(ConfigIniFile.Load(path), "windows-single-instance"));
+    }
+
+    [Fact]
+    public void TrailingCommentStaysPartOfTheValue()
+    {
+        // Matches ghostty's own parser: # only starts a comment at the start of
+        // a line. Pinned so nobody "fixes" it into a divergence.
+        var path = Write("font-family = Cascadia Code # not a comment\n");
+        Assert.Equal(
+            "Cascadia Code # not a comment",
+            ConfigIniFile.First(ConfigIniFile.Load(path), "font-family"));
+    }
+
+    [Fact]
+    public void KeysAreCaseInsensitive()
+    {
+        var path = Write("Windows-Single-Instance = true\n");
+        Assert.Equal("true", ConfigIniFile.First(ConfigIniFile.Load(path), "windows-single-instance"));
+    }
+
+    [Fact]
+    public void RepeatedKey_KeepsFileOrderAndFirstWins()
+    {
+        var path = Write("""
+            keybind = ctrl+a=copy
+            keybind = ctrl+b=paste
+            """);
+
+        var file = ConfigIniFile.Load(path);
+        Assert.Equal(["ctrl+a=copy", "ctrl+b=paste"], file["keybind"]);
+        Assert.Equal("ctrl+a=copy", ConfigIniFile.First(file, "keybind"));
+    }
+
+    [Fact]
+    public void ValueMayContainEqualsSigns()
+    {
+        var path = Write("keybind = ctrl+shift+t=new_tab\n");
+        Assert.Equal("ctrl+shift+t=new_tab", ConfigIniFile.First(ConfigIniFile.Load(path), "keybind"));
+    }
+
+    [Fact]
+    public void LineWithoutSeparator_IsSkipped()
+    {
+        var path = Write("this-is-not-a-pair\nwindows-single-instance = true\n");
+        var file = ConfigIniFile.Load(path);
+
+        Assert.Single(file);
+        Assert.Equal("true", ConfigIniFile.First(file, "windows-single-instance"));
+    }
+
+    [Fact]
+    public void First_OnNullFile_ReturnsDefault()
+    {
+        Assert.Equal("off", ConfigIniFile.First(null, "windows-single-instance", "off"));
+    }
+}

--- a/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
+++ b/windows/Ghostty.Tests/Config/SettingsConfigWriterTests.cs
@@ -130,7 +130,6 @@ public class SettingsConfigWriterTests
         public double BackgroundOpacity => 1.0;
         public bool VerticalTabs => false;
         public bool CommandPaletteGroupCommands => false;
-        public bool WindowsSingleInstance => false;
         public bool WindowsHighContrast => false;
         public void SetHighContrastOverride(string? body) { }
         public string CommandPaletteBackground => "acrylic";

--- a/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
+++ b/windows/Ghostty.Tests/Logging/SettingsConfigWriterLoggingTests.cs
@@ -59,7 +59,6 @@ public class SettingsConfigWriterLoggingTests
         public double BackgroundOpacity => 1.0;
         public bool VerticalTabs => false;
         public bool CommandPaletteGroupCommands => false;
-        public bool WindowsSingleInstance => false;
         public bool WindowsHighContrast => false;
         public void SetHighContrastOverride(string? body) { }
         public string CommandPaletteBackground => "acrylic";

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -80,14 +80,12 @@ public partial class App : Application
     // repeat press would otherwise stack a second menu on top.
     private bool _systemMenuOpen;
 
-    // Single-instance mode (opt-in via windows-single-instance). When this
-    // process is the primary it holds the mutex for the whole process
-    // lifetime, so the GC must not collect it -- hence the field. Null when
-    // single-instance is off, or when mutex acquisition threw (we then fall
-    // back to launching as a normal independent process). The server runs
-    // the forwarding pipe and only exists on the primary.
-    private System.Threading.Mutex? _singleInstanceMutex;
+    // Single-instance mode (opt-in via windows-single-instance). The election
+    // itself lives in Program, which holds it in a static for the process
+    // lifetime -- that static is what keeps the primary's mutex off the GC.
+    // This field is the forwarding pipe server, which only a primary runs.
     private Ghostty.Hosting.SingleInstanceServer? _singleInstanceServer;
+
 
     // The quake chord comes from the quick-terminal-key config value
     // (read via ConfigService.QuickTerminalKeyChord). QuickTerminalKeyChord.Default
@@ -278,7 +276,7 @@ public partial class App : Application
             // Unhandled-exception handlers aren't wired up yet (done
             // below), so Debug.WriteLine is the most signal we can
             // surface to a devenv-attached run without taking the app
-            // down. A packaged Release launch will lose this — that's
+            // down. A packaged Release launch will lose this -- that's
             // acceptable for a one-frame cosmetic flash.
             System.Diagnostics.Debug.WriteLine(
                 $"{AppIdentity.LogTag} OsTheme.IsDark() threw during App ctor; falling back to Dark. {ex.GetType().Name}: {ex.Message}");
@@ -298,6 +296,11 @@ public partial class App : Application
         // needs to attach logs to a bug report.
         UnhandledException += (s, e) =>
         {
+            // Before the log, not after: this tears the process down without
+            // unwinding back through Application.Start, so StartGui's catch
+            // never runs and this is the only chance to take the splash down.
+            // An exception in OnLaunched is exactly when a splash is still up.
+            Ghostty.Shell.SplashWindow.HideNow();
             LogUnhandled("UI-THREAD UNHANDLED", e.Exception.ToString());
             // Leave Handled=false so the runtime still tears the app
             // down -- we just wanted to record the exception first.
@@ -305,6 +308,7 @@ public partial class App : Application
 
         AppDomain.CurrentDomain.UnhandledException += (s, e) =>
         {
+            Ghostty.Shell.SplashWindow.HideNow();
             LogUnhandled("APPDOMAIN UNHANDLED", e.ExceptionObject?.ToString() ?? "(null)");
         };
 
@@ -508,18 +512,12 @@ public partial class App : Application
             if (noColorNotice is not null) _notificationService.Show(noColorNotice);
         }
 
-        // Single-instance gate. Decided here -- after ConfigService gives us
-        // the value and the logger factory exists (so failures are visible
-        // in Release), but before the bootstrap host, window, and DX12
-        // renderer are created -- so a secondary process forwards its launch
-        // and exits without ever creating a window or paying for the
-        // renderer. Off by default: the call is a no-op and this stays a
-        // normal independent process. Returns normally when this process
-        // should keep launching (primary, or a forward that failed and falls
-        // back); calls Environment.Exit(0) itself when it was a secondary
-        // that handed its launch to the primary.
-        if (_configService.WindowsSingleInstance)
-            HandleSingleInstanceGate();
+        // Single-instance gate. Acted on here -- after the logger factory
+        // exists (so failures are visible in Release), but before the
+        // bootstrap host, window, and DX12 renderer are created -- so a
+        // secondary process forwards its launch and exits without ever
+        // creating a window or paying for the renderer.
+        HandleSingleInstanceGate(Program.SingleInstance);
 
         // Power-saving monitor. Reads power-saver-mode from config every
         // time it resolves (Func thunk decouples it from ConfigService
@@ -631,7 +629,7 @@ public partial class App : Application
         // Cache the UI dispatcher up front: the active-process tracker
         // fires Changed from a Timer threadpool callback, and the handler
         // touches TabIconViewModel which raises PropertyChanged consumed
-        // by WinUI bindings — those need the UI thread.
+        // by WinUI bindings -- those need the UI thread.
         _uiDispatcher = uiDispatcher;
         _activeProcessTracker = new Ghostty.Core.Profiles.Tracking.WindowsActiveProcessTracker();
         _activeProcessTracker.Changed += OnActiveProcessChanged;
@@ -791,45 +789,57 @@ public partial class App : Application
 
         // Start the single-instance forwarding server last, once the UI
         // dispatcher and logger factory exist. No-op unless this process is
-        // the single-instance primary (it holds the mutex).
+        // the single-instance primary.
         StartSingleInstanceServer();
     }
 
     /// <summary>
-    /// Acquire the single-instance mutex. If we win it, keep it (this
-    /// process is the primary) and let OnLaunched continue. If another
-    /// process already holds it, forward our launch over the named pipe
-    /// and exit. Any failure on the secondary path falls back to a normal
-    /// independent launch so the user never loses a window.
+    /// Act on the single-instance election Program held before
+    /// <c>Application.Start</c>. A secondary hands its launch to the running
+    /// primary and exits; every other role continues into a normal launch.
     /// </summary>
-    private void HandleSingleInstanceGate()
+    private void HandleSingleInstanceGate(
+        Ghostty.Core.SingleInstance.SingleInstanceElection? election)
     {
-        var exePath = Environment.ProcessPath ?? string.Empty;
-        var names = Ghostty.Core.SingleInstance.SingleInstanceNames.For(exePath);
+        // Null only on a path that never ran Program.StartGui, which OnLaunched
+        // is not reachable from. Treated as "off", the degradation that cannot
+        // cost the user a window.
+        if (election is null) return;
 
-        bool createdNew;
-        try
+        // Every role spelled out, including the two that do nothing: a role
+        // added later should be a visible gap here rather than a silent
+        // fallthrough into "launch normally".
+        switch (election.Role)
         {
-            _singleInstanceMutex = new System.Threading.Mutex(
-                initiallyOwned: true, name: names.Mutex, out createdNew);
-        }
-        catch (Exception ex)
-        {
-            // Could not create the coordination primitive at all. Do not
-            // block the launch: behave as a normal single window.
-            Ghostty.Logging.StaticLoggers.App.LogSingleInstanceMutexFailed(ex);
-            _singleInstanceMutex = null;
-            return;
-        }
+            case Ghostty.Core.SingleInstance.SingleInstanceRole.Disabled:
+                break;
 
-        if (createdNew)
-        {
-            // Primary. The server is started later in OnLaunched once the
-            // UI dispatcher exists (see StartSingleInstanceServer()).
-            return;
-        }
+            case Ghostty.Core.SingleInstance.SingleInstanceRole.Primary:
+                // The server starts at the end of OnLaunched, once the UI
+                // dispatcher exists (see StartSingleInstanceServer).
+                break;
 
-        // Secondary: a primary is already running. Forward and exit.
+            case Ghostty.Core.SingleInstance.SingleInstanceRole.Failed:
+                // Reported here rather than where it happened: the election
+                // runs before there is a logger factory. Launching normally is
+                // worse coordination, never a lost window.
+                Ghostty.Logging.StaticLoggers.App.LogSingleInstanceMutexFailed(
+                    election.Failure!);
+                break;
+
+            case Ghostty.Core.SingleInstance.SingleInstanceRole.Secondary:
+                ForwardLaunchToPrimary(election.Names.Pipe);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Hand this launch to the running primary and exit the process. Returns
+    /// normally instead when the forward failed, so the caller continues into
+    /// an ordinary independent launch rather than dropping the user's launch.
+    /// </summary>
+    private void ForwardLaunchToPrimary(string pipeName)
+    {
         var request = new Ghostty.Core.SingleInstance.LaunchRequest(
             Environment.CurrentDirectory,
             Environment.GetCommandLineArgs());
@@ -837,51 +847,51 @@ public partial class App : Application
         try
         {
             using var client = new System.IO.Pipes.NamedPipeClientStream(
-                ".", names.Pipe, System.IO.Pipes.PipeDirection.Out);
+                ".", pipeName, System.IO.Pipes.PipeDirection.Out);
             client.Connect(2000); // 2s: primary should answer promptly
             using var writer = new System.IO.StreamWriter(client) { AutoFlush = true };
             writer.Write(request.Serialize());
             writer.Flush();
             client.WaitForPipeDrain();
-
-            // The primary owns the launch now. Release everything this
-            // throwaway process holds -- the config service (and its file
-            // watcher + native config handle) and the mutex handle (we never
-            // owned it) -- then exit deterministically rather than leaving
-            // the OS to reclaim them at teardown.
-            _configService?.Dispose();
-            _singleInstanceMutex.Dispose();
-            _singleInstanceMutex = null;
-            Environment.Exit(0);
         }
         catch (Exception ex)
         {
-            // Primary may be mid-shutdown or the pipe is wedged. Fall back
-            // to launching normally rather than dropping the user's launch.
-            // Drop the mutex handle first: we did not create it, and a new
-            // primary election is irrelevant now that we are becoming a
-            // standalone window.
+            // Primary may be mid-shutdown or the pipe is wedged. Fall back to
+            // launching normally rather than dropping the user's launch. This
+            // process does not take the session over; it did not create the
+            // mutex, and the next launch elects a primary again.
             Ghostty.Logging.StaticLoggers.App.LogSingleInstanceForwardFailed(ex);
-            try { _singleInstanceMutex?.Dispose(); } catch { /* ignore */ }
-            _singleInstanceMutex = null;
+            return;
         }
+
+        // Deliberately outside the try above. Once the drain returns, the
+        // primary has the request and will act on it, so nothing here may
+        // divert back into a normal startup: a throw from Dispose inside that
+        // try used to log a forward failure and open a second window for a
+        // launch already on its way.
+        //
+        // Dispose rather than leaving it to teardown, so the config file
+        // watcher and the native config handle go now.
+        _configService?.Dispose();
+        Environment.Exit(0);
     }
 
     /// <summary>
     /// Start the forwarding pipe server. Called near the end of OnLaunched
-    /// (after _uiDispatcher is set) only when this process is the
-    /// single-instance primary (it holds the mutex).
+    /// (after _uiDispatcher is set) and only on the single-instance primary.
     /// </summary>
     private void StartSingleInstanceServer()
     {
-        if (_singleInstanceMutex is null || _loggerFactory is null) return;
+        // The election's own name, not a fresh derivation of it. Deriving it
+        // twice is how the identity gets two answers.
+        if (Program.SingleInstance is not
+            { Role: Ghostty.Core.SingleInstance.SingleInstanceRole.Primary } election) return;
+        if (_loggerFactory is null) return;
 
-        var exePath = Environment.ProcessPath ?? string.Empty;
-        var names = Ghostty.Core.SingleInstance.SingleInstanceNames.For(exePath);
         try
         {
             _singleInstanceServer = new Ghostty.Hosting.SingleInstanceServer(
-                names.Pipe,
+                election.Names.Pipe,
                 req => _uiDispatcher?.TryEnqueue(() => OpenWindowFromLaunch(req)),
                 _loggerFactory.CreateLogger<Ghostty.Hosting.SingleInstanceServer>());
             _singleInstanceServer.Start();
@@ -1371,10 +1381,15 @@ public partial class App : Application
                 LoggerFactory = null;
 
                 _singleInstanceServer = null;
-                // Release the single-instance mutex last so a relaunch can
-                // become the new primary immediately after we exit.
-                try { _singleInstanceMutex?.Dispose(); } catch { /* ignore */ }
-                _singleInstanceMutex = null;
+                // Release the single-instance mutex so a relaunch can become
+                // the new primary immediately after we exit.
+                try { Program.SingleInstance?.Dispose(); } catch { /* ignore */ }
+
+                // The message loop is about to end, which abandons background
+                // threads. A launch whose first frame never arrived can still
+                // have the splash up inside its watchdog, and that thread can
+                // be inside GDI+.
+                Ghostty.Shell.SplashWindow.HideNow();
 
                 Exit();
             }

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Ghostty.Core;
+using Ghostty.Core.Config;
+using Ghostty.Core.SingleInstance;
 using Ghostty.Interop;
 
 namespace Ghostty;
@@ -857,6 +859,14 @@ public static partial class Program
             WinRT.ComWrappersSupport.InitializeComWrappers();
             WriteStderr($"{AppIdentity.LogTag} ComWrappers initialized");
 
+            // Hold the single-instance election here, before anything is on
+            // screen and before WinUI exists. App.OnLaunched acts on the result
+            // much later; deciding it there and asking a cheaper question here
+            // would be two decisions that can disagree.
+            _singleInstance = SingleInstanceElection.Run(
+                ReadSingleInstanceSetting(),
+                Environment.ProcessPath ?? string.Empty);
+
             // Put the launch splash up before WinUI starts. Everything
             // below this line -- Application.Start, App's ctor, config
             // load, libghostty init, the first XAML frame -- is seconds of
@@ -864,7 +874,7 @@ public static partial class Program
             // HWND exists and paints black. The splash covers that rect
             // until there is real content to reveal. It runs on its own
             // thread, so none of that work delays it.
-            if (!AnotherInstanceOwnsTheSession())
+            if (_singleInstance.ShouldShowLaunchSplash)
             {
                 Ghostty.Shell.SplashWindow.Show();
             }
@@ -888,11 +898,12 @@ public static partial class Program
         }
         catch (Exception ex)
         {
-            // Take the splash down before reporting. Startup that dies before
-            // any window exists leaves nothing else to dismiss it, and an
-            // opaque topmost rectangle sitting over the desktop is the worst
-            // possible time to be hiding a crash report.
-            Ghostty.Shell.SplashWindow.Dismiss();
+            // Take the splash down before reporting, and synchronously:
+            // startup that dies before any window exists leaves nothing else
+            // to dismiss it, this method returns straight into process
+            // teardown, and an opaque topmost rectangle sitting over the
+            // desktop is the worst possible time to be hiding a crash report.
+            Ghostty.Shell.SplashWindow.HideNow();
 
             // Same reporting as an escape from MainImpl, so the GUI path also
             // gets the terminal tee instead of only the log.
@@ -900,38 +911,58 @@ public static partial class Program
         }
     }
 
+    private static SingleInstanceElection? _singleInstance;
+
     /// <summary>
-    /// True when a single-instance primary is already running, so this
-    /// process is about to forward its launch and exit.
+    /// This process's single-instance election, or null on a path that never
+    /// starts the GUI. Decided here because it has to happen before
+    /// <c>Application.Start</c>, and because the launch splash and the gate in
+    /// <c>App.OnLaunched</c> have to act on the same answer.
+    /// </summary>
+    internal static SingleInstanceElection? SingleInstance => _singleInstance;
+
+    /// <summary>
+    /// Read <c>windows-single-instance</c> straight from the config file.
     /// </summary>
     /// <remarks>
-    /// The mutex is only ever created when <c>windows-single-instance</c> is
-    /// on, so its presence answers both questions at once: the feature is
-    /// enabled and somebody already owns the session. Without this check the
-    /// secondary paints a full-size opaque splash over the primary's window
-    /// -- the user's actual terminal -- for as long as it takes to reach the
-    /// gate, and is then killed by Environment.Exit mid-GDI+.
+    /// ConfigService is the usual reader for Windows-only keys, but it needs a
+    /// DispatcherQueue and so cannot exist before <c>Application.Start</c>,
+    /// which is where this decision has to be made. Both go through
+    /// <see cref="ConfigIniFile"/> over the same path for the same key.
     ///
-    /// Opened, never acquired: taking ownership here would make this process
-    /// look like the primary to the real gate in App.OnLaunched.
+    /// They are still two reads at two times, and only this one tolerates
+    /// failure. A config file locked by an editor for just this read leaves
+    /// the launch uncoordinated but running; a lock that outlasts both reads
+    /// takes ConfigService's constructor down with it, which is the
+    /// pre-existing behaviour and not something to paper over here.
+    ///
+    /// <c>ghostty_config_open_path</c> resolves (and creates) the path without
+    /// a config handle; it needs only the init <see cref="MainImpl"/> has
+    /// already done. The returned string is deliberately not freed, matching
+    /// ConfigService's call.
     /// </remarks>
-    private static bool AnotherInstanceOwnsTheSession()
+    private static bool ReadSingleInstanceSetting()
     {
         try
         {
-            var names = Ghostty.Core.SingleInstance.SingleInstanceNames.For(
-                Environment.ProcessPath ?? string.Empty);
-            if (!System.Threading.Mutex.TryOpenExisting(names.Mutex, out var existing))
-            {
-                return false;
-            }
-            existing.Dispose();
-            return true;
+            var pathStr = NativeMethods.ConfigOpenPath();
+            var rawPath = pathStr.Ptr != IntPtr.Zero
+                ? Marshal.PtrToStringUTF8(pathStr.Ptr, (int)pathStr.Len) ?? string.Empty
+                : string.Empty;
+            var path = rawPath.Length == 0 ? null : Path.GetFullPath(rawPath);
+
+            var configFile = ConfigIniFile.Load(path);
+            return WindowsOnlyKeyParsers.ParseBool(
+                ConfigIniFile.First(configFile, "windows-single-instance"),
+                defaultValue: false);
         }
-        catch
+        catch (Exception ex)
         {
-            // Probing is best effort. A splash we should have skipped is a
-            // far smaller problem than a launch we blocked.
+            // Off never routes a launch into a process that is not there, so it
+            // is the safe reading. Worth a line: the symptom otherwise is
+            // single-instance silently not working.
+            WriteStartupDiagnostic(
+                $"could not read windows-single-instance ({ex.Message}); treating it as off");
             return false;
         }
     }

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -61,7 +61,6 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
     // optimization.
     public bool VerticalTabs { get; private set; }
     public bool CommandPaletteGroupCommands { get; private set; }
-    public bool WindowsSingleInstance { get; private set; }
     public bool WindowsHighContrast { get; private set; } = true;
     public string CommandPaletteBackground { get; private set; } = "acrylic";
     public string NoColorOverride { get; private set; } = NoColorPolicy.Default;
@@ -774,9 +773,10 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
         CommandPaletteGroupCommands = WindowsOnlyKeyParsers.ParseBool(
             GetFileValue("command-palette-group-commands", ""),
             defaultValue: false);
-        WindowsSingleInstance = WindowsOnlyKeyParsers.ParseBool(
-            GetFileValue("windows-single-instance", ""),
-            defaultValue: false);
+        // No windows-single-instance here on purpose. It is read once, before
+        // Application.Start, by the election in Program: a value that can be
+        // re-read on every reload would let this service disagree with the role
+        // the process is actually running under.
         WindowsHighContrast = WindowsOnlyKeyParsers.ParseBool(
             GetFileValue("windows-high-contrast", ""),
             defaultValue: true);
@@ -1251,37 +1251,10 @@ internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IPro
             : Array.Empty<string>();
 
     /// <summary>
-    /// Load a ghostty-style ini file into a key/value dictionary. Empty
-    /// lines and #-prefixed comments are skipped, empty values are
-    /// ignored entirely (matching the old per-key scanners), and keys
-    /// are matched case-insensitively. Returns an empty dictionary if
-    /// the path is missing or unreadable.
+    /// Load a ghostty-style ini file into a key/value dictionary.
     /// </summary>
     private static Dictionary<string, List<string>> LoadIniFile(string? path)
-    {
-        var dict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-        if (string.IsNullOrEmpty(path) || !File.Exists(path))
-            return dict;
-
-        foreach (var line in File.ReadLines(path))
-        {
-            var trimmed = line.TrimStart();
-            if (trimmed.Length == 0 || trimmed.StartsWith('#')) continue;
-            var eqIndex = trimmed.IndexOf('=');
-            if (eqIndex < 0) continue;
-            var k = trimmed[..eqIndex].Trim();
-            if (k.Length == 0) continue;
-            var v = trimmed[(eqIndex + 1)..].Trim();
-            if (v.Length == 0) continue;
-            if (!dict.TryGetValue(k, out var list))
-            {
-                list = new List<string>(1);
-                dict[k] = list;
-            }
-            list.Add(v);
-        }
-        return dict;
-    }
+        => Ghostty.Core.Config.ConfigIniFile.Load(path);
 
     /// <summary>
     /// Read a color config value. libghostty returns colors as

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -62,6 +62,11 @@ internal static unsafe partial class SplashWindow
     // still go away rather than sit on top of the user's desktop forever.
     private const int WatchdogMs = 10_000;
 
+    // How long HideNow waits for the splash thread to unwind. Long enough
+    // to cover a pump tick and the teardown behind it, short enough that a
+    // wedged splash thread cannot noticeably delay an exit.
+    private const int HideJoinMs = 250;
+
     private const string ClassName = "WinttySplash";
 
     private static nint _hwnd;
@@ -69,6 +74,19 @@ internal static unsafe partial class SplashWindow
     private static int _started;
     private static long _shownAtTicks;
     private static nint _trackedHwnd;
+
+    // The splash thread, so HideNow can wait for it rather than leaving it to
+    // be cut down wherever it happens to be. Volatile like the other fields
+    // HideNow touches: it now runs from the unhandled-exception handlers,
+    // which fire on whatever thread threw. Assigned before Start, so a HideNow
+    // early enough to read null is also early enough that there is nothing yet
+    // to wait for.
+    private static Thread? _thread;
+
+    // Set by HideNow to skip the fade. A fade is a courtesy on the normal
+    // reveal; on the paths HideNow serves the process is about to end, and
+    // 220ms of animation is 220ms of holding a window over the desktop.
+    private static bool _skipFade;
 
     // Current splash geometry, owned by the splash thread. Mutable
     // because the splash follows the main window, which the user can move
@@ -144,6 +162,7 @@ internal static unsafe partial class SplashWindow
             Name = "wintty-splash",
         };
         thread.SetApartmentState(ApartmentState.STA);
+        Volatile.Write(ref _thread, thread);
         thread.Start();
     }
 
@@ -158,6 +177,50 @@ internal static unsafe partial class SplashWindow
         // latching here means a dismissal that races Show can never be
         // dropped and leave the splash up until the watchdog.
         _dismissed.Set();
+    }
+
+    /// <summary>
+    /// Take the splash off the screen before returning, for callers whose
+    /// next move is to end the process.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Dismiss"/> is not enough there. It signals an event and the
+    /// splash thread then fades over 220ms, so a caller that dismisses and
+    /// exits is racing its own teardown: the window is still up when the
+    /// process dies, and the splash thread is cut down wherever it happens to
+    /// be, which can be inside GDI+.
+    ///
+    /// So this waits, and the wait is the whole mechanism. The window is taken
+    /// down by the splash thread's own <c>DestroyWindow</c>, not from here:
+    /// hiding another thread's window is a blocking inter-thread send, and
+    /// posting it asynchronously instead only defers to a thread that has by
+    /// then stopped pumping. Either way it is the splash thread that has to
+    /// act, so the honest thing is to ask it to stop and wait a bounded time
+    /// for it to finish. A wedged splash thread costs the deadline, never the
+    /// caller's exit.
+    ///
+    /// Safe when no splash was shown and safe to call repeatedly.
+    /// </remarks>
+    public static void HideNow()
+    {
+        // Before the signal: a thread waking on the event must see the flag,
+        // or it fades for 220ms while the caller waits on the join.
+        Volatile.Write(ref _skipFade, true);
+        _dismissed.Set();
+
+        try
+        {
+            // Never join ourselves. Diag runs on the splash thread and could in
+            // principle route back here; a self-join would hang the very exit
+            // this method exists to make prompt.
+            if (Volatile.Read(ref _thread) is { } thread && thread != Thread.CurrentThread)
+                thread.Join(HideJoinMs);
+        }
+        catch
+        {
+            // A join that cannot be waited on is not a reason to fail an exit
+            // path.
+        }
     }
 
     /// <summary>
@@ -208,6 +271,12 @@ internal static unsafe partial class SplashWindow
             return;
         }
 
+        // Do not build a window for a splash that has already been called
+        // off. Show and HideNow can race on a startup that fails early, and
+        // creating one here would put a window on screen after the caller
+        // was told it was gone.
+        if (_dismissed.IsSet) return;
+
         fixed (char* className = ClassName)
         {
             // WS_EX_TRANSPARENT is what keeps the app usable underneath.
@@ -241,6 +310,11 @@ internal static unsafe partial class SplashWindow
                 Diag("first paint failed; no splash this launch");
                 return;
             }
+            // A dismissal may have landed since the check above. Narrows the
+            // flash; HideNow's join is what actually closes it, by holding the
+            // caller until the finally below destroys the window.
+            if (_dismissed.IsSet) return;
+
             ShowWindow(_hwnd, SW_SHOWNA);
             Volatile.Write(ref _shownAtTicks, Environment.TickCount64);
 
@@ -416,6 +490,11 @@ internal static unsafe partial class SplashWindow
     /// </summary>
     private static void FadeOut()
     {
+        // HideNow has already taken the window off screen and its caller is
+        // ending the process. Fading a hidden window would only keep this
+        // thread alive through a teardown that is waiting on it.
+        if (Volatile.Read(ref _skipFade)) return;
+
         var steps = Math.Max(1, FadeDurationMs / FadeStepMs);
         for (var i = steps - 1; i >= 0; i--)
         {

--- a/windows/scripts/splash-single-instance-race.ps1
+++ b/windows/scripts/splash-single-instance-race.ps1
@@ -1,0 +1,407 @@
+<#
+.SYNOPSIS
+    Reproduce the launch splash / single-instance race.
+
+.DESCRIPTION
+    With `windows-single-instance` on, a second launch is supposed to forward
+    itself to the primary and exit without ever putting anything on screen.
+    The launch splash is created before WinUI exists, so it goes up long
+    before the single-instance gate runs -- and it is an opaque, full-size,
+    topmost window. A secondary that shows one covers the primary's window,
+    which is the user's actual terminal, until it reaches the gate and exits.
+
+    This script launches two instances a few hundred milliseconds apart --
+    close enough that the second one starts while the first is still in its
+    pre-gate startup -- and samples the top-level window list throughout,
+    looking for a splash window (class WinttySplash) owned by the secondary.
+    It captures the primary's window rect alongside each sighting so the
+    overlap is measurable rather than asserted.
+
+    FAIL means the race reproduced: the secondary painted over the primary.
+
+    Config is isolated. XDG_CONFIG_HOME is redirected to a scratch directory
+    for the launched processes, so this never reads or writes the config
+    file you actually use.
+
+    The election namespace is NOT isolated, and cannot be: the mutex name is
+    derived from the exe path. Any Wintty already running from the same
+    binary owns it, so the script refuses to run while one exists rather
+    than measure two launches that both forward to it.
+
+    This demonstrates the defect; it does not certify its absence. Sampling
+    is on the order of 30-40ms, so a splash shown for less than that would
+    be missed.
+
+.PARAMETER ExePath
+    Wintty.exe to test. Defaults to the x64 Debug build.
+
+.PARAMETER DelayMs
+    Gap between the two launches. The race window is the primary's whole
+    pre-gate startup (config load, logger factory, NO_COLOR resolution), so
+    the default sits well inside it. Raise it to walk the window and find
+    where the race closes.
+
+.PARAMETER Iterations
+    Launch pairs to run. The race is timing-dependent; one clean pass proves
+    nothing.
+
+.PARAMETER SecondaryFeatureOff
+    Launch the second instance with `windows-single-instance` OFF, against a
+    primary that has it on, and INVERT the expectation: that launch is an
+    ordinary independent window and must show its splash.
+
+    This is the other half of the defect. "Does the mutex exist" and "is
+    single-instance on for this process" are different questions, and a
+    primary holds its mutex for its whole lifetime however the config is
+    edited afterwards. Anything answering the first question suppresses a
+    splash that should have appeared.
+
+.EXAMPLE
+    ./windows/scripts/splash-single-instance-race.ps1 -Iterations 5
+
+.EXAMPLE
+    ./windows/scripts/splash-single-instance-race.ps1 -SecondaryFeatureOff
+#>
+[CmdletBinding()]
+param(
+    [string]$ExePath = "$PSScriptRoot/../Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe",
+    [int]$DelayMs = 300,
+    [int]$Iterations = 3,
+    [int]$SampleMs = 25,
+    [int]$TimeoutMs = 20000,
+    [switch]$SecondaryFeatureOff
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ExePath)) {
+    throw "Wintty.exe not found at $ExePath. Build it first: just build-dll && just build-win"
+}
+$ExePath = (Resolve-Path $ExePath).Path
+
+# A Wintty already running from this exe path owns the single-instance mutex,
+# so BOTH launches below would forward to it and neither would ever show a
+# splash. That reports PASS while measuring nothing, which is the worst thing a
+# repro harness can do -- refuse instead.
+# Path is unreadable for a process running elevated or as another user, and
+# those are filtered out rather than assumed to match. They would own the mutex
+# just the same, so a run that reports PASS with one of those around is still
+# measuring nothing -- this catches the case that actually happens (your own
+# Wintty, left open while working on Wintty), not every case.
+$alreadyRunning = @(
+    Get-Process -Name 'Wintty' -ErrorAction SilentlyContinue |
+        Where-Object { try { $_.Path -eq $ExePath } catch { $false } })
+if ($alreadyRunning.Count -gt 0) {
+    throw ("$($alreadyRunning.Count) Wintty process(es) are already running from $ExePath " +
+           "(pids: $($alreadyRunning.Id -join ', ')). They own the single-instance mutex for " +
+           "this exe path, so both launches would forward to them and this run would measure " +
+           "nothing. Close them first.")
+}
+
+# The window enumeration lives in C# rather than being driven from PowerShell:
+# the callback is an argument to a synchronous P/Invoke, so the interop
+# marshaller keeps it alive for the duration of the call. It is never stored,
+# and never invoked after EnumWindows returns.
+if (-not ('SplashProbe' -as [type])) {
+    Add-Type -Language CSharp @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+public static class SplashProbe
+{
+    public struct Win
+    {
+        public int Pid;
+        public string Klass;
+        public int Left, Top, Right, Bottom;
+        public bool Visible;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT { public int L, T, R, B; }
+
+    private delegate bool EnumProc(IntPtr hwnd, IntPtr lp);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumProc cb, IntPtr lp);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassNameW(IntPtr hwnd, char[] buf, int max);
+    [DllImport("user32.dll")]
+    private static extern int GetWindowThreadProcessId(IntPtr hwnd, out int pid);
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hwnd, out RECT r);
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hwnd);
+
+    public static Win[] TopLevel()
+    {
+        var list = new List<Win>();
+        var buf = new char[256];
+        EnumWindows((hwnd, lp) =>
+        {
+            int n = GetClassNameW(hwnd, buf, buf.Length);
+            int pid;
+            GetWindowThreadProcessId(hwnd, out pid);
+            RECT r;
+            GetWindowRect(hwnd, out r);
+            list.Add(new Win
+            {
+                Pid = pid,
+                Klass = n > 0 ? new string(buf, 0, n) : "",
+                Left = r.L, Top = r.T, Right = r.R, Bottom = r.B,
+                Visible = IsWindowVisible(hwnd),
+            });
+            return true;
+        }, IntPtr.Zero);
+        return list.ToArray();
+    }
+
+}
+'@
+}
+
+$SplashClass = 'WinttySplash'
+
+function Get-OverlapArea($a, $b) {
+    $w = [Math]::Min($a.Right, $b.Right) - [Math]::Max($a.Left, $b.Left)
+    $h = [Math]::Min($a.Bottom, $b.Bottom) - [Math]::Max($a.Top, $b.Top)
+    if ($w -le 0 -or $h -le 0) { return 0 }
+    return $w * $h
+}
+
+# Scratch config, one XDG root per role. Normally both roles point at the
+# same "on" config; -SecondaryFeatureOff gives the second launch its own with
+# the key off, which is what makes the two questions differ. The mutex name
+# is derived from the exe path, not the config, so the two still contend for
+# the same election.
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) "wintty-splash-race-$PID"
+
+function New-ScratchConfig([string]$name, [string]$value) {
+    $root = Join-Path $scratch $name
+    $dir = Join-Path $root 'wintty'
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    Set-Content -Path (Join-Path $dir 'config.wintty') -Encoding utf8 -Value @"
+# Scratch config for splash-single-instance-race.ps1.
+windows-single-instance = $value
+"@
+    return $root
+}
+
+$primaryXdg = New-ScratchConfig 'primary' 'true'
+$secondaryXdg = if ($SecondaryFeatureOff) { New-ScratchConfig 'secondary' 'false' } else { $primaryXdg }
+
+# With the feature off, the second launch is an ordinary independent window
+# and SHOULD put its splash up. Suppressing it is the defect.
+$expectSecondarySplash = [bool]$SecondaryFeatureOff
+
+# Process objects, not PIDs. Start-Process -PassThru returns a Process holding
+# an open handle, and an open handle is what stops Windows recycling the PID --
+# a forwarded secondary exits within a second, so a stored PID could name an
+# unrelated process by the time this runs.
+$launched = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
+
+function Stop-Launched {
+    foreach ($p in $launched) {
+        try {
+            if (-not $p.HasExited) { $p.Kill() }
+            # Kill is asynchronous. Without the wait, a primary still unwinding
+            # keeps holding the mutex, and the next iteration's "primary"
+            # elects itself secondary against a dying process -- which the
+            # harness would score as the defect.
+            [void]$p.WaitForExit(10000)
+        } catch {
+            # Already gone: a forwarded secondary exits on its own, and that
+            # is the outcome this script is measuring.
+        }
+    }
+    $launched.Clear()
+}
+
+$results = [System.Collections.Generic.List[object]]::new()
+$previousXdg = $env:XDG_CONFIG_HOME
+
+try {
+    Write-Host "exe    : $ExePath"
+    Write-Host "primary  config: $primaryXdg\wintty\config.wintty (windows-single-instance = true)"
+    Write-Host "secondary config: $secondaryXdg\wintty\config.wintty (windows-single-instance = $(if ($SecondaryFeatureOff) { 'false' } else { 'true' }))"
+    Write-Host "expect : secondary $(if ($expectSecondarySplash) { 'SHOWS' } else { 'shows NO' }) splash"
+    Write-Host "delay  : ${DelayMs}ms between launches, $Iterations iteration(s)`n"
+
+    for ($i = 1; $i -le $Iterations; $i++) {
+        # Waits for exit, so the previous pair's mutex is genuinely gone and
+        # this iteration elects from scratch.
+        Stop-Launched
+
+        # Set per launch: a child inherits the environment as it stands when
+        # it is created, and the two roles can need different configs.
+        $env:XDG_CONFIG_HOME = $primaryXdg
+        $primary = Start-Process -FilePath $ExePath -PassThru
+        $launched.Add($primary)
+
+        Start-Sleep -Milliseconds $DelayMs
+
+        $env:XDG_CONFIG_HOME = $secondaryXdg
+        $secondary = Start-Process -FilePath $ExePath -PassThru
+        $launched.Add($secondary)
+        $t0 = [System.Diagnostics.Stopwatch]::StartNew()
+
+        $sightings = [System.Collections.Generic.List[object]]::new()
+        $secondaryExitedAt = $null
+        # Whether the launch we called "primary" ever actually became one. If it
+        # crashed, or lost the election to the other launch, then the secondary
+        # legitimately owns the session and everything below describes a
+        # different experiment.
+        $primaryWindowSeen = $false
+
+        while ($t0.ElapsedMilliseconds -lt $TimeoutMs) {
+            $windows = [SplashProbe]::TopLevel()
+
+            # The primary's real window, for the overlap measurement. Matched
+            # by PID and visibility rather than by class, so this does not
+            # depend on which WinUI class name the shell happens to use.
+            $primaryWindow = $windows |
+                Where-Object { $_.Pid -eq $primary.Id -and $_.Visible -and $_.Klass -ne $SplashClass } |
+                Sort-Object { ($_.Right - $_.Left) * ($_.Bottom - $_.Top) } -Descending |
+                Select-Object -First 1
+            if ($null -ne $primaryWindow) { $primaryWindowSeen = $true }
+
+            foreach ($w in $windows) {
+                if ($w.Klass -ne $SplashClass) { continue }
+                if ($w.Pid -ne $secondary.Id) { continue }
+                if (-not $w.Visible) { continue }
+
+                $overlap = 0
+                $primaryRect = $null
+                if ($null -ne $primaryWindow) {
+                    $overlap = Get-OverlapArea $w $primaryWindow
+                    $primaryRect = "$($primaryWindow.Left),$($primaryWindow.Top) $($primaryWindow.Right - $primaryWindow.Left)x$($primaryWindow.Bottom - $primaryWindow.Top)"
+                }
+
+                $sightings.Add([pscustomobject]@{
+                    AtMs        = [int]$t0.ElapsedMilliseconds
+                    SplashRect  = "$($w.Left),$($w.Top) $($w.Right - $w.Left)x$($w.Bottom - $w.Top)"
+                    PrimaryRect = $primaryRect
+                    OverlapPx   = $overlap
+                })
+            }
+
+            $secondary.Refresh()
+            if ($secondary.HasExited -and $null -eq $secondaryExitedAt) {
+                $secondaryExitedAt = [int]$t0.ElapsedMilliseconds
+            }
+
+            # Not "stop as soon as the secondary exits". A forwarded secondary
+            # exits at the gate, which runs before the primary has a window --
+            # so stopping there would leave PrimaryWindowSeen false and discard
+            # the iteration as inconclusive. Both facts have to be in hand.
+            if ($primaryWindowSeen -and
+                ($null -ne $secondaryExitedAt -or
+                 ($expectSecondarySplash -and $sightings.Count -gt 0))) {
+                break
+            }
+
+            Start-Sleep -Milliseconds $SampleMs
+        }
+
+        $covered = @($sightings | Where-Object { $_.OverlapPx -gt 0 })
+        $firstSeen = $null
+        $lastSeen = $null
+        if ($sightings.Count -gt 0) {
+            $firstSeen = $sightings[0].AtMs
+            $lastSeen = $sightings[$sightings.Count - 1].AtMs
+        }
+        $maxOverlap = 0
+        if ($covered.Count -gt 0) {
+            $maxOverlap = ($covered | Measure-Object OverlapPx -Maximum).Maximum
+        }
+
+        $result = [pscustomobject]@{
+            Iteration       = $i
+            PrimaryPid      = $primary.Id
+            SecondaryPid    = $secondary.Id
+            SecondaryExitMs = $secondaryExitedAt
+            SplashSightings = $sightings.Count
+            FirstSeenMs     = $firstSeen
+            LastSeenMs      = $lastSeen
+            CoveredPrimary  = $covered.Count -gt 0
+            MaxOverlapPx    = $maxOverlap
+            Inconclusive    = -not $primaryWindowSeen
+        }
+        $results.Add($result)
+
+        $sawSplash = $result.SplashSightings -gt 0
+        if ($result.Inconclusive) {
+            # Without a primary window there was no primary to paint over, and a
+            # splash from the other launch is correct behaviour rather than the
+            # defect. Scoring it either way would be reporting an experiment
+            # that did not run.
+            $verdict = 'INCONCLUSIVE (the primary never showed a window)'
+        }
+        elseif ($expectSecondarySplash) {
+            $verdict = if ($sawSplash) { 'ok (splash shown as it should be)' }
+                       else { 'REPRODUCED (splash suppressed for an independent launch)' }
+        }
+        else {
+            $verdict = 'clean'
+            if ($result.CoveredPrimary) { $verdict = 'REPRODUCED (covered the primary)' }
+            elseif ($sawSplash) { $verdict = 'REPRODUCED (splash shown, overlap not measured)' }
+        }
+
+        $exitText = 'never (timeout)'
+        if ($null -ne $secondaryExitedAt) { $exitText = "${secondaryExitedAt}ms" }
+
+        Write-Host ("iteration {0}: {1} -- secondary pid {2}, {3} sighting(s), exited at {4}" -f `
+            $i, $verdict, $secondary.Id, $result.SplashSightings, $exitText)
+
+        # Prefer the samples that actually measured an overlap. The earliest
+        # sightings usually predate the primary's own window, so they carry no
+        # rect to compare against and say the least about the defect.
+        $shown = $covered
+        if ($shown.Count -eq 0) { $shown = $sightings }
+        if ($shown.Count -gt 0) {
+            $shown | Select-Object -First 6 | Format-Table -AutoSize | Out-String | Write-Host
+            if ($shown.Count -gt 6) {
+                Write-Host ("  ... {0} more sample(s)`n" -f ($shown.Count - 6))
+            }
+        }
+    }
+}
+finally {
+    Stop-Launched
+    $env:XDG_CONFIG_HOME = $previousXdg
+    Remove-Item -Recurse -Force $scratch -ErrorAction SilentlyContinue
+}
+
+Write-Host "`n=== summary ==="
+$results | Format-Table -AutoSize | Out-String | Write-Host
+
+$scored = @($results | Where-Object { -not $_.Inconclusive })
+$skipped = $results.Count - $scored.Count
+if ($skipped -gt 0) {
+    Write-Host "$skipped/$Iterations iteration(s) were INCONCLUSIVE and are not scored." -ForegroundColor Yellow
+}
+if ($scored.Count -eq 0) {
+    Write-Host "FAIL: no iteration produced a usable measurement." -ForegroundColor Red
+    exit 1
+}
+
+if ($expectSecondarySplash) {
+    $bad = @($scored | Where-Object { $_.SplashSightings -eq 0 })
+    if ($bad.Count -gt 0) {
+        Write-Host "FAIL: an independent launch was denied its splash in $($bad.Count)/$($scored.Count) scored iteration(s)." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "PASS: the independent launch showed its splash in all $($scored.Count) scored iteration(s)." -ForegroundColor Green
+    exit 0
+}
+
+$bad = @($scored | Where-Object { $_.SplashSightings -gt 0 })
+if ($bad.Count -gt 0) {
+    Write-Host "FAIL: the secondary put a splash on screen in $($bad.Count)/$($scored.Count) scored iteration(s)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "PASS: no secondary showed a splash in any of $($scored.Count) scored iteration(s)." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
Follow-up to `# 619`, which raised this in review and deferred it as strictly-better-than-before.

The splash goes up in `Program.StartGui`, before WinUI exists. The single-instance gate runs much later in `App.OnLaunched`. `# 619` bridged them by probing the mutex with `TryOpenExisting` and skipping the splash when it was held.

A probe followed by an election is two decisions, and the gap is the defect:

- The primary does not create the mutex until well into `OnLaunched`. A second launch a few hundred ms later probes before it exists, sees no primary, and paints a full-size opaque topmost splash over the primary's window.
- The probe asks whether the mutex exists; the gate asks whether `windows-single-instance` is on for this process. A primary holds its mutex for its whole lifetime however the config is edited afterwards, so turning the setting off and launching again suppresses a splash that should have appeared.

`CreateMutex` is atomic, so an election has no gap -- the check is the decision. `SingleInstanceElection` holds it once, in `Program`, before `Application.Start`, and yields a `SingleInstanceRole` of Disabled / Primary / Secondary / Failed. `App.OnLaunched` switches on that result instead of electing again, and the splash is gated on the same value. `Program` reads the config key through the same parser `ConfigService` uses (extracted to `ConfigIniFile`), since `ConfigService` needs a `DispatcherQueue` and cannot exist that early.

A losing election closes its handle immediately. A named mutex outlives its owner for as long as any handle is open, so a secondary that held one across startup would keep the name alive after the primary exited, and the next launch would elect itself secondary with nobody left to forward to.

`IConfigService.WindowsSingleInstance` is removed. It had no readers left once the gate stopped consulting it, and it was re-evaluated on every config reload -- a second answer to the question this change exists to make single-sourced. `WindowsOnlyKeys` now says the key takes effect on next launch, which is what actually happens.

`SplashWindow.HideNow` is added for callers whose next move is to end the process. `Dismiss` only signals an event and starts a 220ms fade, so a caller that dismisses and exits leaves the window up and the splash thread cut down wherever it happens to be, possibly inside GDI+. `HideNow` skips the fade and waits, bounded, for the splash thread's own teardown -- it does not touch the window cross-thread, because hiding another thread's window is a blocking inter-thread send and posting it asynchronously only defers to a thread that has by then stopped pumping. It is wired into both unhandled-exception handlers and the shutdown path, which are the teardowns that do not unwind through `StartGui`.

**Reproducing it.** `windows/scripts/splash-single-instance-race.ps1` (`just splash-race`) launches two instances a few hundred ms apart and samples top-level windows for class `WinttySplash`, resolving each to its owning PID and measuring overlap against the primary's rect. `XDG_CONFIG_HOME` is redirected to a scratch dir, so it never touches a real config. It refuses to run while a Wintty from the same binary is already up, since that process owns the mutex and both launches would forward to it -- a green run that measured nothing.

| mode | before | after |
|---|---|---|
| default (300ms apart) | 2/2 -- secondary's splash covering the primary, overlap 1,984,620px | 2/2 pass |
| `-SecondaryFeatureOff` | 2/2 -- independent launch denied its splash | 2/2 pass |

The race is worse than assumed in review: the splash sat over the primary for about 10 seconds (the watchdog), not a brief flash.

Tests: 1839 pass in `Ghostty.Tests`, 28 in `Ghostty.Tests.Windows` (`just test-win`). The election tests use the real named mutex, including 16 threads released off a barrier producing exactly one primary, and a three-party case that fails if the losing handle is retained.

**Noticed, not fixed:** at a 300ms delay the secondary sometimes fails to forward and falls back to an independent window -- the primary's pipe server starts at the end of `OnLaunched`, after the secondary's 2s connect window. Identical on baseline (the forward itself did not move), so pre-existing; worth its own issue.
