### PR TITLE
windows: give gradient point handles a name and a pattern

### DIFF
--- a/windows/Ghostty.Core/Settings/GradientPointsLogic.cs
+++ b/windows/Ghostty.Core/Settings/GradientPointsLogic.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Ghostty.Core.Settings;
 
@@ -8,10 +10,87 @@ namespace Ghostty.Core.Settings;
 /// Ghostty.Core so it can be unit-tested without a XAML test host.
 /// All coordinates are in normalized [0,1] canvas space.
 /// </summary>
-public static class GradientPointsLogic
+public static partial class GradientPointsLogic
 {
     public static (float X, float Y) Clamp(float x, float y) =>
         (Math.Clamp(x, 0f, 1f), Math.Clamp(y, 0f, 1f));
+
+    /// <summary>
+    /// A whole written position, anchored end to end: either the spoken
+    /// form ("35% across, 60% down") or the bare pair ("35, 60").
+    ///
+    /// Anchored, and not "the first two numbers anywhere", because this is
+    /// the only check between a client and a config write. Scanning loosely
+    /// makes the round-trip a client is most likely to attempt -
+    /// SetValue(element.Name) - parse "Gradient point 1 of 4" as 1% and 4%
+    /// and silently move the point. It also makes a decimal-comma locale's
+    /// "12,5, 87,5" land on 12% and 5% instead of being refused, which is
+    /// the worse of the two failures.
+    /// </summary>
+    [GeneratedRegex(
+        @"^\s*(-?\d+(?:\.\d+)?)\s*%?\s*(?:across)?\s*,\s*(-?\d+(?:\.\d+)?)\s*%?\s*(?:down)?\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex PositionFormat();
+
+    /// <summary>Longest string that could still be a written position.</summary>
+    private const int MaxPositionLength = 64;
+
+    /// <summary>
+    /// What a client hears when focus lands on a handle. The ordinal
+    /// carries it: the points are otherwise indistinguishable by name.
+    /// </summary>
+    public static string DescribeHandle(int index, int total) =>
+        string.Format(CultureInfo.InvariantCulture, "Gradient point {0} of {1}", index + 1, total);
+
+    /// <summary>
+    /// A position spoken rather than plotted. "Across" and "down" beat
+    /// "X" and "Y" out loud, and whole percents beat four decimals.
+    ///
+    /// Invariant on both sides: this string is a round-trip channel for a
+    /// client, not prose, so it has to parse back under any culture.
+    /// AwayFromZero so 34.5% and 35.5% round the same direction; banker's
+    /// rounding would send one up and the other down.
+    /// </summary>
+    public static string DescribePosition(float x, float y) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}% across, {1}% down",
+            Percent(x),
+            Percent(y));
+
+    private static int Percent(float v) =>
+        (int)Math.Round(Math.Clamp(v, 0f, 1f) * 100, MidpointRounding.AwayFromZero);
+
+    /// <summary>
+    /// Read a position a client wrote back. Out-of-range numbers clamp
+    /// rather than fail - a client asking for 150% wants the edge - but a
+    /// string that is not a position at all is refused outright.
+    /// </summary>
+    public static bool TryParsePosition(string? text, out float x, out float y)
+    {
+        x = 0f;
+        y = 0f;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+
+        // The pattern has several optional runs of whitespace in a row, so a
+        // long failing input costs quadratic backtracking. SetValue is an
+        // arbitrary-string entry point any process on the desktop can reach,
+        // and it runs on the settings window's UI thread; a real position is
+        // a couple of dozen characters.
+        if (text.Length > MaxPositionLength) return false;
+
+        var match = PositionFormat().Match(text);
+        if (!match.Success) return false;
+
+        if (!double.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var px) ||
+            !double.TryParse(match.Groups[2].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var py))
+        {
+            return false;
+        }
+
+        (x, y) = Clamp((float)(px / 100.0), (float)(py / 100.0));
+        return true;
+    }
 
     /// <summary>
     /// Returns the index of the topmost point whose center lies within

