### PR TITLE
windows: rework the tab layout switch motion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ vgcore.*
 # WinUI mouse/AOT fuzz script outputs (screenshots, UIA dumps, JSON).
 windows/scripts/fuzz-out/
 windows/scripts/vtabs-layout-switch/
+windows/scripts/vtabs-morph/
+windows/scripts/vtabs-switcher/

--- a/windows/Ghostty/MainWindow.xaml
+++ b/windows/Ghostty/MainWindow.xaml
@@ -141,6 +141,16 @@
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"/>
 
+        <!--
+            Host for the active-tab morph ghost during a layout switch.
+            Spans both rows and columns so the ghost can travel between the
+            header lane and the sidebar rail in one coordinate space.
+        -->
+        <Canvas x:Name="TabMorphLayer"
+                Grid.Row="0" Grid.RowSpan="2"
+                Grid.Column="0" Grid.ColumnSpan="2"
+                IsHitTestVisible="False"/>
+
         <!-- Command palette popup overlay -->
         <Popup x:Name="CommandPalettePopup"
                IsLightDismissEnabled="True"

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -721,10 +721,8 @@ public sealed partial class MainWindow : Window
         _layout = new LayoutCoordinator(
             StripColumn,
             TitleBarStripMirror,
-            (FrameworkElement)_horizontalTabHost.HostElement,
             _verticalTabHost,
             VerticalTitleBar,
-            _horizontalTabHost.IconBadge,
             _horizontalTabHost,
             TabMorphLayer,
             RootGrid,
@@ -981,7 +979,17 @@ public sealed partial class MainWindow : Window
 
     private void AnimateTabLayoutTo(bool vertical)
     {
-        if (_layout.IsSwitching) return;
+        if (_layout.IsSwitching)
+        {
+            // A change landing inside the 340ms switch window (settings
+            // toggle, config file reload) must not be dropped: nothing
+            // would replay it and the UI would disagree with the config
+            // until the next unrelated reload. Remember the latest target
+            // and apply it when the running switch completes.
+            _pendingLayoutTarget = vertical;
+            return;
+        }
+        _pendingLayoutTarget = null;
         _verticalTabsVisible = vertical;
         _tabHost = vertical ? _verticalTabHost : _horizontalTabHost;
         // Paint caption/title chrome before the cross-fade so the OS
@@ -998,8 +1006,17 @@ public sealed partial class MainWindow : Window
             var leaf = _tabManager.ActiveTab?.PaneHost?.ActiveLeaf;
             if (leaf is not null)
                 leaf.Terminal().Focus(FocusState.Programmatic);
+
+            if (_pendingLayoutTarget is { } target)
+            {
+                _pendingLayoutTarget = null;
+                if (target != _verticalTabsVisible)
+                    AnimateTabLayoutTo(target);
+            }
         });
     }
+
+    private bool? _pendingLayoutTarget;
 
     /// <summary>
     /// Build a <see cref="MainWindow"/> that adopts an existing
@@ -1287,6 +1304,7 @@ public sealed partial class MainWindow : Window
         // before the first await below, so no theme callback fires after
         // teardown begins.
         _isClosed = true;
+        _layout.CancelStripPriming();
         _themeManager.Dispose();
 
         // Close the inspector window before any surface/host teardown below.
@@ -1922,15 +1940,17 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Opaque title-row fills for vertical-tab mode. Without this the
-    /// transparent drag region shows Mica grey over the terminal palette.
-    /// </summary>
-    /// <summary>
     /// Brief, subtle window shake when the layout-switch ghost lands: a
     /// damped nudge along its travel direction, as if the strip absorbed
     /// the impact. Skipped when the window is not a plain movable window
     /// (maximized, fullscreen, quake), where moving it would fight the
-    /// presenter.
+    /// presenter. An Aero-snapped window still reports Restored and will
+    /// take the nudge; there is no public API to tell it apart.
+    ///
+    /// Every step verifies the window still sits where the previous step
+    /// put it and bails otherwise: the awaited delays give the user ~80ms
+    /// to start dragging (or a snap assist to move the window), and a
+    /// blind restore would teleport the window back over their move.
     /// </summary>
     private async void NudgeWindowForImpact(double dx, double dy)
     {
@@ -1942,19 +1962,25 @@ public sealed partial class MainWindow : Window
         try
         {
             var origin = AppWindow.Position;
+            var expected = origin;
             foreach (var amplitude in ImpactAmplitudes)
             {
-                AppWindow.Move(new Windows.Graphics.PointInt32(
+                var current = AppWindow.Position;
+                if (current != expected) return;
+                expected = new Windows.Graphics.PointInt32(
                     origin.X + (int)(dx * amplitude),
-                    origin.Y + (int)(dy * amplitude)));
+                    origin.Y + (int)(dy * amplitude));
+                AppWindow.Move(expected);
                 await System.Threading.Tasks.Task.Delay(26);
             }
-            AppWindow.Move(origin);
+            if (AppWindow.Position == expected)
+                AppWindow.Move(origin);
         }
         catch (Exception)
         {
             // A presenter change mid-shake (user maximizes, monitor sleeps)
-            // can fail the move; the window simply stays where it is.
+            // can fail the move; the window stays wherever the last
+            // successful step left it, at most a few pixels from home.
         }
         finally
         {
@@ -1965,6 +1991,11 @@ public sealed partial class MainWindow : Window
     // Damped: one push in the travel direction, a smaller rebound, done.
     private static readonly int[] ImpactAmplitudes = [4, -2, 1];
     private bool _impactNudgeActive;
+
+    /// <summary>
+    /// Opaque title-row fills for vertical-tab mode. Without this the
+    /// transparent drag region shows Mica grey over the terminal palette.
+    /// </summary>
 
     private void ApplyVerticalTitleBarChrome()
     {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -724,8 +724,18 @@ public sealed partial class MainWindow : Window
             (FrameworkElement)_horizontalTabHost.HostElement,
             _verticalTabHost,
             VerticalTitleBar,
-            _horizontalTabHost.IconBadge);
+            _horizontalTabHost.IconBadge,
+            _horizontalTabHost,
+            TabMorphLayer,
+            RootGrid,
+            PaneHostContainer,
+            activeTab: () => _tabManager.Tabs.Count > 0 ? _tabManager.ActiveTab : null,
+            impact: NudgeWindowForImpact);
         _layout.Snap(_verticalTabsVisible);
+        // The strip that starts hidden has never realized its tab
+        // containers, so the first switch to it would have nothing for the
+        // active-tab morph to aim at.
+        _layout.PrimeHiddenStrip();
         ApplyVerticalTitleBarChrome();
         ApplyCaptionButtonChrome();
         if (_verticalTabsVisible)
@@ -1915,13 +1925,60 @@ public sealed partial class MainWindow : Window
     /// Opaque title-row fills for vertical-tab mode. Without this the
     /// transparent drag region shows Mica grey over the terminal palette.
     /// </summary>
+    /// <summary>
+    /// Brief, subtle window shake when the layout-switch ghost lands: a
+    /// damped nudge along its travel direction, as if the strip absorbed
+    /// the impact. Skipped when the window is not a plain movable window
+    /// (maximized, fullscreen, quake), where moving it would fight the
+    /// presenter.
+    /// </summary>
+    private async void NudgeWindowForImpact(double dx, double dy)
+    {
+        if (IsQuickTerminal) return;
+        if (AppWindow?.Presenter is not Microsoft.UI.Windowing.OverlappedPresenter
+            { State: Microsoft.UI.Windowing.OverlappedPresenterState.Restored }) return;
+        if (_impactNudgeActive) return;
+        _impactNudgeActive = true;
+        try
+        {
+            var origin = AppWindow.Position;
+            foreach (var amplitude in ImpactAmplitudes)
+            {
+                AppWindow.Move(new Windows.Graphics.PointInt32(
+                    origin.X + (int)(dx * amplitude),
+                    origin.Y + (int)(dy * amplitude)));
+                await System.Threading.Tasks.Task.Delay(26);
+            }
+            AppWindow.Move(origin);
+        }
+        catch (Exception)
+        {
+            // A presenter change mid-shake (user maximizes, monitor sleeps)
+            // can fail the move; the window simply stays where it is.
+        }
+        finally
+        {
+            _impactNudgeActive = false;
+        }
+    }
+
+    // Damped: one push in the travel direction, a smaller rebound, done.
+    private static readonly int[] ImpactAmplitudes = [4, -2, 1];
+    private bool _impactNudgeActive;
+
     private void ApplyVerticalTitleBarChrome()
     {
         Windows.UI.Color dragBg;
         Windows.UI.Color stripMirrorBg;
         if (_shellTheme.IsEnabled)
         {
-            dragBg = _shellTheme.TitleBarBackground;
+            // One shade for the whole row, and it is the sidebar's. The
+            // horizontal header paints TabBarBackground, so this row
+            // cross-fades against it on every layout switch; giving the
+            // drag region the title-bar shade instead put two tints of the
+            // same color side by side with a hard cut at the icon lane's
+            // edge, visible through the whole transition.
+            dragBg = _shellTheme.TabBarBackground;
             stripMirrorBg = _shellTheme.TabBarBackground;
         }
         else
@@ -1975,10 +2032,13 @@ public sealed partial class MainWindow : Window
             Windows.UI.Color pressedBg;
             if (_shellTheme.IsEnabled)
             {
-                titleBg = _shellTheme.TitleBarBackground;
+                // Matches ApplyVerticalTitleBarChrome: the row is uniformly
+                // the tab-bar shade, so hover needs the OTHER theme color to
+                // stay visible against it.
+                titleBg = _shellTheme.TabBarBackground;
                 fg = _shellTheme.TitleBarForeground;
-                hoverBg = _shellTheme.TabBarBackground;
-                pressedBg = _shellTheme.TabBarBackground;
+                hoverBg = _shellTheme.TitleBarBackground;
+                pressedBg = _shellTheme.TitleBarBackground;
             }
             else
             {

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -74,7 +74,6 @@ internal sealed class LayoutCoordinator
     /// </summary>
     private const int PrimingFrames = 3;
 
-
     // Feel constants for the icon spin/pop, tuned by eye. The spin is one
     // full turn; the pop dips the scale partway through and springs back
     // past 1.0 as it lands.
@@ -122,20 +121,12 @@ internal sealed class LayoutCoordinator
     // the vertical strip becomes the topmost element above the tabs. Layout
     // switching still works via the keyboard chord.
     private bool _verticalTitleBarSuppressed;
-    // Per-frame handler rather than a DispatcherTimer: the strip column is
-    // resized from managed code every frame, and a queued timer competing
-    // with the switch storyboard and its layout passes got starved down to
-    // two ticks in 190ms -- the column lurched instead of sliding.
-    // CompositionTarget.Rendering is tied to composition, so it keeps step.
-    private EventHandler<object>? _columnFrame;
 
     public LayoutCoordinator(
         ColumnDefinition stripColumn,
         ColumnDefinition titleBarStripMirror,
-        FrameworkElement horizontalHost,
         VerticalTabHost verticalTabHost,
         Grid verticalTitleBar,
-        FrameworkElement horizontalIcon,
         ITabHost horizontalTabHost,
         Canvas morphLayer,
         FrameworkElement morphRoot,
@@ -151,11 +142,11 @@ internal sealed class LayoutCoordinator
         _activeTab = activeTab;
         _stripColumn = stripColumn;
         _titleBarStripMirror = titleBarStripMirror;
-        _horizontalHost = horizontalHost;
+        _horizontalHost = horizontalTabHost.HostElement;
         _verticalTabHost = verticalTabHost;
         _verticalHost = verticalTabHost;
         _verticalTitleBar = verticalTitleBar;
-        _horizontalIcon = horizontalIcon;
+        _horizontalIcon = horizontalTabHost.IconBadge;
         _verticalIcon = verticalTabHost.IconBadge;
 
         // Pin toggle snaps immediately -- NavView needs the full column width
@@ -175,6 +166,15 @@ internal sealed class LayoutCoordinator
     /// </summary>
     public void Snap(bool verticalTabs)
     {
+        // Snap is the end-state authority for interrupted switches too:
+        // SetStripHidden and SuppressVerticalTitleBar call it directly
+        // mid-flight, so everything a switch keeps in the air -- the tab
+        // ghost, the icon stand-in, the pane reveal's margin and clip --
+        // has to come down here, not only in FinishSwitch.
+        FinishActiveTabMorph();
+        FinishIconGhost();
+        FinishPaneReveal();
+
         var w = verticalTabs ? _verticalTabHost.CurrentStripTarget : 0;
         _stripColumn.Width = new GridLength(w);
         _titleBarStripMirror.Width = new GridLength(w);
@@ -272,6 +272,7 @@ internal sealed class LayoutCoordinator
         }
         if (_switching) return;
         _switching = true;
+        MorphTrace($"SWITCH begin vertical={verticalTabs}");
 
         var targetColWidth = verticalTabs ? _verticalTabHost.CurrentStripTarget : 0;
         var fromColWidth = _stripColumn.Width.Value;
@@ -303,8 +304,6 @@ internal sealed class LayoutCoordinator
         var outgoingOffset = verticalTabs
             ? new Windows.Foundation.Point(0, EmergeTravel)
             : new Windows.Foundation.Point(EmergeTravel, 0);
-
-        StopColumnTween();
 
         // The strip column is moved once per switch, never tweened. Changing
         // it resizes the terminal surface, which re-renders synchronously on
@@ -372,10 +371,11 @@ internal sealed class LayoutCoordinator
 
         sb.Completed += (_, _) =>
         {
-            // Only a ghost that actually flew has anything to slam into,
-            // and only a switch that ran to completion has a landing --
-            // the fallback paths below fast-forward without motion.
-            var landed = _morph is not null;
+            // Only a staged flight has anything to slam into: a waiting
+            // morph whose destination never realized parks the ghost and
+            // stages no storyboard, and the fallback paths below
+            // fast-forward without motion.
+            var landed = _morphStoryboard is not null;
             FinishSwitch(verticalTabs, onCompleted);
             if (landed)
                 _impact?.Invoke(verticalTabs ? -1 : 0, verticalTabs ? 0 : -1);
@@ -420,10 +420,35 @@ internal sealed class LayoutCoordinator
         internal required FrameworkElement? From { get; init; }
         internal FrameworkElement? To { get; set; }
         internal EventHandler<object>? Waiting { get; set; }
+        internal EventHandler<object>? WaitingDeadline { get; set; }
     }
 
     private ActiveTabMorph? _morph;
     private Storyboard? _morphStoryboard;
+
+    /// <summary>
+    /// Oracle for the morph fuzz harness: every switch must end with zero
+    /// ghosts on the overlay. Emitting the trace from the product keeps the
+    /// harness runnable against any build, and the env var doubles as the
+    /// per-run log path so concurrent instances never interleave one file.
+    /// Inert (a null check) when the variable is unset.
+    /// </summary>
+    private static readonly string? MorphTracePath =
+        Environment.GetEnvironmentVariable("WINTTY_MORPH_TRACE");
+
+    private static void MorphTrace(string message)
+    {
+        if (MorphTracePath is null) return;
+        try
+        {
+            System.IO.File.AppendAllText(
+                MorphTracePath, message + Environment.NewLine);
+        }
+        catch
+        {
+            // A locked or unwritable log must never take the switch down.
+        }
+    }
 
     /// <summary>
     /// How long to keep waiting for the incoming host to realize the active
@@ -470,11 +495,48 @@ internal sealed class LayoutCoordinator
         {
             if (++frames < PrimingFrames) return;
             CompositionTarget.Rendering -= onFrame;
-            // A switch started meanwhile owns the host's visibility now.
-            if (_switching) return;
+            _primingFrame = null;
+            // Priming owns the host only while it is still the transparent
+            // stand-in it created. A switch in flight, or one that already
+            // landed on this host (Snap sets its opacity back to 1), means
+            // the layout machinery owns visibility now.
+            if (_switching || host.Opacity != 0) return;
             host.Visibility = Visibility.Collapsed;
         };
+        _primingFrame = onFrame;
         CompositionTarget.Rendering += onFrame;
+    }
+
+    /// <summary>
+    /// Detach the priming frame handler on window teardown.
+    /// CompositionTarget.Rendering is a thread-level event, so a pending
+    /// handler would keep the closed window's whole tree alive until the
+    /// thread renders again.
+    /// </summary>
+    public void CancelStripPriming()
+    {
+        if (_primingFrame is null) return;
+        CompositionTarget.Rendering -= _primingFrame;
+        _primingFrame = null;
+    }
+
+    private EventHandler<object>? _primingFrame;
+
+    /// <summary>
+    /// A realized element can still sit scrolled out of the strip's
+    /// viewport; TransformToVisual happily reports its off-screen rect and
+    /// the overlay canvas never clips, so a morph aimed there would fly
+    /// across the terminal to a point where no tab is visible. Off-viewport
+    /// rects count as unavailable and the switch degrades to the
+    /// cross-fade.
+    /// </summary>
+    private static Rect ViewportRectIn(FrameworkElement root, FrameworkElement el)
+    {
+        var rect = RectIn(root, el);
+        if (rect.Width <= 0) return rect;
+        var overlap = new Rect(0, 0, root.ActualWidth, root.ActualHeight);
+        overlap.Intersect(rect);
+        return overlap.IsEmpty ? default : rect;
     }
 
     private static Rect RectIn(FrameworkElement root, FrameworkElement el)
@@ -514,7 +576,7 @@ internal sealed class LayoutCoordinator
 
         var from = outgoing.TabElement(tab);
         if (from is null) return;
-        var fromRect = RectIn(_morphRoot, from);
+        var fromRect = ViewportRectIn(_morphRoot, from);
         if (fromRect.Width <= 0) return;
 
         var (to, toRect) = MeasureIncomingTab(incoming, tab);
@@ -547,6 +609,7 @@ internal sealed class LayoutCoordinator
 
         if (toRect.Width > 0)
         {
+            MorphTrace("MORPH immediate");
             StageMorphAnimations(morph, fromRect, toRect, SwitchDuration);
             return;
         }
@@ -568,7 +631,7 @@ internal sealed class LayoutCoordinator
             }
 
             var late = incoming.TabElement(tab);
-            var rect = late is null ? default : RectIn(_morphRoot, late);
+            var rect = late is null ? default : ViewportRectIn(_morphRoot, late);
 
             // Past the grace period a ghost would have sat still for a
             // noticeable slice of the switch and then lurched. Drop it and
@@ -594,6 +657,7 @@ internal sealed class LayoutCoordinator
 
             // Spend only what is left of the switch, so the ghost still
             // lands with the cross-fade rather than after it.
+            MorphTrace($"MORPH deferred@{clock.ElapsedMilliseconds}ms");
             StageMorphAnimations(
                 morph, fromRect, rect, SwitchDuration - clock.Elapsed);
             try
@@ -607,6 +671,30 @@ internal sealed class LayoutCoordinator
         };
         morph.Waiting = waiting;
         _morphRoot.LayoutUpdated += waiting;
+        MorphTrace("MORPH waiting");
+
+        // LayoutUpdated alone cannot enforce the grace deadline: the switch
+        // storyboard animates only opacity and transforms, which dirty no
+        // layout, so once the visibility-change layout storm settles no
+        // further LayoutUpdated is guaranteed. A container that never
+        // realizes would park the ghost for the whole switch with both real
+        // tabs hidden under it. Rendered frames keep coming regardless, so
+        // they carry the deadline.
+        EventHandler<object>? deadline = null;
+        deadline = (_, _) =>
+        {
+            if (!ReferenceEquals(_morph, morph) || morph.Waiting is null)
+            {
+                CompositionTarget.Rendering -= deadline;
+                return;
+            }
+            if (clock.Elapsed <= RealizationGrace) return;
+            CompositionTarget.Rendering -= deadline;
+            morph.WaitingDeadline = null;
+            FinishActiveTabMorph();
+        };
+        morph.WaitingDeadline = deadline;
+        CompositionTarget.Rendering += deadline;
     }
 
     /// <summary>
