### PR TITLE
windows: make a toast click reach the surface that raised it

### DIFF
--- a/windows/Ghostty.Core/Activation/ProtocolLaunch.cs
+++ b/windows/Ghostty.Core/Activation/ProtocolLaunch.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Activation;
+
+/// <summary>
+/// The command-line half of protocol activation. A packaged launch gets its
+/// URI from <c>AppInstance.GetActivatedEventArgs</c>; an unpackaged one is a
+/// plain process start, so the shell registration passes the URI as
+/// <c>--uri &lt;url&gt;</c> and this recovers it.
+///
+/// Pure and argv-only on purpose: the WinRT probe is the fragile half (it
+/// throws on unpackaged builds), so the fallback it is paired with must not
+/// share its failure. Keeping the scan here means the caller can run it after
+/// a throw as easily as after a miss.
+/// </summary>
+internal static class ProtocolLaunch
+{
+    private const string UriFlag = "--uri";
+
+    /// <summary>
+    /// The URI this launch is about. <paramref name="protocolUri"/> is what
+    /// the WinRT probe produced, or null both when it found no protocol
+    /// activation AND when it threw -- the two cases the argv scan has to
+    /// cover, and the reason the caller must not nest the scan inside the
+    /// probe's try block.
+    ///
+    /// A real protocol activation always wins: argv is a fallback for a
+    /// launch the packaged path could not describe, never an override of one
+    /// it could.
+    /// </summary>
+    public static Uri? Resolve(Uri? protocolUri, IReadOnlyList<string>? args)
+        => protocolUri ?? ParseUri(args);
+
+    /// <summary>
+    /// First absolute URI following a <c>--uri</c> argument, or null when
+    /// argv carries none. A trailing <c>--uri</c> with nothing after it, or a
+    /// value that is not an absolute URI, yields null rather than throwing:
+    /// argv is untrusted input and a bad one must not cost the user a launch.
+    /// A <c>--uri</c> whose value does not parse is skipped rather than
+    /// terminating the scan, so a later well-formed pair still wins.
+    /// </summary>
+    public static Uri? ParseUri(IReadOnlyList<string>? args)
+    {
+        if (args is null) return null;
+
+        for (var i = 0; i < args.Count - 1; i++)
+        {
+            if (string.Equals(args[i], UriFlag, StringComparison.Ordinal)
+                && Uri.TryCreate(args[i + 1], UriKind.Absolute, out var uri))
+                return uri;
+        }
+
+        return null;
+    }
+}

--- a/windows/Ghostty.Core/Activation/ToastActivation.cs
+++ b/windows/Ghostty.Core/Activation/ToastActivation.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Activation;
+
+/// <summary>
+/// What a toast click asked the app to do. Today the only payload is the
+/// surface the toast was raised for, so clicking it can put the user back on
+/// the pane that spoke rather than on whatever window happens to be frontmost.
+///
+/// A struct with a null <see cref="SurfaceKey"/> (<see cref="None"/>) is the
+/// "activated, but we cannot tell which surface" case -- an older toast that
+/// predates the argument, a toast from a previous process, or a malformed
+/// payload. Callers must treat it as an ordinary activation instead of
+/// failing: a click that does nothing is worse than a click that just brings
+/// the app forward.
+/// </summary>
+internal readonly record struct ToastActivation(string? SurfaceKey)
+{
+    /// <summary>
+    /// Key under which the surface travels in the toast's own argument bag
+    /// (<c>AppNotificationBuilder.AddArgument</c> writing it,
+    /// <c>AppNotificationActivatedEventArgs.Arguments</c> reading it back).
+    /// </summary>
+    public const string SurfaceArgumentKey = "surface";
+
+    // The same fact spelled as a command-line argument, for the hop from a
+    // secondary process to the single-instance primary. It rides inside argv
+    // rather than as a new field in the LaunchRequest wire format because the
+    // primary is the OLDER build during an upgrade: it is the process that was
+    // already running. A new wire field would make that primary reject the
+    // whole payload and drop the launch, whereas an argument it does not know
+    // is simply ignored and the launch degrades to opening a window.
+    private const string ForwardedFlagPrefix = "--toast-surface=";
+
+    /// <summary>An activation carrying no surface. See the type remarks.</summary>
+    public static ToastActivation None => default;
+
+    public bool HasSurface => !string.IsNullOrEmpty(SurfaceKey);
+
+    /// <summary>
+    /// Read the surface out of a toast's argument bag. An absent or empty
+    /// value degrades to <see cref="None"/>; unknown keys are ignored so a
+    /// toast raised by a newer build still activates this one.
+    /// </summary>
+    public static ToastActivation FromNotificationArguments(
+        IDictionary<string, string>? arguments)
+    {
+        if (arguments is null) return None;
+        if (!arguments.TryGetValue(SurfaceArgumentKey, out var key)) return None;
+        return string.IsNullOrEmpty(key) ? None : new ToastActivation(key);
+    }
+
+    /// <summary>
+    /// Spell this activation as one extra argv entry for the forward to the
+    /// single-instance primary.
+    /// </summary>
+    public static string ForwardedArg(string surfaceKey)
+        => ForwardedFlagPrefix + surfaceKey;
+
+    /// <summary>
+    /// Recover an activation a secondary process forwarded through argv.
+    /// Last one wins, matching how <c>JumpListLaunch.Parse</c> reads the same
+    /// vector, so the entry the forwarder appended beats anything the user
+    /// happened to type. An empty value degrades to <see cref="None"/>.
+    /// </summary>
+    public static ToastActivation FromForwardedArgs(IReadOnlyList<string>? args)
+    {
+        if (args is null) return None;
+
+        var result = None;
+        foreach (var arg in args)
+        {
+            if (!arg.StartsWith(ForwardedFlagPrefix, StringComparison.Ordinal)) continue;
+            var key = arg[ForwardedFlagPrefix.Length..];
+            result = key.Length == 0 ? None : new ToastActivation(key);
+        }
+
+        return result;
+    }
+}

--- a/windows/Ghostty.Core/Activation/ToastActivation.cs
+++ b/windows/Ghostty.Core/Activation/ToastActivation.cs
@@ -53,14 +53,18 @@ internal readonly record struct ToastActivation(string? SurfaceKey)
 
     /// <summary>
     /// The argv a secondary forwards to the primary: the caller's own command
-    /// line with any pre-existing marker stripped, then this activation
-    /// appended when there is one.
+    /// line, with a TRAILING marker dropped, then this activation appended
+    /// when there is one.
     ///
-    /// Stripping matters. The marker is a plain argument, so a user can type
-    /// it -- <c>wintty -e sometool --toast-surface=x</c> -- and without this
-    /// the primary would read a fabricated click, focus nothing, and drop the
-    /// real launch. After this the marker in the final position can only be
-    /// one the forwarder put there.
+    /// The final position is reserved for the forwarder, and that is the only
+    /// position <see cref="FromForwardedArgs"/> reads. Dropping a trailing one
+    /// is what stops a user's own command line fabricating a click -- typing
+    /// <c>wintty -e sometool --toast-surface=x</c> must not make the primary
+    /// focus a surface and swallow the launch.
+    ///
+    /// An occurrence anywhere EARLIER is left alone. It is the user's
+    /// argument, it cannot be mistaken for a forwarded one, and the primary
+    /// has to receive the command line that was actually typed.
     /// </summary>
     public static List<string> ForwardedArgv(
         IReadOnlyList<string> args, ToastActivation activation)
@@ -68,10 +72,10 @@ internal readonly record struct ToastActivation(string? SurfaceKey)
         ArgumentNullException.ThrowIfNull(args);
 
         var result = new List<string>(args.Count + 1);
-        foreach (var arg in args)
-        {
-            if (!IsForwardedFlag(arg)) result.Add(arg);
-        }
+        result.AddRange(args);
+
+        if (result.Count > 0 && IsForwardedFlag(result[result.Count - 1]))
+            result.RemoveAt(result.Count - 1);
 
         if (activation.SurfaceKey is { Length: > 0 } key)
             result.Add(ForwardedFlagPrefix + key);

--- a/windows/Ghostty.Core/Activation/ToastActivation.cs
+++ b/windows/Ghostty.Core/Activation/ToastActivation.cs
@@ -52,30 +52,53 @@ internal readonly record struct ToastActivation(string? SurfaceKey)
     }
 
     /// <summary>
-    /// Spell this activation as one extra argv entry for the forward to the
-    /// single-instance primary.
+    /// The argv a secondary forwards to the primary: the caller's own command
+    /// line with any pre-existing marker stripped, then this activation
+    /// appended when there is one.
+    ///
+    /// Stripping matters. The marker is a plain argument, so a user can type
+    /// it -- <c>wintty -e sometool --toast-surface=x</c> -- and without this
+    /// the primary would read a fabricated click, focus nothing, and drop the
+    /// real launch. After this the marker in the final position can only be
+    /// one the forwarder put there.
     /// </summary>
-    public static string ForwardedArg(string surfaceKey)
-        => ForwardedFlagPrefix + surfaceKey;
-
-    /// <summary>
-    /// Recover an activation a secondary process forwarded through argv.
-    /// Last one wins, matching how <c>JumpListLaunch.Parse</c> reads the same
-    /// vector, so the entry the forwarder appended beats anything the user
-    /// happened to type. An empty value degrades to <see cref="None"/>.
-    /// </summary>
-    public static ToastActivation FromForwardedArgs(IReadOnlyList<string>? args)
+    public static List<string> ForwardedArgv(
+        IReadOnlyList<string> args, ToastActivation activation)
     {
-        if (args is null) return None;
+        ArgumentNullException.ThrowIfNull(args);
 
-        var result = None;
+        var result = new List<string>(args.Count + 1);
         foreach (var arg in args)
         {
-            if (!arg.StartsWith(ForwardedFlagPrefix, StringComparison.Ordinal)) continue;
-            var key = arg[ForwardedFlagPrefix.Length..];
-            result = key.Length == 0 ? None : new ToastActivation(key);
+            if (!IsForwardedFlag(arg)) result.Add(arg);
         }
+
+        if (activation.SurfaceKey is { Length: > 0 } key)
+            result.Add(ForwardedFlagPrefix + key);
 
         return result;
     }
+
+    /// <summary>
+    /// Recover an activation a secondary forwarded through argv.
+    ///
+    /// Only the FINAL element counts, because that is the one position the
+    /// forwarder controls: it appends there after stripping. An occurrence
+    /// anywhere else is something the user typed, and honouring it would let a
+    /// command line fabricate a click. An empty value degrades to
+    /// <see cref="None"/>.
+    /// </summary>
+    public static ToastActivation FromForwardedArgs(IReadOnlyList<string>? args)
+    {
+        if (args is null || args.Count == 0) return None;
+
+        var last = args[args.Count - 1];
+        if (!IsForwardedFlag(last)) return None;
+
+        var key = last[ForwardedFlagPrefix.Length..];
+        return key.Length == 0 ? None : new ToastActivation(key);
+    }
+
+    private static bool IsForwardedFlag(string arg)
+        => arg.StartsWith(ForwardedFlagPrefix, StringComparison.Ordinal);
 }

--- a/windows/Ghostty.Core/Activation/ToastActivationRelay.cs
+++ b/windows/Ghostty.Core/Activation/ToastActivationRelay.cs
@@ -31,6 +31,7 @@ internal sealed class ToastActivationRelay
     private readonly Action<Exception>? _onHandlerFailed;
     private ToastActivation? _pending;
     private Action<ToastActivation>? _handlers;
+    private bool _launchActivationNoted;
 
     /// <param name="onHandlerFailed">
     /// Where a throw from a handler goes. A replayed activation runs the
@@ -95,13 +96,47 @@ internal sealed class ToastActivationRelay
         // Outside the lock deliberately: a handler activates windows and can
         // re-enter the relay, and holding the gate across it would let one
         // slow handler block every other thread reading Pending.
-        Invoke(handlers, activation);
+        //
+        // Target by target rather than invoking the multicast delegate whole.
+        // A single call propagates the first exception immediately and never
+        // reaches the targets behind it, so one throwing subscriber would
+        // silently cost every later one its click.
+        foreach (var target in handlers.GetInvocationList())
+            Invoke((Action<ToastActivation>)target, activation);
     }
 
     /// <summary>
-    /// Drop every handler and any latched activation. For teardown: the relay
-    /// outlives the objects that subscribe to it, so leaving handlers attached
-    /// roots them for the life of the process.
+    /// Record the activation this PROCESS WAS LAUNCHED FOR, at most once.
+    /// Returns false when it was already recorded and nothing was done.
+    ///
+    /// The launch click can reach the app twice: once off the activation
+    /// arguments the shell hands the process, and once through the
+    /// notification callback, describing the same click. Which arrives first
+    /// is not documented, so both callers come through here and whichever gets
+    /// here first wins. Without it the surface is focused twice for one click
+    /// -- a redundant activation, focus churn, and for the quick terminal a
+    /// second run through its reveal animation.
+    /// </summary>
+    public bool TryNoteLaunchActivation(ToastActivation activation)
+    {
+        lock (_gate)
+        {
+            if (_launchActivationNoted) return false;
+            _launchActivationNoted = true;
+        }
+
+        Note(activation);
+        return true;
+    }
+
+    /// <summary>
+    /// Drop every handler, any latched activation, and the launch-activation
+    /// record. For teardown: the relay outlives the objects that subscribe to
+    /// it, so leaving handlers attached roots them for the life of the process.
+    ///
+    /// Does NOT stop a fan-out already in flight: <see cref="Note"/> snapshots
+    /// the handlers before it starts invoking them, deliberately, so that a
+    /// handler which unsubscribes cannot mutate the list being walked.
     /// </summary>
     public void Reset()
     {
@@ -109,6 +144,7 @@ internal sealed class ToastActivationRelay
         {
             _handlers = null;
             _pending = null;
+            _launchActivationNoted = false;
         }
     }
 
@@ -121,7 +157,13 @@ internal sealed class ToastActivationRelay
         catch (Exception ex)
         {
             if (_onHandlerFailed is null) throw;
-            _onHandlerFailed(ex);
+
+            // The failure sink is caller-supplied and reached from inside a
+            // catch: a throw from it would escape Note or Subscribe, which is
+            // the failure this whole guard exists to prevent. There is nowhere
+            // left to report to, so it is dropped.
+            try { _onHandlerFailed(ex); }
+            catch { /* reporting a failure must not become one */ }
         }
     }
 }

--- a/windows/Ghostty.Core/Activation/ToastActivationRelay.cs
+++ b/windows/Ghostty.Core/Activation/ToastActivationRelay.cs
@@ -31,7 +31,9 @@ internal sealed class ToastActivationRelay
     private readonly Action<Exception>? _onHandlerFailed;
     private ToastActivation? _pending;
     private Action<ToastActivation>? _handlers;
+    private bool _launchWindowOpen = true;
     private bool _launchActivationNoted;
+    private ToastActivation _launchActivation;
 
     /// <param name="onHandlerFailed">
     /// Where a throw from a handler goes. A replayed activation runs the
@@ -106,27 +108,57 @@ internal sealed class ToastActivationRelay
     }
 
     /// <summary>
-    /// Record the activation this PROCESS WAS LAUNCHED FOR, at most once.
-    /// Returns false when it was already recorded and nothing was done.
+    /// Record a click that MAY be the activation this process was launched
+    /// for. Returns false when it was recognised as a repeat and dropped.
     ///
     /// The launch click can reach the app twice: once off the activation
     /// arguments the shell hands the process, and once through the
     /// notification callback, describing the same click. Which arrives first
-    /// is not documented, so both callers come through here and whichever gets
-    /// here first wins. Without it the surface is focused twice for one click
-    /// -- a redundant activation, focus churn, and for the quick terminal a
-    /// second run through its reveal animation.
+    /// is not documented, and either may not arrive at all, so both callers
+    /// come through here and the second one carrying the same activation is
+    /// dropped. Without that the surface is focused twice for one click -- a
+    /// redundant activation, focus churn, and for the quick terminal a second
+    /// run through its reveal animation.
+    ///
+    /// A DIFFERENT activation is never a repeat and is always delivered: the
+    /// shell handing the launch click over one way only must not cost the user
+    /// their next real click. See <see cref="CloseLaunchWindow"/> for the
+    /// remaining case, a real click on the same surface as the launch one.
     /// </summary>
     public bool TryNoteLaunchActivation(ToastActivation activation)
     {
         lock (_gate)
         {
-            if (_launchActivationNoted) return false;
+            // Identity, not ordinal position. An earlier version dropped
+            // whichever call happened to be second, which meant that when the
+            // shell delivered the launch click only ONE way, the next genuine
+            // click a person made was swallowed as if it were the duplicate.
+            // Only a repeat of the SAME activation is a duplicate.
+            if (_launchWindowOpen && _launchActivationNoted && _launchActivation == activation)
+                return false;
+
             _launchActivationNoted = true;
+            _launchActivation = activation;
         }
 
         Note(activation);
         return true;
+    }
+
+    /// <summary>
+    /// Declare startup over: from here on nothing can be the launch click
+    /// arriving a second time, so every activation is delivered, including one
+    /// naming the same surface the launch click did.
+    ///
+    /// Without this, a person whose first click after launching happened to be
+    /// on a toast for the SAME surface would see it swallowed as a duplicate.
+    /// Call it once the first subscriber is wired: by then the launch click
+    /// has been acted on, and anything later is a person clicking a new toast
+    /// rather than the shell re-announcing an old one.
+    /// </summary>
+    public void CloseLaunchWindow()
+    {
+        lock (_gate) _launchWindowOpen = false;
     }
 
     /// <summary>
@@ -144,7 +176,9 @@ internal sealed class ToastActivationRelay
         {
             _handlers = null;
             _pending = null;
+            _launchWindowOpen = true;
             _launchActivationNoted = false;
+            _launchActivation = default;
         }
     }
 

--- a/windows/Ghostty.Core/Activation/ToastActivationRelay.cs
+++ b/windows/Ghostty.Core/Activation/ToastActivationRelay.cs
@@ -1,0 +1,127 @@
+using System;
+
+namespace Ghostty.Core.Activation;
+
+/// <summary>
+/// Carries a toast click from wherever it lands to whoever can act on it.
+///
+/// The awkward part it exists to solve is timing. A cold launch delivers the
+/// click during shell registration, at the very top of startup, long before
+/// the windows and services that could act on it are constructed. So an
+/// activation that arrives with nobody listening is LATCHED and handed to the
+/// next subscriber instead of being raised into an empty invocation list and
+/// lost.
+///
+/// The latch is consumed by the FIRST subscriber to arrive after it, and only
+/// that one. Subscription order is therefore load-bearing: a subscriber wired
+/// earlier than the one that can actually act on a click will swallow every
+/// cold-launch activation. Anyone adding a second subscriber must wire it
+/// AFTER the one that focuses windows, or accept that it sees only clicks that
+/// arrive while the app is already running.
+///
+/// Thread-safe. <see cref="Note"/> is reached from a WinRT COM callback
+/// thread; handlers are invoked with no lock held, so a handler may call back
+/// into the relay and a slow handler cannot block another thread's
+/// <see cref="Pending"/> read. Handlers must therefore do their own marshalling
+/// to a UI thread.
+/// </summary>
+internal sealed class ToastActivationRelay
+{
+    private readonly object _gate = new();
+    private readonly Action<Exception>? _onHandlerFailed;
+    private ToastActivation? _pending;
+    private Action<ToastActivation>? _handlers;
+
+    /// <param name="onHandlerFailed">
+    /// Where a throw from a handler goes. A replayed activation runs the
+    /// handler inline on the subscriber's own thread, which on a cold launch
+    /// is the startup path: without this, a future subscriber that throws
+    /// turns a toast-driven launch into a silent launch failure.
+    /// </param>
+    public ToastActivationRelay(Action<Exception>? onHandlerFailed = null)
+        => _onHandlerFailed = onHandlerFailed;
+
+    /// <summary>
+    /// The activation waiting for its first subscriber, or
+    /// <see cref="ToastActivation.None"/>. A read, not a consume: a process
+    /// that forwards its launch elsewhere and exits never subscribes, so the
+    /// latch is the only record of its click.
+    /// </summary>
+    public ToastActivation Pending
+    {
+        get { lock (_gate) return _pending ?? ToastActivation.None; }
+    }
+
+    /// <summary>
+    /// Add a handler, and hand it any latched activation immediately. See the
+    /// type remarks on why order matters.
+    /// </summary>
+    public void Subscribe(Action<ToastActivation> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        ToastActivation? replay;
+        lock (_gate)
+        {
+            _handlers += handler;
+            replay = _pending;
+            _pending = null;
+        }
+
+        if (replay is { } pending) Invoke(handler, pending);
+    }
+
+    public void Unsubscribe(Action<ToastActivation> handler)
+    {
+        lock (_gate) _handlers -= handler;
+    }
+
+    /// <summary>
+    /// Record a click. Fans out when anyone is listening; latches otherwise.
+    /// </summary>
+    public void Note(ToastActivation activation)
+    {
+        Action<ToastActivation>? handlers;
+        lock (_gate)
+        {
+            handlers = _handlers;
+            if (handlers is null)
+            {
+                _pending = activation;
+                return;
+            }
+        }
+
+        // Outside the lock deliberately: a handler activates windows and can
+        // re-enter the relay, and holding the gate across it would let one
+        // slow handler block every other thread reading Pending.
+        Invoke(handlers, activation);
+    }
+
+    /// <summary>
+    /// Drop every handler and any latched activation. For teardown: the relay
+    /// outlives the objects that subscribe to it, so leaving handlers attached
+    /// roots them for the life of the process.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            _handlers = null;
+            _pending = null;
+        }
+    }
+
+    private void Invoke(Action<ToastActivation> handler, ToastActivation activation)
+    {
+        try
+        {
+            handler(activation);
+        }
+        catch (Exception ex)
+        {
+            if (_onHandlerFailed is null) throw;
+            _onHandlerFailed(ex);
+        }
+    }
+}