--- a/windows/Ghostty.Tests/Settings/GradientPointHandleAutomationTests.cs
+++ b/windows/Ghostty.Tests/Settings/GradientPointHandleAutomationTests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Settings;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+/// <summary>
+/// The gradient drag handles were bare ContentControls: focusable by
+/// keyboard, and absent from the UI Automation tree entirely, so nothing
+/// reading the window could name them, read where they sat, or move them.
+///
+/// The vocabulary a client round-trips is pure and tested directly. The
+/// wiring that gives the handles an identity lives in WinUI types this
+/// project cannot reference, so it is scanned out of the shipped source -
+/// the same fallback StripCloseAutomationTests uses, and for the same
+/// reason: that file shipped once as bare title text, silently dropping
+/// the close button, while its own assertions still passed.
+/// </summary>
+public class GradientPointHandleAutomationTests
+{
+    [Fact]
+    public void Handle_IsNamedByItsOrdinal_OneBased()
+    {
+        Assert.Equal("Gradient point 1 of 4", GradientPointsLogic.DescribeHandle(0, 4));
+        Assert.Equal("Gradient point 4 of 4", GradientPointsLogic.DescribeHandle(3, 4));
+    }
+
+    /// <summary>
+    /// Spoken, not plotted: whole percents, and words a listener can place
+    /// on a canvas without seeing it.
+    /// </summary>
+    [Theory]
+    [InlineData(0f, 0f, "0% across, 0% down")]
+    [InlineData(0.5f, 0.5f, "50% across, 50% down")]
+    [InlineData(1f, 1f, "100% across, 100% down")]
+    [InlineData(0.36f, 0.6f, "36% across, 60% down")]
+    public void Position_ReadsAsWholePercents(float x, float y, string expected)
+    {
+        Assert.Equal(expected, GradientPointsLogic.DescribePosition(x, y));
+    }
+
+    /// <summary>
+    /// Both halves of a percent round the same way. Banker's rounding sends
+    /// 34.5 down and 35.5 up, which reads as a display bug from the outside.
+    /// </summary>
+    [Fact]
+    public void Position_RoundsHalvesAwayFromZero()
+    {
+        Assert.Equal("35% across, 36% down", GradientPointsLogic.DescribePosition(0.345f, 0.355f));
+    }
+
+    [Fact]
+    public void Position_ClampsBeforeDescribing()
+    {
+        Assert.Equal("0% across, 100% down", GradientPointsLogic.DescribePosition(-0.4f, 1.8f));
+    }
+
+    [Theory]
+    [InlineData("80, 20", 0.8f, 0.2f)]
+    [InlineData("80% across, 20% down", 0.8f, 0.2f)]
+    [InlineData("80%, 20%", 0.8f, 0.2f)]
+    [InlineData("  12.5 , 87.5  ", 0.125f, 0.875f)]
+    public void BarePairsAndSpokenForm_BothParse(string text, float x, float y)
+    {
+        Assert.True(GradientPointsLogic.TryParsePosition(text, out var px, out var py));
+        Assert.Equal(x, px, 3);
+        Assert.Equal(y, py, 3);
+    }
+
+    /// <summary>
+    /// A client asking for somewhere off the canvas wants the edge, not an
+    /// exception: SetValue has no way to report a partial success.
+    /// </summary>
+    [Fact]
+    public void OutOfRangeRequests_ClampToTheCanvas()
+    {
+        Assert.True(GradientPointsLogic.TryParsePosition("150, -20", out var x, out var y));
+        Assert.Equal(1f, x);
+        Assert.Equal(0f, y);
+    }
+
+    /// <summary>
+    /// The parse is the only thing between a client and a config write, so
+    /// it matches a whole position or nothing. Scanning for "the first two
+    /// numbers anywhere" would make SetValue(element.Name) - the round-trip
+    /// a client is most likely to try - read "Gradient point 1 of 4" as 1%
+    /// and 4% and move the point. A decimal-comma locale's "12,5, 87,5" has
+    /// to be refused for the same reason: parsing it as 12 and 5 is a wrong
+    /// answer where a refusal is a safe one.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("middle")]
+    [InlineData("50")]
+    [InlineData("Gradient point 1 of 4")]
+    [InlineData("12,5, 87,5")]
+    [InlineData("10, 20, 30")]
+    [InlineData("1e2, 50")]
+    public void AnythingThatIsNotAWholePosition_IsRefused(string? text)
+    {
+        Assert.False(GradientPointsLogic.TryParsePosition(text, out _, out _));
+    }
+
+    /// <summary>
+    /// Reading a position and writing it straight back must not move the
+    /// point. Asserted on the parsed coordinates, not on a re-description:
+    /// re-describing an already-quantized value is green however coarse the
+    /// quantization gets.
+    /// </summary>
+    [Fact]
+    public void SpokenPosition_RoundTripsToTheSameCoordinates()
+    {
+        var spoken = GradientPointsLogic.DescribePosition(0.35f, 0.6f);
+        Assert.True(GradientPointsLogic.TryParsePosition(spoken, out var x, out var y));
+        Assert.Equal(0.35f, x, 4);
+        Assert.Equal(0.6f, y, 4);
+    }
+
+    /// <summary>
+    /// A bare ContentControl produces no automation element at all, so the
+    /// handles were unreachable rather than merely unnamed. Reverting the
+    /// subclass is the regression this exists to catch.
+    /// </summary>
+    [Fact]
+    public void Canvas_BuildsHandlesThatHaveAPeer()
+    {
+        var editor = Source("GradientPointsEditor.xaml.cs");
+        Assert.Contains("new GradientPointHandle", editor);
+        Assert.DoesNotContain("new ContentControl", editor);
+
+        var handle = Source("GradientPointHandle.cs");
+        Assert.Contains("OnCreateAutomationPeer", handle);
+        Assert.Contains("GradientPointHandleAutomationPeer", handle);
+    }
+
+    /// <summary>
+    /// RenderCanvas clears every child, so an arrow key that rebuilds the
+    /// canvas destroys the handle holding focus and the next key press goes
+    /// nowhere. MovePoint is the in-place update drag already used.
+    ///
+    /// The whole handler is scanned bar the Delete case, whose rebuild is
+    /// legitimate: a window that stopped at the switch would miss a
+    /// RenderCanvas re-added next to MovePoint, which is where it used to be.
+    /// </summary>
+    [Fact]
+    public void ArrowKeys_MoveInPlace_SoFocusSurvives()
+    {
+        var keyDown = Between(
+            Source("GradientPointsEditor.xaml.cs"),
+            "handle.KeyDown +=",
+            "handle.PositionRequested =");
+
+        Assert.Contains("MovePoint(capturedIndex)", keyDown);
+
+        // Cut out the Delete arm, whose rebuild is legitimate, and require the
+        // whole rest of the handler to be free of it. Windowing on landmarks
+        // instead leaves gaps: a RenderCanvas re-added just above MovePoint
+        // sat between two of them and went unnoticed.
+        var deleteCase = Between(keyDown, "VirtualKey.Delete", "return;");
+        Assert.DoesNotContain("RenderCanvas()", keyDown.Replace(deleteCase, string.Empty));
+    }
+
+    /// <summary>
+    /// A client keeps its provider across a canvas rebuild. Trusting the
+    /// index the handle was built with would move whichever point now sits
+    /// at that index, so the resolved index has to be the one that is used.
+    /// </summary>
+    [Fact]
+    public void ClientWrites_ResolveTheHandleByIdentity()
+    {
+        var requested = Between(
+            Source("GradientPointsEditor.xaml.cs"),
+            "handle.PositionRequested =",
+            "handle.PointerPressed +=");
+
+        Assert.Contains("_handles.IndexOf(h)", requested);
+        Assert.Contains("_points[live] = point with", requested);
+        // The snapshot index must not be what the write lands on.
+        Assert.DoesNotContain("_points[h.Index]", requested);
+        Assert.Contains("_dragIndex != -1", requested);
+    }
+
+    /// <summary>
+    /// Both refusals return early, so without a signal a client reads back
+    /// the old value believing its write landed.
+    /// </summary>
+    [Fact]
+    public void RefusedWrites_ReachTheClient()
+    {
+        var requested = Between(
+            Source("GradientPointsEditor.xaml.cs"),
+            "handle.PositionRequested =",
+            "handle.PointerPressed +=");
+        Assert.Contains("return false", requested);
+
+        var peer = Source("GradientPointHandleAutomationPeer.cs");
+        Assert.Contains("throw new InvalidOperationException", peer);
+        Assert.Contains("throw new ElementNotEnabledException", peer);
+    }
+
+    /// <summary>
+    /// Removing a row destroys the button that was clicked, and this diff is
+    /// what made that button a named, tabbable target in the first place.
+    /// </summary>
+    [Fact]
+    public void RemovingARow_LandsFocusSomewhere()
+    {
+        var click = Between(
+            Source("GradientPointsEditor.xaml.cs"),
+            "remove.Click +=",
+            "row.Children.Add(remove)");
+        Assert.Contains("FocusHandle(", click);
+
+        // The fallback is what keeps focus off the floor when the deleted
+        // point had no neighbour.
+        var focus = Between(
+            Source("GradientPointsEditor.xaml.cs"),
+            "private void FocusHandle(",
+            "private void MovePoint(");
+        Assert.Contains("AddPointButton.Focus", focus);
+    }
+
+    /// <summary>
+    /// Every raise crosses the UIA boundary whether or not anyone advised,
+    /// and a drag reaches it once per whole percent crossed.
+    /// </summary>
+    [Fact]
+    public void ValueChanges_AreRaisedOnlyWhenSomeoneIsListening()
+    {
+        var peer = Source("GradientPointHandleAutomationPeer.cs");
+        Assert.Contains("ListenerExists(AutomationEvents.PropertyChanged)", peer);
+    }
+
+    private static string Between(string source, string start, string end)
+    {
+        var from = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"'{start}' not found");
+        var to = source.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"'{end}' not found after '{start}'");
+        return source[from..to];
+    }
+
+    /// <summary>
+    /// Read the shipped source with every comment removed, so no assertion
+    /// here can be satisfied - or defeated - by prose naming the same thing.
+    /// Block comments and trailing // count: a revert that leaves
+    /// "// was: new GradientPointHandle" behind is the shape to see through.
+    /// </summary>
+    private static string Source(string suffix) => StripComments(ReadEmbedded(suffix));
+
+    private static string StripComments(string source)
+    {
+        var withoutBlocks = Regex.Replace(source, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        var lines = withoutBlocks.Split('\n').Select(line =>
+        {
+            var slash = line.IndexOf("//", StringComparison.Ordinal);
+            return slash >= 0 ? line[..slash] : line;
+        });
+        return string.Join('\n', lines);
+    }
+
+    /// <summary>
+    /// These ride the Ghostty\**\*.cs glob that MarshalComplianceTests
+    /// declares; they need no entry of their own, and adding one would be a
+    /// duplicate-item error.
+    /// </summary>
+    private static string ReadEmbedded(string suffix)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty/Accessibility/GradientPointHandleAutomationPeer.cs
+++ b/windows/Ghostty/Accessibility/GradientPointHandleAutomationPeer.cs
@@ -1,0 +1,113 @@
+using System;
+using Ghostty.Controls.Settings;
+using Ghostty.Core.Settings;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// UIA peer for a gradient point handle. Reports the handle as a Thumb -
+/// the control type for something a user drags - names it by its ordinal,
+/// and carries its position through the Value pattern.
+///
+/// Value rather than RangeValue: a gradient point is two coordinates, and
+/// RangeValue is one number. Rather than pick an axis and leave the other
+/// unreachable, the whole position is one readable string that a client can
+/// also write back.
+/// </summary>
+internal sealed partial class GradientPointHandleAutomationPeer
+    : FrameworkElementAutomationPeer, IValueProvider
+{
+    private readonly GradientPointHandle _owner;
+
+    internal GradientPointHandleAutomationPeer(GradientPointHandle owner)
+        : base(owner) => _owner = owner;
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+        => AutomationControlType.Thumb;
+
+    protected override string GetClassNameCore() => nameof(GradientPointHandle);
+
+    /// <summary>
+    /// NVDA reads the raw type as "thumb control", which says how it is
+    /// operated and not what it is.
+    /// </summary>
+    protected override string GetLocalizedControlTypeCore() => "gradient point";
+
+    protected override string GetNameCore()
+    {
+        var explicitName = base.GetNameCore();
+        return string.IsNullOrEmpty(explicitName) ? _owner.AccessibleName : explicitName;
+    }
+
+    /// <summary>
+    /// Neither key is discoverable from the canvas, and the visible hint
+    /// above it mentions only the mouse.
+    /// </summary>
+    protected override string GetHelpTextCore() =>
+        "Arrow keys move the point. Delete removes it.";
+
+    protected override string GetAutomationIdCore() => $"GradientPoint{_owner.Index + 1}";
+
+    protected override object GetPatternCore(PatternInterface patternInterface)
+        => patternInterface == PatternInterface.Value
+            ? this
+            : base.GetPatternCore(patternInterface);
+
+    /// <summary>
+    /// IValueProvider ties writability to the element being enabled, and a
+    /// client checks this before it bothers calling SetValue.
+    /// </summary>
+    public bool IsReadOnly => !IsEnabled();
+
+    public string Value => _owner.PositionText;
+
+    /// <summary>
+    /// Accepts a whole written position: the spoken form ("35% across, 60%
+    /// down") or a bare pair ("35, 60"). Anything else throws, because the
+    /// parse is the only thing between a client and a config write.
+    ///
+    /// Out-of-range numbers clamp rather than throw - a client asking for
+    /// 150% wants the edge - but a disabled element, an unreadable value, or
+    /// a request the editor refuses all surface as exceptions. Returning
+    /// quietly would leave a client believing a move it can never observe.
+    /// </summary>
+    public void SetValue(string value)
+    {
+        if (!IsEnabled()) throw new ElementNotEnabledException();
+
+        if (!GradientPointsLogic.TryParsePosition(value, out var x, out var y))
+            throw new ArgumentException(
+                $"'{value}' is not a gradient point position.", nameof(value));
+
+        // Writing the exact position back is a no-op, not a move. Compared on
+        // coordinates and not on the spoken text: the text is whole percents,
+        // so comparing it would also swallow a deliberate snap from 35.2% to
+        // 35%, which is a real move a client is likely to ask for.
+        if (x == _owner.X && y == _owner.Y) return;
+
+        if (!_owner.RequestPosition(x, y))
+            throw new InvalidOperationException(
+                "The gradient point could not be moved: the handle is no longer "
+                + "on the canvas, or a drag is in progress.");
+    }
+
+    /// <summary>
+    /// Raise the change so a client polling nothing still hears the move.
+    /// Dragging, arrow keys and SetValue all land here.
+    /// </summary>
+    internal void NotifyValueChanged(string oldPosition, string newPosition)
+    {
+        if (oldPosition == newPosition) return;
+
+        // Gated like TerminalAutomationPeer's raises: a raise with nobody
+        // advised still crosses the UIA boundary, and a drag reaches here
+        // once per whole percent it crosses.
+        if (!ListenerExists(AutomationEvents.PropertyChanged)) return;
+
+        RaisePropertyChangedEvent(
+            ValuePatternIdentifiers.ValueProperty, oldPosition, newPosition);
+    }
+}

--- a/windows/Ghostty/Controls/Settings/GradientPointHandle.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointHandle.cs
@@ -1,0 +1,68 @@
+using System;
+using Ghostty.Accessibility;
+using Ghostty.Core.Settings;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Ghostty.Controls.Settings;
+
+/// <summary>
+/// One draggable point on the gradient canvas.
+///
+/// A plain <see cref="ContentControl"/> is still the right base: Button's
+/// internal pointer template steals PointerPressed before the editor's drag
+/// handler can run. But a bare ContentControl produces no automation element
+/// at all, so the handles were absent from the UIA tree entirely - focusable
+/// by keyboard, and invisible to anything reading the window. This subclass
+/// exists to give them a peer.
+/// </summary>
+internal sealed partial class GradientPointHandle : ContentControl
+{
+    private GradientPointHandleAutomationPeer? _peer;
+
+    /// <summary>Zero-based position of this point in the editor's list.</summary>
+    internal int Index { get; set; }
+
+    /// <summary>How many points the editor currently has.</summary>
+    internal int Total { get; set; }
+
+    /// <summary>Normalized 0..1 position across the canvas.</summary>
+    internal float X { get; set; }
+
+    /// <summary>Normalized 0..1 position down the canvas.</summary>
+    internal float Y { get; set; }
+
+    /// <summary>
+    /// Asked when a client requests a new position through the Value
+    /// pattern. Coordinates are normalized and clamped. Returns false when
+    /// the editor refuses - the handle is no longer on the canvas, or a
+    /// drag is in flight - so the peer can tell the client rather than
+    /// return a success it did not deliver.
+    /// </summary>
+    internal Func<GradientPointHandle, float, float, bool>? PositionRequested;
+
+    /// <summary>What a client hears when focus lands here.</summary>
+    internal string AccessibleName => GradientPointsLogic.DescribeHandle(Index, Total);
+
+    /// <summary>The position, spoken rather than plotted.</summary>
+    internal string PositionText => GradientPointsLogic.DescribePosition(X, Y);
+
+    internal bool RequestPosition(float x, float y) =>
+        PositionRequested?.Invoke(this, x, y) ?? false;
+
+    /// <summary>
+    /// Whether a peer has ever been asked for. Formatting a position costs
+    /// a string, and the drag path runs this per pointer sample.
+    /// </summary>
+    internal bool HasAutomationPeer => _peer is not null;
+
+    /// <summary>
+    /// Tell any listening client the point moved. Called after a drag, an
+    /// arrow key, or a client's own SetValue, so all three routes announce.
+    /// </summary>
+    internal void NotifyPositionChanged(string oldPosition) =>
+        _peer?.NotifyValueChanged(oldPosition, PositionText);
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+        => _peer ??= new GradientPointHandleAutomationPeer(this);
+}

--- a/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
+++ b/windows/Ghostty/Controls/Settings/GradientPointsEditor.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Ghostty.Core.Settings;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Shapes;
@@ -38,7 +39,7 @@ public sealed partial class GradientPointsEditor : UserControl
     // _points. RenderCanvas clears and repopulates these. MovePoint
     // mutates existing instances in place so pointer capture survives.
     private readonly List<Microsoft.UI.Xaml.Shapes.Ellipse> _falloffs = new();
-    private readonly List<Microsoft.UI.Xaml.UIElement> _handles = new();
+    private readonly List<GradientPointHandle> _handles = new();
 
     public event EventHandler<IReadOnlyList<GradientPointModel>>? PointsChanged;
 
@@ -157,32 +158,53 @@ public sealed partial class GradientPointsEditor : UserControl
             });
         row.Children.Add(picker);
 
