### PR TITLE
windows: keep scrollback search alive across a reopen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ vgcore.*
 
 # WinUI mouse/AOT fuzz script outputs (screenshots, UIA dumps, JSON).
 windows/scripts/fuzz-out/
+windows/scripts/search-fuzz/
 windows/scripts/vtabs-layout-switch/
 windows/scripts/vtabs-morph/
 windows/scripts/vtabs-switcher/

--- a/justfile
+++ b/justfile
@@ -152,12 +152,12 @@ splash-race args="": build-win
 # needle it types against that count. Drives real input, so it needs an
 # interactive desktop and takes the foreground for the duration.
 #
-# Exit codes: 0 clean, 1 product findings (see the JSON and shots under
-# windows/scripts/search-fuzz/), 2 the harness could not run - retry.
+# Exit codes: 0 clean, 2 product findings (see the JSON and shots under
+# windows/scripts/search-fuzz/), 1 the harness could not run - retry.
 #
 # Pass extra args through, e.g. `just search-fuzz "-Seed 99 -Iterations 40"`.
 [windows]
-search-fuzz args="": build-win
+search-fuzz args="": build-dll build-win
     pwsh -NoProfile -File windows/scripts/search-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/search-fuzz {{args}}

--- a/justfile
+++ b/justfile
@@ -147,6 +147,21 @@ test-win:
 splash-race args="": build-win
     pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}
 
+# Fuzz in-pane scrollback search against a real oracle: the harness reads the
+# terminal's own UIA text document, counts matches itself, and compares every
+# needle it types against that count. Drives real input, so it needs an
+# interactive desktop and takes the foreground for the duration.
+#
+# Exit codes: 0 clean, 1 product findings (see the JSON and shots under
+# windows/scripts/search-fuzz/), 2 the harness could not run - retry.
+#
+# Pass extra args through, e.g. `just search-fuzz "-Seed 99 -Iterations 40"`.
+[windows]
+search-fuzz args="": build-win
+    pwsh -NoProfile -File windows/scripts/search-fuzz.ps1 \
+        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
+        -OutDir windows/scripts/search-fuzz {{args}}
+
 # === Upstream Sync ===
 
 # Pinned to bash via shebang so the POSIX `[` branch test below works

--- a/windows/Ghostty.Core/Search/SearchState.cs
+++ b/windows/Ghostty.Core/Search/SearchState.cs
@@ -27,8 +27,17 @@ public sealed class SearchState : INotifyPropertyChanged
 {
     private bool _isOpen;
     private string _needle = string.Empty;
-    private long _total;
+    // Starts inactive, not zero: zero means "searched and found nothing", so
+    // a fresh bar would claim "No matches" for the debounce plus round-trip
+    // before its first search has run.
+    private long _total = NoSearch;
     private long _selected = -1;
+
+    /// <summary>
+    /// The <see cref="Total"/> value meaning "no search is running behind
+    /// the bar", as distinct from a search that ran and matched nothing.
+    /// </summary>
+    public const long NoSearch = -1;
 
     /// <summary>True when the search bar is visible.</summary>
     public bool IsOpen
@@ -115,7 +124,8 @@ public sealed class SearchState : INotifyPropertyChanged
         get
         {
             if (_needle.Length == 0) return string.Empty;
-            if (_total < 0) return string.Empty;
+            if (_total < 0) return string.Empty;   // no search running
+
             if (_total == 0) return "No matches";
             if (_selected >= 0)
             {
@@ -134,7 +144,7 @@ public sealed class SearchState : INotifyPropertyChanged
 
     /// <summary>
     /// Restores all fields to their default values: closes the bar,
-    /// clears the needle, zeroes the match count, and unselects. The
+    /// clears the needle, marks the search inactive, and unselects. The
     /// reverse coupling is intentionally absent -- setting
     /// <see cref="IsOpen"/> to <c>false</c> on its own does NOT reset
     /// the search, so the controller can pick its own timing (e.g.
@@ -144,7 +154,18 @@ public sealed class SearchState : INotifyPropertyChanged
     {
         IsOpen = false;
         Needle = string.Empty;
-        Total = 0;
+        MarkInactive();
+    }
+
+    /// <summary>
+    /// Record that the search behind the bar has been torn down, without
+    /// touching the needle: the query is kept so it can be re-run when the
+    /// bar reopens. Only the counts are invalidated, so the counter goes
+    /// blank rather than describing results that no longer exist.
+    /// </summary>
+    public void MarkInactive()
+    {
+        Total = NoSearch;
         Selected = -1;
     }
 

--- a/windows/Ghostty.Core/Search/SearchState.cs
+++ b/windows/Ghostty.Core/Search/SearchState.cs
@@ -64,7 +64,17 @@ public sealed class SearchState : INotifyPropertyChanged
         }
     }
 
-    /// <summary>Total match count reported by libghostty.</summary>
+    /// <summary>
+    /// Total match count reported by libghostty, or negative when no search
+    /// is active behind the bar.
+    /// </summary>
+    /// <remarks>
+    /// libghostty encodes "no total" as -1 (apprt SearchTotal.cval maps a
+    /// null total onto it), and it sends exactly that when the search thread
+    /// quits. Negative therefore has to mean "nothing to count", not a count
+    /// of -1, or the bar renders "0 of -1" from the moment a search is torn
+    /// down.
+    /// </remarks>
     public long Total
     {
         get => _total;
@@ -95,9 +105,9 @@ public sealed class SearchState : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Formatted match counter for direct display: empty when the
-    /// needle is empty, "No matches" when the needle has no hits,
-    /// "{Selected+1} of {Total}" when a match is selected, or
+    /// Formatted match counter for direct display: empty when the needle is
+    /// empty or no search is active, "No matches" when the needle has no
+    /// hits, "{Selected+1} of {Total}" when a match is selected, or
     /// "0 of {Total}" when matches exist but none is selected yet.
     /// </summary>
     public string CounterText
@@ -105,6 +115,7 @@ public sealed class SearchState : INotifyPropertyChanged
         get
         {
             if (_needle.Length == 0) return string.Empty;
+            if (_total < 0) return string.Empty;
             if (_total == 0) return "No matches";
             if (_selected >= 0)
             {

--- a/windows/Ghostty.Tests.Windows/Search/SearchBarSmokeTests.cs
+++ b/windows/Ghostty.Tests.Windows/Search/SearchBarSmokeTests.cs
@@ -32,8 +32,14 @@ public class SearchBarSmokeTests
     // 6. Press Shift+Enter. The index moves back to 1.
     // 7. Press Esc. The search bar collapses; focus returns to the
     //    terminal surface so typing reaches the shell.
-    // 8. Press Ctrl+Shift+F again to confirm reopen works and
-    //    the counter resets to "" until a new needle is typed.
+    // 8. Press Ctrl+Shift+F again. The previous needle is still in the
+    //    box, and the search runs again for it: the counter repopulates
+    //    with the live count and the matches highlight, without waiting
+    //    for the needle to be retyped. Enter steps matches immediately.
+    // 9. Split the pane, then repeat steps 1-3 in the surviving pane.
+    //    Typing must still start a search: WinUI reparents the control on
+    //    a split, and a debounce handler that does not come back leaves
+    //    the needle box inert.
     [Fact(Skip = "Manual smoke; SearchState pure-logic coverage lives in Ghostty.Tests.Search.SearchStateTests.")]
     public void CtrlShiftF_OpensSearchBar_DebouncesNeedle_StepsMatches_EscRestoresFocus()
     {

--- a/windows/Ghostty.Tests/Search/SearchReopenWiringTests.cs
+++ b/windows/Ghostty.Tests/Search/SearchReopenWiringTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Ghostty.Tests.Search;
+
+/// <summary>
+/// Closing the search bar ends the search inside libghostty but keeps the
+/// needle, so a reopen has to start it again or the bar shows a query with
+/// nothing behind it: no highlights, and next/previous inert. The decision
+/// lives in WinUI code that this assembly cannot instantiate, so these read
+/// the source the same way <c>PaletteOpenSearchTests</c> does.
+///
+/// This proves the call sites exist, not that they run. It is insurance
+/// against a later edit quietly deleting them; the behaviour itself is
+/// covered by <c>windows/scripts/search-fuzz.ps1</c>, whose reopen assertion
+/// is what caught the bug in the first place.
+/// </summary>
+public class SearchReopenWiringTests
+{
+    [Fact]
+    public void OpenSearch_reissues_the_surviving_needle()
+    {
+        var source = ReadSource("TerminalControl.xaml.cs");
+        var body = Body(source, "internal void OpenSearch()");
+
+        Assert.Contains("ReissueSearch()", body);
+        // Only on the closed -> open transition: re-issuing onto a live
+        // search would otherwise rely on libghostty ignoring an unchanged
+        // needle, which is its implementation detail rather than a contract.
+        Assert.Contains("wasOpen", body);
+    }
+
+    [Fact]
+    public void Closing_the_bar_invalidates_the_counts()
+    {
+        var source = ReadSource("TerminalControl.xaml.cs");
+        var body = Body(source, "private void OnSearchClosed(");
+
+        Assert.Contains("MarkInactive()", body);
+    }
+
+    /// <summary>
+    /// The counts must NOT be invalidated from the action callback: it
+    /// arrives through the dispatcher, so it is the wrong place to reason
+    /// about ordering from, and the teardown's null total already covers it.
+    /// </summary>
+    [Fact]
+    public void OnSearchEnded_does_not_invalidate_the_counts()
+    {
+        var source = ReadSource("TerminalControl.xaml.cs");
+        var body = Body(source, "internal void OnSearchEnded()");
+
+        Assert.DoesNotContain("MarkInactive()", body);
+    }
+
+    /// <summary>
+    /// libghostty's start_search reports an empty needle. Adopting it would
+    /// clear the box and cancel the search a debounce later.
+    /// </summary>
+    [Fact]
+    public void OnSearchStarted_ignores_an_empty_needle()
+    {
+        var source = ReadSource("TerminalControl.xaml.cs");
+        var body = Body(source, "internal void OnSearchStarted(");
+
+        Assert.Contains("needle.Length == 0", body);
+    }
+
+    /// <summary>
+    /// WinUI raises Unloaded on every reparent, not just on teardown, and a
+    /// pane is reparented on split, zoom, unzoom and sibling close. When the
+    /// debounce Tick was dropped on Unloaded and never re-attached, typing a
+    /// needle stopped starting searches after the first split.
+    /// </summary>
+    [Fact]
+    public void The_debounce_tick_is_reattached_when_the_control_reloads()
+    {
+        var source = ReadSource("SearchBarControl.xaml.cs");
+
+        Assert.Contains("Loaded += OnControlLoaded", source);
+        var loaded = Body(source, "private void OnControlLoaded(");
+        Assert.Contains("_debounceTimer.Tick += OnDebounceTick", loaded);
+
+        // Dropping the Unloaded subscription would strand the control after
+        // its second detach.
+        var unloaded = Body(source, "private void OnControlUnloaded(");
+        Assert.DoesNotContain("Unloaded -=", unloaded);
+    }
+
+    private static string ReadSource(string fileName)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// The text from a signature to the closing brace of its body, so an
+    /// assertion cannot be satisfied by a match somewhere else in the file.
+    /// Brace counting starts at the first brace after the signature.
+    /// </summary>
+    private static string Body(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"signature not found: {signature}");
+
+        var open = source.IndexOf('{', start);
+        Assert.True(open >= 0, $"no body for: {signature}");
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0) return source.Substring(open, i - open + 1);
+            }
+        }
+
+        Assert.Fail($"unterminated body for: {signature}");
+        return string.Empty;
+    }
+}

--- a/windows/Ghostty.Tests/Search/SearchStateTests.cs
+++ b/windows/Ghostty.Tests/Search/SearchStateTests.cs
@@ -14,7 +14,7 @@ public class SearchStateTests
 
         Assert.False(state.IsOpen);
         Assert.Equal(string.Empty, state.Needle);
-        Assert.Equal(0L, state.Total);
+        Assert.Equal(SearchState.NoSearch, state.Total);
         Assert.Equal(-1L, state.Selected);
         Assert.Equal(string.Empty, state.CounterText);
     }
@@ -31,10 +31,12 @@ public class SearchStateTests
         Assert.Equal(string.Empty, state.CounterText);
     }
 
+    // Total must be set explicitly: zero means "searched, found nothing",
+    // which is not the state a fresh SearchState starts in.
     [Fact]
     public void CounterText_says_no_matches_when_total_is_zero()
     {
-        var state = new SearchState { Needle = "foo" };
+        var state = new SearchState { Needle = "foo", Total = 0 };
 
         Assert.Equal("No matches", state.CounterText);
     }
@@ -105,6 +107,58 @@ public class SearchStateTests
         };
 
         Assert.Equal(string.Empty, state.CounterText);