--- a/windows/Ghostty.Core/SingleInstance/LaunchRequest.cs
+++ b/windows/Ghostty.Core/SingleInstance/LaunchRequest.cs
@@ -10,6 +10,14 @@ namespace Ghostty.Core.SingleInstance;
 /// single-instance mode is on: the working directory it was started in
 /// and its full argv. Immutable; serialized to a wire format the primary
 /// parses off the named pipe.
+///
+/// New facts about a launch belong in <see cref="Args"/> as an extra
+/// argument (the way jump-list clicks and toast activations already travel),
+/// not as a new field in the wire format. During an upgrade the PRIMARY is
+/// the older build -- it is the process that was already running -- and its
+/// parser rejects any payload shape it does not know, which drops the
+/// forwarded launch entirely. An argument it does not recognize is simply
+/// ignored, and the launch degrades into opening a window.
 /// </summary>
 public sealed record LaunchRequest(string WorkingDirectory, IReadOnlyList<string> Args)
 {

--- a/windows/Ghostty.Tests/Activation/ProtocolLaunchTests.cs
+++ b/windows/Ghostty.Tests/Activation/ProtocolLaunchTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Ghostty.Core.Activation;
+using Xunit;
+
+namespace Ghostty.Tests.Activation;
+
+public sealed class ProtocolLaunchTests
+{
+    [Fact]
+    public void ParseUri_FindsValueAfterFlag()
+    {
+        var uri = ProtocolLaunch.ParseUri(["wintty.exe", "--uri", "wintty://open/x"]);
+        Assert.Equal(new Uri("wintty://open/x"), uri);
+    }
+
+    [Fact]
+    public void ParseUri_NoFlag_ReturnsNull()
+        => Assert.Null(ProtocolLaunch.ParseUri(["wintty.exe", "--jumplist-action=new-tab"]));
+
+    [Fact]
+    public void ParseUri_NullArgs_ReturnsNull()
+        => Assert.Null(ProtocolLaunch.ParseUri(null));
+
+    [Fact]
+    public void ParseUri_FlagWithNothingAfterIt_ReturnsNull()
+        => Assert.Null(ProtocolLaunch.ParseUri(["wintty.exe", "--uri"]));
+
+    [Fact]
+    public void ParseUri_RelativeValue_IsRejected()
+        => Assert.Null(ProtocolLaunch.ParseUri(["wintty.exe", "--uri", "not/absolute"]));
+
+    [Fact]
+    public void ParseUri_SkipsUnparseablePair_AndTakesTheNextGoodOne()
+    {
+        var uri = ProtocolLaunch.ParseUri(
+            ["wintty.exe", "--uri", "not/absolute", "--uri", "wintty://second"]);
+        Assert.Equal(new Uri("wintty://second"), uri);
+    }
+
+    // The rule the restructured probe exists to preserve: argv is a fallback
+    // for a launch the packaged path could not describe, never an override.
+    [Fact]
+    public void Resolve_ProtocolActivation_BeatsArgv()
+    {
+        var resolved = ProtocolLaunch.Resolve(
+            new Uri("wintty://from-winrt"),
+            ["wintty.exe", "--uri", "wintty://from-argv"]);
+        Assert.Equal(new Uri("wintty://from-winrt"), resolved);
+    }
+
+    // Null protocolUri is both "the probe found no protocol activation" and
+    // "the probe threw". The scan must cover the second, which is the whole
+    // point of hoisting it out of the try block.
+    [Fact]
+    public void Resolve_NoProtocolActivation_FallsBackToArgv()
+    {
+        var resolved = ProtocolLaunch.Resolve(
+            null, ["wintty.exe", "--uri", "wintty://from-argv"]);
+        Assert.Equal(new Uri("wintty://from-argv"), resolved);
+    }
+
+    [Fact]
+    public void Resolve_NeitherSource_ReturnsNull()
+        => Assert.Null(ProtocolLaunch.Resolve(null, ["wintty.exe"]));
+}

--- a/windows/Ghostty.Tests/Activation/ToastActivationRelayTests.cs
+++ b/windows/Ghostty.Tests/Activation/ToastActivationRelayTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghostty.Core.Activation;
+using Xunit;
+
+namespace Ghostty.Tests.Activation;
+
+public sealed class ToastActivationRelayTests
+{
+    private static readonly TimeSpan Generous = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ShortEnoughToFailFast = TimeSpan.FromSeconds(2);
+
+    [Fact]
+    public void Note_ThenSubscribe_ReplaysToTheSubscriber()
+    {
+        var relay = new ToastActivationRelay();
+        relay.Note(new ToastActivation("abc"));
+
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+
+        Assert.Equal("abc", Assert.Single(seen).SurfaceKey);
+    }
+
+    [Fact]
+    public void Subscribe_ThenNote_DeliversLive()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.Equal("abc", Assert.Single(seen).SurfaceKey);
+    }
+
+    // The latch belongs to whoever gets there first. A second subscriber
+    // arriving later must not see a click that was already handed over, or a
+    // cold-launch activation would be acted on twice.
+    [Fact]
+    public void Replay_GoesToTheFirstSubscriberOnly()
+    {
+        var relay = new ToastActivationRelay();
+        relay.Note(new ToastActivation("abc"));
+
+        var first = new List<ToastActivation>();
+        var second = new List<ToastActivation>();
+        relay.Subscribe(first.Add);
+        relay.Subscribe(second.Add);
+
+        Assert.Single(first);
+        Assert.Empty(second);
+    }
+
+    [Fact]
+    public void Replay_ConsumesTheLatch()
+    {
+        var relay = new ToastActivationRelay();
+        relay.Note(new ToastActivation("abc"));
+        Assert.Equal("abc", relay.Pending.SurfaceKey);
+
+        relay.Subscribe(_ => { });
+
+        Assert.False(relay.Pending.HasSurface);
+    }
+
+    // Pending is a read, not a consume: the forwarding path reads it and then
+    // exits the process without ever subscribing.
+    [Fact]
+    public void Pending_DoesNotConsumeTheLatch()
+    {
+        var relay = new ToastActivationRelay();
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.Equal("abc", relay.Pending.SurfaceKey);
+        Assert.Equal("abc", relay.Pending.SurfaceKey);
+    }
+
+    [Fact]
+    public void Note_WithSubscribers_DoesNotLatch()
+    {
+        var relay = new ToastActivationRelay();
+        relay.Subscribe(_ => { });
+
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.False(relay.Pending.HasSurface);
+    }
+
+    [Fact]
+    public void Note_ReachesEverySubscriber()
+    {
+        var relay = new ToastActivationRelay();
+        var first = new List<ToastActivation>();
+        var second = new List<ToastActivation>();
+        relay.Subscribe(first.Add);
+        relay.Subscribe(second.Add);
+
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.Single(first);
+        Assert.Single(second);
+    }
+
+    [Fact]
+    public void Unsubscribe_StopsDelivery()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        void Handler(ToastActivation a) => seen.Add(a);
+
+        relay.Subscribe(Handler);
+        relay.Unsubscribe(Handler);
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.Empty(seen);
+        // Nobody is listening any more, so the click latches rather than
+        // vanishing.
+        Assert.Equal("abc", relay.Pending.SurfaceKey);
+    }
+
+    // Teardown: the relay is process-lifetime and outlives what subscribes to
+    // it, so a handler left attached roots its owner for the life of the
+    // process.
+    [Fact]
+    public void Reset_DropsHandlers()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+
+        relay.Reset();
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.Empty(seen);
+    }
+
+    [Fact]
+    public void Reset_DropsTheLatch()
+    {
+        var relay = new ToastActivationRelay();
+        relay.Note(new ToastActivation("abc"));
+
+        relay.Reset();
+
+        Assert.False(relay.Pending.HasSurface);
+    }
+
+    // A throwing handler on the replay path runs inline on the startup thread.
+    // Left unguarded it would turn a toast-driven cold launch into a silent
+    // launch failure.
+    [Fact]
+    public void ThrowingHandler_IsReportedNotPropagated_OnReplay()
+    {
+        var failures = new List<Exception>();
+        var relay = new ToastActivationRelay(failures.Add);
+        relay.Note(new ToastActivation("abc"));
+
+        relay.Subscribe(_ => throw new InvalidOperationException("boom"));
+
+        Assert.Equal("boom", Assert.Single(failures).Message);
+    }
+
+    [Fact]
+    public void ThrowingHandler_IsReportedNotPropagated_OnNote()
+    {
+        var failures = new List<Exception>();
+        var relay = new ToastActivationRelay(failures.Add);
+        relay.Subscribe(_ => throw new InvalidOperationException("boom"));
+
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.Equal("boom", Assert.Single(failures).Message);
+    }
+
+    // Handlers activate windows and can re-enter the relay. Holding the gate
+    // across the call would let one slow handler block every other thread, and
+    // Note runs on a WinRT callback thread while Pending is read from the
+    // forwarding path.
+    [Fact]
+    public void Note_DoesNotHoldTheLockWhileInvokingHandlers()
+    {
+        var relay = new ToastActivationRelay();
+        using var inHandler = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+
+        relay.Subscribe(_ =>
+        {
+            inHandler.Set();
+            release.Wait(Generous);
+        });
+
+        var noting = Task.Run(() => relay.Note(new ToastActivation("abc")));
+        Assert.True(inHandler.Wait(Generous), "handler never ran");
+
+        try
+        {
+            var probe = Task.Run(() => relay.Pending);
+            Assert.True(
+                probe.Wait(ShortEnoughToFailFast),
+                "Pending blocked while a handler was running: the gate is held across invocation");
+        }
+        finally
+        {
+            release.Set();
+            noting.Wait(Generous);
+        }
+    }
+
+    [Fact]
+    public void Subscribe_DoesNotHoldTheLockWhileReplaying()
+    {
+        var relay = new ToastActivationRelay();
+        relay.Note(new ToastActivation("abc"));
+
+        using var inHandler = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+
+        var subscribing = Task.Run(() => relay.Subscribe(_ =>
+        {
+            inHandler.Set();
+            release.Wait(Generous);
+        }));
+        Assert.True(inHandler.Wait(Generous), "replay never ran");
+
+        try
+        {
+            var probe = Task.Run(() => relay.Pending);
+            Assert.True(
+                probe.Wait(ShortEnoughToFailFast),
+                "Pending blocked while a replay was running: the gate is held across invocation");
+        }
+        finally
+        {
+            release.Set();
+            subscribing.Wait(Generous);
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Activation/ToastActivationRelayTests.cs
+++ b/windows/Ghostty.Tests/Activation/ToastActivationRelayTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ghostty.Core.Activation;
@@ -173,6 +174,89 @@ public sealed class ToastActivationRelayTests
         relay.Note(new ToastActivation("abc"));
 
         Assert.Equal("boom", Assert.Single(failures).Message);
+    }
+
+    // The intersection nothing else covered: Note_ReachesEverySubscriber uses
+    // only well-behaved handlers, and ThrowingHandler_..._OnNote uses only one
+    // subscriber. Invoking the multicast delegate as a single call propagates
+    // the first exception immediately, so every target behind the thrower is
+    // silently skipped.
+    [Fact]
+    public void Note_ThrowingFirstHandler_StillReachesTheSecond()
+    {
+        var failures = new List<Exception>();
+        var relay = new ToastActivationRelay(failures.Add);
+        var second = new List<ToastActivation>();
+
+        relay.Subscribe(_ => throw new InvalidOperationException("boom"));
+        relay.Subscribe(second.Add);
+
+        relay.Note(new ToastActivation("abc"));
+
+        Assert.Equal("abc", Assert.Single(second).SurfaceKey);
+        Assert.Single(failures);
+    }
+
+    // The failure sink is caller-supplied and is called from inside a catch.
+    // A throw from it would escape the very call the guard exists to protect.
+    [Fact]
+    public void ThrowingFailureSink_DoesNotEscapeNote()
+    {
+        var relay = new ToastActivationRelay(_ => throw new InvalidOperationException("sink"));
+        relay.Subscribe(_ => throw new InvalidOperationException("boom"));
+
+        relay.Note(new ToastActivation("abc"));
+    }
+
+    // The launch click can arrive twice, from the activation arguments and
+    // from the notification callback, describing the same click. Only the
+    // first record may act.
+    [Fact]
+    public void TryNoteLaunchActivation_OnlyTheFirstCallDelivers()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+
+        Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+        Assert.False(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+
+        Assert.Equal("abc", Assert.Single(seen).SurfaceKey);
+    }
+
+    // Deduping the launch click must not dedupe the warm ones behind it.
+    [Fact]
+    public void TryNoteLaunchActivation_DoesNotSuppressLaterWarmClicks()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+
+        relay.TryNoteLaunchActivation(new ToastActivation("launch"));
+        relay.Note(new ToastActivation("warm"));
+
+        Assert.Equal(["launch", "warm"], seen.Select(a => a.SurfaceKey));
+    }
+
+    [Fact]
+    public void TryNoteLaunchActivation_LatchesWhenNobodyIsListening()
+    {
+        var relay = new ToastActivationRelay();
+
+        Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+
+        Assert.Equal("abc", relay.Pending.SurfaceKey);
+    }
+
+    [Fact]
+    public void Reset_ClearsTheLaunchActivationRecord()
+    {
+        var relay = new ToastActivationRelay();
+        relay.TryNoteLaunchActivation(new ToastActivation("abc"));
+
+        relay.Reset();
+
+        Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
     }
 
     // Handlers activate windows and can re-enter the relay. Holding the gate

--- a/windows/Ghostty.Tests/Activation/ToastActivationRelayTests.cs
+++ b/windows/Ghostty.Tests/Activation/ToastActivationRelayTests.cs
@@ -248,15 +248,75 @@ public sealed class ToastActivationRelayTests
         Assert.Equal("abc", relay.Pending.SurfaceKey);
     }
 
+    // The shell may hand the launch click over ONE way only, in which case no
+    // second call ever arrives -- and the next call is a person clicking a new
+    // toast. Deduping on ordinal position instead of identity swallowed it:
+    // the click did nothing at all, not even bring the app forward.
     [Fact]
-    public void Reset_ClearsTheLaunchActivationRecord()
+    public void TryNoteLaunchActivation_ADifferentActivationIsNotADuplicate()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+
+        Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("launch")));
+        Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("clicked-later")));
+
+        Assert.Equal(["launch", "clicked-later"], seen.Select(a => a.SurfaceKey));
+    }
+
+    // The remaining ambiguity: a real click on the SAME surface the launch
+    // click named. Indistinguishable from a redelivery until startup declares
+    // itself over.
+    [Fact]
+    public void TryNoteLaunchActivation_SameActivationIsADuplicateUntilTheWindowCloses()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+
+        Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+        Assert.False(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+
+        relay.CloseLaunchWindow();
+        Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+
+        Assert.Equal(["abc", "abc"], seen.Select(a => a.SurfaceKey));
+    }
+
+    [Fact]
+    public void CloseLaunchWindow_LetsAnyLaterClickThrough()
+    {
+        var relay = new ToastActivationRelay();
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
+        relay.TryNoteLaunchActivation(new ToastActivation("abc"));
+        relay.CloseLaunchWindow();
+
+        relay.TryNoteLaunchActivation(new ToastActivation("abc"));
+        relay.TryNoteLaunchActivation(new ToastActivation("abc"));
+
+        Assert.Equal(3, seen.Count);
+    }
+
+    // Reset exists to make the relay reusable, so it has to restore the WHOLE
+    // launch gate. Leaving half of it set (the record cleared, the window
+    // closed) is how a second startup delivers the launch click twice.
+    [Fact]
+    public void Reset_RestoresTheWholeLaunchGate()
     {
         var relay = new ToastActivationRelay();
         relay.TryNoteLaunchActivation(new ToastActivation("abc"));
+        relay.CloseLaunchWindow();
 
         relay.Reset();
 
+        var seen = new List<ToastActivation>();
+        relay.Subscribe(seen.Add);
         Assert.True(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+        Assert.False(relay.TryNoteLaunchActivation(new ToastActivation("abc")));
+
+        Assert.Single(seen);
     }
 
     // Handlers activate windows and can re-enter the relay. Holding the gate

--- a/windows/Ghostty.Tests/Activation/ToastActivationTests.cs
+++ b/windows/Ghostty.Tests/Activation/ToastActivationTests.cs
@@ -76,24 +76,39 @@ public sealed class ToastActivationTests
         Assert.False(ToastActivation.FromForwardedArgs(argv).HasSurface);
     }
 
-    // A user can type the marker. Without the strip, the primary would read a
-    // fabricated click, focus nothing, and eat the real launch.
+    // The trailing slot is reserved for the forwarder, so a marker the user
+    // typed there is dropped: otherwise a command line fabricates a click, the
+    // primary focuses nothing, and the real launch is eaten.
     [Fact]
-    public void ForwardedArgv_StripsAMarkerTheUserTyped()
+    public void ForwardedArgv_DropsATrailingMarkerTheUserTyped()
     {
         var argv = ToastActivation.ForwardedArgv(
-            ["wintty.exe", "--toast-surface=typed", "-e", "sometool"],
+            ["wintty.exe", "-e", "sometool", "--toast-surface=typed"],
             ToastActivation.None);
 
         Assert.Equal(["wintty.exe", "-e", "sometool"], argv);
         Assert.False(ToastActivation.FromForwardedArgs(argv).HasSurface);
     }
 
+    // Anywhere else it is the user's own argument. It cannot be mistaken for a
+    // forwarded one, and deleting it would hand the primary a command line the
+    // user never typed.
     [Fact]
-    public void ForwardedArgv_RealActivationSurvivesTheStrip()
+    public void ForwardedArgv_KeepsAMarkerThatIsNotTrailing()
     {
         var argv = ToastActivation.ForwardedArgv(
             ["wintty.exe", "--toast-surface=typed", "-e", "sometool"],
+            ToastActivation.None);
+
+        Assert.Equal(["wintty.exe", "--toast-surface=typed", "-e", "sometool"], argv);
+        Assert.False(ToastActivation.FromForwardedArgs(argv).HasSurface);
+    }
+
+    [Fact]
+    public void ForwardedArgv_RealActivationReplacesATrailingMarker()
+    {
+        var argv = ToastActivation.ForwardedArgv(
+            ["wintty.exe", "-e", "sometool", "--toast-surface=typed"],
             new ToastActivation("real"));
 
         Assert.Equal(["wintty.exe", "-e", "sometool", "--toast-surface=real"], argv);

--- a/windows/Ghostty.Tests/Activation/ToastActivationTests.cs
+++ b/windows/Ghostty.Tests/Activation/ToastActivationTests.cs
@@ -57,12 +57,59 @@ public sealed class ToastActivationTests
     }
 
     [Fact]