-        row.Children.Add(BuildNumberBox("X", _points[index].X, v =>
+        // The headers are one letter each, so out of five identical rows a
+        // client hears "X" ten times with nothing to tell the rows apart.
+        // The visible header stays terse; the spoken name carries the row.
+        //
+        // The range is spoken too, because the handle on the canvas reports
+        // the same axis in percent: without it, a client can read 0.5 here
+        // and write it to the handle, landing the point on 0.5%.
+        var point = GradientPointsLogic.DescribeHandle(index, _points.Count);
+
+        var xBox = BuildNumberBox("X", _points[index].X, v =>
         {
             var p = _points[index];
             _points[index] = p with { X = (float)v };
-        }));
-        row.Children.Add(BuildNumberBox("Y", _points[index].Y, v =>
+        });
+        AutomationProperties.SetName(xBox, $"{point} across, 0 to 1");
+        row.Children.Add(xBox);
+        var yBox = BuildNumberBox("Y", _points[index].Y, v =>
         {
             var p = _points[index];
             _points[index] = p with { Y = (float)v };
-        }));
-        row.Children.Add(BuildNumberBox("R", _points[index].Radius, v =>
+        });
+        AutomationProperties.SetName(yBox, $"{point} down, 0 to 1");
+        row.Children.Add(yBox);
+        var rBox = BuildNumberBox("R", _points[index].Radius, v =>
         {
             var p = _points[index];
             _points[index] = p with { Radius = (float)v };
-        }));
+        });
+        AutomationProperties.SetName(rBox, $"{point} radius, 0 to 1");
+        row.Children.Add(rBox);
 
         var remove = new Button
         {
             Content = "\u2715",
             Padding = new Thickness(6, 2, 6, 2),
         };
