### PR TITLE
termio: flag first content on print_slice, not just print

### DIFF
--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -233,6 +233,10 @@ pub const StreamHandler = struct {
             .print_slice => {
                 @branchHint(.likely);
                 try self.terminal.printSlice(value.cps);
+                if (!self.first_content_flagged) {
+                    self.first_content_flagged = true;
+                    self.renderer_state.first_content = true;
+                }
             },
             .print_repeat => try self.terminal.printRepeat(value),
             .bell => self.bell(),


### PR DESCRIPTION
`first_content` was flagged in the `.print` case only. `src/terminal/stream.zig:701` shows the ground-state fast path hands every printable run to the handler as `.print_slice`, single characters included (`cps[i..end]` with `end == i+1`), so real shell output never takes the `.print` branch.

The consequence is that `renderer_state.first_content` is never set, the renderer never latches it, and the one-shot `.first_render` surface message is **never emitted at all**. Every consumer of it silently gets nothing.

`stream.zig:469` documents exactly this trap:

> printable text is delivered via `print_slice` actions (runs of codepoints) whenever the stream can decode multiple codepoints at once, and via `print` actions otherwise. Handlers that care about text must handle both.

## How it was found, and what it does not fix

The Windows launch splash dismisses on `min(first_render, first-composed-frame + 2500ms)`. It was always taking the 2500ms fallback. Temporary tracing on the C# side showed no `first_render` reaching the app at all in 14s; with this change it arrives reliably.

Worth being clear that **this does not make the splash faster**. First content lands well after the grace expires either way, so the splash timing is unchanged:

| shell | first composed frame | grace expiry | first_render (with this fix) |
|---|---|---|---|
| pwsh | 4619ms | 7133ms | 10582ms |
| `-e cmd /k echo READY` | 3593ms | 6108ms | 9114ms |

Why first content takes ~5.5s after compose even with a shell that prints instantly is a separate, still-open question. This change is worth making on its own terms: a documented apprt signal that never fires is a trap for the next consumer, and the splash is only the first one.

## Verification

`zig build test -Dapp-runtime=none` passes; `zig fmt --check` clean.

No unit test. `src/termio/stream_handler.zig` has no test block today, and constructing a `StreamHandler` needs a terminal, three mailboxes, renderer state and an `xev.Async` — a harness disproportionate to a four-line fix, and one this PR would be inventing from scratch. The evidence is the before/after trace above. Flagging the gap rather than implying coverage.

The added branch is on the hottest action in the parser, but it is a single already-hot bool that is false exactly once per surface.