@@ -624,17 +712,10 @@ internal sealed class LayoutCoordinator
         _morphRoot.UpdateLayout();
 
         var to = incoming.TabElement(tab);
-        var toRect = to is null ? default : RectIn(_morphRoot, to);
+        var toRect = to is null ? default : ViewportRectIn(_morphRoot, to);
         return (to, toRect);
     }
 
-    /// <summary>
-    /// Drive the ghost from one rect to the other. Width and Height are
-    /// dependent animations because the label must re-lay-out rather than
-    /// scale: squashing a 240px header tab into a 48px rail smears the
-    /// text, which is the artifact in a different costume. One small
-    /// element for the length of a switch is a cheap layout pass.
-    /// </summary>
     /// <summary>
     /// Share of the flight the ghost spends changing size. Position runs
     /// the full duration; size and label settle at this fraction, so the
@@ -643,15 +724,22 @@ internal sealed class LayoutCoordinator
     /// </summary>
     private const double ShapeSettleFraction = 0.75;
 
+    /// <summary>
+    /// Drive the ghost from one rect to the other. Width and Height are
+    /// dependent animations because the label must re-lay-out rather than
+    /// scale: squashing a 240px header tab into a 48px rail smears the
+    /// text, which is the artifact in a different costume. One small
+    /// element for the length of a switch is a cheap layout pass.
+    /// </summary>
     private void StageMorphAnimations(
         ActiveTabMorph morph, Rect from, Rect to, TimeSpan duration)
     {
         var settle = duration * ShapeSettleFraction;
         var sb = new Storyboard();
-        Add(sb, morph.Ghost.Translate, "X", from.X, to.X);
-        Add(sb, morph.Ghost.Translate, "Y", from.Y, to.Y);
-        Add(sb, morph.Ghost, "Width", from.Width, to.Width, dependent: true, settle);
-        Add(sb, morph.Ghost, "Height", from.Height, to.Height, dependent: true, settle);
+        Add(morph.Ghost.Translate, "X", from.X, to.X);
+        Add(morph.Ghost.Translate, "Y", from.Y, to.Y);
+        Add(morph.Ghost, "Width", from.Width, to.Width, dependent: true, settle);
+        Add(morph.Ghost, "Height", from.Height, to.Height, dependent: true, settle);
 
         // The label survives a modest width change but not the collapse to
         // a 48px rail, so it fades on the leg that loses most of its room
@@ -661,14 +749,14 @@ internal sealed class LayoutCoordinator
         if (shrinking || growing)
         {
             morph.Ghost.Label.Opacity = shrinking ? 1 : 0;
-            Add(sb, morph.Ghost.Label, "Opacity",
+            Add(morph.Ghost.Label, "Opacity",
                 shrinking ? 1 : 0, shrinking ? 0 : 1, dependent: false, settle);
         }
 
         _morphStoryboard = sb;
 
         void Add(
-            Storyboard sb, DependencyObject target, string path,
+            DependencyObject target, string path,
             double f, double t, bool dependent = false, TimeSpan? span = null)
         {
             var anim = new DoubleAnimation
@@ -699,6 +787,11 @@ internal sealed class LayoutCoordinator
             _morphRoot.LayoutUpdated -= _morph.Waiting;
             _morph.Waiting = null;
         }
+        if (_morph.WaitingDeadline is not null)
+        {
+            CompositionTarget.Rendering -= _morph.WaitingDeadline;
+            _morph.WaitingDeadline = null;
+        }
         _morphLayer.Children.Remove(_morph.Ghost);
         if (_morph.From is not null) _morph.From.Opacity = 1;
         if (_morph.To is not null) _morph.To.Opacity = 1;
@@ -709,11 +802,11 @@ internal sealed class LayoutCoordinator
     private void FinishSwitch(bool verticalTabs, Action? onCompleted)
     {
         if (!_switching) return;
-        StopColumnTween();
-        FinishActiveTabMorph();
-        FinishIconGhost();
-        FinishPaneReveal();
+        // Snap tears down the in-flight morph, icon ghost, and pane reveal
+        // itself, so the direct-interrupt callers get the same cleanup.
         Snap(verticalTabs);
+        MorphTrace(
+            $"SWITCH end ghosts={_morphLayer.Children.Count} morph={(_morph is null ? "null" : "LEAKED")}");
         _switching = false;
         onCompleted?.Invoke();
     }
@@ -725,48 +818,17 @@ internal sealed class LayoutCoordinator
     /// </summary>
     public void SnapStripColumn(double width)
     {
-        StopColumnTween();
+        // Arriving mid-switch (chevron and pin stay clickable during the
+        // 340ms flight), a width change invalidates every rect the morph
+        // measured; drop the flourishes and let the cross-fade finish.
+        FinishActiveTabMorph();
+        FinishIconGhost();
+        FinishPaneReveal();
         _stripColumn.Width = new GridLength(width);
         _titleBarStripMirror.Width = new GridLength(width);
         _verticalTabHost.SetInternalStripWidth(width);
     }
 
-    /// <summary>
-    /// Tween <see cref="ColumnDefinition.Width"/> from its current
-    /// value to <paramref name="to"/>. Used by the chevron expand
-    /// path inside <see cref="VerticalTabHost"/>; the runtime layout
-    /// switch above bundles its column tween into the cross-fade
-    /// Storyboard instead.
-    ///
-    /// Cancels any in-flight column tween so the chevron toggle and
-    /// the layout switch cannot race on the same column.
-    /// </summary>
-    public void TweenStripColumn(double from, double to, Action<double>? onTick = null)
-    {
-        StopColumnTween();
-        var sw = Stopwatch.StartNew();
-        var span = TimeSpan.FromMilliseconds(SwitchDurationMs);
-        EventHandler<object>? frame = null;
-        frame = (_, _) =>
-        {
-            var t = Math.Min(sw.Elapsed / span, 1.0);
-            var value = from + (to - from) * EaseInOutCubic(t);
-            _stripColumn.Width = new GridLength(value);
-            _titleBarStripMirror.Width = new GridLength(value);
-            onTick?.Invoke(value);
-            if (t >= 1.0 && ReferenceEquals(_columnFrame, frame))
-                StopColumnTween();
-        };
-        _columnFrame = frame;
-        CompositionTarget.Rendering += frame;
-    }
-
-    private void StopColumnTween()
-    {
-        if (_columnFrame is null) return;
-        CompositionTarget.Rendering -= _columnFrame;
-        _columnFrame = null;
-    }
 
     private static TranslateTransform GetOrCreateTranslate(FrameworkElement fe)
     {
@@ -828,7 +890,6 @@ internal sealed class LayoutCoordinator
         _iconGhost = ghost;
         outgoing.Opacity = 0;
         incoming.Opacity = 0;
-        _iconGhostHidden = (outgoing, incoming);
 
         sb.Children.Add(MakeRotateAnim(rotate, 0, spin));
         sb.Children.Add(MakePopAnim(scale, "ScaleX"));
@@ -838,15 +899,13 @@ internal sealed class LayoutCoordinator
 
     private void FinishIconGhost()
     {
-        if (_iconGhost is not null)
-        {
-            _morphLayer.Children.Remove(_iconGhost);
-            _iconGhost = null;
-        }
-        if (_iconGhostHidden is not { } pair) return;
-        pair.Outgoing.Opacity = 1;
-        pair.Incoming.Opacity = 1;
-        _iconGhostHidden = null;
+        if (_iconGhost is null) return;
+        _morphLayer.Children.Remove(_iconGhost);
+        _iconGhost = null;
+        // The hidden pair is always the two badge fields, whichever
+        // direction flew.
+        _horizontalIcon.Opacity = 1;
+        _verticalIcon.Opacity = 1;
     }
 
     /// <summary>
@@ -872,13 +931,13 @@ internal sealed class LayoutCoordinator
         FinishPaneReveal();
         try
         {
-            _savedPaneMargin = _paneHost.Margin;
-            _paneRevealActive = true;
+            var saved = _paneHost.Margin;
+            _savedPaneMargin = saved;
             _paneHost.Margin = new Thickness(
-                _savedPaneMargin.Left - laneWidth,
-                _savedPaneMargin.Top,
-                _savedPaneMargin.Right,
-                _savedPaneMargin.Bottom);
+                saved.Left - laneWidth,
+                saved.Top,
+                saved.Right,
+                saved.Bottom);
             _morphRoot.UpdateLayout();
 
             var visual = Microsoft.UI.Xaml.Hosting.ElementCompositionPreview
@@ -907,18 +966,17 @@ internal sealed class LayoutCoordinator
     /// </summary>
     private void FinishPaneReveal()
     {
-        if (!_paneRevealActive) return;
-        _paneRevealActive = false;
+        if (_savedPaneMargin is not { } saved) return;
+        _savedPaneMargin = null;
         Microsoft.UI.Xaml.Hosting.ElementCompositionPreview
             .GetElementVisual(_paneHost).Clip = null;
-        _paneHost.Margin = _savedPaneMargin;
+        _paneHost.Margin = saved;
     }
 
-    private bool _paneRevealActive;
-    private Thickness _savedPaneMargin;
+    /// <summary>Non-null exactly while a pane reveal is in flight.</summary>
+    private Thickness? _savedPaneMargin;
 
     private Image? _iconGhost;
-    private (FrameworkElement Outgoing, FrameworkElement Incoming)? _iconGhostHidden;
 
     /// <summary>Matches the ImageIcon inside AppIconBadge.</summary>
     private const double AppIconSize = 16;
@@ -994,11 +1052,6 @@ internal sealed class LayoutCoordinator
                 _verticalTitleBar, "Y", titleTx.Y, -TitleBarSlideDistance));
         }
     }
-
-    private static double EaseInOutCubic(double t)
-        => t < 0.5
-            ? 4.0 * t * t * t
-            : 1.0 - Math.Pow(-2.0 * t + 2.0, 3.0) / 2.0;
 
     private static DoubleAnimationUsingKeyFrames MakeStaggeredFadeIn(FrameworkElement target)
     {

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Diagnostics;
+using Ghostty.Branding;
+using Ghostty.Core.Tabs;
 using Ghostty.Tabs;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Media.Animation;
+using Windows.Foundation;
 
 namespace Ghostty.Shell;
 
@@ -50,6 +54,27 @@ internal sealed class LayoutCoordinator
     private const double OutgoingFadeEnd = 0.78;
     private const double TitleBarSlideDistance = 10;
 
+    // Distance a strip travels between the terminal surface and its lane.
+    // Tuned by eye: short enough that the strip never leaves its own lane
+    // for long, far enough that the arrival reads as the strip coming out
+    // of the terminal rather than settling in place.
+    private const double EmergeTravel = 40;
+
+    /// <summary>
+    /// Fade the ghost's label when the destination keeps less than this
+    /// share of the source width. Above it the text still fits well
+    /// enough that fading reads as a flicker.
+    /// </summary>
+    private const double LabelFadeRatio = 0.6;
+
+    /// <summary>
+    /// Rendered frames a primed strip is left visible for. Two is what
+    /// it takes for a viewport to reach the repeater and the containers
+    /// to come back measurable; the third is slack.
+    /// </summary>
+    private const int PrimingFrames = 3;
+
+
     // Feel constants for the icon spin/pop, tuned by eye. The spin is one
     // full turn; the pop dips the scale partway through and springs back
     // past 1.0 as it lands.
@@ -70,6 +95,22 @@ internal sealed class LayoutCoordinator
     private readonly FrameworkElement _horizontalIcon;
     private readonly FrameworkElement _verticalIcon;
 
+    // Active-tab morph. The ghost lives on its own canvas above both hosts
+    // and is measured against the root so one coordinate space covers the
+    // header lane and the sidebar rail.
+    private readonly Canvas _morphLayer;
+    private readonly FrameworkElement _morphRoot;
+    private readonly FrameworkElement _paneHost;
+
+    /// <summary>
+    /// Fired when the active-tab ghost lands at the end of an uninterrupted
+    /// switch, with the unit direction it was travelling. The window uses
+    /// it for a small inertia nudge.
+    /// </summary>
+    private readonly Action<double, double>? _impact;
+    private readonly ITabHost _horizontalTabHost;
+    private readonly Func<TabModel?> _activeTab;
+
     private bool _switching;
     // When true (quake window with a single tab), the strip + vertical
     // title bar are forced hidden regardless of layout mode, leaving only
@@ -81,7 +122,12 @@ internal sealed class LayoutCoordinator
     // the vertical strip becomes the topmost element above the tabs. Layout
     // switching still works via the keyboard chord.
     private bool _verticalTitleBarSuppressed;
-    private DispatcherTimer? _columnTimer;
+    // Per-frame handler rather than a DispatcherTimer: the strip column is
+    // resized from managed code every frame, and a queued timer competing
+    // with the switch storyboard and its layout passes got starved down to
+    // two ticks in 190ms -- the column lurched instead of sliding.
+    // CompositionTarget.Rendering is tied to composition, so it keeps step.
+    private EventHandler<object>? _columnFrame;
 
     public LayoutCoordinator(
         ColumnDefinition stripColumn,
@@ -89,8 +135,20 @@ internal sealed class LayoutCoordinator
         FrameworkElement horizontalHost,
         VerticalTabHost verticalTabHost,
         Grid verticalTitleBar,
-        FrameworkElement horizontalIcon)
+        FrameworkElement horizontalIcon,
+        ITabHost horizontalTabHost,
+        Canvas morphLayer,
+        FrameworkElement morphRoot,
+        FrameworkElement paneHost,
+        Func<TabModel?> activeTab,
+        Action<double, double>? impact = null)
     {
+        _impact = impact;
+        _horizontalTabHost = horizontalTabHost;
+        _morphLayer = morphLayer;
+        _morphRoot = morphRoot;
+        _paneHost = paneHost;
+        _activeTab = activeTab;
         _stripColumn = stripColumn;
         _titleBarStripMirror = titleBarStripMirror;
         _horizontalHost = horizontalHost;
@@ -228,12 +286,58 @@ internal sealed class LayoutCoordinator
 
         var incoming = verticalTabs ? _verticalHost : _horizontalHost;
         var outgoing = verticalTabs ? _horizontalHost : _verticalHost;
+        // Both strips travel along the axis that connects them to the
+        // terminal surface: the incoming one emerges out of the terminal and
+        // settles into its lane, the outgoing one retreats back into it.
+        // Sliding in from beyond the window edge instead reads as chrome
+        // appearing from nowhere.
+        //
+        // Going vertical, the sidebar's lane is the left edge and the
+        // terminal is to its right, so the incoming strip starts right of
+        // home and moves left. Going horizontal, the header's lane is the
+        // top and the terminal is below it, so the incoming strip starts
+        // below home and rises.
         var incomingOffset = verticalTabs
-            ? new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0)
-            : new Windows.Foundation.Point(0, -VerticalTitleBarHeight);
+            ? new Windows.Foundation.Point(EmergeTravel, 0)
+            : new Windows.Foundation.Point(0, EmergeTravel);
         var outgoingOffset = verticalTabs
