### PR TITLE
windows: name each tab for screen readers

### DIFF
--- a/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
+++ b/windows/Ghostty.Core/Tabs/TabAccessibleText.cs
@@ -1,0 +1,69 @@
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// What an assistive client reads for one tab in a strip.
+///
+/// Both strips build a row out of a panel and hand it to the item, and
+/// neither item gets a usable name out of a panel on its own. An unnamed
+/// NavigationViewItem falls back to its content's ToString, so every row
+/// in the vertical strip read as "Ghostty.Tabs.VerticalTabNavRow"; an
+/// unnamed TabViewItem gets nothing at all out of a panel header, so
+/// every tab in the horizontal strip read as blank. Either way tabs with
+/// different titles read identically.
+///
+/// Naming them from the title makes tabs with distinct titles distinct
+/// to a listener. Tabs that are all untitled still collapse onto the same
+/// fallback name, exactly as their visible labels collapse onto the same
+/// text; position in the strip is what separates those, and the strips
+/// leave PositionInSet and SizeOfSet to the framework.
+///
+/// The name has to be non-empty: empty is exactly the state that sent the
+/// vertical strip down the ToString path in the first place.
+/// </summary>
+internal static class TabAccessibleText
+{
+    /// <summary>Accessible name for <paramref name="tab"/>.</summary>
+    internal static string Name(TabModel tab) => Name(tab.EffectiveTitle);
+
+    /// <summary>
+    /// Accessible name for the tab whose title is
+    /// <paramref name="effectiveTitle"/>.
+    /// </summary>
+    internal static string Name(string? effectiveTitle)
+        => string.IsNullOrWhiteSpace(effectiveTitle)
+            ? AppIdentity.ProductName
+            : effectiveTitle;
+
+    /// <summary>Transient state for <paramref name="tab"/>.</summary>
+    internal static string Status(TabModel tab) => Status(tab.BellRinging);
+
+    /// <summary>
+    /// Transient state for the tab, for AutomationProperties.ItemStatus.
+    /// Empty when there is nothing to report.
+    ///
+    /// The bell is not folded into the name. A name is an identity: it is
+    /// what a client matches on to find a tab, what focus announces, and
+    /// what the user is told the tab is called. Appending "bell" to it
+    /// renames the tab twice per bell, so a client that found it a moment
+    /// ago can no longer find it, and every unrelated focus move re-reads
+    /// the state. ItemStatus is the property UIA defines for exactly this
+    /// -- state that rides along with an item and changes under it -- and
+    /// it leaves the name alone.
+    /// </summary>
+    internal static string Status(bool bellRinging)
+        => bellRinging ? "Bell" : string.Empty;
+
+    /// <summary>
+    /// Spoken when a tab starts ringing. ItemStatus is the correct
+    /// property for the state but nothing reads it: NVDA does not surface
+    /// ItemStatus on a tab or a list item, on focus or on change
+    /// (measured). A bell nobody hears until they focus the tab that rang
+    /// is a bell that told them nothing, so the same state also goes out
+    /// as an announcement, which is read wherever focus happens to be.
+    ///
+    /// Carries the title because the point of the announcement is which
+    /// tab wants attention, and the user is not looking at the strip.
+    /// </summary>
+    internal static string BellAnnouncement(TabModel tab)
+        => $"Bell in {Name(tab)}";
+}