-    public void ForwardedArg_RoundTripsThroughArgv()
+    public void ForwardedArgv_RoundTripsThroughArgv()
     {
-        var arg = ToastActivation.ForwardedArg("abc-123");
-        var activation = ToastActivation.FromForwardedArgs(["wintty.exe", arg]);
+        var argv = ToastActivation.ForwardedArgv(
+            ["wintty.exe"], new ToastActivation("abc-123"));
 
-        Assert.Equal("abc-123", activation.SurfaceKey);
+        Assert.Equal(["wintty.exe", "--toast-surface=abc-123"], argv);
+        Assert.Equal("abc-123", ToastActivation.FromForwardedArgs(argv).SurfaceKey);
+    }
+
+    [Fact]
+    public void ForwardedArgv_NoActivation_AppendsNothing()
+    {
+        var argv = ToastActivation.ForwardedArgv(
+            ["wintty.exe", "--jumplist-action=new-tab"], ToastActivation.None);
+
+        Assert.Equal(["wintty.exe", "--jumplist-action=new-tab"], argv);
+        Assert.False(ToastActivation.FromForwardedArgs(argv).HasSurface);
+    }
+
+    // A user can type the marker. Without the strip, the primary would read a
+    // fabricated click, focus nothing, and eat the real launch.
+    [Fact]
+    public void ForwardedArgv_StripsAMarkerTheUserTyped()
+    {
+        var argv = ToastActivation.ForwardedArgv(
+            ["wintty.exe", "--toast-surface=typed", "-e", "sometool"],
+            ToastActivation.None);
+
+        Assert.Equal(["wintty.exe", "-e", "sometool"], argv);
+        Assert.False(ToastActivation.FromForwardedArgs(argv).HasSurface);
+    }
+
+    [Fact]
+    public void ForwardedArgv_RealActivationSurvivesTheStrip()
+    {
+        var argv = ToastActivation.ForwardedArgv(
+            ["wintty.exe", "--toast-surface=typed", "-e", "sometool"],
+            new ToastActivation("real"));
+
+        Assert.Equal(["wintty.exe", "-e", "sometool", "--toast-surface=real"], argv);
+        Assert.Equal("real", ToastActivation.FromForwardedArgs(argv).SurfaceKey);
+    }
+
+    // Only the final element counts: that is the one position the forwarder
+    // controls, because it appends there after stripping.
+    [Fact]
+    public void FromForwardedArgs_MarkerNotInFinalPosition_IsIgnored()
+    {
+        var activation = ToastActivation.FromForwardedArgs(
+            ["wintty.exe", "--toast-surface=typed", "-e", "sometool"]);
+
+        Assert.False(activation.HasSurface);
+        Assert.Null(activation.SurfaceKey);
     }
 
     [Fact]
@@ -71,8 +118,11 @@ public sealed class ToastActivationTests
             .FromForwardedArgs(["wintty.exe", "--jumplist-action=new-tab"]).HasSurface);
 
     [Fact]
-    public void FromForwardedArgs_NullArgs_IsNone()
-        => Assert.False(ToastActivation.FromForwardedArgs(null).HasSurface);
+    public void FromForwardedArgs_NullOrEmptyArgs_IsNone()
+    {
+        Assert.False(ToastActivation.FromForwardedArgs(null).HasSurface);
+        Assert.False(ToastActivation.FromForwardedArgs([]).HasSurface);
+    }
 
     [Fact]
     public void FromForwardedArgs_EmptyValue_IsNone()
@@ -81,18 +131,5 @@ public sealed class ToastActivationTests
 
         Assert.False(activation.HasSurface);
         Assert.Null(activation.SurfaceKey);
-    }
-
-    [Fact]
-    public void FromForwardedArgs_LastMarkerWins()
-    {
-        var activation = ToastActivation.FromForwardedArgs(
-        [
-            "wintty.exe",
-            ToastActivation.ForwardedArg("typed-by-the-user"),
-            ToastActivation.ForwardedArg("appended-by-the-forwarder"),
-        ]);
-
-        Assert.Equal("appended-by-the-forwarder", activation.SurfaceKey);
     }
 }

--- a/windows/Ghostty.Tests/Activation/ToastActivationTests.cs
+++ b/windows/Ghostty.Tests/Activation/ToastActivationTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using Ghostty.Core.Activation;
+using Xunit;
+
+namespace Ghostty.Tests.Activation;
+
+public sealed class ToastActivationTests
+{
+    [Fact]
+    public void FromNotificationArguments_ReadsSurface()
+    {
+        var activation = ToastActivation.FromNotificationArguments(
+            new Dictionary<string, string> { ["surface"] = "abc-123" });
+
+        Assert.True(activation.HasSurface);
+        Assert.Equal("abc-123", activation.SurfaceKey);
+    }
+
+    [Fact]
+    public void FromNotificationArguments_IgnoresUnknownKeys()
+    {
+        var activation = ToastActivation.FromNotificationArguments(
+            new Dictionary<string, string>
+            {
+                ["surface"] = "abc-123",
+                ["somethingANewerBuildAdded"] = "whatever",
+            });
+
+        Assert.Equal("abc-123", activation.SurfaceKey);
+    }
+
+    [Fact]
+    public void FromNotificationArguments_NullBag_IsNone()
+        => Assert.False(ToastActivation.FromNotificationArguments(null).HasSurface);
+
+    // A toast raised before the argument existed activates the app with an
+    // empty bag. That must read as a plain activation, not as a surface named
+    // "".
+    [Fact]
+    public void FromNotificationArguments_MissingKey_IsNone()
+    {
+        var activation = ToastActivation.FromNotificationArguments(
+            new Dictionary<string, string> { ["other"] = "x" });
+
+        Assert.False(activation.HasSurface);
+        Assert.Null(activation.SurfaceKey);
+    }
+
+    [Fact]
+    public void FromNotificationArguments_EmptyValue_IsNone()
+    {
+        var activation = ToastActivation.FromNotificationArguments(
+            new Dictionary<string, string> { ["surface"] = "" });
+
+        Assert.False(activation.HasSurface);
+        Assert.Null(activation.SurfaceKey);
+    }
+
+    [Fact]
+    public void ForwardedArg_RoundTripsThroughArgv()
+    {
+        var arg = ToastActivation.ForwardedArg("abc-123");
+        var activation = ToastActivation.FromForwardedArgs(["wintty.exe", arg]);
+
+        Assert.Equal("abc-123", activation.SurfaceKey);
+    }
+
+    [Fact]
+    public void FromForwardedArgs_NoMarker_IsNone()
+        => Assert.False(ToastActivation
+            .FromForwardedArgs(["wintty.exe", "--jumplist-action=new-tab"]).HasSurface);
+
+    [Fact]
+    public void FromForwardedArgs_NullArgs_IsNone()
+        => Assert.False(ToastActivation.FromForwardedArgs(null).HasSurface);
+
+    [Fact]
+    public void FromForwardedArgs_EmptyValue_IsNone()
+    {
+        var activation = ToastActivation.FromForwardedArgs(["wintty.exe", "--toast-surface="]);
+
+        Assert.False(activation.HasSurface);
+        Assert.Null(activation.SurfaceKey);
+    }
+
+    [Fact]
+    public void FromForwardedArgs_LastMarkerWins()
+    {
+        var activation = ToastActivation.FromForwardedArgs(
+        [
+            "wintty.exe",
+            ToastActivation.ForwardedArg("typed-by-the-user"),
+            ToastActivation.ForwardedArg("appended-by-the-forwarder"),
+        ]);
+
+        Assert.Equal("appended-by-the-forwarder", activation.SurfaceKey);
+    }
+}

--- a/windows/Ghostty.Tests/Shell/CSharpSourceText.cs
+++ b/windows/Ghostty.Tests/Shell/CSharpSourceText.cs
@@ -13,10 +13,20 @@ namespace Ghostty.Tests.Shell;
 /// App.xaml.cs do exactly that -- so a raw-text search finds the prose and
 /// passes while the code says the opposite. A string literal can do the same:
 /// a diagnostic message naming the API it reports on satisfies any assertion
-/// looking for that API.
+/// looking for that API. An interpolation hole is code inside a literal, so a
+/// nested literal inside one has to be skipped as a literal in its own right,
+/// or its contents leak back into the text an assertion reads.
 ///
-/// Literals are replaced by an empty literal of the same kind rather than
-/// deleted, so the surrounding code keeps its shape and offsets stay ordered.
+/// Literals are replaced by an empty literal rather than deleted, so the
+/// surrounding code keeps its shape and offsets stay ordered.
+///
+/// KNOWN LIMIT: raw string literals are not parsed. Their content can hold an
+/// unbalanced number of quotes, which would desynchronise this scanner and
+/// make it swallow real code silently -- the worst failure a helper that
+/// fourteen assertions depend on could have. One is therefore refused loudly
+/// via <see cref="NotSupportedException"/>. There is not one in the scanned
+/// corpus today; a source file that grows one gets a diagnostic naming this
+/// class, not a quiet false green.
 /// </summary>
 internal static class CSharpSourceText
 {
@@ -43,26 +53,17 @@ internal static class CSharpSourceText
                 continue;
             }
 
-            // Verbatim, in any of its prefix spellings: @"", $@"", @$"".
-            var verbatim = VerbatimBodyStart(source, i);
-            if (verbatim > 0)
-            {
-                i = SkipVerbatim(source, verbatim);
-                sb.Append("\"\"");
-                continue;
-            }
-
-            if (c == '"' || (c == '$' && Next(source, i) == '"'))
-            {
-                i = SkipRegular(source, c == '$' ? i + 2 : i + 1);
-                sb.Append("\"\"");
-                continue;
-            }
-
             if (c == '\'')
             {
                 i = SkipRegular(source, i + 1, terminator: '\'');
                 sb.Append("''");
+                continue;
+            }
+
+            if (TryReadLiteral(source, i, out var end))
+            {
+                sb.Append("\"\"");
+                i = end;
                 continue;
             }
 
@@ -130,14 +131,53 @@ internal static class CSharpSourceText
 
     private static char Next(string s, int i) => i + 1 < s.Length ? s[i + 1] : '\0';
 
-    // Returns the index just past the opening quote of a verbatim literal
-    // starting at i, or 0 when there is not one there.
-    private static int VerbatimBodyStart(string s, int i)
+    /// <summary>
+    /// If a string literal starts at <paramref name="i"/> -- including its
+    /// <c>@</c> / <c>$</c> prefixes in either order -- reports the index just
+    /// past its closing quote.
+    /// </summary>
+    private static bool TryReadLiteral(string s, int i, out int end)
     {
-        if (s[i] == '@' && Next(s, i) == '"') return i + 2;
-        if (s[i] == '@' && Next(s, i) == '$' && i + 2 < s.Length && s[i + 2] == '"') return i + 3;
-        if (s[i] == '$' && Next(s, i) == '@' && i + 2 < s.Length && s[i + 2] == '"') return i + 3;
-        return 0;
+        end = 0;
+
+        var j = i;
+        var verbatim = false;
+        var interpolated = false;
+        while (j < s.Length && (s[j] == '@' || s[j] == '$'))
+        {
+            if (s[j] == '@') verbatim = true; else interpolated = true;
+            j++;
+        }
+
+        // A prefix character only IS a prefix when a quote follows it;
+        // otherwise it was an identifier sigil and this is not a literal.
+        if (j >= s.Length || s[j] != '"') return false;
+
+        var quotes = 0;
+        while (j + quotes < s.Length && s[j + quotes] == '"') quotes++;
+
+        // Three or more opening quotes is a raw string -- unless the literal is
+        // verbatim, where a run just means it opens with escaped quotes.
+        if (!verbatim && quotes >= 3)
+        {
+            throw new NotSupportedException(
+                "CSharpSourceText cannot read raw string literals. One has appeared in a "
+                + "scanned source file. Parsing it wrongly would silently delete code from "
+                + "the text the wiring assertions read, so it is refused instead. Teach this "
+                + "class the raw-string forms before scanning that file.");
+        }
+
+        // An empty regular literal: nothing to skip past.
+        if (!verbatim && quotes == 2)
+        {
+            end = j + 2;
+            return true;
+        }
+
+        end = interpolated
+            ? SkipInterpolated(s, j + 1, verbatim)
+            : verbatim ? SkipVerbatim(s, j + 1) : SkipRegular(s, j + 1);
+        return true;
     }
 
     // In a verbatim literal a doubled quote is an escaped quote; a lone one
