### PR TITLE
windows: make CsWinRT1028 a build error

### DIFF
--- a/windows/Directory.Build.props
+++ b/windows/Directory.Build.props
@@ -29,4 +29,25 @@
   <PropertyGroup Condition="!Exists('$(AppxMSBuildToolsPath)Microsoft.Build.Packaging.Pri.Tasks.dll')">
     <AppxMSBuildToolsPath>$(ProgramW6432)\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VisualStudio\v17.0\AppxPackage\</AppxMSBuildToolsPath>
   </PropertyGroup>
+  <!--
+    CsWinRT1028 says a type implementing WinRT interfaces is not partial. It
+    ships as a warning, but the type it names is unusable across the WinRT
+    ABI: the generated vtable never attaches, and the first XAML call into
+    it - MeasureOverride, usually - takes the process down with 0xC000027B
+    before anything paints. VerticalTabNavRow shipped exactly that way and
+    crashed every launch on the tab strip while the build stayed green, so
+    this one is not survivable.
+
+    Only Ghostty.csproj pulls in WindowsAppSDK, so this binds that project
+    alone; Ghostty.Core is plain net10.0 and the analyzer never loads there.
+    Core types that reach XAML through an object-typed path get no diagnostic
+    from anywhere, which is why KeybindListWinUiAbiTests scans source instead.
+
+    Kept last in the file on purpose: the tiered build patches this props file
+    with a hunk anchored on the opening tag, and materialize applies it with
+    no fuzz, so anything inserted at the top breaks every tier that uses it.
+  -->
+  <PropertyGroup>
+    <WarningsAsErrors>$(WarningsAsErrors);CsWinRT1028</WarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -18,7 +18,7 @@ internal enum PaletteMode
 /// INPC is hand-rolled with the C# 14 <c>field</c> keyword for the
 /// same reason as <c>TabModel</c>: no source generator dependency.
 /// </summary>