+        // Content is a glyph, so the implicit name is the glyph.
+        AutomationProperties.SetName(remove, $"Remove {point.ToLowerInvariant()}");
+        ToolTipService.SetToolTip(remove, $"Remove {point.ToLowerInvariant()}");
         remove.Click += (_, _) =>
         {
             _points.RemoveAt(index);
             RenderCanvas();
+            // RebuildRows clears the panel, so the button that was just
+            // clicked goes with it. Same landing as the Delete key.
             RebuildRows();
+            FocusHandle(Math.Min(index, _points.Count - 1));
             RaisePointsChanged();
         };
         row.Children.Add(remove);
@@ -271,19 +293,20 @@ public sealed partial class GradientPointsEditor : UserControl
             _falloffs.Add(falloff);
 
             // Handle: a small circular drag target above the falloff.
-            // ContentControl (not Button) so Button's internal pointer template
-            // does not steal PointerPressed before our drag handler can run.
             // XY focus nav is disabled so Up/Down reach our KeyDown instead of
             // moving focus to the next control outside the canvas.
             var handleSize = HandleDiameter + 4;
-            var handle = new ContentControl
+            var handle = new GradientPointHandle
             {
                 Width = handleSize,
                 Height = handleSize,
                 Padding = new Microsoft.UI.Xaml.Thickness(0),
                 IsTabStop = true,
                 XYFocusKeyboardNavigation = XYFocusKeyboardNavigationMode.Disabled,
-                Tag = i,
+                Index = i,
+                Total = _points.Count,
+                X = p.X,
+                Y = p.Y,
                 Content = new Ellipse
                 {
                     Width = HandleDiameter,
@@ -320,16 +343,47 @@ public sealed partial class GradientPointsEditor : UserControl
                         _points.RemoveAt(capturedIndex);
                         RenderCanvas();
                         RebuildRows();
+                        // Before RaisePointsChanged: the focused handle went away
+                        // with the rest of the canvas. The write it triggers does
+                        // not re-seed the editor today (AppearancePage suppresses
+                        // the echo of its own writes), so this ordering is
+                        // insurance against that suppression going away.
+                        FocusHandle(Math.Min(capturedIndex, _points.Count - 1));
                         RaisePointsChanged();
                         e.Handled = true;
                         return;
                     default:
                         return;
                 }
-                RenderCanvas();
+                // MovePoint, not RenderCanvas: rebuilding the canvas destroys
+                // the handle that has focus, so the next arrow key would go
+                // nowhere. This is the same reason drag uses it.
+                MovePoint(capturedIndex);
+                AnnouncePosition(handle);
                 SyncRowNumbers(capturedIndex);
                 RaisePointsChanged();
                 e.Handled = true;
+            };
+            handle.PositionRequested = (h, nx, ny) =>
+            {
+                // Resolve the index by identity, not by the handle's own copy.
+                // RenderCanvas discards every handle on add, remove and row
+                // edit, and a client keeps its provider across that: trusting
+                // the stale index would move whichever point now sits there.
+                var live = _handles.IndexOf(h);
+                if (live < 0 || live >= _points.Count) return false;
+
+                // Same guard SetPoints uses: an external write landing mid-drag
+                // fights the pointer for the same point.
+                if (_dragIndex != -1) return false;
+
+                var point = _points[live];
+                _points[live] = point with { X = nx, Y = ny };
+                MovePoint(live);
+                AnnouncePosition(h);
+                SyncRowNumbers(live);
+                RaisePointsChanged();
+                return true;
             };
             handle.PointerPressed += (_, e) =>
             {
@@ -349,6 +403,7 @@ public sealed partial class GradientPointsEditor : UserControl
                 var cur = _points[capturedIndex];
                 _points[capturedIndex] = cur with { X = nx, Y = ny };
                 MovePoint(capturedIndex);
+                AnnouncePosition(handle);
                 SyncRowNumbers(capturedIndex);
                 RaisePointsChanged();
             };
