### PR TITLE
identity: give each flavour one place to name its state directory

### DIFF
--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -75,4 +75,16 @@ internal static class AppIdentity
     /// brand.
     /// </summary>
     public const string LogTag = $"[{ProductName}]";
+
+    /// <summary>
+    /// Folder name for this build's per-user state, under both
+    /// <c>LocalApplicationData</c> (logs, crash log, caches) and
+    /// <c>ApplicationData</c> (session restore).
+    ///
+    /// Separate from <see cref="ProductName"/> even though the two agree
+    /// here: one is a display string and the other is a path component,
+    /// and they stop agreeing as soon as a build wants a distinct state
+    /// directory without renaming itself on screen.
+    /// </summary>
+    public const string StateDirName = "Wintty";
 }

--- a/windows/Ghostty.Core/AppIdentity.cs
+++ b/windows/Ghostty.Core/AppIdentity.cs
@@ -49,10 +49,10 @@ internal static class AppIdentity
     /// <list type="bullet">
     /// <item>the shell's own <c>%APPDATA%\Wintty</c> (session, window
     /// state, command frecency) and <c>%LOCALAPPDATA%\Wintty</c> (logs,
-    /// crash.log, gpu.log, icon cache), spelled out at each call site
-    /// rather than read from here. Unlike the libghostty caches above
-    /// this is state the user would notice losing, with nothing left to
-    /// migrate it;</item>
+    /// crash.log, gpu.log, icon cache), which read <see cref="StateDirName"/>
+    /// rather than this constant. Unlike the libghostty caches above this
+    /// is state the user would notice losing, with nothing left to migrate
+    /// it;</item>
     /// <item>the assembly name, which <c>InternalsVisibleTo</c> and
     /// <c>Process.GetProcessesByName</c> have to match;</item>
     /// <item>kernel object and window class names, which single-instance

--- a/windows/Ghostty.Core/Commands/FrecencyStore.cs
+++ b/windows/Ghostty.Core/Commands/FrecencyStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Ghostty.Core;
 using Ghostty.Core.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -63,7 +64,7 @@ internal sealed partial class FrecencyStore
 
     private static string FilePath => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "Wintty",
+        AppIdentity.StateDirName,
         "command-frecency.json");
 
     public static FrecencyStore Load()

--- a/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
+++ b/windows/Ghostty.Core/Profiles/WindowsIconResolver.cs
@@ -217,6 +217,6 @@ internal sealed class WindowsIconResolver(IFileSystem fs) : IIconResolver
     private string? CachePathFor(string sha)
     {
         var local = fs.GetKnownFolder(KnownFolderId.LocalAppData);
-        return local is null ? null : Path.Combine(local, "Wintty", "IconCache", sha + ".png");
+        return local is null ? null : Path.Combine(local, AppIdentity.StateDirName, "IconCache", sha + ".png");
     }
 }

--- a/windows/Ghostty.Tests/AppIdentityTests.cs
+++ b/windows/Ghostty.Tests/AppIdentityTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using System.Linq;
 using Ghostty.Core;
 using Ghostty.Core.Version;
 using Xunit;
@@ -9,6 +11,9 @@ namespace Ghostty.Tests;
 /// of whatever the build produced rather than one fixed string. Only the
 /// OSS default is pinned to an exact value, guarded on the edition, so a
 /// wintty-release build overriding it does not have to patch this file.
+/// StateDirName is guarded the same way, since the shared tiering patch
+/// sets Edition per tier and is expected to make the state dir per-flavour
+/// too.
 /// </summary>
 public sealed class AppIdentityTests
 {
@@ -48,6 +53,34 @@ public sealed class AppIdentityTests
         if (BuildInfo.Edition == Edition.Oss)
         {
             Assert.Equal("com.deblasis.wintty", AppIdentity.AumId);
+        }
+    }
+
+    [Fact]
+    public void StateDirName_IsNotEmpty()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(AppIdentity.StateDirName));
+    }
+
+    [Fact]
+    public void StateDirName_HasNoInvalidFileNameChars()
+    {
+        // What actually matters once callers build directory paths from
+        // this: whitespace and length are fine in a folder name, invalid
+        // path characters are not.
+        Assert.DoesNotContain(AppIdentity.StateDirName, c => Path.GetInvalidFileNameChars().Contains(c));
+    }
+
+    [Fact]
+    public void StateDirName_DefaultsToWinttyInAnOssBuild()
+    {
+        // Guarded the same way as AumId_DefaultsToTheUnsuffixedIdInAnOssBuild:
+        // the shared tiering patch sets Edition per tier, and is expected to
+        // make StateDirName per-flavour along with it, so this assertion
+        // must not run for a non-OSS build.
+        if (BuildInfo.Edition == Edition.Oss)
+        {
+            Assert.Equal("Wintty", AppIdentity.StateDirName);
         }
     }
 }

