### PR TITLE
windows: stop the search fuzz killing Wintty instances it did not start

### DIFF
--- a/justfile
+++ b/justfile
@@ -147,17 +147,26 @@ test-win:
 splash-race args="": build-win
     pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}
 
+# Checked before the builds, not after: search-fuzz refuses to run while a
+# Wintty is open, and dotnet build cannot overwrite a locked Wintty.exe, so
+# without this the developer pays a full zig + dotnet build only to be told
+# to close a window -- or gets an MSB file-in-use error that hides the real
+# reason. Prerequisites run in the order listed.
+[windows]
+_no-wintty-running:
+    $p = @(Get-Process Wintty -ErrorAction SilentlyContinue); if ($p.Count -gt 0) { Write-Host ("close the running Wintty first (pid: " + ($p.Id -join ', ') + ")") -ForegroundColor Red; exit 1 }
+
 # Fuzz in-pane scrollback search against a real oracle: the harness reads the
 # terminal's own UIA text document, counts matches itself, and compares every
 # needle it types against that count. Drives real input, so it needs an
 # interactive desktop and takes the foreground for the duration.
 #
 # Exit codes: 0 clean, 2 product findings (see the JSON and shots under
-# windows/scripts/search-fuzz/), 1 the harness could not run - retry.
+# windows/scripts/search-fuzz/), 1 the harness could not run.
 #
 # Pass extra args through, e.g. `just search-fuzz "-Seed 99 -Iterations 40"`.
 [windows]
-search-fuzz args="": build-dll build-win
+search-fuzz args="": _no-wintty-running build-dll build-win
     pwsh -NoProfile -File windows/scripts/search-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/search-fuzz {{args}}

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -42,7 +42,7 @@ away from:
 |------|---------|
 | 0 | clean |
 | 2 | product findings - read `run-<seed>.json` and `shots/` |
-| 1 | the harness could not run (no window, foreground stolen, shell never came up); the product was never exercised, so retry rather than file a bug |
+| 1 | the harness could not run; the product was never exercised, so do not file a bug. Retrying helps when the cause was transient (no window, foreground stolen, shell never came up); it will not help when the run was refused because a Wintty is open - close it first |
 
 The numbering follows `verified-input-probe.ps1`, `mouse-fuzz-loop.ps1` and
 `mouse-fuzz-probe.ps1`, which already use 2 for a product failure.
@@ -53,11 +53,15 @@ product, and how a real defect gets dismissed as flakiness.
 ## Before you run search-fuzz
 
 - It **refuses to start while any Wintty is running**, and names the pids so
-  you can close them. It will not kill an instance it did not start: builds
-  from several worktrees are often open at once, and a running instance
-  would absorb the launch anyway when single-instance is on. On the way out
-  it kills only the processes that appeared during the run and came from the
-  exe under test.
+  you can close them. That includes a Wintty you launched it from, so run it
+  from another terminal. The reason is not single-instance - that mutex is
+  keyed on a hash of the exe path, so another worktree's build would not
+  absorb the launch. It is that `crash.log` is shared: it lives under
+  `%LOCALAPPDATA%` per user rather than per exe path, `XDG_CONFIG_HOME` does
+  not move it, and the harness reports everything the file gains during a
+  run as a defect in the build under test. On the way out it kills only
+  processes that started after the launch and whose image path is the exe
+  under test, and leaves anything it cannot positively identify alone.
 - By default it uses **your real config and state directory**, because a
   throwaway `XDG_CONFIG_HOME` made the app crash at startup on the machine
   it was written on. `-IsolatedConfig` opts into the throwaway dir. The

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -52,9 +52,12 @@ product, and how a real defect gets dismissed as flakiness.
 
 ## Before you run search-fuzz
 
-- It **force-kills every running Wintty** first. Do not launch it from a
-  Wintty window: it will kill its own host, and the cleanup in `finally`
-  never runs.
+- It **refuses to start while any Wintty is running**, and names the pids so
+  you can close them. It will not kill an instance it did not start: builds
+  from several worktrees are often open at once, and a running instance
+  would absorb the launch anyway when single-instance is on. On the way out
+  it kills only the processes that appeared during the run and came from the
+  exe under test.
 - By default it uses **your real config and state directory**, because a
   throwaway `XDG_CONFIG_HOME` made the app crash at startup on the machine
   it was written on. `-IsolatedConfig` opts into the throwaway dir. The

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -22,8 +22,10 @@
     mouse-fuzz scripts:
       0  clean
       2  product findings - see run-<seed>.json and shots/ under -OutDir
-      1  the harness could not run (no window, foreground stolen, shell never
-         came up); the product was never exercised, so retry rather than file
+      1  the harness could not run; the product was never exercised, so do
+         not file a bug. Retrying helps when the cause was transient (window
+         never appeared, foreground stolen); it will not help when the run
+         was refused because a Wintty is already open - close it first
 
     A seed replays the op sequence, but not the corpus-slice needles drawn
     from live terminal text: those depend on the shell prompt and the window