@@ -160,6 +200,62 @@ internal static class CSharpSourceText
         {
             if (s[i] == '\\') { i += 2; continue; }
             if (s[i] == terminator) return i + 1;
+            i++;
+        }
+
+        return i;
+    }
+
+    // An interpolated literal is text with holes of real code in it. Only a
+    // quote at brace depth zero closes it; inside a hole a quote opens a
+    // nested literal, which has to be skipped as one or its contents surface
+    // in the stripped text and satisfy assertions they have nothing to do with.
+    private static int SkipInterpolated(string s, int i, bool verbatim)
+    {
+        var depth = 0;
+
+        while (i < s.Length)
+        {
+            var c = s[i];
+
+            if (!verbatim && c == '\\' && depth == 0) { i += 2; continue; }
+
+            if (c == '{')
+            {
+                if (Next(s, i) == '{' && depth == 0) { i += 2; continue; }
+                depth++;
+                i++;
+                continue;
+            }
+
+            if (c == '}')
+            {
+                if (depth == 0)
+                {
+                    if (Next(s, i) == '}') { i += 2; continue; }
+                    i++;
+                    continue;
+                }
+
+                depth--;
+                i++;
+                continue;
+            }
+
+            if (depth > 0)
+            {
+                if (TryReadLiteral(s, i, out var nested)) { i = nested; continue; }
+                if (c == '\'') { i = SkipRegular(s, i + 1, terminator: '\''); continue; }
+                i++;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                if (verbatim && Next(s, i) == '"') { i += 2; continue; }
+                return i + 1;
+            }
+
             i++;
         }
 

--- a/windows/Ghostty.Tests/Shell/CSharpSourceText.cs
+++ b/windows/Ghostty.Tests/Shell/CSharpSourceText.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Text;
+using Xunit;
+
+namespace Ghostty.Tests.Shell;
+
+/// <summary>
+/// Reduces C# source to the part a wiring assertion may look at: comments and
+/// string/char literal CONTENT removed, everything else intact.
+///
+/// Both halves matter and both were learned the hard way. A comment above a
+/// statement can quote that statement verbatim -- the ordering comments in
+/// App.xaml.cs do exactly that -- so a raw-text search finds the prose and
+/// passes while the code says the opposite. A string literal can do the same:
+/// a diagnostic message naming the API it reports on satisfies any assertion
+/// looking for that API.
+///
+/// Literals are replaced by an empty literal of the same kind rather than
+/// deleted, so the surrounding code keeps its shape and offsets stay ordered.
+/// </summary>
+internal static class CSharpSourceText
+{
+    public static string Strip(string source)
+    {
+        var sb = new StringBuilder(source.Length);
+        var i = 0;
+
+        while (i < source.Length)
+        {
+            var c = source[i];
+
+            if (c == '/' && Next(source, i) == '/')
+            {
+                while (i < source.Length && source[i] != '\n') i++;
+                continue;
+            }
+
+            if (c == '/' && Next(source, i) == '*')
+            {
+                i += 2;
+                while (i < source.Length && !(source[i] == '*' && Next(source, i) == '/')) i++;
+                i = Math.Min(i + 2, source.Length);
+                continue;
+            }
+
+            // Verbatim, in any of its prefix spellings: @"", $@"", @$"".
+            var verbatim = VerbatimBodyStart(source, i);
+            if (verbatim > 0)
+            {
+                i = SkipVerbatim(source, verbatim);
+                sb.Append("\"\"");
+                continue;
+            }
+
+            if (c == '"' || (c == '$' && Next(source, i) == '"'))
+            {
+                i = SkipRegular(source, c == '$' ? i + 2 : i + 1);
+                sb.Append("\"\"");
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                i = SkipRegular(source, i + 1, terminator: '\'');
+                sb.Append("''");
+                continue;
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The body of the member declared by <paramref name="declaration"/>,
+    /// stripped. Scoping keeps an assertion about one method from passing on a
+    /// match somewhere else in a 1700-line file.
+    /// </summary>
+    public static string Member(string source, string declaration)
+    {
+        var stripped = Strip(source);
+
+        var start = stripped.IndexOf(declaration, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"'{declaration}' is gone from the source");
+
+        var open = stripped.IndexOf('{', start);
+        Assert.True(open >= 0, $"no body found for '{declaration}'");
+
+        var depth = 0;
+        for (var i = open; i < stripped.Length; i++)
+        {
+            if (stripped[i] == '{') depth++;
+            else if (stripped[i] == '}')
+            {
+                depth--;
+                if (depth == 0) return stripped[start..(i + 1)];
+            }
+        }
+
+        Assert.Fail($"unbalanced braces reading the body of '{declaration}'");
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Index of <paramref name="needle"/>, asserting it is present. Callers
+    /// compare these to assert order, which is the only thing this style of
+    /// test can meaningfully say.
+    /// </summary>
+    public static int RequireIndex(string body, string needle, string whatIsMissing)
+    {
+        var at = body.IndexOf(needle, StringComparison.Ordinal);
+        Assert.True(at >= 0, whatIsMissing);
+        return at;
+    }
+
+    public static int Count(string body, string needle)
+    {
+        var count = 0;
+        var at = 0;
+        while ((at = body.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static char Next(string s, int i) => i + 1 < s.Length ? s[i + 1] : '\0';
+
+    // Returns the index just past the opening quote of a verbatim literal
+    // starting at i, or 0 when there is not one there.
+    private static int VerbatimBodyStart(string s, int i)
+    {
+        if (s[i] == '@' && Next(s, i) == '"') return i + 2;
+        if (s[i] == '@' && Next(s, i) == '$' && i + 2 < s.Length && s[i + 2] == '"') return i + 3;
+        if (s[i] == '$' && Next(s, i) == '@' && i + 2 < s.Length && s[i + 2] == '"') return i + 3;
+        return 0;
+    }
+
+    // In a verbatim literal a doubled quote is an escaped quote; a lone one
+    // ends it. Backslash has no special meaning.
+    private static int SkipVerbatim(string s, int i)
+    {
+        while (i < s.Length)
+        {
+            if (s[i] != '"') { i++; continue; }
+            if (Next(s, i) == '"') { i += 2; continue; }
+            return i + 1;
+        }
+
+        return i;
+    }
+
+    private static int SkipRegular(string s, int i, char terminator = '"')
+    {
+        while (i < s.Length)
+        {
+            if (s[i] == '\\') { i += 2; continue; }
+            if (s[i] == terminator) return i + 1;
+            i++;
+        }
+
+        return i;
+    }
+}

--- a/windows/Ghostty.Tests/Shell/CSharpSourceTextTests.cs
+++ b/windows/Ghostty.Tests/Shell/CSharpSourceTextTests.cs
@@ -1,0 +1,146 @@
+using Xunit;
+
+namespace Ghostty.Tests.Shell;
+
+/// <summary>
+/// The stripper is the load-bearing part of the wiring tests: every one of
+/// them is only as trustworthy as its refusal to see prose and diagnostic
+/// strings as code. Both defeats it exists to close are pinned here.
+/// </summary>
+public class CSharpSourceTextTests
+{
+    [Fact]
+    public void LineComments_AreRemoved()
+    {
+        var stripped = CSharpSourceText.Strip("var a = 1; // Register();\nvar b = 2;");
+
+        Assert.DoesNotContain("Register()", stripped);
+        Assert.Contains("var b = 2;", stripped);
+    }
+
+    [Fact]
+    public void WholeLineComments_AreRemoved()
+    {
+        var stripped = CSharpSourceText.Strip("// NotificationInvoked += Handler;\nCallMe();");
+
+        Assert.DoesNotContain("NotificationInvoked", stripped);
+        Assert.Contains("CallMe();", stripped);
+    }
+
+    [Fact]
+    public void BlockComments_AreRemoved()
+    {
+        var stripped = CSharpSourceText.Strip("a(); /* Register(); still a comment */ b();");
+
+        Assert.DoesNotContain("Register()", stripped);
+        Assert.Contains("a();", stripped);
+        Assert.Contains("b();", stripped);
+    }
+
+    [Fact]
+    public void StringLiteralContent_IsRemoved()
+    {
+        var stripped = CSharpSourceText.Strip("Log(\"ExtendedActivationKind.AppNotification\");");
+
+        Assert.DoesNotContain("AppNotification", stripped);
+        Assert.Contains("Log(", stripped);
+    }
+
+    [Fact]
+    public void InterpolatedStringContent_IsRemoved()
+    {
+        var stripped = CSharpSourceText.Strip("Log($\"probe failed {ToastActivations.Note}\");");
+
+        Assert.DoesNotContain("ToastActivations", stripped);
+        Assert.Contains("Log(", stripped);
+    }
+
+    [Fact]
+    public void VerbatimStringContent_IsRemoved()
+    {
+        var stripped = CSharpSourceText.Strip("var p = @\"C:\\AddArgument\\x\"; Keep();");
+
+        Assert.DoesNotContain("AddArgument", stripped);
+        Assert.Contains("Keep();", stripped);
+    }
+
+    // A doubled quote inside a verbatim literal is an escaped quote, not the
+    // end of it.
+    //
+    // Asserted on the whole output, not by substring. A scanner that stops at
+    // the first quote of the pair treats the rest as an alternating run of
+    // strings, and the quote count of a well-formed literal is always even --
+    // so it resynchronizes at the end and every substring assertion passes
+    // either way. What differs is how many empty literals it leaves behind.
+    [Fact]
+    public void VerbatimString_DoubledQuoteDoesNotEndIt()
+    {
+        var stripped = CSharpSourceText.Strip("var s = @\"p\"\"AddArgument\"\"q\"; Keep();");
+
+        Assert.Equal("var s = \"\"; Keep();", stripped);
+    }
+
+    [Fact]
+    public void RegularString_EscapedQuoteDoesNotEndIt()
+    {
+        var stripped = CSharpSourceText.Strip("var s = \"a\\\"Register();b\"; Keep();");
+
+        Assert.DoesNotContain("Register()", stripped);
+        Assert.Contains("Keep();", stripped);
+    }
+
+    // A char literal holding a quote used to open a phantom string and swallow
+    // everything after it.
+    [Fact]
+    public void CharLiteralHoldingAQuote_DoesNotOpenAString()
+    {
+        var stripped = CSharpSourceText.Strip("if (c == '\"') Register();");
+
+        Assert.Contains("Register();", stripped);
+    }
+
+    [Fact]
+    public void CharLiteralHoldingAnEscapedQuote_DoesNotOpenAString()
+    {
+        var stripped = CSharpSourceText.Strip("if (c == '\\'') Register();");
+
+        Assert.Contains("Register();", stripped);
+    }
+
+    [Fact]
+    public void Member_ScopesToTheDeclaredBody()
+    {
+        const string source = """
+            class C
+            {
+                void First() { Alpha(); }
+                void Second() { Beta(); }
+            }
+            """;
+
+        var first = CSharpSourceText.Member(source, "void First()");
+
+        Assert.Contains("Alpha();", first);
+        Assert.DoesNotContain("Beta();", first);
+    }
+
+    [Fact]
+    public void Member_StripsInsideTheBody()
+    {
+        const string source = """
+            class C
+            {
+                void First()
+                {
+                    // Beta();
+                    Alpha();
+                }
+            }
+            """;
+
+        var first = CSharpSourceText.Member(source, "void First()");
+
+        Assert.Contains("Alpha();", first);
+        Assert.DoesNotContain("Beta();", first);
+    }
+}

--- a/windows/Ghostty.Tests/Shell/CSharpSourceTextTests.cs
+++ b/windows/Ghostty.Tests/Shell/CSharpSourceTextTests.cs
@@ -1,11 +1,19 @@
+using System;
 using Xunit;
 
 namespace Ghostty.Tests.Shell;
 
 /// <summary>
 /// The stripper is the load-bearing part of the wiring tests: every one of
-/// them is only as trustworthy as its refusal to see prose and diagnostic
-/// strings as code. Both defeats it exists to close are pinned here.
+/// them is only as trustworthy as its refusal to read prose and diagnostic
+/// strings as code. The two defeats it exists to close are pinned here, as are
+/// the two holes review found afterwards -- a nested literal leaking out of an
+/// interpolation hole, and a raw literal desynchronising the scan.
+///
+/// Several assertions compare WHOLE output rather than searching it. That is
+/// deliberate: for a well-formed literal the quote count is even, so a scanner
+/// that mis-handles one still resynchronizes by the end and every substring
+/// assertion passes either way. What differs is what it leaves behind.
 /// </summary>
 public class CSharpSourceTextTests
 {
@@ -46,22 +54,91 @@ public class CSharpSourceTextTests
         Assert.Contains("Log(", stripped);
     }
 
+    // Whole output, not a substring. The plain-quote path strips the body of
+    // $"..." identically, so a "content is removed" assertion passes with the
+    // interpolated handling deleted outright. What actually differs is whether
+    // the sigil survives into the code text.
     [Fact]
-    public void InterpolatedStringContent_IsRemoved()
+    public void InterpolatedString_IsConsumedIncludingItsSigil()
     {
         var stripped = CSharpSourceText.Strip("Log($\"probe failed {ToastActivations.Note}\");");
 
-        Assert.DoesNotContain("ToastActivations", stripped);
-        Assert.Contains("Log(", stripped);
+        Assert.Equal("Log(\"\");", stripped);
     }
 
     [Fact]
-    public void VerbatimStringContent_IsRemoved()
+    public void VerbatimString_IsConsumedIncludingItsSigil()
     {
-        var stripped = CSharpSourceText.Strip("var p = @\"C:\\AddArgument\\x\"; Keep();");
+        var stripped = CSharpSourceText.Strip("var p = @\"C:\\AddArgument\"; Keep();");
 
-        Assert.DoesNotContain("AddArgument", stripped);
-        Assert.Contains("Keep();", stripped);
+        Assert.Equal("var p = \"\"; Keep();", stripped);
+    }
+
+    // An interpolation hole is code, so a literal inside one is a literal.
+    // Left unparsed, its content lands in the text an assertion reads -- and
+    // an indexer keyed by a string is ordinary C#.
+    [Fact]
+    public void InterpolationHole_NestedStringDoesNotLeak()
+    {
+        var stripped = CSharpSourceText.Strip("Log($\"cfg={_map[\"theme\"]} done\"); Register();");
+
+        Assert.DoesNotContain("theme", stripped);
+        Assert.Equal("Log(\"\"); Register();", stripped);
+    }
+
+    // Skipping a nested literal AS a literal only shows when it holds a brace:
+    // otherwise ignoring its quotes reaches the same answer. Here the brace
+    // inside the nested string closes the hole early, the real closing quote
+    // then opens a phantom string, and the rest of the file is eaten.
+    [Fact]
+    public void InterpolationHole_NestedStringContainingABraceDoesNotEndTheHole()
+    {
+        var stripped = CSharpSourceText.Strip("Log($\"{Fmt(\"}\")} done\"); Register();");
+
+        Assert.Equal("Log(\"\"); Register();", stripped);
+    }
+
+    [Fact]
+    public void InterpolationHole_EscapedBracesAreNotHoles()
+    {
+        var stripped = CSharpSourceText.Strip("Log($\"{{literal}} {x}\"); Keep();");
+
+        Assert.Equal("Log(\"\"); Keep();", stripped);
+    }
+
+    // Refused, not guessed at. A raw literal can hold an unbalanced quote
+    // count, and a scanner that desynchronises on one deletes real code from
+    // the text every wiring assertion reads.
+    [Fact]
+    public void RawStringLiteral_IsRefusedLoudly()
+    {
+        var ex = Assert.Throws<NotSupportedException>(
+            () => CSharpSourceText.Strip("var s = \"\"\"the \" char\"\"\"; Secret();"));
+
+        Assert.Contains("raw string", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void InterpolatedRawStringLiteral_IsRefusedLoudly()
+        => Assert.Throws<NotSupportedException>(
+            () => CSharpSourceText.Strip("var s = $$\"\"\"x\"\"\"; Secret();"));
+
+    // A verbatim literal opening with an escaped quote also starts with a run
+    // of three, and is not a raw string.
+    [Fact]
+    public void VerbatimStringOpeningWithAnEscapedQuote_IsNotMistakenForRaw()
+    {
+        var stripped = CSharpSourceText.Strip("var s = @\"\"\"hi\"\"\"; Keep();");
+
+        Assert.Equal("var s = \"\"; Keep();", stripped);
+    }
+
+    [Fact]
+    public void EmptyStringLiteral_IsConsumed()
+    {
+        var stripped = CSharpSourceText.Strip("Log(\"\"); Keep();");
+
+        Assert.Equal("Log(\"\"); Keep();", stripped);
     }
 
     // A doubled quote inside a verbatim literal is an escaped quote, not the

--- a/windows/Ghostty.Tests/Shell/ToastActivationWiringTests.cs
+++ b/windows/Ghostty.Tests/Shell/ToastActivationWiringTests.cs
@@ -1,0 +1,321 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Ghostty.Tests.Shell;
+
+/// <summary>
+/// Guards the shell-side wiring of toast activation by reading the source as
+/// text, the way <c>TrayIconWiringTests</c> does. This project deliberately
+/// does not reference Ghostty.csproj (it would drag the WinAppSDK MRT/PRI
+/// targets into a plain net10.0 assembly), so the decision logic lives in
+/// Ghostty.Core and is unit-tested there -- but the wiring that connects it to
+/// WinRT cannot be, and unguarded wiring is how the whole feature silently
+/// stops working while every unit test stays green.
+///
+/// These assertions are deliberately few and are about ORDER and PRESENCE of
+/// facts that are load-bearing and non-obvious. They are not a substitute for
+/// exercising a real toast click on a packaged build.
+/// </summary>
+public class ToastActivationWiringTests
+{
+    // The WindowsAppSDK contract: a handler attached after Register() throws
+    // ERROR_NOT_FOUND, and Register() picks its COM class-registration flag
+    // from whether a handler exists at that instant -- registering single-use
+    // when none does, which makes a click spawn a second process instead of
+    // reaching the running one. Neither failure is visible at compile time and
+    // neither reproduces without a packaged install, so the order is pinned
+    // here.
+    [Fact]
+    public void NotificationInvoked_IsSubscribedBeforeRegister()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+
+        var subscribe = app.IndexOf("NotificationInvoked +=", StringComparison.Ordinal);
+        var register = app.IndexOf(
+            "AppNotificationManager.Default.Register()", StringComparison.Ordinal);
+
+        Assert.True(subscribe >= 0, "no NotificationInvoked subscription in App.xaml.cs");
+        Assert.True(register >= 0, "no AppNotificationManager.Default.Register() in App.xaml.cs");
+        Assert.True(
+            subscribe < register,
+            "NotificationInvoked must be subscribed before Register(): a late subscribe "
+            + "throws ERROR_NOT_FOUND, and Register() with no handler attached registers "
+            + "the COM activator single-use.");
+    }
+
+    // Register() is a process-wide registration; a second call is not additive.
+    [Fact]
+    public void Register_IsCalledExactlyOnce()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+
+        var occurrences = CountOccurrences(app, "AppNotificationManager.Default.Register()");
+
+        Assert.Equal(1, occurrences);
+    }
+
+    // The activation probe has to run before the single-instance gate, because
+    // a secondary forwards its launch and exits there: anything read after it
+    // never reaches a secondary at all, and the click degrades to a bare
+    // window.
+    [Fact]
+    public void ActivationIsProbedBeforeTheSingleInstanceGate()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+
+        var probe = app.IndexOf("ProbeActivation()", StringComparison.Ordinal);
+        var gate = app.IndexOf("HandleSingleInstanceGate(", StringComparison.Ordinal);
+
+        Assert.True(probe >= 0, "OnLaunched no longer probes the activation");
+        Assert.True(gate >= 0, "OnLaunched no longer runs the single-instance gate");
+        Assert.True(
+            probe < gate,
+            "the activation probe must run before the single-instance gate, or a "
+            + "secondary exits at the gate without ever reading its own activation.");
+    }
+
+    // Reading the AppNotification kind off GetActivatedEventArgs is what makes
+    // the forward independent of when WinAppSDK chooses to dispatch
+    // NotificationInvoked. Losing it reintroduces a timing assumption that
+    // cannot be verified without a packaged build.
+    [Fact]
+    public void ProbeReadsBothProtocolAndAppNotificationKinds()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+        var probe = Section(app, "private static Uri? ProbeActivation()");
+
+        Assert.Contains("ExtendedActivationKind.Protocol", probe);
+        Assert.Contains("ExtendedActivationKind.AppNotification", probe);
+        Assert.Contains("ToastActivations.Note(", probe);
+    }
+
+    // The argv scan is the fallback for a probe that THREW, so it cannot live
+    // inside the probe's try block. Pinned by requiring the resolve to come
+    // after the catch.
+    [Fact]
+    public void UriFallbackRunsAfterTheProbeCatch()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+        var probe = Section(app, "private static Uri? ProbeActivation()");
+
+        var catchBlock = probe.IndexOf("catch (Exception ex)", StringComparison.Ordinal);
+        var resolve = probe.IndexOf("ProtocolLaunch.Resolve(", StringComparison.Ordinal);
+
+        Assert.True(catchBlock >= 0, "the probe no longer guards GetActivatedEventArgs");
+        Assert.True(resolve >= 0, "the probe no longer resolves the --uri fallback");
+        Assert.True(
+            resolve > catchBlock,
+            "the --uri fallback must run after the probe's catch: nested inside the try "
+            + "it is unreachable exactly when GetActivatedEventArgs throws, which is the "
+            + "case it exists to cover.");
+    }
+
+    // The forward is the only record a secondary leaves before exiting, and
+    // ForwardedArgv is what strips a marker a user typed so a command line
+    // cannot fabricate a click.
+    [Fact]
+    public void ForwardCarriesTheLatchedActivationThroughForwardedArgv()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+        var forward = Section(app, "private void ForwardLaunchToPrimary(string pipeName)");
+
+        Assert.Contains("ToastActivation.ForwardedArgv(", forward);
+        Assert.Contains("ToastActivations.Pending", forward);
+    }
+
+    // A forwarded marker naming a surface that is not here must fall through to
+    // an ordinary launch, or the user loses the window (and any jump-list
+    // action) they actually asked for.
+    [Fact]
+    public void ForwardedLaunchChecksLivenessAndFallsThrough()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+        var open = Section(app, "internal void OpenWindowFromLaunch(");
+
+        var liveness = open.IndexOf("AnyWindowHasToastSurface(", StringComparison.Ordinal);
+        var fallthrough = open.IndexOf("HandleJumpListLaunch(", StringComparison.Ordinal);
+
+        Assert.True(liveness >= 0, "a forwarded activation is honoured without checking it can be");
+        Assert.True(fallthrough >= 0, "a forwarded launch no longer falls through to a normal launch");
+        Assert.True(liveness < fallthrough);
+    }
+
+    // The promise a notification click makes is that the app comes forward.
+    // The fallback therefore has to sit outside the try that wraps the scan,
+    // so a throwing scan does not swallow it too.
+    [Fact]
+    public void ToastConsumerFallsBackToPlainActivationOutsideTheScanTry()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+        var consumer = Section(app, "private void OnToastActivated(");
+
+        var scan = consumer.IndexOf("TryFocusToastSurface(", StringComparison.Ordinal);
+        var guard = consumer.IndexOf("if (focused) return;", StringComparison.Ordinal);
+        var fallback = consumer.IndexOf("ShowOrFocusWindowsFromTray()", StringComparison.Ordinal);
+
+        Assert.True(scan >= 0, "the toast consumer no longer looks for the surface");
+        Assert.True(guard >= 0, "the toast consumer no longer separates the scan from its fallback");
+        Assert.True(fallback > guard, "the fallback must run after, and outside, the scan's try");
+    }
+
+    // Both handles are process-lifetime singletons, so a subscription left
+    // attached roots App for the life of the process.
+    [Fact]
+    public void TeardownDetachesBothToastSubscriptions()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+
+        Assert.Contains("NotificationInvoked -= OnToastNotificationInvoked", app);
+        Assert.Contains("ToastActivations.Reset()", app);
+    }
+
+    // Without an argument the activation callback sees only "the app was
+    // clicked", never which pane asked for attention.
+    [Fact]
+    public void ToastCarriesTheSurfaceAsALaunchArgument()
+    {
+        var notifier = ReadEmbedded("AppNotificationToastNotifier.cs");
+
+        Assert.Contains("AddArgument(", notifier);
+        Assert.Contains("ToastActivation.SurfaceArgumentKey", notifier);
+    }
+
+    // The quick terminal's only legal reveal is its own Show(), which
+    // re-positions, runs the clip/slide reveal and arms autohide. A bare
+    // AppWindow.Show() leaves the last animation frame applied, so the window
+    // takes keyboard focus while the user sees nothing.
+    [Fact]
+    public void QuickTerminalIsRevealedThroughItsOwnShowPath()
+    {
+        var window = ReadEmbedded("MainWindow.xaml.cs");
+        var reveal = Section(window, "private void RevealForActivation()");
+
+        var quakeBranch = reveal.IndexOf("IsQuickTerminal", StringComparison.Ordinal);
+        var quakeShow = reveal.IndexOf("Show();", StringComparison.Ordinal);
+        var plainShow = reveal.IndexOf("AppWindow.Show()", StringComparison.Ordinal);
+
+        Assert.True(quakeBranch >= 0, "the reveal no longer distinguishes the quick terminal");
+        Assert.True(quakeShow >= 0, "the quick terminal is no longer revealed through Show()");
+        Assert.True(
+            quakeShow < plainShow,
+            "the quick terminal branch must be taken before the bare AppWindow.Show().");
+    }
+
+    // Focus has to wait a tick: the tab swap and the activation both rebuild
+    // the visual tree, and Focus on an unrealized element silently does
+    // nothing.
+    [Fact]
+    public void ToastFocusIsDeferredAfterTheTabSwap()
+    {
+        var window = ReadEmbedded("MainWindow.xaml.cs");
+        var focus = Section(window, "internal bool TryFocusToastSurface(string surfaceKey)");
+
+        Assert.Contains("_tabManager.Activate(", focus);
+        Assert.Contains("RevealForActivation()", focus);
+        Assert.Contains("DispatcherQueue.TryEnqueue(", focus);
+    }
+
+    // Something other than the toggle put a window back on screen, so the
+    // toggle's bookkeeping has to learn about it or the next press restores
+    // instead of hiding.
+    [Fact]
+    public void RevealingAWindowForAToastUpdatesTheVisibilityToggleBookkeeping()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+        var scan = Section(app, "private bool TryFocusToastSurface(string surfaceKey)");
+
+        Assert.Contains("NoteWindowRevealed(", scan);
+
+        var note = Section(app, "private void NoteWindowRevealed(MainWindow window)");
+        Assert.Contains("_hiddenByVisibilityToggle.Remove(", note);
+        Assert.Contains("_windowsHiddenByVisibilityToggle = false", note);
+    }
+
+    // One window mid-teardown throws RO_E_CLOSED out of AppWindow. Unguarded,
+    // it ends the scan before a live window behind it is reached.
+    [Fact]
+    public void WindowScanIsGuardedPerWindow()
+    {
+        var app = ReadEmbedded("App.xaml.cs");
+        var scan = Section(app, "private bool TryFocusToastSurface(string surfaceKey)");
+
+        var loop = scan.IndexOf("foreach (var window", StringComparison.Ordinal);
+        var guard = scan.IndexOf("catch (System.Exception", StringComparison.Ordinal);
+        var carryOn = scan.IndexOf("continue;", guard < 0 ? 0 : guard, StringComparison.Ordinal);
+
+        Assert.True(loop >= 0, "the scan no longer walks the windows");
+        Assert.True(guard > loop, "the guard must be inside the loop, not around it");
+        Assert.True(carryOn > guard, "a dead window must be skipped, not end the scan");
+    }
+
+    // Reads a member's body by brace matching, with comments stripped. Scoping
+    // keeps each assertion about the method it names rather than passing on a
+    // match somewhere else in a 1700-line file; stripping keeps prose from
+    // satisfying an assertion about code, which matters here because these
+    // methods are commented heavily enough to quote the very calls under test.
+    private static string Section(string source, string declaration)
+    {
+        var start = source.IndexOf(declaration, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"'{declaration}' is gone from the source");
+
+        var open = source.IndexOf('{', start);
+        Assert.True(open >= 0, $"no body found for '{declaration}'");
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0) return StripComments(source[start..(i + 1)]);
+            }
+        }
+
+        Assert.Fail($"unbalanced braces reading the body of '{declaration}'");
+        return string.Empty;
+    }
+
+    // Drops whole comment lines, and a trailing comment only on lines with no
+    // string literal -- a "//" inside a literal (a URL, say) is code, and
+    // telling the two apart properly would need a lexer this does not warrant.
+    private static string StripComments(string body)
+    {
+        var kept = body.Split('\n').Select(line =>
+        {
+            if (line.TrimStart().StartsWith("//", StringComparison.Ordinal)) return string.Empty;
+            if (line.Contains('"')) return line;
+            var at = line.IndexOf("//", StringComparison.Ordinal);
+            return at < 0 ? line : line[..at];
+        });
+
+        return string.Join('\n', kept);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var at = 0;
+        while ((at = haystack.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static string ReadEmbedded(string suffix)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty.Tests/Shell/ToastActivationWiringTests.cs
+++ b/windows/Ghostty.Tests/Shell/ToastActivationWiringTests.cs
@@ -127,25 +127,39 @@ public class ToastActivationWiringTests
             + "case it exists to cover.");
     }
 
-    // Both the probe and the first callback describe the same launch click.
-    // Routing both through TryNoteLaunchActivation is what stops one click
-    // being acted on twice, whichever of them WinAppSDK delivers first.
+    // Both the probe and the notification callback can describe the same
+    // launch click. Both go through TryNoteLaunchActivation so the relay can
+    // dedupe on what the click IS -- the callback must not keep its own idea
+    // of which one is the launch, because ordinal position is not identity and
+    // guessing it swallowed real clicks.
     [Fact]
     public void LaunchActivationIsRecordedThroughTheDedupe()
     {
         var callback = Member("App.xaml.cs", "private void OnToastNotificationInvoked(");
 
-        var first = CSharpSourceText.RequireIndex(
-            callback, "_toastCallbackIsFirst",
-            "the callback no longer distinguishes the launch click from a warm one");
-        var dedupe = CSharpSourceText.RequireIndex(
-            callback, "TryNoteLaunchActivation(",
-            "the launch click no longer goes through the dedupe and can be acted on twice");
-        var warm = CSharpSourceText.RequireIndex(
-            callback, "ToastActivations.Note(", "warm clicks are no longer delivered");
+        CSharpSourceText.RequireIndex(
+            callback, "ToastActivations.TryNoteLaunchActivation(",
+            "the callback no longer routes through the dedupe and a click can be acted on twice");
+        Assert.Equal(0, CSharpSourceText.Count(callback, "ToastActivations.Note("));
+    }
 
-        Assert.True(first < dedupe, "the dedupe belongs to the first callback only");
-        Assert.True(dedupe < warm, "a warm click must not go through the launch dedupe");
+    // The launch window has to be closed once startup is over, or a real click
+    // on the same surface the launch click named is dropped as a duplicate.
+    // After the first subscriber, because that is when the launch click has
+    // been acted on.
+    [Fact]
+    public void LaunchWindowIsClosedAfterTheFirstSubscriber()
+    {
+        var launched = OnLaunched();
+
+        var subscribe = CSharpSourceText.RequireIndex(
+            launched, "ToastActivations.Subscribe(", "OnLaunched no longer subscribes to toast clicks");
+        var close = CSharpSourceText.RequireIndex(
+            launched, "ToastActivations.CloseLaunchWindow()",
+            "startup never declares the launch window over, so a click on the launch surface "
+            + "is dropped as a duplicate");
+
+        Assert.True(close > subscribe, "the window closes only once the launch click can be acted on");
     }
 
     // The forward is the only record a secondary leaves before exiting, and

--- a/windows/Ghostty.Tests/Shell/ToastActivationWiringTests.cs
+++ b/windows/Ghostty.Tests/Shell/ToastActivationWiringTests.cs
@@ -11,13 +11,22 @@ namespace Ghostty.Tests.Shell;
 /// text, the way <c>TrayIconWiringTests</c> does. This project deliberately
 /// does not reference Ghostty.csproj (it would drag the WinAppSDK MRT/PRI
 /// targets into a plain net10.0 assembly), so the decision logic lives in
-/// Ghostty.Core and is unit-tested there -- but the wiring that connects it to
-/// WinRT cannot be, and unguarded wiring is how the whole feature silently
-/// stops working while every unit test stays green.
+/// Ghostty.Core and is unit-tested there -- while the wiring that connects it
+/// to WinRT cannot be, and unguarded wiring is how a feature silently stops
+/// working with every unit test still green.
 ///
-/// These assertions are deliberately few and are about ORDER and PRESENCE of
-/// facts that are load-bearing and non-obvious. They are not a substitute for
-/// exercising a real toast click on a packaged build.
+/// What these can catch: a call deleted, or two calls whose ORDER is
+/// load-bearing swapped. That is the whole of it.
+///
+/// What they cannot catch: whether any of it works. They do not run WinRT, do
+/// not construct a window, and do not observe a click. A change that keeps the
+/// shape and breaks the behaviour passes every one of them. Only a toast click
+/// on a packaged, installed build tests that.
+///
+/// Every assertion reads source that has been through
+/// <see cref="CSharpSourceText.Strip"/>. Assertions against raw file text are
+/// defeatable by a comment or a diagnostic string that quotes the very
+/// statement under test, and the comments in these methods do quote them.
 /// </summary>
 public class ToastActivationWiringTests
 {
@@ -26,19 +35,19 @@ public class ToastActivationWiringTests
     // from whether a handler exists at that instant -- registering single-use
     // when none does, which makes a click spawn a second process instead of
     // reaching the running one. Neither failure is visible at compile time and
-    // neither reproduces without a packaged install, so the order is pinned
-    // here.
+    // neither reproduces without a packaged install, so the order is pinned.
     [Fact]
     public void NotificationInvoked_IsSubscribedBeforeRegister()
     {
-        var app = ReadEmbedded("App.xaml.cs");
+        var launched = OnLaunched();
 
-        var subscribe = app.IndexOf("NotificationInvoked +=", StringComparison.Ordinal);
-        var register = app.IndexOf(
-            "AppNotificationManager.Default.Register()", StringComparison.Ordinal);
+        var subscribe = CSharpSourceText.RequireIndex(
+            launched, "NotificationInvoked +=",
+            "OnLaunched no longer subscribes to NotificationInvoked");
+        var register = CSharpSourceText.RequireIndex(
+            launched, "AppNotificationManager.Default.Register()",
+            "OnLaunched no longer registers for toast notifications");
 
-        Assert.True(subscribe >= 0, "no NotificationInvoked subscription in App.xaml.cs");
-        Assert.True(register >= 0, "no AppNotificationManager.Default.Register() in App.xaml.cs");
         Assert.True(
             subscribe < register,
             "NotificationInvoked must be subscribed before Register(): a late subscribe "
@@ -50,27 +59,27 @@ public class ToastActivationWiringTests
     [Fact]
     public void Register_IsCalledExactlyOnce()
     {
-        var app = ReadEmbedded("App.xaml.cs");
+        var app = Stripped("App.xaml.cs");
 
-        var occurrences = CountOccurrences(app, "AppNotificationManager.Default.Register()");
-
-        Assert.Equal(1, occurrences);
+        Assert.Equal(1, CSharpSourceText.Count(app, "AppNotificationManager.Default.Register()"));
     }
 
-    // The activation probe has to run before the single-instance gate, because
-    // a secondary forwards its launch and exits there: anything read after it
-    // never reaches a secondary at all, and the click degrades to a bare
-    // window.
+    // The probe has to run before the single-instance gate, because a
+    // secondary forwards its launch and exits there: anything read after the
+    // gate never reaches a secondary at all, and its click degrades to a bare
+    // window. Scoped to OnLaunched so these are the two CALL sites -- an
+    // unscoped search finds the ProbeActivation declaration too, and would go
+    // on passing after a reorder that broke the real thing.
     [Fact]
     public void ActivationIsProbedBeforeTheSingleInstanceGate()
     {
-        var app = ReadEmbedded("App.xaml.cs");
+        var launched = OnLaunched();
 
-        var probe = app.IndexOf("ProbeActivation()", StringComparison.Ordinal);
-        var gate = app.IndexOf("HandleSingleInstanceGate(", StringComparison.Ordinal);
+        var probe = CSharpSourceText.RequireIndex(
+            launched, "ProbeActivation()", "OnLaunched no longer probes the activation");
+        var gate = CSharpSourceText.RequireIndex(
+            launched, "HandleSingleInstanceGate(", "OnLaunched no longer runs the single-instance gate");
 
-        Assert.True(probe >= 0, "OnLaunched no longer probes the activation");
-        Assert.True(gate >= 0, "OnLaunched no longer runs the single-instance gate");
         Assert.True(
             probe < gate,
             "the activation probe must run before the single-instance gate, or a "
@@ -78,34 +87,39 @@ public class ToastActivationWiringTests
     }
 
     // Reading the AppNotification kind off GetActivatedEventArgs is what makes
-    // the forward independent of when WinAppSDK chooses to dispatch
-    // NotificationInvoked. Losing it reintroduces a timing assumption that
-    // cannot be verified without a packaged build.
+    // the forward independent of when WinAppSDK dispatches NotificationInvoked.
+    // Losing it reintroduces a timing assumption that cannot be verified
+    // without a packaged build.
     [Fact]
     public void ProbeReadsBothProtocolAndAppNotificationKinds()
     {
-        var app = ReadEmbedded("App.xaml.cs");
-        var probe = Section(app, "private static Uri? ProbeActivation()");
+        var probe = Member("App.xaml.cs", "private static Uri? ProbeActivation()");
 
-        Assert.Contains("ExtendedActivationKind.Protocol", probe);
-        Assert.Contains("ExtendedActivationKind.AppNotification", probe);
-        Assert.Contains("ToastActivations.Note(", probe);
+        var protocol = CSharpSourceText.RequireIndex(
+            probe, "ExtendedActivationKind.Protocol", "the probe no longer reads protocol activation");
+        var appNotification = CSharpSourceText.RequireIndex(
+            probe, "ExtendedActivationKind.AppNotification",
+            "the probe no longer reads the toast activation kind, which is what makes the "
+            + "forward independent of WinAppSDK dispatch timing");
+        var note = CSharpSourceText.RequireIndex(
+            probe, "TryNoteLaunchActivation(", "the probe reads the toast kind but records nothing");
+
+        Assert.True(protocol < appNotification, "the protocol branch is expected first");
+        Assert.True(note > appNotification, "the record must belong to the toast branch");
     }
 
     // The argv scan is the fallback for a probe that THREW, so it cannot live
-    // inside the probe's try block. Pinned by requiring the resolve to come
-    // after the catch.
+    // inside the probe's try block.
     [Fact]
     public void UriFallbackRunsAfterTheProbeCatch()
     {
-        var app = ReadEmbedded("App.xaml.cs");
-        var probe = Section(app, "private static Uri? ProbeActivation()");
+        var probe = Member("App.xaml.cs", "private static Uri? ProbeActivation()");
 
-        var catchBlock = probe.IndexOf("catch (Exception ex)", StringComparison.Ordinal);
-        var resolve = probe.IndexOf("ProtocolLaunch.Resolve(", StringComparison.Ordinal);
+        var catchBlock = CSharpSourceText.RequireIndex(
+            probe, "catch (Exception ex)", "the probe no longer guards GetActivatedEventArgs");
+        var resolve = CSharpSourceText.RequireIndex(
+            probe, "ProtocolLaunch.Resolve(", "the probe no longer resolves the --uri fallback");
 
-        Assert.True(catchBlock >= 0, "the probe no longer guards GetActivatedEventArgs");
-        Assert.True(resolve >= 0, "the probe no longer resolves the --uri fallback");
         Assert.True(
             resolve > catchBlock,
             "the --uri fallback must run after the probe's catch: nested inside the try "
@@ -113,63 +127,109 @@ public class ToastActivationWiringTests
             + "case it exists to cover.");
     }
 
+    // Both the probe and the first callback describe the same launch click.
+    // Routing both through TryNoteLaunchActivation is what stops one click
+    // being acted on twice, whichever of them WinAppSDK delivers first.
+    [Fact]
+    public void LaunchActivationIsRecordedThroughTheDedupe()
+    {
+        var callback = Member("App.xaml.cs", "private void OnToastNotificationInvoked(");
+
+        var first = CSharpSourceText.RequireIndex(
+            callback, "_toastCallbackIsFirst",
+            "the callback no longer distinguishes the launch click from a warm one");
+        var dedupe = CSharpSourceText.RequireIndex(
+            callback, "TryNoteLaunchActivation(",
+            "the launch click no longer goes through the dedupe and can be acted on twice");
+        var warm = CSharpSourceText.RequireIndex(
+            callback, "ToastActivations.Note(", "warm clicks are no longer delivered");
+
+        Assert.True(first < dedupe, "the dedupe belongs to the first callback only");
+        Assert.True(dedupe < warm, "a warm click must not go through the launch dedupe");
+    }
+
     // The forward is the only record a secondary leaves before exiting, and
-    // ForwardedArgv is what strips a marker a user typed so a command line
-    // cannot fabricate a click.
+    // ForwardedArgv is what keeps the reserved trailing slot honest.
     [Fact]
     public void ForwardCarriesTheLatchedActivationThroughForwardedArgv()
     {
-        var app = ReadEmbedded("App.xaml.cs");
-        var forward = Section(app, "private void ForwardLaunchToPrimary(string pipeName)");
+        var forward = Member("App.xaml.cs", "private void ForwardLaunchToPrimary(string pipeName)");
 
-        Assert.Contains("ToastActivation.ForwardedArgv(", forward);
-        Assert.Contains("ToastActivations.Pending", forward);
+        var build = CSharpSourceText.RequireIndex(
+            forward, "ToastActivation.ForwardedArgv(",
+            "the forward no longer builds its argv through ForwardedArgv");
+        var pending = CSharpSourceText.RequireIndex(
+            forward, "ToastActivations.Pending", "the forward no longer reads the latched activation");
+        var request = CSharpSourceText.RequireIndex(
+            forward, "new Ghostty.Core.SingleInstance.LaunchRequest(",
+            "the forward no longer builds a LaunchRequest");
+
+        Assert.True(build < request, "argv must be built before the request that carries it");
+        Assert.True(pending < request);
     }
 
-    // A forwarded marker naming a surface that is not here must fall through to
-    // an ordinary launch, or the user loses the window (and any jump-list
+    // A forwarded marker naming a surface that is not here must fall through
+    // to an ordinary launch, or the user loses the window (and any jump-list
     // action) they actually asked for.
     [Fact]
     public void ForwardedLaunchChecksLivenessAndFallsThrough()
     {
-        var app = ReadEmbedded("App.xaml.cs");
-        var open = Section(app, "internal void OpenWindowFromLaunch(");
+        var open = Member("App.xaml.cs", "internal void OpenWindowFromLaunch(");
 
-        var liveness = open.IndexOf("AnyWindowHasToastSurface(", StringComparison.Ordinal);
-        var fallthrough = open.IndexOf("HandleJumpListLaunch(", StringComparison.Ordinal);
+        var liveness = CSharpSourceText.RequireIndex(
+            open, "AnyWindowHasToastSurface(",
+            "a forwarded activation is honoured without checking it can be");
+        var note = CSharpSourceText.RequireIndex(
+            open, "ToastActivations.Note(", "a forwarded activation is no longer delivered");
+        var fallthrough = CSharpSourceText.RequireIndex(
+            open, "HandleJumpListLaunch(",
+            "a forwarded launch no longer falls through to an ordinary launch");
 
-        Assert.True(liveness >= 0, "a forwarded activation is honoured without checking it can be");
-        Assert.True(fallthrough >= 0, "a forwarded launch no longer falls through to a normal launch");
-        Assert.True(liveness < fallthrough);
+        Assert.True(liveness < note, "liveness must be decided before the click is honoured");
+        Assert.True(note < fallthrough, "the ordinary launch must be the fall-through, not the first choice");
     }
 
     // The promise a notification click makes is that the app comes forward.
-    // The fallback therefore has to sit outside the try that wraps the scan,
-    // so a throwing scan does not swallow it too.
+    // The fallback therefore sits outside the try that wraps the scan, so a
+    // throwing scan does not swallow it too.
     [Fact]
     public void ToastConsumerFallsBackToPlainActivationOutsideTheScanTry()
     {
-        var app = ReadEmbedded("App.xaml.cs");
-        var consumer = Section(app, "private void OnToastActivated(");
+        var consumer = Member("App.xaml.cs", "private void OnToastActivated(");
 
-        var scan = consumer.IndexOf("TryFocusToastSurface(", StringComparison.Ordinal);
-        var guard = consumer.IndexOf("if (focused) return;", StringComparison.Ordinal);
-        var fallback = consumer.IndexOf("ShowOrFocusWindowsFromTray()", StringComparison.Ordinal);
+        var scan = CSharpSourceText.RequireIndex(
+            consumer, "TryFocusToastSurface(", "the toast consumer no longer looks for the surface");
+        var guard = CSharpSourceText.RequireIndex(
+            consumer, "if (focused) return;",
+            "the toast consumer no longer separates the scan from its fallback");
+        var fallback = CSharpSourceText.RequireIndex(
+            consumer, "ShowOrFocusWindowsFromTray()", "the toast consumer no longer falls back at all");
 
-        Assert.True(scan >= 0, "the toast consumer no longer looks for the surface");
-        Assert.True(guard >= 0, "the toast consumer no longer separates the scan from its fallback");
+        Assert.True(scan < guard);
         Assert.True(fallback > guard, "the fallback must run after, and outside, the scan's try");
     }
 
     // Both handles are process-lifetime singletons, so a subscription left
-    // attached roots App for the life of the process.
+    // attached roots App for the life of the process. Anchored between two
+    // neighbours so a deletion cannot pass by leaving the names elsewhere.
     [Fact]
     public void TeardownDetachesBothToastSubscriptions()
     {
-        var app = ReadEmbedded("App.xaml.cs");
+        var teardown = Member(
+            "App.xaml.cs", "internal void OnAnyWindowClosedInternal(object sender, WindowEventArgs args)");
 
-        Assert.Contains("NotificationInvoked -= OnToastNotificationInvoked", app);
-        Assert.Contains("ToastActivations.Reset()", app);
+        var tray = CSharpSourceText.RequireIndex(
+            teardown, "_trayIconService = null;", "the teardown no longer drops the tray icon");
+        var detach = CSharpSourceText.RequireIndex(
+            teardown, "NotificationInvoked -= OnToastNotificationInvoked",
+            "the teardown no longer detaches the WinRT toast handler");
+        var reset = CSharpSourceText.RequireIndex(
+            teardown, "ToastActivations.Reset()", "the teardown no longer resets the relay");
+        var host = CSharpSourceText.RequireIndex(
+            teardown, "_bootstrapHost?.Dispose()", "the teardown no longer disposes the bootstrap host");
+
+        Assert.True(detach > tray && detach < host, "the detach must sit in the teardown sequence");
+        Assert.True(reset > tray && reset < host, "the relay reset must sit in the teardown sequence");
     }
 
     // Without an argument the activation callback sees only "the app was
@@ -177,10 +237,21 @@ public class ToastActivationWiringTests
     [Fact]
     public void ToastCarriesTheSurfaceAsALaunchArgument()
     {
-        var notifier = ReadEmbedded("AppNotificationToastNotifier.cs");
+        var show = Member("AppNotificationToastNotifier.cs", "public void Show(ToastRequest request)");
 
-        Assert.Contains("AddArgument(", notifier);
-        Assert.Contains("ToastActivation.SurfaceArgumentKey", notifier);
+        var body = CSharpSourceText.RequireIndex(
+            show, "builder.AddText(request.Body)", "the toast no longer carries its body");
+        var argument = CSharpSourceText.RequireIndex(
+            show, "builder.AddArgument(", "the toast no longer carries a launch argument");
+        var key = CSharpSourceText.RequireIndex(
+            show, "ToastActivation.SurfaceArgumentKey",
+            "the launch argument is no longer keyed to the surface");
+        var build = CSharpSourceText.RequireIndex(
+            show, "builder.BuildNotification()", "the toast is no longer built");
+
+        Assert.True(argument > body, "the argument is added to the builder");
+        Assert.True(key > argument);
+        Assert.True(argument < build, "the argument must be added before the notification is built");
     }
 
     // The quick terminal's only legal reveal is its own Show(), which
@@ -190,15 +261,16 @@ public class ToastActivationWiringTests
     [Fact]
     public void QuickTerminalIsRevealedThroughItsOwnShowPath()
     {
-        var window = ReadEmbedded("MainWindow.xaml.cs");
-        var reveal = Section(window, "private void RevealForActivation()");
+        var reveal = Member("MainWindow.xaml.cs", "private void RevealForActivation()");
 
-        var quakeBranch = reveal.IndexOf("IsQuickTerminal", StringComparison.Ordinal);
-        var quakeShow = reveal.IndexOf("Show();", StringComparison.Ordinal);
-        var plainShow = reveal.IndexOf("AppWindow.Show()", StringComparison.Ordinal);
+        var quakeBranch = CSharpSourceText.RequireIndex(
+            reveal, "IsQuickTerminal", "the reveal no longer distinguishes the quick terminal");
+        var quakeShow = CSharpSourceText.RequireIndex(
+            reveal, "Show();", "the quick terminal is no longer revealed through Show()");
+        var plainShow = CSharpSourceText.RequireIndex(
+            reveal, "AppWindow.Show()", "the ordinary window is no longer shown");
 
-        Assert.True(quakeBranch >= 0, "the reveal no longer distinguishes the quick terminal");
-        Assert.True(quakeShow >= 0, "the quick terminal is no longer revealed through Show()");
+        Assert.True(quakeBranch < quakeShow);
         Assert.True(
             quakeShow < plainShow,
             "the quick terminal branch must be taken before the bare AppWindow.Show().");
@@ -210,12 +282,18 @@ public class ToastActivationWiringTests
     [Fact]
     public void ToastFocusIsDeferredAfterTheTabSwap()
     {
-        var window = ReadEmbedded("MainWindow.xaml.cs");
-        var focus = Section(window, "internal bool TryFocusToastSurface(string surfaceKey)");
+        var focus = Member("MainWindow.xaml.cs", "internal bool TryFocusToastSurface(string surfaceKey)");
 
-        Assert.Contains("_tabManager.Activate(", focus);
-        Assert.Contains("RevealForActivation()", focus);
-        Assert.Contains("DispatcherQueue.TryEnqueue(", focus);
+        var tab = CSharpSourceText.RequireIndex(
+            focus, "_tabManager.Activate(", "the toast focus no longer selects the surface's tab");
+        var reveal = CSharpSourceText.RequireIndex(
+            focus, "RevealForActivation()", "the toast focus no longer reveals the window");
+        var defer = CSharpSourceText.RequireIndex(
+            focus, "DispatcherQueue.TryEnqueue(",
+            "the pane focus is applied inline again, before the visual tree is realized");
+
+        Assert.True(tab < reveal, "the tab is selected before the window is revealed");
+        Assert.True(defer > reveal, "the focus is deferred after the reveal, not before it");
     }
 
     // Something other than the toggle put a window back on screen, so the
@@ -224,89 +302,62 @@ public class ToastActivationWiringTests
     [Fact]
     public void RevealingAWindowForAToastUpdatesTheVisibilityToggleBookkeeping()
     {
-        var app = ReadEmbedded("App.xaml.cs");
-        var scan = Section(app, "private bool TryFocusToastSurface(string surfaceKey)");
+        var scan = Member("App.xaml.cs", "private bool TryFocusToastSurface(string surfaceKey)");
+        CSharpSourceText.RequireIndex(
+            scan, "NoteWindowRevealed(", "a toast reveal no longer tells the toggle bookkeeping");
 
-        Assert.Contains("NoteWindowRevealed(", scan);
+        var note = Member("App.xaml.cs", "private void NoteWindowRevealed(MainWindow window)");
+        var remove = CSharpSourceText.RequireIndex(
+            note, "_hiddenByVisibilityToggle.Remove(", "the revealed window is not dropped from the hidden set");
+        var clear = CSharpSourceText.RequireIndex(
+            note, "_windowsHiddenByVisibilityToggle = false", "the hidden flag is never cleared");
 
-        var note = Section(app, "private void NoteWindowRevealed(MainWindow window)");
-        Assert.Contains("_hiddenByVisibilityToggle.Remove(", note);
-        Assert.Contains("_windowsHiddenByVisibilityToggle = false", note);
+        Assert.True(remove < clear, "the flag is cleared only once the set has drained");
     }
 
-    // One window mid-teardown throws RO_E_CLOSED out of AppWindow. Unguarded,
-    // it ends the scan before a live window behind it is reached.
-    [Fact]
-    public void WindowScanIsGuardedPerWindow()
+    // One window mid-teardown throws out of its own state. Unguarded, it ends
+    // the scan before a live window behind it is reached. Both scans walk the
+    // same state and both need it.
+    [Theory]
+    [InlineData("private bool TryFocusToastSurface(string surfaceKey)")]
+    [InlineData("private static bool AnyWindowHasToastSurface(string surfaceKey)")]
+    public void WindowScansAreGuardedPerWindow(string declaration)
     {
-        var app = ReadEmbedded("App.xaml.cs");
-        var scan = Section(app, "private bool TryFocusToastSurface(string surfaceKey)");
+        var scan = Member("App.xaml.cs", declaration);
 
-        var loop = scan.IndexOf("foreach (var window", StringComparison.Ordinal);
-        var guard = scan.IndexOf("catch (System.Exception", StringComparison.Ordinal);
-        var carryOn = scan.IndexOf("continue;", guard < 0 ? 0 : guard, StringComparison.Ordinal);
+        var loop = CSharpSourceText.RequireIndex(scan, "foreach (var window", "the scan no longer walks the windows");
+        var guard = CSharpSourceText.RequireIndex(
+            scan, "catch (System.Exception", "one dead window can end this scan and take the caller with it");
+        var close = CSharpSourceText.RequireIndex(scan, "return false;", "the scan no longer reports a miss");
 
-        Assert.True(loop >= 0, "the scan no longer walks the windows");
         Assert.True(guard > loop, "the guard must be inside the loop, not around it");
-        Assert.True(carryOn > guard, "a dead window must be skipped, not end the scan");
+        Assert.True(guard < close, "the guard must be inside the loop, not after it");
     }
 
-    // Reads a member's body by brace matching, with comments stripped. Scoping
-    // keeps each assertion about the method it names rather than passing on a
-    // match somewhere else in a 1700-line file; stripping keeps prose from
-    // satisfying an assertion about code, which matters here because these
-    // methods are commented heavily enough to quote the very calls under test.
-    private static string Section(string source, string declaration)
+    // Enqueued from a pipe thread onto the UI thread, where nothing above
+    // catches: an escape takes the process down.
+    [Fact]
+    public void InboundForwardedLaunchIsGuarded()
     {
-        var start = source.IndexOf(declaration, StringComparison.Ordinal);
-        Assert.True(start >= 0, $"'{declaration}' is gone from the source");
+        var start = Member("App.xaml.cs", "private void StartSingleInstanceServer()");
 
-        var open = source.IndexOf('{', start);
-        Assert.True(open >= 0, $"no body found for '{declaration}'");
+        var enqueue = CSharpSourceText.RequireIndex(
+            start, "OpenWindowFromLaunch(req)", "the server no longer hands forwarded launches to the app");
+        var guard = CSharpSourceText.RequireIndex(
+            start, "LogInboundLaunchFailed(",
+            "a throwing forwarded launch is an unhandled UI-thread exception again");
 
-        var depth = 0;
-        for (var i = open; i < source.Length; i++)
-        {
-            if (source[i] == '{') depth++;
-            else if (source[i] == '}')
-            {
-                depth--;
-                if (depth == 0) return StripComments(source[start..(i + 1)]);
-            }
-        }
-
-        Assert.Fail($"unbalanced braces reading the body of '{declaration}'");
-        return string.Empty;
+        Assert.True(guard > enqueue, "the guard wraps the call");
     }
 
-    // Drops whole comment lines, and a trailing comment only on lines with no
-    // string literal -- a "//" inside a literal (a URL, say) is code, and
-    // telling the two apart properly would need a lexer this does not warrant.
-    private static string StripComments(string body)
-    {
-        var kept = body.Split('\n').Select(line =>
-        {
-            if (line.TrimStart().StartsWith("//", StringComparison.Ordinal)) return string.Empty;
-            if (line.Contains('"')) return line;
-            var at = line.IndexOf("//", StringComparison.Ordinal);
-            return at < 0 ? line : line[..at];
-        });
+    private static string OnLaunched()
+        => Member("App.xaml.cs", "protected override void OnLaunched(LaunchActivatedEventArgs args)");
 
-        return string.Join('\n', kept);
-    }
+    private static string Member(string fileSuffix, string declaration)
+        => CSharpSourceText.Member(ReadEmbedded(fileSuffix), declaration);
 
-    private static int CountOccurrences(string haystack, string needle)
-    {
-        var count = 0;
-        var at = 0;
-        while ((at = haystack.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
-        {
-            count++;
-            at += needle.Length;
-        }
-
-        return count;
-    }
+    private static string Stripped(string fileSuffix)
+        => CSharpSourceText.Strip(ReadEmbedded(fileSuffix));
 
     private static string ReadEmbedded(string suffix)
     {

--- a/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
@@ -36,42 +36,67 @@ public sealed class LaunchRequestTests
         Assert.Equal(req.Args, back.Args);
     }
 
-    // Defect-4 wire: the toast activation rides as one more argv entry, so it
-    // survives Serialize/TryParse unchanged and a primary that predates it
-    // simply does not recognize the argument.
+    // The toast activation rides as one more argv entry, so it survives
+    // Serialize/TryParse unchanged and a primary that predates it simply does
+    // not recognize the argument.
+    //
+    // Each case below carries its own positive control: a bare
+    // "reads as no activation" assertion would pass just as well against a
+    // parser that never recognizes anything.
     [Fact]
     public void RoundTrips_ForwardedToastActivation()
     {
-        var req = new LaunchRequest(
-            @"C:\dir",
-            ["wintty.exe", ToastActivation.ForwardedArg("abc-123")]);
+        var argv = ToastActivation.ForwardedArgv(
+            ["wintty.exe"], new ToastActivation("abc-123"));
+        var req = new LaunchRequest(@"C:\dir", argv);
 
         Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
-        Assert.Equal("abc-123", ToastActivation.FromForwardedArgs(back!.Args).SurfaceKey);
+        Assert.Equal(argv, back!.Args);
+        Assert.Equal("abc-123", ToastActivation.FromForwardedArgs(back.Args).SurfaceKey);
     }
 
     // The other half of the upgrade window: an older secondary forwards argv
     // with no activation in it. The payload must parse and read as a plain
-    // launch rather than as a surface nobody can find.
+    // launch rather than as a surface nobody can find -- while the same
+    // vector WITH a marker still reads as one.
     [Fact]
     public void RoundTrips_WithoutActivation_ReadsAsPlainLaunch()
     {
-        var req = new LaunchRequest(@"C:\dir", ["wintty.exe", "--jumplist-action=new-tab"]);
+        string[] plain = ["wintty.exe", "--jumplist-action=new-tab"];
+        var req = new LaunchRequest(@"C:\dir", plain);
 
         Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
-        Assert.False(ToastActivation.FromForwardedArgs(back!.Args).HasSurface);
+        Assert.Equal(plain, back!.Args);
+        Assert.False(ToastActivation.FromForwardedArgs(back.Args).HasSurface);
+
+        // Positive control over the identical vector.
+        var withMarker = new LaunchRequest(
+            @"C:\dir", ToastActivation.ForwardedArgv(plain, new ToastActivation("abc-123")));
+        Assert.True(LaunchRequest.TryParse(withMarker.Serialize(), out var markedBack));
+        Assert.Equal("abc-123", ToastActivation.FromForwardedArgs(markedBack!.Args).SurfaceKey);
     }
 
-    // A field a future build adds the same way must not cost the launch: an
-    // unrecognized argument round-trips and is ignored, leaving a plain launch.
+    // An argument a future build adds the same way must not cost the launch:
+    // it round-trips verbatim, reads as no activation, and does not stop a
+    // real marker appended after it from being seen.
     [Fact]
     public void RoundTrips_UnknownArgument_IsIgnoredNotRejected()
     {
-        var req = new LaunchRequest(@"C:\dir", ["wintty.exe", "--something-a-newer-build-sends=7"]);
+        string[] unknown = ["wintty.exe", "--something-a-newer-build-sends=7"];
+        var req = new LaunchRequest(@"C:\dir", unknown);
 
         Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
-        Assert.Equal(req.Args, back!.Args);
+        Assert.Equal(unknown, back!.Args);
         Assert.False(ToastActivation.FromForwardedArgs(back.Args).HasSurface);
+
+        // Positive control: the unknown argument does not shadow a real one.
+        var alsoActivated = new LaunchRequest(
+            @"C:\dir", ToastActivation.ForwardedArgv(unknown, new ToastActivation("abc-123")));
+        Assert.True(LaunchRequest.TryParse(alsoActivated.Serialize(), out var bothBack));
+        Assert.Equal(
+            ["wintty.exe", "--something-a-newer-build-sends=7", "--toast-surface=abc-123"],
+            bothBack!.Args);
+        Assert.Equal("abc-123", ToastActivation.FromForwardedArgs(bothBack.Args).SurfaceKey);
     }
 
     [Theory]

--- a/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
+++ b/windows/Ghostty.Tests/SingleInstance/LaunchRequestTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Ghostty.Core.Activation;
 using Ghostty.Core.SingleInstance;
 using Xunit;
 
@@ -33,6 +34,44 @@ public sealed class LaunchRequestTests
         Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
         Assert.Equal(req.WorkingDirectory, back!.WorkingDirectory);
         Assert.Equal(req.Args, back.Args);
+    }
+
+    // Defect-4 wire: the toast activation rides as one more argv entry, so it
+    // survives Serialize/TryParse unchanged and a primary that predates it
+    // simply does not recognize the argument.
+    [Fact]
+    public void RoundTrips_ForwardedToastActivation()
+    {
+        var req = new LaunchRequest(
+            @"C:\dir",
+            ["wintty.exe", ToastActivation.ForwardedArg("abc-123")]);
+
+        Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
+        Assert.Equal("abc-123", ToastActivation.FromForwardedArgs(back!.Args).SurfaceKey);
+    }
+
+    // The other half of the upgrade window: an older secondary forwards argv
+    // with no activation in it. The payload must parse and read as a plain
+    // launch rather than as a surface nobody can find.
+    [Fact]
+    public void RoundTrips_WithoutActivation_ReadsAsPlainLaunch()
+    {
+        var req = new LaunchRequest(@"C:\dir", ["wintty.exe", "--jumplist-action=new-tab"]);
+
+        Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
+        Assert.False(ToastActivation.FromForwardedArgs(back!.Args).HasSurface);
+    }
+
+    // A field a future build adds the same way must not cost the launch: an
+    // unrecognized argument round-trips and is ignored, leaving a plain launch.
+    [Fact]
+    public void RoundTrips_UnknownArgument_IsIgnoredNotRejected()
+    {
+        var req = new LaunchRequest(@"C:\dir", ["wintty.exe", "--something-a-newer-build-sends=7"]);
+
+        Assert.True(LaunchRequest.TryParse(req.Serialize(), out var back));
+        Assert.Equal(req.Args, back!.Args);
+        Assert.False(ToastActivation.FromForwardedArgs(back.Args).HasSurface);
     }
 
     [Theory]

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -673,34 +673,29 @@ public partial class App : Application
         _highContrastMonitor = new Ghostty.Accessibility.HighContrastMonitor(
             _configService, DispatcherQueue.GetForCurrentThread());
 
-        Uri? activationUri = null;
+        Uri? protocolUri = null;
         try
         {
             var activated = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
             if (activated.Kind == Microsoft.Windows.AppLifecycle.ExtendedActivationKind.Protocol
                 && activated.Data is Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs proto)
             {
-                activationUri = proto.Uri;
-            }
-            else
-            {
-                // Unpackaged fallback: command line --uri <url>.
-                var argv = Environment.GetCommandLineArgs();
-                for (int i = 0; i < argv.Length - 1; i++)
-                {
-                    if (string.Equals(argv[i], "--uri", StringComparison.Ordinal)
-                        && Uri.TryCreate(argv[i + 1], UriKind.Absolute, out var u))
-                    {
-                        activationUri = u;
-                        break;
-                    }
-                }
+                protocolUri = proto.Uri;
             }
         }
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"[app] protocol activation probe failed: {ex.Message}");
         }
+
+        // The unpackaged fallback runs OUTSIDE the try above, deliberately.
+        // GetActivatedEventArgs is the half that throws on an unpackaged
+        // build, which is the exact case the --uri scan exists to cover:
+        // nested inside that try it was unreachable precisely when it was
+        // needed. Resolve keeps the precedence rule in one testable place --
+        // a real protocol activation still beats anything in argv.
+        Uri? activationUri = Ghostty.Core.Activation.ProtocolLaunch.Resolve(
+            protocolUri, Environment.GetCommandLineArgs());
 
         // Session manager: owns restore decision + debounced persistence.
         // Constructed before window creation so we can decide whether to

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -410,6 +410,16 @@ public partial class App : Application
         // app can be toast-activated later. AUMID is already set above.
         try
         {
+            // NotificationInvoked MUST be attached before Register(), not
+            // after, for two separate reasons. WinAppSDK throws
+            // ERROR_NOT_FOUND from a subscribe that arrives late, and
+            // Register() picks its COM class-registration flag from whether a
+            // handler exists at that instant: with none attached it registers
+            // single-use, so a toast click would spawn a SECOND process
+            // instead of reaching this one. Exactly one Register() call may
+            // exist in the process, so this is the only window to do it in.
+            Microsoft.Windows.AppNotifications.AppNotificationManager.Default
+                .NotificationInvoked += OnToastNotificationInvoked;
             Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
         }
         catch (System.Exception ex)
@@ -800,6 +810,12 @@ public partial class App : Application
         // quick-terminal-key takes effect without a restart.
         _configService.ConfigChanged += OnConfigReloaded_ReRegisterHotKey;
 
+        // Subscribe to toast clicks down here, not next to Register(): the
+        // handler focuses windows, and up there none exist yet. A click that
+        // already arrived (a cold launch delivers it during Register()) is
+        // replayed to this subscription, so nothing is lost by waiting.
+        ToastActivated += OnToastActivated;
+
         // Start the single-instance forwarding server last, once the UI
         // dispatcher and logger factory exist. No-op unless this process is
         // the single-instance primary.
@@ -853,9 +869,19 @@ public partial class App : Application
     /// </summary>
     private void ForwardLaunchToPrimary(string pipeName)
     {
+        // A toast click can be what started this process, and argv alone does
+        // not say so in any form the primary can read -- the activator's own
+        // token is a WinAppSDK implementation detail. Append the surface we
+        // latched so the primary acts on the click instead of reading it as a
+        // bare launch and opening a window. Nothing is appended when no
+        // activation arrived, so an ordinary secondary forwards exactly what
+        // it forwarded before.
+        var argv = new List<string>(Environment.GetCommandLineArgs());
+        if (PendingToastActivation is { HasSurface: true, SurfaceKey: { } surfaceKey })
+            argv.Add(Ghostty.Core.Activation.ToastActivation.ForwardedArg(surfaceKey));
+
         var request = new Ghostty.Core.SingleInstance.LaunchRequest(
-            Program.LaunchWorkingDirectory,
-            Environment.GetCommandLineArgs());
+            Program.LaunchWorkingDirectory, argv);
 
         try
         {
@@ -931,9 +957,171 @@ public partial class App : Application
             || _lifetimeSupervisor is null || _loggerFactory is null)
             return;
 
+        // A notification click that spawned a secondary lands here carrying
+        // the surface it was raised for. Route it through the same entry point
+        // the in-process click uses, so downstream subscribers see a forwarded
+        // click and an in-process one identically. An older build's payload
+        // (or a user who typed the flag with no value) parses as no surface
+        // and falls through to the ordinary launch below.
+        var activation = Ghostty.Core.Activation.ToastActivation
+            .FromForwardedArgs(req.Args);
+        if (activation.HasSurface)
+        {
+            NoteToastActivation(activation);
+            return;
+        }
+
         HandleJumpListLaunch(
             Ghostty.Core.JumpList.JumpListLaunch.Parse(req.Args),
             req.WorkingDirectory);
+    }
+
+    // Toast activation ---------------------------------------------------
+
+    // Latch + fan-out for toast clicks. Static because the WinRT handler is
+    // wired at the very top of OnLaunched, before the instance state any
+    // consumer needs exists, and because the click can arrive on a COM
+    // callback thread with no relationship to this App instance's lifetime.
+    private static readonly object _toastActivationGate = new();
+    private static Ghostty.Core.Activation.ToastActivation? _pendingToastActivation;
+    private static EventHandler<Ghostty.Core.Activation.ToastActivation>? _toastActivatedHandlers;
+
+    /// <summary>
+    /// Raised when the user clicks one of this app's toasts, whether the click
+    /// reached this process directly or was forwarded from a secondary.
+    ///
+    /// May fire on a WinRT COM callback thread: subscribers that touch windows
+    /// must marshal to the UI dispatcher themselves. A subscriber that arrives
+    /// after an activation has already been delivered receives that activation
+    /// immediately on subscribe -- a cold launch delivers the click during
+    /// <c>Register()</c>, long before any later-constructed consumer exists,
+    /// and raising it into an empty invocation list would lose it outright.
+    /// </summary>
+    internal static event EventHandler<Ghostty.Core.Activation.ToastActivation> ToastActivated
+    {
+        add
+        {
+            Ghostty.Core.Activation.ToastActivation? replay;
+            lock (_toastActivationGate)
+            {
+                _toastActivatedHandlers += value;
+                replay = _pendingToastActivation;
+                _pendingToastActivation = null;
+            }
+
+            // Outside the lock: the handler runs arbitrary code (window
+            // activation, in the one consumer we ship) and must not do it
+            // while holding the gate every other thread needs.
+            if (replay is { } pending) value(null, pending);
+        }
+        remove
+        {
+            lock (_toastActivationGate) _toastActivatedHandlers -= value;
+        }
+    }
+
+    /// <summary>
+    /// The activation waiting for its first subscriber, or
+    /// <c>ToastActivation.None</c>. Read (not consumed) by
+    /// <see cref="ForwardLaunchToPrimary"/>: a secondary never subscribes, so
+    /// the latch is the only place its click is recorded.
+    /// </summary>
+    internal static Ghostty.Core.Activation.ToastActivation PendingToastActivation
+    {
+        get
+        {
+            lock (_toastActivationGate)
+                return _pendingToastActivation ?? Ghostty.Core.Activation.ToastActivation.None;
+        }
+    }
+
+    /// <summary>
+    /// Single entry point for every toast click, whichever direction it came
+    /// from. Latches when nobody is listening yet; fans out otherwise.
+    /// </summary>
+    internal static void NoteToastActivation(
+        Ghostty.Core.Activation.ToastActivation activation)
+    {
+        EventHandler<Ghostty.Core.Activation.ToastActivation>? handlers;
+        lock (_toastActivationGate)
+        {
+            handlers = _toastActivatedHandlers;
+            if (handlers is null)
+            {
+                _pendingToastActivation = activation;
+                return;
+            }
+        }
+
+        handlers(null, activation);
+    }
+
+    private void OnToastNotificationInvoked(
+        Microsoft.Windows.AppNotifications.AppNotificationManager sender,
+        Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs args)
+    {
+        try
+        {
+            NoteToastActivation(
+                Ghostty.Core.Activation.ToastActivation.FromNotificationArguments(
+                    args.Arguments));
+        }
+        catch (System.Exception ex)
+        {
+            // This is a WinRT COM callback. A managed exception escaping back
+            // into the activator kills the process from inside code the user
+            // has no way to relate to the notification they clicked.
+            Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex);
+        }
+    }
+
+    /// <summary>
+    /// The one in-repo consumer of <see cref="ToastActivated"/>: put the user
+    /// back on the pane whose toast they clicked.
+    /// </summary>
+    private void OnToastActivated(
+        object? sender, Ghostty.Core.Activation.ToastActivation activation)
+    {
+        // Everything below touches windows, and this can arrive on a COM
+        // callback thread. TryEnqueue is right for the replay path too, which
+        // already runs on the UI thread: one dispatcher tick later is fine,
+        // and it keeps a single ordering rule instead of two.
+        _uiDispatcher?.TryEnqueue(() =>
+        {
+            try
+            {
+                if (activation.SurfaceKey is { Length: > 0 } key
+                    && TryFocusToastSurface(key))
+                    return;
+
+                // The surface is gone: its pane or window closed, or the toast
+                // outlived the process that raised it (every cold launch lands
+                // here). Bring the app forward the same way the tray icon
+                // does, so the click still does the thing a notification
+                // click always does.
+                ShowOrFocusWindowsFromTray();
+            }
+            catch (System.Exception ex)
+            {
+                Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Find the window owning the surface a toast was raised for, select its
+    /// tab, and focus it. Returns false when no live surface carries the key.
+    /// </summary>
+    private static bool TryFocusToastSurface(string surfaceKey)
+    {
+        // Snapshot: activating a window runs XAML handlers that can add or
+        // remove registry entries under us.
+        foreach (var window in AllWindows.ToArray())
+        {
+            if (window.TryFocusToastSurface(surfaceKey)) return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -1541,6 +1729,12 @@ internal static partial class AppLogExtensions
                    Level = LogLevel.Warning,
                    Message = "Failed to register for toast notifications")]
     internal static partial void LogToastRegisterFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Notifications.ActivationFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to act on a toast notification click")]
+    internal static partial void LogToastActivationFailed(
         this ILogger<App> logger, System.Exception ex);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.TrayInitFailed,

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -408,24 +408,42 @@ public partial class App : Application
         // under the AUMID before any Show(); without it Show() throws. The
         // registration persists in the registry (we never Unregister) so the
         // app can be toast-activated later. AUMID is already set above.
+        // NotificationInvoked MUST be attached before Register(), not after,
+        // for two separate reasons. WinAppSDK throws ERROR_NOT_FOUND from a
+        // subscribe that arrives late, and Register() picks its COM
+        // class-registration flag from whether a handler exists at that
+        // instant: with none attached it registers single-use, so a toast
+        // click would spawn a SECOND process instead of reaching this one.
+        //
+        // Its own try, not folded in with Register() below: a throw from the
+        // subscribe would otherwise skip the registration too, costing every
+        // toast rather than only the click routing.
         try
         {
-            // NotificationInvoked MUST be attached before Register(), not
-            // after, for two separate reasons. WinAppSDK throws
-            // ERROR_NOT_FOUND from a subscribe that arrives late, and
-            // Register() picks its COM class-registration flag from whether a
-            // handler exists at that instant: with none attached it registers
-            // single-use, so a toast click would spawn a SECOND process
-            // instead of reaching this one. Exactly one Register() call may
-            // exist in the process, so this is the only window to do it in.
             Microsoft.Windows.AppNotifications.AppNotificationManager.Default
                 .NotificationInvoked += OnToastNotificationInvoked;
+            _toastInvokedSubscribed = true;
+        }
+        catch (System.Exception ex)
+        {
+            Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex);
+        }
+
+        // Exactly one Register() call may exist in the process.
+        try
+        {
             Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
         }
         catch (System.Exception ex)
         {
             Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex);
         }
+
+        // Read the activation this process was started for, before the
+        // single-instance gate below acts on it. Position is load-bearing: a
+        // secondary forwards its launch and exits at that gate, so anything
+        // probed after it never reaches a secondary at all.
+        var activationUri = ProbeActivation();
 
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
         ConfigService = _configService;
@@ -683,30 +701,6 @@ public partial class App : Application
         _highContrastMonitor = new Ghostty.Accessibility.HighContrastMonitor(
             _configService, DispatcherQueue.GetForCurrentThread());
 
-        Uri? protocolUri = null;
-        try
-        {
-            var activated = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
-            if (activated.Kind == Microsoft.Windows.AppLifecycle.ExtendedActivationKind.Protocol
-                && activated.Data is Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs proto)
-            {
-                protocolUri = proto.Uri;
-            }
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[app] protocol activation probe failed: {ex.Message}");
-        }
-
-        // The unpackaged fallback runs OUTSIDE the try above, deliberately.
-        // GetActivatedEventArgs is the half that throws on an unpackaged
-        // build, which is the exact case the --uri scan exists to cover:
-        // nested inside that try it was unreachable precisely when it was
-        // needed. Resolve keeps the precedence rule in one testable place --
-        // a real protocol activation still beats anything in argv.
-        Uri? activationUri = Ghostty.Core.Activation.ProtocolLaunch.Resolve(
-            protocolUri, Environment.GetCommandLineArgs());
-
         // Session manager: owns restore decision + debounced persistence.
         // Constructed before window creation so we can decide whether to
         // rebuild a saved session or open a single default window.
@@ -812,9 +806,12 @@ public partial class App : Application
 
         // Subscribe to toast clicks down here, not next to Register(): the
         // handler focuses windows, and up there none exist yet. A click that
-        // already arrived (a cold launch delivers it during Register()) is
-        // replayed to this subscription, so nothing is lost by waiting.
-        ToastActivated += OnToastActivated;
+        // already arrived (the probe latches one, and a cold launch also
+        // delivers it during Register()) is replayed to this subscription, so
+        // nothing is lost by waiting. This must stay the FIRST subscriber --
+        // see ToastActivationRelay on why a second one wired above this line
+        // would swallow every cold-launch click.
+        ToastActivations.Subscribe(OnToastActivated);
 
         // Start the single-instance forwarding server last, once the UI
         // dispatcher and logger factory exist. No-op unless this process is
@@ -871,14 +868,13 @@ public partial class App : Application
     {
         // A toast click can be what started this process, and argv alone does
         // not say so in any form the primary can read -- the activator's own
-        // token is a WinAppSDK implementation detail. Append the surface we
-        // latched so the primary acts on the click instead of reading it as a
-        // bare launch and opening a window. Nothing is appended when no
-        // activation arrived, so an ordinary secondary forwards exactly what
-        // it forwarded before.
-        var argv = new List<string>(Environment.GetCommandLineArgs());
-        if (PendingToastActivation is { HasSurface: true, SurfaceKey: { } surfaceKey })
-            argv.Add(Ghostty.Core.Activation.ToastActivation.ForwardedArg(surfaceKey));
+        // token is a WinAppSDK implementation detail. Append the surface the
+        // probe latched so the primary acts on the click instead of reading it
+        // as a bare launch and opening a window. ForwardedArgv also strips any
+        // marker the user's own command line carried, so the one the primary
+        // finds is the one this process put there.
+        var argv = Ghostty.Core.Activation.ToastActivation.ForwardedArgv(
+            Environment.GetCommandLineArgs(), ToastActivations.Pending);
 
         var request = new Ghostty.Core.SingleInstance.LaunchRequest(
             Program.LaunchWorkingDirectory, argv);
@@ -957,17 +953,19 @@ public partial class App : Application
             || _lifetimeSupervisor is null || _loggerFactory is null)
             return;
 
-        // A notification click that spawned a secondary lands here carrying
-        // the surface it was raised for. Route it through the same entry point
-        // the in-process click uses, so downstream subscribers see a forwarded
-        // click and an in-process one identically. An older build's payload
-        // (or a user who typed the flag with no value) parses as no surface
-        // and falls through to the ordinary launch below.
+        // A notification click that spawned a secondary lands here carrying the
+        // surface it was raised for. Liveness is checked BEFORE handing it to
+        // the relay, because only this call site can fall through to an
+        // ordinary launch: a marker naming a surface that is not here is a
+        // pane that closed, or a flag a user typed on a command line an older
+        // secondary forwarded verbatim, and neither may cost them the window
+        // (or the --jumplist-action) they actually asked for.
         var activation = Ghostty.Core.Activation.ToastActivation
             .FromForwardedArgs(req.Args);
-        if (activation.HasSurface)
+        if (activation.SurfaceKey is { Length: > 0 } key
+            && AnyWindowHasToastSurface(key))
         {
-            NoteToastActivation(activation);
+            ToastActivations.Note(activation);
             return;
         }
 
@@ -978,82 +976,64 @@ public partial class App : Application
 
     // Toast activation ---------------------------------------------------
 
-    // Latch + fan-out for toast clicks. Static because the WinRT handler is
+    // Whether the NotificationInvoked subscribe succeeded, so teardown only
+    // detaches what it actually attached.
+    private bool _toastInvokedSubscribed;
+
+    // The relay is where the awkward part lives (latch a click that arrives
+    // before anyone can act on it, replay it to the first subscriber, fan out
+    // afterwards). Static and process-lifetime because the WinRT handler is
     // wired at the very top of OnLaunched, before the instance state any
-    // consumer needs exists, and because the click can arrive on a COM
-    // callback thread with no relationship to this App instance's lifetime.
-    private static readonly object _toastActivationGate = new();
-    private static Ghostty.Core.Activation.ToastActivation? _pendingToastActivation;
-    private static EventHandler<Ghostty.Core.Activation.ToastActivation>? _toastActivatedHandlers;
+    // consumer needs exists. App keeps only the WinRT wiring.
+    internal static Ghostty.Core.Activation.ToastActivationRelay ToastActivations { get; }
+        = new(ex => Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex));
 
     /// <summary>
-    /// Raised when the user clicks one of this app's toasts, whether the click
-    /// reached this process directly or was forwarded from a secondary.
+    /// Read what this process was activated for. Both kinds come off the same
+    /// <c>GetActivatedEventArgs</c> call, which is the only synchronous
+    /// account of the activation available: the AppNotification kind is
+    /// already present when OnLaunched runs, whereas NotificationInvoked fires
+    /// whenever WinAppSDK decides to dispatch it. Reading both means the
+    /// single-instance forward does not depend on that timing.
     ///
-    /// May fire on a WinRT COM callback thread: subscribers that touch windows
-    /// must marshal to the UI dispatcher themselves. A subscriber that arrives
-    /// after an activation has already been delivered receives that activation
-    /// immediately on subscribe -- a cold launch delivers the click during
-    /// <c>Register()</c>, long before any later-constructed consumer exists,
-    /// and raising it into an empty invocation list would lose it outright.
+    /// Returns the protocol URI, if any. The toast half is latched into the
+    /// relay rather than returned, because its consumer is constructed much
+    /// later in startup.
     /// </summary>
-    internal static event EventHandler<Ghostty.Core.Activation.ToastActivation> ToastActivated
+    private static Uri? ProbeActivation()
     {
-        add
+        Uri? protocolUri = null;
+        try
         {
-            Ghostty.Core.Activation.ToastActivation? replay;
-            lock (_toastActivationGate)
+            var activated = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
+            switch (activated.Kind)
             {
-                _toastActivatedHandlers += value;
-                replay = _pendingToastActivation;
-                _pendingToastActivation = null;
-            }
+                case Microsoft.Windows.AppLifecycle.ExtendedActivationKind.Protocol
+                    when activated.Data is Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs proto:
+                    protocolUri = proto.Uri;
+                    break;
 
-            // Outside the lock: the handler runs arbitrary code (window
-            // activation, in the one consumer we ship) and must not do it
-            // while holding the gate every other thread needs.
-            if (replay is { } pending) value(null, pending);
-        }
-        remove
-        {
-            lock (_toastActivationGate) _toastActivatedHandlers -= value;
-        }
-    }
-
-    /// <summary>
-    /// The activation waiting for its first subscriber, or
-    /// <c>ToastActivation.None</c>. Read (not consumed) by
-    /// <see cref="ForwardLaunchToPrimary"/>: a secondary never subscribes, so
-    /// the latch is the only place its click is recorded.
-    /// </summary>
-    internal static Ghostty.Core.Activation.ToastActivation PendingToastActivation
-    {
-        get
-        {
-            lock (_toastActivationGate)
-                return _pendingToastActivation ?? Ghostty.Core.Activation.ToastActivation.None;
-        }
-    }
-
-    /// <summary>
-    /// Single entry point for every toast click, whichever direction it came
-    /// from. Latches when nobody is listening yet; fans out otherwise.
-    /// </summary>
-    internal static void NoteToastActivation(
-        Ghostty.Core.Activation.ToastActivation activation)
-    {
-        EventHandler<Ghostty.Core.Activation.ToastActivation>? handlers;
-        lock (_toastActivationGate)
-        {
-            handlers = _toastActivatedHandlers;
-            if (handlers is null)
-            {
-                _pendingToastActivation = activation;
-                return;
+                case Microsoft.Windows.AppLifecycle.ExtendedActivationKind.AppNotification
+                    when activated.Data is Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs toast:
+                    ToastActivations.Note(
+                        Ghostty.Core.Activation.ToastActivation.FromNotificationArguments(
+                            toast.Arguments));
+                    break;
             }
         }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[app] activation probe failed: {ex.Message}");
+        }
 
-        handlers(null, activation);
+        // The unpackaged fallback runs OUTSIDE the try above, deliberately.
+        // GetActivatedEventArgs is the half that throws on an unpackaged
+        // build, which is the exact case the --uri scan exists to cover:
+        // nested inside that try it was unreachable precisely when it was
+        // needed. Resolve keeps the precedence rule in one testable place --
+        // a real protocol activation still beats anything in argv.
+        return Ghostty.Core.Activation.ProtocolLaunch.Resolve(
+            protocolUri, Environment.GetCommandLineArgs());
     }
 
     private void OnToastNotificationInvoked(
@@ -1062,7 +1042,7 @@ public partial class App : Application
     {
         try
         {
-            NoteToastActivation(
+            ToastActivations.Note(
                 Ghostty.Core.Activation.ToastActivation.FromNotificationArguments(
                     args.Arguments));
         }
@@ -1076,11 +1056,10 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// The one in-repo consumer of <see cref="ToastActivated"/>: put the user
-    /// back on the pane whose toast they clicked.
+    /// The one in-repo consumer of <see cref="ToastActivations"/>: put the
+    /// user back on the pane whose toast they clicked.
     /// </summary>
-    private void OnToastActivated(
-        object? sender, Ghostty.Core.Activation.ToastActivation activation)
+    private void OnToastActivated(Ghostty.Core.Activation.ToastActivation activation)
     {
         // Everything below touches windows, and this can arrive on a COM
         // callback thread. TryEnqueue is right for the replay path too, which
@@ -1088,17 +1067,27 @@ public partial class App : Application
         // and it keeps a single ordering rule instead of two.
         _uiDispatcher?.TryEnqueue(() =>
         {
+            var focused = false;
             try
             {
-                if (activation.SurfaceKey is { Length: > 0 } key
-                    && TryFocusToastSurface(key))
-                    return;
+                focused = activation.SurfaceKey is { Length: > 0 } key
+                    && TryFocusToastSurface(key);
+            }
+            catch (System.Exception ex)
+            {
+                Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex);
+            }
 
-                // The surface is gone: its pane or window closed, or the toast
-                // outlived the process that raised it (every cold launch lands
-                // here). Bring the app forward the same way the tray icon
-                // does, so the click still does the thing a notification
-                // click always does.
+            if (focused) return;
+
+            // Outside the try above on purpose. The surface may be gone (its
+            // pane or window closed, or the toast outlived the process that
+            // raised it -- every cold launch lands here), and the scan itself
+            // may have failed; either way the promise a notification click
+            // makes is that the app comes forward, so this has to run even
+            // when the scan threw.
+            try
+            {
                 ShowOrFocusWindowsFromTray();
             }
             catch (System.Exception ex)
@@ -1109,19 +1098,64 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Find the window owning the surface a toast was raised for, select its
-    /// tab, and focus it. Returns false when no live surface carries the key.
+    /// Whether any live pane carries <paramref name="surfaceKey"/>. Read-only:
+    /// the forwarded-launch path has to know whether a click can be honoured
+    /// BEFORE it commits to honouring it, so a marker naming nothing falls
+    /// through to an ordinary launch instead of eating it.
     /// </summary>
-    private static bool TryFocusToastSurface(string surfaceKey)
+    private static bool AnyWindowHasToastSurface(string surfaceKey)
     {
-        // Snapshot: activating a window runs XAML handlers that can add or
-        // remove registry entries under us.
         foreach (var window in AllWindows.ToArray())
         {
-            if (window.TryFocusToastSurface(surfaceKey)) return true;
+            if (window.HasToastSurface(surfaceKey)) return true;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Find the window owning the surface a toast was raised for, reveal it,
+    /// select its tab and focus the pane. False when no live surface carries
+    /// the key.
+    /// </summary>
+    private bool TryFocusToastSurface(string surfaceKey)
+    {
+        // Snapshot: revealing a window runs XAML handlers that can add or
+        // remove registry entries under us.
+        foreach (var window in AllWindows.ToArray())
+        {
+            try
+            {
+                if (!window.TryFocusToastSurface(surfaceKey)) continue;
+            }
+            catch (System.Exception ex)
+            {
+                // Per window, not per scan. A window mid-teardown throws
+                // RO_E_CLOSED out of AppWindow, and one dead window must not
+                // stop the search reaching a live one behind it. The net is
+                // wide because this walks arbitrary window state and the cost
+                // of a miss is the user's click.
+                Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex);
+                continue;
+            }
+
+            NoteWindowRevealed(window);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Keep the toggle_visibility bookkeeping honest when something other than
+    /// the toggle put a window back on screen. Without this a user who hid
+    /// every window, then clicked a toast, gets a restore rather than a hide
+    /// from the next toggle.
+    /// </summary>
+    private void NoteWindowRevealed(MainWindow window)
+    {
+        if (!_hiddenByVisibilityToggle.Remove(window)) return;
+        if (_hiddenByVisibilityToggle.Count == 0) _windowsHiddenByVisibilityToggle = false;
     }
 
     /// <summary>
@@ -1581,6 +1615,26 @@ public partial class App : Application
                 _systemMenuHook?.Dispose();
                 _trayIconService?.Dispose();
                 _trayIconService = null;
+
+                // Detach both halves of the toast wiring. AppNotificationManager.Default
+                // and the relay are both process-lifetime, so a handler left
+                // attached roots this App for as long as the process runs -- and
+                // a relay handler that outlives the dispatcher it marshals to is
+                // a click delivered into a dead window tree.
+                if (_toastInvokedSubscribed)
+                {
+                    try
+                    {
+                        Microsoft.Windows.AppNotifications.AppNotificationManager.Default
+                            .NotificationInvoked -= OnToastNotificationInvoked;
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex);
+                    }
+                    _toastInvokedSubscribed = false;
+                }
+                ToastActivations.Reset();
 
                 // Force-close the quake window. It does not participate
                 // in WindowsByRoot (so this branch fires when the last

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -443,6 +443,10 @@ public partial class App : Application
         // single-instance gate below acts on it. Position is load-bearing: a
         // secondary forwards its launch and exits at that gate, so anything
         // probed after it never reaches a secondary at all.
+        // Assigned and, in this repository, never read. It is not dead: a
+        // downstream build tier's URI router consumes it, and that is the live
+        // path behind deep links and the jump list. Deleting it here, or the
+        // probe behind it, breaks activation in the shipping builds.
         var activationUri = ProbeActivation();
 
         _configService = new ConfigService(DispatcherQueue.GetForCurrentThread());
@@ -927,7 +931,22 @@ public partial class App : Application
         {
             _singleInstanceServer = new Ghostty.Hosting.SingleInstanceServer(
                 election.Names.Pipe,
-                req => _uiDispatcher?.TryEnqueue(() => OpenWindowFromLaunch(req)),
+                req => _uiDispatcher?.TryEnqueue(() =>
+                {
+                    try
+                    {
+                        OpenWindowFromLaunch(req);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Enqueued from a pipe thread onto the UI thread, so
+                        // nothing above catches it: an escape here is an
+                        // unhandled UI-thread exception and the process goes
+                        // down. Losing one forwarded launch is the cheaper
+                        // failure.
+                        Ghostty.Logging.StaticLoggers.App.LogInboundLaunchFailed(ex);
+                    }
+                }),
                 _loggerFactory.CreateLogger<Ghostty.Hosting.SingleInstanceServer>());
             _singleInstanceServer.Start();
         }
@@ -1006,19 +1025,17 @@ public partial class App : Application
         try
         {
             var activated = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
-            switch (activated.Kind)
+            if (activated.Kind == Microsoft.Windows.AppLifecycle.ExtendedActivationKind.Protocol
+                && activated.Data is Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs proto)
             {
-                case Microsoft.Windows.AppLifecycle.ExtendedActivationKind.Protocol
-                    when activated.Data is Windows.ApplicationModel.Activation.IProtocolActivatedEventArgs proto:
-                    protocolUri = proto.Uri;
-                    break;
-
-                case Microsoft.Windows.AppLifecycle.ExtendedActivationKind.AppNotification
-                    when activated.Data is Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs toast:
-                    ToastActivations.Note(
-                        Ghostty.Core.Activation.ToastActivation.FromNotificationArguments(
-                            toast.Arguments));
-                    break;
+                protocolUri = proto.Uri;
+            }
+            else if (activated.Kind == Microsoft.Windows.AppLifecycle.ExtendedActivationKind.AppNotification
+                && activated.Data is Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs toast)
+            {
+                ToastActivations.TryNoteLaunchActivation(
+                    Ghostty.Core.Activation.ToastActivation.FromNotificationArguments(
+                        toast.Arguments));
             }
         }
         catch (Exception ex)
@@ -1036,15 +1053,31 @@ public partial class App : Application
             protocolUri, Environment.GetCommandLineArgs());
     }
 
+    // Cleared by the first NotificationInvoked callback this process receives.
+    // That first one is the launch click, which the activation probe may
+    // already have recorded off the same launch; every later one is a warm
+    // click and always goes through.
+    private static int _toastCallbackIsFirst = 1;
+
     private void OnToastNotificationInvoked(
         Microsoft.Windows.AppNotifications.AppNotificationManager sender,
         Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs args)
     {
         try
         {
-            ToastActivations.Note(
-                Ghostty.Core.Activation.ToastActivation.FromNotificationArguments(
-                    args.Arguments));
+            var activation = Ghostty.Core.Activation.ToastActivation
+                .FromNotificationArguments(args.Arguments);
+
+            // Interlocked because this runs on a WinRT callback thread while
+            // the probe runs on the startup thread, and the whole point is
+            // that their order is not knowable.
+            if (System.Threading.Interlocked.Exchange(ref _toastCallbackIsFirst, 0) == 1)
+            {
+                ToastActivations.TryNoteLaunchActivation(activation);
+                return;
+            }
+
+            ToastActivations.Note(activation);
         }
         catch (System.Exception ex)
         {
@@ -1107,7 +1140,20 @@ public partial class App : Application
     {
         foreach (var window in AllWindows.ToArray())
         {
-            if (window.HasToastSurface(surfaceKey)) return true;
+            try
+            {
+                if (window.HasToastSurface(surfaceKey)) return true;
+            }
+            catch (System.Exception ex)
+            {
+                // Same reasoning as the acting scan below, over the same
+                // window state: a window mid-teardown throws out of AppWindow,
+                // and a leaf whose Tag has been cleared throws out of the cast
+                // inside Terminal(). A window that cannot answer is treated as
+                // not having it, so one dead window neither decides the answer
+                // for the live ones nor takes down the caller.
+                Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex);
+            }
         }
 
         return false;
@@ -1630,7 +1676,7 @@ public partial class App : Application
                     }
                     catch (System.Exception ex)
                     {
-                        Ghostty.Logging.StaticLoggers.App.LogToastActivationFailed(ex);
+                        Ghostty.Logging.StaticLoggers.App.LogToastDetachFailed(ex);
                     }
                     _toastInvokedSubscribed = false;
                 }
@@ -1789,6 +1835,18 @@ internal static partial class AppLogExtensions
                    Level = LogLevel.Warning,
                    Message = "Failed to act on a toast notification click")]
     internal static partial void LogToastActivationFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Notifications.DetachFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Failed to detach the toast notification handler")]
+    internal static partial void LogToastDetachFailed(
+        this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.SingleInstance.InboundLaunchFailed,
+                   Level = LogLevel.Warning,
+                   Message = "A forwarded launch could not be acted on; it was dropped.")]
+    internal static partial void LogInboundLaunchFailed(
         this ILogger<App> logger, System.Exception ex);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.TrayInitFailed,

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -817,6 +817,11 @@ public partial class App : Application
         // would swallow every cold-launch click.
         ToastActivations.Subscribe(OnToastActivated);
 
+        // Startup is over and the launch click, if there was one, has been
+        // acted on. Anything arriving from here is a person clicking a new
+        // toast, so it must be delivered even when it names the same surface.
+        ToastActivations.CloseLaunchWindow();
+
         // Start the single-instance forwarding server last, once the UI
         // dispatcher and logger factory exist. No-op unless this process is
         // the single-instance primary.
@@ -1053,31 +1058,22 @@ public partial class App : Application
             protocolUri, Environment.GetCommandLineArgs());
     }
 
-    // Cleared by the first NotificationInvoked callback this process receives.
-    // That first one is the launch click, which the activation probe may
-    // already have recorded off the same launch; every later one is a warm
-    // click and always goes through.
-    private static int _toastCallbackIsFirst = 1;
-
     private void OnToastNotificationInvoked(
         Microsoft.Windows.AppNotifications.AppNotificationManager sender,
         Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs args)
     {
         try
         {
-            var activation = Ghostty.Core.Activation.ToastActivation
-                .FromNotificationArguments(args.Arguments);
-
-            // Interlocked because this runs on a WinRT callback thread while
-            // the probe runs on the startup thread, and the whole point is
-            // that their order is not knowable.
-            if (System.Threading.Interlocked.Exchange(ref _toastCallbackIsFirst, 0) == 1)
-            {
-                ToastActivations.TryNoteLaunchActivation(activation);
-                return;
-            }
-
-            ToastActivations.Note(activation);
+            // Every callback goes through the same door as the probe, and the
+            // relay decides. This one used to keep its own "is this the first
+            // callback" flag, which encoded ordinal position rather than
+            // identity: when the shell handed the launch click over only via
+            // the activation arguments, the user's next real click was the
+            // first callback and got swallowed. The relay dedupes on what the
+            // click IS, and nothing here needs to guess.
+            ToastActivations.TryNoteLaunchActivation(
+                Ghostty.Core.Activation.ToastActivation.FromNotificationArguments(
+                    args.Arguments));
         }
         catch (System.Exception ex)
         {

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -75,8 +75,9 @@ internal static class LogEvents
     // 2700-2799: Notifications
     internal static class Notifications
     {
-        public const int ShowFailed  = 2701;
-        public const int ClearFailed = 2702;
+        public const int ShowFailed       = 2701;
+        public const int ClearFailed      = 2702;
+        public const int ActivationFailed = 2703;
     }
 
     // 2800-2899: Session restoration

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -75,8 +75,8 @@ internal static class LogEvents
     // 2700-2799: Notifications
     internal static class Notifications
     {
-        public const int ShowFailed       = 2701;
-        public const int ClearFailed      = 2702;
+        public const int ShowFailed  = 2701;
+        public const int ClearFailed = 2702;
         public const int ActivationFailed = 2703;
     }
 

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -78,6 +78,7 @@ internal static class LogEvents
         public const int ShowFailed  = 2701;
         public const int ClearFailed = 2702;
         public const int ActivationFailed = 2703;
+        public const int DetachFailed = 2704;
     }
 
     // 2800-2899: Session restoration
@@ -97,6 +98,7 @@ internal static class LogEvents
         public const int MutexFailed       = 2903;
         public const int ForwardFailed     = 2904;
         public const int ServerStartFailed = 2905;
+        public const int InboundLaunchFailed = 2906;
     }
 
     // 3000-3099: Inspector

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1048,6 +1048,44 @@ public sealed partial class MainWindow : Window
     internal void ActivateAfterPlacement() => Activate();
 
     /// <summary>
+    /// Bring the surface a toast was raised for back in front of the user.
+    /// Returns false when no pane in this window carries
+    /// <paramref name="surfaceKey"/>, so the caller can try the next window
+    /// and ultimately fall back to plain activation.
+    ///
+    /// Keyed on <see cref="TerminalControl.ToastSurfaceKey"/> -- the same key
+    /// the toast was grouped under and the same one focus-regain clears by --
+    /// rather than the native surface handle, which can be recycled onto a
+    /// different surface between raising a toast and clicking it.
+    /// UI-thread only.
+    /// </summary>
+    internal bool TryFocusToastSurface(string surfaceKey)
+    {
+        foreach (var tab in _tabManager.Tabs)
+        {
+            var paneHost = (PaneHost)tab.PaneHost;
+            foreach (var leaf in PaneTree.Leaves(paneHost.RootNode))
+            {
+                var terminal = leaf.Terminal();
+                if (!string.Equals(terminal.ToastSurfaceKey, surfaceKey, StringComparison.Ordinal))
+                    continue;
+
+                // Tab first, then window, then pane: selecting the tab after
+                // activating would show the user the old tab for a frame, and
+                // focusing the pane before its tab is on screen puts focus on
+                // a collapsed PaneHost.
+                _tabManager.Activate(tab);
+                if (!AppWindow.IsVisible) AppWindow.Show();
+                Activate();
+                terminal.Focus(FocusState.Programmatic);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Jump-list / single-instance "New Tab". Resolves
     /// <paramref name="profileId"/> (or the registry default) when
     /// possible; otherwise opens a tab with no snapshot. Must never

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1048,6 +1048,14 @@ public sealed partial class MainWindow : Window
     internal void ActivateAfterPlacement() => Activate();
 
     /// <summary>
+    /// Whether a pane in this window carries <paramref name="surfaceKey"/>.
+    /// Read-only, so a caller can decide whether a toast click is honourable
+    /// here before committing to honouring it. UI-thread only.
+    /// </summary>
+    internal bool HasToastSurface(string surfaceKey)
+        => FindToastSurface(surfaceKey) is not null;
+
+    /// <summary>
     /// Bring the surface a toast was raised for back in front of the user.
     /// Returns false when no pane in this window carries
     /// <paramref name="surfaceKey"/>, so the caller can try the next window
@@ -1061,28 +1069,58 @@ public sealed partial class MainWindow : Window
     /// </summary>
     internal bool TryFocusToastSurface(string surfaceKey)
     {
+        if (FindToastSurface(surfaceKey) is not { } found) return false;
+
+        _tabManager.Activate(found.Tab);
+        RevealForActivation();
+        Activate();
+
+        // Deferred, not inline. The tab swap and the activation both rebuild
+        // the visual tree, and the target control is not guaranteed to be
+        // realized in this turn -- Focus on an unrealized element silently
+        // does nothing and the user gets a window with no keyboard target.
+        // Every other focus-after-layout site in this window defers for the
+        // same reason.
+        DispatcherQueue.TryEnqueue(
+            () => found.Terminal.Focus(FocusState.Programmatic));
+        return true;
+    }
+
+    private (TabModel Tab, TerminalControl Terminal)? FindToastSurface(string surfaceKey)
+    {
         foreach (var tab in _tabManager.Tabs)
         {
-            var paneHost = (PaneHost)tab.PaneHost;
-            foreach (var leaf in PaneTree.Leaves(paneHost.RootNode))
+            foreach (var leaf in PaneTree.Leaves(tab.PaneHost.RootNode))
             {
                 var terminal = leaf.Terminal();
-                if (!string.Equals(terminal.ToastSurfaceKey, surfaceKey, StringComparison.Ordinal))
-                    continue;
-
-                // Tab first, then window, then pane: selecting the tab after
-                // activating would show the user the old tab for a frame, and
-                // focusing the pane before its tab is on screen puts focus on
-                // a collapsed PaneHost.
-                _tabManager.Activate(tab);
-                if (!AppWindow.IsVisible) AppWindow.Show();
-                Activate();
-                terminal.Focus(FocusState.Programmatic);
-                return true;
+                if (string.Equals(terminal.ToastSurfaceKey, surfaceKey, StringComparison.Ordinal))
+                    return (tab, terminal);
             }
         }
 
-        return false;
+        return null;
+    }
+
+    /// <summary>
+    /// Put this window on screen for something other than a user gesture.
+    /// </summary>
+    private void RevealForActivation()
+    {
+        if (IsQuickTerminal)
+        {
+            // Show() is the quick terminal's only legal reveal: it re-derives
+            // the position for the current monitor, seeds and runs the
+            // clip/slide reveal, and arms autohide. A bare AppWindow.Show()
+            // leaves the last animation frame applied -- fully clipped, or at
+            // opacity 0 -- so the window would take keyboard focus while the
+            // user sees nothing and types into an invisible terminal. Skipped
+            // when it is already shown and not sliding out, where the reveal
+            // would only re-run its animation over itself.
+            if (!AppWindow.IsVisible || _hiding) Show();
+            return;
+        }
+
+        if (!AppWindow.IsVisible) AppWindow.Show();
     }
 
     /// <summary>

--- a/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
+++ b/windows/Ghostty/Notifications/AppNotificationToastNotifier.cs
@@ -12,8 +12,10 @@ namespace Ghostty.Notifications;
 /// plus a per-surface Group (the surface key): Windows replaces a toast when
 /// both match, so a newer toast for a surface supersedes the older one, and
 /// <see cref="ClearForSurface"/> removes a surface's toast by group on focus
-/// regain. Every call is guarded -- a toast failure must never propagate back
-/// through GhosttyHost into the libghostty callback.
+/// regain. The same surface key also travels in the toast's launch arguments,
+/// which is the only part of it a click can read back. Every call is guarded
+/// -- a toast failure must never propagate back through GhosttyHost into the
+/// libghostty callback.
 /// </summary>
 internal sealed class AppNotificationToastNotifier : IToastNotifier
 {
@@ -36,6 +38,19 @@ internal sealed class AppNotificationToastNotifier : IToastNotifier
             var builder = new AppNotificationBuilder();
             if (!string.IsNullOrEmpty(request.Title)) builder.AddText(request.Title);
             builder.AddText(request.Body);
+
+            // Name the surface in the toast's launch arguments. Group already
+            // carries it, but Group is only readable by us for replace/remove;
+            // the activation callback sees arguments and nothing else, so
+            // without this a click knows the app was clicked and not which
+            // pane asked for attention.
+            if (!string.IsNullOrEmpty(request.SurfaceKey))
+            {
+                builder.AddArgument(
+                    Ghostty.Core.Activation.ToastActivation.SurfaceArgumentKey,
+                    request.SurfaceKey);
+            }
+
             var notification = builder.BuildNotification();
             notification.Tag = NotificationTag;
             notification.Group = request.SurfaceKey;


### PR DESCRIPTION
Clicking a notification this app raises did nothing useful. Nothing subscribed `NotificationInvoked`, and the toasts carried no payload, so the shell COM-activated the app and the click was dropped. Separately, the `--uri` fallback sat inside the same `try` as `GetActivatedEventArgs()`, so a throw from the WinRT call skipped the fallback that exists to cover it.

Four changes:

- The argv scan moves out of the `try`. A real protocol activation still wins over an argv value.
- A `NotificationInvoked` handler is attached before the existing `Register()`. WinAppSDK throws from the add-handler path once the COM activator is registered, and picks a single-use class registration when no handler is attached at that moment.
- Terminal notifications carry their surface key, and a click focuses that surface. Gone surfaces fall back to plain activation.
- The activation probe reads `AppNotification` as well as `Protocol`, and moves above the single-instance gate. A secondary exits at that gate, so anything read after it never reaches the process that forwards.

`ToastActivationRelay` holds the latch, replay and fan-out so it is testable outside the app assembly. It dedupes the launch click on identity rather than arrival order, because whether the shell redelivers a launch click through the callback is not knowable from here and the design has to hold either way.

## What is not verified

Every cold path needs a packaged, installed build: whether `NotificationInvoked` fires, whether the COM class registers multi-use, whether `AddArgument` survives the round trip through the OS, and whether the quake reveal paints. The wiring tests assert that calls exist in the right order, not that they behave. A change that keeps the shape and breaks the behaviour passes all of them.

One trade is deliberate. If the shell redelivers the launch click after the first subscriber exists, that click is delivered twice: a redundant activate and a focus on the pane that already has it. A dead click is worse than a cosmetic one, and every redelivery landing during startup is still caught by the identity check.

## Tests

2143 passing, up from 2057. Reverting the four shell files while keeping the tests fails 17.

`activationUri` is assigned and never read in this repository. It is not dead - a downstream build tier consumes it, and that is the live path behind deep links and the jump list.

Closes # 319. Part of # 317.
