### PR TITLE
windows: tab color swatches as selectable grid items

### DIFF
--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -125,6 +125,14 @@
     <EmbeddedResource Include="..\Ghostty\Settings\CheatSheetDialog.xaml"
                       Link="Settings\CheatSheetDialog.xaml"
                       LogicalName="Ghostty.Tests.Settings.CheatSheetDialog.xaml" />
+    <!--
+      The picker's XAML, for TabColorSwatchAutomationTests. Its .xaml.cs half
+      needs no entry here: the Ghostty\**\*.cs glob further down already
+      embeds it, and naming it twice is a duplicate-item error.
+    -->
+    <EmbeddedResource Include="..\Ghostty\Tabs\TabColorPalettePicker.xaml"
+                      Link="Tabs\TabColorPalettePicker.xaml"
+                      LogicalName="Ghostty.Tests.Tabs.TabColorPalettePicker.xaml" />
     <EmbeddedResource Include="..\Ghostty\Tabs\VerticalTabStrip.xaml"
                       Link="Tabs\VerticalTabStrip.xaml"
                       LogicalName="Ghostty.Tests.Tabs.VerticalTabStrip.xaml" />

--- a/windows/Ghostty.Tests/Tabs/TabColorSwatchAutomationTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabColorSwatchAutomationTests.cs
@@ -1,29 +1,166 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Xml.Linq;
+using Ghostty.Core.Tabs;
 using Xunit;
 
 namespace Ghostty.Tests.Tabs;
 
 /// <summary>