@@ -276,7 +278,16 @@ function Wait-Ready($proc) {
         Start-Sleep -Milliseconds 300
         $proc.Refresh()
         if ($proc.HasExited) {
-            Add-Finding 'crash' "app exited during startup, code $($proc.ExitCode)" @{}
+            $grew = $false
+            try {
+                $cp = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
+                if (Test-Path $cp) { $grew = (Get-Item $cp).Length -gt $script:CrashBaseline }
+            } catch { }
+            # Only a corroborated crash is the product's fault. Without a log
+            # entry this is far more likely an instance that started between
+            # the gate and the launch and absorbed it.
+            Add-Finding $(if ($grew) { 'crash' } else { 'harness' }) `
+                "app exited during startup, code $($proc.ExitCode)$(if (-not $grew) { ' (crash.log did not grow; another instance may have absorbed the launch)' })" @{}
             throw 'app exited during startup'
         }
         $m = Get-Main ([uint32]$proc.Id)
@@ -580,6 +591,12 @@ $origXdg = $env:XDG_CONFIG_HOME
 $script:Proc = $null
 $script:Iter = 0
 $script:ExitCode = 0
+# Set before the try so a throw that precedes their real assignment cannot
+# leave the teardown sweep with a null filter, which matches every process
+# rather than none.
+$script:ExeFull = $null
+$script:PreExisting = @()
+$script:StartedAt = $null
 $result = [ordered]@{
     seed = $Seed; iterations = $Iterations; ops = @()
 }
@@ -593,20 +610,30 @@ try {
     if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath" }
     Write-Host ("config: {0}" -f $(if ($IsolatedConfig) { $tempXdg } else { 'user environment' }))
 
-    # Never kill by name. Developers keep builds from several worktrees open
-    # at once, and a harness that force-kills every Wintty takes down work it
-    # has nothing to do with. Refuse to start instead: a running instance
-    # would absorb this launch anyway when single-instance is on, so there is
-    # no run to be had either way.
+    # Never kill by name: developers keep builds from several worktrees open
+    # at once, and force-killing every Wintty takes down work this run has
+    # nothing to do with. Refuse instead.
+    #
+    # The reason is not single-instance -- that mutex is keyed on a hash of
+    # the exe path (SingleInstanceNames.For), so another worktree's build
+    # would not absorb this launch. It is that crash.log is shared: it lives
+    # at %LOCALAPPDATA%\<StateDirName>\crash.log, per user rather than per
+    # exe path, and XDG_CONFIG_HOME does not move it. This harness attributes
+    # every byte the file gains to the run, as a product finding. Any other
+    # instance crashing during a run would therefore be reported as a defect
+    # in the build under test.
     $script:ExeFull = (Resolve-Path $ExePath).Path
     $script:PreExisting = @(Get-Process Wintty -ErrorAction SilentlyContinue |
         Select-Object -ExpandProperty Id)
     if ($script:PreExisting.Count -gt 0) {
-        throw ("close the running Wintty first (pid $($script:PreExisting -join ', ')); " +
-               'this harness will not kill instances it did not start')
+        throw ("close the running Wintty first (pid: $($script:PreExisting -join ', ')). " +
+               'It shares crash.log with the build under test, so its crashes ' +
+               'would be reported as defects in this run, and this harness ' +
+               'will not kill instances it did not start')
     }
 
-    $script:Proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
+    $script:StartedAt = Get-Date
+    $script:Proc = Start-Process -FilePath $script:ExeFull -PassThru -WorkingDirectory (Split-Path -Parent $script:ExeFull)
     $pid32 = [uint32]$script:Proc.Id
     $main = Wait-Ready $script:Proc
     $script:Hwnd64 = [int64]$main.Hwnd64
@@ -1083,22 +1110,37 @@ finally {
     $result.checks = $script:Checks
     $result.findings = @($script:Findings)
     $result.failed = $script:Findings.Count
-    $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir "run-$Seed.json") -Encoding utf8
+    # A run that never got to assert anything has nothing to record, and
+    # writing it would overwrite the last real run's results.
+    if ($script:Checks -gt 0) {
+        $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir "run-$Seed.json") -Encoding utf8
+    }
 
-    # Tear down only what this run started. The launched process is not
-    # always the one left holding the window -- the launch splash can elect a
-    # different instance -- so sweep for processes that appeared during the
-    # run and came from the exe under test, and leave everything else alone.
+    # Tear down only what this run started, and fail closed on anything the
+    # sweep cannot positively identify: an unreadable path or start time is a
+    # reason to leave a process alone, never a reason to kill it. Process.Path
+    # returns null rather than throwing when the process cannot be opened, so
+    # the null checks are the real guard here.
+    #
+    # $script:PreExisting is empty on every path that reaches a launch (the
+    # gate refuses otherwise); it is only non-empty on the refusal path, where
+    # it is exactly what stops this sweep touching the developer's instances.
     if (-not $KeepOpen) {
         if ($script:Proc) {
-            try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill() } } catch { }
+            try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill($true) } } catch { }
             try { [void]$script:Proc.WaitForExit(3000) } catch { }
         }
-        foreach ($p in @(Get-Process Wintty -ErrorAction SilentlyContinue)) {
-            if ($script:PreExisting -contains $p.Id) { continue }
-            $path = try { $p.Path } catch { $null }
-            if ($path -ne $script:ExeFull) { continue }
-            try { $p.Kill(); [void]$p.WaitForExit(3000) } catch { }
+        if ($script:ExeFull -and $script:StartedAt) {
+            foreach ($p in @(Get-Process Wintty -ErrorAction SilentlyContinue)) {
+                if ($script:PreExisting -contains $p.Id) { continue }
+                $path = try { $p.Path } catch { $null }
+                if ([string]::IsNullOrEmpty($path) -or $path -ne $script:ExeFull) { continue }
+                # Without this a same-build window the developer opened while
+                # the run was going gets killed with it.
+                $started = try { $p.StartTime } catch { $null }
+                if ($null -eq $started -or $started -lt $script:StartedAt) { continue }
+                try { $p.Kill($true); [void]$p.WaitForExit(3000) } catch { }
+            }
         }
     }
     if ($IsolatedConfig) {
@@ -1106,7 +1148,7 @@ finally {
         else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
     }
     Start-Sleep -Milliseconds 500
-    Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
+    if (-not $KeepOpen) { Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue }
 
     Write-Host ""
     if ($script:Findings.Count -eq 0) {

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -593,11 +593,19 @@ try {
     if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath" }
     Write-Host ("config: {0}" -f $(if ($IsolatedConfig) { $tempXdg } else { 'user environment' }))
 
-    # A surviving instance would absorb the launch when single-instance is on.
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-    # Give a killed primary time to release the single-instance claim, or the
-    # launch below hands itself off to a dying instance and owns no window.
-    Start-Sleep -Seconds 3
+    # Never kill by name. Developers keep builds from several worktrees open
+    # at once, and a harness that force-kills every Wintty takes down work it
+    # has nothing to do with. Refuse to start instead: a running instance
+    # would absorb this launch anyway when single-instance is on, so there is
+    # no run to be had either way.
+    $script:ExeFull = (Resolve-Path $ExePath).Path
+    $script:PreExisting = @(Get-Process Wintty -ErrorAction SilentlyContinue |
+        Select-Object -ExpandProperty Id)
+    if ($script:PreExisting.Count -gt 0) {
+        throw ("close the running Wintty first (pid $($script:PreExisting -join ', ')); " +
+               'this harness will not kill instances it did not start')
+    }
+
     $script:Proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path -Parent (Resolve-Path $ExePath))
     $pid32 = [uint32]$script:Proc.Id
     $main = Wait-Ready $script:Proc
@@ -1077,9 +1085,21 @@ finally {
     $result.failed = $script:Findings.Count
     $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir "run-$Seed.json") -Encoding utf8
 
-    if ($script:Proc -and -not $KeepOpen) {
-        try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill() } } catch { }
-        try { [void]$script:Proc.WaitForExit(3000) } catch { }
+    # Tear down only what this run started. The launched process is not
+    # always the one left holding the window -- the launch splash can elect a
+    # different instance -- so sweep for processes that appeared during the
+    # run and came from the exe under test, and leave everything else alone.
+    if (-not $KeepOpen) {
+        if ($script:Proc) {
+            try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill() } } catch { }
+            try { [void]$script:Proc.WaitForExit(3000) } catch { }
+        }
+        foreach ($p in @(Get-Process Wintty -ErrorAction SilentlyContinue)) {
+            if ($script:PreExisting -contains $p.Id) { continue }
+            $path = try { $p.Path } catch { $null }
+            if ($path -ne $script:ExeFull) { continue }
+            try { $p.Kill(); [void]$p.WaitForExit(3000) } catch { }
+        }
     }
     if ($IsolatedConfig) {
         if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }


### PR DESCRIPTION
The harness force-killed every process named Wintty before launching. With
builds from several worktrees open at once that takes down unrelated work, and
a running instance would absorb the launch anyway when single-instance is on.

It now refuses to start while any Wintty is running and names the pids. Teardown
kills only processes that appeared during the run and came from the exe under
test, rather than just the launched pid: the launch splash can elect a different
instance to hold the window, so the pid that was started is not always the one
left behind.

Verified both paths: with an instance already running the harness exits 1 and
that instance survives; with none running a seeded run completes and exits 0.