--- a/windows/Ghostty.Core/Tabs/TabBellAnnouncer.cs
+++ b/windows/Ghostty.Core/Tabs/TabBellAnnouncer.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Ghostty.Core.Tabs;
+
+/// <summary>
+/// Turns a tab that starts ringing into one announcement, so a listener
+/// hears which tab wants attention without having to go looking for it.
+///
+/// Window-level rather than per-strip. Both strips are alive at once (the
+/// layout switch cross-fades between them) and both watch the same
+/// TabModel, so an announcement raised from a strip would be raised
+/// twice, once by the strip on screen and once by the one waiting behind
+/// it. One announcer per window is one announcement per ring.
+///
+/// Rising edge only. BellRinging guards its setter on equality, so a
+/// change notification for it already IS the edge: a second bell while
+/// the tab is still ringing raises no notification and says nothing, and
+/// the acknowledge that clears the flag is the falling edge and is
+/// likewise silent.
+///
+/// Pure logic. The sink is a delegate so the UIA raise stays on the WinUI
+/// side and this stays testable, in the shape
+/// <see cref="Ghostty.Core.Taskbar.TaskbarAttentionCoordinator"/> uses.
+/// It gets the tab as well as the words: the raise has to come from an
+/// element that has an automation peer, and the tab's own item is one.
+/// </summary>
+internal sealed class TabBellAnnouncer : IDisposable
+{
+    private readonly TabManager _manager;
+    private readonly Action<TabModel, string> _announce;
+    private readonly Dictionary<TabModel, PropertyChangedEventHandler> _hooks = new();
+
+    public TabBellAnnouncer(TabManager manager, Action<TabModel, string> announce)
+    {
+        _manager = manager;
+        _announce = announce;
+        foreach (var tab in manager.Tabs) Watch(tab);
+        manager.TabAdded += OnTabAdded;
+        manager.TabRemoved += OnTabRemoved;
+    }
+
+    private void OnTabAdded(object? sender, TabModel tab) => Watch(tab);
+
+    private void OnTabRemoved(object? sender, TabModel tab) => Unwatch(tab);
+
+    private void Watch(TabModel tab)
+    {
+        if (_hooks.ContainsKey(tab)) return;
+        PropertyChangedEventHandler handler = (_, e) =>
+        {
+            if (e.PropertyName != nameof(TabModel.BellRinging)) return;
+            if (!tab.BellRinging) return;
+            _announce(tab, TabAccessibleText.BellAnnouncement(tab));
+        };
+        tab.PropertyChanged += handler;
+        _hooks[tab] = handler;
+    }
+
+    private void Unwatch(TabModel tab)
+    {
+        if (!_hooks.Remove(tab, out var handler)) return;
+        tab.PropertyChanged -= handler;
+    }
+
+    public void Dispose()
+    {
+        _manager.TabAdded -= OnTabAdded;
+        _manager.TabRemoved -= OnTabRemoved;
+        foreach (var (tab, handler) in _hooks) tab.PropertyChanged -= handler;
+        _hooks.Clear();
+    }
+}

--- a/windows/Ghostty.Core/Tabs/TabModel.cs
+++ b/windows/Ghostty.Core/Tabs/TabModel.cs
@@ -147,8 +147,20 @@ internal sealed class TabModel : INotifyPropertyChanged
     // button reads its profile Name rather than the generic fallback
     // before the shell sends a title); then the product name for the
     // no-profile / pre-OSC-2 cold-start case.
+    //
+    // Each level is coalesced on whitespace, not just on null. A shell
+    // can report a title that is empty or all spaces (`printf
+    // '\033]2;\007'` does it), and that arrives here as a non-null empty
+    // string, which would otherwise win the precedence chain and leave
+    // the tab with a blank label and a blank name.
     public string EffectiveTitle =>