-            ? new Windows.Foundation.Point(0, -VerticalTitleBarHeight)
-            : new Windows.Foundation.Point(-VerticalStripCollapsedWidth, 0);
+            ? new Windows.Foundation.Point(0, EmergeTravel)
+            : new Windows.Foundation.Point(EmergeTravel, 0);
+
+        StopColumnTween();
+
+        // The strip column is moved once per switch, never tweened. Changing
+        // it resizes the terminal surface, which re-renders synchronously on
+        // the UI thread, so any per-frame tween starves the thread it runs
+        // on: measured over a switch, a DispatcherTimer and
+        // CompositionTarget.Rendering each got two frames in before the
+        // column jumped the rest of the way -- the lane lurched open under
+        // the arriving strip. Opening happens up front, so the strip and the
+        // active-tab ghost travel toward a lane that is already the right
+        // size (the header spans both grid columns, so nothing measured
+        // below shifts); closing leaves the lane in place for the strip to
+        // retreat through and lets Snap collapse it once the switch lands.
+        //
+        // This is also the switch's only pane-mode change. The measure pass
+        // used to stage the target width and put it back, which toggled the
+        // rail expanded -> compact -> expanded inside one blocked UI turn,
+        // and MUXC's starved pane transition left the rows stuck compact in
+        // a full-width lane.
+        if (targetColWidth > fromColWidth)
+        {
+            SnapStripColumn(targetColWidth);
+            _morphRoot.UpdateLayout();
+        }
+        else if (fromColWidth > 0)
+        {
+            StartPaneReveal(fromColWidth);
+        }
+
+        // Staged before any transform is applied below. TransformToVisual
+        // reads whatever offset the strip is already carrying, so measuring
+        // after the incoming translate would aim the ghost at the strip's
+        // pre-animation position and leave it EmergeTravel short of home.
+        PrepareActiveTabMorph(verticalTabs, incomingOffset);
 
         incoming.IsHitTestVisible = true;
         outgoing.IsHitTestVisible = false;
@@ -241,9 +345,6 @@ internal sealed class LayoutCoordinator
         incomingTx.X = incomingOffset.X;
         incomingTx.Y = incomingOffset.Y;
         incoming.Opacity = 0;
-
-        _columnTimer?.Stop();
-        _columnTimer = null;
 
         var sb = new Storyboard();
         sb.Children.Add(MakeStaggeredFadeIn(incoming));
@@ -261,18 +362,24 @@ internal sealed class LayoutCoordinator
         var spin = verticalTabs ? -360.0 : 360.0;
         var incomingIcon = verticalTabs ? _verticalIcon : _horizontalIcon;
         var outgoingIcon = verticalTabs ? _horizontalIcon : _verticalIcon;
-        SpinIconInPlace(sb, incomingIcon, spin,
-            -incomingOffset.X, -incomingOffset.Y, 0, 0, incoming: true);
-        SpinIconInPlace(sb, outgoingIcon, spin,
-            0, 0, -outgoingOffset.X, -outgoingOffset.Y, incoming: false);
-
-        TweenStripColumn(fromColWidth, targetColWidth, onTick: w =>
+        if (!PrepareIconGhost(sb, outgoingIcon, incomingIcon, spin))
         {
-            if (w > 0.5)
-                _verticalTabHost.SetInternalStripWidth(w);
-        });
+            SpinIconInPlace(sb, incomingIcon, spin,
+                -incomingOffset.X, -incomingOffset.Y, 0, 0, incoming: true);
+            SpinIconInPlace(sb, outgoingIcon, spin,
+                0, 0, -outgoingOffset.X, -outgoingOffset.Y, incoming: false);
+        }
 
-        sb.Completed += (_, _) => FinishSwitch(verticalTabs, onCompleted);
+        sb.Completed += (_, _) =>
+        {
+            // Only a ghost that actually flew has anything to slam into,
+            // and only a switch that ran to completion has a landing --
+            // the fallback paths below fast-forward without motion.
+            var landed = _morph is not null;
+            FinishSwitch(verticalTabs, onCompleted);
+            if (landed)
+                _impact?.Invoke(verticalTabs ? -1 : 0, verticalTabs ? 0 : -1);
+        };
 
         // If Begin throws, Completed never fires and _switching stays
         // latched -- every later layout toggle (keybind, palette, settings)
@@ -285,14 +392,327 @@ internal sealed class LayoutCoordinator
         catch (Exception)
         {
             FinishSwitch(verticalTabs, onCompleted);
+            return;
         }
