### PR TITLE
shell: fix the launch splash's scale and multi-window placement

### DIFF
--- a/windows/Ghostty.Core/Session/WindowGeometryGate.cs
+++ b/windows/Ghostty.Core/Session/WindowGeometryGate.cs
@@ -1,0 +1,48 @@
+namespace Ghostty.Core.Session;
+
+/// <summary>
+/// Decides whether a saved window geometry is worth honouring, and
+/// normalizes it into a concrete rect. Pure, so the rules are testable
+/// without a window.
+///
+/// <para>Shared because two callers must agree on them and cannot see each
+/// other: the window places itself from this, and the pre-XAML splash sizes
+/// itself to cover the window it is about to hide. A rect one of them
+/// accepts and the other rejects puts the splash somewhere the window is
+/// not, which is the whole failure the splash exists to prevent. They were
+/// previously two copies of the same literals kept in step by a comment.</para>
+///
+/// <para>Deliberately stops short of asking where the monitors are. The
+/// window answers that with WinUI's DisplayArea and the splash with
+/// MonitorFromRect, because the splash runs on its own thread before any
+/// WinUI type exists -- so the on-screen test stays with each caller and
+/// only the size and position rules live here.</para>
+/// </summary>
+internal static class WindowGeometryGate
+{
+    /// <summary>
+    /// Smallest saved size worth believing. Closing while minimized saves a
+    /// 160x31 rect at (-32000,-32000); honouring that would put the window
+    /// and the splash off-screen.
+    /// </summary>
+    public const int MinWidth = 200;
+    public const int MinHeight = 150;
+
+    /// <summary>
+    /// Turn a saved geometry into a rect, or fail when it is too small to
+    /// be real. A null position normalizes to the origin rather than
+    /// failing: it means "wherever the OS put it", which is a reason to
+    /// pick a corner, not a reason to discard a perfectly good size.
+    /// </summary>
+    public static bool TryNormalize(
+        WindowGeometry? geometry, out (int X, int Y, int Width, int Height) rect)
+    {
+        rect = default;
+        if (geometry is null) return false;
+        if (geometry.Width is not int w || w < MinWidth) return false;
+        if (geometry.Height is not int h || h < MinHeight) return false;
+
+        rect = (geometry.X ?? 0, geometry.Y ?? 0, w, h);
+        return true;
+    }
+}