-        UserOverrideTitle ?? ShellReportedTitle ?? ProfileSnapshot?.DisplayName ?? AppIdentity.ProductName;
+        Titled(UserOverrideTitle)
+        ?? Titled(ShellReportedTitle)
+        ?? Titled(ProfileSnapshot?.DisplayName)
+        ?? AppIdentity.ProductName;
+
+    private static string? Titled(string? title)
+        => string.IsNullOrWhiteSpace(title) ? null : title;
 
     public TabModel(IPaneHost paneHost)
     {

--- a/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabAccessibleTextTests.cs
@@ -1,0 +1,284 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Ghostty.Core;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// Every tab in the vertical strip announced itself as
+/// "Ghostty.Tabs.VerticalTabNavRow": nothing named the
+/// NavigationViewItem, so its peer fell back to the content's ToString,
+/// and the content is a panel. The horizontal strip failed the other
+/// way: a TabViewItem gets no name out of a StackPanel header, so its
+/// tabs announced nothing at all. A listener could hear how many tabs
+/// were open and nothing else about any of them.
+///
+/// The text itself is pure and tested directly. The wiring that puts it
+/// on the item lives in WinUI types this project cannot reference, so it
+/// is scanned out of the shipped source -- the same fallback
+/// StripCloseAutomationTests uses.
+/// </summary>
+public class TabAccessibleTextTests
+{
+    [Fact]
+    public void Name_IsTheTitleTheUserSees()
+    {
+        Assert.Equal("pwsh", TabAccessibleText.Name("pwsh"));
+        Assert.Equal("vim README.md", TabAccessibleText.Name("vim README.md"));
+    }
+
+    /// <summary>
+    /// An empty name is not a blank name: the peer treats it as "nobody
+    /// named this" and goes back to the type name, which is the bug. A
+    /// shell that reports an empty OSC 2 title, or one that reports a run
+    /// of spaces, has to land on something a listener can hear.
+    ///
+    /// TabModel.EffectiveTitle now coalesces whitespace itself, so no
+    /// live caller can reach this any more. It stays as the helper's own
+    /// floor: the whole point of the class is that the name is never
+    /// empty, and that should not depend on a caller getting it right.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void EmptyTitles_FallBackToAName(string? title)
+    {
+        Assert.Equal(AppIdentity.ProductName, TabAccessibleText.Name(title));
+    }
+
+    /// <summary>
+    /// Titles are not trimmed or rewritten. What the strip renders and
+    /// what it announces have to be the same string, or a user reading
+    /// over someone's shoulder and a user listening are looking for
+    /// different tabs.
+    /// </summary>
+    [Fact]
+    public void Name_PassesTitlesThroughUntouched()
+    {
+        Assert.Equal(" pwsh ", TabAccessibleText.Name(" pwsh "));
+        Assert.Equal("C:\\src -- build", TabAccessibleText.Name("C:\\src -- build"));
+    }
+
+    /// <summary>
+    /// The tab overloads exist so a caller cannot quietly pass the wrong
+    /// title. ShellReportedTitle compiles just as well as EffectiveTitle
+    /// in the string overload and is wrong: it ignores a rename.
+    /// </summary>
+    [Fact]
+    public void TabOverloads_ReadTheEffectiveTitle()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        tab.ShellReportedTitle = "vim file.txt";
+        tab.UserOverrideTitle = "renamed";
+
+        Assert.Equal("renamed", TabAccessibleText.Name(tab));
+        Assert.Equal(string.Empty, TabAccessibleText.Status(tab));
+
+        tab.BellRinging = true;
+        Assert.Equal("Bell", TabAccessibleText.Status(tab));
+    }
+
+    /// <summary>
+    /// The bell is state, not identity, so it rides ItemStatus and the
+    /// name stays put across a ring and an acknowledge.
+    /// </summary>
+    [Fact]
+    public void Bell_IsStatus_AndLeavesTheNameAlone()
+    {
+        Assert.Equal("Bell", TabAccessibleText.Status(bellRinging: true));
+        Assert.Equal(string.Empty, TabAccessibleText.Status(bellRinging: false));
+        Assert.Equal("pwsh", TabAccessibleText.Name("pwsh"));
+    }
+
+    /// <summary>
+    /// Acknowledging a bell has to clear the status. Returning null or
+    /// leaving the previous value in place would leave a tab reading
+    /// "Bell" long after the bell was answered.
+    /// </summary>
+    [Fact]
+    public void AcknowledgedBell_ClearsTheStatus()
+    {
+        var status = TabAccessibleText.Status(bellRinging: false);
+        Assert.NotNull(status);
+        Assert.Equal(string.Empty, status);
+    }
+
+    /// <summary>
+    /// The announcement has to say which tab rang; the user is not
+    /// looking at the strip, which is why it is being spoken at all.
+    /// </summary>
+    [Fact]
+    public void BellAnnouncement_NamesTheTab()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        tab.ShellReportedTitle = "make -j8";
+
+        Assert.Equal("Bell in make -j8", TabAccessibleText.BellAnnouncement(tab));
+    }
+
+    /// <summary>
+    /// The vertical strip is where this was reported. The name has to be
+    /// on the NavigationViewItem, not on the row inside it: the item is
+    /// what surfaces as the ListItem.
+    /// </summary>
+    [Fact]
+    public void VerticalStrip_NamesTheNavItem()
+    {
+        var strip = Source("VerticalTabStrip.xaml.cs");
+        var apply = MethodBody(strip, "private static void ApplyItemTitleChrome");
+
+        Assert.Contains("AutomationProperties.SetName(item, TabAccessibleText.Name(", apply);
+        Assert.Contains("AutomationProperties.SetItemStatus(item, TabAccessibleText.Status(", apply);
+    }
+
+    /// <summary>
+    /// Naming the item once at build time is half a fix: a renamed tab,
+    /// or one whose shell reported a new title, keeps the name it was
+    /// born with. The title binding already re-applies the row text and
+    /// the tooltip, so it is the one place that has to carry the name too.
+    /// </summary>
+    [Fact]
+    public void VerticalStrip_RenamesTheNavItemWhenTheTitleChanges()
+    {
+        var strip = Source("VerticalTabStrip.xaml.cs");
+
+        var build = Between(strip, "var item = new NavigationViewItem", "var textBinding");
+        Assert.Contains("ApplyItemTitleChrome(item, tab)", build);
+
+        var binding = Between(strip, "var textBinding = AotBinding.Create", "var colorBinding");
+        Assert.Contains("ApplyItemTitleChrome(navItem, tab)", binding);
+        Assert.Contains("nameof(TabModel.EffectiveTitle)", binding);
+        Assert.Contains("nameof(TabModel.BellRinging)", binding);
+    }
+
+    /// <summary>
+    /// The horizontal strip has the same hole with a different symptom:
+    /// its tabs came out unnamed rather than identically named. Both
+    /// layouts run against one TabManager, so a fix in only one of them
+    /// is a fix the user loses by switching layout.
+    /// </summary>
+    [Fact]
+    public void HorizontalStrip_NamesTheTabViewItem()
+    {
+        var host = Source("TabHost.xaml.cs");
+        var apply = MethodBody(host, "private static void ApplyItemAccessibleText");
+
+        Assert.Contains("AutomationProperties.SetName(item, TabAccessibleText.Name(", apply);
+        Assert.Contains("AutomationProperties.SetItemStatus(item, TabAccessibleText.Status(", apply);
+    }
+
+    /// <summary>
+    /// Build, rename and bell all have to reach the write, and the
+    /// property handler is a chain of else-if arms, so each arm is its
+    /// own call site. Asserted arm by arm rather than by counting the
+    /// calls in the method: a count ties no call to any arm, so moving
+    /// the bell arm's call up into the title arm keeps the total at three
+    /// while a tab that rings once reads "Bell" for the rest of its life.
+    /// </summary>
+    [Fact]
+    public void HorizontalStrip_RenamesTheItemOnBuildRenameAndBell()
+    {
+        var host = Source("TabHost.xaml.cs");
+        const string call = "ApplyItemAccessibleText(item, tab)";
+
+        var build = Between(host, "var item = new TabViewItem", "tab.PropertyChanged +=");
+        Assert.Contains(call, build);
+
+        var titleArm = Between(host, "headerText.Text = tab.EffectiveTitle", "else if");
+        Assert.Contains(call, titleArm);
+
+        var bellArm = Between(host, "bellGlyph.Visibility = tab.BellRinging", "_itemByModel[tab] = item");
+        Assert.Contains(call, bellArm);
+    }
+
+    /// <summary>
+    /// The announcement is raised once per window, not once per strip.
+    /// Both strips are alive at once and both watch the same TabModel, so
+    /// a strip-level raise would speak every bell twice.
+    ///
+    /// This only proves the wiring exists; when it fires is covered
+    /// directly by TabBellAnnouncerTests.
+    /// </summary>
+    [Fact]
+    public void Window_RaisesTheBellAnnouncement()
+    {
+        var window = Source("MainWindow.xaml.cs");
+
+        Assert.Contains("new TabBellAnnouncer(", window);
+        Assert.Contains("UiaAnnouncer.Announce(", window);
+    }
+
+    private static string Between(string source, string start, string end)
+    {
+        var from = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"'{start}' not found");
+        var to = source.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"'{end}' not found after '{start}'");
+        return source[from..to];
+    }
+
+    /// <summary>
+    /// One method, ending at its own closing brace rather than at
+    /// whatever declaration happens to follow it. A window that runs to
+    /// the next declaration also covers the gap between the two, so
+    /// gutting the method and dropping its contents into a new one below
+    /// would still satisfy every assertion made against it.
+    /// </summary>
+    private static string MethodBody(string source, string signature)
+    {
+        var from = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"'{signature}' not found");
+        // Members sit at one indent level, so the first line that closes
+        // at that level closes this method.
+        var to = source.IndexOf("\n    }", from, StringComparison.Ordinal);
+        Assert.True(to > from, $"'{signature}' has no closing brace");
+        return source[from..to];
+    }
+
+    /// <summary>
+    /// Read the shipped source with every comment removed, so no assertion
+    /// here can be satisfied by prose naming the same thing.
+    /// </summary>
+    private static string Source(string suffix) => StripComments(ReadEmbedded(suffix));
+
+    private static string StripComments(string source)
+    {
+        var withoutBlocks = Regex.Replace(source, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        var lines = withoutBlocks.Split('\n').Select(line =>
+        {
+            var slash = line.IndexOf("//", StringComparison.Ordinal);
+            return slash >= 0 ? line[..slash] : line;
+        });
+        return string.Join('\n', lines);
+    }
+
+    /// <summary>
+    /// These ride the Ghostty\**\*.cs glob that MarshalComplianceTests
+    /// declares; they need no entry of their own.
+    ///
+    /// A plain EndsWith is not enough here: "TabHost.xaml.cs" is also the
+    /// tail of "VerticalTabHost.xaml.cs", and the two are the horizontal
+    /// and vertical halves of this very fix. Requiring a non-identifier
+    /// character in front of the suffix separates them without assuming
+    /// which separator the host substituted for the source folder.
+    /// </summary>
+    private static string ReadEmbedded(string suffix)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.Length > suffix.Length
+                && n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+                && !char.IsLetterOrDigit(n[n.Length - suffix.Length - 1]));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabBellAnnouncerTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabBellAnnouncerTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using Ghostty.Core.Tabs;
+using Xunit;
+
+namespace Ghostty.Tests.Tabs;
+
+/// <summary>
+/// ItemStatus is the right property for a ringing tab and no shipping
+/// screen reader reads it off a tab or a list item, on focus or on
+/// change. So the ring also goes out as an announcement, and everything
+/// about when that fires lives here.
+/// </summary>
+public class TabBellAnnouncerTests
+{
+    private static (TabManager mgr, List<string> spoken, TabBellAnnouncer announcer) NewAnnouncer()
+    {
+        var mgr = new TabManager(_ => new FakePaneHost());
+        var spoken = new List<string>();
+        return (mgr, spoken, new TabBellAnnouncer(mgr, (_, text) => spoken.Add(text)));
+    }
+
+    [Fact]
+    public void Ringing_tab_is_announced_with_its_title()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+        mgr.Tabs[0].ShellReportedTitle = "vim file.txt";
+
+        mgr.Tabs[0].BellRinging = true;
+
+        Assert.Equal(new[] { "Bell in vim file.txt" }, spoken);
+    }
+
+    /// <summary>
+    /// A shell that rings twice while the tab is still ringing has told
+    /// the user nothing new. BellRinging guards its setter on equality,
+    /// so the second write raises no change and this stays silent.
+    /// </summary>
+    [Fact]
+    public void Second_ring_while_still_ringing_says_nothing()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+
+        mgr.Tabs[0].BellRinging = true;
+        mgr.Tabs[0].BellRinging = true;
+
+        Assert.Single(spoken);
+    }
+
+    [Fact]
+    public void Acknowledging_the_bell_says_nothing()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+        mgr.Tabs[0].BellRinging = true;
+        spoken.Clear();
+
+        mgr.Tabs[0].BellRinging = false;
+
+        Assert.Empty(spoken);
+    }
+
+    [Fact]
+    public void Ringing_again_after_an_acknowledge_is_announced_again()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+
+        mgr.Tabs[0].BellRinging = true;
+        mgr.Tabs[0].BellRinging = false;
+        mgr.Tabs[0].BellRinging = true;
+
+        Assert.Equal(2, spoken.Count);
+    }
+
+    /// <summary>
+    /// Unrelated changes on the tab are not bells. A rename raises
+    /// PropertyChanged too, and announcing on it would speak a bell every
+    /// time the shell emitted OSC 2.
+    /// </summary>
+    [Fact]
+    public void Other_property_changes_say_nothing()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+
+        mgr.Tabs[0].ShellReportedTitle = "vim file.txt";
+        mgr.Tabs[0].Color = TabColor.Red;
+
+        Assert.Empty(spoken);
+    }
+
+    /// <summary>
+    /// The whole point is a tab the user is not on, and tabs are opened
+    /// long after the window is built, so a tab that arrives later has to
+    /// be watched too.
+    /// </summary>
+    [Fact]
+    public void Tab_added_after_construction_is_announced()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+        mgr.NewTab();
+        mgr.Tabs[1].ShellReportedTitle = "pwsh";
+
+        mgr.Tabs[1].BellRinging = true;
+
+        Assert.Equal(new[] { "Bell in pwsh" }, spoken);
+    }
+
+    [Fact]
+    public void Closed_tab_is_no_longer_announced()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+        mgr.NewTab();
+        var closed = mgr.Tabs[1];
+
+        mgr.CloseTab(closed);
+        closed.BellRinging = true;
+
+        Assert.Empty(spoken);
+    }
+
+    [Fact]
+    public void Disposed_announcer_says_nothing()
+    {
+        var (mgr, spoken, announcer) = NewAnnouncer();
+
+        announcer.Dispose();
+        mgr.Tabs[0].BellRinging = true;
+
+        Assert.Empty(spoken);
+    }
+
+    /// <summary>
+    /// An untitled tab still has to name something a listener can hear:
+    /// the announcement runs through the same fallback the tab's name
+    /// does, so the two agree.
+    /// </summary>
+    [Fact]
+    public void Untitled_tab_is_announced_by_its_fallback_name()
+    {
+        var (mgr, spoken, _) = NewAnnouncer();
+        mgr.Tabs[0].ShellReportedTitle = "   ";
+
+        mgr.Tabs[0].BellRinging = true;
+
+        Assert.Equal(new[] { $"Bell in {Ghostty.Core.AppIdentity.ProductName}" }, spoken);
+    }
+}