--- a/windows/Ghostty.Tests/AppIdentityTests.cs
+++ b/windows/Ghostty.Tests/AppIdentityTests.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Linq;
 using Ghostty.Core;
 using Ghostty.Core.Version;
 using Xunit;
@@ -63,21 +61,17 @@ public sealed class AppIdentityTests
     }
 
     [Fact]
-    public void StateDirName_HasNoInvalidFileNameChars()
+    public void StateDirName_SurvivesWin32PathNormalization()
     {
-        // What actually matters once callers build directory paths from
-        // this: whitespace and length are fine in a folder name, invalid
-        // path characters are not.
-        Assert.DoesNotContain(AppIdentity.StateDirName, c => Path.GetInvalidFileNameChars().Contains(c));
+        // A state directory name has to survive Win32 path normalisation:
+        // invalid characters are rejected outright, and a trailing space or
+        // dot is silently stripped, which would collide two flavours.
+        Assert.Matches(@"^[A-Za-z0-9._-]*[A-Za-z0-9_-]$", AppIdentity.StateDirName);
     }
 
     [Fact]
     public void StateDirName_DefaultsToWinttyInAnOssBuild()
     {
-        // Guarded the same way as AumId_DefaultsToTheUnsuffixedIdInAnOssBuild:
-        // the shared tiering patch sets Edition per tier, and is expected to
-        // make StateDirName per-flavour along with it, so this assertion
-        // must not run for a non-OSS build.
         if (BuildInfo.Edition == Edition.Oss)
         {
             Assert.Equal("Wintty", AppIdentity.StateDirName);

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -9,9 +9,9 @@ public class JumpListBuilderTests
 {
     private const string TestExe = @"C:\fake\Wintty.exe";
 
-    // References the real constant instead of duplicating it, so a future
-    // AUMID change cannot leave this fixture silently out of sync.
-    private const string TestAppId = Ghostty.Core.AppIdentity.AumId;
+    // A synthetic id keeps the fixture from duplicating the real identity
+    // without coupling it to a build-generated constant.
+    private const string TestAppId = "com.example.jumplist-test";
 
     [Fact]
     public void Build_sets_app_id()

--- a/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
+++ b/windows/Ghostty.Tests/JumpList/JumpListBuilderTests.cs
@@ -8,7 +8,10 @@ namespace Ghostty.Tests.JumpList;
 public class JumpListBuilderTests
 {
     private const string TestExe = @"C:\fake\Wintty.exe";
-    private const string TestAppId = "com.deblasis.wintty";
+
+    // References the real constant instead of duplicating it, so a future
+    // AUMID change cannot leave this fixture silently out of sync.
+    private const string TestAppId = Ghostty.Core.AppIdentity.AumId;
 
     [Fact]
     public void Build_sets_app_id()

--- a/windows/Ghostty.Tests/Profiles/WindowsIconResolverBundledKeyTests.cs
+++ b/windows/Ghostty.Tests/Profiles/WindowsIconResolverBundledKeyTests.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Ghostty.Core;
 using Ghostty.Core.Profiles;
 using Ghostty.Tests.Profiles.Fakes;
 using Xunit;
@@ -61,7 +62,7 @@ public sealed class WindowsIconResolverBundledKeyTests
         // under IconCache\<sha>.png so subsequent resolves can short-circuit.
         var cacheFile = System.Linq.Enumerable.Single(
             fs.EnumerateKeys(),
-            k => k.StartsWith(@"C:\cache\Wintty\IconCache\", System.StringComparison.Ordinal));
+            k => k.StartsWith($@"C:\cache\{AppIdentity.StateDirName}\IconCache\", System.StringComparison.Ordinal));
         Assert.Equal(bytes, fs.ReadAllBytesSync(cacheFile));
     }
 
@@ -77,7 +78,7 @@ public sealed class WindowsIconResolverBundledKeyTests
         _ = await first.ResolveAsync(new IconSpec.BundledKey("cmd"), CancellationToken.None);
         var cachePath = System.Linq.Enumerable.Single(
             fs.EnumerateKeys(),
-            k => k.StartsWith(@"C:\cache\Wintty\IconCache\", System.StringComparison.Ordinal));
+            k => k.StartsWith($@"C:\cache\{AppIdentity.StateDirName}\IconCache\", System.StringComparison.Ordinal));
 
         var sentinel = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0xAA, 0xBB, 0xCC, 0xDD };
         fs.AddFile(cachePath, sentinel);

--- a/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
+++ b/windows/Ghostty/Accessibility/HighContrastOverrideFile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Security;
+using Ghostty.Core;
 
 namespace Ghostty.Accessibility;
 
@@ -23,7 +24,7 @@ internal static class HighContrastOverrideFile
         {
             var dir = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Wintty");
+                AppIdentity.StateDirName);
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, "high-contrast.conf");
             File.WriteAllText(path, body);

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -351,7 +351,7 @@ public partial class App : Application
         {
             var localAppData = Environment.GetFolderPath(
                 Environment.SpecialFolder.LocalApplicationData);
-            var dir = Path.Combine(localAppData, "Wintty");
+            var dir = Path.Combine(localAppData, AppIdentity.StateDirName);
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, "crash.log");
             lock (_crashLogLock)
@@ -433,7 +433,7 @@ public partial class App : Application
         // one folder to attach.
         var logDir = System.IO.Path.Combine(
             System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
-            "Wintty", "logs");
+            Ghostty.Core.AppIdentity.StateDirName, "logs");
         var (factory, fileSink, filters) = Ghostty.Core.Logging.LoggingBootstrap.Build(
             logLevel: _configService.LogLevel,
             logFilter: _configService.LogFilter,
@@ -592,7 +592,7 @@ public partial class App : Application
         // file again.
         var discoveryCachePath = System.IO.Path.Combine(
             System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
-            "Wintty", "DiscoveryCache", "v2.json");
+            Ghostty.Core.AppIdentity.StateDirName, "DiscoveryCache", "v2.json");
         var winttyVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "dev";
 
         var processRunner = new Ghostty.Core.Profiles.WindowsProcessRunner();

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -118,7 +118,7 @@ public static partial class Program
     /// </summary>
     private static readonly string GpuLogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "Wintty", "gpu.log");
+        AppIdentity.StateDirName, "gpu.log");
 
     /// <summary>
     /// Set to any value to force the <see cref="GpuLogPath"/> redirect on for

--- a/windows/Ghostty/Session/SessionStore.cs
+++ b/windows/Ghostty/Session/SessionStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Ghostty.Core;
 using Ghostty.Core.Session;
 using Ghostty.Logging;
 using Microsoft.Extensions.Logging;
@@ -24,7 +25,7 @@ internal sealed class SessionStore
     // directory, because writing is the only operation that needs one.
     private static string Dir => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "Wintty");
+        AppIdentity.StateDirName);
 
     internal static string FilePath => Path.Combine(Dir, "session.json");
 

--- a/windows/Ghostty/Settings/WindowState.cs
+++ b/windows/Ghostty/Settings/WindowState.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Ghostty.Core;
 using Ghostty.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -56,7 +57,7 @@ internal sealed class WindowState
         {
             var dir = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "Wintty");
+                AppIdentity.StateDirName);
             Directory.CreateDirectory(dir);
             return dir;
         }


### PR DESCRIPTION
Four flavours are meant to install side by side but all write logs, crash log, GPU
log, caches, session and window state into the same `%LOCALAPPDATA%\Wintty` and
`%APPDATA%\Wintty`, because nine call sites spell the folder name out. This adds
`AppIdentity.StateDirName` and routes those, plus the one test that asserted the
literal path, through it, so the tiered build patches one constant instead of ten
files. The value is unchanged, so every resolved path is byte-identical and no
existing state moves.

Also drops the last duplicated AUMID literal, in `JumpListBuilderTests`.

## Test plan

- [x] `dotnet test windows/Ghostty.Tests -p:Platform=x64`: 1931 passed, 1 pre-existing skip
- [x] `dotnet build windows/Ghostty.sln -p:Platform=x64`
- [x] `git grep -F '\Wintty\'` leaves only doc comments and install-path fixtures, no live state path