@@ -364,6 +419,51 @@ public sealed partial class GradientPointsEditor : UserControl
             PointsCanvas.Children.Add(handle);
             _handles.Add(handle);
         }
+    }
+
+    /// <summary>
+    /// Carry a moved point back onto its handle and tell any listening
+    /// client. MovePoint moves the pixels; this moves what the handle
+    /// reports about itself, which is otherwise stale the moment the
+    /// canvas stops being rebuilt on every keystroke.
+    /// </summary>
+    private void AnnouncePosition(GradientPointHandle handle)
+    {
+        var index = _handles.IndexOf(handle);
+        if (index < 0 || index >= _points.Count) return;
+
+        // The drag path runs this per pointer sample, and describing a
+        // position costs a formatted string that nothing would read.
+        if (!handle.HasAutomationPeer)
+        {
+            var moved = _points[index];
+            handle.X = moved.X;
+            handle.Y = moved.Y;
+            return;
+        }
+
+        var before = handle.PositionText;
+        var p = _points[index];
+        handle.X = p.X;
+        handle.Y = p.Y;
+        handle.NotifyPositionChanged(before);
+    }
+
+    /// <summary>
+    /// Move keyboard focus to a handle by index. Measured to land on the
+    /// neighbouring handle after a delete; the fallback covers the cases that
+    /// have no neighbour to land on - the last point removed, or a canvas
+    /// that has not been arranged - rather than leaving focus nowhere.
+    /// </summary>
+    private void FocusHandle(int index)
+    {
+        if (index >= 0 && index < _handles.Count
+            && _handles[index].Focus(FocusState.Programmatic))
+        {
+            return;
+        }
+
+        AddPointButton.Focus(FocusState.Programmatic);
     }
 
     /// <summary>