--- a/windows/Ghostty.Tests/Tabs/TabModelProfileSnapshotTests.cs
+++ b/windows/Ghostty.Tests/Tabs/TabModelProfileSnapshotTests.cs
@@ -82,4 +82,43 @@ public class TabModelProfileSnapshotTests
 
         Assert.Equal("Wintty", tab.EffectiveTitle);
     }
+
+    /// <summary>
+    /// A shell can report a title that is empty or all spaces:
+    /// an OSC 2 with an empty payload lands here as "" and never as null, and
+    /// the setter only guards against null. Coalescing on null alone let
+    /// that win the precedence chain, so the strip drew a blank label and
+    /// a reader read a blank name.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void EffectiveTitle_BlankShellTitle_FallsThroughToProfile(string blank)
+    {
+        var tab = new TabModel(new FakePaneHost());
+        tab.AttachProfileSnapshot(SampleSnapshot());
+        tab.ShellReportedTitle = blank;
+
+        Assert.Equal("Foo", tab.EffectiveTitle);
+    }
+
+    [Fact]
+    public void EffectiveTitle_BlankShellTitleAndNoProfile_FallsBackToProductName()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        tab.ShellReportedTitle = "   ";
+
+        Assert.Equal("Wintty", tab.EffectiveTitle);
+    }
+
+    [Fact]
+    public void EffectiveTitle_BlankUserOverride_FallsThroughToShellTitle()
+    {
+        var tab = new TabModel(new FakePaneHost());
+        tab.ShellReportedTitle = "vim file.txt";
+        tab.UserOverrideTitle = "   ";
+
+        Assert.Equal("vim file.txt", tab.EffectiveTitle);
+    }
 }