-/// Tab color swatches only had ToolTipService.ToolTip. UIA Name stayed
-/// empty, so a remaining-chrome fuzz could open Tab Color... but never
-/// find "Blue" / "None" under the hwnd.
+/// Tab color swatches were decorated Borders carrying nothing but an
+/// automation name. A Border exposes no pattern and takes no focus, so a
+/// client could find "Blue" and then had nothing to invoke, the keyboard
+/// could not reach the palette at all, and the applied color was carried
+/// by a drawn ring that no client could read.
+///
+/// The test project cannot host XAML, so these read the shipped markup and
+/// source instead. They are aimed at the decisions that are silent when
+/// broken, not at how any of it is spelled.
 /// </summary>
 public class TabColorSwatchAutomationTests
 {
     [Fact]
-    public void WrapSwatch_SetsAutomationNameFromLocalizedName()
+    public void Swatches_TakeAutomationNameFromLocalizedName()
+    {
+        var source = ReadEmbedded("TabColorPalettePicker.xaml.cs");
+        Assert.Contains("AutomationProperties.SetName(", source);
+        Assert.Contains("TabColorPalette.LocalizedName(color)", source);
+    }
+
+    /// <summary>
+    /// Without a name of its own the palette reaches a client as an
+    /// anonymous list. The heading is out of the automation tree, so
+    /// LabeledBy would point at nothing and the name has to be set.
+    /// </summary>
+    [Fact]
+    public void Palette_IsNamedAfterItsHeading()
+    {
+        var source = ReadEmbedded("TabColorPalettePicker.xaml.cs");
+        Assert.Contains("AutomationProperties.SetName(Swatches, PaletteLabel.Text)", source);
+
+        var label = Element("TextBlock");
+        Assert.Equal("Raw", (string?)label.Attribute("AutomationProperties.AccessibilityView"));
+    }
+
+    /// <summary>
+    /// The applied color has to be state a client can query, not just a
+    /// ring. SelectionItem is what carries it.
+    /// </summary>
+    [Fact]
+    public void AppliedColor_IsSelected_NotOnlyRinged()
+    {
+        var source = ReadEmbedded("TabColorPalettePicker.xaml.cs");
+        Assert.Contains(".SelectedItem = swatch", source);
+        Assert.Equal("Single", (string?)Element("GridView").Attribute("SelectionMode"));
+    }
+
+    /// <summary>
+    /// Every activation route the control has - click, Space, Enter and a
+    /// client's Invoke - arrives as ItemClick, and IsItemClickEnabled is
+    /// also what puts Invoke on the items next to SelectionItem. Verified
+    /// by removing it: the pattern disappears from every swatch.
+    /// </summary>
+    [Fact]
+    public void Activation_ArrivesAsItemClick()
+    {
+        var grid = Element("GridView");
+        Assert.Equal("True", (string?)grid.Attribute("IsItemClickEnabled"));
+        Assert.Equal("OnSwatchClick", (string?)grid.Attribute("ItemClick"));
+
+        var source = ReadEmbedded("TabColorPalettePicker.xaml.cs");
+        Assert.Contains("ItemClickEventArgs", source);
+    }
+
+    /// <summary>
+    /// An item added as its own container suppresses ItemClick, which
+    /// silently costs the control every one of its activation routes. The
+    /// swatch has to go in as plain content and let the GridView generate
+    /// the container.
+    /// </summary>
+    [Fact]
+    public void Swatches_AreContent_NotTheirOwnContainers()
+    {
+        var source = StripComments(ReadEmbedded("TabColorPalettePicker.xaml.cs"));
+        Assert.Contains("private FrameworkElement BuildSwatch(TabColor color)", source);
+        Assert.DoesNotContain("GridViewItem", source);
+    }
+
+    /// <summary>
+    /// The stock container template paints a rounded fill and a check mark
+    /// over the swatch. Losing the style is a visual regression nothing
+    /// else here would catch.
+    /// </summary>
+    [Fact]
+    public void Containers_KeepTheirOwnTemplate()
+    {
+        Assert.Equal(
+            "{StaticResource TabColorSwatchStyle}",
+            (string?)Element("GridView").Attribute("ItemContainerStyle"));
+
+        var style = Doc().Descendants()
+            .Single(e => e.Name.LocalName == "Style"
+                && (string?)e.Attribute(X + "Key") == "TabColorSwatchStyle");
+        Assert.Equal("GridViewItem", (string?)style.Attribute("TargetType"));
+    }
+
+    /// <summary>
+    /// Flattening PaletteRows only stays faithful to the macOS layout if
+    /// the grid wraps where the rows ended AND fills row-major. Vertical
+    /// orientation would reinterpret the same wrap count as five rows.
+    /// </summary>
+    [Fact]
+    public void WrapPoint_MatchesPaletteRowWidth()
+    {
+        var width = TabColorPalette.PaletteRows[0].Length;
+        Assert.All(TabColorPalette.PaletteRows, row => Assert.Equal(width, row.Length));
+
+        var panel = Element("ItemsWrapGrid");
+        Assert.Equal("Horizontal", (string?)panel.Attribute("Orientation"));
+        Assert.Equal(width, int.Parse(
+            (string)panel.Attribute("MaximumRowsOrColumns")!, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// ListViewBase drags the selection along with the caret by default,
+    /// which would leave SelectionItem reporting where the user is looking
+    /// rather than which color the tab has.
+    /// </summary>
+    [Fact]
+    public void Selection_TracksTheAppliedColor_NotTheCaret()
+    {
+        Assert.Equal("False", (string?)Element("GridView").Attribute("SingleSelectionFollowsFocus"));
+    }
+
+    private static readonly XNamespace X = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    private static XDocument Doc() => XDocument.Parse(ReadEmbedded("TabColorPalettePicker.xaml"));
+
+    private static XElement Element(string localName) =>
+        Doc().Descendants().Single(e => e.Name.LocalName == localName);
+
+    /// <summary>
+    /// So an assertion about the code is not satisfied, or defeated, by
+    /// prose that happens to name the same type.
+    /// </summary>
+    private static string StripComments(string source) =>
+        string.Join('\n', source.Split('\n').Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+    /// <summary>
+    /// The .xaml half is embedded by this project's csproj; the .xaml.cs
+    /// half rides the MarshalCompliance source glob. Reading either by
+    /// suffix works only because ".xaml.cs" does not end with ".xaml".
+    /// </summary>
+    private static string ReadEmbedded(string suffix)
     {
         var asm = Assembly.GetExecutingAssembly();
         var name = asm.GetManifestResourceNames()
-            .Single(n => n.EndsWith("TabColorPalettePicker.xaml.cs", StringComparison.OrdinalIgnoreCase));
+            .Single(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
         using var stream = asm.GetManifestResourceStream(name);
         Assert.NotNull(stream);
         using var reader = new StreamReader(stream!);
-        var source = reader.ReadToEnd();
-        Assert.Contains("AutomationProperties.SetName", source);
-        Assert.Contains("TabColorPalette.LocalizedName(color)", source);
+        return reader.ReadToEnd();
     }
 }

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml
@@ -6,18 +6,160 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <!--
+            The container owns the whole swatch chrome. The stock
+            GridViewItem template (DefaultGridViewItemStyle) is a
+            ListViewItemPresenter whose selected state paints a rounded fill
+            plus a check mark; over a 20 DIP colour circle that reads as a
+            second, competing colour, so the presenter is replaced by a ring.
+
+            Both ring brushes carry HighContrast mappings of their own
+            (accent to SystemColorHighlightColor, stroke to
+            SystemColorButtonTextColor), which is what keeps "this is
+            the applied colour" perceivable when the swatch fills
+            themselves cannot follow the theme.
+        -->
+        <!--
+            No BasedOn, but the container's built-in default style still supplies
+            everything this one leaves unset, so the stock values below have to be
+            overridden explicitly rather than assumed gone. Measured: dropping the
+            two minimums alone takes the swatches from 26 to 44 DIP.
+        -->
+        <Style x:Key="TabColorSwatchStyle" TargetType="GridViewItem">
+            <Setter Property="Width" Value="26" />
+            <Setter Property="Height" Value="26" />
+            <!-- Stock is 44 DIP square, which would blow the palette out to five
+                 times a touch target. 26 still clears the 24 DIP pointer floor. -->
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="Margin" Value="1" />
+            <Setter Property="Background" Value="Transparent" />
+            <!-- Stretch, so the swatch tile can carry hit-testing and the
+                 tooltip across the whole container instead of its circle. -->
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Stretch" />
+            <!-- Stock opts items into being drop targets; these are not. -->
+            <Setter Property="AllowDrop" Value="False" />
+            <Setter Property="UseSystemFocusVisuals" Value="True" />
+            <Setter Property="FocusVisualMargin" Value="-1" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="GridViewItem">
+                        <Grid Background="{TemplateBinding Background}">
+                            <!--
+                                Separate from the content so state changes never
+                                resize the circle underneath. It is also the focus
+                                target: the system focus visual follows the corner
+                                radius of whatever it is anchored to, and anchoring
+                                it to the square root would ring a circle with a box.
+                            -->
+                            <Border x:Name="Ring"
+                                    Control.IsTemplateFocusTarget="True"
+                                    FocusVisualMargin="{TemplateBinding FocusVisualMargin}"
+                                    CornerRadius="13"
+                                    BorderThickness="0"
+                                    BorderBrush="{ThemeResource SystemControlHighlightAccentBrush}" />
+                            <ContentPresenter
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+                            <VisualStateManager.VisualStateGroups>
+                                <!-- Every member of CommonStates, taken from the
+                                     shipped GridViewItemExpanded style (the presenter-free
+                                     one, so its state list is readable). A state a template
+                                     omits is not a no-op: GoToState fails and the item keeps
+                                     the setters of whatever state it was already in. The
+                                     other groups that style declares are dropped on purpose;
+                                     none is reachable here. -->
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="PointerOver">
+                                        <VisualState.Setters>
+                                            <Setter Target="Ring.BorderThickness" Value="1" />
+                                            <Setter Target="Ring.BorderBrush"
+                                                    Value="{ThemeResource ControlStrongStrokeColorDefaultBrush}" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Pressed">
+                                        <VisualState.Setters>
+                                            <Setter Target="Ring.BorderThickness" Value="1" />
+                                            <Setter Target="Ring.BorderBrush"
+                                                    Value="{ThemeResource ControlStrongStrokeColorDefaultBrush}" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Selected">
+                                        <VisualState.Setters>
+                                            <Setter Target="Ring.BorderThickness" Value="2" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="PointerOverSelected">
+                                        <VisualState.Setters>
+                                            <Setter Target="Ring.BorderThickness" Value="2" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <!-- Re-picking the colour already applied is a
+                                         supported route, so the press has to read as
+                                         something even though selection cannot change. -->
+                                    <VisualState x:Name="PressedSelected">
+                                        <VisualState.Setters>
+                                            <Setter Target="Ring.BorderThickness" Value="2" />
+                                            <Setter Target="Ring.BorderBrush"
+                                                    Value="{ThemeResource ControlStrongStrokeColorDefaultBrush}" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
     <StackPanel Orientation="Vertical"
                 Spacing="4"
                 Padding="8">
-        <TextBlock Text="Tab Color"
+        <!-- Raw, not Content: the grid already borrows this text as its
+             automation name, and a client that sees both reads it twice. -->
+        <TextBlock x:Name="PaletteLabel"
+                   Text="Tab Color"
+                   AutomationProperties.AccessibilityView="Raw"
                    FontWeight="SemiBold"
-                   Margin="2,0,0,4"/>
+                   Margin="2,0,0,4" />
         <!--
-            Rows are built in code-behind from TabColorPalette.PaletteRows
-            so the macOS ordering stays the single source of truth. The
-            StackPanels below are just layout scaffolding.
+            Swatches are built in code-behind from TabColorPalette.PaletteRows
+            so the macOS ordering stays the single source of truth; the wrap
+            point below folds that flat sequence back into 2x5, and a test ties
+            it to the row width rather than to this literal.
+
+            A GridView rather than the Buttons SnapZonePicker uses, or a
+            RadioButtons group: the applied colour has to reach a client as a
+            selected item and not only as a drawn ring, and a radio group checks
+            as the caret moves, which here would apply every colour arrowed past.
+
+            Selection holds the applied colour and ItemClick commits, so
+            SingleSelectionFollowsFocus stays off. With it on, arrowing drags the
+            selection along with the caret and "selected" starts reporting where
+            the user is looking rather than what the tab is.
         -->
-        <StackPanel x:Name="Row0" Orientation="Horizontal" Spacing="4"/>
-        <StackPanel x:Name="Row1" Orientation="Horizontal" Spacing="4"/>
+        <GridView x:Name="Swatches"
+                  SelectionMode="Single"
+                  SingleSelectionFollowsFocus="False"
+                  IsItemClickEnabled="True"
+                  ItemClick="OnSwatchClick"
+                  ItemContainerStyle="{StaticResource TabColorSwatchStyle}"
+                  Padding="0"
+                  ScrollViewer.HorizontalScrollMode="Disabled"
+                  ScrollViewer.VerticalScrollMode="Disabled"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
+            <GridView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <ItemsWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="5" />
+                </ItemsPanelTemplate>
+            </GridView.ItemsPanel>
+        </GridView>
     </StackPanel>
 </UserControl>

--- a/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
+++ b/windows/Ghostty/Tabs/TabColorPalettePicker.xaml.cs
@@ -1,140 +1,208 @@
 using System;
+using System.Collections.Generic;
 using Ghostty.Core.Tabs;
+using Ghostty.Services;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
-using Microsoft.UI.Xaml.Automation;
 
 namespace Ghostty.Tabs;
 
 /// <summary>
 /// Small 2-row, 5-column swatch grid used to pick a preset
 /// <see cref="TabColor"/>. Hosted inside a secondary
-/// <see cref="Flyout"/> anchored to the target <c>TabViewItem</c>.
+/// <see cref="Flyout"/> anchored to the right-clicked tab.
 ///
 /// This is NOT a <c>MenuFlyoutItem</c>-with-templated-content hack.
-/// WinAppSDK 1.6 has known hit-testing quirks when hosting arbitrary
-/// UI inside a menu item; hosting in a separate Flyout sidesteps them
-/// at the cost of one extra click on color change.
+/// WinAppSDK 1.6 had hit-testing quirks when hosting arbitrary UI inside
+/// a menu item (not re-checked since; we are on 2.2 now), and hosting in
+/// a separate Flyout sidesteps them at the cost of one extra click on
+/// color change.
+///
+/// Swatches are items of a single-selection <see cref="GridView"/> so
+/// UI Automation sees focusable, selectable elements: the applied color
+/// is reported through SelectionItem rather than implied by a drawn
+/// ring, and Invoke activates one.
 /// </summary>
 internal sealed partial class TabColorPalettePicker : UserControl
 {
+    /// <summary>Theme brush for the <see cref="TabColor.None"/> outline.</summary>
+    private const string NoneStrokeKey = "TextFillColorSecondaryBrush";
+
     /// <summary>
-    /// Raised when the user clicks a swatch. The parent flyout is
+    /// Raised when the user picks a swatch. The parent flyout is
     /// responsible for closing itself (the picker does not know about
-    /// its host).
+    /// its host). Never raised more than once per picker instance.
     /// </summary>
     public event EventHandler<TabColor>? ColorSelected;
 
-    private readonly TabColor _initial;
+    /// <summary>
+    /// Swatch element to color, mirroring <c>TabOverviewControl</c>'s
+    /// tile map. The elements carry no payload of their own, and the
+    /// color cannot be recovered from the geometry on the way back out.
+    /// </summary>
+    private readonly Dictionary<FrameworkElement, TabColor> _colors = new();
+
+    /// <summary>
+    /// The two shapes making up the <see cref="TabColor.None"/> swatch.
+    /// Their stroke cannot be resolved until the control has a theme.
+    /// </summary>
+    private readonly List<Shape> _noneStrokes = new();
+
+    /// <summary>
+    /// <c>TabContextMenuBuilder.ShowColorPicker</c> builds one picker per
+    /// invocation, hides the flyout on the first notification and never
+    /// reuses the picker, so the event is single-shot by construction.
+    /// This keeps that true even if a second click lands before the
+    /// flyout finishes hiding.
+    /// </summary>
+    private bool _picked;
+
+    /// <summary>
+    /// Loaded fires whenever the control re-enters the tree, and focusing
+    /// again would throw away wherever the user had arrowed to.
+    /// </summary>
+    private bool _openedFocus;
 
     public TabColorPalettePicker(TabColor initial)
     {
-        _initial = initial;
         InitializeComponent();
-        BuildSwatches();
+
+        // The grid is the palette's automation element, so it takes its
+        // name from the visible heading rather than repeating the string.
+        // Set rather than LabeledBy: the heading is out of the automation
+        // tree (see the XAML), and LabeledBy would point into nothing.
+        AutomationProperties.SetName(Swatches, PaletteLabel.Text);
+
+        BuildSwatches(initial);
+
+        Loaded += (_, _) =>
+        {
+            ApplyNoneStroke();
+            if (_openedFocus) return;
+            _openedFocus = true;
+
+            // Open on the applied color. ListViewBase is not itself a tab
+            // stop, so Focus() hands off to the selected container.
+            Swatches.Focus(FocusState.Programmatic);
+        };
     }
 
-    private void BuildSwatches()
+    private void BuildSwatches(TabColor initial)
     {
-        // Render the two rows declared in TabColorPalette.PaletteRows.
-        // We intentionally read the macOS-derived layout from
-        // Ghostty.Core so platform divergence stays in one file.
-        var rows = TabColorPalette.PaletteRows;
-        AddRow(Row0, rows[0]);
-        AddRow(Row1, rows[1]);
+        // TabColorPalette.PaletteRows is the macOS-derived layout, kept in
+        // Ghostty.Core so platform divergence stays in one file. Flattening
+        // it here and letting the panel wrap keeps that ordering authoritative.
+        foreach (var row in TabColorPalette.PaletteRows)
+        {
+            foreach (var color in row)
+            {
+                var swatch = BuildSwatch(color);
+                _colors[swatch] = color;
+                Swatches.Items.Add(swatch);
+                if (color == initial)
+                    Swatches.SelectedItem = swatch;
+            }
+        }
+
+        // Only reachable if TabColor gains a member PaletteRows does not
+        // list. Opening on None misreports the tab by one swatch; opening
+        // with nothing selected and nothing focused strands the keyboard.
+        Swatches.SelectedItem ??= Swatches.Items[0];
     }
 
-    private void AddRow(StackPanel host, TabColor[] row)
+    private FrameworkElement BuildSwatch(TabColor color)
     {
-        foreach (var color in row)
-            host.Children.Add(BuildSwatch(color));
-    }
-
-    private Border BuildSwatch(TabColor color)
-    {
-        // Each swatch is a 20x20 DIP Ellipse wrapped in a Border that
-        // owns the selection ring (2 DIP, SystemAccentColor). Pointer
-        // input goes on the Border so the whole tile is clickable, not
-        // only the ellipse interior.
-        var ellipse = new Ellipse { Width = 20, Height = 20 };
+        // Plain content, NOT a GridViewItem: an item that arrives as its own
+        // container suppresses ItemClick entirely, and every activation route
+        // here (click, Space, Enter, UIA Invoke) is that one event. The
+        // container, its size and its ring come from TabColorSwatchStyle.
+        //
+        // The 20 DIP circle sits on a transparent tile the size of the
+        // container so the tooltip and the click target are the same region:
+        // an Ellipse hit-tests to its geometry, which would leave the corners
+        // and the ring gap clickable but silent on hover.
+        // No explicit size: the container style stretches its content, so the
+        // tile takes the container's bounds without restating them here.
+        var tile = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+        var ellipse = new Ellipse
+        {
+            Width = 20,
+            Height = 20,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
 
         if (color == TabColor.None)
         {
             // Hollow circle with a diagonal slash, matching the macOS
             // .circle.slash symbol. Implemented as an Ellipse with
             // Stroke plus a Line inside a Grid.
-            var secondaryBrush = GetBrushResource("TextFillColorSecondaryBrush");
             ellipse.Fill = new SolidColorBrush(Colors.Transparent);
-            ellipse.Stroke = secondaryBrush;
             ellipse.StrokeThickness = 1;
 
             var slash = new Line
             {
                 X1 = 3, Y1 = 17, X2 = 17, Y2 = 3,
                 StrokeThickness = 1.5,
-                Stroke = secondaryBrush,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Width = 20,
+                Height = 20,
             };
 
-            var grid = new Grid { Width = 20, Height = 20 };
-            grid.Children.Add(ellipse);
-            grid.Children.Add(slash);
-
-            return WrapSwatch(grid, color);
+            _noneStrokes.Add(ellipse);
+            _noneStrokes.Add(slash);
+            tile.Children.Add(ellipse);
+            tile.Children.Add(slash);
         }
         else
         {
             var drawing = TabColorPalette.Colors[color];
             ellipse.Fill = new SolidColorBrush(
                 Windows.UI.Color.FromArgb(255, drawing.R, drawing.G, drawing.B));
-            return WrapSwatch(ellipse, color);
+            tile.Children.Add(ellipse);
         }
-    }
-
-    private Border WrapSwatch(FrameworkElement content, TabColor color)
-    {
-        // The border paints the selection ring when this swatch matches
-        // the currently-applied TabColor. 2 DIP ring in SystemAccentColor,
-        // inset so the visual ring sits outside the 20x20 circle.
-        bool selected = color == _initial;
-
-        var border = new Border
-        {
-            Width = 24,
-            Height = 24,
-            CornerRadius = new CornerRadius(12),
-            BorderThickness = new Thickness(selected ? 2 : 0),
-            BorderBrush = selected
-                ? GetBrushResource("SystemControlHighlightAccentBrush")
-                : new SolidColorBrush(Colors.Transparent),
-            Background = new SolidColorBrush(Colors.Transparent),
-            Padding = new Thickness(2),
-            Child = content,
-        };
 
         var label = TabColorPalette.LocalizedName(color);
-        ToolTipService.SetToolTip(border, label);
-        AutomationProperties.SetName(border, label);
-        border.Tapped += (_, e) =>
-        {
-            e.Handled = true;
-            ColorSelected?.Invoke(this, color);
-        };
-        return border;
+        ToolTipService.SetToolTip(tile, label);
+        AutomationProperties.SetName(tile, label);
+        return tile;
     }
 
     /// <summary>
-    /// Look up a theme brush resource with a fallback. WinUI 3 theme
-    /// resources are not always <see cref="SolidColorBrush"/>; a raw
-    /// cast would throw on unexpected types or missing keys.
+    /// Paint the None outline from the theme this control actually renders
+    /// under. Application.Current.Resources picks its theme dictionary by
+    /// Application.RequestedTheme, and the tab hosts pin their subtree to
+    /// Dark, so the app-theme lookup hands a light-theme stroke to a dark
+    /// flyout whenever the OS theme is light (issue # 325).
     /// </summary>
-    private static SolidColorBrush GetBrushResource(string key)
+    private void ApplyNoneStroke()
     {
-        if (Application.Current.Resources.TryGetValue(key, out var value) && value is SolidColorBrush brush)
-            return brush;
-        return new SolidColorBrush(Colors.Gray);
+        var stroke = ThemedResources.TryFindBrush(
+            Application.Current.Resources, NoneStrokeKey, ActualTheme, out var themed)
+            ? themed
+            : Ghostty.Controls.ThemeResources.Get<Brush>(
+                NoneStrokeKey, new SolidColorBrush(Colors.Gray));
+
+        foreach (var shape in _noneStrokes)
+            shape.Stroke = stroke;
+    }
+
+    private void OnSwatchClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is FrameworkElement swatch)
+            Pick(swatch);
+    }
+
+    private void Pick(FrameworkElement swatch)
+    {
+        if (_picked) return;
+        if (!_colors.TryGetValue(swatch, out var color)) return;
+        _picked = true;
+        ColorSelected?.Invoke(this, color);
     }
 }


### PR DESCRIPTION
Each swatch in the "Tab Color..." flyout was a `Border` carrying an automation name and a `Tapped` handler. A Border exposes no automation pattern and takes no focus, so the palette was mouse-only: a client could find "Blue" by name and then had nothing to invoke, and the applied colour was carried by a drawn ring nothing could read.

The swatches are now items of a single-selection `GridView`. They take focus, answer Space and Enter, and report the applied colour through SelectionItem. A container template replaces the stock `ListViewItemPresenter`, whose selected state paints a fill plus a check mark that fight a 20 DIP colour circle.

`PaletteRows` stays the source of truth; the `ItemsWrapGrid` wrap point folds the flat sequence back into the macOS 2x5 layout, and a test ties that wrap point to the row width instead of to the literal.

Two things that are not obvious and cost an experiment each:

- A swatch must go in as plain content, not as a `GridViewItem`. An item that arrives as its own container suppresses `ItemClick` entirely, and `ItemClick` is where click, Space, Enter and a client's `Invoke()` all land. `TabOverviewControl` adds plain panels for the same reason.
- `IsItemClickEnabled` is also what puts Invoke on the items next to SelectionItem. With it off, every swatch drops to SelectionItem only.

`SingleSelectionFollowsFocus` stays off so selection keeps meaning "the colour this tab has" rather than "where the caret is". Selection holds, `ItemClick` commits.

Verified by driving the built app through UI Automation: each swatch is a focusable ListItem exposing Invoke and SelectionItem under its colour name, the grid is a List named "Tab Color", the layout measures 2 rows of 5 in macOS order, focus opens on the applied colour, arrowing moves focus without disturbing selection, and click, re-clicking the applied colour, Space, Enter and `Invoke()` all apply and close.