+
+        // Kept separate: a morph that will not start should cost the ghost,
+        // not the whole switch. Dropping it here leaves the plain cross-fade.
+        try
+        {
+            _morphStoryboard?.Begin();
+        }
+        catch (Exception)
+        {
+            FinishActiveTabMorph();
+        }
+    }
+
+
+    /// <summary>
+    /// One active-tab morph in flight: the ghost plus the two real elements
+    /// it stands in for, so Finish can put them all back. To and Waiting are
+    /// mutable because the destination element may not exist yet when the
+    /// morph starts; see <see cref="PrepareActiveTabMorph"/>.
+    /// </summary>
+    private sealed class ActiveTabMorph
+    {
+        internal required TabMorphGhost Ghost { get; init; }
+        internal required FrameworkElement? From { get; init; }
+        internal FrameworkElement? To { get; set; }
+        internal EventHandler<object>? Waiting { get; set; }
+    }
+
+    private ActiveTabMorph? _morph;
+    private Storyboard? _morphStoryboard;
+
+    /// <summary>
+    /// How long to keep waiting for the incoming host to realize the active
+    /// tab's container. Long enough for a couple of frames, short enough
+    /// that a ghost which will never find a home is dropped while the
+    /// cross-fade underneath still has time to cover for it.
+    /// </summary>
+    private static readonly TimeSpan RealizationGrace = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Give a collapsed horizontal strip the rendered frames it needs to
+    /// realize its item containers.
+    ///
+    /// TabView's ItemsRepeater realizes on an effective viewport, and a
+    /// viewport only arrives once the element has actually rendered --
+    /// UpdateLayout will not conjure one. A header that has been collapsed
+    /// since launch therefore has no container for any tab, so nothing for
+    /// the morph to aim at on the first switch to it. Showing it fully
+    /// transparent for a few frames costs nothing on screen and leaves the
+    /// containers in place, where they survive being collapsed again.
+    ///
+    /// Deliberately never primes the vertical host. Its NavigationView
+    /// realizes rows synchronously under UpdateLayout, so the first switch
+    /// toward it measures fine unprimed -- and showing the never-laid-out
+    /// NavigationView from the window constructor crashed XAML's measure
+    /// walk (InvalidCastException in MeasureOverride) seconds into every
+    /// horizontal-mode launch.
+    /// </summary>
+    public void PrimeHiddenStrip()
+    {
+        if (_switching || _stripHidden) return;
+        var host = _horizontalHost.Visibility == Visibility.Collapsed
+            ? _horizontalHost
+            : null;
+        if (host is null) return;
+
+        host.Opacity = 0;
+        host.IsHitTestVisible = false;
+        host.Visibility = Visibility.Visible;
+
+        var frames = 0;
+        EventHandler<object>? onFrame = null;
+        onFrame = (_, _) =>
+        {
+            if (++frames < PrimingFrames) return;
+            CompositionTarget.Rendering -= onFrame;
+            // A switch started meanwhile owns the host's visibility now.
+            if (_switching) return;
+            host.Visibility = Visibility.Collapsed;
+        };
+        CompositionTarget.Rendering += onFrame;
+    }
+
+    private static Rect RectIn(FrameworkElement root, FrameworkElement el)
+    {
+        if (el.ActualWidth <= 0 || el.ActualHeight <= 0) return default;
+        try
+        {
+            var origin = el.TransformToVisual(root).TransformPoint(new Point(0, 0));
+            return new Rect(origin.X, origin.Y, el.ActualWidth, el.ActualHeight);
+        }
+        catch
+        {
+            // TransformToVisual throws when the element is not in the same
+            // tree as root (collapsed ancestor, mid-teardown). No rect means
+            // no morph, which degrades to the plain cross-fade.
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Put a ghost of the active tab on the outgoing rect and drive it to
+    /// the incoming one, hiding both real elements meanwhile. Assigns
+    /// <see cref="_morph"/>, and leaves it null when there is nothing to
+    /// morph, in which case the switch is just the cross-fade.
+    /// </summary>
+    private void PrepareActiveTabMorph(
+        bool verticalTabs, Point incomingOffset)
+    {
+        // A ghost left over from an aborted switch would never be collected
+        // otherwise: the field is about to be overwritten.
+        FinishActiveTabMorph();
+
+        if (_activeTab() is not { } tab) return;
+
+        var outgoing = verticalTabs ? _horizontalTabHost : (ITabHost)_verticalTabHost;
+        var incoming = verticalTabs ? (ITabHost)_verticalTabHost : _horizontalTabHost;
+
+        var from = outgoing.TabElement(tab);
+        if (from is null) return;
+        var fromRect = RectIn(_morphRoot, from);
+        if (fromRect.Width <= 0) return;
+
+        var (to, toRect) = MeasureIncomingTab(incoming, tab);
+
+        var chrome = _verticalTabHost.ActiveRowChrome(tab);
+        // Rail rows are square and meet the pane edge-to-edge; header tabs
+        // keep the tab-like rounding on their top corners only.
+        var destinationShape = verticalTabs
+            ? new CornerRadius(0)
+            : new CornerRadius(4, 4, 0, 0);
+        var ghost = new TabMorphGhost(tab, chrome.Fill, chrome.Foreground, destinationShape)
+        {
+            Width = fromRect.Width,
+            Height = fromRect.Height,
+        };
+        ghost.Translate.X = fromRect.X;
+        ghost.Translate.Y = fromRect.Y;
+        _morphLayer.Children.Add(ghost);
+
+        // Hide both real ones for the duration. Leaving them visible is
+        // exactly the double image the ghost exists to remove. The rail's
+        // selected-row fill is a separate overlay, so it has to be told
+        // as well.
+        from.Opacity = 0;
+        if (to is not null) to.Opacity = 0;
+        _verticalTabHost.SetSelectionRowSuppressed(true);
+
+        var morph = new ActiveTabMorph { Ghost = ghost, From = from, To = to };
+        _morph = morph;
+
+        if (toRect.Width > 0)
+        {
+            StageMorphAnimations(morph, fromRect, toRect, SwitchDuration);
+            return;
+        }
+
+        // No container to aim at yet. A host that has been collapsed since
+        // launch has never realized its items: ItemsRepeater realizes on an
+        // effective viewport, which arrives with a rendered frame, so no
+        // amount of UpdateLayout conjures one. The host is visible from here
+        // on, so the container lands within a frame or two -- hold the ghost
+        // on the outgoing rect and stage the moment it does.
+        var clock = Stopwatch.StartNew();
+        EventHandler<object>? waiting = null;
+        waiting = (_, _) =>
+        {
+            if (!ReferenceEquals(_morph, morph))
+            {
+                _morphRoot.LayoutUpdated -= waiting;
+                return;
+            }
+
+            var late = incoming.TabElement(tab);
+            var rect = late is null ? default : RectIn(_morphRoot, late);
+
+            // Past the grace period a ghost would have sat still for a
+            // noticeable slice of the switch and then lurched. Drop it and
+            // let the cross-fade carry the rest.
+            if (rect.Width <= 0 && clock.Elapsed <= RealizationGrace) return;
+
+            _morphRoot.LayoutUpdated -= waiting;
+            morph.Waiting = null;
+            if (rect.Width <= 0 || clock.Elapsed > RealizationGrace)
+            {
+                FinishActiveTabMorph();
+                return;
+            }
+
+            // The strip is already carrying its travel offset by now, so the
+            // rect measured through it is short of where the tab comes to
+            // rest.
+            rect.X -= incomingOffset.X;
+            rect.Y -= incomingOffset.Y;
+
+            morph.To = late;
+            late!.Opacity = 0;
+
+            // Spend only what is left of the switch, so the ghost still
+            // lands with the cross-fade rather than after it.
+            StageMorphAnimations(
+                morph, fromRect, rect, SwitchDuration - clock.Elapsed);
+            try
+            {
+                _morphStoryboard?.Begin();
+            }
+            catch (Exception)
+            {
+                FinishActiveTabMorph();
+            }
+        };
+        morph.Waiting = waiting;
+        _morphRoot.LayoutUpdated += waiting;
+    }
+
+    /// <summary>
+    /// Where the active tab will sit once the switch lands. By the time
+    /// this runs the lane is already at its final width -- Animate opens it
+    /// before staging the morph, and a closing switch leaves it open -- so
+    /// the incoming host only needs a layout pass to realize its rects
+    /// after being made visible. No width is staged here: setting and
+    /// restoring the strip width toggled the rail's pane mode twice inside
+    /// one blocked UI turn, which left MUXC's rows stuck at compact size.
+    /// </summary>
+    private (FrameworkElement? Element, Rect Rect) MeasureIncomingTab(
+        ITabHost incoming, TabModel tab)
+    {
+        _morphRoot.UpdateLayout();
+
+        var to = incoming.TabElement(tab);
+        var toRect = to is null ? default : RectIn(_morphRoot, to);
+        return (to, toRect);
+    }
+
+    /// <summary>
+    /// Drive the ghost from one rect to the other. Width and Height are
+    /// dependent animations because the label must re-lay-out rather than
+    /// scale: squashing a 240px header tab into a 48px rail smears the
+    /// text, which is the artifact in a different costume. One small
+    /// element for the length of a switch is a cheap layout pass.
+    /// </summary>
+    /// <summary>
+    /// Share of the flight the ghost spends changing size. Position runs
+    /// the full duration; size and label settle at this fraction, so the
+    /// ghost covers the last stretch already in its destination shape and
+    /// the landing is a pure glide instead of arrive-then-resize.
+    /// </summary>
+    private const double ShapeSettleFraction = 0.75;
+
+    private void StageMorphAnimations(
+        ActiveTabMorph morph, Rect from, Rect to, TimeSpan duration)
+    {
+        var settle = duration * ShapeSettleFraction;
+        var sb = new Storyboard();
+        Add(sb, morph.Ghost.Translate, "X", from.X, to.X);
+        Add(sb, morph.Ghost.Translate, "Y", from.Y, to.Y);
+        Add(sb, morph.Ghost, "Width", from.Width, to.Width, dependent: true, settle);
+        Add(sb, morph.Ghost, "Height", from.Height, to.Height, dependent: true, settle);
+
+        // The label survives a modest width change but not the collapse to
+        // a 48px rail, so it fades on the leg that loses most of its room
+        // and fades back in on the return leg.
+        var shrinking = to.Width < from.Width * LabelFadeRatio;
+        var growing = from.Width < to.Width * LabelFadeRatio;
+        if (shrinking || growing)
+        {
+            morph.Ghost.Label.Opacity = shrinking ? 1 : 0;
+            Add(sb, morph.Ghost.Label, "Opacity",
+                shrinking ? 1 : 0, shrinking ? 0 : 1, dependent: false, settle);
+        }
+
+        _morphStoryboard = sb;
+
+        void Add(
+            Storyboard sb, DependencyObject target, string path,
+            double f, double t, bool dependent = false, TimeSpan? span = null)
+        {
+            var anim = new DoubleAnimation
+            {
+                From = f,
+                To = t,
+                Duration = new Duration(span ?? duration),
+                EnableDependentAnimation = dependent,
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseInOut },
+            };
+            Storyboard.SetTarget(anim, target);
+            Storyboard.SetTargetProperty(anim, path);
+            sb.Children.Add(anim);
+        }
+    }
+
+    /// <summary>
+    /// Drop the ghost and give the real elements their opacity back.
+    /// Safe to call twice; FinishSwitch and the failure paths all do.
+    /// </summary>
+    private void FinishActiveTabMorph()
+    {
+        _morphStoryboard?.Stop();
+        _morphStoryboard = null;
+        if (_morph is null) return;
+        if (_morph.Waiting is not null)
+        {
+            _morphRoot.LayoutUpdated -= _morph.Waiting;
+            _morph.Waiting = null;
+        }
+        _morphLayer.Children.Remove(_morph.Ghost);
+        if (_morph.From is not null) _morph.From.Opacity = 1;
+        if (_morph.To is not null) _morph.To.Opacity = 1;
+        _verticalTabHost.SetSelectionRowSuppressed(false);
+        _morph = null;
     }
 
     private void FinishSwitch(bool verticalTabs, Action? onCompleted)
     {
         if (!_switching) return;
-        _columnTimer?.Stop();
-        _columnTimer = null;
+        StopColumnTween();
+        FinishActiveTabMorph();
+        FinishIconGhost();
+        FinishPaneReveal();
         Snap(verticalTabs);
         _switching = false;
         onCompleted?.Invoke();
@@ -305,8 +725,7 @@ internal sealed class LayoutCoordinator
     /// </summary>
     public void SnapStripColumn(double width)
     {
-        _columnTimer?.Stop();
-        _columnTimer = null;
+        StopColumnTween();
         _stripColumn.Width = new GridLength(width);
         _titleBarStripMirror.Width = new GridLength(width);
         _verticalTabHost.SetInternalStripWidth(width);
@@ -324,27 +743,29 @@ internal sealed class LayoutCoordinator
     /// </summary>
     public void TweenStripColumn(double from, double to, Action<double>? onTick = null)
     {
-        _columnTimer?.Stop();
+        StopColumnTween();
         var sw = Stopwatch.StartNew();
-        var duration = TimeSpan.FromMilliseconds(SwitchDurationMs);
-        var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
-        timer.Tick += (_, _) =>
+        var span = TimeSpan.FromMilliseconds(SwitchDurationMs);
+        EventHandler<object>? frame = null;
+        frame = (_, _) =>
         {
-            var t = Math.Min(sw.Elapsed / duration, 1.0);
-            var eased = EaseInOutCubic(t);
-            var value = from + (to - from) * eased;
+            var t = Math.Min(sw.Elapsed / span, 1.0);
+            var value = from + (to - from) * EaseInOutCubic(t);
             _stripColumn.Width = new GridLength(value);
             _titleBarStripMirror.Width = new GridLength(value);
             onTick?.Invoke(value);
-            if (t >= 1.0)
-            {
-                timer.Stop();
-                if (ReferenceEquals(_columnTimer, timer))
-                    _columnTimer = null;
-            }
+            if (t >= 1.0 && ReferenceEquals(_columnFrame, frame))
+                StopColumnTween();
         };
-        _columnTimer = timer;
-        timer.Start();
+        _columnFrame = frame;
+        CompositionTarget.Rendering += frame;
+    }
+
+    private void StopColumnTween()
+    {
+        if (_columnFrame is null) return;
+        CompositionTarget.Rendering -= _columnFrame;
+        _columnFrame = null;
     }
 
     private static TranslateTransform GetOrCreateTranslate(FrameworkElement fe)
@@ -359,6 +780,149 @@ internal sealed class LayoutCoordinator
     // translate runs from/to the negative of the host's slide so it
     // exactly cancels it (same easing + duration as the host slide),
     // leaving only the in-place rotate and scale visible.
+    /// <summary>
+    /// Hold one app icon on screen for the whole switch.
+    ///
+    /// Each host owns its own badge, so cross-fading the hosts cross-fades
+    /// the icon with them: through the middle of the switch neither copy is
+    /// fully opaque and the mark visibly dips out. Both hosts place the
+    /// badge on the same pixel, so a single stand-in can hold that spot at
+    /// full opacity while the real ones are hidden -- and being outside the
+    /// sliding hosts it needs no counter-slide to stay put.
+    ///
+    /// Returns false when the badge cannot be measured, in which case the
+    /// caller falls back to spinning the hosts' own icons.
+    /// </summary>
+    private bool PrepareIconGhost(
+        Storyboard sb, FrameworkElement outgoing, FrameworkElement incoming, double spin)
+    {
+        FinishIconGhost();
+
+        var rect = RectIn(_morphRoot, outgoing);
+        if (rect.Width <= 0) return false;
+
+        var ghost = new Image
+        {
+            Source = new BitmapImage(AppIconSource.Current),
+            Width = AppIconSize,
+            Height = AppIconSize,
+            IsHitTestVisible = false,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            RenderTransformOrigin = new Point(0.5, 0.5),
+        };
+
+        var scale = new ScaleTransform();
+        var rotate = new RotateTransform();
+        var translate = new TranslateTransform
+        {
+            X = rect.X + ((rect.Width - AppIconSize) / 2),
+            Y = rect.Y + ((rect.Height - AppIconSize) / 2),
+        };
+        ghost.RenderTransform = new TransformGroup
+        {
+            Children = { scale, rotate, translate },
+        };
+
+        _morphLayer.Children.Add(ghost);
+        _iconGhost = ghost;
+        outgoing.Opacity = 0;
+        incoming.Opacity = 0;
+        _iconGhostHidden = (outgoing, incoming);
+
+        sb.Children.Add(MakeRotateAnim(rotate, 0, spin));
+        sb.Children.Add(MakePopAnim(scale, "ScaleX"));
+        sb.Children.Add(MakePopAnim(scale, "ScaleY"));
+        return true;
+    }
+
+    private void FinishIconGhost()
+    {
+        if (_iconGhost is not null)
+        {
+            _morphLayer.Children.Remove(_iconGhost);
+            _iconGhost = null;
+        }
+        if (_iconGhostHidden is not { } pair) return;
+        pair.Outgoing.Opacity = 1;
+        pair.Incoming.Opacity = 1;
+        _iconGhostHidden = null;
+    }
+
+    /// <summary>
+    /// Let the terminal grow fluidly into the lane a closing switch vacates.
+    ///
+    /// The lane itself cannot be tweened: every strip-column change resizes
+    /// the terminal surface, which re-renders synchronously on the UI
+    /// thread, so a per-frame tween starves the thread that drives it. The
+    /// terminal is instead resized ONCE, up front -- a negative left margin
+    /// extends it under the still-open lane -- and hidden there by an
+    /// InsetClip whose left inset sweeps to zero. The sweep runs on the
+    /// compositor's thread, so the terminal's edge glides left at full
+    /// frame rate no matter how busy the UI thread is, advancing over the
+    /// fading strip (both tab hosts sit at ZIndex -1, below the pane
+    /// container).
+    ///
+    /// FinishSwitch then collapses the column and removes the margin in the
+    /// same layout pass, which cancel out: the terminal's arrange rect is
+    /// identical before and after, so landing costs no second resize.
+    /// </summary>
+    private void StartPaneReveal(double laneWidth)
+    {
+        FinishPaneReveal();
+        try
+        {
+            _savedPaneMargin = _paneHost.Margin;
+            _paneRevealActive = true;
+            _paneHost.Margin = new Thickness(
+                _savedPaneMargin.Left - laneWidth,
+                _savedPaneMargin.Top,
+                _savedPaneMargin.Right,
+                _savedPaneMargin.Bottom);
+            _morphRoot.UpdateLayout();
+
+            var visual = Microsoft.UI.Xaml.Hosting.ElementCompositionPreview
+                .GetElementVisual(_paneHost);
+            var compositor = visual.Compositor;
+            var clip = compositor.CreateInsetClip((float)laneWidth, 0f, 0f, 0f);
+            visual.Clip = clip;
+
+            var sweep = compositor.CreateScalarKeyFrameAnimation();
+            sweep.InsertKeyFrame(1f, 0f, compositor.CreateCubicBezierEasingFunction(
+                new System.Numerics.Vector2(0.65f, 0f),
+                new System.Numerics.Vector2(0.35f, 1f)));
+            sweep.Duration = SwitchDuration;
+            clip.StartAnimation(nameof(Microsoft.UI.Composition.InsetClip.LeftInset), sweep);
+        }
+        catch (Exception)
+        {
+            // Composition refused; put the margin back and fall back to the
+            // plain cross-fade with the lane collapsing at the end.
+            FinishPaneReveal();
+        }
+    }
+
+    /// <summary>
+    /// Safe to call twice; FinishSwitch and the failure path both do.
+    /// </summary>
+    private void FinishPaneReveal()
+    {
+        if (!_paneRevealActive) return;
+        _paneRevealActive = false;
+        Microsoft.UI.Xaml.Hosting.ElementCompositionPreview
+            .GetElementVisual(_paneHost).Clip = null;
+        _paneHost.Margin = _savedPaneMargin;
+    }
+
+    private bool _paneRevealActive;
+    private Thickness _savedPaneMargin;
+
+    private Image? _iconGhost;
+    private (FrameworkElement Outgoing, FrameworkElement Incoming)? _iconGhostHidden;
+
+    /// <summary>Matches the ImageIcon inside AppIconBadge.</summary>
+    private const double AppIconSize = 16;
+
     private static void SpinIconInPlace(
         Storyboard sb, FrameworkElement? icon, double spin,
         double fromX, double fromY, double toX, double toY,

--- a/windows/Ghostty/Shell/TabMorphGhost.cs
+++ b/windows/Ghostty/Shell/TabMorphGhost.cs
@@ -1,0 +1,82 @@
+using Ghostty.Core.Tabs;
+using Ghostty.Tabs;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Shell;
+
+/// <summary>
+/// Stand-in for the active tab while the layout switches.
+///
+/// The two hosts render the active tab as different controls at different
+/// sizes: a TabViewItem roughly 240x32 in the header, a NavigationViewItem
+/// on a rail that is 220 wide pinned but only 48 collapsed. Cross-fading
+/// the hosts therefore shows the active tab twice, at two sizes, drifting
+/// apart. This element is the only active-tab visual on screen during the
+/// switch: both real ones are hidden, and it travels from the outgoing
+/// rect to the incoming one.
+///
+/// The ghost paints the active row's real fill, preset color or not. Both
+/// real elements are hidden for the flight, so a content-only ghost would
+/// drop the tab's chrome for the length of the switch and hand it back on
+/// arrival -- the tab would appear to lose its selection while in the air.
+/// </summary>
+internal sealed partial class TabMorphGhost : Grid
+{
+    private readonly TextBlock _label;
+
+    /// <summary>Label opacity, animated separately from the ghost body.</summary>
+    internal UIElement Label => _label;
+
+    /// <summary>
+    /// The corner geometry is the DESTINATION's, not a blend: the eye
+    /// follows the ghost to its landing, so it should arrive already in the
+    /// shape it hands over to, and the mismatch at departure is masked by
+    /// the switch starting around it.
+    /// </summary>
+    internal TabMorphGhost(
+        TabModel tab, Brush? fill, Brush? foreground, CornerRadius cornerRadius)
+    {
+        IsHitTestVisible = false;
+        HorizontalAlignment = HorizontalAlignment.Left;
+        VerticalAlignment = VerticalAlignment.Top;
+        RenderTransform = new TranslateTransform();
+        Background = fill;
+        CornerRadius = cornerRadius;
+
+        ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        var icon = TabIconElementFactory.Create(tab.TabIcon);
+        if (icon is not null)
+        {
+            icon.VerticalAlignment = VerticalAlignment.Center;
+            icon.Margin = new Thickness(6, 0, 6, 0);
+            SetColumn(icon, 0);
+            Children.Add(icon);
+        }
+
+        _label = new TextBlock
+        {
+            Text = tab.EffectiveTitle,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextTrimming = TextTrimming.Clip,
+            TextWrapping = TextWrapping.NoWrap,
+            Margin = new Thickness(0, 0, 6, 0),
+        };
+        if (foreground is not null)
+            _label.Foreground = foreground;
+        SetColumn(_label, 1);
+        Children.Add(_label);
+
+        // Clip to the animated bounds so the label is cut off by the
+        // shrinking rect rather than spilling over the rail while it fades.
+        var clip = new RectangleGeometry();
+        Clip = clip;
+        SizeChanged += (_, e) =>
+            clip.Rect = new Windows.Foundation.Rect(0, 0, e.NewSize.Width, e.NewSize.Height);
+    }
+
+    internal TranslateTransform Translate => (TranslateTransform)RenderTransform;
+}

--- a/windows/Ghostty/Tabs/ITabHost.cs
+++ b/windows/Ghostty/Tabs/ITabHost.cs
@@ -24,6 +24,9 @@ internal interface ITabHost
     /// </summary>
     FrameworkElement HostElement { get; }
 
+    /// <summary>The app-icon badge this host shows in its strip corner.</summary>
+    FrameworkElement IconBadge { get; }
+
     /// <summary>
     /// The drag-region element for extended title bar mode. In
     /// horizontal layout this is the TabView's TabStripFooter; in

--- a/windows/Ghostty/Tabs/ITabHost.cs
+++ b/windows/Ghostty/Tabs/ITabHost.cs
@@ -35,6 +35,13 @@ internal interface ITabHost
     UIElement DragRegion { get; }
 
     /// <summary>
+    /// The element rendering <paramref name="tab"/> in this host, or null
+    /// if the host has no row for it yet. LayoutCoordinator measures this
+    /// on both hosts to morph the active tab across a layout switch.
+    /// </summary>
+    FrameworkElement? TabElement(TabModel tab);
+
+    /// <summary>
     /// Single entry point for closing a tab. Shows the multi-pane
     /// confirmation dialog if needed and only then closes.
     /// </summary>

--- a/windows/Ghostty/Tabs/TabColorBrush.cs
+++ b/windows/Ghostty/Tabs/TabColorBrush.cs
@@ -1,0 +1,24 @@
+using Microsoft.UI.Xaml.Media;
+
+namespace Ghostty.Tabs;
+
+/// <summary>
+/// Bridge between the palette in Ghostty.Core, which speaks
+/// <see cref="System.Drawing.Color"/> and packed sRGB because it has no WinUI
+/// dependency, and the brushes the strips and previews paint with.
+/// </summary>
+internal static class TabColorBrush
+{
+    public static SolidColorBrush From(System.Drawing.Color drawing)
+        => new(Windows.UI.Color.FromArgb(
+            drawing.A, drawing.R, drawing.G, drawing.B));
+
+    /// <summary>
+    /// Brush from a 0x00RRGGBB value, as returned by the palette's
+    /// foreground and effective-background helpers. Always opaque: the
+    /// packed form carries no alpha.
+    /// </summary>
+    public static SolidColorBrush FromPackedRgb(uint packed)
+        => new(Windows.UI.Color.FromArgb(
+            0xFF, (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed));
+}

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -40,6 +40,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
     public FrameworkElement HostElement => this;
 
+    public FrameworkElement? TabElement(TabModel tab)
+        => _itemByModel.TryGetValue(tab, out var item) ? item : null;
+
     /// <summary>
     /// The wintty icon shown at the start of the tab strip. Exposed so
     /// the layout switch can spin it independently of the strip chrome.
@@ -306,8 +309,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
 
         if (tab.Color != TabColor.None)
         {
-            normalHandle = DrawingColorBrush(TabColorPalette.Background(tab.Color, selected: false));
-            selectedHandle = DrawingColorBrush(TabColorPalette.Background(tab.Color, selected: true));
+            normalHandle = TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: false));
+            selectedHandle = TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: true));
         }
         else if (selected && _selectedTabFillBrush is not null)
         {
@@ -350,15 +353,11 @@ internal sealed partial class TabHost : UserControl, ITabHost
         finally { _suppressSelectionEvent = false; }
     }
 
-    private static SolidColorBrush DrawingColorBrush(System.Drawing.Color drawing)
-        => new(Windows.UI.Color.FromArgb(
-            drawing.A, drawing.R, drawing.G, drawing.B));
-
     private SolidColorBrush TabColorForegroundBrush(TabModel tab, bool selected)
     {
         var packed = TabColorPalette.ForegroundRgb(
             tab.Color, selected, _stripBackdropPacked);
-        return new SolidColorBrush(UnpackColor(packed));
+        return TabColorBrush.FromPackedRgb(packed);
     }
 
     private static void ApplyHeaderRowForeground(StackPanel iconRow, SolidColorBrush fg)
@@ -565,8 +564,8 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // otherwise drop to a readable black/white. (#342)
         uint accentPacked = PackColor(theme.AccentColor);
         uint activePacked = PackColor(theme.ActiveTabText);
-        _shellActiveTextBrush = new SolidColorBrush(UnpackColor(
-            ThemeResolution.EnsureReadableForeground(accentPacked, activePacked)));
+        _shellActiveTextBrush = TabColorBrush.FromPackedRgb(
+            ThemeResolution.EnsureReadableForeground(accentPacked, activePacked));
 
         uint tabBgPacked = PackColor(theme.TabBarBackground);
         var inactiveColor = ThemeResolution.PreferLightForeground(tabBgPacked)
@@ -636,10 +635,6 @@ internal sealed partial class TabHost : UserControl, ITabHost
     private static uint PackColor(Windows.UI.Color c) =>
         ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
 
-    private static Windows.UI.Color UnpackColor(uint packed) =>
-        Windows.UI.Color.FromArgb(0xFF,
-            (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed);
-
     private ElementTheme _cachedTheme = ElementTheme.Default;
 
 
@@ -703,9 +698,9 @@ internal sealed partial class TabHost : UserControl, ITabHost
         // a pathological fg/bg that doesn't contrast.
         _accentBrush = new SolidColorBrush(
             Windows.UI.Color.FromArgb(0xFF, background.R, background.G, background.B));
-        _defaultActiveTextBrush = new SolidColorBrush(UnpackColor(
+        _defaultActiveTextBrush = TabColorBrush.FromPackedRgb(
             ThemeResolution.EnsureReadableForeground(
-                PackColor(background), PackColor(foreground))));
+                PackColor(background), PackColor(foreground)));
 
         // Preset tint foregrounds blend against the tab-bar backdrop, which
         // ApplyShellTheme sets from TabBarBackground -- not terminal bg.

--- a/windows/Ghostty/Tabs/TabSwitcherPopup.xaml
+++ b/windows/Ghostty/Tabs/TabSwitcherPopup.xaml
@@ -15,9 +15,18 @@
                 Padding="12"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center">
-            <StackPanel x:Name="CandidateRow"
-                        Orientation="Horizontal"
-                        Spacing="8"/>
+            <!-- Tiles wrap into a grid rather than one row: a horizontal
+                 StackPanel grew the card past the window once a session had
+                 more than a handful of tabs, pushing the far tiles off screen
+                 with no way to see them. Show() picks the column count and
+                 caps the height; past that the grid scrolls. -->
+            <ScrollViewer x:Name="CandidateScroll"
+                          HorizontalScrollMode="Disabled"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <VariableSizedWrapGrid x:Name="CandidateRow"
+                                       Orientation="Horizontal"/>
+            </ScrollViewer>
         </Border>
     </Grid>
 </UserControl>

--- a/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
+++ b/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Ghostty.Controls;
 using Ghostty.Core.Tabs;
@@ -18,6 +19,10 @@ internal sealed partial class TabSwitcherPopup : UserControl
 {
     private readonly Dictionary<TabModel, Border> _cellByTab = new();
 
+    // Idle border per tab rather than one shared brush: a tab carrying a
+    // preset color rings itself in that color when it is not the active one.
+    private readonly Dictionary<TabModel, Brush> _idleBorderByTab = new();
+
     // Fluent theme resources the tile build loop and Highlight() need, resolved
     // once per Show() instead of re-hitting the resource dictionary for every
     // element of every tile. Re-resolved on each open (not cached at ctor) so a
@@ -36,13 +41,42 @@ internal sealed partial class TabSwitcherPopup : UserControl
     private const double PreviewHeight = 84;
     private const double PreviewFontSize = 9;
 
+    private const double CellMargin = 4;
+
+    /// <summary>
+    /// Outer width of one tile: the preview plus the cell's padding, border
+    /// and margin. Drives the column count, so it has to track the values
+    /// the build loop actually applies.
+    /// </summary>
+    private const double CellOuterWidth =
+        PreviewWidth + (CellPadding * 2) + (CellBorder * 2) + (CellMargin * 2);
+
+    private const double CellPadding = 6;
+    private const double CellBorder = 2;
+
+    /// <summary>
+    /// Share of the window the tile grid may take before it starts
+    /// scrolling, leaving the card's chrome and a margin visible around it.
+    /// </summary>
+    private const double MaxGridHeightRatio = 0.7;
+    private const double MaxGridWidthRatio = 0.9;
+
     public TabSwitcherPopup() => InitializeComponent();
 
     public void Show(IReadOnlyList<TabModel> tabs, TabModel active, string? fontFamily)
     {
         CandidateRow.Children.Clear();
         _cellByTab.Clear();
+        _idleBorderByTab.Clear();
         _theme = ResolveTheme();
+        // MainWindow assigns Width/Height immediately before calling Show, so
+        // ActualWidth still holds the previous open's value (zero the first
+        // time). Prefer the explicit size.
+        var hostWidth = double.IsNaN(Width) ? ActualWidth : Width;
+        var hostHeight = double.IsNaN(Height) ? ActualHeight : Height;
+        CandidateRow.MaximumRowsOrColumns = ColumnsFor(tabs.Count, hostWidth);
+        if (hostHeight > 0)
+            CandidateScroll.MaxHeight = hostHeight * MaxGridHeightRatio;
 
         var renderer = new PanePreviewRenderer(PreviewFont.Resolve(fontFamily));
         foreach (var tab in tabs)
@@ -85,13 +119,26 @@ internal sealed partial class TabSwitcherPopup : UserControl
             content.Children.Add(header);
             content.Children.Add(new Border { CornerRadius = new CornerRadius(4), Child = body });
 
+            // A tab's preset color reaches the preview the same way it
+            // reaches the strip: the tint composites over the card fill
+            // rather than replacing it, so a colored tile still reads as the
+            // same surface as an uncolored one.
+            var colored = tab.Color != TabColor.None;
+            var idleBorder = colored
+                ? TabColorBrush.From(TabColorPalette.Border(tab.Color))
+                : _theme.BorderIdle;
+            _idleBorderByTab[tab] = idleBorder;
+
             var cell = new Border
             {
                 CornerRadius = new CornerRadius(8),
-                BorderThickness = new Thickness(2),
-                BorderBrush = _theme.BorderIdle,
-                Background = _theme.CardBackground,
-                Padding = new Thickness(6),
+                BorderThickness = new Thickness(CellBorder),
+                BorderBrush = idleBorder,
+                Background = colored
+                    ? TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: false))
+                    : _theme.CardBackground,
+                Padding = new Thickness(CellPadding),
+                Margin = new Thickness(CellMargin),
                 Child = content,
             };
             _cellByTab[tab] = cell;
@@ -115,13 +162,30 @@ internal sealed partial class TabSwitcherPopup : UserControl
         BorderActive: ThemeResources.Get<Brush>("AccentFillColorDefaultBrush",
             new SolidColorBrush(Color.FromArgb(0xFF, 0x60, 0xCD, 0xFF))));
 