--- a/windows/Ghostty/Accessibility/UiaAnnouncer.cs
+++ b/windows/Ghostty/Accessibility/UiaAnnouncer.cs
@@ -1,0 +1,51 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+
+namespace Ghostty.Accessibility;
+
+/// <summary>
+/// Raises a UIA notification from an element, for state a screen reader
+/// has to hear about even though it is nowhere near the user's focus.
+///
+/// AutomationProperties carry state correctly but only answer questions;
+/// nothing asks about a tab the user is not on. A notification is the one
+/// UIA event that is spoken regardless of where focus sits, which is what
+/// "something happened over there" needs.
+/// </summary>
+internal static class UiaAnnouncer
+{
+    /// <summary>
+    /// Speak <paramref name="text"/> from <paramref name="source"/>.
+    /// <paramref name="activityId"/> groups related announcements so a
+    /// client can coalesce or filter them.
+    /// </summary>
+    internal static void Announce(FrameworkElement? source, string text, string activityId)
+    {
+        if (source is null || string.IsNullOrEmpty(text)) return;
+        if (!AnyoneListening()) return;
+
+        var peer = FrameworkElementAutomationPeer.FromElement(source)
+            ?? FrameworkElementAutomationPeer.CreatePeerForElement(source)
+            ?? new FrameworkElementAutomationPeer(source);
+        peer.RaiseNotificationEvent(
+            AutomationNotificationKind.Other,
+            // MostRecent, not All: a burst of bells is one situation, and
+            // a queue of stale "tab rang" lines read out minutes later is
+            // worse than the latest one.
+            AutomationNotificationProcessing.MostRecent,
+            text,
+            activityId);
+    }
+
+    /// <summary>
+    /// Whether anything is listening. Gated like TerminalAutomationPeer's
+    /// raises: crossing the UIA boundary with nobody advised is work for
+    /// nothing. There is no AutomationEvents.Notification to ask
+    /// ListenerExists about, so the gate is the screen-reader flag plus
+    /// LiveRegionChanged, which the automation clients that want
+    /// announcements but do not set the flag advise for.
+    /// </summary>
+    private static bool AnyoneListening() =>
+        ScreenReaderDetector.IsRunning()
+        || AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Ghostty.Accessibility;
 using Ghostty.Commands;
 using Ghostty.Controls;
 using Ghostty.Core.Config;
@@ -133,6 +134,7 @@ public sealed partial class MainWindow : Window
     private readonly LayoutCoordinator _layout;
     private readonly TitleBarCoordinator _titleBar;
     private readonly TaskbarHost _taskbar;
+    private readonly TabBellAnnouncer _bellAnnouncer;
     private readonly WindowThemeManager _themeManager;
     private readonly ShellThemeService _shellTheme;
     private readonly ThemePreviewService _themePreview;
@@ -754,6 +756,13 @@ public sealed partial class MainWindow : Window
 
         _taskbar = new TaskbarHost(this, _tabManager, loggerFactory.CreateLogger<TaskbarHost>());
 
+        // One announcer per window, not one per strip: both strips are alive
+        // at once and both watch the same tab, so a strip-level announcer
+        // would speak every bell twice.
+        _bellAnnouncer = new TabBellAnnouncer(
+            _tabManager,
+            (tab, text) => UiaAnnouncer.Announce(BellAnnouncementSource(tab), text, "tab-bell"));
+
         AppWindow.Changed += (_, args) =>
         {
             _taskbar.OnAppWindowChanged(AppWindow);
@@ -945,6 +954,19 @@ public sealed partial class MainWindow : Window
 
         Closed += OnClosedAsync;
     }
+
+    /// <summary>
+    /// Where a bell announcement is raised from. A screen reader does not
+    /// listen to the whole tree: NVDA scopes its UIA event handlers around
+    /// whatever holds focus, and a notification raised from the ringing
+    /// tab's own item was measured being dropped while the identical
+    /// notification from the focused surface was spoken. So the
+    /// announcement rides the focused element, and falls back to the tab's
+    /// item when nothing in this window holds focus.
+    /// </summary>
+    private FrameworkElement? BellAnnouncementSource(TabModel tab)
+        => FocusManager.GetFocusedElement(Content.XamlRoot) as FrameworkElement
+            ?? _tabHost.TabElement(tab);
 
     private void OnActivatedInstallBeepSuppressor(object sender, WindowActivatedEventArgs args)
     {
@@ -1491,6 +1513,7 @@ public sealed partial class MainWindow : Window
         _gradientVisual = null;
         _slideAnimator?.Dispose();
         _taskbar.Dispose();
+        _bellAnnouncer.Dispose();
         // _themeManager was disposed at the top of this method, before the
         // first await, so no theme callback can fire mid-teardown (#208).
 

--- a/windows/Ghostty/Tabs/TabHost.xaml.cs
+++ b/windows/Ghostty/Tabs/TabHost.xaml.cs
@@ -6,6 +6,7 @@ using Ghostty.Input;
 using Ghostty.Panes;
 using Ghostty.Services;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -165,6 +166,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 detachWithZone: DetachWithZone),
             DataContext = tab,
         };