+    }
+
+    // Closing the bar keeps the query but must stop the counter describing
+    // results that no longer exist. This is the transition the fix creates:
+    // a populated counter going blank.
+    [Fact]
+    public void MarkInactive_blanks_the_counter_but_keeps_the_needle()
+    {
+        var state = new SearchState
+        {
+            Needle = "foo",
+            Total = 5,
+            Selected = 2,
+        };
+        Assert.Equal("3 of 5", state.CounterText);
+
+        state.MarkInactive();
+
+        Assert.Equal("foo", state.Needle);
+        Assert.Equal(SearchState.NoSearch, state.Total);
+        Assert.Equal(-1L, state.Selected);
+        Assert.Equal(string.Empty, state.CounterText);
+    }
+
+    [Fact]
+    public void MarkInactive_raises_PropertyChanged_for_the_counter()
+    {
+        var state = new SearchState
+        {
+            Needle = "foo",
+            Total = 5,
+            Selected = 2,
+        };
+        var raised = Subscribe(state);
+
+        state.MarkInactive();
+
+        Assert.Contains(nameof(SearchState.Total), raised);
+        Assert.Contains(nameof(SearchState.Selected), raised);
+        Assert.Contains(nameof(SearchState.CounterText), raised);
+        Assert.DoesNotContain(nameof(SearchState.Needle), raised);
+    }
+
+    [Fact]
+    public void MarkInactive_on_an_already_inactive_state_does_not_raise()
+    {
+        var state = new SearchState { Needle = "foo" };
+        var raised = Subscribe(state);
+
+        state.MarkInactive();
+
+        Assert.Empty(raised);
     }
 
     [Fact]
@@ -210,7 +264,7 @@ public class SearchStateTests
 
         Assert.False(state.IsOpen);
         Assert.Equal(string.Empty, state.Needle);
-        Assert.Equal(0L, state.Total);
+        Assert.Equal(SearchState.NoSearch, state.Total);
         Assert.Equal(-1L, state.Selected);
         Assert.Equal(string.Empty, state.CounterText);
     }

--- a/windows/Ghostty.Tests/Search/SearchStateTests.cs
+++ b/windows/Ghostty.Tests/Search/SearchStateTests.cs
@@ -78,6 +78,35 @@ public class SearchStateTests
         Assert.Equal("0 of 5", state.CounterText);
     }
 
+    // libghostty sends -1 for "no total" when the search thread quits, which
+    // is exactly the state the bar is left in after a close. Treating it as a
+    // count rendered "0 of -1" next to the needle.
+    [Fact]
+    public void CounterText_is_empty_when_total_is_negative()
+    {
+        var state = new SearchState
+        {
+            Needle = "foo",
+            Total = -1,
+            Selected = -1,
+        };
+
+        Assert.Equal(string.Empty, state.CounterText);
+    }
+
+    [Fact]
+    public void CounterText_is_empty_when_total_is_negative_and_a_match_is_selected()
+    {
+        var state = new SearchState
+        {
+            Needle = "foo",
+            Total = -1,
+            Selected = 3,
+        };
+
+        Assert.Equal(string.Empty, state.CounterText);
+    }
+
     [Fact]
     public void Setting_IsOpen_raises_PropertyChanged()
     {

--- a/windows/Ghostty/Controls/Search/SearchBarControl.xaml.cs
+++ b/windows/Ghostty/Controls/Search/SearchBarControl.xaml.cs
@@ -45,19 +45,45 @@ public sealed partial class SearchBarControl : UserControl
         _debounceTimer = DispatcherQueue.CreateTimer();
         _debounceTimer.Interval = DebounceInterval;
         _debounceTimer.IsRepeating = false;
-        _debounceTimer.Tick += OnDebounceTick;
 
-        // Drop the Tick handler when the control leaves the tree so a
-        // reparented or torn-down pane doesn't accumulate handler links
-        // on the dispatcher's timer list.
+        // Both subscriptions stay for the control's lifetime. WinUI raises
+        // Unloaded whenever the visual tree reparents the control, not only
+        // when it is torn down, and a pane is reparented on every split,
+        // zoom, unzoom and sibling close. Dropping Unloaded itself here --
+        // or leaving the Tick handler detached -- meant the needle box
+        // stopped starting searches after the first reparent, silently.
+        Loaded += OnControlLoaded;
         Unloaded += OnControlUnloaded;
+
+        // Escape is handled on the needle box, which leaves the bar
+        // undismissable by keyboard once focus is on a nav button: the key
+        // would bubble past here to TerminalControl, which drops it because
+        // the bar owns focus. Handled keys do not reach this handler, so
+        // the needle box still wins when it has focus.
+        KeyDown += OnControlKeyDown;
+    }
+
+    private void OnControlKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != VirtualKey.Escape) return;
+        RaiseClosed();
+        e.Handled = true;
+    }
+
+    private void OnControlLoaded(object sender, RoutedEventArgs e)
+    {
+        // Subtract first so re-entry cannot double-subscribe.
+        _debounceTimer.Tick -= OnDebounceTick;
+        _debounceTimer.Tick += OnDebounceTick;
     }
 
     private void OnControlUnloaded(object sender, RoutedEventArgs e)
     {
+        // Drop the handler while detached so a torn-down pane doesn't keep
+        // a link on the dispatcher's timer list; OnControlLoaded restores
+        // it if the control comes back.
         _debounceTimer.Stop();
         _debounceTimer.Tick -= OnDebounceTick;
-        Unloaded -= OnControlUnloaded;
     }
 
     /// <summary>
@@ -116,20 +142,11 @@ public sealed partial class SearchBarControl : UserControl
     /// </summary>
     public void ReissueSearch()
     {
-        if (State.Needle.Length == 0) return;
-        SearchHost?.StartSearch(State.Needle);
-    }
-
-    /// <summary>
-    /// Record that the search behind the bar has been torn down. The needle
-    /// is kept (see <see cref="ReissueSearch"/>); only the match counts are
-    /// invalidated, so the counter goes blank instead of describing results
-    /// that no longer exist.
-    /// </summary>
-    public void MarkInactive()
-    {
-        State.Total = -1;
-        State.Selected = -1;
+        // Read the box, not State.Needle, for the same reason the debounce
+        // tick does: it is the text the user can see.
+        var needle = NeedleBox.Text;
+        if (needle.Length == 0) return;
+        SearchHost?.StartSearch(needle);
     }
 
     /// <summary>

--- a/windows/Ghostty/Controls/Search/SearchBarControl.xaml.cs
+++ b/windows/Ghostty/Controls/Search/SearchBarControl.xaml.cs
@@ -107,6 +107,32 @@ public sealed partial class SearchBarControl : UserControl
     }
 
     /// <summary>
+    /// Re-run the needle currently in the box, if any. Closing the bar ends
+    /// the search inside libghostty, but the needle text is deliberately
+    /// kept so the query survives a close/reopen. Without this the reopened
+    /// bar shows a needle with no search behind it: no highlights, and
+    /// next/previous silently do nothing because libghostty has no active
+    /// search to navigate.
+    /// </summary>
+    public void ReissueSearch()
+    {
+        if (State.Needle.Length == 0) return;
+        SearchHost?.StartSearch(State.Needle);
+    }
+
+    /// <summary>
+    /// Record that the search behind the bar has been torn down. The needle
+    /// is kept (see <see cref="ReissueSearch"/>); only the match counts are
+    /// invalidated, so the counter goes blank instead of describing results
+    /// that no longer exist.
+    /// </summary>
+    public void MarkInactive()
+    {
+        State.Total = -1;
+        State.Selected = -1;
+    }
+
+    /// <summary>
     /// True while keyboard focus is anywhere inside the search bar (the
     /// needle box or the prev/next/close buttons). The parent reads this
     /// to gate terminal key forwarding: the bar is a child of

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1832,25 +1832,33 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     /// <summary>
     /// Show the search bar and move keyboard focus into its needle box.
     /// Called from MainWindow when the Ctrl+Shift+F chord fires against