-internal class CommandPaletteViewModel : INotifyPropertyChanged
+internal partial class CommandPaletteViewModel : INotifyPropertyChanged
 {
     private readonly IReadOnlyList<ICommandSource> _sources;
     private readonly FrecencyStore _frecency;

--- a/windows/Ghostty/Dialogs/DialogTracker.cs
+++ b/windows/Ghostty/Dialogs/DialogTracker.cs
@@ -21,7 +21,7 @@ namespace Ghostty.Dialogs;
 /// <see cref="ContentDialog.ShowAsync"/> completes, whether the user
 /// confirmed, cancelled, or the runtime forced it to close.
 /// </summary>
-internal sealed class DialogTracker
+internal sealed partial class DialogTracker
 {
     private readonly HashSet<TaskCompletionSource> _pending = new();
     private readonly object _lock = new();
@@ -66,7 +66,7 @@ internal sealed class DialogTracker
         tcs.TrySetResult();
     }
 
-    private sealed class Token : System.IDisposable
+    private sealed partial class Token : System.IDisposable
     {
         private readonly DialogTracker _tracker;
         private readonly TaskCompletionSource _tcs;

--- a/windows/Ghostty/Hosting/BellAudioPlayer.cs
+++ b/windows/Ghostty/Hosting/BellAudioPlayer.cs
@@ -14,7 +14,7 @@ namespace Ghostty.Hosting;
 /// Failures (missing/unreadable/unsupported file) are logged and swallowed:
 /// a broken audio path must never crash or block the rest of the bell.
 /// </summary>
-internal sealed class BellAudioPlayer : IDisposable
+internal sealed partial class BellAudioPlayer : IDisposable
 {
     private readonly ILogger _logger;
     private MediaPlayer? _player;

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -43,7 +43,7 @@ internal readonly record struct SizeLimitRequest(
 /// drain-last invariant -- every per-window host must Dispose before
 /// the bootstrap host.
 /// </summary>
-internal sealed class GhosttyHost : IDisposable
+internal sealed partial class GhosttyHost : IDisposable
 {
     private GhosttyConfig _config;
     private GhosttyApp _app;

--- a/windows/Ghostty/Hosting/QuickTerminalFrame.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalFrame.cs
@@ -174,7 +174,7 @@ internal sealed partial class QuickTerminalFrame : IDisposable
     /// </summary>
     public IDisposable SuppressStyleChanges() => new StyleSuppressionScope(this);
 
-    private sealed class StyleSuppressionScope : IDisposable
+    private sealed partial class StyleSuppressionScope : IDisposable
     {
         private readonly QuickTerminalFrame _owner;
         public StyleSuppressionScope(QuickTerminalFrame owner)

--- a/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
+++ b/windows/Ghostty/Hosting/QuickTerminalSlideAnimator.cs
@@ -30,7 +30,7 @@ namespace Ghostty.Hosting;
 /// ease-out curve. A monotonic token guards completion so a re-toggle mid
 /// animation does not fire a stale <c>Hide()</c>.
 /// </summary>
-internal sealed class QuickTerminalSlideAnimator : IDisposable
+internal sealed partial class QuickTerminalSlideAnimator : IDisposable
 {
     private readonly nint _hwnd;
     private readonly Visual _visual; // content visual, used only for the Center fade

--- a/windows/Ghostty/Hosting/SingleInstanceServer.cs
+++ b/windows/Ghostty/Hosting/SingleInstanceServer.cs
@@ -17,7 +17,7 @@ namespace Ghostty.Hosting;
 /// (the same policy the theme-preview pipe uses) so a server-creation
 /// failure stands the loop down instead of busy-looping.
 /// </summary>
-public sealed class SingleInstanceServer : IDisposable
+public sealed partial class SingleInstanceServer : IDisposable
 {
     private readonly string _pipeName;
     private readonly Action<LaunchRequest> _onLaunch;

--- a/windows/Ghostty/Logging/StaticLoggers.cs
+++ b/windows/Ghostty/Logging/StaticLoggers.cs
@@ -58,7 +58,7 @@ namespace Ghostty.Logging;
 /// generic path would have produced, so filter rules keyed on
 /// "Ghostty.Settings.WindowStateMigration" behave identically.
 /// </summary>
-internal static class StaticLoggers
+internal static partial class StaticLoggers
 {
     private static ILogger<Ghostty.Services.ConfigService>? _configService;
 
@@ -128,7 +128,7 @@ internal static class StaticLoggers
         ILogger<App>? App,
         ILogger<Ghostty.Hosting.BellAudioPlayer>? BellAudio);
 
-    private sealed class Scope : IDisposable
+    private sealed partial class Scope : IDisposable
     {
         private readonly Snapshot _prior;
         public Scope(Snapshot prior) => _prior = prior;

--- a/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
+++ b/windows/Ghostty/Power/WindowsPowerStateMonitor.cs
@@ -17,7 +17,7 @@ namespace Ghostty.Power;
 /// raises <see cref="LowPowerChanged"/> only when the resolved bool
 /// flips.
 /// </summary>
-internal sealed class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
+internal sealed partial class WindowsPowerStateMonitor : IPowerStateMonitor, IDisposable
 {
     // Debounce window for coalescing bursts. A mode flip, a battery
     // unplug, and a transparency toggle triggered by the OS power

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -28,7 +28,7 @@ internal readonly record struct GradientPoint(
 /// <see cref="RefreshForOsColorScheme"/>) -- the file has not changed
 /// there, but what a conditional theme resolves to may have.
 /// </summary>
-internal sealed class ConfigService : IConfigService, Ghostty.Core.Profiles.IProfileConfigSource
+internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profiles.IProfileConfigSource
 {
     private GhosttyConfig _config;
     private GhosttyApp _app;

--- a/windows/Ghostty/Services/KeyBindingsProvider.cs
+++ b/windows/Ghostty/Services/KeyBindingsProvider.cs
@@ -5,7 +5,7 @@ using Ghostty.Core.Config;
 
 namespace Ghostty.Services;
 
-internal sealed class KeyBindingsProvider : IKeyBindingsProvider, IDisposable
+internal sealed partial class KeyBindingsProvider : IKeyBindingsProvider, IDisposable
 {
     private readonly IConfigService _configService;
     private List<BindingEntry> _bindings = new();

--- a/windows/Ghostty/Services/ThemePreviewService.cs
+++ b/windows/Ghostty/Services/ThemePreviewService.cs
@@ -22,7 +22,7 @@ namespace Ghostty.Services;
 ///   "CONFIRM:ThemeName\n"  -- user accepted the theme
 ///   (pipe closed)          -- user cancelled, revert to original
 /// </summary>
-internal sealed class ThemePreviewService : IAsyncDisposable, IDisposable
+internal sealed partial class ThemePreviewService : IAsyncDisposable, IDisposable
 {
     // Path.GetInvalidFileNameChars() allocates a fresh char[] on each
     // call (defensive copy); SearchValues caches the set once and picks

--- a/windows/Ghostty/Services/ThemeProvider.cs
+++ b/windows/Ghostty/Services/ThemeProvider.cs
@@ -6,7 +6,7 @@ using Ghostty.Core.Config;
 
 namespace Ghostty.Services;
 
-internal sealed class ThemeProvider : IThemeProvider, IDisposable
+internal sealed partial class ThemeProvider : IThemeProvider, IDisposable
 {
     private readonly IConfigService _configService;
 

--- a/windows/Ghostty/Services/WindowThemeManager.cs
+++ b/windows/Ghostty/Services/WindowThemeManager.cs
@@ -22,7 +22,7 @@ namespace Ghostty.Services;
 /// <see cref="Ghostty.Core.Windows.ThemeResolution"/> so it can be
 /// unit-tested without a WinUI runtime.
 /// </summary>
-internal sealed class WindowThemeManager : IDisposable
+internal sealed partial class WindowThemeManager : IDisposable
 {
     private readonly IConfigService _configService;
     private readonly DispatcherQueue _dispatcher;

--- a/windows/Ghostty/Shell/GradientTintVisual.cs
+++ b/windows/Ghostty/Shell/GradientTintVisual.cs
@@ -15,7 +15,7 @@ namespace Ghostty.Shell;
 /// overlay mode, sits on top of all content as a semi-transparent
 /// tint layer (always visible regardless of terminal opacity).
 /// </summary>
-internal sealed class GradientTintVisual : IDisposable
+internal sealed partial class GradientTintVisual : IDisposable
 {
     private readonly Compositor _compositor;
     private readonly SpriteVisual _rootVisual;

--- a/windows/Ghostty/Shell/TaskbarHost.cs
+++ b/windows/Ghostty/Shell/TaskbarHost.cs
@@ -22,7 +22,7 @@ namespace Ghostty.Shell;
 /// is a nice-to-have. <see cref="IsAvailable"/> reports whether the
 /// wiring is live; if not, every call is a no-op.
 /// </summary>
-internal sealed class TaskbarHost : IDisposable
+internal sealed partial class TaskbarHost : IDisposable
 {
     private readonly TaskbarList3Facade? _facade;
     private readonly TaskbarProgressCoordinator? _coordinator;

--- a/windows/Ghostty/Tabs/NewTabSplitButtonViewModel.cs
+++ b/windows/Ghostty/Tabs/NewTabSplitButtonViewModel.cs
@@ -12,7 +12,7 @@ namespace Ghostty.Tabs;
 /// pending an async-safe SetSourceAsync flow (the prior implementation
 /// disposed the source MemoryStream synchronously, racing the async load).
 /// </summary>
-internal sealed class NewTabSplitButtonViewModel : IDisposable
+internal sealed partial class NewTabSplitButtonViewModel : IDisposable
 {
     private readonly NewTabFlyoutController _controller;
 

--- a/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
+++ b/windows/Ghostty/Taskbar/TaskbarOverlayFacade.cs
@@ -18,7 +18,7 @@ namespace Ghostty.Taskbar;
 /// One facade per window. <see cref="Ghostty.Shell.TaskbarHost"/>
 /// constructs it. Mirrors <see cref="TaskbarList3Facade"/>.
 /// </summary>
-internal sealed class TaskbarOverlayFacade : ITaskbarOverlaySink, IDisposable
+internal sealed partial class TaskbarOverlayFacade : ITaskbarOverlaySink, IDisposable
 {
     // Accessibility text surfaced by screen readers on the overlay.
     private const string OverlayDescription = "Bell";


### PR DESCRIPTION
`VerticalTabNavRow` shipped without `partial` and crashed every launch with vertical tabs on. The WinRT vtable never attaches, so the first XAML call into the type - `MeasureOverride` here - takes the process down with `0xC000027B` before anything paints. The build stayed green the whole time, because CsWinRT1028 is only a warning.

The one-word fix landed in #643. This is the part that stops the next one reaching a user: CsWinRT1028 becomes an error.

Turning it on surfaced 18 more types, mostly `IDisposable` implementers caught through its projection to `IClosable`. Most are hygiene, but two are not: `CommandPaletteViewModel` and `NewTabSplitButtonViewModel` are bound from XAML, so they genuinely cross the ABI and would have broken under NativeAOT. `DialogTracker` and `StaticLoggers` are marked partial too, because a nested type needs its containing type marked as well.

The property group sits at the **end** of `Directory.Build.props`, not the top. The tiered build patches this file with a hunk anchored on the opening tag and applies it with no fuzz, so anything inserted at the top breaks materialization for every tier that consumes it. Confirmed both ways against the real patch: appended applies cleanly, prepended fails with `patch does not apply`.

## Verification

Removed `partial` from `VerticalTabNavRow` again with the guard in place:

```
error CsWinRT1028: Class 'VerticalTabNavRow' implements WinRT interfaces
but it or a parent type isn't marked partial.
```

Before the guard, that same mutation built successfully and produced a binary that died at startup.

Solution builds clean with no CsWinRT warnings left. 2178 tests pass, 1 skipped. The app launches and the strip renders a real `VerticalTabNavRow` - UIA finds the row and its close button under `MenuItemsHost`.

## Scope and follow-ups

**The guard binds `Ghostty.csproj` only.** It is the sole project pulling in WindowsAppSDK, so it is the only place the analyzer loads. `Ghostty.Core` is plain `net10.0`; Core types that reach XAML through an `object`-typed path still get no diagnostic from anywhere, which is why `KeybindListWinUiAbiTests` scans source instead. Noted in the file.

**The tier overlays need the same treatment before the next pin bump.** The pro overlay has 9 non-partial types and sponsor has 7, none visible from this repo. Four of the pro ones are `INotifyPropertyChanged` ViewModels, so they are the same real defect, not hygiene. The sponsor ones are the dangerous set: they sit behind the `SponsorBuild` gate, which tier CI does not set, so they would stay green through CI and fail at release publish. Tracked separately.

**The analyzer is a floating dependency.** CsWinRT1028 ships in the SDK's bundled `WinRT.SourceGenerator`, not a pinned package, and `global.json` uses `rollForward: latestFeature`. A future SDK that widens the rule can turn green source red with no code change. Nothing in this repo's CI builds .NET at all, so that would surface locally rather than in CI.