+        ApplyItemAccessibleText(item, tab);
         tab.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(TabModel.EffectiveTitle) ||
@@ -172,6 +174,7 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 e.PropertyName == nameof(TabModel.UserOverrideTitle))
             {
                 headerText.Text = tab.EffectiveTitle;
+                ApplyItemAccessibleText(item, tab);
             }
             else if (e.PropertyName == nameof(TabModel.Progress))
             {
@@ -192,12 +195,25 @@ internal sealed partial class TabHost : UserControl, ITabHost
                 bellGlyph.Visibility = tab.BellRinging
                     ? Visibility.Visible
                     : Visibility.Collapsed;
+                ApplyItemAccessibleText(item, tab);
             }
         };
         _itemByModel[tab] = item;
         _headerTextByModel[tab] = headerText;
         TabViewControl.TabItems.Add(item);
         ApplyTabChrome(item, headerPanel, tab, selected: false);
+    }
+
+    /// <summary>
+    /// Screen-reader text for a tab. The header is a StackPanel, and an
+    /// unnamed TabViewItem gets no name out of a panel header, so
+    /// without this every tab in the strip is nameless -- an automation
+    /// client sees how many tabs are open and nothing about any of them.
+    /// </summary>
+    private static void ApplyItemAccessibleText(TabViewItem item, TabModel tab)
+    {
+        AutomationProperties.SetName(item, TabAccessibleText.Name(tab));
+        AutomationProperties.SetItemStatus(item, TabAccessibleText.Status(tab));
     }
 
     private void RemoveItem(TabModel tab)

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -10,6 +10,7 @@ using Ghostty.Core.Windows;
 using Ghostty.Services;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
