### PR TITLE
windows: stop the GUI harnesses killing Wintty by name

### DIFF
--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -50,6 +50,27 @@ The numbering follows `verified-input-probe.ps1`, `mouse-fuzz-loop.ps1` and
 Conflating those two is how a broken harness gets mistaken for a broken
 product, and how a real defect gets dismissed as flakiness.
 
+## Process policy
+
+`lib/wintty-process.ps1` holds the rule, and every harness here dot-sources
+it rather than reimplementing it:
+
+- `Assert-NoWintty` - refuse to start while any Wintty is running, naming the
+  pids. Call it once, before the first launch.
+- `Get-WinttyLaunchStamp` / `Stop-WinttyStartedAfter` - clean up only what the
+  run started, matched on start time and, where the caller knows it, image
+  path. Anything that cannot be positively identified is skipped: an
+  unreadable path or start time is a reason to leave a process alone, never a
+  reason to kill it.
+
+These scripts used to open with `Get-Process Wintty | Stop-Process -Force`,
+which takes down builds from other worktrees and the window the developer is
+working in. That is not a harness's call to make. Two exceptions are
+deliberate and stay: `splash-single-instance-race.ps1` launches a second
+instance on purpose, and `mouse-fuzz-jumplist.ps1` launches secondaries
+against a running primary, so both gate once at the start rather than before
+each launch.
+
 ## Before you run search-fuzz
 
 - It **refuses to start while any Wintty is running**, and names the pids so

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -52,8 +52,7 @@ product, and how a real defect gets dismissed as flakiness.
 
 ## Process policy
 
-`lib/wintty-process.ps1` holds the rule, and every harness here dot-sources
-it rather than reimplementing it:
+`lib/wintty-process.ps1` holds the rule:
 
 - `Assert-NoWintty` - refuse to start while any Wintty is running, naming the
   pids. Call it once, before the first launch.
@@ -63,13 +62,30 @@ it rather than reimplementing it:
   unreadable path or start time is a reason to leave a process alone, never a
   reason to kill it.
 
-These scripts used to open with `Get-Process Wintty | Stop-Process -Force`,
+Most scripts here used to open with `Get-Process Wintty | Stop-Process -Force`,
 which takes down builds from other worktrees and the window the developer is
-working in. That is not a harness's call to make. Two exceptions are
-deliberate and stay: `splash-single-instance-race.ps1` launches a second
-instance on purpose, and `mouse-fuzz-jumplist.ps1` launches secondaries
-against a running primary, so both gate once at the start rather than before
-each launch.
+working in. That is not a harness's call to make.
+
+Four scripts predate the lib and still carry their own copy of the rule.
+They are not exceptions to the policy, just not folded onto it yet, and
+`search-fuzz.ps1` and `splash-single-instance-race.ps1` are in fact stricter
+than the shared helper because they match on image path as well as time:
+
+| script | why it is separate |
+|---|---|
+| `search-fuzz.ps1` | keeps a pre-existing-pid allowlist the helper has no equivalent of |
+| `splash-single-instance-race.ps1` | launches a second instance on purpose, path-scoped gate |
+| `mouse-fuzz-tab-colors.ps1` | already pid-scoped before the lib existed |
+| `vtabs-visual-qa.ps1` | already pid-scoped before the lib existed |
+
+`justfile` also has its own copy of the gate, so `just search-fuzz` can
+refuse before paying for a build.
+
+Two scripts need care beyond a single gate. `mouse-fuzz-jumplist.ps1`
+launches secondaries against a running primary, so its sweep rather than a
+per-process kill is what reaps them. `verified-input-probe.ps1` deliberately
+leaves its window up for inspection and therefore takes no stamp and runs no
+sweep; close it by hand before the next harness.
 
 ## Before you run search-fuzz
 

--- a/windows/scripts/aot-fuzz.ps1
+++ b/windows/scripts/aot-fuzz.ps1
@@ -11,6 +11,7 @@ param(
         'mouse-fuzz-loop.ps1'
     )
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
 $PublishExe = (Resolve-Path -LiteralPath $PublishExe -ErrorAction SilentlyContinue)?.Path
@@ -35,13 +36,17 @@ $base = Join-Path $PSScriptRoot "fuzz-out/aot-$stamp"
 New-Item -ItemType Directory -Force -Path $base | Out-Null
 
 $results = @()