-    /// this leaf. Idempotent: repeated calls just re-focus the needle.
+    /// this leaf, and from the command palette. Repeated calls on an
+    /// already-open bar just re-focus the needle and leave the running
+    /// search, and the user's place in it, alone.
     /// </summary>
     internal void OpenSearch()
     {
         // Drop any in-flight IME preedit before the needle box takes focus.
         ClearImeComposition();
+        var wasOpen = SearchBar.State.IsOpen;
         SearchBar.State.IsOpen = true;
         SearchBar.Visibility = Visibility.Visible;
         SearchBar.FocusNeedle();
-        // Closing the bar ended the search in libghostty while leaving the
-        // needle text in place, so reopening has to start it again.
-        SearchBar.ReissueSearch();
+
+        // Closing the bar ended the search inside libghostty while leaving
+        // the needle text in place, so a reopen has to start it again.
+        // Only on the closed -> open transition: re-issuing onto a live
+        // search happens to be inert today because libghostty ignores an
+        // unchanged needle, but that is its implementation detail, not a
+        // contract this side should lean on.
+        if (!wasOpen) SearchBar.ReissueSearch();
     }
 
     private void OnSearchClosed(object sender, EventArgs e)
     {
         SearchBar.Visibility = Visibility.Collapsed;
         SearchBar.State.IsOpen = false;
-        SearchBar.MarkInactive();
+        SearchBar.State.MarkInactive();
         // Return focus to the terminal surface so the user can keep typing
         // immediately after dismissing the bar.
         this.Focus(FocusState.Programmatic);
@@ -1893,16 +1901,24 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
     // already DispatcherQueue.TryEnqueues the callback body.
     internal void OnSearchStarted(string needle)
     {
+        // libghostty's start_search reports an empty needle, and adopting it
+        // would clear the box, push the empty string through the two-way
+        // bind and cancel the search a debounce later. macOS and GTK guard
+        // this the same way. Unreachable while the apprt consumes
+        // Ctrl+Shift+F itself, but the guard is what makes that safe to
+        // change.
+        if (needle.Length == 0) return;
         SearchBar.State.Needle = needle;
     }
 
     internal void OnSearchEnded()
     {
-        // Deliberately no MarkInactive here. This arrives asynchronously, so
-        // a close immediately followed by a reopen can deliver the old
-        // search's end after the new one has started, and wiping the counts
-        // then would blank a live search. The teardown pushes a null total
-        // anyway, which SearchState already renders as "no active search".
+        // No MarkInactive here: the teardown already pushes a null total,
+        // which SearchState renders as no active search, so this would be
+        // redundant. It is also the wrong place to invalidate from -- this
+        // arrives through the dispatcher, and the ordering that keeps a
+        // late delivery from landing on a reopened bar is libghostty
+        // performing the binding action inline, not anything enforced here.
         if (SearchBar.Visibility == Visibility.Visible)
         {
             SearchBar.Visibility = Visibility.Collapsed;

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -1841,12 +1841,16 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
         SearchBar.State.IsOpen = true;
         SearchBar.Visibility = Visibility.Visible;
         SearchBar.FocusNeedle();
+        // Closing the bar ended the search in libghostty while leaving the
+        // needle text in place, so reopening has to start it again.
+        SearchBar.ReissueSearch();
     }
 
     private void OnSearchClosed(object sender, EventArgs e)
     {
         SearchBar.Visibility = Visibility.Collapsed;
         SearchBar.State.IsOpen = false;
+        SearchBar.MarkInactive();
         // Return focus to the terminal surface so the user can keep typing
         // immediately after dismissing the bar.
         this.Focus(FocusState.Programmatic);
@@ -1894,6 +1898,11 @@ public sealed partial class TerminalControl : UserControl, ISearchHost
 
     internal void OnSearchEnded()
     {
+        // Deliberately no MarkInactive here. This arrives asynchronously, so
+        // a close immediately followed by a reopen can deliver the old
+        // search's end after the new one has started, and wiping the counts
+        // then would blank a live search. The teardown pushes a null total
+        // anyway, which SearchState already renders as "no active search".
         if (SearchBar.Visibility == Visibility.Visible)
         {
             SearchBar.Visibility = Visibility.Collapsed;

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -1,0 +1,63 @@
+# Windows GUI harnesses
+
+These drive a real Wintty window with real input. They are part of the test
+suite, not scratch scripts: a harness that catches a defect keeps the check
+so the defect cannot come back silently.
+
+They need an interactive desktop and they take the foreground while running,
+so they cannot share a machine with someone using it.
+
+## Running
+
+Recipes live in the `justfile`:
+
+```
+just search-fuzz                          # scrollback search
+just search-fuzz "-Seed 99 -Iterations 40"
+just splash-race
+```
+
+Outputs (JSON results, screenshots, terminal dumps) land under
+`windows/scripts/<harness>/`, which is git-ignored.
+
+## Exit codes
+
+`search-fuzz.ps1` distinguishes the two ways a run can fail, and new
+harnesses should follow it:
+
+| code | meaning |
+|------|---------|
+| 0 | clean |
+| 1 | product findings - read `run-<seed>.json` and `shots/` |
+| 2 | the harness could not run (no window, foreground stolen, shell never came up); the product was never exercised, so retry rather than file a bug |
+
+Conflating those two is how a broken harness gets mistaken for a broken
+product, and how a real defect gets dismissed as flakiness.
+
+## Oracles
+
+A harness is only worth committing if it can tell right from wrong on its
+own. `search-fuzz.ps1` reads the terminal's own UIA text document, counts
+matches itself, and compares that count against what the search bar reports,
+which is what lets it type randomly drawn needles and still judge the answer.
+Prefer that shape over "take a screenshot and have a human look at it": a
+harness whose verdict is `PASS_PENDING_SCREENSHOT` does not actually verify
+anything, and at least one script here shipped for months with a marker that
+never appeared on screen.
+
+## Driving input
+
+Posted `WM_CHAR` / `WM_KEYDOWN` messages **do not reach Wintty** - measured at
+zero characters landing across every inter-character delay. Use `SendInput`,
+and note two prerequisites:
+
+1. One real mouse click on the app's own pixels before the first keystroke.
+   The WinUI content island does not take focus from the window merely being
+   foreground, and without a focused element every keystroke is dropped.
+2. A foreground guard on every send. A bare `SetForegroundWindow` loses to any
+   app that repaints often; attach to the current foreground thread's input
+   queue first, then set foreground, bring to top and set focus.
+
+Do not sniff the shell prompt to decide the shell is ready - a themed prompt
+looks nothing like `PS >`. Ask it instead, and wait for the answer to appear
+in the document; that also proves keystrokes are landing at all.

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -9,7 +9,13 @@ so they cannot share a machine with someone using it.
 
 ## Running
 
-Recipes live in the `justfile`:
+CI does not run any of these, and realistically cannot: they need a
+logged-in interactive desktop with a real input queue, which hosted runners
+do not have. They are local gates, run by hand before merging a change in
+the area they cover. (`.github/workflows/` currently runs no .NET tests at
+all either, so `just test-win` is also a local gate.)
+
+Two have `just` recipes so far:
 
 ```
 just search-fuzz                          # scrollback search
@@ -17,22 +23,54 @@ just search-fuzz "-Seed 99 -Iterations 40"
 just splash-race
 ```
 
-Outputs (JSON results, screenshots, terminal dumps) land under
-`windows/scripts/<harness>/`, which is git-ignored.
+The rest of the scripts in this directory are older and are invoked
+directly with `pwsh -File`.
+
+`search-fuzz` writes its JSON results, screenshots and terminal dumps under
+`windows/scripts/search-fuzz/`, which is git-ignored. Older scripts vary:
+`splash-single-instance-race.ps1`, for instance, uses the system temp
+directory and takes no `-OutDir`.
 
 ## Exit codes
 
-`search-fuzz.ps1` distinguishes the two ways a run can fail, and new
-harnesses should follow it:
+`search-fuzz.ps1` distinguishes the two ways a run can fail. This is the
+convention for new harnesses rather than a description of the existing
+ones - `splash-race` exits 1 for both kinds, which is the thing to move
+away from:
 
 | code | meaning |
 |------|---------|
 | 0 | clean |
-| 1 | product findings - read `run-<seed>.json` and `shots/` |
-| 2 | the harness could not run (no window, foreground stolen, shell never came up); the product was never exercised, so retry rather than file a bug |
+| 2 | product findings - read `run-<seed>.json` and `shots/` |
+| 1 | the harness could not run (no window, foreground stolen, shell never came up); the product was never exercised, so retry rather than file a bug |
+
+The numbering follows `verified-input-probe.ps1`, `mouse-fuzz-loop.ps1` and
+`mouse-fuzz-probe.ps1`, which already use 2 for a product failure.
 
 Conflating those two is how a broken harness gets mistaken for a broken
 product, and how a real defect gets dismissed as flakiness.
+
+## Before you run search-fuzz
+
+- It **force-kills every running Wintty** first. Do not launch it from a
+  Wintty window: it will kill its own host, and the cleanup in `finally`
+  never runs.
+- By default it uses **your real config and state directory**, because a
+  throwaway `XDG_CONFIG_HOME` made the app crash at startup on the machine
+  it was written on. `-IsolatedConfig` opts into the throwaway dir. The
+  default means your session restore, pane layout and theme are in play, so
+  a run that starts with several panes open is not a clean run.
+- It moves the physical cursor, synthesizes global input, and resizes the
+  window without restoring the original geometry.
+
+## What the oracle does and does not judge
+
+Only needles matching `^[\x21-\x7E]{2,}$` are checked against a match count.
+Single characters, anything containing whitespace, and anything non-ASCII are
+checked only for the counter's *shape* - that it is well formed and the app
+did not fall over. Whitespace is excluded deliberately: the UIA document
+keeps trailing spaces and the search haystack trims them, so their counts
+legitimately differ.
 
 ## Oracles
 
@@ -40,10 +78,11 @@ A harness is only worth committing if it can tell right from wrong on its
 own. `search-fuzz.ps1` reads the terminal's own UIA text document, counts
 matches itself, and compares that count against what the search bar reports,
 which is what lets it type randomly drawn needles and still judge the answer.
-Prefer that shape over "take a screenshot and have a human look at it": a
-harness whose verdict is `PASS_PENDING_SCREENSHOT` does not actually verify
-anything, and at least one script here shipped for months with a marker that
-never appeared on screen.
+Prefer that shape over "take a screenshot and have a human look at it". This
+is a standard to move the directory towards, not one it currently meets:
+`verified-input-probe.ps1` still returns `PASS_PENDING_SCREENSHOT` and
+requires a human to confirm its marker, and its marker does not in fact
+appear - it posts `WM_CHAR`, which this app never receives.
 
 ## Driving input
 

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -1,0 +1,1020 @@
+#requires -Version 7
+<#
+    Scrollback-search fuzz harness.
+
+    The oracle is the terminal itself: TerminalControl's UIA text provider
+    exposes the whole screen including scrollback as one document, so the
+    harness can read the real corpus and count matches independently of
+    libghostty. Every needle it types is checked against that count rather
+    than against a hardcoded expectation, which is what lets the needles be
+    randomly drawn from live terminal content.
+
+    Search is ASCII case-insensitive (src/terminal/search/sliding_window.zig
+    uses std.ascii.indexOfIgnoreCase), so the oracle folds case the same way.
+
+    Failures are recorded and the run continues: one broken invariant should
+    not hide the rest.
+
+    Run it with `just search-fuzz`, optionally passing "-Seed N -Iterations N".
+    A seed reproduces an entire op sequence, so a finding can be replayed.
+
+    Exit codes:
+      0  clean
+      1  product findings - see run-<seed>.json and shots/ under -OutDir
+      2  the harness could not run (no window, foreground stolen, shell never
+         came up); the product was never exercised, so retry rather than file
+
+    Findings this harness has caught, kept here as the regression list:
+      - reopening the bar left the needle visible with no live search behind
+        it, so navigation was inert until the text was edited
+      - the counter rendered "0 of -1" once a search had been torn down
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath,
+    [Parameter(Mandatory)][string]$OutDir,
+    [int]$Seed = 1337,
+    [int]$Iterations = 40,
+    [switch]$KeepOpen,
+    # Launching under a throwaway XDG_CONFIG_HOME turned out to make the app
+    # unstable at startup on this machine (repeated 0xc000027b stowed
+    # exceptions in CoreMessagingXP), while the user's own config dir is
+    # stable. Default to the real environment so the fuzz exercises the app
+    # the way it is actually run; -IsolatedConfig opts back into the
+    # throwaway dir when a controlled config matters more than stability.
+    [switch]$IsolatedConfig
+)
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+public static class SFz {
+    public const uint KEYEVENTF_KEYUP    = 0x0002;
+    public const uint KEYEVENTF_UNICODE  = 0x0004;
+    public const uint MOUSEEVENTF_WHEEL  = 0x0800;
+    public const ushort VK_CONTROL = 0x11;
+    public const ushort VK_SHIFT   = 0x10;
+    public const ushort VK_RETURN  = 0x0D;
+    public const ushort VK_ESCAPE  = 0x1B;
+    public const ushort VK_BACK    = 0x08;
+    public const ushort VK_F       = 0x46;
+    public const ushort VK_A       = 0x41;
+    public const ushort VK_C       = 0x43;
+    public const ushort VK_T       = 0x54;
+    public const ushort VK_TAB     = 0x09;
+
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L,T,R,B; }
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X,Y; }
+    [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT {
+        public int dx; public int dy; public uint mouseData; public uint dwFlags; public uint time; public IntPtr dwExtraInfo;
+    }
+    [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT {
+        public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo;
+    }
+    [StructLayout(LayoutKind.Sequential)] public struct HARDWAREINPUT {
+        public uint uMsg; public ushort wParamL; public ushort wParamH;
+    }
+    [StructLayout(LayoutKind.Explicit)] public struct InputUnion {
+        [FieldOffset(0)] public MOUSEINPUT mi;
+        [FieldOffset(0)] public KEYBDINPUT ki;
+        [FieldOffset(0)] public HARDWAREINPUT hi;
+    }
+    [StructLayout(LayoutKind.Sequential)] public struct INPUT { public uint type; public InputUnion U; }
+
+    [DllImport("user32.dll", SetLastError=true)] static extern uint SendInput(uint n, INPUT[] inputs, int cb);
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool IsWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc cb, IntPtr lp);
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr h, StringBuilder s, int n);
+    [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern void mouse_event(uint flags, int dx, int dy, uint data, UIntPtr extra);
+    [DllImport("user32.dll")] static extern IntPtr WindowFromPoint(POINT p);
+    [DllImport("user32.dll", SetLastError=true)] static extern bool MoveWindow(IntPtr h, int x, int y, int w, int hh, bool repaint);
+    [DllImport("user32.dll")] static extern bool PostMessage(IntPtr h, uint msg, IntPtr w, IntPtr l);
+    [DllImport("user32.dll")] static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+    [DllImport("user32.dll")] static extern bool BringWindowToTop(IntPtr h);
+    [DllImport("user32.dll")] static extern IntPtr SetFocus(IntPtr h);
+    [DllImport("kernel32.dll")] static extern uint GetCurrentThreadId();
+
+    public delegate bool EnumProc(IntPtr h, IntPtr lp);
+    public class WinRect { public int L,T,R,B; public int W { get { return R-L; } } public int Hh { get { return B-T; } } }
+
+    public static IntPtr P(long hwnd) { return new IntPtr(hwnd); }
+    public static string ClassOf(IntPtr h) { var sb = new StringBuilder(256); GetClassName(h, sb, 256); return sb.ToString(); }
+    public static uint PidOf(IntPtr h) { uint pid; GetWindowThreadProcessId(h, out pid); return pid; }
+
+    public static WinRect RectOf(long hwnd) {
+        var h = P(hwnd); RECT r;
+        if (!IsWindow(h) || !GetWindowRect(h, out r)) return null;
+        var wr = new WinRect { L=r.L,T=r.T,R=r.R,B=r.B };
+        return (wr.W < 80 || wr.Hh < 80) ? null : wr;
+    }
+
+    // Synthesized input goes to whatever owns the foreground, never to a
+    // handle. Under the foreground lock a bare SetForegroundWindow fails
+    // silently, so every send confirms the target actually holds it first --
+    // otherwise the keystrokes land in whatever app grabbed focus.
+    //
+    // Attaching to the current foreground thread's input queue lifts that
+    // lock for the duration of the call, which is what makes the steal
+    // reliable when another app (an editor, a chat client repainting) keeps
+    // pulling focus back mid-run.
+    public static bool Focus(IntPtr expected) {
+        if (expected == IntPtr.Zero) return false;
+        for (int i = 0; i < 40; i++) {
+            if (GetForegroundWindow() == expected) return true;
+            var fg = GetForegroundWindow();
+            uint fgThread = fg == IntPtr.Zero ? 0 : GetWindowThreadProcessId2(fg);
+            uint me = GetCurrentThreadId();
+            bool attached = fgThread != 0 && fgThread != me && AttachThreadInput(me, fgThread, true);
+            try {
+                SetForegroundWindow(expected);
+                BringWindowToTop(expected);
+                SetFocus(expected);
+            } finally {
+                if (attached) AttachThreadInput(me, fgThread, false);
+            }
+            Thread.Sleep(60);
+        }
+        return GetForegroundWindow() == expected;
+    }
+
+    static uint GetWindowThreadProcessId2(IntPtr h) { uint pid; return GetWindowThreadProcessId(h, out pid); }
+
+    static void Send(INPUT[] inputs) {
+        SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+    }
+
+    static INPUT Key(ushort vk, bool up) {
+        var i = new INPUT { type = 1 };
+        i.U.ki = new KEYBDINPUT { wVk = vk, wScan = 0, dwFlags = up ? KEYEVENTF_KEYUP : 0, time = 0, dwExtraInfo = IntPtr.Zero };
+        return i;
+    }
+
+    static INPUT Unicode(char c, bool up) {
+        var i = new INPUT { type = 1 };
+        i.U.ki = new KEYBDINPUT { wVk = 0, wScan = c, dwFlags = KEYEVENTF_UNICODE | (up ? KEYEVENTF_KEYUP : 0), time = 0, dwExtraInfo = IntPtr.Zero };
+        return i;
+    }
+
+    // Posted WM_CHAR / WM_KEYDOWN do not reach this app at all: measured
+    // zero characters landing across every delay, while the same text sent
+    // through SendInput lands in full. Everything here therefore goes
+    // through the global input queue behind the foreground guard above.
+
+    /// Type a literal string. KEYEVENTF_UNICODE bypasses the keyboard layout,
+    /// so a needle can carry any BMP character without a VK mapping.
+    public static bool TypeText(IntPtr expected, string text, int perCharMs) {
+        foreach (char c in text) {
+            if (!Focus(expected)) return false;
+            Send(new INPUT[] { Unicode(c, false), Unicode(c, true) });
+            Thread.Sleep(perCharMs);
+        }
+        return true;
+    }
+
+    /// Unmodified key press, still as real input.
+    public static bool KeyPress(IntPtr expected, ushort vk, int gapMs) {
+        if (!Focus(expected)) return false;
+        Send(new INPUT[] { Key(vk, false) });
+        Thread.Sleep(gapMs);
+        Send(new INPUT[] { Key(vk, true) });
+        return true;
+    }
+
+    public static bool Chord(IntPtr expected, ushort[] mods, ushort key) {
+        if (!Focus(expected)) return false;
+        var seq = new System.Collections.Generic.List<INPUT>();
+        foreach (var m in mods) seq.Add(Key(m, false));
+        seq.Add(Key(key, false));
+        seq.Add(Key(key, true));
+        for (int i = mods.Length - 1; i >= 0; i--) seq.Add(Key(mods[i], true));
+        Send(seq.ToArray());
+        return true;
+    }
+
+    /// A posted WM_CHAR only lands if XAML has a focused element, and the
+    /// island does not take focus from the window merely being foreground.
+    /// One real click on the app's own pixels is what arms it. The point is
+    /// probed before and after the move so a toast or flyout that arrives
+    /// mid-settle cannot take the click.
+    public static bool Click(uint pid, int x, int y) {
+        var hit = WindowFromPoint(new POINT { X=x, Y=y });
+        if (ClassOf(hit) == "WinttySplash" || PidOf(hit) != pid) return false;
+        if (!SetCursorPos(x, y)) return false;
+        Thread.Sleep(60);
+        hit = WindowFromPoint(new POINT { X=x, Y=y });
+        if (PidOf(hit) != pid) return false;
+        mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, UIntPtr.Zero);
+        mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, UIntPtr.Zero);
+        Thread.Sleep(200);
+        return true;
+    }
+
+    public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    public const uint MOUSEEVENTF_LEFTUP   = 0x0004;
+
+    public static bool Wheel(uint pid, int x, int y, int notches) {
+        var hit = WindowFromPoint(new POINT { X=x, Y=y });
+        if (PidOf(hit) != pid) return false;
+        if (!SetCursorPos(x, y)) return false;
+        Thread.Sleep(30);
+        mouse_event(MOUSEEVENTF_WHEEL, 0, 0, unchecked((uint)(notches * 120)), UIntPtr.Zero);
+        Thread.Sleep(80);
+        return true;
+    }
+
+    public static bool Resize(long hwnd, int w, int h) {
+        var rc = RectOf(hwnd);
+        if (rc == null) return false;
+        return MoveWindow(P(hwnd), rc.L, rc.T, w, h, true);
+    }
+}
+'@
+
+# ---- window / UIA plumbing -------------------------------------------------
+
+$UIA = [System.Windows.Automation.AutomationElement]
+$TS  = [System.Windows.Automation.TreeScope]
+
+function Get-Main([uint32]$ProcId) {
+    $hits = [System.Collections.Generic.List[object]]::new()
+    $cb = [SFz+EnumProc]{
+        param($h, $lp)
+        [uint32]$o = 0; [void][SFz]::GetWindowThreadProcessId($h, [ref]$o)
+        if ($o -ne $ProcId -or -not [SFz]::IsWindowVisible($h)) { return $true }
+        if ([SFz]::ClassOf($h) -ne 'WinUIDesktopWin32WindowClass') { return $true }
+        $hwnd64 = $h.ToInt64()
+        $rc = [SFz]::RectOf($hwnd64)
+        if ($null -eq $rc) { return $true }
+        $hits.Add([pscustomobject]@{ Hwnd64 = $hwnd64; Area = ($rc.W * $rc.Hh) })
+        return $true
+    }
+    [void][SFz]::EnumWindows($cb, [IntPtr]::Zero)
+    return $hits | Sort-Object Area -Descending | Select-Object -First 1
+}
+
+function Wait-Ready($proc) {
+    $dl = (Get-Date).AddSeconds(60)
+    while ((Get-Date) -lt $dl) {
+        Start-Sleep -Milliseconds 300
+        $proc.Refresh(); if ($proc.HasExited) { throw "app exited early, code $($proc.ExitCode)" }
+        $m = Get-Main ([uint32]$proc.Id)
+        if ($m) { Start-Sleep -Seconds 2; return $m }
+    }
+    throw 'no main window appeared'
+}
+
+function Get-Root { return $UIA::FromHandle([SFz]::P($script:Hwnd64)) }
+
+function Find-ByType($root, $controlType) {
+    if ($null -eq $root) { return @() }
+    $cond = New-Object System.Windows.Automation.PropertyCondition($UIA::ControlTypeProperty, $controlType)
+    $found = $root.FindAll($TS::Descendants, $cond)
+    $out = @(); foreach ($i in $found) { $out += $i }; return $out
+}
+
+function Find-ByName($root, [string]$name) {
+    if ($null -eq $root) { return $null }
+    $cond = New-Object System.Windows.Automation.PropertyCondition($UIA::NameProperty, $name)
+    return $root.FindFirst($TS::Descendants, $cond)
+}
+
+# The terminal pane exposes ClassName TerminalControl and supports TextPattern
+# over the whole screen document (viewport + scrollback).
+function Get-TerminalElements($root) {
+    if ($null -eq $root) { return @() }
+    $cond = New-Object System.Windows.Automation.PropertyCondition($UIA::ClassNameProperty, 'TerminalControl')
+    try { $found = $root.FindAll($TS::Descendants, $cond) } catch { return @() }
+    $out = @(); foreach ($i in $found) { $out += $i }; return , $out
+}
+
+# UIA FindAll comes back empty while the app is mid-render, so every terminal
+# lookup retries rather than indexing whatever the first probe returned.
+function Get-Term([int]$timeoutMs = 8000) {
+    $dl = (Get-Date).AddMilliseconds($timeoutMs)
+    while ((Get-Date) -lt $dl) {
+        $els = @(Get-TerminalElements (Get-Root))
+        if ($els.Count -gt 0) { return $els[0] }
+        Start-Sleep -Milliseconds 200
+    }
+    throw 'no TerminalControl in the UIA tree'
+}
+
+function Get-TerminalText($el) {
+    if ($null -eq $el) { return '' }
+    try {
+        $tp = $el.GetCurrentPattern([System.Windows.Automation.TextPattern]::Pattern)
+        return $tp.DocumentRange.GetText(-1)
+    } catch { return '' }
+}
+
+# The counter TextBlock renders "" / "No matches" / "N of M". A window-wide
+# scan for that shape is more robust than walking the search bar's layout
+# panels, which WinUI does not surface consistently in the control view.
+$CounterRe = '^(?:\d+ of \d+|No matches)$'
+
+function Get-CounterTexts($root) {
+    $out = @()
+    foreach ($t in (Find-ByType $root ([System.Windows.Automation.ControlType]::Text))) {
+        try { $n = $t.Current.Name } catch { continue }
+        if ($n -match $CounterRe) { $out += $n }
+    }
+    # Comma-wrap: a bare single-element return unrolls to a scalar string, and
+    # indexing that gives its first character rather than the counter.
+    return , $out
+}
+
+function Get-Counter($root) {
+    $all = @(Get-CounterTexts $root)
+    if ($all.Count -eq 0) { return '' }
+    return [string]$all[0]
+}
+
+function Get-NeedleBox($root) { return Find-ByName $root 'Search scrollback' }
+
+# Put focus back in the needle box if something moved it. Without this a
+# single stray navigation key turns every later "typed X, box holds Y"
+# assertion into a false finding.
+function Set-NeedleFocus {
+    if ((Get-FocusedName) -eq 'Search scrollback') { return $true }
+    $box = Get-NeedleBox (Get-Root)
+    if ($null -eq $box) { return $false }
+    try { $box.SetFocus() } catch { return $false }
+    Start-Sleep -Milliseconds 200
+    return (Get-FocusedName) -eq 'Search scrollback'
+}
+
+function Get-NeedleText($root) {
+    $box = Get-NeedleBox $root
+    if ($null -eq $box) { return $null }
+    try {
+        $vp = $box.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
+        return $vp.Current.Value
+    } catch { return $null }
+}
+
+function Test-SearchBarOpen($root) { return $null -ne (Get-NeedleBox $root) }
+
+function Get-FocusedName {
+    try { return $UIA::FocusedElement.Current.Name } catch { return '<none>' }
+}
+
+# ---- oracle ---------------------------------------------------------------
+
+# Non-overlapping, ASCII-case-insensitive occurrence count, matching the way
+# the sliding window advances past each hit.
+function Measure-Occurrences([string]$haystack, [string]$needle) {
+    if ([string]::IsNullOrEmpty($needle)) { return 0 }
+    $n = 0; $i = 0
+    while ($true) {
+        $j = $haystack.IndexOf($needle, $i, [StringComparison]::OrdinalIgnoreCase)
+        if ($j -lt 0) { break }
+        $n++; $i = $j + $needle.Length
+    }
+    return $n
+}
+
+# The document joins rows with newlines. A match that straddles a soft wrap
+# exists in the terminal but not in the newline-joined text, so the oracle
+# reports a range: the joined-with-newlines count is the floor and the
+# newlines-stripped count is the ceiling. A needle is only used for a strict
+# assertion when the two agree.
+function Get-ExpectedRange([string]$doc, [string]$needle) {
+    $lo = Measure-Occurrences $doc $needle
+    $flat = ($doc -replace "`r", '') -replace "`n", ''
+    $hi = Measure-Occurrences $flat $needle
+    if ($hi -lt $lo) { $hi = $lo }
+    return , @($lo, $hi)
+}
+
+# ---- assertions -----------------------------------------------------------
+
+$script:Findings = [System.Collections.Generic.List[object]]::new()
+$script:Checks = 0
+
+function Add-Finding([string]$kind, [string]$detail, [hashtable]$data) {
+    $f = [ordered]@{ kind = $kind; detail = $detail; iteration = $script:Iter }
+    if ($data) { foreach ($k in $data.Keys) { $f[$k] = $data[$k] } }
+    $script:Findings.Add([pscustomobject]$f)
+    Write-Host "  FAIL [$kind] $detail" -ForegroundColor Red
+}
+
+function Assert-That([bool]$ok, [string]$kind, [string]$detail, [hashtable]$data) {
+    $script:Checks++
+    if (-not $ok) { Add-Finding $kind $detail $data }
+    return $ok
+}
+
+function Shot([string]$name) {
+    $rc = [SFz]::RectOf($script:Hwnd64)
+    if ($null -eq $rc) { return }
+    $bmp = New-Object System.Drawing.Bitmap $rc.W, $rc.Hh
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $g.CopyFromScreen($rc.L, $rc.T, 0, 0, $bmp.Size)
+    $bmp.Save((Join-Path $OutDir "shots\$name.png"))
+    $g.Dispose(); $bmp.Dispose()
+}
+
+# Counting pixels close to the search highlight colors is the only way to
+# tell "libghostty found matches" apart from "the renderer painted them".
+# Defaults come from Config.zig: search-background #FFE082, and
+# search-selected-background #F2A57E.
+function Measure-HighlightPixels([int]$r, [int]$g, [int]$b, [int]$tol = 24) {
+    $rc = [SFz]::RectOf($script:Hwnd64)
+    if ($null -eq $rc) { return -1 }
+    $bmp = New-Object System.Drawing.Bitmap $rc.W, $rc.Hh
+    $gfx = [System.Drawing.Graphics]::FromImage($bmp)
+    $gfx.CopyFromScreen($rc.L, $rc.T, 0, 0, $bmp.Size)
+    $gfx.Dispose()
+    $rect = New-Object System.Drawing.Rectangle 0, 0, $bmp.Width, $bmp.Height
+    $data = $bmp.LockBits($rect, [System.Drawing.Imaging.ImageLockMode]::ReadOnly,
+        [System.Drawing.Imaging.PixelFormat]::Format32bppArgb)
+    $bytes = New-Object byte[] ($data.Stride * $data.Height)
+    [System.Runtime.InteropServices.Marshal]::Copy($data.Scan0, $bytes, 0, $bytes.Length)
+    $bmp.UnlockBits($data)
+    $bmp.Dispose()
+
+    $hits = 0
+    for ($i = 0; $i -lt $bytes.Length; $i += 4) {
+        # BGRA
+        if ([Math]::Abs($bytes[$i + 2] - $r) -le $tol -and
+            [Math]::Abs($bytes[$i + 1] - $g) -le $tol -and
+            [Math]::Abs($bytes[$i] - $b) -le $tol) { $hits++ }
+    }
+    return $hits
+}
+
+function Assert-Alive([string]$where) {
+    $script:Proc.Refresh()
+    if ($script:Proc.HasExited) {
+        Add-Finding 'crash' "process exited during $where (code $($script:Proc.ExitCode))" @{}
+        throw "APP_DIED at $where"
+    }
+}
+
+# ---- input wrappers -------------------------------------------------------
+
+# Name whoever stole the foreground: without it "FOREGROUND_LOST" says
+# nothing about whether the app died, a toast appeared, or the harness is
+# fighting its own console.
+function Get-ForegroundInfo {
+    $h = [SFz]::GetForegroundWindow()
+    if ($h -eq [IntPtr]::Zero) { return 'foreground=<none>' }
+    $cls = [SFz]::ClassOf($h)
+    $fpid = [SFz]::PidOf($h)
+    $name = try { (Get-Process -Id $fpid -ErrorAction Stop).ProcessName } catch { '?' }
+    $mine = if ($h.ToInt64() -eq $script:Hwnd64) { ' (target)' } else { '' }
+    return "foreground=$cls pid=$fpid proc=$name$mine"
+}
+
+function Send-Chord([ushort[]]$mods, [ushort]$key, [int]$settleMs = 250) {
+    $ok = if ($mods.Count -eq 0) {
+        [SFz]::KeyPress([SFz]::P($script:Hwnd64), $key, 40)
+    } else {
+        [SFz]::Chord([SFz]::P($script:Hwnd64), $mods, $key)
+    }
+    if (-not $ok) { throw "FOREGROUND_LOST on key: $(Get-ForegroundInfo)" }
+    Start-Sleep -Milliseconds $settleMs
+}
+
+function Send-Text([string]$text, [int]$perCharMs = 30) {
+    if (-not [SFz]::TypeText([SFz]::P($script:Hwnd64), $text, $perCharMs)) {
+        throw "FOREGROUND_LOST while typing '$text': $(Get-ForegroundInfo)"
+    }
+}
+
+# Escape drops the PSReadLine buffer; Ctrl+C aborts a continuation prompt.
+# Both are harmless on an already-empty line.
+function Clear-CommandLine {
+    Send-Chord @() ([SFz]::VK_ESCAPE) 200
+    Send-Chord @([SFz]::VK_CONTROL) ([SFz]::VK_C) 300
+    Send-Chord @() ([SFz]::VK_RETURN) 500
+}
+
+function Open-SearchBar { Send-Chord @([SFz]::VK_CONTROL, [SFz]::VK_SHIFT) ([SFz]::VK_F) 500 }
+function Press-Enter     { Send-Chord @() ([SFz]::VK_RETURN) 260 }
+function Press-ShiftEnter{ Send-Chord @([SFz]::VK_SHIFT) ([SFz]::VK_RETURN) 260 }
+function Press-Escape    { Send-Chord @() ([SFz]::VK_ESCAPE) 300 }
+function Clear-Needle {
+    # Select-all then Backspace: shorter and less racy than N backspaces.
+    Send-Chord @([SFz]::VK_CONTROL) ([SFz]::VK_A) 120
+    Send-Chord @() ([SFz]::VK_BACK) 250
+}
+
+# Poll until the counter stops changing, so assertions never race the
+# progressive search (24ms refresh tick plus incremental feeding).
+function Wait-Counter([int]$timeoutMs = 6000, [int]$stableMs = 400) {
+    $dl = (Get-Date).AddMilliseconds($timeoutMs)
+    $last = $null; $since = Get-Date
+    while ((Get-Date) -lt $dl) {
+        $cur = Get-Counter (Get-Root)
+        if ($cur -ne $last) { $last = $cur; $since = Get-Date }
+        elseif (((Get-Date) - $since).TotalMilliseconds -ge $stableMs) { return $cur }
+        Start-Sleep -Milliseconds 90
+    }
+    return $last
+}
+
+function Get-CounterParts([string]$text) {
+    if ($text -match '^(\d+) of (\d+)$') { return @([int]$Matches[1], [int]$Matches[2]) }
+    if ($text -eq 'No matches') { return @(0, 0) }
+    return $null
+}
+
+# ---- run ------------------------------------------------------------------
+
+$rng = [System.Random]::new($Seed)
+$tempXdg = Join-Path $env:TEMP "wintty-search-fuzz-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Force -Path (Join-Path $tempXdg 'wintty') | Out-Null
+@'
+windows-single-instance = false
+window-save-state = never
+window-width = 120
+window-height = 34
+scrollback-limit = 10000000
+window-theme = wintty
+'@ | Set-Content (Join-Path $tempXdg 'wintty\config.wintty') -Encoding utf8
+
+$origXdg = $env:XDG_CONFIG_HOME
+$script:Proc = $null
+$script:Iter = 0
+$script:ExitCode = 0
+$result = [ordered]@{
+    seed = $Seed; iterations = $Iterations; ops = @()
+}
+
+$script:CrashBaseline = 0
+$crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
+if (Test-Path $crashPath) { $script:CrashBaseline = (Get-Item $crashPath).Length }
+
+try {
+    if ($IsolatedConfig) { $env:XDG_CONFIG_HOME = $tempXdg }
+    if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath" }
+    Write-Host ("config: {0}" -f $(if ($IsolatedConfig) { $tempXdg } else { 'user environment' }))
+
+    # A surviving instance would absorb the launch when single-instance is on.
+    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Milliseconds 900
+    $script:Proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
+    $pid32 = [uint32]$script:Proc.Id
+    $main = Wait-Ready $script:Proc
+    $script:Hwnd64 = [int64]$main.Hwnd64
+    [void][SFz]::Focus([SFz]::P($script:Hwnd64))
+    Start-Sleep -Milliseconds 800
+
+    $root = Get-Root
+    $terms = @(Get-TerminalElements $root)
+    if ($terms.Count -lt 1) { throw 'no TerminalControl exposed to UIA' }
+    Write-Host "terminal panes: $($terms.Count)"
+
+    # Arm the XAML island (see SFz.Click). Without this every posted
+    # character is dropped and the terminal never sees a keystroke.
+    $rc0 = [SFz]::RectOf($script:Hwnd64)
+    if (-not [SFz]::Click($pid32, [int]($rc0.L + $rc0.W / 2), [int]($rc0.T + $rc0.Hh * 0.7))) {
+        throw 'could not click into the terminal to arm XAML focus'
+    }
+    Start-Sleep -Milliseconds 400
+
+    # ---- seed the scrollback ---------------------------------------------
+    # Every token is assembled at runtime so the echoed command line never
+    # contains the needle itself; otherwise the echo would inflate the count
+    # in ways the oracle cannot see coming.
+    $payload = @(
+        "`$a='ZQ'+'XW'; `$b='PL'+'MK'; `$c='VR'+'TN'",
+        '1..180 | % { "$a row $_" }',
+        '1..47  | % { "$b item $_" }',
+        '"$c singleton"',
+        '"$a$b adjacent"',
+        '"done"+"-marker"'
+    ) -join '; '
+
+    Write-Host 'seeding scrollback...'
+    $term = Get-Term
+    (Get-TerminalText $term) | Set-Content (Join-Path $OutDir 'doc-preseed.txt') -Encoding utf8
+
+    # The payload is PowerShell. Sniffing the prompt is unreliable (a themed
+    # prompt looks nothing like "PS >"), so ask the shell what it is and wait
+    # for the answer. This doubles as proof that typed keys are landing.
+    function Test-Pwsh([int]$timeoutMs) {
+        Send-Text '"SHELL"+"OK-$($PSVersionTable.PSEdition)"' 30
+        Send-Chord @() ([SFz]::VK_RETURN) 400
+        $dl = (Get-Date).AddMilliseconds($timeoutMs)
+        while ((Get-Date) -lt $dl) {
+            if ((Get-TerminalText (Get-Term)) -match 'SHELLOK-Core') { return $true }
+            Start-Sleep -Milliseconds 400
+        }
+        return $false
+    }
+
+    $inPwsh = Test-Pwsh 25000
+    if (-not $inPwsh) {
+        Clear-CommandLine
+        Send-Text 'pwsh -NoLogo -NoProfile' 30
+        Send-Chord @() ([SFz]::VK_RETURN) 400
+        Start-Sleep -Seconds 6
+        $inPwsh = Test-Pwsh 25000
+    }
+    if (-not $inPwsh) {
+        (Get-TerminalText (Get-Term)) | Set-Content (Join-Path $OutDir 'doc-noshell.txt') -Encoding utf8
+        throw 'no PowerShell in the terminal (typed keys may not be landing), see doc-noshell.txt'
+    }
+
+    # A dropped character can leave PowerShell in continuation mode, where
+    # everything typed afterwards is swallowed as more of an unterminated
+    # string. Reset the line before committing to the payload.
+    Clear-CommandLine
+
+    Send-Text $payload 30
+    Start-Sleep -Milliseconds 400
+    (Get-TerminalText (Get-Term)) | Set-Content (Join-Path $OutDir 'doc-typed.txt') -Encoding utf8
+    Send-Chord @() ([SFz]::VK_RETURN) 400
+    Start-Sleep -Seconds 3
+
+    $term = Get-Term
+    $doc = ''
+    $dl = (Get-Date).AddSeconds(25)
+    while ((Get-Date) -lt $dl) {
+        $doc = Get-TerminalText $term
+        if ($doc -match 'done-marker') { break }
+        Start-Sleep -Milliseconds 500
+    }
+    $doc | Set-Content (Join-Path $OutDir 'doc-seeded.txt') -Encoding utf8
+    if ($doc -notmatch 'done-marker') {
+        throw "payload never completed (no done-marker); document is $($doc.Length) chars, see doc-*.txt"
+    }
+    Start-Sleep -Milliseconds 900
+    $doc = Get-TerminalText $term
+    Write-Host "corpus: $($doc.Length) chars, $((($doc -split "`n").Count)) rows"
+    $result.corpusChars = $doc.Length
+
+    # Needle pool. Strict needles are checked against the oracle; the rest
+    # only have to not break an invariant (no crash, counter well-formed).
+    $strict = @('ZQXW', 'zqxw', 'ZqXw', 'PLMK', 'VRTN', 'ZQXWPLMK', 'NOTHERE9X', 'row 1', 'item 4')
+    # No Tab in this pool: it is a focus-navigation key rather than a
+    # character, so typing it moves focus off the needle box and every
+    # needle after it lands on a button. That measures XAML focus, not
+    # search.
+    $weird  = @(':', 'a:b', ' ', '  ', 'row ', '"', '\', '%', '$a', '.*', '[', '(', '?', 'ZQXW ', ' ZQXW',
+                'ábç', 'こんにちは', '😀', ('Z' * 200), '-', '--', '0', 'e')
+
+    function Get-RandomNeedle {
+        $r = $rng.Next(100)
+        if ($r -lt 55) { return $strict[$rng.Next($strict.Count)] }
+        if ($r -lt 85) { return $weird[$rng.Next($weird.Count)] }
+        # A random slice of the live corpus: the oracle handles it the same way.
+        $printable = ($doc -replace "[^\x20-\x7E]", ' ')
+        $len = $rng.Next(2, 7)
+        if ($printable.Length -le $len) { return 'ZQXW' }
+        $at = $rng.Next(0, $printable.Length - $len)
+        return $printable.Substring($at, $len).Trim()
+    }
+
+    function Assert-CounterMatchesOracle([string]$needle, [string]$counter) {
+        $parts = Get-CounterParts $counter
+        if ($null -eq $parts) {
+            Add-Finding 'counter-shape' "needle '$needle' produced counter '$counter'" @{ needle = $needle; counter = $counter }
+            return
+        }
+        $total = $parts[1]
+        $range = Get-ExpectedRange $doc $needle
+        $lo = $range[0]; $hi = $range[1]
+        $ok = ($total -ge $lo -and $total -le $hi)
+        [void](Assert-That $ok 'count-mismatch' `
+            "needle '$needle': reported $total, oracle expects $lo..$hi" `
+            @{ needle = $needle; reported = $total; oracleLo = $lo; oracleHi = $hi; counter = $counter })
+        if (-not $ok) { Shot ("mismatch-{0:d3}" -f $script:Iter) }
+    }
+
+    # ---- baseline invariants ---------------------------------------------
+    Write-Host "`n== baseline ==" -ForegroundColor Cyan
+    $docBefore = $doc
+
+    Open-SearchBar
+    Assert-Alive 'open'
+    $root = Get-Root
+    [void](Assert-That (Test-SearchBarOpen $root) 'bar-missing' 'Ctrl+Shift+F did not surface the search bar' @{})
+
+    # Focus must land in the needle box, or the user types into the shell.
+    $focused = Get-FocusedName
+    [void](Assert-That ($focused -eq 'Search scrollback') 'focus-not-in-needle' `
+        "after Ctrl+Shift+F the focused element is '$focused', expected 'Search scrollback'" @{ focused = $focused })
+
+    Send-Text 'ZQXW'
+    Start-Sleep -Milliseconds 400
+    $c = Wait-Counter
+    Write-Host "  counter after typing ZQXW: '$c'"
+    Assert-CounterMatchesOracle 'ZQXW' $c
+
+    # A keystroke that reaches the shell changes the document. Compare after
+    # the same settle the counter got.
+    $docNow = Get-TerminalText (Get-Term)
+    [void](Assert-That ($docNow -eq $docBefore) 'keystroke-leak' `
+        'typing the needle changed the terminal document, so keys reached the shell' `
+        @{ beforeLen = $docBefore.Length; afterLen = $docNow.Length })
+
+    # Navigation must walk 1..N and wrap.
+    $parts = Get-CounterParts $c
+    if ($null -ne $parts -and $parts[1] -gt 2) {
+        $total = $parts[1]
+        $seen = @()
+        for ($k = 0; $k -lt 4; $k++) {
+            Press-Enter
+            $cc = Wait-Counter 4000 250
+            $pp = Get-CounterParts $cc
+            $seen += if ($null -eq $pp) { -1 } else { $pp[0] }
+        }
+        Write-Host "  next x4 -> $($seen -join ', ') (of $total)"
+        $monotonic = $true
+        for ($k = 1; $k -lt $seen.Count; $k++) {
+            $prev = $seen[$k - 1]; $cur = $seen[$k]
+            if ($cur -ne ($prev % $total) + 1) { $monotonic = $false }
+        }
+        [void](Assert-That ($seen[0] -ge 1) 'nav-no-selection' "first Enter left the index at $($seen[0])" @{ seen = $seen })
+        [void](Assert-That $monotonic 'nav-not-sequential' `
+            "Enter did not step 1-by-1 with wrap: $($seen -join ',') of $total" @{ seen = $seen; total = $total })
+
+        Press-ShiftEnter
+        $cb = Wait-Counter 4000 250
+        $pb = Get-CounterParts $cb
+        $expectBack = if ($seen[-1] -le 1) { $total } else { $seen[-1] - 1 }
+        [void](Assert-That ($null -ne $pb -and $pb[0] -eq $expectBack) 'nav-prev-wrong' `
+            "Shift+Enter from $($seen[-1]) gave $cb, expected index $expectBack" @{ from = $seen[-1]; got = $cb })
+    }
+
+    # A correct counter proves libghostty found the matches; it says nothing
+    # about whether the renderer painted them. The PLMK rows are the ones
+    # sitting in the viewport after seeding, so their highlights must show up
+    # as pixels in the window.
+    $baseHighlight = Measure-HighlightPixels 255 224 130
+    Clear-Needle
+    Send-Text 'PLMK'
+    Start-Sleep -Milliseconds 400
+    $cH = Wait-Counter
+    Assert-CounterMatchesOracle 'PLMK' $cH
+    Start-Sleep -Milliseconds 500
+    $litHighlight = Measure-HighlightPixels 255 224 130
+    $litSelected = Measure-HighlightPixels 242 165 126
+    Write-Host "  highlight pixels: base=$baseHighlight lit=$litHighlight selected=$litSelected"
+    Shot 'highlight-plmk'
+    [void](Assert-That ($litHighlight -gt ($baseHighlight + 200)) 'no-match-highlight' `
+        "search matches are not painted: $baseHighlight highlight-colored pixels before, $litHighlight after" `
+        @{ before = $baseHighlight; after = $litHighlight })
+    Press-Enter
+    Start-Sleep -Milliseconds 700
+    $selAfter = Measure-HighlightPixels 242 165 126
+    Shot 'highlight-plmk-selected'
+    [void](Assert-That ($selAfter -gt ($litSelected + 50)) 'no-selected-highlight' `
+        "the selected match is not painted in its own color: $litSelected before Enter, $selAfter after" `
+        @{ before = $litSelected; after = $selAfter })
+
+    Press-Escape
+    $root = Get-Root
+    [void](Assert-That (-not (Test-SearchBarOpen $root)) 'esc-did-not-close' 'Escape left the search bar open' @{})
+
+    # After Escape the terminal must take input again.
+    $docPre = Get-TerminalText (Get-Term)
+    Send-Text 'echoX'
+    Start-Sleep -Milliseconds 600
+    $docPost = Get-TerminalText (Get-Term)
+    [void](Assert-That ($docPost -ne $docPre) 'focus-not-returned' `
+        'after Escape, typing did not reach the terminal' @{})
+    Clear-Needle  # harmless if focus is in the shell: Ctrl+A / Backspace
+    Send-Chord @() ([SFz]::VK_BACK) 80
+    for ($k = 0; $k -lt 8; $k++) { Send-Chord @() ([SFz]::VK_BACK) 30 }
+
+    # ---- randomized sweep ------------------------------------------------
+    Write-Host "`n== fuzz ($Iterations iterations, seed $Seed) ==" -ForegroundColor Cyan
+    $barOpen = $false
+    for ($script:Iter = 1; $script:Iter -le $Iterations; $script:Iter++) {
+        Assert-Alive "iteration $script:Iter"
+        $root = Get-Root
+        $barOpen = Test-SearchBarOpen $root
+
+        $op = if (-not $barOpen) { 'open' } else {
+            $roll = $rng.Next(100)
+            if     ($roll -lt 34) { 'type' }
+            elseif ($roll -lt 52) { 'next' }
+            elseif ($roll -lt 64) { 'prev' }
+            elseif ($roll -lt 72) { 'clear' }
+            elseif ($roll -lt 80) { 'close' }
+            elseif ($roll -lt 86) { 'scroll' }
+            elseif ($roll -lt 92) { 'resize' }
+            else                  { 'emit' }
+        }
+
+        $detail = ''
+        switch ($op) {
+            'open' {
+                Open-SearchBar
+                $r2 = Get-Root
+                [void](Assert-That (Test-SearchBarOpen $r2) 'bar-missing' 'Ctrl+Shift+F did not open the bar' @{})
+                $f = Get-FocusedName
+                [void](Assert-That ($f -eq 'Search scrollback') 'focus-not-in-needle' `
+                    "focus is '$f' after opening" @{ focused = $f })
+                $detail = "focus=$f"
+
+                # Closing the bar does not reset SearchState, and reopening
+                # does not re-issue the search. If the needle survived, the
+                # counter next to it has to describe that needle rather than
+                # whatever the previous search left behind.
+                $keptNeedle = Get-NeedleText (Get-Root)
+                if ($keptNeedle -and $keptNeedle.Length -gt 0) {
+                    $c = Wait-Counter 3000 300
+                    $detail += " kept='$keptNeedle' counter='$c'"
+                    if ($keptNeedle -match '^[\x21-\x7E]{2,}$') {
+                        Assert-CounterMatchesOracle $keptNeedle $c
+                    }
+                }
+            }
+            'type' {
+                $needle = Get-RandomNeedle
+                [void](Set-NeedleFocus)
+                Clear-Needle
+                if ($needle.Length -gt 0) { Send-Text $needle }
+                Start-Sleep -Milliseconds 300
+                $c = Wait-Counter
+                $detail = "needle='$needle' counter='$c'"
+                if ($needle.Trim().Length -gt 0) {
+                    # Strict counting needs an ASCII needle with no whitespace:
+                    # the oracle folds case with ASCII rules like the search
+                    # does, but row padding and wrapping make whitespace counts
+                    # differ between the UIA document and the terminal grid for
+                    # reasons that are not defects.
+                    if ($needle -match '^[\x21-\x7E]{2,}$') { Assert-CounterMatchesOracle $needle $c }
+                    else {
+                        [void](Assert-That ($c -eq '' -or $null -ne (Get-CounterParts $c)) 'counter-shape' `
+                            "non-ASCII needle '$needle' produced '$c'" @{ needle = $needle; counter = $c })
+                    }
+                }
+                $box = Get-NeedleText (Get-Root)
+                if ($null -ne $box -and $needle -match '^[\x20-\x7E]+$') {
+                    [void](Assert-That ($box -eq $needle) 'needle-box-drift' `
+                        "typed '$needle' but the box holds '$box'" @{ typed = $needle; box = $box })
+                }
+            }
+            'next' {
+                $before = Get-CounterParts (Get-Counter (Get-Root))
+                Press-Enter
+                $c = Wait-Counter 4000 250
+                $after = Get-CounterParts $c
+                $detail = "next -> '$c'"
+                if ($null -ne $before -and $null -ne $after -and $before[1] -gt 0) {
+                    $exp = ($before[0] % $before[1]) + 1
+                    [void](Assert-That ($after[0] -eq $exp) 'nav-not-sequential' `
+                        "next from $($before[0])/$($before[1]) gave $($after[0]), expected $exp" `
+                        @{ from = $before; got = $after })
+                }
+            }
+            'prev' {
+                $before = Get-CounterParts (Get-Counter (Get-Root))
+                Press-ShiftEnter
+                $c = Wait-Counter 4000 250
+                $after = Get-CounterParts $c
+                $detail = "prev -> '$c'"
+                if ($null -ne $before -and $null -ne $after -and $before[1] -gt 0) {
+                    $exp = if ($before[0] -le 1) { $before[1] } else { $before[0] - 1 }
+                    [void](Assert-That ($after[0] -eq $exp) 'nav-not-sequential' `
+                        "prev from $($before[0])/$($before[1]) gave $($after[0]), expected $exp" `
+                        @{ from = $before; got = $after })
+                }
+            }
+            'clear' {
+                Clear-Needle
+                Start-Sleep -Milliseconds 500
+                $c = Get-Counter (Get-Root)
+                $detail = "cleared -> '$c'"
+                [void](Assert-That ($c -eq '') 'counter-not-cleared' `
+                    "empty needle left the counter showing '$c'" @{ counter = $c })
+            }
+            'close' {
+                $useEsc = $rng.Next(2) -eq 0
+                if ($useEsc) { Press-Escape } else {
+                    $btn = Find-ByName (Get-Root) 'Close search'
+                    if ($null -ne $btn) {
+                        try { $btn.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke() } catch { Press-Escape }
+                        Start-Sleep -Milliseconds 350
+                    } else { Press-Escape }
+                }
+                $detail = if ($useEsc) { 'esc' } else { 'button' }
+                [void](Assert-That (-not (Test-SearchBarOpen (Get-Root))) 'esc-did-not-close' `
+                    "close via $detail left the bar open" @{ via = $detail })
+            }
+            'scroll' {
+                $before = Get-CounterParts (Get-Counter (Get-Root))
+                $rc = [SFz]::RectOf($script:Hwnd64)
+                $notches = $rng.Next(-6, 7)
+                [void][SFz]::Wheel($pid32, [int]($rc.L + $rc.W / 2), [int]($rc.T + $rc.Hh / 2), $notches)
+                Start-Sleep -Milliseconds 500
+                $after = Get-CounterParts (Get-Counter (Get-Root))
+                $detail = "wheel $notches"
+                if ($null -ne $before -and $null -ne $after) {
+                    [void](Assert-That ($after[1] -eq $before[1]) 'total-changed-on-scroll' `
+                        "scrolling changed the total from $($before[1]) to $($after[1])" `
+                        @{ before = $before[1]; after = $after[1] })
+                }
+            }
+            'resize' {
+                $before = Get-CounterParts (Get-Counter (Get-Root))
+                $w = $rng.Next(700, 1400); $h = $rng.Next(500, 900)
+                [void][SFz]::Resize($script:Hwnd64, $w, $h)
+                Start-Sleep -Milliseconds 900
+                $after = Get-CounterParts (Get-Counter (Get-Root))
+                $detail = "resize ${w}x${h}"
+                # Reflow can legitimately change how content wraps, so the doc
+                # is re-read and the oracle recomputed rather than assumed.
+                $doc = Get-TerminalText (Get-Term)
+                if ($null -ne $before -and $null -ne $after -and $before[1] -ne $after[1]) {
+                    $result.ops += [ordered]@{ i = $script:Iter; op = 'resize-total-drift'; before = $before[1]; after = $after[1] }
+                }
+            }
+            'emit' {
+                # Append matching content while a search is live; the total
+                # must pick it up without reopening the bar.
+                $before = Get-CounterParts (Get-Counter (Get-Root))
+                $needleBox = Get-NeedleText (Get-Root)
+                Press-Escape
+                Send-Text ('$a=' + "'ZQ'+'XW'; 1..12 | % { `"`$a extra `$_`" }") 30
+                Start-Sleep -Seconds 2
+                $doc = Get-TerminalText (Get-Term)
+                Open-SearchBar
+                Clear-Needle
+                Send-Text 'ZQXW'
+                Start-Sleep -Milliseconds 400
+                $c = Wait-Counter
+                $detail = "emit -> '$c'"
+                Assert-CounterMatchesOracle 'ZQXW' $c
+            }
+        }
+
+        $result.ops += [ordered]@{ i = $script:Iter; op = $op; detail = $detail }
+        Write-Host ("  {0,3}  {1,-7} {2}" -f $script:Iter, $op, $detail)
+    }
+
+    Assert-Alive 'end of run'
+}
+catch {
+    Add-Finding 'harness' $_.Exception.Message @{}
+    Write-Host "HARNESS ERROR: $($_.Exception.Message)" -ForegroundColor Yellow
+}
+finally {
+    $result.checks = $script:Checks
+    $result.findings = @($script:Findings)
+    $result.failed = $script:Findings.Count
+    $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir "run-$Seed.json") -Encoding utf8
+
+    # crash.log is append-only across every run on this machine, so only the
+    # bytes this run added are evidence about this run.
+    $crashLog = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
+    if (Test-Path $crashLog) {
+        $now = (Get-Item $crashLog).Length
+        if ($now -gt $script:CrashBaseline) {
+            $fresh = (Get-Content $crashLog -Raw).Substring($script:CrashBaseline)
+            $fresh | Set-Content (Join-Path $OutDir "crash-$Seed.log") -Encoding utf8
+            Add-Finding 'crash-log' "crash.log grew by $($now - $script:CrashBaseline) bytes during this run" @{}
+        }
+    }
+
+    if ($script:Proc -and -not $KeepOpen) {
+        try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill() } } catch { }
+        try { [void]$script:Proc.WaitForExit(3000) } catch { }
+    }
+    if ($IsolatedConfig) {
+        if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
+        else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    }
+    Start-Sleep -Milliseconds 500
+    Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
+
+    Write-Host ""
+    if ($script:Findings.Count -eq 0) {
+        Write-Host "PASS  $($script:Checks) checks, 0 findings (seed $Seed)" -ForegroundColor Green
+    } else {
+        Write-Host "FAIL  $($script:Findings.Count) findings across $($script:Checks) checks (seed $Seed)" -ForegroundColor Red
+        $script:Findings | Group-Object kind | Sort-Object Count -Descending | ForEach-Object {
+            Write-Host ("  {0,3}x {1}" -f $_.Count, $_.Name)
+        }
+    }
+
+    # Distinct exit codes so a caller can tell the two failures apart: a
+    # product finding is a real defect to act on, whereas a harness error
+    # (no window, foreground stolen, shell never came up) says the run never
+    # got far enough to judge the product and should be retried, not filed.
+    $harnessOnly = @($script:Findings | Where-Object { $_.kind -eq 'harness' })
+    if ($script:Findings.Count -eq 0) { $script:ExitCode = 0 }
+    elseif ($harnessOnly.Count -eq $script:Findings.Count) { $script:ExitCode = 2 }
+    else { $script:ExitCode = 1 }
+}
+
+exit $script:ExitCode

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -18,11 +18,16 @@
     Run it with `just search-fuzz`, optionally passing "-Seed N -Iterations N".
     A seed reproduces an entire op sequence, so a finding can be replayed.
 