@@ -700,7 +701,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             Icon = TabIconElementFactory.Create(tab.TabIcon),
             Content = row,
         };
-        ToolTipService.SetToolTip(item, tab.EffectiveTitle);
+        ApplyItemTitleChrome(item, tab);
 
         // Title and bell are cheap to reapply, so they share one binding.
         // Color is separate because it triggers a whole-strip recolor, and
@@ -713,7 +714,7 @@ internal sealed partial class VerticalTabStrip : UserControl
             if (!_items.TryGetValue(tab, out var navItem)) return;
             if (navItem.Content is VerticalTabNavRow navRow)
                 navRow.Refresh(tab);
-            ToolTipService.SetToolTip(navItem, tab.EffectiveTitle);
+            ApplyItemTitleChrome(navItem, tab);
         },
         nameof(TabModel.EffectiveTitle),
         nameof(TabModel.ShellReportedTitle),
@@ -743,6 +744,20 @@ internal sealed partial class VerticalTabStrip : UserControl
         else
             NavView.MenuItems.Add(item);
         ApplyItemTabColor(item, tab);
+    }
+
+    /// <summary>
+    /// Everything on the item that follows the tab's title: the hover
+    /// tooltip and the text an assistive client reads. The row itself
+    /// cannot do this -- it does not know which item holds it, and the
+    /// name has to sit on the item, which is the ListItem in the
+    /// automation tree.
+    /// </summary>
+    private static void ApplyItemTitleChrome(NavigationViewItem item, TabModel tab)
+    {
+        ToolTipService.SetToolTip(item, tab.EffectiveTitle);
+        AutomationProperties.SetName(item, TabAccessibleText.Name(tab));
+        AutomationProperties.SetItemStatus(item, TabAccessibleText.Status(tab));
     }
 
     private void OnRowCloseClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Every tab in the vertical strip announced itself as `Ghostty.Tabs.VerticalTabNavRow`. Nothing set `AutomationProperties.Name` on the `NavigationViewItem`, so its peer fell back to the content's `ToString`, and the content is a `VerticalTabNavRow`. A screen reader user could hear how many tabs were open and nothing about which was which.