### PR DESCRIPTION
The drag handles on the gradient canvas were bare `ContentControl`s. That produces no automation element at all, so they were absent from the UI Automation tree entirely: focusable by keyboard, and invisible to anything reading the window. Measured before the change, a client enumerating the settings window found all the point rows and zero handles. There was nothing to hang a name on, which is why this is not just a missing `AutomationProperties.SetName`.

They are now a `GradientPointHandle` with its own peer, reported as a Thumb, named by ordinal, and carrying position through the Value pattern.

Value rather than RangeValue: a gradient point is two coordinates and RangeValue is one number, so exposing one axis would leave the other unreachable. The whole position is one readable string a client can also write back.

The parse is the only thing between a client and a config write, so it matches a whole position or nothing. Scanning for "the first two numbers anywhere" made `SetValue(element.Name)` - the round-trip a client is most likely to try - read "Gradient point 1 of 4" as 1% and 4%, move the point, and persist it.

Three things found while reading, all fixed here because the requested behaviour does not work without them:

- Arrow keys called `RenderCanvas`, which clears every child and so destroys the handle holding focus. Keyboard editing stopped after a single press. They now use `MovePoint`, the in-place update drag already used for exactly this reason.
- Deleting a point, by key or by the row button, left focus on the floor. Both now land on a neighbouring handle, falling back to Add point when there is no neighbour.
- The row spinners were five identical "X"/"Y"/"R" and the remove buttons were a bare glyph. They now carry row-qualified names, including the 0-to-1 range, since the handle reports the same axis in percent.

Naming, formatting and parsing live in `GradientPointsLogic`, whose own doc comment says it exists to be unit-testable without a XAML host. The wiring cannot be reached from a net10.0 test assembly, so it is scanned out of the shipped source with comments stripped, and the guards are mutation-verified: reverting the subclass, re-adding `RenderCanvas` to the arrow path, or writing through the stale snapshot index each turn the suite red.

Verified by driving the built app through UI Automation, and by an NVDA transcript:

```
NVDA: 'Gradient point 1 of 2', 'thumb control', '50% across, 50% down'
after Right:  '51% across, 50% down'   (focus retained)
SetValue(element.Name) -> refused
SetValue(own value)    -> no-op
SetValue("80, 20")     -> '80% across, 20% down'
```