--- a/windows/Ghostty.Tests/Session/WindowGeometryGateTests.cs
+++ b/windows/Ghostty.Tests/Session/WindowGeometryGateTests.cs
@@ -1,0 +1,111 @@
+using Ghostty.Core.Session;
+using Xunit;
+
+namespace Ghostty.Tests.Session;
+
+/// <summary>
+/// Unit tests for <see cref="WindowGeometryGate"/>. These rules decide where
+/// both the window and the pre-XAML splash go, and the two used to hold
+/// separate copies of them; a divergence here puts the splash on a rect the
+/// window does not use, which is the failure the splash exists to prevent.
+/// </summary>
+public sealed class WindowGeometryGateTests
+{
+    private static WindowGeometry Geometry(
+        int? x = 0, int? y = 0, int? w = 800, int? h = 600, bool maximized = false) =>
+        new() { X = x, Y = y, Width = w, Height = h, Maximized = maximized };
+
+    [Fact]
+    public void NullGeometryIsRejected()
+    {
+        Assert.False(WindowGeometryGate.TryNormalize(null, out _));
+    }
+
+    [Fact]
+    public void PlausibleGeometryPassesThroughUnchanged()
+    {
+        Assert.True(WindowGeometryGate.TryNormalize(
+            Geometry(x: 120, y: 80, w: 1024, h: 768), out var rect));
+        Assert.Equal((120, 80, 1024, 768), rect);
+    }
+
+    [Theory]
+    [InlineData(null, 600)]
+    [InlineData(800, null)]
+    [InlineData(null, null)]
+    public void MissingSizeIsRejected(int? w, int? h)
+    {
+        Assert.False(WindowGeometryGate.TryNormalize(Geometry(w: w, h: h), out _));
+    }
+
+    [Theory]
+    [InlineData(WindowGeometryGate.MinWidth - 1, 600)]
+    [InlineData(800, WindowGeometryGate.MinHeight - 1)]
+    public void UndersizedGeometryIsRejected(int w, int h)
+    {
+        Assert.False(WindowGeometryGate.TryNormalize(Geometry(w: w, h: h), out _));
+    }
+
+    [Fact]
+    public void MinimumSizeIsAccepted()
+    {
+        Assert.True(WindowGeometryGate.TryNormalize(
+            Geometry(w: WindowGeometryGate.MinWidth, h: WindowGeometryGate.MinHeight),
+            out var rect));
+        Assert.Equal(
+            (0, 0, WindowGeometryGate.MinWidth, WindowGeometryGate.MinHeight), rect);
+    }
+
+    /// <summary>
+    /// The rect saved when a window is closed while minimized. Honouring it
+    /// would put the window, and the splash covering it, off-screen.
+    /// </summary>
+    [Fact]
+    public void MinimizedPlaceholderRectIsRejected()
+    {
+        Assert.False(WindowGeometryGate.TryNormalize(
+            Geometry(x: -32000, y: -32000, w: 160, h: 31), out _));
+    }
+
+    /// <summary>
+    /// A null position means "wherever the OS put it", not "discard this".
+    /// Rejecting it would have sent the splash to a fallback while the window
+    /// went to the origin.
+    /// </summary>
+    [Theory]
+    [InlineData(null, 40, 0, 40)]
+    [InlineData(40, null, 40, 0)]
+    [InlineData(null, null, 0, 0)]
+    public void NullPositionNormalizesToTheOrigin(int? x, int? y, int wantX, int wantY)
+    {
+        Assert.True(WindowGeometryGate.TryNormalize(Geometry(x: x, y: y), out var rect));
+        Assert.Equal(wantX, rect.X);
+        Assert.Equal(wantY, rect.Y);
+    }
+
+    /// <summary>
+    /// A negative position is legitimate on a multi-monitor desktop, where
+    /// the primary display is not necessarily the top-left one.
+    /// </summary>
+    [Fact]
+    public void NegativePositionIsPreserved()
+    {
+        Assert.True(WindowGeometryGate.TryNormalize(
+            Geometry(x: -1920, y: -200), out var rect));
+        Assert.Equal(-1920, rect.X);
+        Assert.Equal(-200, rect.Y);
+    }
+
+    /// <summary>
+    /// The maximized flag is the caller's business: the window replays it
+    /// with SW_SHOWMAXIMIZED and the splash resolves the monitor work area,
+    /// so the gate must hand back the saved restored rect either way.
+    /// </summary>
+    [Fact]
+    public void MaximizedDoesNotChangeTheNormalizedRect()
+    {
+        Assert.True(WindowGeometryGate.TryNormalize(
+            Geometry(x: 10, y: 20, w: 900, h: 700, maximized: true), out var rect));
+        Assert.Equal((10, 20, 900, 700), rect);
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -555,6 +555,16 @@ public sealed partial class MainWindow : Window
         else
             RestoreWindowPlacement();
 
+        // Hand the splash this window's real rect the moment it has one,
+        // rather than after the panes are built. Up to here the splash is on
+        // a rect it resolved from disk before this process had a window at
+        // all, and only this window knows which of the two saved sources
+        // actually won -- or that both were rejected and the OS placed it.
+        // Tracking from here also keeps the two together if the user drags or
+        // resizes the window before the splash comes down.
+        if (showLaunchIcon)
+            Shell.SplashWindow.Track(WindowNative.GetWindowHandle(this));
+
         _horizontalTabHost = new TabHost(_tabManager, _router, _dialogs);
         _horizontalTabHost.AttachOwner(this);
         _verticalTabHost = new VerticalTabHost(_tabManager, _router, _dialogs, _host);
@@ -619,12 +629,6 @@ public sealed partial class MainWindow : Window
         {
             _launchIcon = new Shell.LaunchIconCoordinator(DispatcherQueue);
             _launchIcon.Arm();
-
-            // Let the splash follow this window. It was positioned from the
-            // saved window state before this window existed, so this both
-            // corrects any mismatch and keeps the two together if the user
-            // drags or resizes the window before the splash comes down.
-            Shell.SplashWindow.Track(WindowNative.GetWindowHandle(this));
 
             // The active tab, not tab zero: a restored session can make any
             // tab active, and a background tab never presents, so waiting on
@@ -2610,31 +2614,30 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void ApplyGeometry(Ghostty.Core.Session.WindowGeometry geometry)
     {
-        var w = geometry.Width;
-        var h = geometry.Height;
-        if (w is null || h is null || w < 200 || h < 150) return;
-
-        var x = geometry.X ?? 0;
-        var y = geometry.Y ?? 0;
+        // Shared with the pre-XAML splash, which sizes itself to cover this
+        // window and must accept and reject exactly the same saved rects.
+        if (!Ghostty.Core.Session.WindowGeometryGate.TryNormalize(geometry, out var rect))
+            return;
+        var (x, y, width, height) = rect;
 
         // Ensure the window's top-left quadrant is on a live monitor.
         // DisplayArea.GetFromPoint returns the nearest display if the
         // point is off-screen, but we check explicitly so we don't
         // place the window somewhere invisible.
         var checkPoint = new Windows.Graphics.PointInt32(
-            x + Math.Min(100, w.Value / 2),
-            y + Math.Min(50, h.Value / 2));
+            x + Math.Min(100, width / 2),
+            y + Math.Min(50, height / 2));
         var display = Microsoft.UI.Windowing.DisplayArea.GetFromPoint(
             checkPoint, Microsoft.UI.Windowing.DisplayAreaFallback.Nearest);
 
         // If the saved position is completely outside any display's
         // work area, let the OS pick a default position.
         var work = display.WorkArea;
-        if (x + w.Value < work.X || x > work.X + work.Width ||
-            y + h.Value < work.Y || y > work.Y + work.Height)
+        if (x + width < work.X || x > work.X + work.Width ||
+            y + height < work.Y || y > work.Y + work.Height)
             return;
 
-        AppWindow.Resize(new Windows.Graphics.SizeInt32(w.Value, h.Value));
+        AppWindow.Resize(new Windows.Graphics.SizeInt32(width, height));
         AppWindow.Move(new Windows.Graphics.PointInt32(x, y));
 
         if (geometry.Maximized)

--- a/windows/Ghostty/Session/SessionStore.cs
+++ b/windows/Ghostty/Session/SessionStore.cs
@@ -18,27 +18,48 @@ internal sealed class SessionStore
 
     public SessionStore(ILogger<SessionStore> logger) => _logger = logger;
 
-    private static string Dir
-    {
-        get
-        {
-            var dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "Wintty");
-            Directory.CreateDirectory(dir);
-            return dir;
-        }
-    }
+    // No Directory.CreateDirectory here. Reading the path is not a reason to
+    // mutate the filesystem, and the splash asks for it on the pre-XAML
+    // thread whose whole job is to be on screen first. Save creates the
+    // directory, because writing is the only operation that needs one.
+    private static string Dir => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Wintty");
 
     internal static string FilePath => Path.Combine(Dir, "session.json");
+
+    /// <summary>
+    /// Read and deserialize the session file, or null when there is none.
+    /// Throws on an unreadable file; callers decide how to report it.
+    /// </summary>
+    /// <remarks>
+    /// Static and logger-free so the pre-XAML splash can share it: that
+    /// thread needs the same path and, more importantly, the same share
+    /// mode, and it runs long before DI exists.
+    ///
+    /// FileShare.ReadWrite rather than File.ReadAllText's implicit
+    /// FileShare.Read. The splash reads this file during startup while
+    /// SessionManager.LoadForRestore is rewriting it to arm the dirty flag,
+    /// and a reader that locks writers out makes that write fail -- silently,
+    /// because Save swallows and logs. The cost of losing it is that a crash
+    /// this run leaves the previous clean snapshot on disk for `default` to
+    /// wrongly restore, which is the exact outcome the arming prevents.
+    /// </remarks>
+    internal static SessionState? ReadFile()
+    {
+        if (!File.Exists(FilePath)) return null;
+
+        using var stream = new FileStream(
+            FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        return SessionSerializer.Deserialize(reader.ReadToEnd());
+    }
 
     public SessionState? Load()
     {
         try
         {
-            return File.Exists(FilePath)
-                ? SessionSerializer.Deserialize(File.ReadAllText(FilePath))
-                : null;
+            return ReadFile();
         }
         catch (Exception ex)
         {
@@ -51,6 +72,7 @@ internal sealed class SessionStore
     {
         try
         {
+            Directory.CreateDirectory(Dir);
             File.WriteAllText(FilePath, SessionSerializer.Serialize(state));
         }
         catch (Exception ex)

--- a/windows/Ghostty/Shell/SplashWindow.cs
+++ b/windows/Ghostty/Shell/SplashWindow.cs
@@ -19,11 +19,11 @@ namespace Ghostty.Shell;
 /// with its own message pump, up within a few hundred milliseconds of
 /// process start and owing nothing to the WinUI stack.</para>
 ///
-/// <para>It covers the rect the main window is about to restore to (from
-/// <see cref="Ghostty.Settings.WindowState"/>) and fills it with the
-/// terminal background colour, so the black gap is never visible. When
-/// the main window reports content, the splash fades and closes,
-/// revealing the real window underneath.</para>
+/// <para>It covers the rect the main window is about to restore to --
+/// resolved from the saved session or, failing that, the saved window
+/// placement -- and fills it with the terminal background colour, so the
+/// black gap is never visible. When the main window reports content, the
+/// splash fades and closes, revealing the real window underneath.</para>
 ///
 /// <para>Interop here is hand-written rather than CsWin32-generated for
 /// the same reason <c>NativeMethods.txt</c> already documents for
@@ -49,12 +49,6 @@ internal static unsafe partial class SplashWindow
     // lands where the window will.
     private const int FallbackWidth = 1200;
     private const int FallbackHeight = 800;
-
-    // Smallest saved rect worth believing. Matches MainWindow.ApplyGeometry,
-    // which discards anything smaller, so the splash and the window agree on
-    // when saved geometry is junk.
-    private const int MinPlausibleWidth = 200;
-    private const int MinPlausibleHeight = 150;
 
     private const int FadeDurationMs = 220;
     private const int FadeStepMs = 16;
@@ -82,7 +76,17 @@ internal static unsafe partial class SplashWindow
     private static int _width;
     private static int _height;
     private static uint _background;
-    private static double _scale = 1.0;
+
+    // DPI of the monitor the splash is currently on. Mutable for the same
+    // reason as the geometry above: the splash follows the main window, and
+    // a window dragged onto a monitor at a different scale changes what a
+    // pixel means without necessarily changing the rect.
+    private static uint _dpi = 96;
+
+    // Alpha of the last blend, so a repaint forced by something other than
+    // the fade -- a resize, a scale change -- redraws at the opacity the
+    // fade has reached rather than snapping back to fully opaque.
+    private static byte _alpha = 255;
 
     // The composed splash bitmap, kept alive between blends. Building it
     // costs a full-window DIB, a per-pixel fill and a PNG decode, none of
@@ -95,6 +99,7 @@ internal static unsafe partial class SplashWindow
     private static nint _surfaceOldBitmap;
     private static int _surfaceWidth;
     private static int _surfaceHeight;
+    private static uint _surfaceDpi;
 
     /// <summary>
     /// Follow <paramref name="hwnd"/> from now on. Called once the main
@@ -229,9 +234,7 @@ internal static unsafe partial class SplashWindow
         {
             // DPI is only knowable once the window exists and the OS has
             // assigned it to a monitor.
-            var dpi = GetDpiForWindow(_hwnd);
-            if (dpi == 0) dpi = 96;
-            _scale = dpi / 96.0;
+            AdoptDpi(GetDpiForWindow(_hwnd));
 
             if (!Paint(255))
             {
@@ -246,9 +249,15 @@ internal static unsafe partial class SplashWindow
         }
         finally
         {
-            ReleaseSurface();
-            DestroyWindow(_hwnd);
+            // Clear the handle first. It is what WndProc matches on, and
+            // DestroyWindow dispatches the messages the system has sent this
+            // window -- so a WM_DPICHANGED arriving inside that call would
+            // otherwise pass the guard and rebuild a full-window surface that
+            // nothing is left to free. Zeroing first turns that into a no-op.
+            var hwnd = _hwnd;
             _hwnd = 0;
+            ReleaseSurface();
+            DestroyWindow(hwnd);
         }
     }
 
@@ -327,6 +336,14 @@ internal static unsafe partial class SplashWindow
         var tracked = Volatile.Read(ref _trackedHwnd);
         if (tracked == 0) return true;
 
+        // A tracked window that has not been shown yet is still ours. The
+        // splash is handed the window as soon as its geometry is applied,
+        // which is well before Activate, and until then the foreground window
+        // is whatever launched the app -- so testing the foreground alone
+        // would stop re-asserting topmost for the whole of that stretch,
+        // exactly while the window behind is about to appear painting black.
+        if (IsWindowVisible(tracked) == 0) return true;
+
         var foreground = GetForegroundWindow();
         return foreground == 0 || foreground == tracked || foreground == _hwnd;
     }
@@ -360,10 +377,35 @@ internal static unsafe partial class SplashWindow
 
         SetWindowPos(_hwnd, HWND_TOPMOST, r.left, r.top, width, height, SWP_NOACTIVATE);
 
-        // A move alone keeps the existing layered bitmap; a resize needs a
-        // new one, both because the surface is a different size and
-        // because the icon rescales with the window.
-        if (resized) Paint(255);
+        // Belt and braces. A move across a DPI boundary normally arrives as
+        // WM_DPICHANGED sent synchronously from inside the SetWindowPos above,
+        // so by this line WndProc has usually adopted the new scale already
+        // and this call is a no-op. It stays because the whole feature turns
+        // on that message: the icon would silently keep the launch monitor's
+        // size if it ever went undelivered, and one GetDpiForWindow per moved
+        // frame is not a cost worth trading for that.
+        var rescaled = AdoptDpi(GetDpiForWindow(_hwnd));
+
+        // A move alone keeps the existing layered bitmap; a resize or a scale
+        // change needs a new one, both because the surface is a different size
+        // and because the icon rescales with the window.
+        if (resized || rescaled) Paint(_alpha);
+    }
+
+    /// <summary>
+    /// Adopt <paramref name="dpi"/> as the scale the splash draws at.
+    /// Returns true when it actually changed, which means the composed
+    /// bitmap is stale and the caller owes a repaint.
+    /// </summary>
+    private static bool AdoptDpi(uint dpi)
+    {
+        // GetDpiForWindow returns zero for an invalid window. Treating that
+        // as 100% keeps a failure looking like an unscaled display rather
+        // than collapsing the icon to nothing.
+        if (dpi == 0) dpi = 96;
+        if (dpi == _dpi) return false;
+        _dpi = dpi;
+        return true;
     }
 
     /// <summary>
@@ -395,6 +437,8 @@ internal static unsafe partial class SplashWindow
     {
         if (!EnsureSurface()) return false;
 
+        _alpha = alpha;
+
         var size = new SIZE { cx = _surfaceWidth, cy = _surfaceHeight };
         var srcPoint = new POINT { x = 0, y = 0 };
         var blend = new BLENDFUNCTION
@@ -424,7 +468,11 @@ internal static unsafe partial class SplashWindow
         var height = _height;
         if (width <= 0 || height <= 0) return false;
 
-        if (_surfaceDib != 0 && _surfaceWidth == width && _surfaceHeight == height)
+        // The DPI is part of the key, not just the size: the icon is sized
+        // from it, so a same-size move onto a monitor at a different scale
+        // leaves a bitmap that is the right shape and the wrong drawing.
+        if (_surfaceDib != 0 && _surfaceWidth == width && _surfaceHeight == height
+            && _surfaceDpi == _dpi)
         {
             return true;
         }
@@ -432,8 +480,10 @@ internal static unsafe partial class SplashWindow
         ReleaseSurface();
 
         var background = _background;
+        var dpi = _dpi;
+        var scale = dpi / 96.0;
         var iconPx = (int)Math.Round(
-            LaunchIconMetrics.Resolve(width / _scale, height / _scale) * _scale);
+            LaunchIconMetrics.Resolve(width / scale, height / scale) * scale);
 
         var screenDc = GetDC(0);
         if (screenDc == 0)
@@ -483,6 +533,7 @@ internal static unsafe partial class SplashWindow
         _surfaceOldBitmap = oldBitmap;
         _surfaceWidth = width;
         _surfaceHeight = height;
+        _surfaceDpi = dpi;
 
         FillOpaque(bits, width, height, background);
         DrawIcon(memDc, width, height, iconPx);
@@ -509,6 +560,7 @@ internal static unsafe partial class SplashWindow
         _surfaceOldBitmap = 0;
         _surfaceWidth = 0;
         _surfaceHeight = 0;
+        _surfaceDpi = 0;
     }
 
     /// <summary>
@@ -630,39 +682,124 @@ internal static unsafe partial class SplashWindow
     /// Where the main window is about to appear, in physical pixels.
     /// </summary>
     /// <remarks>
-    /// Applies the same plausibility rules as
-    /// <c>MainWindow.ApplyGeometry</c>, which decides where the window
-    /// really goes. A saved rect the window would reject is one the splash
-    /// must reject too: closing while minimized saves a 160x31 rect at
-    /// (-32000,-32000), and honouring that puts the splash off-screen for
-    /// the whole cold start, which is a silent no-op of the feature.
-    /// The window's own check uses WinUI's DisplayArea, which does not
-    /// exist yet on this thread, so this uses the virtual screen instead.
+    /// <para>Two sources, most specific first. A restored session places its
+    /// first window from that session's saved geometry; every other launch
+    /// places its window from window-state.json. Reading only the latter is
+    /// wrong for any multi-window session, because window-state.json is
+    /// written by whichever window closed last while the window being
+    /// covered is the first one restored -- so the splash would sit on a
+    /// different window's rect for exactly the gap it exists to cover.</para>
+    ///
+    /// <para>A best guess rather than a mirror of the window's own decision.
+    /// The window consults exactly one of the two, and when it rejects that
+    /// one it lets the OS place it instead of trying the other. The guess
+    /// only has to hold until <see cref="Track"/> hands over the real rect.</para>
+    ///
+    /// <para>Both sources go through <c>WindowGeometryGate</c>, which is the
+    /// same size and position check <c>MainWindow.ApplyGeometry</c> applies:
+    /// a rect the window would reject is one the splash must reject too. The
+    /// on-screen test is not shared, because the window's uses WinUI's
+    /// DisplayArea and nothing WinUI exists yet on this thread.</para>
     /// </remarks>
     private static (int X, int Y, int Width, int Height) ResolveRect(
         Ghostty.Settings.WindowState? state)
     {
-        if (state is not null
-            && state.WindowWidth is int w and >= MinPlausibleWidth
-            && state.WindowHeight is int h and >= MinPlausibleHeight
-            && state.WindowX is int x
-            && state.WindowY is int y
-            && IntersectsLiveMonitor(x, y, w, h))
-        {
-            // A maximized window comes up filling its monitor's work area,
-            // not the restored rect that was saved alongside the flag.
-            if (state.WindowMaximized && TryGetWorkArea(x, y, w, h, out var work))
-            {
-                return work;
-            }
-            return (x, y, w, h);
-        }
+        if (TryResolveGeometry(LoadSessionGeometry(), out var rect)) return rect;
+        if (TryResolveGeometry(ToGeometry(state), out rect)) return rect;
 
         var screenWidth = GetSystemMetrics(SM_CXSCREEN);
         var screenHeight = GetSystemMetrics(SM_CYSCREEN);
         var width = Math.Min(FallbackWidth, screenWidth);
         var height = Math.Min(FallbackHeight, screenHeight);
         return ((screenWidth - width) / 2, (screenHeight - height) / 2, width, height);
+    }
+
+    /// <summary>
+    /// Turn a saved geometry into the physical rect the window will occupy,
+    /// or fail when the window itself would refuse to use it.
+    /// </summary>
+    private static bool TryResolveGeometry(
+        Ghostty.Core.Session.WindowGeometry? geometry,
+        out (int X, int Y, int Width, int Height) rect)
+    {
+        rect = default;
+        if (geometry is null) return false;
+        if (!Ghostty.Core.Session.WindowGeometryGate.TryNormalize(geometry, out var r))
+        {
+            return false;
+        }
+
+        var (x, y, w, h) = r;
+        if (!IntersectsLiveMonitor(x, y, w, h)) return false;
+
+        // A maximized window comes up filling its monitor's work area, not
+        // the restored rect that was saved alongside the flag.
+        if (geometry.Maximized && TryGetWorkArea(x, y, w, h, out var work))
+        {
+            rect = work;
+            return true;
+        }
+
+        rect = r;
+        return true;
+    }
+
+    /// <summary>
+    /// The window-state.json placement in the shape ApplyGeometry consumes.
+    /// Mirrors <c>MainWindow.RestoreWindowPlacement</c>, which builds the
+    /// same geometry from the same fields for the non-restore path.
+    /// </summary>
+    private static Ghostty.Core.Session.WindowGeometry? ToGeometry(
+        Ghostty.Settings.WindowState? state) =>
+        state is null ? null : new Ghostty.Core.Session.WindowGeometry
+        {
+            X = state.WindowX,
+            Y = state.WindowY,
+            Width = state.WindowWidth,
+            Height = state.WindowHeight,
+            Maximized = state.WindowMaximized,
+        };
+
+    /// <summary>
+    /// Geometry of the first window a session restore would rebuild, or null
+    /// when there is no session to restore from.
+    /// </summary>
+    /// <remarks>
+    /// <para>Approximates <c>SessionManager.LoadForRestore</c>. The real gate
+    /// also consults <c>window-save-state</c>, which lives in the Wintty
+    /// config and so behind a libghostty load -- seconds of work on the one
+    /// path whose whole job is to be on screen first. The clean-shutdown flag
+    /// is in the session file itself and is what the default policy turns on,
+    /// so it is read here and the config key is not.</para>
+    ///
+    /// <para>That buys the common case at the cost of two rare ones, both of
+    /// which end with the splash on a rect the window does not use:
+    /// <c>always</c> after an unclean exit, where the window restores and
+    /// this declines; and the single launch after a switch to <c>never</c>,
+    /// where a stale clean file is still on disk, this honours it and the
+    /// window discards it. Neither is silent for long -- <see cref="Track"/>
+    /// hands over the real rect as soon as the window has one.</para>
+    /// </remarks>
+    private static Ghostty.Core.Session.WindowGeometry? LoadSessionGeometry()
+    {
+        try
+        {
+            var session = Ghostty.Session.SessionStore.ReadFile();
+            if (session is null || !session.CleanShutdown) return null;
+            if (session.Windows.Count == 0) return null;
+
+            // A window with no tabs is one the restore will not rebuild, and
+            // MainWindow then falls back to window-state.json for its
+            // placement. Following it here would reintroduce the very
+            // mismatch this method exists to remove.
+            var first = session.Windows[0];
+            return first.Tabs.Count > 0 ? first.Geometry : null;
+        }
+        catch (Exception ex)
+        {
+            Diag($"could not read the saved session: {ex.Message}");
+            return null;
+        }
     }
 
     /// <summary>
@@ -674,7 +811,21 @@ internal static unsafe partial class SplashWindow
     /// </summary>
     private static bool IntersectsLiveMonitor(int x, int y, int w, int h)
     {
-        var rect = new RECT { left = x, top = y, right = x + w, bottom = y + h };
+        // Grown by a pixel on every side before the test. MonitorFromRect
+        // wants a real overlap, so a rect whose right edge is exactly a
+        // monitor's left edge reads as off-screen -- while ApplyGeometry,
+        // whose bounds test is a strict inequality, would still place the
+        // window there. This only reconciles that touching-edge case; the two
+        // tests are not otherwise equivalent, since ApplyGeometry measures
+        // against one nearest display's work area and this measures against
+        // the bounds of every live monitor.
+        var rect = new RECT
+        {
+            left = x - 1,
+            top = y - 1,
+            right = x + w + 1,
+            bottom = y + h + 1,
+        };
         return MonitorFromRect(ref rect, MONITOR_DEFAULTTONULL) != 0;
     }
 
@@ -741,6 +892,30 @@ internal static unsafe partial class SplashWindow
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
     private static nint WndProc(nint hwnd, uint msg, nint wParam, nint lParam)
     {
+        // How the splash learns its scale changed under it: the user drags
+        // the covered window onto a monitor at a different scale, or edits
+        // the display's scale factor in Settings while the splash is up.
+        // DefWindowProc does nothing with this for a layered window, so
+        // without the case the icon keeps the launch monitor's physical size
+        // for the rest of the splash -- half or double what it should be.
+        //
+        // The DPI comes from wParam because that is what the message carries
+        // and it is authoritative for the move that raised it. The suggested
+        // rect in lParam is ignored: that is advice for a window that owns
+        // its placement, and this one takes its rect from the window it
+        // covers.
+        //
+        // Guarded on the handle because the splash is a singleton addressed
+        // through a static. WndProc runs for messages sent during
+        // CreateWindowExW, before _hwnd is assigned, and for messages
+        // dispatched by DestroyWindow, after it is cleared; neither should
+        // touch a surface.
+        if (msg == WM_DPICHANGED && hwnd == _hwnd)
+        {
+            if (AdoptDpi((uint)wParam & 0xFFFF)) Paint(_alpha);
+            return 0;
+        }
+
         // Layered content is supplied wholesale by UpdateLayeredWindow, so
         // there is no WM_PAINT work and no background to erase.
         if (msg == WM_DESTROY)
@@ -760,6 +935,7 @@ internal static unsafe partial class SplashWindow
     private const int SW_SHOWNA = 8;
     private const uint PM_REMOVE = 0x0001;
     private const uint WM_DESTROY = 0x0002;
+    private const uint WM_DPICHANGED = 0x02E0;
     private const uint ULW_ALPHA = 0x00000002;
     private const int SM_CXSCREEN = 0;
     private const int SM_CYSCREEN = 1;
@@ -906,6 +1082,9 @@ internal static unsafe partial class SplashWindow
 
     [LibraryImport("user32.dll")]
     private static partial nint GetForegroundWindow();
+
+    [LibraryImport("user32.dll")]
+    private static partial int IsWindowVisible(nint hwnd);
 
     [LibraryImport("user32.dll")]
     private static partial nint MonitorFromPoint(POINT pt, uint flags);


### PR DESCRIPTION
Two placement defects in the splash added by # 619, both found in review there and deferred.

**Scale.** `_scale` was sampled once after `CreateWindowExW` and never re-read, and the composed surface was cached on width and height alone. A same-size move across monitors therefore never rebuilt anything and the icon stayed at the launch monitor's physical size. Now `WM_DPICHANGED` is handled (taking the DPI from `wParam`, ignoring the suggested rect since the splash takes its rect from the window it covers), `FollowTrackedWindow` re-reads the scale after each move, and the DPI is part of the surface cache key. A new `_alpha` field records the last blend so a forced repaint does not snap back to opaque mid-fade.

**Multi-window placement.** The splash resolved its rect from window-state.json, written by whichever window closed last. The window that arms it is the first one a session restore rebuilds, placed from the session file. In a multi-window session those are different rects. `ResolveRect` now reads the session's first window first and falls back to window-state.json, and `Track` moved up to just after the geometry is applied instead of after pane construction.

**Shared rules.** The size and position checks now live in one `WindowGeometryGate` in `Ghostty.Core`, beside `SessionGate`. `ApplyGeometry` and the splash held separate copies kept in step by a comment and two pairs of literals, which is the drift this bug grew out of; they are unit-tested now. That also folds in two divergences found alongside: a null saved X/Y is the origin rather than a reject, and a rect exactly on the work-area edge is accepted.

The splash cannot cheaply read `window-save-state` (it is behind a libghostty load), so it approximates the restore gate with the session file's own `CleanShutdown` flag. Two rare cases still put it on a rect the window does not use -- `always` after an unclean exit, and the one launch after switching to `never` -- and `Track` closes both as soon as the window has a rect.

## From review

- `DestroyWindow` dispatches messages the system has sent the window, so a `WM_DPICHANGED` arriving there ran after `ReleaseSurface` and rebuilt a full-window surface nothing would free. The handle is cleared first so the guard rejects it.
- The session read uses `FileShare.ReadWrite`. `File.ReadAllText` locks writers out, and the splash reads at startup exactly while `SessionManager` rewrites the same file to arm its dirty flag -- a write whose failure `Save` swallows, so losing it would silently let a crash restore a stale clean snapshot.
- `SessionStore.FilePath` no longer creates a directory as a side effect of being read; only `Save` needs one.
- A session whose first window has no tabs is declined: the restore does not rebuild it, so the window falls back to window-state.json and following the session geometry would put the splash back on the wrong rect.
- Topmost is still re-asserted while the tracked window is not yet visible; the splash is handed the window well before `Activate`, and testing the foreground alone stopped the nudge for that whole stretch.
- Corrected comments that stated the opposite of what happens: `WM_DPICHANGED` is sent synchronously from inside `SetWindowPos` rather than posted for a later tick, `window-save-state=never` diverges rather than falling back, and the inflate reconciles the monitor test only at the touching edge.

## Verification

Measured on screen, base vs this branch, with a fixture putting session window 0 at `0,0 3400x1380` and window-state at `200,150 900x700`:

- Splash rect: base sits on `200,150 900x700` from 2101ms and only corrects at 5651ms. This branch lands on `0,0 3400x1380` at first appearance and never moves.
- Icon after a `WM_DPICHANGED(192)`: base holds 159px across 25 samples over 3s. This branch goes 159px to 317px (expected 160 to 320), confirmed against saved crops.

The DPI bug is only observable where `LaunchIconMetrics`' 160-DIP clamp binds; below it the icon is a pure fraction of the physical rect and the scale cancels out.

Not covered: a real cross-monitor drag. This machine has one display at 100%, so the handler was exercised by sending the message rather than by moving a window. Note `WM_DPICHANGED` cannot be posted, only sent, since `lParam` is a `RECT*`.

`dotnet test`: 1863 passed, 0 failed (14 new).