The horizontal strip turned out to have the same hole with a different symptom: an unnamed `TabViewItem` gets no name out of a `StackPanel` header, so its tabs read as blank. Both layouts drive one `TabManager`, so fixing only the vertical one is a fix the user loses by switching layout.

## What changed

Both strips now name their item from the tab's `EffectiveTitle`, re-applied wherever the title is re-applied. `TabAccessibleText` in `Ghostty.Core` holds the strings so the two strips cannot drift and the logic is testable without WinUI.

Tabs with distinct titles are now distinguishable. Tabs that are all untitled still collapse onto one fallback name, exactly as their visible labels collapse onto one label; `PositionInSet`/`SizeOfSet` is what separates those, so NVDA still says "1 of 3".

`TabModel.EffectiveTitle` coalesced only on null. A shell reporting an empty OSC 2 title arrives as `""` and not null, so it won the precedence chain and left the tab with a blank label as well as a blank name. Every level now coalesces on whitespace, which fixes the visible label too.

## The bell

The bell rides `AutomationProperties.ItemStatus`, not the name. A name is an identity: it is what a client matches on to find a tab and what focus announces, and appending "bell" to it renames the tab twice per ring.

But `ItemStatus` alone is inaudible. Measured with NVDA 2026.1.1 against a confirmed `ItemStatus='Bell'`: focusing the ringing tab spoke only its name, its role and its position, and `bell` appears nowhere in the log. NVDA does not surface `ItemStatus` for a `TabItem` or a `ListItem`, on focus or as a change.

So the rising edge of `BellRinging` also raises a UIA notification naming the tab, which is read wherever focus happens to be. Rising edge only: a second bell while the tab is still ringing says nothing, and the acknowledge is silent. One announcer per window, not one per strip, because both strips are alive at once and would otherwise speak every bell twice.

The notification is raised from the focused element. NVDA scopes its UIA event handlers around focus, and the same notification raised from the ringing tab's own item was measured being dropped while the one from the focused surface was spoken.

## Evidence

Two tabs, focus moved into the second, a BEL delivered to the first. NVDA 2026.1.1, throwaway config, `synth = silence`, `-l 10`:

```
Speaking [LangChangeCommand ('en'), 'Bell in RINGER-TAB']
```

`System.Windows.Automation` against the same window at that moment:

```
ListItem name='RINGER-TAB' status='Bell'
ListItem name='C:\Program Files\PowerShell\7\pwsh.exe' status=''
```

Before the fix, both of those read `name='Ghostty.Tabs.VerticalTabNavRow'`.

## Tests

2207 pass, up from 2189. The text and the rising-edge logic are pure and tested directly; the wiring is scanned out of the shipped source with comments stripped, as `StripCloseAutomationTests` does.

Two source-scan guards were escapable and are fixed:

- the horizontal strip's guard counted `ApplyItemAccessibleText` calls across the whole add path, tying no call to any arm, so moving the bell arm's call into the title arm kept the count at three while a tab that rang once would read "Bell" forever. Now asserted arm by arm.
- the vertical strip's guard ran from one method's signature to the next declaration, so gutting `ApplyItemTitleChrome` and dropping its automation writes into a new uncalled method below it passed. The window now ends at the method's own closing brace.

Both mutants turn the matching test red and only that test; restoring turns it green.

## Not fixed

`TabOverviewControl` builds its `GridView` tiles out of `StackPanel`s the same way, and `TabSwitcherPopup` builds plain `Border`s that produce no item peers at all. Neither was measured here and both are transient overlays, so they are left alone rather than half-fixed.

`TabHost` never unsubscribes its `PropertyChanged` lambda. Pre-existing and not worsened here; filed separately.