+# Twice with a pause between: a Wintty that is mid-startup can outlive the
+# first sweep.
 function Stop-Wintty {
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     Start-Sleep -Milliseconds 1200
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     Start-Sleep -Milliseconds 600
 }
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 Stop-Wintty
 $idx = 0
 foreach ($s in $Scripts) {

--- a/windows/scripts/lib/wintty-process.ps1
+++ b/windows/scripts/lib/wintty-process.ps1
@@ -57,7 +57,14 @@ function Stop-WinttyStartedAfter {
         [int]$TimeoutMs = 3000
     )
 
-    $full = if ($ExePath) { (Resolve-Path -LiteralPath $ExePath -ErrorAction SilentlyContinue)?.Path } else { $null }
+    $full = $null
+    if ($ExePath) {
+        $full = (Resolve-Path -LiteralPath $ExePath -ErrorAction SilentlyContinue)?.Path
+        # A path the caller supplied but that does not resolve means the
+        # filter cannot be applied. Sweep nothing rather than quietly
+        # widening to every process started since the stamp.
+        if (-not $full) { return }
+    }
 
     foreach ($p in @(Get-Process Wintty -ErrorAction SilentlyContinue)) {
         # Process.StartTime and .Path return null or throw for a process the

--- a/windows/scripts/lib/wintty-process.ps1
+++ b/windows/scripts/lib/wintty-process.ps1
@@ -1,0 +1,78 @@
+#requires -Version 7
+<#
+    Shared process policy for the GUI harnesses in this directory.
+
+    These scripts used to open with `Get-Process Wintty | Stop-Process -Force`
+    to get a clean slate. That kills every Wintty on the machine, including
+    builds from other worktrees and the window the developer is working in,
+    which is not a harness's call to make.
+
+    The replacement is two rules:
+
+      1. Refuse to start while any Wintty is running. Say which pids, so the
+         developer can close them. This is not about the single-instance
+         mutex - that is keyed on a hash of the exe path, so another
+         worktree's build would not collide. It is that state is shared:
+         crash.log lives under %LOCALAPPDATA% per user rather than per exe
+         path, and a harness that reads it cannot tell whose crash it saw.
+
+      2. Clean up only what the run started, identified by start time and,
+         where the caller knows it, image path. Anything that cannot be
+         positively identified is left alone: an unreadable path or start
+         time is a reason to skip a process, never a reason to kill it.
+
+    Dot-source it:
+
+        . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+#>
+
+# Throws if any Wintty is running. Call once, before the first launch.
+function Assert-NoWintty {
+    param([string]$Context = 'This harness')
+
+    $running = @(Get-Process Wintty -ErrorAction SilentlyContinue)
+    if ($running.Count -eq 0) { return }
+
+    $pids = ($running | ForEach-Object { $_.Id }) -join ', '
+    throw ("close the running Wintty first (pid: $pids). " +
+           "$Context shares crash.log and the state directory with it, so " +
+           'its crashes would be read as belonging to this run, and this ' +
+           'harness will not kill instances it did not start.')
+}
+
+# The timestamp to hand to Stop-WinttyStartedAfter. Take it immediately
+# before the first Start-Process, not at script start: anything earlier
+# widens the window in which an unrelated instance looks like ours.
+function Get-WinttyLaunchStamp { return Get-Date }
+
+# Kill the Wintty processes this run started. Fails closed on anything it
+# cannot identify.
+function Stop-WinttyStartedAfter {
+    param(
+        [Parameter(Mandatory)][datetime]$Since,
+        # Optional, and worth passing whenever the caller knows which exe it
+        # launched: start time alone will also match an instance the
+        # developer opened while the run was in flight.
+        [string]$ExePath,
+        [int]$TimeoutMs = 3000
+    )
+
+    $full = if ($ExePath) { (Resolve-Path -LiteralPath $ExePath -ErrorAction SilentlyContinue)?.Path } else { $null }
+
+    foreach ($p in @(Get-Process Wintty -ErrorAction SilentlyContinue)) {
+        # Process.StartTime and .Path return null or throw for a process the
+        # harness cannot open (elevated, another session, or one that exited
+        # between enumeration and the read). Skip those.
+        $started = try { $p.StartTime } catch { $null }
+        if ($null -eq $started -or $started -lt $Since) { continue }
+
+        if ($full) {
+            $path = try { $p.Path } catch { $null }
+            if ([string]::IsNullOrEmpty($path) -or $path -ne $full) { continue }
+        }
+
+        # Kill the tree: the shell runs as a child, and a wedged one would
+        # otherwise outlive every run.
+        try { $p.Kill($true); [void]$p.WaitForExit($TimeoutMs) } catch { }
+    }
+}

--- a/windows/scripts/mouse-fuzz-confirm-always.ps1
+++ b/windows/scripts/mouse-fuzz-confirm-always.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -236,7 +237,8 @@ $tabsAfterClose = 0
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -295,7 +297,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-confirm-always.ps1
+++ b/windows/scripts/mouse-fuzz-confirm-always.ps1
@@ -235,10 +235,10 @@ $tabsAfterNew = 0
 $tabsAfterCancel = 0
 $tabsAfterClose = 0
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -297,7 +297,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-dialogs.ps1
+++ b/windows/scripts/mouse-fuzz-dialogs.ps1
@@ -438,5 +438,10 @@ $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc
     cheatsheetSave = $null -ne $saveMd
 } | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
-if ($proc.HasExited -or $crashGrew) { exit 2 }
+$diedEarly = $proc.HasExited
+# Leave nothing behind: every other harness here refuses to start while a
+# Wintty is running, and this script used to rely on the next one's
+# blanket kill to reap it.
+Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
+if ($diedEarly -or $crashGrew) { exit 2 }
 exit 0

--- a/windows/scripts/mouse-fuzz-dialogs.ps1
+++ b/windows/scripts/mouse-fuzz-dialogs.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -330,7 +331,8 @@ function Close-Extras([int64]$MainHwnd, [uint32]$ProcId) {
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id

--- a/windows/scripts/mouse-fuzz-ime-cjk.ps1
+++ b/windows/scripts/mouse-fuzz-ime-cjk.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -402,7 +403,8 @@ $imeCompositionImplemented = $true  # WinUI TextComposition -> SurfacePreedit; l
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -452,7 +454,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-ime-cjk.ps1
+++ b/windows/scripts/mouse-fuzz-ime-cjk.ps1
@@ -400,11 +400,11 @@ $cjkMarker = 'CJK-FUZZ-日中文🚀'
 $allowClicked = $false
 $imeCompositionImplemented = $true  # WinUI TextComposition -> SurfacePreedit; live IME still manual
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -454,7 +454,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-inspector.ps1
+++ b/windows/scripts/mouse-fuzz-inspector.ps1
@@ -512,7 +512,7 @@ $result = @{
 $result | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
 
-Stop-WinttyStartedAfter -Since $script:WinttyStamp
+Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 
 if (-not $alive -or $crashGrew) { exit 2 }
 if ($noticeOpen -or -not $renderOk -or -not $closedOk) { exit 1 }

--- a/windows/scripts/mouse-fuzz-inspector.ps1
+++ b/windows/scripts/mouse-fuzz-inspector.ps1
@@ -4,6 +4,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -367,7 +368,8 @@ function Inspector-NoticeVisible([int64]$MainHwnd) {
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id
@@ -510,7 +512,7 @@ $result = @{
 $result | ConvertTo-Json -Depth 4 | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
 
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Stop-WinttyStartedAfter -Since $script:WinttyStamp
 
 if (-not $alive -or $crashGrew) { exit 2 }
 if ($noticeOpen -or -not $renderOk -or -not $closedOk) { exit 1 }

--- a/windows/scripts/mouse-fuzz-jumplist.ps1
+++ b/windows/scripts/mouse-fuzz-jumplist.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -372,8 +373,10 @@ $tabsAfterProfile = 0
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     Start-Sleep -Milliseconds 500
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
     $main = Wait-Ready $proc
@@ -462,7 +465,7 @@ finally {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
         }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-jumplist.ps1
+++ b/windows/scripts/mouse-fuzz-jumplist.ps1
@@ -371,12 +371,11 @@ $tabsBefore = 0
 $tabsAfter = 0
 $tabsAfterProfile = 0
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     Start-Sleep -Milliseconds 500
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
     $main = Wait-Ready $proc
@@ -465,7 +464,7 @@ finally {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
         }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-kitty.ps1
+++ b/windows/scripts/mouse-fuzz-kitty.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -425,7 +426,8 @@ Write-Host "conptyPresent=$conptyPresent"
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -475,7 +477,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-kitty.ps1
+++ b/windows/scripts/mouse-fuzz-kitty.ps1
@@ -423,11 +423,11 @@ $conptyPresent = Test-Path (Join-Path (Split-Path $ExePath) 'conpty.dll')
 $allowClicked = $false
 Write-Host "conptyPresent=$conptyPresent"
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -477,7 +477,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-loop.ps1
+++ b/windows/scripts/mouse-fuzz-loop.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -340,7 +341,8 @@ function Invoke-UiaOrClick([System.Windows.Automation.AutomationElement]$el, [ui
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id

--- a/windows/scripts/mouse-fuzz-loop.ps1
+++ b/windows/scripts/mouse-fuzz-loop.ps1
@@ -515,5 +515,9 @@ $alive = -not $proc.HasExited
     hwnd = "$hwnd64"
 } | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host "alive=$alive crashGrew=$crashGrew"
+# Leave nothing behind: every other harness here refuses to start while a
+# Wintty is running, and this script used to rely on the next one's
+# blanket kill to reap it.
+Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 if (-not $alive -or $crashGrew) { exit 2 }
 exit 0

--- a/windows/scripts/mouse-fuzz-mica-dpi.ps1
+++ b/windows/scripts/mouse-fuzz-mica-dpi.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -419,7 +420,8 @@ $configPath = Join-Path $tempXdg 'wintty\config.wintty'
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 400
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -497,7 +499,7 @@ finally {
             Start-Sleep -Milliseconds 300
         }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }
@@ -522,7 +524,7 @@ exit 0
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     Start-Sleep -Milliseconds 400
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -641,7 +643,7 @@ finally {
             Start-Sleep -Milliseconds 300
         }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-mica-dpi.ps1
+++ b/windows/scripts/mouse-fuzz-mica-dpi.ps1
@@ -417,11 +417,11 @@ $styleAfterCrystal = $null
 $paletteBackdropAfter = $null
 $configPath = Join-Path $tempXdg 'wintty\config.wintty'
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 400
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -499,7 +499,7 @@ finally {
             Start-Sleep -Milliseconds 300
         }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }
@@ -524,7 +524,7 @@ exit 0
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     Start-Sleep -Milliseconds 400
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -643,7 +643,7 @@ finally {
             Start-Sleep -Milliseconds 300
         }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-osc-paste.ps1
+++ b/windows/scripts/mouse-fuzz-osc-paste.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -393,7 +394,8 @@ $allowClicked = $false
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -443,7 +445,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-osc-paste.ps1
+++ b/windows/scripts/mouse-fuzz-osc-paste.ps1
@@ -391,11 +391,11 @@ $oscOk = $false
 $oscTitle = ''
 $allowClicked = $false
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -445,7 +445,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-probe.ps1
+++ b/windows/scripts/mouse-fuzz-probe.ps1
@@ -10,6 +10,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -237,7 +238,8 @@ function Post-Text([int64]$Hwnd64, [string]$text) {
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id

--- a/windows/scripts/mouse-fuzz-probe.ps1
+++ b/windows/scripts/mouse-fuzz-probe.ps1
@@ -324,5 +324,9 @@ $alive = -not $proc.HasExited
     hwnd = "$hwnd64"
 } | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host "alive=$alive crashGrew=$crashGrew"
+# Leave nothing behind: every other harness here refuses to start while a
+# Wintty is running, and this script used to rely on the next one's
+# blanket kill to reap it.
+Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 if (-not $alive -or $crashGrew) { exit 2 }
 exit 0

--- a/windows/scripts/mouse-fuzz-remain-title.ps1
+++ b/windows/scripts/mouse-fuzz-remain-title.ps1
@@ -6,6 +6,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -241,7 +242,8 @@ $tabsAfterClose = 0
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -290,7 +292,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-remain-title.ps1
+++ b/windows/scripts/mouse-fuzz-remain-title.ps1
@@ -240,10 +240,10 @@ $remainOk = $false
 $tabsAfterNew = 0
 $tabsAfterClose = 0
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -292,7 +292,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-remain.ps1
+++ b/windows/scripts/mouse-fuzz-remain.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -311,7 +312,8 @@ function Open-TabMenu([int64]$MainHwnd, [uint32]$ProcId) {
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
 $crashStamp = if (Test-Path $crashPath) { (Get-Item $crashPath).LastWriteTimeUtc } else { [datetime]::MinValue }
 
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
 $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
 $pid32 = [uint32]$proc.Id
@@ -485,8 +487,8 @@ $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc
 } | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
 if ($proc.HasExited -or $crashGrew -or -not $overview) {
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     exit 2
 }
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Stop-WinttyStartedAfter -Since $script:WinttyStamp
 exit 0

--- a/windows/scripts/mouse-fuzz-remain.ps1
+++ b/windows/scripts/mouse-fuzz-remain.ps1
@@ -487,8 +487,8 @@ $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc
 } | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
 if ($proc.HasExited -or $crashGrew -or -not $overview) {
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     exit 2
 }
-Stop-WinttyStartedAfter -Since $script:WinttyStamp
+Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 exit 0

--- a/windows/scripts/mouse-fuzz-settings.ps1
+++ b/windows/scripts/mouse-fuzz-settings.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -299,7 +300,8 @@ $script:vtabFound = @()
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 400
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -418,7 +420,7 @@ finally {
             Start-Sleep -Milliseconds 300
         }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-settings.ps1
+++ b/windows/scripts/mouse-fuzz-settings.ps1
@@ -298,10 +298,10 @@ $settingsTitle = $null
 $pages = @()
 $script:vtabFound = @()
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 400
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -420,7 +420,7 @@ finally {
             Start-Sleep -Milliseconds 300
         }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-undo-osc.ps1
+++ b/windows/scripts/mouse-fuzz-undo-osc.ps1
@@ -336,10 +336,10 @@ $tabsAfterClose = 0
 $tabsAfterReopen = 0
 $oscTitle = ''
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -409,7 +409,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-undo-osc.ps1
+++ b/windows/scripts/mouse-fuzz-undo-osc.ps1
@@ -5,6 +5,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -337,7 +338,8 @@ $oscTitle = ''
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -407,7 +409,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-vertical-tabs.ps1
+++ b/windows/scripts/mouse-fuzz-vertical-tabs.ps1
@@ -4,6 +4,7 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -242,7 +243,8 @@ $widthCollapsed = 0
 
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Assert-NoWintty
+    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -295,7 +297,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/mouse-fuzz-vertical-tabs.ps1
+++ b/windows/scripts/mouse-fuzz-vertical-tabs.ps1
@@ -241,10 +241,10 @@ $collapsedNarrow = $false
 $widthPinned = 0
 $widthCollapsed = 0
 
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     $env:XDG_CONFIG_HOME = $tempXdg
-    Assert-NoWintty
-    $script:WinttyStamp = Get-WinttyLaunchStamp
     Start-Sleep -Milliseconds 500
     $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
     $pid32 = [uint32]$proc.Id
@@ -297,7 +297,7 @@ finally {
         $proc.Refresh()
         if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
 }

--- a/windows/scripts/release-smoke.ps1
+++ b/windows/scripts/release-smoke.ps1
@@ -8,6 +8,8 @@ param(
 $ErrorActionPreference = 'Stop'
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
 Push-Location $repo
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 try {
     Write-Host '== build-dll-release (ReleaseFast libghostty) =='
     just build-dll-release
@@ -23,8 +25,6 @@ try {
 
     if (-not $SkipLaunch) {
         Write-Host '== launch Release smoke (3s) =='
-        Assert-NoWintty
-        $script:WinttyStamp = Get-WinttyLaunchStamp
         Start-Sleep -Milliseconds 400
         $proc = Start-Process -FilePath $releaseExe -PassThru -WorkingDirectory (Split-Path $releaseExe)
         Start-Sleep -Seconds 3
@@ -52,7 +52,7 @@ try {
         Write-Host "aot publish ok: $pubExe"
         if (-not $SkipLaunch) {
             Write-Host '== launch NativeAOT smoke (3s) =='
-            Stop-WinttyStartedAfter -Since $script:WinttyStamp
+            Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $releaseExe
             Start-Sleep -Milliseconds 400
             $proc = Start-Process -FilePath $pubExe -PassThru -WorkingDirectory (Split-Path $pubExe)
             Start-Sleep -Seconds 3

--- a/windows/scripts/release-smoke.ps1
+++ b/windows/scripts/release-smoke.ps1
@@ -4,6 +4,7 @@ param(
     [switch]$SkipAot,
     [switch]$SkipLaunch
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
 Push-Location $repo
@@ -22,7 +23,8 @@ try {
 
     if (-not $SkipLaunch) {
         Write-Host '== launch Release smoke (3s) =='
-        Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+        Assert-NoWintty
+        $script:WinttyStamp = Get-WinttyLaunchStamp
         Start-Sleep -Milliseconds 400
         $proc = Start-Process -FilePath $releaseExe -PassThru -WorkingDirectory (Split-Path $releaseExe)
         Start-Sleep -Seconds 3
@@ -50,7 +52,7 @@ try {
         Write-Host "aot publish ok: $pubExe"
         if (-not $SkipLaunch) {
             Write-Host '== launch NativeAOT smoke (3s) =='
-            Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+            Stop-WinttyStartedAfter -Since $script:WinttyStamp
             Start-Sleep -Milliseconds 400
             $proc = Start-Process -FilePath $pubExe -PassThru -WorkingDirectory (Split-Path $pubExe)
             Start-Sleep -Seconds 3

--- a/windows/scripts/verified-input-probe.ps1
+++ b/windows/scripts/verified-input-probe.ps1
@@ -213,8 +213,9 @@ function Post-Chars([IntPtr]$Root, [string]$Text) {
 
 # --- launch ---
 if (-not (Test-Path -LiteralPath $ExePath)) { throw "exe missing: $ExePath" }
+# No stamp and no sweep here on purpose: this probe leaves its window up so
+# the screenshots can be inspected (see the note at the end).
 Assert-NoWintty
-$script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
 
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'
@@ -295,6 +296,9 @@ if ($proc.HasExited -or $crashGrew) {
 $result | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host ($result | ConvertTo-Json -Depth 5)
 
-# Leave Wintty up so the shots can be inspected. Do not Alt+F4.
+# Leave Wintty up so the shots can be inspected. Do not Alt+F4. This is the
+# one harness here that does, and it has a cost: the others refuse to start
+# while a Wintty is running, so close it by hand before the next one.
+Write-Host 'NOTE: Wintty left running for inspection; close it before running another harness.' -ForegroundColor Yellow
 if ($result.verdict -eq 'PRODUCT_FAIL') { exit 2 }
 exit 0

--- a/windows/scripts/verified-input-probe.ps1
+++ b/windows/scripts/verified-input-probe.ps1
@@ -21,6 +21,7 @@ param(
     [Parameter(Mandatory)][string]$OutDir
 )
 
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -212,7 +213,8 @@ function Post-Chars([IntPtr]$Root, [string]$Text) {
 
 # --- launch ---
 if (-not (Test-Path -LiteralPath $ExePath)) { throw "exe missing: $ExePath" }
-Get-Process Wintty -ErrorAction SilentlyContinue | Stop-Process -Force
+Assert-NoWintty
+$script:WinttyStamp = Get-WinttyLaunchStamp
 Start-Sleep -Milliseconds 400
 
 $crashPath = Join-Path $env:LOCALAPPDATA 'Wintty\crash.log'


### PR DESCRIPTION
Eighteen scripts opened with `Get-Process Wintty | Stop-Process -Force`, some
several times over. That takes down builds from other worktrees and the window
the developer is working in. Two scripts already had the scoped version with a
comment explaining why, so the convention existed and just had not been applied.

The policy now lives in `lib/wintty-process.ps1` instead of being pasted into
each script:

- `Assert-NoWintty` refuses to start while any Wintty is running, naming the pids
- `Stop-WinttyStartedAfter` cleans up only what the run started, matched on start
  time and optionally image path, skipping anything it cannot positively
  identify - an unreadable path or start time is a reason to leave a process
  alone, not to kill it

Placement needed care twice. `aot-fuzz` calls `Stop-Wintty` once per iteration,
so a gate inside it would refuse on the second call and re-stamping would make
the sweep a no-op. `mouse-fuzz-jumplist` launches secondaries against a running
primary on purpose. Both gate once at the start instead.

Verified by running two end to end: `verified-input-probe` exits 0, and
`mouse-fuzz-vertical-tabs` drives the sidebar through 220 -> 48 -> 220 with
`crashGrew` false. The other sixteen are checked by parse and by reading where
each gate landed, not by execution - they need an interactive desktop and
several minutes each.