+    /// <summary>
+    /// Column count for <paramref name="count"/> tiles: square-ish, so a
+    /// handful of tabs still make a compact card, but never wider than the
+    /// window can show.
+    /// </summary>
+    private static int ColumnsFor(int count, double hostWidth)
+    {
+        if (count <= 1) return 1;
+        var square = (int)Math.Ceiling(Math.Sqrt(count));
+        var byWidth = hostWidth > 0
+            ? (int)((hostWidth * MaxGridWidthRatio) / CellOuterWidth)
+            : square;
+        return Math.Max(1, Math.Min(square, byWidth));
+    }
+
     private void Highlight(TabModel tab)
     {
         foreach (var (model, cell) in _cellByTab)
         {
             cell.BorderBrush = ReferenceEquals(model, tab)
                 ? _theme.BorderActive
-                : _theme.BorderIdle;
+                : _idleBorderByTab.TryGetValue(model, out var idle)
+                    ? idle
+                    : _theme.BorderIdle;
         }
     }
 }

--- a/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
+++ b/windows/Ghostty/Tabs/TabSwitcherPopup.xaml.cs
@@ -77,6 +77,9 @@ internal sealed partial class TabSwitcherPopup : UserControl
         CandidateRow.MaximumRowsOrColumns = ColumnsFor(tabs.Count, hostWidth);
         if (hostHeight > 0)
             CandidateScroll.MaxHeight = hostHeight * MaxGridHeightRatio;
+        // A scroll offset left over from the previous open would show the
+        // new grid already scrolled past its first rows.
+        CandidateScroll.ChangeView(null, 0, null, disableAnimation: true);
 
         var renderer = new PanePreviewRenderer(PreviewFont.Resolve(fontFamily));
         foreach (var tab in tabs)
@@ -186,6 +189,10 @@ internal sealed partial class TabSwitcherPopup : UserControl
                 : _idleBorderByTab.TryGetValue(model, out var idle)
                     ? idle
                     : _theme.BorderIdle;
+            // Once the grid scrolls, the ring alone cannot tell the user
+            // which tile is active if it sits below the fold.
+            if (ReferenceEquals(model, tab))
+                cell.StartBringIntoView();
         }
     }
 }

--- a/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabHost.xaml.cs
@@ -59,6 +59,14 @@ internal sealed partial class VerticalTabHost : UserControl, ITabHost
     private bool _shellThemeActive;
 
     public FrameworkElement HostElement => this;
+
+    public FrameworkElement? TabElement(TabModel tab) => _strip.TabElement(tab);
+
+    internal void SetSelectionRowSuppressed(bool suppressed)
+        => _strip.SetSelectionRowSuppressed(suppressed);
+
+    internal (SolidColorBrush Fill, SolidColorBrush Foreground) ActiveRowChrome(TabModel tab)
+        => _strip.ActiveRowChrome(tab);
     public UIElement DragRegion => this;
 
     public event EventHandler<double>? StripWidthChangeRequested;

--- a/windows/Ghostty/Tabs/VerticalTabNavRow.cs
+++ b/windows/Ghostty/Tabs/VerticalTabNavRow.cs
@@ -9,7 +9,7 @@ namespace Ghostty.Tabs;
 /// Expanded-pane row content for a vertical-tab
 /// <see cref="NavigationViewItem"/>: title, optional bell, close.
 /// </summary>
-internal sealed class VerticalTabNavRow : Grid
+internal sealed partial class VerticalTabNavRow : Grid
 {
     private readonly TextBlock _title;
     private readonly FontIcon _bell;

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -352,15 +352,15 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// </summary>
     internal (SolidColorBrush Fill, SolidColorBrush Foreground) ActiveRowChrome(TabModel tab)
     {
+        // The fill always comes from ResolveSelectionRowFill so the ghost and
+        // the real row can never disagree on the selected color.
+        var fill = ResolveSelectionRowFill(tab);
         if (tab.Color != TabColor.None)
         {
-            return (
-                TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: true)),
-                TabColorBrush.FromPackedRgb(TabColorPalette.ForegroundRgb(
-                    tab.Color, selected: true, _stripBackdropPacked)));
+            return (fill, TabColorBrush.FromPackedRgb(TabColorPalette.ForegroundRgb(
+                tab.Color, selected: true, _stripBackdropPacked)));
         }
 
-        var fill = ResolveSelectionRowFill(tab);
         var rowPacked = PackColor(fill.Color);
         var preferred = _shellActiveTextBrush is not null
             ? PackColor(_shellActiveTextBrush.Color)

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -145,8 +145,8 @@ internal sealed partial class VerticalTabStrip : UserControl
 
         uint accentPacked = PackColor(theme.AccentColor);
         uint activePacked = PackColor(theme.ActiveTabText);
-        _shellActiveTextBrush = new SolidColorBrush(UnpackColor(
-            ThemeResolution.EnsureReadableForeground(accentPacked, activePacked)));
+        _shellActiveTextBrush = TabColorBrush.FromPackedRgb(
+            ThemeResolution.EnsureReadableForeground(accentPacked, activePacked));
 
         uint tabBgPacked = PackColor(theme.TabBarBackground);
         _shellInactiveTextBrush = new SolidColorBrush(
@@ -206,9 +206,9 @@ internal sealed partial class VerticalTabStrip : UserControl
     {
         _defaultSelectedTabBgBrush = new SolidColorBrush(
             Windows.UI.Color.FromArgb(0xFF, background.R, background.G, background.B));
-        _defaultActiveTextBrush = new SolidColorBrush(UnpackColor(
+        _defaultActiveTextBrush = TabColorBrush.FromPackedRgb(
             ThemeResolution.EnsureReadableForeground(
-                PackColor(background), PackColor(foreground))));
+                PackColor(background), PackColor(foreground)));
 
         // Tab-bar backdrop for preset tint blending is owned by
         // ApplyShellChrome / ApplyDefaultPaneChrome. Terminal bg != tab bar.
@@ -293,8 +293,32 @@ internal sealed partial class VerticalTabStrip : UserControl
     /// Paint one straight selected row from the strip inset to the pane edge.
     /// MUXC's rounded pill is hidden; this overlay is the sole selection fill.
     /// </summary>
+    /// <summary>
+    /// Hide the selected-row fill while the active tab is being morphed
+    /// across a layout switch.
+    ///
+    /// SelectionRow is an overlay on its own canvas rather than part of the
+    /// NavigationViewItem, so hiding the item leaves the fill sitting on the
+    /// rail -- a colored block still marking a tab that has visibly flown
+    /// off to the header.
+    /// </summary>
+    internal void SetSelectionRowSuppressed(bool suppressed)
+    {
+        if (_selectionRowSuppressed == suppressed) return;
+        _selectionRowSuppressed = suppressed;
+        UpdateSelectionRow();
+    }
+
+    private bool _selectionRowSuppressed;
+
     private void UpdateSelectionRow()
     {
+        if (_selectionRowSuppressed)
+        {
+            SelectionRow.Visibility = Visibility.Collapsed;
+            return;
+        }
+
         if (_manager.ActiveTab is null
             || !_items.TryGetValue(_manager.ActiveTab, out var item)
             || item.ActualWidth <= 0
@@ -319,10 +343,38 @@ internal sealed partial class VerticalTabStrip : UserControl
         SelectionRow.Visibility = Visibility.Visible;
     }
 
+    /// <summary>
+    /// Fill and readable foreground the active row paints itself with.
+    /// The morph ghost stands in for that row across a layout switch, so it
+    /// asks for the real chrome rather than approximating it -- an
+    /// uncolored tab has a fill too, and a ghost without one reads as the
+    /// tab losing its selection for the length of the switch.
+    /// </summary>
+    internal (SolidColorBrush Fill, SolidColorBrush Foreground) ActiveRowChrome(TabModel tab)
+    {
+        if (tab.Color != TabColor.None)
+        {
+            return (
+                TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: true)),
+                TabColorBrush.FromPackedRgb(TabColorPalette.ForegroundRgb(
+                    tab.Color, selected: true, _stripBackdropPacked)));
+        }
+
+        var fill = ResolveSelectionRowFill(tab);
+        var rowPacked = PackColor(fill.Color);
+        var preferred = _shellActiveTextBrush is not null
+            ? PackColor(_shellActiveTextBrush.Color)
+            : _defaultActiveTextBrush is not null
+                ? PackColor(_defaultActiveTextBrush.Color)
+                : rowPacked;
+        return (fill, TabColorBrush.FromPackedRgb(
+            ThemeResolution.EnsureReadableForeground(rowPacked, preferred)));
+    }
+
     private SolidColorBrush ResolveSelectionRowFill(TabModel tab)
     {
         if (tab.Color != TabColor.None)
-            return DrawingColorBrush(TabColorPalette.Background(tab.Color, selected: true));
+            return TabColorBrush.From(TabColorPalette.Background(tab.Color, selected: true));
 
         // Mirror horizontal TabHost: shell theme paints accent on the selected
         // handle; default path uses terminal background so the row meets the pane.
@@ -360,7 +412,7 @@ internal sealed partial class VerticalTabStrip : UserControl
                 item.ClearValue(Control.BackgroundProperty);
             else
             {
-                item.Background = DrawingColorBrush(
+                item.Background = TabColorBrush.From(
                     TabColorPalette.Background(tab.Color, selected: false));
             }
         }
@@ -383,10 +435,6 @@ internal sealed partial class VerticalTabStrip : UserControl
                 : Color.FromArgb(0xB3, 0x00, 0x00, 0x00));
     }
 
-    private static SolidColorBrush DrawingColorBrush(System.Drawing.Color drawing)
-        => new(Windows.UI.Color.FromArgb(
-            drawing.A, drawing.R, drawing.G, drawing.B));
-
     private static readonly string[] NavItemForegroundKeys =
     [
         "NavigationViewItemForeground",
@@ -406,27 +454,16 @@ internal sealed partial class VerticalTabStrip : UserControl
             var active = ReferenceEquals(model, _manager.ActiveTab);
             if (model.Color != TabColor.None)
             {
-                var fg = new SolidColorBrush(UnpackColor(
+                var fg = TabColorBrush.FromPackedRgb(
                     TabColorPalette.ForegroundRgb(
-                        model.Color, active, _stripBackdropPacked)));
+                        model.Color, active, _stripBackdropPacked));
                 ApplyItemForeground(item, fg, active);
                 ApplyItemTabColor(item, model);
                 continue;
             }
 
             if (active)
-            {
-                var rowFill = ResolveSelectionRowFill(model).Color;
-                var rowPacked = PackColor(rowFill);
-                uint preferred = _shellActiveTextBrush is not null
-                    ? PackColor(_shellActiveTextBrush.Color)
-                    : _defaultActiveTextBrush is not null
-                        ? PackColor(_defaultActiveTextBrush.Color)
-                        : rowPacked;
-                var fg = new SolidColorBrush(UnpackColor(
-                    ThemeResolution.EnsureReadableForeground(rowPacked, preferred)));
-                ApplyItemForeground(item, fg, active: true);
-            }
+                ApplyItemForeground(item, ActiveRowChrome(model).Foreground, active: true);
             else
                 ApplyItemForeground(item, ResolveInactiveTextBrush(), active: false);
 
@@ -601,9 +638,6 @@ internal sealed partial class VerticalTabStrip : UserControl
     private static uint PackColor(Color c)
         => ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
 
-    private static Color UnpackColor(uint packed)
-        => Color.FromArgb(0xFF, (byte)(packed >> 16), (byte)(packed >> 8), (byte)packed);
-
     private void RebuildAllItems()
     {
         // Remove by what we hold, not by what the manager still has:
@@ -739,6 +773,10 @@ internal sealed partial class VerticalTabStrip : UserControl
         RecolorNavItems();
         RefreshSelectionChrome();
     }
+
+    /// <summary>The row rendering <paramref name="tab"/>, if built.</summary>
+    internal FrameworkElement? TabElement(TabModel tab)
+        => _items.TryGetValue(tab, out var item) ? item : null;
 
     /// <summary>Resolve TabModel for a nav item hit-test target.</summary>
     internal TabModel? TabFromElement(DependencyObject? source)

--- a/windows/scripts/vtabs-layout-switch-capture.ps1
+++ b/windows/scripts/vtabs-layout-switch-capture.ps1
@@ -136,7 +136,10 @@ try {
 }
 finally {
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg } else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    if ($proc -and -not $proc.HasExited) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        try { $proc.WaitForExit(3000) } catch {}
+    }
     Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
 }
 Write-Host "OUT=$OutDir"

--- a/windows/scripts/vtabs-layout-switch-capture.ps1
+++ b/windows/scripts/vtabs-layout-switch-capture.ps1
@@ -83,6 +83,7 @@ $cfgDir = Join-Path $tempXdg 'wintty'
 New-Item -ItemType Directory -Path $cfgDir -Force | Out-Null
 @'
 vertical-tabs = true
+windows-single-instance = false
 window-theme = wintty
 theme = Catppuccin Mocha
 '@ | Set-Content -Path (Join-Path $cfgDir 'config.wintty') -Encoding utf8