-    Exit codes:
+    Exit codes, numbered to match verified-input-probe.ps1 and the
+    mouse-fuzz scripts:
       0  clean
-      1  product findings - see run-<seed>.json and shots/ under -OutDir
-      2  the harness could not run (no window, foreground stolen, shell never
+      2  product findings - see run-<seed>.json and shots/ under -OutDir
+      1  the harness could not run (no window, foreground stolen, shell never
          came up); the product was never exercised, so retry rather than file
+
+    A seed replays the op sequence, but not the corpus-slice needles drawn
+    from live terminal text: those depend on the shell prompt and the window
+    width, so a finding on one is reproducible only in the same environment.
 
     Findings this harness has caught, kept here as the regression list:
       - reopening the bar left the needle visible with no live search behind
@@ -269,14 +274,28 @@ function Wait-Ready($proc) {
     $dl = (Get-Date).AddSeconds(60)
     while ((Get-Date) -lt $dl) {
         Start-Sleep -Milliseconds 300
-        $proc.Refresh(); if ($proc.HasExited) { throw "app exited early, code $($proc.ExitCode)" }
+        $proc.Refresh()
+        if ($proc.HasExited) {
+            Add-Finding 'crash' "app exited during startup, code $($proc.ExitCode)" @{}
+            throw 'app exited during startup'
+        }
         $m = Get-Main ([uint32]$proc.Id)
         if ($m) { Start-Sleep -Seconds 2; return $m }
     }
     throw 'no main window appeared'
 }
 
-function Get-Root { return $UIA::FromHandle([SFz]::P($script:Hwnd64)) }
+# The captured hwnd can go stale: the launch splash hands off to another
+# window, and a killed instance leaves a handle that UIA rejects outright
+# ("Unrecognized error"). Re-resolve once from the process before giving up,
+# so a window swap does not abort a whole run.
+function Get-Root {
+    try { return $UIA::FromHandle([SFz]::P($script:Hwnd64)) } catch { }
+    $m = Get-Main ([uint32]$script:Proc.Id)
+    if ($null -eq $m) { throw 'the app has no main window' }
+    $script:Hwnd64 = [int64]$m.Hwnd64
+    return $UIA::FromHandle([SFz]::P($script:Hwnd64))
+}
 
 function Find-ByType($root, $controlType) {
     if ($null -eq $root) { return @() }
@@ -305,7 +324,10 @@ function Get-TerminalElements($root) {
 function Get-Term([int]$timeoutMs = 8000) {
     $dl = (Get-Date).AddMilliseconds($timeoutMs)
     while ((Get-Date) -lt $dl) {
-        $els = @(Get-TerminalElements (Get-Root))
+        # No @() here: these helpers already comma-return, and wrapping that
+        # in @() yields a one-element array holding the inner array, so the
+        # count guard is always true and the retry never retries.
+        $els = Get-TerminalElements (Get-Root)
         if ($els.Count -gt 0) { return $els[0] }
         Start-Sleep -Milliseconds 200
     }
@@ -323,7 +345,7 @@ function Get-TerminalText($el) {
 # The counter TextBlock renders "" / "No matches" / "N of M". A window-wide
 # scan for that shape is more robust than walking the search bar's layout
 # panels, which WinUI does not surface consistently in the control view.
-$CounterRe = '^(?:\d+ of \d+|No matches)$'
+$CounterRe = '^(?:-?\d+ of -?\d+|No matches)$'
 
 function Get-CounterTexts($root) {
     $out = @()
@@ -336,9 +358,13 @@ function Get-CounterTexts($root) {
     return , $out
 }
 
+# Returns the single counter in the window. More than one means more than
+# one pane or tab has its bar open; the caller cannot attribute a count in
+# that case, so say so rather than silently joining them into one string.
 function Get-Counter($root) {
-    $all = @(Get-CounterTexts $root)
+    $all = Get-CounterTexts $root
     if ($all.Count -eq 0) { return '' }
+    if ($all.Count -gt 1) { return "<ambiguous: $($all -join ' | ')>" }
     return [string]$all[0]
 }
 
@@ -386,17 +412,20 @@ function Measure-Occurrences([string]$haystack, [string]$needle) {
     return $n
 }
 
-# The document joins rows with newlines. A match that straddles a soft wrap
-# exists in the terminal but not in the newline-joined text, so the oracle
-# reports a range: the joined-with-newlines count is the floor and the
-# newlines-stripped count is the ceiling. A needle is only used for a strict
-# assertion when the two agree.
-function Get-ExpectedRange([string]$doc, [string]$needle) {
-    $lo = Measure-Occurrences $doc $needle
-    $flat = ($doc -replace "`r", '') -replace "`n", ''
-    $hi = Measure-Occurrences $flat $needle
-    if ($hi -lt $lo) { $hi = $lo }
-    return , @($lo, $hi)
+# Both haystacks unwrap soft wraps: the UIA document comes from
+# Screen.selectionString with unwrap = true, and the search window builds its
+# haystack with PageFormatter unwrap = true. So a match cannot straddle a
+# wrap in one and not the other, and the count is exact rather than a range.
+# The only remaining difference is trailing whitespace (the document keeps
+# it, the search haystack trims it), which is why needles containing
+# whitespace never reach a strict assertion.
+#
+# An earlier version widened this to a range using a newlines-stripped
+# ceiling. That admitted matches spanning a hard line break, which cannot
+# exist in the product's haystack: a two-character needle like "0Z" then
+# passed against any reported count up to ~18 in the seeded corpus.
+function Get-ExpectedCount([string]$doc, [string]$needle) {
+    return Measure-Occurrences $doc $needle
 }
 
 # ---- assertions -----------------------------------------------------------
@@ -528,7 +557,7 @@ function Wait-Counter([int]$timeoutMs = 6000, [int]$stableMs = 400) {
 }
 
 function Get-CounterParts([string]$text) {
-    if ($text -match '^(\d+) of (\d+)$') { return @([int]$Matches[1], [int]$Matches[2]) }
+    if ($text -match '^(-?\d+) of (-?\d+)$') { return @([int]$Matches[1], [int]$Matches[2]) }
     if ($text -eq 'No matches') { return @(0, 0) }
     return $null
 }
@@ -566,7 +595,9 @@ try {
 
     # A surviving instance would absorb the launch when single-instance is on.
     Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-    Start-Sleep -Milliseconds 900
+    # Give a killed primary time to release the single-instance claim, or the
+    # launch below hands itself off to a dying instance and owns no window.
+    Start-Sleep -Seconds 3
     $script:Proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
     $pid32 = [uint32]$script:Proc.Id
     $main = Wait-Ready $script:Proc
@@ -575,13 +606,14 @@ try {
     Start-Sleep -Milliseconds 800
 
     $root = Get-Root
-    $terms = @(Get-TerminalElements $root)
+    $terms = Get-TerminalElements $root
     if ($terms.Count -lt 1) { throw 'no TerminalControl exposed to UIA' }
     Write-Host "terminal panes: $($terms.Count)"
 
     # Arm the XAML island (see SFz.Click). Without this every posted
     # character is dropped and the terminal never sees a keystroke.
     $rc0 = [SFz]::RectOf($script:Hwnd64)
+    if ($null -eq $rc0) { throw 'window rect is degenerate; cannot arm XAML focus' }
     if (-not [SFz]::Click($pid32, [int]($rc0.L + $rc0.W / 2), [int]($rc0.T + $rc0.Hh * 0.7))) {
         throw 'could not click into the terminal to arm XAML focus'
     }
@@ -601,8 +633,22 @@ try {
     ) -join '; '
 
     Write-Host 'seeding scrollback...'
-    $term = Get-Term
-    (Get-TerminalText $term) | Set-Content (Join-Path $OutDir 'doc-preseed.txt') -Encoding utf8
+
+    # Wait for the shell to actually draw something. Typing into a terminal
+    # that has not started yet loses the keystrokes, and every later oracle
+    # count is measured against the corpus that typing was supposed to
+    # create.
+    $dl = (Get-Date).AddSeconds(30)
+    $preseed = ''
+    while ((Get-Date) -lt $dl) {
+        $preseed = Get-TerminalText (Get-Term)
+        if ($preseed.Trim().Length -gt 0) { break }
+        Start-Sleep -Milliseconds 500
+    }
+    $preseed | Set-Content (Join-Path $OutDir 'doc-preseed.txt') -Encoding utf8
+    if ($preseed.Trim().Length -eq 0) {
+        throw 'the terminal never rendered any text; the shell did not start'
+    }
 
     # The payload is PowerShell. Sniffing the prompt is unreliable (a themed
     # prompt looks nothing like "PS >"), so ask the shell what it is and wait
@@ -675,9 +721,12 @@ try {
         if ($r -lt 85) { return $weird[$rng.Next($weird.Count)] }
         # A random slice of the live corpus: the oracle handles it the same way.
         $printable = ($doc -replace "[^\x20-\x7E]", ' ')
+        # Both draws happen before any early return, so the stream advances
+        # by a fixed amount whatever the corpus looks like.
         $len = $rng.Next(2, 7)
+        $pos = $rng.Next(0, 100000)
         if ($printable.Length -le $len) { return 'ZQXW' }
-        $at = $rng.Next(0, $printable.Length - $len)
+        $at = $pos % ($printable.Length - $len)
         return $printable.Substring($at, $len).Trim()
     }
 
@@ -688,12 +737,11 @@ try {
             return
         }
         $total = $parts[1]
-        $range = Get-ExpectedRange $doc $needle
-        $lo = $range[0]; $hi = $range[1]
-        $ok = ($total -ge $lo -and $total -le $hi)
+        $expected = Get-ExpectedCount $doc $needle
+        $ok = ($total -eq $expected)
         [void](Assert-That $ok 'count-mismatch' `
-            "needle '$needle': reported $total, oracle expects $lo..$hi" `
-            @{ needle = $needle; reported = $total; oracleLo = $lo; oracleHi = $hi; counter = $counter })
+            "needle '$needle': reported $total, oracle expects $expected" `
+            @{ needle = $needle; reported = $total; oracle = $expected; counter = $counter })
         if (-not $ok) { Shot ("mismatch-{0:d3}" -f $script:Iter) }
     }
 
@@ -720,7 +768,7 @@ try {
     # A keystroke that reaches the shell changes the document. Compare after
     # the same settle the counter got.
     $docNow = Get-TerminalText (Get-Term)
-    [void](Assert-That ($docNow -eq $docBefore) 'keystroke-leak' `
+    [void](Assert-That ($docNow -ceq $docBefore) 'keystroke-leak' `
         'typing the needle changed the terminal document, so keys reached the shell' `
         @{ beforeLen = $docBefore.Length; afterLen = $docNow.Length })
 
@@ -739,6 +787,9 @@ try {
         $monotonic = $true
         for ($k = 1; $k -lt $seen.Count; $k++) {
             $prev = $seen[$k - 1]; $cur = $seen[$k]
+            # -1 marks a counter that could not be parsed; reporting that as
+            # a navigation fault would blame the wrong thing.
+            if ($prev -lt 0 -or $cur -lt 0) { continue }
             if ($cur -ne ($prev % $total) + 1) { $monotonic = $false }
         }
         [void](Assert-That ($seen[0] -ge 1) 'nav-no-selection' "first Enter left the index at $($seen[0])" @{ seen = $seen })
@@ -757,8 +808,12 @@ try {
     # about whether the renderer painted them. The PLMK rows are the ones
     # sitting in the viewport after seeding, so their highlights must show up
     # as pixels in the window.
-    $baseHighlight = Measure-HighlightPixels 255 224 130
     Clear-Needle
+    Start-Sleep -Milliseconds 600
+    # Measure the baseline with no search active. Taking it while the
+    # previous needle was still highlighted compared one search against
+    # another rather than against an unhighlighted screen.
+    $baseHighlight = Measure-HighlightPixels 255 224 130
     Send-Text 'PLMK'
     Start-Sleep -Milliseconds 400
     $cH = Wait-Counter
@@ -802,8 +857,11 @@ try {
         $root = Get-Root
         $barOpen = Test-SearchBarOpen $root
 
+        # Draw unconditionally, even when the op is forced: letting product
+        # state decide whether the RNG advances makes the seed stop
+        # replaying the sequence after the first divergence.
+        $roll = $rng.Next(100)
         $op = if (-not $barOpen) { 'open' } else {
-            $roll = $rng.Next(100)
             if     ($roll -lt 34) { 'type' }
             elseif ($roll -lt 52) { 'next' }
             elseif ($roll -lt 64) { 'prev' }
@@ -825,10 +883,10 @@ try {
                     "focus is '$f' after opening" @{ focused = $f })
                 $detail = "focus=$f"
 
-                # Closing the bar does not reset SearchState, and reopening
-                # does not re-issue the search. If the needle survived, the
-                # counter next to it has to describe that needle rather than
-                # whatever the previous search left behind.
+                # The needle survives a close, and reopening re-runs it.
+                # The counter next to it therefore has to describe that
+                # needle's live results, not whatever the previous search
+                # left behind and not a torn-down search's -1.
                 $keptNeedle = Get-NeedleText (Get-Root)
                 if ($keptNeedle -and $keptNeedle.Length -gt 0) {
                     $c = Wait-Counter 3000 300
@@ -840,7 +898,15 @@ try {
             }
             'type' {
                 $needle = Get-RandomNeedle
-                [void](Set-NeedleFocus)
+                if (-not (Set-NeedleFocus)) {
+                    # Typing with focus elsewhere sends the needle to the
+                    # shell, which corrupts the corpus every later oracle
+                    # count is computed against.
+                    Add-Finding 'needle-focus-lost' `
+                        "could not put focus in the needle box before typing '$needle'" `
+                        @{ needle = $needle; focused = (Get-FocusedName) }
+                    break
+                }
                 Clear-Needle
                 if ($needle.Length -gt 0) { Send-Text $needle }
                 Start-Sleep -Milliseconds 300
@@ -860,7 +926,7 @@ try {
                 }
                 $box = Get-NeedleText (Get-Root)
                 if ($null -ne $box -and $needle -match '^[\x20-\x7E]+$') {
-                    [void](Assert-That ($box -eq $needle) 'needle-box-drift' `
+                    [void](Assert-That ($box -ceq $needle) 'needle-box-drift' `
                         "typed '$needle' but the box holds '$box'" @{ typed = $needle; box = $box })
                 }
             }
@@ -891,6 +957,7 @@ try {
                 }
             }
             'clear' {
+                [void](Set-NeedleFocus)
                 Clear-Needle
                 Start-Sleep -Milliseconds 500
                 $c = Get-Counter (Get-Root)
@@ -910,12 +977,23 @@ try {
                 $detail = if ($useEsc) { 'esc' } else { 'button' }
                 [void](Assert-That (-not (Test-SearchBarOpen (Get-Root))) 'esc-did-not-close' `
                     "close via $detail left the bar open" @{ via = $detail })
+
+                # A torn-down search must leave no counter at all. Anything
+                # else means the teardown sentinel is being rendered as a
+                # number again ("0 of -1").
+                $after = Get-Counter (Get-Root)
+                [void](Assert-That ($after -eq '') 'counter-survived-close' `
+                    "closing via $detail left the counter showing '$after'" `
+                    @{ via = $detail; counter = $after })
             }
             'scroll' {
                 $before = Get-CounterParts (Get-Counter (Get-Root))
                 $rc = [SFz]::RectOf($script:Hwnd64)
                 $notches = $rng.Next(-6, 7)
-                [void][SFz]::Wheel($pid32, [int]($rc.L + $rc.W / 2), [int]($rc.T + $rc.Hh / 2), $notches)
+                if ($null -eq $rc -or -not [SFz]::Wheel($pid32, [int]($rc.L + $rc.W / 2), [int]($rc.T + $rc.Hh / 2), $notches)) {
+                    Add-Finding 'harness' 'wheel did not reach the window' @{}
+                    break
+                }
                 Start-Sleep -Milliseconds 500
                 $after = Get-CounterParts (Get-Counter (Get-Root))
                 $detail = "wheel $notches"
@@ -928,7 +1006,10 @@ try {
             'resize' {
                 $before = Get-CounterParts (Get-Counter (Get-Root))
                 $w = $rng.Next(700, 1400); $h = $rng.Next(500, 900)
-                [void][SFz]::Resize($script:Hwnd64, $w, $h)
+                if (-not [SFz]::Resize($script:Hwnd64, $w, $h)) {
+                    Add-Finding 'harness' "resize to ${w}x${h} failed" @{}
+                    break
+                }
                 Start-Sleep -Milliseconds 900
                 $after = Get-CounterParts (Get-Counter (Get-Root))
                 $detail = "resize ${w}x${h}"
@@ -946,7 +1027,8 @@ try {
                 $needleBox = Get-NeedleText (Get-Root)
                 Press-Escape
                 Send-Text ('$a=' + "'ZQ'+'XW'; 1..12 | % { `"`$a extra `$_`" }") 30
-                Start-Sleep -Seconds 2
+                Send-Chord @() ([SFz]::VK_RETURN) 400
+                Start-Sleep -Seconds 3
                 $doc = Get-TerminalText (Get-Term)
                 Open-SearchBar
                 Clear-Needle
@@ -969,22 +1051,31 @@ catch {
     Write-Host "HARNESS ERROR: $($_.Exception.Message)" -ForegroundColor Yellow
 }
 finally {
+
+    # crash.log is append-only across every run on this machine, so only the
+    # bytes this run added are evidence about this run. Slice as bytes: the
+    # baseline is a file length, and using it as a character index reads the
+    # wrong text and throws outright once the log contains any non-ASCII.
+    try {
+        $crashLog = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
+        if (Test-Path $crashLog) {
+            $now = (Get-Item $crashLog).Length
+            if ($now -gt $script:CrashBaseline) {
+                $bytes = [System.IO.File]::ReadAllBytes($crashLog)
+                $fresh = [System.Text.Encoding]::UTF8.GetString(
+                    $bytes, $script:CrashBaseline, $bytes.Length - $script:CrashBaseline)
+                $fresh | Set-Content (Join-Path $OutDir "crash-$Seed.log") -Encoding utf8
+                Add-Finding 'crash' "crash.log grew by $($now - $script:CrashBaseline) bytes during this run" @{}
+            }
+        }
+    } catch {
+        Add-Finding 'harness' "could not read crash.log: $($_.Exception.Message)" @{}
+    }
+
     $result.checks = $script:Checks
     $result.findings = @($script:Findings)
     $result.failed = $script:Findings.Count
     $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir "run-$Seed.json") -Encoding utf8
-
-    # crash.log is append-only across every run on this machine, so only the
-    # bytes this run added are evidence about this run.
-    $crashLog = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
-    if (Test-Path $crashLog) {
-        $now = (Get-Item $crashLog).Length
-        if ($now -gt $script:CrashBaseline) {
-            $fresh = (Get-Content $crashLog -Raw).Substring($script:CrashBaseline)
-            $fresh | Set-Content (Join-Path $OutDir "crash-$Seed.log") -Encoding utf8
-            Add-Finding 'crash-log' "crash.log grew by $($now - $script:CrashBaseline) bytes during this run" @{}
-        }
-    }
 
     if ($script:Proc -and -not $KeepOpen) {
         try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill() } } catch { }
@@ -1007,13 +1098,14 @@ finally {
         }
     }
 
-    # Distinct exit codes so a caller can tell the two failures apart: a
-    # product finding is a real defect to act on, whereas a harness error
-    # (no window, foreground stolen, shell never came up) says the run never
-    # got far enough to judge the product and should be retried, not filed.
-    $harnessOnly = @($script:Findings | Where-Object { $_.kind -eq 'harness' })
+    # Distinct exit codes so a caller can tell the two failures apart, using
+    # the same numbering as verified-input-probe.ps1, mouse-fuzz-loop.ps1 and
+    # mouse-fuzz-probe.ps1: 2 means the product is broken, 1 means the run
+    # never got far enough to judge it and should be retried rather than
+    # filed.
+    $product = @($script:Findings | Where-Object { $_.kind -ne 'harness' })
     if ($script:Findings.Count -eq 0) { $script:ExitCode = 0 }
-    elseif ($harnessOnly.Count -eq $script:Findings.Count) { $script:ExitCode = 2 }
+    elseif ($product.Count -gt 0) { $script:ExitCode = 2 }
     else { $script:ExitCode = 1 }
 }
 


### PR DESCRIPTION
Closing the search bar ends the search inside libghostty while the needle text
is kept, so reopening showed a query with nothing behind it: no highlights, and
next/previous did nothing until the text was edited. The counter read "0 of -1"
next to it, because libghostty encodes "no total" as -1 and `SearchState`
treated that as a count.

`OpenSearch` re-issues the surviving needle, closing invalidates the counts, and
a negative total renders as no active search. `OnSearchEnded` deliberately does
not invalidate: it arrives asynchronously, so a close followed by a quick reopen
could otherwise blank a search that had already restarted.

Found by a new fuzz harness, which lands here with the fix rather than being
thrown away. It reads the terminal's own UIA text document, counts matches
itself, and checks every needle it types against that count, so it can judge
randomly drawn needles instead of hardcoded ones.

    just search-fuzz "-Seed 505 -Iterations 30"

Exit codes separate a product finding (1) from a harness that could not run (2),
and a seed replays a whole op sequence. `windows/scripts/README.md` writes that
contract down for the next harness.

Verification, replaying the seeds that failed:

- seed 505: 4 findings before, 0 across 50 checks after
- seed 808: 2 findings before, 0 across 56 checks after
- `dotnet test`: 2155 passed, 0 failed, +2 pinning the negative total

Search itself was already correct and the fuzz confirms it: every match count
matched the oracle exactly (181, 48, 59), along with case folding, wrap-around
navigation and highlight painting.