--- a/windows/scripts/vtabs-morph-filmstrip.ps1
+++ b/windows/scripts/vtabs-morph-filmstrip.ps1
@@ -37,6 +37,7 @@ public static class VtMorph {
     [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
     [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr h, out RECT r);
     [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool IsWindow(IntPtr h);
     [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr lp);
     [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
     [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool repaint);
@@ -68,7 +69,7 @@ public static class VtMorph {
     // SetForegroundWindow fails silently under the foreground lock. Confirm
     // ownership before sending anything or the chord lands in the editor.
     static bool Focus(IntPtr expected) {
-        if (expected == IntPtr.Zero) return false;
+        if (expected == IntPtr.Zero || !IsWindow(expected)) return false;
         for (int i = 0; i < 20; i++) {
             if (GetForegroundWindow() == expected) return true;
             SetForegroundWindow(expected);
@@ -86,13 +87,18 @@ public static class VtMorph {
     }
     public static bool ToggleLayout(IntPtr h) { if (!Focus(h)) return false; Chord(VK_OEM_COMMA, true); return true; }
     [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern bool GetCursorPos(out POINT p);
     [DllImport("user32.dll")] static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
     [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
     [DllImport("user32.dll")] static extern IntPtr WindowFromPoint(POINT p);
     public static bool Click(uint pid, int x, int y, bool right) {
         SetCursorPos(x, y); Thread.Sleep(60);
-        var p = new POINT { X = x, Y = y };
-        uint owner = 0; GetWindowThreadProcessId(WindowFromPoint(p), out owner);
+        // Probe the live cursor, not the scripted point: the buttons land
+        // wherever the cursor is now, and a user mouse move during the
+        // settle would divorce the pid check from the click.
+        POINT live; if (!GetCursorPos(out live)) return false;
+        if (Math.Abs(live.X - x) > 2 || Math.Abs(live.Y - y) > 2) return false;
+        uint owner = 0; GetWindowThreadProcessId(WindowFromPoint(live), out owner);
         if (owner != pid) return false;
         uint down = right ? 0x0008u : 0x0002u, up = right ? 0x0010u : 0x0004u;
         mouse_event(down, 0, 0, 0, UIntPtr.Zero);
@@ -218,7 +224,12 @@ try {
 }
 finally {
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg } else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    if ($proc -and -not $proc.HasExited) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        # The dying process can still hold handles under the temp dir; an
+        # immediate delete leaks the GUID dir silently.
+        try { $proc.WaitForExit(3000) } catch {}
+    }
     Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
 }
 Write-Host "OUT=$OutDir"

--- a/windows/scripts/vtabs-morph-filmstrip.ps1
+++ b/windows/scripts/vtabs-morph-filmstrip.ps1
@@ -1,0 +1,224 @@
+#requires -Version 7
+# Dense frame capture across a horizontal<->vertical tab layout switch.
+#
+# The existing vtabs-layout-switch-capture takes one frame per direction,
+# which is enough to prove the end states but says nothing about the motion
+# in between. This grabs a burst at roughly one frame per compositor tick so
+# the travel direction and the active-tab morph can be judged frame by frame.
+param(
+    [string]$ExePath = (Join-Path $PSScriptRoot '..\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'),
+    [string]$OutDir = (Join-Path $PSScriptRoot ("vtabs-morph/run-" + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
+    [int]$Frames = 26,
+    [int]$IntervalMs = 22,
+    # Only the strip corner is interesting, and copying the whole window cost
+    # more per frame than the interval itself, stretching a 340ms animation
+    # across a third of a second of sampling.
+    [int]$RegionW = 720,
+    [int]$RegionH = 420,
+    [switch]$ColorActive,
+    [string]$ColorName = 'Red',
+    [switch]$Vertical,
+    # The pinned rail is where the column tween has real distance to cover,
+    # so it is where the strip lagging behind the ghost shows up.
+    [switch]$Pinned
+)
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+public static class VtMorph {
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L,T,R,B; }
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr lp);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool repaint);
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr h, StringBuilder s, int n);
+    public delegate bool EnumProc(IntPtr h, IntPtr lp);
+    [DllImport("user32.dll")] static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
+    const uint KEYUP = 0x0002;
+    const byte VK_CONTROL = 0x11;
+    const byte VK_SHIFT = 0x10;
+    const byte VK_OEM_COMMA = 0xBC;
+    const byte VK_T = 0x54;
+    public static IntPtr FindWin(uint pid) {
+        IntPtr best = IntPtr.Zero; int bestArea = 0;
+        EnumProc cb = (h, lp) => {
+            uint p = 0; GetWindowThreadProcessId(h, out p);
+            if (p != pid || !IsWindowVisible(h)) return true;
+            var sb = new StringBuilder(256); GetClassName(h, sb, 256);
+            if (sb.ToString() != "WinUIDesktopWin32WindowClass") return true;
+            RECT r; if (!GetWindowRect(h, out r)) return true;
+            int area = Math.Max(0, r.R - r.L) * Math.Max(0, r.B - r.T);
+            if (area > bestArea) { bestArea = area; best = h; }
+            return true;
+        };
+        EnumWindows(cb, IntPtr.Zero);
+        return best;
+    }
+    public static RECT Rect(IntPtr h) { RECT r; GetWindowRect(h, out r); return r; }
+    // Synthesized keys go to the foreground owner, not to a handle, and
+    // SetForegroundWindow fails silently under the foreground lock. Confirm
+    // ownership before sending anything or the chord lands in the editor.
+    static bool Focus(IntPtr expected) {
+        if (expected == IntPtr.Zero) return false;
+        for (int i = 0; i < 20; i++) {
+            if (GetForegroundWindow() == expected) return true;
+            SetForegroundWindow(expected);
+            Thread.Sleep(50);
+        }
+        return GetForegroundWindow() == expected;
+    }
+    static void Chord(byte key, bool shift) {
+        keybd_event(VK_CONTROL, 0, 0, UIntPtr.Zero);
+        if (shift) keybd_event(VK_SHIFT, 0, 0, UIntPtr.Zero);
+        keybd_event(key, 0, 0, UIntPtr.Zero);
+        keybd_event(key, 0, KEYUP, UIntPtr.Zero);
+        if (shift) keybd_event(VK_SHIFT, 0, KEYUP, UIntPtr.Zero);
+        keybd_event(VK_CONTROL, 0, KEYUP, UIntPtr.Zero);
+    }
+    public static bool ToggleLayout(IntPtr h) { if (!Focus(h)) return false; Chord(VK_OEM_COMMA, true); return true; }
+    [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
+    [DllImport("user32.dll")] static extern IntPtr WindowFromPoint(POINT p);
+    public static bool Click(uint pid, int x, int y, bool right) {
+        SetCursorPos(x, y); Thread.Sleep(60);
+        var p = new POINT { X = x, Y = y };
+        uint owner = 0; GetWindowThreadProcessId(WindowFromPoint(p), out owner);
+        if (owner != pid) return false;
+        uint down = right ? 0x0008u : 0x0002u, up = right ? 0x0010u : 0x0004u;
+        mouse_event(down, 0, 0, 0, UIntPtr.Zero);
+        mouse_event(up, 0, 0, 0, UIntPtr.Zero);
+        return true;
+    }
+    public static bool NewTab(IntPtr h) { if (!Focus(h)) return false; Chord(VK_T, false); return true; }
+}
+'@
+
+# Capture into memory first and save afterwards: encoding PNG inside the
+# loop costs more than the frame interval and would smear the timeline.
+function Start-Burst([IntPtr]$hwnd, [string]$tag) {
+    $r = [VtMorph]::Rect($hwnd)
+    $w = [Math]::Min($RegionW, $r.R - $r.L)
+    $h = [Math]::Min($RegionH, $r.B - $r.T)
+    if ($w -lt 80 -or $h -lt 80) { throw "bad rect for $tag" }
+    $shots = New-Object System.Collections.Generic.List[object]
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    for ($i = 0; $i -lt $Frames; $i++) {
+        $bmp = New-Object System.Drawing.Bitmap $w, $h
+        $g = [System.Drawing.Graphics]::FromImage($bmp)
+        $g.CopyFromScreen($r.L, $r.T, 0, 0, $bmp.Size)
+        $g.Dispose()
+        $shots.Add([pscustomobject]@{ Bmp = $bmp; At = $sw.ElapsedMilliseconds })
+        $due = ($i + 1) * $IntervalMs
+        $wait = $due - $sw.ElapsedMilliseconds
+        if ($wait -gt 0) { Start-Sleep -Milliseconds $wait }
+    }
+    $sw.Stop()
+    for ($i = 0; $i -lt $shots.Count; $i++) {
+        $n = '{0}-{1:d2}-t{2:d3}ms' -f $tag, $i, $shots[$i].At
+        $shots[$i].Bmp.Save((Join-Path $OutDir "$n.png"))
+        $shots[$i].Bmp.Dispose()
+    }
+    Write-Host "$tag : $($shots.Count) frames, last t=$($shots[$shots.Count-1].At)ms"
+}
+
+$tempXdg = Join-Path $env:TEMP "wintty-morph-$([guid]::NewGuid())"
+$cfgDir = Join-Path $tempXdg 'wintty'
+New-Item -ItemType Directory -Path $cfgDir -Force | Out-Null
+@"
+vertical-tabs = $($Vertical.IsPresent.ToString().ToLower())
+vertical-tabs-pinned = $($Pinned.IsPresent.ToString().ToLower())
+windows-single-instance = false
+window-theme = wintty
+theme = Catppuccin Mocha
+"@ | Set-Content -Path (Join-Path $cfgDir 'config.wintty') -Encoding utf8
+
+$origXdg = $env:XDG_CONFIG_HOME
+$env:XDG_CONFIG_HOME = $tempXdg
+$proc = $null
+try {
+    $proc = Start-Process -FilePath $ExePath -PassThru
+    $dl = (Get-Date).AddSeconds(45)
+    $hwnd = [IntPtr]::Zero
+    while ((Get-Date) -lt $dl) {
+        Start-Sleep -Milliseconds 300
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "exit $($proc.ExitCode)" }
+        $hwnd = [VtMorph]::FindWin([uint32]$proc.Id)
+        if ($hwnd -ne [IntPtr]::Zero) { break }
+    }
+    if ($hwnd -eq [IntPtr]::Zero) { throw 'no hwnd' }
+    Start-Sleep -Seconds 4
+
+    [void][VtMorph]::MoveWindow($hwnd, 60, 60, 1280, 820, $true)
+    Start-Sleep -Milliseconds 600
+
+    # Three tabs so the strip has something to animate and the active one is
+    # not the only row on screen.
+    foreach ($i in 1..2) {
+        if (-not [VtMorph]::NewTab($hwnd)) { throw 'FOREGROUND_MISS: new tab' }
+        Start-Sleep -Milliseconds 900
+    }
+    Start-Sleep -Milliseconds 800
+
+    if ($ColorActive) {
+        Add-Type -AssemblyName UIAutomationClient
+        Add-Type -AssemblyName UIAutomationTypes
+        $root = [System.Windows.Automation.AutomationElement]::FromHandle($hwnd)
+        $ct = if ($Vertical) { 'ListItem' } else { 'TabItem' }
+        $hits = $root.FindAll(
+            [System.Windows.Automation.TreeScope]::Descendants,
+            (New-Object System.Windows.Automation.PropertyCondition(
+                [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+                [System.Windows.Automation.ControlType]::$ct)))
+        if ($hits.Count -gt 0) {
+            $r = $hits[$hits.Count - 1].Current.BoundingRectangle
+            [void][VtMorph]::Click([uint32]$proc.Id,
+                [int]($r.X + $r.Width * 0.4), [int]($r.Y + $r.Height / 2), $true)
+            Start-Sleep -Milliseconds 500
+            $root = [System.Windows.Automation.AutomationElement]::FromHandle($hwnd)
+            foreach ($name in @('Tab Color...', $ColorName)) {
+                $el = $root.FindFirst(
+                    [System.Windows.Automation.TreeScope]::Descendants,
+                    (New-Object System.Windows.Automation.PropertyCondition(
+                        [System.Windows.Automation.AutomationElement]::NameProperty, $name)))
+                if ($null -eq $el) { Write-Host "color step '$name' not found"; break }
+                $b = $el.Current.BoundingRectangle
+                [void][VtMorph]::Click([uint32]$proc.Id,
+                    [int]($b.X + $b.Width / 2), [int]($b.Y + $b.Height / 2), $false)
+                Start-Sleep -Milliseconds 450
+                $root = [System.Windows.Automation.AutomationElement]::FromHandle($hwnd)
+            }
+            Write-Host "active tab coloured $ColorName"
+        }
+        # UIA leaves focus on whatever it clicked; the layout chord only
+        # reaches the router from the terminal surface.
+        $wr = [VtMorph]::Rect($hwnd)
+        [void][VtMorph]::Click([uint32]$proc.Id,
+            [int](($wr.L + $wr.R) / 2), [int](($wr.T + $wr.B) / 2), $false)
+        Start-Sleep -Milliseconds 500
+    }
+
+    if (-not [VtMorph]::ToggleLayout($hwnd)) { throw 'FOREGROUND_MISS: to horizontal' }
+    Start-Burst $hwnd 'A-vertical-to-horizontal'
+    Start-Sleep -Milliseconds 900
+
+    if (-not [VtMorph]::ToggleLayout($hwnd)) { throw 'FOREGROUND_MISS: to vertical' }
+    Start-Burst $hwnd 'B-horizontal-to-vertical'
+    Start-Sleep -Milliseconds 900
+}
+finally {
+    if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg } else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
+}
+Write-Host "OUT=$OutDir"

--- a/windows/scripts/vtabs-morph-fuzz.ps1
+++ b/windows/scripts/vtabs-morph-fuzz.ps1
@@ -6,10 +6,11 @@
 # arrive before the previous one has finished. This drives all of that from a
 # seeded RNG so a failure can be replayed with -Seed.
 #
-# Pass/fail is not "did it crash": the app is built with morph tracing for
-# this run, and every SWITCH end line must report ghosts=0 and morph=null.
-# A ghost left parked on the morph layer is the artifact this whole change
-# exists to remove, so it is the thing worth asserting.
+# Pass/fail is not "did it crash": the app emits a morph trace whenever the
+# WINTTY_MORPH_TRACE env var names a log file (set per run below), and every
+# SWITCH end line must report ghosts=0 and morph=null. A ghost left parked on
+# the morph layer is the artifact this whole change exists to remove, so it
+# is the thing worth asserting.
 param(
     [string]$ExePath = (Join-Path $PSScriptRoot '..\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'),
     [int]$Seed = 0,
@@ -44,6 +45,7 @@ public static class MFz {
     public delegate bool EnumProc(IntPtr h, IntPtr lp);
     [DllImport("user32.dll")] static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
     [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern bool GetCursorPos(out POINT p);
     [DllImport("user32.dll")] static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
     const uint KEYUP = 0x0002;
     public static IntPtr FindWin(uint pid) {
@@ -88,6 +90,10 @@ public static class MFz {
     public static bool Type(IntPtr h, string text) {
         if (!Focus(h)) return false;
         foreach (char c in text) {
+            // The burst runs for hundreds of ms; re-confirm ownership per
+            // character so an alt-tab (or app crash) cannot route the tail
+            // of a shell command into a foreign window.
+            if (GetForegroundWindow() != h) return false;
             short vk = VkKeyScan(c);
             bool shift = (vk & 0x100) != 0;
             byte k = (byte)(vk & 0xFF);
@@ -97,6 +103,8 @@ public static class MFz {
             if (shift) keybd_event(0x10, 0, KEYUP, UIntPtr.Zero);
             Thread.Sleep(6);
         }
+        // Enter is the keystroke that executes; never send it blind.
+        if (GetForegroundWindow() != h) return false;
         keybd_event(0x0D, 0, 0, UIntPtr.Zero);
         keybd_event(0x0D, 0, KEYUP, UIntPtr.Zero);
         return true;
@@ -107,8 +115,13 @@ public static class MFz {
     public static bool Click(uint pid, int x, int y, bool right) {
         SetCursorPos(x, y);
         Thread.Sleep(60);
-        var p = new POINT { X = x, Y = y };
-        IntPtr under = WindowFromPoint(p);
+        // The buttons land wherever the cursor is NOW, not at the scripted
+        // point: a user mouse move during the settle would divorce the pid
+        // probe from the click. Probe the live position and require it to
+        // still be ours.
+        POINT live; if (!GetCursorPos(out live)) return false;
+        if (Math.Abs(live.X - x) > 2 || Math.Abs(live.Y - y) > 2) return false;
+        IntPtr under = WindowFromPoint(live);
         uint owner = 0; GetWindowThreadProcessId(under, out owner);
         if (owner != pid) return false;
         uint down = right ? 0x0008u : 0x0002u;
@@ -149,8 +162,9 @@ function Invoke-El($el) {
     } catch { return $false }
 }
 
-$log = Join-Path $env:TEMP 'wintty-morph.log'
-Remove-Item $log -ErrorAction SilentlyContinue
+# Per-run path: a fixed name would interleave lines from a concurrently
+# running instrumented instance in another worktree and corrupt the oracle.
+$log = Join-Path $env:TEMP "wintty-morph-$([guid]::NewGuid()).log"
 
 $tempXdg = Join-Path $env:TEMP "wintty-morphfuzz-$([guid]::NewGuid())"
 $cfgDir = Join-Path $tempXdg 'wintty'
@@ -165,6 +179,8 @@ theme = Catppuccin Mocha
 
 $origXdg = $env:XDG_CONFIG_HOME
 $env:XDG_CONFIG_HOME = $tempXdg
+$origTrace = $env:WINTTY_MORPH_TRACE
+$env:WINTTY_MORPH_TRACE = $log
 $proc = $null
 $actions = @{}
 $chordMisses = 0
@@ -192,6 +208,14 @@ try {
         Start-Sleep -Milliseconds 500
     }
     $tabs = 8
+
+    # One deterministic toggle up front proves the oracle is alive before
+    # minutes of fuzzing are spent on a build that cannot report it.
+    if (-not [MFz]::Chord($hwnd, $VK.Comma, $true, $true)) { throw 'FOREGROUND_MISS: probe toggle' }
+    Start-Sleep -Milliseconds 1200
+    if (-not (Test-Path $log)) {
+        throw "no morph trace at $log - the app ignored WINTTY_MORPH_TRACE; this build predates the built-in trace"
+    }
 
     for ($i = 0; $i -lt $Iterations; $i++) {
         if (-not [MFz]::IsWindow($hwnd)) { throw "window gone at iteration $i" }
@@ -323,6 +347,8 @@ finally {
     Start-Sleep -Milliseconds 600
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    if ($null -ne $origTrace) { $env:WINTTY_MORPH_TRACE = $origTrace }
+    else { Remove-Item Env:WINTTY_MORPH_TRACE -ErrorAction SilentlyContinue }
     Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
 }
 
@@ -330,7 +356,7 @@ Write-Host ''
 Write-Host 'actions:'
 $actions.GetEnumerator() | Sort-Object Name | ForEach-Object { Write-Host ("  {0,-20} {1}" -f $_.Key, $_.Value) }
 
-if (-not (Test-Path $log)) { throw 'no morph trace: is this an instrumented build?' }
+if (-not (Test-Path $log)) { throw "no morph trace at $log - the app ignored WINTTY_MORPH_TRACE" }
 $lines = Get-Content $log
 $begins = @($lines | Where-Object { $_ -like 'SWITCH begin*' }).Count
 $ends = @($lines | Where-Object { $_ -like 'SWITCH end*' }).Count

--- a/windows/scripts/vtabs-morph-fuzz.ps1
+++ b/windows/scripts/vtabs-morph-fuzz.ps1
@@ -1,0 +1,368 @@
+#requires -Version 7
+# Randomized stress for the horizontal<->vertical tab layout switch.
+#
+# The layout switch has to hold up with a strip full of tabs, tabs whose
+# titles and icons keep changing under it, per-tab colors, and switches that
+# arrive before the previous one has finished. This drives all of that from a
+# seeded RNG so a failure can be replayed with -Seed.
+#
+# Pass/fail is not "did it crash": the app is built with morph tracing for
+# this run, and every SWITCH end line must report ghosts=0 and morph=null.
+# A ghost left parked on the morph layer is the artifact this whole change
+# exists to remove, so it is the thing worth asserting.
+param(
+    [string]$ExePath = (Join-Path $PSScriptRoot '..\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'),
+    [int]$Seed = 0,
+    [int]$Iterations = 60,
+    [switch]$StartHorizontal
+)
+$ErrorActionPreference = 'Stop'
+if ($Seed -eq 0) { $Seed = Get-Random -Minimum 1 -Maximum 999999 }
+$rng = [System.Random]::new($Seed)
+Write-Host "seed=$Seed iterations=$Iterations"
+
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+public static class MFz {
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L,T,R,B; }
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool IsWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr lp);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool r);
+    [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr h, StringBuilder s, int n);
+    [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT p);
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
+    public delegate bool EnumProc(IntPtr h, IntPtr lp);
+    [DllImport("user32.dll")] static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
+    [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
+    const uint KEYUP = 0x0002;
+    public static IntPtr FindWin(uint pid) {
+        IntPtr best = IntPtr.Zero; int bestArea = 0;
+        EnumProc cb = (h, lp) => {
+            uint p = 0; GetWindowThreadProcessId(h, out p);
+            if (p != pid || !IsWindowVisible(h)) return true;
+            var sb = new StringBuilder(256); GetClassName(h, sb, 256);
+            if (sb.ToString() != "WinUIDesktopWin32WindowClass") return true;
+            RECT r; if (!GetWindowRect(h, out r)) return true;
+            int area = Math.Max(0, r.R - r.L) * Math.Max(0, r.B - r.T);
+            if (area > bestArea) { bestArea = area; best = h; }
+            return true;
+        };
+        EnumWindows(cb, IntPtr.Zero);
+        return best;
+    }
+    public static RECT Rect(IntPtr h) { RECT r; GetWindowRect(h, out r); return r; }
+    // Synthesized input goes to whoever owns the foreground, not to a
+    // handle, and SetForegroundWindow fails silently under the foreground
+    // lock. Every send confirms ownership first so a stray chord cannot land
+    // in the developer's editor.
+    public static bool Focus(IntPtr expected) {
+        if (expected == IntPtr.Zero || !IsWindow(expected)) return false;
+        for (int i = 0; i < 20; i++) {
+            if (GetForegroundWindow() == expected) return true;
+            SetForegroundWindow(expected);
+            Thread.Sleep(50);
+        }
+        return GetForegroundWindow() == expected;
+    }
+    public static bool Chord(IntPtr h, byte key, bool ctrl, bool shift) {
+        if (!Focus(h)) return false;
+        if (ctrl) keybd_event(0x11, 0, 0, UIntPtr.Zero);
+        if (shift) keybd_event(0x10, 0, 0, UIntPtr.Zero);
+        keybd_event(key, 0, 0, UIntPtr.Zero);
+        keybd_event(key, 0, KEYUP, UIntPtr.Zero);
+        if (shift) keybd_event(0x10, 0, KEYUP, UIntPtr.Zero);
+        if (ctrl) keybd_event(0x11, 0, KEYUP, UIntPtr.Zero);
+        return true;
+    }
+    public static bool Type(IntPtr h, string text) {
+        if (!Focus(h)) return false;
+        foreach (char c in text) {
+            short vk = VkKeyScan(c);
+            bool shift = (vk & 0x100) != 0;
+            byte k = (byte)(vk & 0xFF);
+            if (shift) keybd_event(0x10, 0, 0, UIntPtr.Zero);
+            keybd_event(k, 0, 0, UIntPtr.Zero);
+            keybd_event(k, 0, KEYUP, UIntPtr.Zero);
+            if (shift) keybd_event(0x10, 0, KEYUP, UIntPtr.Zero);
+            Thread.Sleep(6);
+        }
+        keybd_event(0x0D, 0, 0, UIntPtr.Zero);
+        keybd_event(0x0D, 0, KEYUP, UIntPtr.Zero);
+        return true;
+    }
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)] static extern short VkKeyScan(char c);
+    // Re-probe after the cursor settles: the point that was over a tab when
+    // the rect was measured may be over a flyout by the time the click lands.
+    public static bool Click(uint pid, int x, int y, bool right) {
+        SetCursorPos(x, y);
+        Thread.Sleep(60);
+        var p = new POINT { X = x, Y = y };
+        IntPtr under = WindowFromPoint(p);
+        uint owner = 0; GetWindowThreadProcessId(under, out owner);
+        if (owner != pid) return false;
+        uint down = right ? 0x0008u : 0x0002u;
+        uint up = right ? 0x0010u : 0x0004u;
+        mouse_event(down, 0, 0, 0, UIntPtr.Zero);
+        mouse_event(up, 0, 0, 0, UIntPtr.Zero);
+        return true;
+    }
+}
+'@
+
+$VK = @{ T = 0x54; W = 0x57; Comma = 0xBC; Tab = 0x09; Esc = 0x1B }
+$Colors = @('Red', 'Orange', 'Yellow', 'Green', 'Teal', 'Blue', 'Purple', 'Pink', 'None')
+# Each spawns a different foreground process, so tab icons and titles differ
+# and the morph ghost has to copy something other than a default cmd tab.
+$Shells = @('powershell -NoLogo', 'cmd', 'powershell -NoLogo -Command "$host.UI.RawUI.WindowTitle=''fuzz''; cmd"')
+
+function Get-UiaRoot([int64]$h) {
+    return [System.Windows.Automation.AutomationElement]::FromHandle([IntPtr]::new($h))
+}
+function Find-ByName($root, [string]$name, [int]$timeoutMs) {
+    $dl = (Get-Date).AddMilliseconds($timeoutMs)
+    $cond = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::NameProperty, $name)
+    while ((Get-Date) -lt $dl) {
+        $el = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
+        if ($null -ne $el) { return $el }
+        Start-Sleep -Milliseconds 120
+        $root = Get-UiaRoot $script:Hwnd64
+    }
+    return $null
+}
+function Invoke-El($el) {
+    try {
+        $pat = $el.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)
+        $pat.Invoke()
+        return $true
+    } catch { return $false }
+}
+
+$log = Join-Path $env:TEMP 'wintty-morph.log'
+Remove-Item $log -ErrorAction SilentlyContinue
+
+$tempXdg = Join-Path $env:TEMP "wintty-morphfuzz-$([guid]::NewGuid())"
+$cfgDir = Join-Path $tempXdg 'wintty'
+New-Item -ItemType Directory -Path $cfgDir -Force | Out-Null
+$startVertical = -not $StartHorizontal
+@"
+vertical-tabs = $($startVertical.ToString().ToLower())
+windows-single-instance = false
+window-theme = wintty
+theme = Catppuccin Mocha
+"@ | Set-Content -Path (Join-Path $cfgDir 'config.wintty') -Encoding utf8
+
+$origXdg = $env:XDG_CONFIG_HOME
+$env:XDG_CONFIG_HOME = $tempXdg
+$proc = $null
+$actions = @{}
+$chordMisses = 0
+$failures = New-Object System.Collections.Generic.List[string]
+try {
+    $proc = Start-Process -FilePath $ExePath -PassThru
+    $hwnd = [IntPtr]::Zero
+    $dl = (Get-Date).AddSeconds(45)
+    while ((Get-Date) -lt $dl) {
+        Start-Sleep -Milliseconds 300
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "exit $($proc.ExitCode)" }
+        $hwnd = [MFz]::FindWin([uint32]$proc.Id)
+        if ($hwnd -ne [IntPtr]::Zero) { break }
+    }
+    if ($hwnd -eq [IntPtr]::Zero) { throw 'no hwnd' }
+    $script:Hwnd64 = $hwnd.ToInt64()
+    Start-Sleep -Seconds 4
+    [void][MFz]::MoveWindow($hwnd, 40, 40, 1400, 860, $true)
+    Start-Sleep -Milliseconds 700
+
+    # Seed the strip so the very first switches already have a crowd.
+    foreach ($i in 1..7) {
+        if (-not [MFz]::Chord($hwnd, $VK.T, $true, $false)) { throw 'FOREGROUND_MISS: seed tab' }
+        Start-Sleep -Milliseconds 500
+    }
+    $tabs = 8
+
+    for ($i = 0; $i -lt $Iterations; $i++) {
+        if (-not [MFz]::IsWindow($hwnd)) { throw "window gone at iteration $i" }
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "process exited at iteration $i (code $($proc.ExitCode))" }
+
+        $roll = $rng.Next(100)
+        if ($roll -lt 45) {
+            $act = 'toggle'
+            # A flyout left open by an earlier color pick would swallow the
+            # chord, and a swallowed toggle is a fuzz iteration that tested
+            # nothing.
+            [void][MFz]::Chord($hwnd, $VK.Esc, $false, $false)
+            Start-Sleep -Milliseconds 90
+            if (-not [MFz]::Chord($hwnd, $VK.Comma, $true, $true)) { $chordMisses++ }
+            # Sometimes toggle again before the switch has landed: the
+            # coordinator must not leave a ghost behind when interrupted.
+            if ($rng.Next(100) -lt 30) {
+                Start-Sleep -Milliseconds $rng.Next(40, 320)
+                [void][MFz]::Chord($hwnd, $VK.Comma, $true, $true)
+                $act = 'toggle-interrupted'
+            }
+        }
+        elseif ($roll -lt 58) {
+            $act = 'new-tab'
+            [void][MFz]::Chord($hwnd, $VK.T, $true, $false)
+            $tabs++
+        }
+        elseif ($roll -lt 66 -and $tabs -gt 3) {
+            # Dismiss any confirmation dialog left from an earlier close, then
+            # trust the strip over the shadow counter: with a stale counter the
+            # fuzz eventually closes the last tab, which closes the window.
+            [void][MFz]::Chord($hwnd, $VK.Esc, $false, $false)
+            Start-Sleep -Milliseconds 120
+            $actual = 0
+            try {
+                $root = Get-UiaRoot $script:Hwnd64
+                foreach ($ct in @('TabItem', 'ListItem')) {
+                    $n = $root.FindAll(
+                        [System.Windows.Automation.TreeScope]::Descendants,
+                        (New-Object System.Windows.Automation.PropertyCondition(
+                            [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+                            [System.Windows.Automation.ControlType]::$ct))).Count
+                    if ($n -gt $actual) { $actual = $n }
+                }
+            } catch { $actual = 0 }
+            if ($actual -gt 3) {
+                $act = 'close-tab'
+                [void][MFz]::Chord($hwnd, $VK.W, $true, $false)
+                $tabs = $actual - 1
+            } else {
+                $act = 'close-skipped'
+                if ($actual -gt 0) { $tabs = $actual }
+            }
+        }
+        elseif ($roll -lt 78) {
+            $act = 'switch-tab'
+            [void][MFz]::Chord($hwnd, $VK.Tab, $true, ($rng.Next(2) -eq 0))
+        }
+        elseif ($roll -lt 90) {
+            $act = 'spawn-shell'
+            # A pending confirmation dialog would treat the trailing Enter as
+            # its accept button; clear it before typing.
+            [void][MFz]::Chord($hwnd, $VK.Esc, $false, $false)
+            Start-Sleep -Milliseconds 100
+            [void][MFz]::Type($hwnd, $Shells[$rng.Next($Shells.Count)])
+        }
+        else {
+            $act = 'tab-color'
+            $color = $Colors[$rng.Next($Colors.Count)]
+            try {
+                $root = Get-UiaRoot $script:Hwnd64
+                # The strip is TabItems in the header and ListItems on the
+                # rail, so the color path has to work either way round.
+                $nav = $null
+                foreach ($ct in @('TabItem', 'ListItem')) {
+                    $hits = $root.FindAll(
+                        [System.Windows.Automation.TreeScope]::Descendants,
+                        (New-Object System.Windows.Automation.PropertyCondition(
+                            [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+                            [System.Windows.Automation.ControlType]::$ct)))
+                    if ($hits.Count -gt 0) {
+                        $nav = $hits[$rng.Next($hits.Count)]
+                        break
+                    }
+                }
+                if ($null -eq $nav) {
+                    $act = 'tab-color-skipped'
+                } else {
+                    $r = $nav.Current.BoundingRectangle
+                    $x = [int]($r.X + $r.Width * 0.4); $y = [int]($r.Y + $r.Height / 2)
+                    if ([MFz]::Click([uint32]$proc.Id, $x, $y, $true)) {
+                        Start-Sleep -Milliseconds 400
+                        $root = Get-UiaRoot $script:Hwnd64
+                        $pick = Find-ByName $root 'Tab Color...' 1800
+                        if ($null -ne $pick -and (Invoke-El $pick)) {
+                            Start-Sleep -Milliseconds 350
+                            $root = Get-UiaRoot $script:Hwnd64
+                            $sw = Find-ByName $root $color 1500
+                            if ($null -ne $sw) { [void](Invoke-El $sw) } else { $act = 'tab-color-miss' }
+                        } else { $act = 'tab-color-miss' }
+                        Start-Sleep -Milliseconds 250
+                        [void][MFz]::Chord($hwnd, $VK.Esc, $false, $false)
+                        # UIA leaves focus on the swatch it clicked, and the
+                        # layout chord only reaches the router from the
+                        # terminal surface. Without this the fuzz spends the
+                        # rest of the run sending toggles nobody handles.
+                        $wr = [MFz]::Rect($hwnd)
+                        [void][MFz]::Click([uint32]$proc.Id,
+                            [int](($wr.L + $wr.R) / 2), [int](($wr.T + $wr.B) / 2), $false)
+                        Start-Sleep -Milliseconds 200
+                    } else { $act = 'tab-color-skipped' }
+                }
+            } catch {
+                $act = 'tab-color-error'
+                [void][MFz]::Chord($hwnd, $VK.Esc, $false, $false)
+            }
+        }
+
+        $actions[$act] = 1 + ($actions[$act] ?? 0)
+        Start-Sleep -Milliseconds $rng.Next(160, 700)
+    }
+
+    # Let the last switch land before reading the trace.
+    Start-Sleep -Milliseconds 1200
+}
+finally {
+    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    Start-Sleep -Milliseconds 600
+    if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
+    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+Write-Host 'actions:'
+$actions.GetEnumerator() | Sort-Object Name | ForEach-Object { Write-Host ("  {0,-20} {1}" -f $_.Key, $_.Value) }
+
+if (-not (Test-Path $log)) { throw 'no morph trace: is this an instrumented build?' }
+$lines = Get-Content $log
+$begins = @($lines | Where-Object { $_ -like 'SWITCH begin*' }).Count
+$ends = @($lines | Where-Object { $_ -like 'SWITCH end*' }).Count
+$immediate = @($lines | Where-Object { $_ -like 'MORPH immediate*' }).Count
+$deferred = @($lines | Where-Object { $_ -like 'MORPH deferred*' }).Count
+$waiting = @($lines | Where-Object { $_ -like 'MORPH waiting*' }).Count
+$none = @($lines | Where-Object { $_ -like 'MORPH none*' }).Count
+$leaked = @($lines | Where-Object { $_ -match 'ghosts=[1-9]|morph=LEAKED' })
+
+Write-Host ''
+Write-Host "chord misses   : $chordMisses"
+Write-Host "switches begun : $begins"
+Write-Host "switches ended : $ends"
+Write-Host "morph immediate: $immediate"
+Write-Host "morph deferred : $deferred  (waited: $waiting)"
+Write-Host "morph none     : $none"
+
+if ($leaked.Count -gt 0) {
+    $failures.Add("$($leaked.Count) switch(es) ended with a ghost still on the morph layer")
+    $leaked | Select-Object -First 8 | ForEach-Object { Write-Host "  LEAK: $_" }
+}
+if ($begins -ne $ends) {
+    $failures.Add("switch begin/end mismatch: $begins vs $ends (a switch never finished)")
+}
+if ($immediate -eq 0 -and $begins -gt 0) {
+    $failures.Add('no switch ever staged a morph immediately')
+}
+
+Write-Host ''
+if ($failures.Count -gt 0) {
+    $failures | ForEach-Object { Write-Host "FAIL: $_" }
+    Write-Host "reproduce with: -Seed $Seed"
+    exit 1
+}
+Write-Host "PASS (seed $Seed)"

--- a/windows/scripts/vtabs-switcher-capture.ps1
+++ b/windows/scripts/vtabs-switcher-capture.ps1
@@ -1,0 +1,246 @@
+#requires -Version 7
+# Open a session with many colored tabs and capture the Ctrl+Tab switcher.
+#
+# Two things to look at in the output: the tiles wrap into a grid instead of
+# running off the right edge, and tabs carrying a preset color show it on
+# their tile.
+param(
+    [string]$ExePath = (Join-Path $PSScriptRoot '..\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'),
+    [string]$OutDir = (Join-Path $PSScriptRoot ("vtabs-switcher/run-" + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
+    [int]$TabCount = 14,
+    [switch]$Vertical
+)
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+public static class SwCap {
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L,T,R,B; }
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr lp);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool r);
+    [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr h, StringBuilder s, int n);
+    [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT p);
+    public delegate bool EnumProc(IntPtr h, IntPtr lp);
+    [DllImport("user32.dll")] static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
+    [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
+    const uint KEYUP = 0x0002;
+    public static IntPtr FindWin(uint pid) {
+        IntPtr best = IntPtr.Zero; int bestArea = 0;
+        EnumProc cb = (h, lp) => {
+            uint p = 0; GetWindowThreadProcessId(h, out p);
+            if (p != pid || !IsWindowVisible(h)) return true;
+            var sb = new StringBuilder(256); GetClassName(h, sb, 256);
+            if (sb.ToString() != "WinUIDesktopWin32WindowClass") return true;
+            RECT r; if (!GetWindowRect(h, out r)) return true;
+            int area = Math.Max(0, r.R - r.L) * Math.Max(0, r.B - r.T);
+            if (area > bestArea) { bestArea = area; best = h; }
+            return true;
+        };
+        EnumWindows(cb, IntPtr.Zero);
+        return best;
+    }
+    public static RECT Rect(IntPtr h) { RECT r; GetWindowRect(h, out r); return r; }
+    // Confirm the target owns the foreground before synthesizing anything:
+    // SetForegroundWindow fails silently under the foreground lock and the
+    // keystrokes would land in whatever is actually in front.
+    public static bool Focus(IntPtr e) {
+        for (int i = 0; i < 20; i++) {
+            if (GetForegroundWindow() == e) return true;
+            SetForegroundWindow(e); Thread.Sleep(50);
+        }
+        return GetForegroundWindow() == e;
+    }
+    public static bool Chord(IntPtr h, byte key, bool ctrl, bool shift) {
+        if (!Focus(h)) return false;
+        if (ctrl) keybd_event(0x11, 0, 0, UIntPtr.Zero);
+        if (shift) keybd_event(0x10, 0, 0, UIntPtr.Zero);
+        keybd_event(key, 0, 0, UIntPtr.Zero);
+        keybd_event(key, 0, KEYUP, UIntPtr.Zero);
+        if (shift) keybd_event(0x10, 0, KEYUP, UIntPtr.Zero);
+        if (ctrl) keybd_event(0x11, 0, KEYUP, UIntPtr.Zero);
+        return true;
+    }
+    public static bool Click(uint pid, int x, int y, bool right) {
+        SetCursorPos(x, y); Thread.Sleep(60);
+        var p = new POINT { X = x, Y = y };
+        uint owner = 0; GetWindowThreadProcessId(WindowFromPoint(p), out owner);
+        if (owner != pid) return false;
+        uint down = right ? 0x0008u : 0x0002u, up = right ? 0x0010u : 0x0004u;
+        mouse_event(down, 0, 0, 0, UIntPtr.Zero);
+        mouse_event(up, 0, 0, 0, UIntPtr.Zero);
+        return true;
+    }
+}
+'@
+
+$script:Hwnd64 = 0
+function Get-UiaRoot { [System.Windows.Automation.AutomationElement]::FromHandle([IntPtr]::new($script:Hwnd64)) }
+function Find-ByName([string]$name, [int]$timeoutMs) {
+    $dl = (Get-Date).AddMilliseconds($timeoutMs)
+    $cond = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::NameProperty, $name)
+    while ((Get-Date) -lt $dl) {
+        $el = (Get-UiaRoot).FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
+        if ($null -ne $el) { return $el }
+        Start-Sleep -Milliseconds 120
+    }
+    return $null
+}
+function Invoke-El($el) {
+    try { $el.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke(); return $true }
+    catch { return $false }
+}
+# The color swatches are Borders carrying only an automation Name, so they
+# expose no Invoke pattern and have to be clicked where they sit.
+function Click-El($el, [uint32]$ProcId) {
+    try {
+        $r = $el.Current.BoundingRectangle
+        if ($r.Width -le 0 -or $r.Height -le 0) { return $false }
+        return [SwCap]::Click($ProcId, [int]($r.X + $r.Width / 2), [int]($r.Y + $r.Height / 2), $false)
+    } catch { return $false }
+}
+# Anything driven through UIA leaves focus on the element it touched, and the
+# app's chords only reach the router when the terminal surface has focus.
+# Every UIA interaction has to be followed by this or the next chord is lost.
+function Restore-TerminalFocus([IntPtr]$hwnd, [uint32]$ProcId) {
+    $r = [SwCap]::Rect($hwnd)
+    [void][SwCap]::Click($ProcId, [int](($r.L + $r.R) / 2), [int](($r.T + $r.B) / 2), $false)
+    Start-Sleep -Milliseconds 250
+}
+function Save-Shot([IntPtr]$hwnd, [string]$name) {
+    $r = [SwCap]::Rect($hwnd)
+    $w = $r.R - $r.L; $h = $r.B - $r.T
+    $bmp = New-Object System.Drawing.Bitmap $w, $h
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $g.CopyFromScreen($r.L, $r.T, 0, 0, $bmp.Size)
+    $bmp.Save((Join-Path $OutDir "$name.png")); $g.Dispose(); $bmp.Dispose()
+    Write-Host "saved $name (${w}x${h})"
+}
+
+$tempXdg = Join-Path $env:TEMP "wintty-switchercap-$([guid]::NewGuid())"
+$cfgDir = Join-Path $tempXdg 'wintty'
+New-Item -ItemType Directory -Path $cfgDir -Force | Out-Null
+@"
+vertical-tabs = $($Vertical.IsPresent.ToString().ToLower())
+windows-single-instance = false
+window-theme = wintty
+theme = Catppuccin Mocha
+"@ | Set-Content -Path (Join-Path $cfgDir 'config.wintty') -Encoding utf8
+
+$origXdg = $env:XDG_CONFIG_HOME
+$env:XDG_CONFIG_HOME = $tempXdg
+$proc = $null
+try {
+    $proc = Start-Process -FilePath $ExePath -PassThru
+    $hwnd = [IntPtr]::Zero
+    $dl = (Get-Date).AddSeconds(45)
+    while ((Get-Date) -lt $dl) {
+        Start-Sleep -Milliseconds 300
+        $proc.Refresh()
+        if ($proc.HasExited) { throw "exit $($proc.ExitCode)" }
+        $hwnd = [SwCap]::FindWin([uint32]$proc.Id)
+        if ($hwnd -ne [IntPtr]::Zero) { break }
+    }
+    if ($hwnd -eq [IntPtr]::Zero) { throw 'no hwnd' }
+    $script:Hwnd64 = $hwnd.ToInt64()
+    Start-Sleep -Seconds 4
+    [void][SwCap]::MoveWindow($hwnd, 30, 30, 1500, 900, $true)
+    Start-Sleep -Milliseconds 700
+
+    # The NO_COLOR infobar takes keyboard focus on launch when the
+    # environment sets it, and swallows the chords that follow.
+    $dismiss = Find-ByName 'Keep it off' 1500
+    if ($null -ne $dismiss) { [void](Invoke-El $dismiss); Write-Host 'dismissed NO_COLOR infobar'; Start-Sleep -Milliseconds 400 }
+    Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
+
+    foreach ($i in 2..$TabCount) {
+        if (-not [SwCap]::Chord($hwnd, 0x54, $true, $false)) { throw 'FOREGROUND_MISS: new tab' }
+        Start-Sleep -Milliseconds 420
+    }
+    Start-Sleep -Milliseconds 900
+
+    # Color a spread of tabs so the capture shows colored and plain tiles
+    # side by side.
+    $wanted = @('Red', 'Green', 'Blue', 'Orange', 'Purple', 'Teal')
+    $ctName = if ($Vertical) { 'ListItem' } else { 'TabItem' }
+    $applied = 0
+    $hits = (Get-UiaRoot).FindAll(
+        [System.Windows.Automation.TreeScope]::Descendants,
+        (New-Object System.Windows.Automation.PropertyCondition(
+            [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+            [System.Windows.Automation.ControlType]::$ctName)))
+    Write-Host "strip items found: $($hits.Count) (expected $TabCount)"
+    if ($hits.Count -lt 2) { throw "only $($hits.Count) tab(s) in the strip: the new-tab chords did not land" }
+    for ($i = 0; $i -lt $hits.Count -and $applied -lt $wanted.Count; $i += 2) {
+        $r = $hits[$i].Current.BoundingRectangle
+        if ($r.Width -le 0) { continue }
+        $x = [int]($r.X + $r.Width * 0.4); $y = [int]($r.Y + $r.Height / 2)
+        if (-not [SwCap]::Click([uint32]$proc.Id, $x, $y, $true)) {
+            Write-Host "  item $i : right-click rejected at $x,$y"
+            continue
+        }
+        Start-Sleep -Milliseconds 400
+        $pick = Find-ByName 'Tab Color...' 1800
+        if ($null -eq $pick) {
+            Write-Host "  item $i : no 'Tab Color...' in the flyout"
+            [void][SwCap]::Chord($hwnd, 0x1B, $false, $false); continue
+        }
+        if (-not (Invoke-El $pick)) {
+            Write-Host "  item $i : 'Tab Color...' would not invoke"
+            [void][SwCap]::Chord($hwnd, 0x1B, $false, $false); continue
+        }
+        Start-Sleep -Milliseconds 350
+        $sw = Find-ByName $wanted[$applied] 1500
+        if ($null -eq $sw) {
+            Write-Host "  item $i : swatch '$($wanted[$applied])' not found"
+        } elseif (Click-El $sw ([uint32]$proc.Id)) {
+            Write-Host "  item $i -> $($wanted[$applied])"
+            $applied++
+        } else {
+            Write-Host "  item $i : swatch would not click"
+        }
+        Start-Sleep -Milliseconds 300
+        [void][SwCap]::Chord($hwnd, 0x1B, $false, $false)
+        Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
+    }
+    Write-Host "colors applied: $applied"
+
+    Save-Shot $hwnd 'strip-with-colors'
+
+    Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
+
+    # The popup auto-dismisses after ~1.2s, so take a burst rather than bet
+    # on one moment.
+    if (-not [SwCap]::Chord($hwnd, 0x09, $true, $false)) { throw 'FOREGROUND_MISS: ctrl+tab' }
+    foreach ($n in 0..3) {
+        Start-Sleep -Milliseconds 150
+        Save-Shot $hwnd ("switcher-$n")
+    }
+
+    Start-Sleep -Milliseconds 1500
+    Restore-TerminalFocus $hwnd ([uint32]$proc.Id)
+    if (-not [SwCap]::Chord($hwnd, 0x45, $true, $true)) { throw 'FOREGROUND_MISS: ctrl+shift+e' }
+    Start-Sleep -Milliseconds 700
+    Save-Shot $hwnd 'overview'
+}
+finally {
+    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
+    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
+}
+Write-Host "OUT=$OutDir"

--- a/windows/scripts/vtabs-switcher-capture.ps1
+++ b/windows/scripts/vtabs-switcher-capture.ps1
@@ -36,6 +36,7 @@ public static class SwCap {
     public delegate bool EnumProc(IntPtr h, IntPtr lp);
     [DllImport("user32.dll")] static extern void keybd_event(byte vk, byte scan, uint flags, UIntPtr extra);
     [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern bool GetCursorPos(out POINT p);
     [DllImport("user32.dll")] static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
     const uint KEYUP = 0x0002;
     public static IntPtr FindWin(uint pid) {
@@ -76,8 +77,12 @@ public static class SwCap {
     }
     public static bool Click(uint pid, int x, int y, bool right) {
         SetCursorPos(x, y); Thread.Sleep(60);
-        var p = new POINT { X = x, Y = y };
-        uint owner = 0; GetWindowThreadProcessId(WindowFromPoint(p), out owner);
+        // Probe the live cursor, not the scripted point: the buttons land
+        // wherever the cursor is now, and a user mouse move during the
+        // settle would divorce the pid check from the click.
+        POINT live; if (!GetCursorPos(out live)) return false;
+        if (Math.Abs(live.X - x) > 2 || Math.Abs(live.Y - y) > 2) return false;
+        uint owner = 0; GetWindowThreadProcessId(WindowFromPoint(live), out owner);
         if (owner != pid) return false;
         uint down = right ? 0x0008u : 0x0002u, up = right ? 0x0010u : 0x0004u;
         mouse_event(down, 0, 0, 0, UIntPtr.Zero);
@@ -186,7 +191,8 @@ try {
     Write-Host "strip items found: $($hits.Count) (expected $TabCount)"
     if ($hits.Count -lt 2) { throw "only $($hits.Count) tab(s) in the strip: the new-tab chords did not land" }
     for ($i = 0; $i -lt $hits.Count -and $applied -lt $wanted.Count; $i += 2) {
-        $r = $hits[$i].Current.BoundingRectangle
+        # A cached UIA element can go stale if the strip rebuilt mid-loop.
+        try { $r = $hits[$i].Current.BoundingRectangle } catch { continue }
         if ($r.Width -le 0) { continue }
         $x = [int]($r.X + $r.Width * 0.4); $y = [int]($r.Y + $r.Height / 2)
         if (-not [SwCap]::Click([uint32]$proc.Id, $x, $y, $true)) {
@@ -238,7 +244,10 @@ try {
     Save-Shot $hwnd 'overview'
 }
 finally {
-    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    if ($proc -and -not $proc.HasExited) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        try { $proc.WaitForExit(3000) } catch {}
+    }
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
     Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue


### PR DESCRIPTION
`ci.yml` had two jobs and neither tested this repo.

It ran `just prepare`, which applies `patches/` and `overlay/` from the repo root. Both moved under `builds/<tier>/` when tiering landed. `prepare.ps1` guards them with `Test-Path`, so it applies nothing and leaves a bare OSS checkout at `build/wintty.sha`, a pin far older than any tier's.

- `build-and-test` could never pass: the workflow installs no zig, so `dotnet build` always died on a missing `ghostty.dll`.
- `test-debug` always passed having run nothing. From its log: `No test matches the given testcase filter`, once per assembly. `dotnet test` exits 0 when a filter selects nothing.

`test-tier.yml` already builds and tests every tier at the right toolchain, so the only coverage `ci.yml` was meant to add was the Debug run of the `#if DEBUG` tests the Release matrix compiles out. That moves onto the sponsor leg, which owns those files (pro and pro-legacy inherit them via `parent_tier`). It is cheap there: `Ghostty.Tests` references `Ghostty.Core`, not the WinUI app, so it needs neither zig nor `ghostty.dll`.

`scripts/test-debug-gated.ps1` is called by both the workflow and `smoke-tier.ps1`, so the CI and local paths cannot drift. It fails when the filter matches nothing.

## Local runs

`just ci` runs the test-tier matrix locally, leg for leg, for when Actions is unavailable. It adds the two legs `smoke-all` was missing (pro-legacy, and the enterprise MSI). `smoke-all` stays the faster three-tier sweep, and `just test-debug-gated` runs the Debug pass alone in seconds against a materialised tier.

Making that honest needed a second fix. `smoke-tier.ps1` assumed one libghostty toolchain for every tier and used whatever `zig` was on PATH, but pro is on 0.16.0 while oss, sponsor and pro-legacy are on 0.15.2. CI is fine because setup-zig installs `matrix.zig` per leg; locally three of the five legs built with the wrong compiler and only printed a warning. It now reads `minimum_zig_version` from the materialised `build.zig.zon` and resolves a matching zig: a `WINTTY_ZIG_<major>_<minor>_<patch>` override, else PATH when it matches, else the mise and scoop install trees. `WINTTY_OVERLAY_ZIG_EXE` stays the explicit override for the overlay projects, and a mismatch there is now an error instead of a warning.

## Verified

Actions is down on billing, so this was verified locally, which is rather the point.

- `just smoke-tier sponsor`: GREEN end to end. It picked `zig 0.15.2` out of the mise tree while PATH had 0.16.0, then 1154 + 218 + 19 + 11 tests passed.
- `just smoke-tier pro`: GREEN. Both toolchains resolved with no env vars set (0.15.2 from mise for the overlay, 0.16.0 from PATH for libghostty), then 2254 + 122 + 25 + 21 + 20 tests passed.
- Debug-gated tests: 0 before, 218 now.
- The one `#if DEBUG` test passes when targeted directly, 1/1.
- A filter matching nothing exits 1 instead of going green.

## Not fixed here

`bump.yml` has the same problem. Its validation job runs `just prepare` + `just test`, and its PRs bump `build/wintty.sha`, which nothing consumes any more; the real pins in `builds/*/pin` are advanced by hand. `drift-nudge.yml` reads that same dead file weekly. Moving the bump flow onto tiers is a redesign, not a CI config fix, so this only corrects bump.yml's header comment where it named ci.yml.
