### PR TITLE
windows: one fuzz suite over the GUI harnesses, and a self-test for the runner

### DIFF
--- a/justfile
+++ b/justfile
@@ -144,10 +144,10 @@ test-win:
 # windows, so it needs an interactive desktop and no Wintty already running.
 # Pass extra args through, e.g. `just splash-race "-SecondaryFeatureOff"`.
 [windows]
-splash-race args="": build-win
+splash-race args="": _no-wintty-running build-win
     pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}
 
-# Checked before the builds, not after: search-fuzz refuses to run while a
+# Checked before the builds, not after: the harnesses refuse to run while a
 # Wintty is open, and dotnet build cannot overwrite a locked Wintty.exe, so
 # without this the developer pays a full zig + dotnet build only to be told
 # to close a window -- or gets an MSB file-in-use error that hides the real
@@ -170,6 +170,38 @@ search-fuzz args="": _no-wintty-running build-dll build-win
     pwsh -NoProfile -File windows/scripts/search-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
         -OutDir windows/scripts/search-fuzz {{args}}
+
+# Real windows and real input, so it needs an interactive desktop and holds
+# the foreground for the duration - about 40 minutes budgeted for everything,
+# 5 for `-Tag smoke` (measured 3). Each harness is killed if it overruns its
+# budget, so a wedged one cannot hold the desktop indefinitely.
+#
+# Exit codes: 0 clean, 2 product findings, 1 one or more harnesses could not
+# run (so their area is untested, not proven good).
+#
+# Args pass through, e.g. `just fuzz "-Tag smoke"` or `just fuzz "-Only search"`.
+#
+# Run every GUI fuzz harness against the Debug build.
+[windows]
+fuzz args="": _no-wintty-running build-dll build-win
+    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 \
+        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe {{args}}
+
+# No build, no desktop.
+#
+# List the suite: what it runs, what each harness catches, what it costs.
+[windows]
+fuzz-list:
+    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -List
+
+# Runs the suite runner against fixtures that exit 0, 1, 2 and 3 on purpose,
+# plus ones that throw, hang, and fail once then work. About a minute, no
+# build, no desktop, and safe to run with Wintty open.
+#
+# Prove the suite still tells a product finding from a harness that broke.
+[windows]
+fuzz-selftest:
+    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -SelfTest
 
 # === Upstream Sync ===
 

--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -15,40 +15,135 @@ do not have. They are local gates, run by hand before merging a change in
 the area they cover. (`.github/workflows/` currently runs no .NET tests at
 all either, so `just test-win` is also a local gate.)
 
-Two have `just` recipes so far:
+`fuzz-suite.ps1` is the entry point:
 
 ```
-just search-fuzz                          # scrollback search
+just fuzz-list                  # what it runs, no build and no desktop needed
+just fuzz-selftest              # prove the runner classifies exit codes, seconds
+just fuzz                       # everything, about 40 minutes budgeted
+just fuzz "-Tag smoke"          # the fast, high-signal subset, 5 budgeted / 3 measured
+just fuzz "-Only search,loop"
+```
+
+Individual harnesses still run standalone, which is what you want while
+fixing something:
+
+```
 just search-fuzz "-Seed 99 -Iterations 40"
 just splash-race
+pwsh -NoProfile -File windows/scripts/mouse-fuzz-loop.ps1 -ExePath ... -OutDir ...
 ```
 
-The rest of the scripts in this directory are older and are invoked
-directly with `pwsh -File`.
-
-`search-fuzz` writes its JSON results, screenshots and terminal dumps under
-`windows/scripts/search-fuzz/`, which is git-ignored. Older scripts vary:
-`splash-single-instance-race.ps1`, for instance, uses the system temp
-directory and takes no `-OutDir`.
+Results go under `windows/scripts/fuzz-out/`, which is git-ignored;
+`search-fuzz` on its own writes to `windows/scripts/search-fuzz/`. A suite
+run writes `summary.json` at the root and one directory per harness holding
+that harness's own `result.json`, screenshots and `console.log`.
 
 ## Exit codes
 
-`search-fuzz.ps1` distinguishes the two ways a run can fail. This is the
-convention for new harnesses rather than a description of the existing
-ones - `splash-race` exits 1 for both kinds, which is the thing to move
-away from:
+Every harness in the suite manifest follows this. It is the whole basis for
+telling a broken product from a broken harness, and for deciding what is
+worth retrying:
 
 | code | meaning |
 |------|---------|
 | 0 | clean |
-| 2 | product findings - read `run-<seed>.json` and `shots/` |
+| 2 | product findings - read the harness's `result.json` and `shots/` |
 | 1 | the harness could not run; the product was never exercised, so do not file a bug. Retrying helps when the cause was transient (no window, foreground stolen, shell never came up); it will not help when the run was refused because a Wintty is open - close it first |
 
-The numbering follows `verified-input-probe.ps1`, `mouse-fuzz-loop.ps1` and
-`mouse-fuzz-probe.ps1`, which already use 2 for a product failure.
+The suite retries 1 and never retries 2. Re-running a real defect until it
+passes is how a regression gets buried, which is what `aot-fuzz.ps1` used to
+do by retrying every non-zero exit and keeping only the last attempt.
 
-Conflating those two is how a broken harness gets mistaken for a broken
-product, and how a real defect gets dismissed as flakiness.
+Conflating the two is also how a broken harness gets mistaken for a broken
+product, and getting it right needed more than fixing the tail of each
+script. The harnesses signal a defect by throwing, and an unhandled throw
+makes `pwsh -File` return 1 - so 56 `throw "PRODUCT_FAIL: ..."` sites across
+16 harnesses were reporting real defects on the code that means "nothing was
+measured", to a runner that then retried them. Each of those scripts now
+opens with:
+
+```powershell
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') { Write-Host "$_"; exit 2 }
+    break
+}
+```
+
+`exit` from a trap still unwinds the `finally` blocks, so the config restore
+and the process sweep both still run - `lib/fuzz-selftest/product-throw.ps1`
+asserts exactly that, and `just fuzz-selftest` fails if either half breaks.
+
+The prefix is the whole contract, so it has to be right at the throw site.
+`HARVEST_MISS` (a UIA element that was not found, a click the window refused)
+and `FOREGROUND_MISS` deliberately stay 1: those are usually another app
+stealing the foreground, and filing them as defects would put noise in front
+of real findings.
+
+## The suite cannot quietly pass
+
+The most likely defect in a runner is the one that looks like success, and
+this is not hypothetical. `vtabs-visual-qa.ps1` judged each step on whether
+its body threw - and a sub-script that exits 2 does not throw, so a run that
+found real defects printed all green. That runner was what the vertical-tabs
+work leaned on.
+
+`just fuzz-selftest` runs the suite's own runner against fixtures in
+`lib/fuzz-selftest/` that exit 0, 1, 2 and 3 on purpose, plus one that
+throws, one that throws `PRODUCT_FAIL` from inside a `try`/`finally`, one
+that fails once and then works, and one that hangs forever. It asserts the
+verdict *and* the attempt count for each. It takes about a minute, needs no
+build or desktop, and is safe to run with Wintty open.
+
+Two details make it worth trusting rather than just running:
+
+- It asserts against `Get-SuiteOutcome`, the same function the real run exits
+  on, instead of re-deriving the rules. An earlier version checked a copy of
+  that logic, so neutering the shipped roll-up left the self-test green.
+- It then spawns a child run over the same fixtures through the ordinary
+  report path and asserts the child's real process exit code, because
+  everything else happens before the two lines that actually end a run.
+
+The way to keep it honest is to break the runner on purpose and check that it
+notices: make it retry findings, make it treat 2 as 0, invert `-Skip`, force
+the final `exit` to 0. All of those are caught today.
+
+## What a green run does and does not mean
+
+The suite judges nothing itself; it reports what each harness reports, and
+several harnesses check much less than their names suggest. `just fuzz-list`
+prints what each one actually rules out. Three worth knowing before trusting
+a green run:
+
+- `tab-colors` reads no pixel at all. It confirms the swatches were findable
+  and the layout switched; a build that painted every tab the same colour
+  would pass.
+- `loop` saves screenshots and reads none of them back, and skips any
+  affordance it cannot find. Its verdict is liveness.
+- `mica-dpi` never changes the DPI - it reads it once - and checks
+  `PerMonitorV2` by grepping the manifest in the source tree rather than the
+  binary under test.
+
+Those strings were wrong in the first version of this manifest, in the
+direction that matters: they promised checks the code did not contain.
+
+A harness is only worth committing if it can tell right from wrong on its
+own. `search-fuzz.ps1` reads the terminal's own UIA text document, counts
+matches itself, and compares that count against what the search bar reports,
+which is what lets it type randomly drawn needles and still judge the
+answer. Prefer that shape over "take a screenshot and have a human look at
+it". It is a standard to move the directory towards, not one it currently
+meets.
+
+## Not in the suite
+
+| script | why |
+|---|---|
+| `verified-input-probe.ps1` | leaves its window up for inspection by design, which would make the next harness refuse; and its `PASS_PENDING_SCREENSHOT` is not self-checked - its marker does not in fact appear, because it posts `WM_CHAR`, which this app never receives |
+| `mouse-smoke-run.ps1` | the operator drives the checklist by hand |
+| `vtabs-layout-switch-capture.ps1`, `vtabs-switcher-capture.ps1`, `vtabs-morph-filmstrip.ps1` | produce frames for a human to look at; no verdict to aggregate |
+| `gen-bell.ps1` | generates a test asset |
+| `aot-fuzz.ps1`, `vtabs-visual-qa.ps1`, `release-smoke.ps1` | runners in their own right. `aot-fuzz` targets the NativeAOT publish, which the suite can also do with `-ExePath` |
 
 ## Process policy
 
@@ -66,26 +161,49 @@ Most scripts here used to open with `Get-Process Wintty | Stop-Process -Force`,
 which takes down builds from other worktrees and the window the developer is
 working in. That is not a harness's call to make.
 
-Four scripts predate the lib and still carry their own copy of the rule.
-They are not exceptions to the policy, just not folded onto it yet, and
-`search-fuzz.ps1` and `splash-single-instance-race.ps1` are in fact stricter
-than the shared helper because they match on image path as well as time:
+Take the stamp immediately before the launch it covers, not at script start.
+`release-smoke.ps1` takes one per launch for that reason: a single stamp at
+the top would be minutes stale behind a ReleaseFast build, and every Wintty
+opened while it ran would look like the run's own.
 
-| script | why it is separate |
+Every script here that launches Wintty uses the helper except two:
+
+| script | why |
 |---|---|
-| `search-fuzz.ps1` | keeps a pre-existing-pid allowlist the helper has no equivalent of |
-| `splash-single-instance-race.ps1` | launches a second instance on purpose, path-scoped gate |
-| `mouse-fuzz-tab-colors.ps1` | already pid-scoped before the lib existed |
-| `vtabs-visual-qa.ps1` | already pid-scoped before the lib existed |
+| `splash-single-instance-race.ps1` | its gate is deliberately *narrower* than `Assert-NoWintty`: it refuses only over instances running from the exe under test, because the mutex it is measuring is keyed on that path, and it needs to be able to launch a second instance itself |
+| `mouse-smoke-run.ps1` | the operator drives it by hand and quits the app themselves |
 
-`justfile` also has its own copy of the gate, so `just search-fuzz` can
-refuse before paying for a build.
+`vtabs-visual-qa.ps1` launches nothing directly - each sub-script gates and
+reaps its own, including `vtabs-layout-switch-capture.ps1`, which it runs
+first and which had neither until it was given both.
+
+`justfile` also has its own copy of the gate, so `just fuzz`, `just
+search-fuzz` and `just splash-race` can refuse before paying for a build.
 
 Two scripts need care beyond a single gate. `mouse-fuzz-jumplist.ps1`
 launches secondaries against a running primary, so its sweep rather than a
 per-process kill is what reaps them. `verified-input-probe.ps1` deliberately
-leaves its window up for inspection and therefore takes no stamp and runs no
-sweep; close it by hand before the next harness.
+leaves its window up and therefore takes no stamp and runs no sweep; close it
+by hand before the next harness.
+
+Kill the tree, not the process. `Stop-Process -Id` leaves the ConPTY shell
+running as an orphan, and an orphan does not trip `Assert-NoWintty` because
+its image name is not Wintty - so it is invisible to the gate and simply
+accumulates. Use `$proc.Kill($true)`.
+
+Take the stamp immediately before the launch it covers. `fuzz-suite.ps1`
+takes one per harness rather than one per run for that reason: a single
+stamp at minute zero means every sweep for the next 40 minutes matches
+anything from that exe, and the exe it defaults to is the one `just run-win`
+opens.
+
+Put the gate above the top-level `try`, or guard the sweep in the `finally`
+on the stamp being set. With the gate inside the `try` and an unguarded
+sweep below, a refusal binds `$null` to a mandatory `[datetime]`, and that
+binding error *replaces* the refusal message and abandons the rest of the
+`finally` - including the `XDG_CONFIG_HOME` restore. `search-fuzz.ps1` keeps
+its gate inside the `try` on purpose, because its `catch` records the refusal
+as a harness finding; its sweep is guarded for exactly this reason.
 
 ## Before you run search-fuzz
 
@@ -96,9 +214,7 @@ sweep; close it by hand before the next harness.
   absorb the launch. It is that `crash.log` is shared: it lives under
   `%LOCALAPPDATA%` per user rather than per exe path, `XDG_CONFIG_HOME` does
   not move it, and the harness reports everything the file gains during a
-  run as a defect in the build under test. On the way out it kills only
-  processes that started after the launch and whose image path is the exe
-  under test, and leaves anything it cannot positively identify alone.
+  run as a defect in the build under test.
 - By default it uses **your real config and state directory**, because a
   throwaway `XDG_CONFIG_HOME` made the app crash at startup on the machine
   it was written on. `-IsolatedConfig` opts into the throwaway dir. The
@@ -107,7 +223,7 @@ sweep; close it by hand before the next harness.
 - It moves the physical cursor, synthesizes global input, and resizes the
   window without restoring the original geometry.
 
-## What the oracle does and does not judge
+### What its oracle does and does not judge
 
 Only needles matching `^[\x21-\x7E]{2,}$` are checked against a match count.
 Single characters, anything containing whitespace, and anything non-ASCII are
@@ -115,18 +231,6 @@ checked only for the counter's *shape* - that it is well formed and the app
 did not fall over. Whitespace is excluded deliberately: the UIA document
 keeps trailing spaces and the search haystack trims them, so their counts
 legitimately differ.
-
-## Oracles
-
-A harness is only worth committing if it can tell right from wrong on its
-own. `search-fuzz.ps1` reads the terminal's own UIA text document, counts
-matches itself, and compares that count against what the search bar reports,
-which is what lets it type randomly drawn needles and still judge the answer.
-Prefer that shape over "take a screenshot and have a human look at it". This
-is a standard to move the directory towards, not one it currently meets:
-`verified-input-probe.ps1` still returns `PASS_PENDING_SCREENSHOT` and
-requires a human to confirm its marker, and its marker does not in fact
-appear - it posts `WM_CHAR`, which this app never receives.
 
 ## Driving input
 
@@ -144,3 +248,8 @@ and note two prerequisites:
 Do not sniff the shell prompt to decide the shell is ready - a themed prompt
 looks nothing like `PS >`. Ask it instead, and wait for the answer to appear
 in the document; that also proves keystrokes are landing at all.
+
+Be equally suspicious of a UIA check that can only pass. `Ensure-VerticalLayout`
+in the tab-colours harness bailed out early because the NavigationView is in
+the tree even when collapsed, so the script never switched layout and still
+reported a clean parity check.

--- a/windows/scripts/aot-fuzz.ps1
+++ b/windows/scripts/aot-fuzz.ps1
@@ -13,6 +13,15 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A harness exiting non-zero is this runner's input, not an error. When
+# $PSNativeCommandUseErrorActionPreference is on - it is the default on some
+# hosts and a profile can set it - $ErrorActionPreference = 'Stop' turns the
+# first harness that reports findings into a terminating error, and the run
+# ends with no summary and no verdict. Assign it only where it exists.
+if (Test-Path Variable:PSNativeCommandUseErrorActionPreference) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
 $PublishExe = (Resolve-Path -LiteralPath $PublishExe -ErrorAction SilentlyContinue)?.Path
 if (-not $PublishExe) {
@@ -38,16 +47,21 @@ New-Item -ItemType Directory -Force -Path $base | Out-Null
 $results = @()
 # Twice with a pause between: a Wintty that is mid-startup can outlive the
 # first sweep.
+#
+# -ExePath is not optional here even though the stamp alone would find the
+# leaks. Without it the sweep matches on time only, and this runs for tens of
+# minutes across five harnesses: any Wintty the developer opens from any
+# worktree while it works gets tree-killed with its shell.
 function Stop-Wintty {
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $script:PublishExe
     Start-Sleep -Milliseconds 1200
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $script:PublishExe
     Start-Sleep -Milliseconds 600
 }
 
-Assert-NoWintty
+$script:PublishExe = $PublishExe
+Assert-NoWintty -Context 'The AOT fuzz'
 $script:WinttyStamp = Get-WinttyLaunchStamp
-Stop-Wintty
 $idx = 0
 foreach ($s in $Scripts) {
     $idx++
@@ -56,17 +70,21 @@ foreach ($s in $Scripts) {
     $out = Join-Path $base $name
     New-Item -ItemType Directory -Force -Path $out | Out-Null
     Write-Host "`n========== $s (AOT) =========="
+    # Retry only exit 1, "the harness could not run": nothing was learned,
+    # and the causes are transient. This used to retry every non-zero exit
+    # and keep the last attempt, so a product finding that passed on the
+    # second run was reported as clean.
     $attempts = 2
     $code = 1
     for ($try = 1; $try -le $attempts; $try++) {
         if ($try -gt 1) {
-            Write-Host "retry $try/$attempts for $name"
+            Write-Host "retry $try/$attempts for $name (could not run)"
             Stop-Wintty
             Start-Sleep -Seconds 2
         }
         & pwsh -NoProfile -File (Join-Path $PSScriptRoot $s) -ExePath $PublishExe -OutDir $out
         $code = $LASTEXITCODE
-        if ($code -eq 0) { break }
+        if ($code -ne 1) { break }
     }
     Stop-Wintty
     $row = [ordered]@{ script = $name; exit = $code; aot = $true }
@@ -84,5 +102,6 @@ $summary = Join-Path $base 'summary.json'
 } | ConvertTo-Json -Depth 6 | Set-Content $summary
 Write-Host "`nAOT SUMMARY -> $summary"
 $results | Format-Table script, exit -AutoSize
+if ($results | Where-Object { $_.exit -eq 2 }) { exit 2 }
 if ($results | Where-Object { $_.exit -ne 0 }) { exit 1 }
 exit 0

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -1,0 +1,675 @@
+#requires -Version 7
+<#
+    The GUI fuzz suite: one entry point over the harnesses in this directory.
+
+    Each harness already knows how to drive Wintty and judge what it sees.
+    What was missing was something that runs them in a known order, keeps
+    their verdicts apart, and cannot quietly turn a failure into a pass.
+
+    That last part is the reason this exists. The suite's own most likely
+    defect is the one that looks like success, and it is not hypothetical:
+    vtabs-visual-qa.ps1 marked a step OK whenever the sub-script did not
+    throw, and a sub-script that exits 2 does not throw - so a run that
+    found real defects printed all green. aot-fuzz.ps1 retried every
+    non-zero exit, product findings included, and reported only the last
+    attempt. -SelfTest runs the runner against fixtures that exit each way
+    on purpose, so those two failure modes are checked rather than assumed.
+    It needs no build and no desktop.
+
+    Verdicts, from each harness's exit code:
+
+      0  pass
+      2  product findings, in the build under test
+      1  the harness could not run, so nothing is known about the product
+
+    A 1 is retried, because a run that never started tells you nothing and
+    the causes are usually transient - the window never appeared, something
+    stole the foreground. A 2 is never retried: re-running a real defect
+    until it passes is how a regression gets buried.
+
+    That split only works because each harness leaves with the right code.
+    They signal defects by throwing, and an unhandled throw makes pwsh return
+    1, so every one of them opens with a trap that maps a PRODUCT_FAIL throw
+    to 2 and lets anything else through as 1. HARVEST_MISS and
+    FOREGROUND_MISS stay 1 on purpose: a refused click is usually another app
+    taking the foreground, not a defect.
+
+    Each harness also gets a wall-clock budget - four times its manifest
+    estimate, floor three minutes - after which it is killed and recorded as
+    1. A harness that wedges holding the foreground would otherwise stop the
+    run dead and leave the desktop unusable.
+
+    The suite's own exit code follows the same numbering. Findings win over
+    harness failures, because a finding is the actionable result; harnesses
+    that could not run are reported separately as incomplete coverage rather
+    than folded into either.
+
+    What this does NOT do: judge anything itself. It reports what the
+    harnesses report, and several check far less than their names suggest -
+    tab-colors reads no pixel, loop saves screenshots and reads none of them
+    back, mica-dpi never changes the DPI. The `oracle` field in the manifest
+    below says what each one actually rules out, so a green suite is not read
+    as more than it is. Keep those strings honest: they were wrong here once,
+    in the direction of promising checks the code did not contain.
+
+    Three integrity checks run on every invocation, including -List, and all
+    are free: the manifest cannot name a script that is gone, a script cannot
+    sit in this directory unclassified, and a harness cannot stop declaring a
+    parameter the manifest passes it. That last one matters because
+    `pwsh -File` ignores an argument the script does not declare, so a
+    renamed -ExePath would leave every harness quietly testing its own
+    default build.
+
+    Usage:
+
+        just fuzz                     # everything, against the Debug build
+        just fuzz "-Tag smoke"        # the fast, high-signal subset
+        just fuzz "-Only search,loop"
+        just fuzz-list                # the manifest, no desktop needed
+        just fuzz-selftest            # prove the runner classifies correctly
+#>
+param(
+    [string]$ExePath = (Join-Path $PSScriptRoot '../Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe'),
+    [string]$OutRoot = (Join-Path $PSScriptRoot ('fuzz-out/suite-' + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
+    [string[]]$Tag,
+    [string[]]$Only,
+    [string[]]$Skip,
+    [int]$Seed = 1337,
+    # Retries apply to exit 1 only. 0 disables them. Range-checked because a
+    # negative value would skip the run loop entirely, leaving a null exit
+    # code that reads as a pass.
+    [ValidateRange(0, 10)][int]$Retries = 1,
+    [switch]$List,
+    [switch]$SelfTest,
+    # Used by -SelfTest, not meant to be called directly: runs the same
+    # fixtures through the ORDINARY report path so the child's real process
+    # exit code can be asserted. Without it the self-test would exercise
+    # everything except the two lines that actually end the run.
+    [switch]$SelfTestInner,
+    # Stop at the first harness that reports findings, leaving its artifacts
+    # as the newest thing on disk. Off by default: one broken area should
+    # not hide the state of the rest.
+    [switch]$StopOnFindings
+)
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
+$ErrorActionPreference = 'Stop'
+
+# A harness exiting non-zero is this runner's input, not an error. When
+# $PSNativeCommandUseErrorActionPreference is on - it is the default on some
+# hosts and a profile can set it - $ErrorActionPreference = 'Stop' turns the
+# first harness that reports findings into a terminating error, and the run
+# ends with no summary and no verdict. Assign it only where it exists.
+if (Test-Path Variable:PSNativeCommandUseErrorActionPreference) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+# name      short id, what -Only and -Skip match
+# script    relative to this directory
+# tags      -Tag matches any
+# outDir    does it take -OutDir
+# seed      does it take -Seed
+# minutes   rough wall clock, so a full run can be planned around. Only the
+#           smoke four are measured; the rest are upper-bound guesses
+# oracle    what a pass from this harness actually rules out
+$Harnesses = @(
+    [ordered]@{ name = 'search';         script = 'search-fuzz.ps1';               tags = @('smoke','search'); outDir = $true;  seed = $true;  minutes = 2
+                oracle = 'counts matches in the terminal UIA document itself; printable non-space needles are checked against that count, the rest only for a well-formed counter' }
+    [ordered]@{ name = 'probe';          script = 'mouse-fuzz-probe.ps1';          tags = @('smoke','core');   outDir = $true;  seed = $false; minutes = 1
+                oracle = 'liveness: the app survived the click stream and crash.log did not grow' }
+    [ordered]@{ name = 'loop';           script = 'mouse-fuzz-loop.ps1';           tags = @('smoke','core','chrome'); outDir = $true; seed = $false; minutes = 1
+                oracle = 'liveness across a click stream over the chrome; it saves screenshots but reads no pixel back, and skips any affordance it cannot find' }
+    [ordered]@{ name = 'vertical-tabs';  script = 'mouse-fuzz-vertical-tabs.ps1';  tags = @('smoke','tabs');   outDir = $true;  seed = $false; minutes = 1
+                oracle = 'measures the pane width through collapse and expand, so a dead toggle fails' }
+    [ordered]@{ name = 'tab-colors';     script = 'mouse-fuzz-tab-colors.ps1';     tags = @('tabs');           outDir = $true;  seed = $false; minutes = 3
+                oracle = 'drives every preset plus None, recolor and a layout round-trip, and asserts the swatches were findable and the layout switched; it compares no pixel, so a build that paints them all alike passes' }
+    [ordered]@{ name = 'morph';          script = 'vtabs-morph-fuzz.ps1';          tags = @('tabs');           outDir = $false; seed = $true;  minutes = 3
+                oracle = 'randomized layout switching against a full strip, checked against a trace the product emits; a seed replays the sequence' }
+    [ordered]@{ name = 'inspector';      script = 'mouse-fuzz-inspector.ps1';      tags = @('inspector');      outDir = $true;  seed = $false; minutes = 3
+                oracle = 'the inspector opens, renders something other than a flat surface, and closes; the tab-switch dismissal is gated but a missing second tab only warns' }
+    [ordered]@{ name = 'dialogs';        script = 'mouse-fuzz-dialogs.ps1';        tags = @('dialogs');        outDir = $true;  seed = $false; minutes = 2
+                oracle = 'each of About, Keyboard Shortcuts and the inspector toggle opened a window, plus liveness' }
+    [ordered]@{ name = 'settings';       script = 'mouse-fuzz-settings.ps1';       tags = @('dialogs');        outDir = $true;  seed = $false; minutes = 2
+                oracle = 'the settings window opens with three named vertical-tab cards and the Keybindings page does not take the app down' }
+    [ordered]@{ name = 'confirm-always'; script = 'mouse-fuzz-confirm-always.ps1'; tags = @('dialogs');        outDir = $true;  seed = $false; minutes = 2
+                oracle = 'the close confirmation appears for a single-pane tab under confirm-close-surface=always' }
+    [ordered]@{ name = 'ime-cjk';        script = 'mouse-fuzz-ime-cjk.ps1';        tags = @('input');          outDir = $true;  seed = $false; minutes = 2
+                oracle = 'liveness pasting CJK and supplementary-plane text; the paste itself is not read back' }
+    [ordered]@{ name = 'kitty';          script = 'mouse-fuzz-kitty.ps1';          tags = @('vt');             outDir = $true;  seed = $false; minutes = 2
+                oracle = 'scans the surface for the image the kitty sequence should have drawn, so a dropped image fails' }
+    [ordered]@{ name = 'osc-paste';      script = 'mouse-fuzz-osc-paste.ps1';      tags = @('vt');             outDir = $true;  seed = $false; minutes = 2
+                oracle = 'the window title changes to what the OSC sequence set, plus liveness' }
+    [ordered]@{ name = 'undo-osc';       script = 'mouse-fuzz-undo-osc.ps1';       tags = @('vt');             outDir = $true;  seed = $false; minutes = 2
+                oracle = 'liveness across undo after split, reopen-closed-tab, and console title' }
+    [ordered]@{ name = 'mica-dpi';       script = 'mouse-fuzz-mica-dpi.ps1';       tags = @('chrome');         outDir = $true;  seed = $false; minutes = 3
+                oracle = 'two backdrop presets and one palette backdrop round-trip into the config file; it reads DPI once and never changes it, and checks PerMonitorV2 by grepping the manifest source' }
+    [ordered]@{ name = 'remain';         script = 'mouse-fuzz-remain.ps1';         tags = @('chrome');         outDir = $true;  seed = $false; minutes = 3
+                oracle = 'liveness plus the tab overview opening; rename, color, snap, zoom, paste and quake are driven and logged but not gated, so a build missing all six still passes' }
+    [ordered]@{ name = 'remain-title';   script = 'mouse-fuzz-remain-title.ps1';   tags = @('session');        outDir = $true;  seed = $false; minutes = 2
+                oracle = 'the surviving tab keeps the default profile title after a tab closes; its config defines one profile, so the cross-shell case its header describes is not staged' }
+    [ordered]@{ name = 'jumplist';       script = 'mouse-fuzz-jumplist.ps1';       tags = @('shell');          outDir = $true;  seed = $false; minutes = 3
+                oracle = 'jump-list CLI arguments reach the running primary and open what they name, across five checks' }
+    [ordered]@{ name = 'splash-race';    script = 'splash-single-instance-race.ps1'; tags = @('startup');      outDir = $false; seed = $false; minutes = 2
+                oracle = 'samples the window list for a splash owned by a secondary; demonstrates the race, does not certify its absence' }
+)
+
+# Deliberately not in the manifest. This is a list rather than a comment
+# because the integrity check below reads it: a new harness dropped into this
+# directory has to be classified, and prose does not fail a run.
+$NotInSuite = [ordered]@{
+    'fuzz-suite.ps1'                = 'this runner'
+    'aot-fuzz.ps1'                  = 'a runner; targets the NativeAOT publish, which this suite can also do with -ExePath'
+    'vtabs-visual-qa.ps1'           = 'a runner'
+    'release-smoke.ps1'             = 'a runner'
+    'verified-input-probe.ps1'      = 'leaves its window up for inspection by design, which would make the next harness refuse, and its PASS_PENDING_SCREENSHOT is not self-checked'
+    'mouse-smoke-run.ps1'           = 'the operator drives the checklist by hand'
+    'vtabs-layout-switch-capture.ps1' = 'produces frames for a human to look at; no verdict to aggregate'
+    'vtabs-switcher-capture.ps1'    = 'produces frames for a human to look at; no verdict to aggregate'
+    'vtabs-morph-filmstrip.ps1'     = 'produces frames for a human to look at; no verdict to aggregate'
+    'gen-bell.ps1'                  = 'generates a test asset'
+}
+
+$SelfTestHarnesses = @(
+    [ordered]@{ name = 'st-pass';       script = 'lib/fuzz-selftest/pass.ps1';       tags = @('selftest'); outDir = $true;  seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-findings';   script = 'lib/fuzz-selftest/findings.ps1';   tags = @('selftest'); outDir = $true;  seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-cannot-run'; script = 'lib/fuzz-selftest/cannot-run.ps1'; tags = @('selftest'); outDir = $true;  seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-throws';     script = 'lib/fuzz-selftest/throws.ps1';     tags = @('selftest'); outDir = $true;  seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-flaky';      script = 'lib/fuzz-selftest/flaky.ps1';      tags = @('selftest'); outDir = $true;  seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-no-outdir';  script = 'lib/fuzz-selftest/no-outdir.ps1';  tags = @('selftest'); outDir = $false; seed = $true;  minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-product-throw'; script = 'lib/fuzz-selftest/product-throw.ps1'; tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-unknown-code';  script = 'lib/fuzz-selftest/unknown-code.ps1';  tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
+    # Deliberately short budget: the point is the runaway guard, not the wait.
+    [ordered]@{ name = 'st-hangs';         script = 'lib/fuzz-selftest/hangs.ps1';         tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; timeoutSeconds = 2; oracle = 'fixture' }
+)
+
+# `pwsh -File` hands every argument over as a string, so `-Only search,loop`
+# arrives as one element "search,loop" and matches nothing. Splitting here
+# means the documented form works, and the -Only typo check below still
+# catches a genuinely wrong name rather than blaming the whole list.
+function Split-List {
+    param([string[]]$Value)
+    if (-not $Value) { return $Value }
+    return @($Value | ForEach-Object { $_ -split ',' } | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+}
+$Tag  = Split-List $Tag
+$Only = Split-List $Only
+$Skip = Split-List $Skip
+
+# $null is handled explicitly rather than left to [int] coercion, which would
+# turn "no exit code was ever collected" into 0, into 'pass'. Only -Retries
+# validation currently keeps that unreachable, and a guard three hundred lines
+# away is not a guard.
+function Get-Verdict {
+    param($Code)
+    if ($null -eq $Code) { return 'error' }
+    switch ([int]$Code) {
+        0       { 'pass' }
+        2       { 'findings' }
+        1       { 'harness' }
+        default { 'error' }
+    }
+}
+
+# The single place the run's outcome is decided. The self-test asserts against
+# THIS function rather than re-deriving the same rules, because a self-test
+# that checks a copy of the logic passes happily while the shipped roll-up is
+# broken - which is the whole failure this suite exists to catch.
+function Get-SuiteOutcome {
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Rows,
+          [Parameter(Mandatory)][int]$SelectedCount)
+
+    $findings = @($Rows | Where-Object { $_.verdict -eq 'findings' })
+    $broken   = @($Rows | Where-Object { $_.verdict -eq 'harness' -or $_.verdict -eq 'error' })
+    $notRun   = $SelectedCount - @($Rows).Count
+
+    # Findings outrank a harness that could not run: a finding is actionable,
+    # and incomplete coverage is reported alongside rather than folded in.
+    $code = if ($findings.Count -gt 0) { 2 }
+            elseif ($broken.Count -gt 0 -or $notRun -gt 0) { 1 }
+            else { 0 }
+
+    [ordered]@{ findings = $findings; broken = $broken; notRun = $notRun; exit = $code }
+}
+
+# Start-Process -ArgumentList does NOT quote array elements: hand it a path
+# containing a space and pwsh receives two arguments and prints its usage.
+# Every path here is caller-supplied, so quote before handing them over.
+function ConvertTo-ProcessArgs {
+    param([Parameter(Mandatory)][string[]]$Argv)
+    return @($Argv | ForEach-Object {
+        if ($_ -match '\s' -and $_ -notmatch '^".*"$') { '"' + $_ + '"' } else { $_ }
+    })
+}
+
+# Waits for a child, echoing its log as it grows, and kills it if it outstays
+# its budget. Returns the child's exit code, or 1 on a timeout: a harness that
+# had to be killed judged nothing, which is exactly what 1 means.
+function Wait-ChildWithTail {
+    param(
+        [Parameter(Mandatory)]$Child,
+        [Parameter(Mandatory)][string]$LogPath,
+        [Parameter(Mandatory)][int]$TimeoutSeconds,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $offset = 0
+    while (-not $Child.HasExited) {
+        if ((Get-Date) -gt $deadline) {
+            Write-Host ("  {0} exceeded its {1}s budget; killing it" -f $Label, $TimeoutSeconds) -ForegroundColor Yellow
+            try { $Child.Kill($true); [void]$Child.WaitForExit(5000) } catch { }
+            $offset = Write-NewLines -Path $LogPath -Offset $offset
+            return 1
+        }
+        $offset = Write-NewLines -Path $LogPath -Offset $offset
+        Start-Sleep -Milliseconds 250
+    }
+    [void]$Child.WaitForExit(5000)
+    # Once more after exit: the last writes land between the final poll and
+    # the process going away.
+    [void](Write-NewLines -Path $LogPath -Offset $offset)
+    return $Child.ExitCode
+}
+
+# Echoes whatever has been appended to a file since $Offset, and returns the
+# new offset. Opened share-write because the child still holds it open.
+function Write-NewLines {
+    param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][int]$Offset)
+    if (-not (Test-Path -LiteralPath $Path)) { return $Offset }
+    try {
+        $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open,
+                                     [System.IO.FileAccess]::Read,
+                                     [System.IO.FileShare]::ReadWrite)
+        try {
+            if ($fs.Length -le $Offset) { return $Offset }
+            [void]$fs.Seek($Offset, [System.IO.SeekOrigin]::Begin)
+            $sr = New-Object System.IO.StreamReader($fs)
+            $text = $sr.ReadToEnd()
+            if ($text) { Write-Host $text.TrimEnd() }
+            return [int]$fs.Length
+        } finally { $fs.Dispose() }
+    } catch { return $Offset }
+}
+
+# Runs one harness to a verdict, retrying only what is worth retrying.
+# Returns the row that goes into summary.json.
+function Invoke-Harness {
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$Harness,
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string]$Exe,
+        [int]$SeedValue,
+        [int]$RetryCount
+    )
+
+    $scriptPath = Join-Path $PSScriptRoot $Harness.script
+    $out = Join-Path $Root $Harness.name
+    New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+    # Four times the manifest estimate, floor three minutes. Generous, because
+    # this is a runaway guard and not a performance assertion.
+    $timeoutSeconds = if ($Harness.Contains('timeoutSeconds')) { [int]$Harness.timeoutSeconds }
+                      else { [int][math]::Max(180, $Harness.minutes * 60 * 4) }
+
+    $code = $null
+    $attempts = 0
+    $started = Get-Date
+    for ($try = 0; $try -le $RetryCount; $try++) {
+        if ($try -gt 0) {
+            Write-Host ("  retry {0}/{1} ({2} could not run)" -f $try, $RetryCount, $Harness.name) -ForegroundColor Yellow
+            # Keep the failed attempt. The harness writes result.json and
+            # shots/ to a fixed path, so a retry would overwrite the evidence
+            # of why the first attempt could not run - which is the only
+            # thing that explains an eventual pass on a flaky harness.
+            $kept = "$out.attempt$try"
+            Remove-Item -Recurse -Force $kept -ErrorAction SilentlyContinue
+            try { Move-Item -LiteralPath $out -Destination $kept -ErrorAction Stop } catch { }
+            New-Item -ItemType Directory -Force -Path $out | Out-Null
+            Start-Sleep -Seconds 2
+        }
+        $argv = @('-NoProfile', '-File', $scriptPath, '-ExePath', $Exe)
+        if ($Harness.outDir) { $argv += @('-OutDir', $out) }
+        if ($Harness.seed)   { $argv += @('-Seed', $SeedValue) }
+
+        $attempts++
+        # Start-Process rather than `& pwsh`, because a call operator cannot
+        # be interrupted: a harness that wedges with the foreground grabbed
+        # would otherwise hang the whole run with no way out but Ctrl-C.
+        # Output is redirected to files and tailed back to the host, which
+        # keeps the live progress a long run needs.
+        $log = Join-Path $out 'console.log'
+        $errLog = Join-Path $out 'console.err.log'
+        $child = Start-Process -FilePath 'pwsh' -ArgumentList (ConvertTo-ProcessArgs $argv) `
+                               -PassThru -NoNewWindow `
+                               -RedirectStandardOutput $log -RedirectStandardError $errLog
+        $code = Wait-ChildWithTail -Child $child -LogPath $log -TimeoutSeconds $timeoutSeconds -Label $Harness.name
+
+        # Only "could not run" is worth another go. A finding is a result.
+        if ($code -ne 1) { break }
+    }
+
+    [ordered]@{
+        name     = $Harness.name
+        script   = $Harness.script
+        exit     = $code
+        verdict  = Get-Verdict $code
+        attempts = $attempts
+        seconds  = [int]((Get-Date) - $started).TotalSeconds
+        outDir   = $out
+        oracle   = $Harness.oracle
+    }
+}
+
+# ---- manifest integrity ---------------------------------------------------
+# All of this is cheap and needs no desktop, and it runs on every invocation
+# including -List. Between them these three checks cover the ways the manifest
+# rots, in both directions.
+$problems = @()
+
+# 1. The manifest names something that is not there any more.
+foreach ($h in @($Harnesses) + @($SelfTestHarnesses)) {
+    if (-not (Test-Path (Join-Path $PSScriptRoot $h.script))) {
+        $problems += "manifest names a script that does not exist: $($h.name) -> $($h.script)"
+    }
+}
+
+# 2. A harness exists that the manifest does not name. Without this the
+#    manifest silently shrinks: delete an entry and the suite reports PASS
+#    for an area it never touched.
+$claimed = @(@($Harnesses) | ForEach-Object { Split-Path -Leaf $_.script })
+foreach ($f in Get-ChildItem -Path $PSScriptRoot -Filter '*.ps1' -File) {
+    if ($claimed -contains $f.Name) { continue }
+    if ($NotInSuite.Contains($f.Name)) { continue }
+    $problems += "$($f.Name) is in this directory but neither in the manifest nor in `$NotInSuite; classify it"
+}
+
+# 3. The manifest's calling convention still matches what each script accepts.
+#    `pwsh -File` silently ignores a parameter the script does not declare, so
+#    a renamed -ExePath would leave every harness quietly testing its own
+#    default build while the suite reported on the exe you asked for.
+foreach ($h in @($Harnesses) + @($SelfTestHarnesses)) {
+    $path = Join-Path $PSScriptRoot $h.script
+    if (-not (Test-Path $path)) { continue }
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$null)
+    $declared = @()
+    if ($ast.ParamBlock) { $declared = @($ast.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath }) }
+    foreach ($need in @('ExePath') + $(if ($h.outDir) { 'OutDir' }) + $(if ($h.seed) { 'Seed' })) {
+        if ($declared -notcontains $need) {
+            $problems += "$($h.name) is called with -$need but $($h.script) does not declare it"
+        }
+    }
+}
+
+if ($problems.Count -gt 0) {
+    Write-Host 'manifest integrity:' -ForegroundColor Red
+    $problems | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+    exit 1
+}
+
+if ($List) {
+    $Harnesses | ForEach-Object {
+        [pscustomobject]@{ name = $_.name; tags = ($_.tags -join ','); minutes = $_.minutes; oracle = $_.oracle }
+    } | Format-Table -AutoSize -Wrap
+    $total = ($Harnesses | ForEach-Object { $_.minutes } | Measure-Object -Sum).Sum
+    Write-Host ("{0} harnesses, about {1} minutes for a full run" -f $Harnesses.Count, $total)
+    exit 0
+}
+
+# ---- selection ------------------------------------------------------------
+# Both switches run the fixtures; only -SelfTest asserts. -SelfTestInner
+# falls through to the real report block and exits on its verdict.
+$useFixtures = $SelfTest -or $SelfTestInner
+$all = if ($useFixtures) { @($SelfTestHarnesses) } else { @($Harnesses) }
+
+# The assertions are written against the whole fixture set at exactly one
+# retry, so anything that would change either is refused rather than
+# silently ignored.
+if ($SelfTest -and ($Tag -or $Only -or $Skip -or
+                    $PSBoundParameters.ContainsKey('Retries') -or
+                    $PSBoundParameters.ContainsKey('Seed') -or
+                    $StopOnFindings)) {
+    Write-Host '-SelfTest asserts against the whole fixture set at one retry; it takes no filters, -Retries, -Seed or -StopOnFindings' -ForegroundColor Red
+    exit 1
+}
+
+# An unknown name in -Only is a typo, and silently running a smaller suite
+# than was asked for is the failure mode this whole script exists to avoid.
+if ($Only) {
+    $known = @($all | ForEach-Object { $_.name })
+    $unknown = @($Only | Where-Object { $known -notcontains $_ })
+    if ($unknown.Count -gt 0) {
+        Write-Host ("-Only names no such harness: {0}" -f ($unknown -join ', ')) -ForegroundColor Red
+        exit 1
+    }
+}
+
+$selected = $all
+if ($Tag)  { $selected = @($selected | Where-Object { @($_.tags | Where-Object { $Tag -contains $_ }).Count -gt 0 }) }
+if ($Only) { $selected = @($selected | Where-Object { $Only -contains $_.name }) }
+if ($Skip) { $selected = @($selected | Where-Object { $Skip -notcontains $_.name }) }
+$selected = @($selected)
+
+if ($selected.Count -eq 0) {
+    Write-Host 'no harness matched the filters; run with -List to see the manifest' -ForegroundColor Red
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $OutRoot | Out-Null
+
+# Before the exe check and the gate, so a filter typo or a missing build is
+# diagnosed against a visible selection rather than in the dark.
+Write-Host ("run:  {0} harness(es) - {1}" -f $selected.Count, (($selected | ForEach-Object { $_.name }) -join ', '))
+Write-Host "out:  $OutRoot"
+
+if ($useFixtures) {
+    # The fixtures ignore it, and pointing at a real exe would suggest they
+    # do not.
+    $ExePath = 'selftest-no-exe'
+    # The assertions below cover the whole fixture set and each fixture's
+    # expected attempt count, so both are fixed here rather than taken from
+    # the caller. -Seed is what st-no-outdir checks was passed through.
+    $Retries = 1
+    $Seed = 4242
+} else {
+    if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath (build it first: just build-dll build-win)" }
+    $ExePath = (Resolve-Path -LiteralPath $ExePath).Path
+    # Once, up front. Each harness gates itself too, but paying for that at
+    # the start of a 40-minute run rather than 30 minutes in is the point.
+    Assert-NoWintty -Context 'The fuzz suite'
+    Write-Host "exe:  $ExePath"
+}
+
+# ---- run ------------------------------------------------------------------
+$rows = @()
+# One stamp per harness, taken immediately before it launches, not one for the
+# whole run. A single stamp at minute zero means every sweep for the next 40
+# minutes matches anything from this exe started at any point in them - and
+# the default exe is the one `just run-win` opens, so a window the developer
+# starts by hand mid-run gets tree-killed with its shell.
+$script:CurrentStamp = $null
+try {
+    foreach ($h in $selected) {
+        Write-Host ("`n===== {0} =====" -f $h.name) -ForegroundColor Cyan
+        if (-not $useFixtures) { $script:CurrentStamp = Get-WinttyLaunchStamp }
+        $row = Invoke-Harness -Harness $h -Root $OutRoot -Exe $ExePath -SeedValue $Seed -RetryCount $Retries
+        $rows += $row
+
+        $colour = switch ($row.verdict) { 'pass' { 'Green' } 'findings' { 'Red' } default { 'Yellow' } }
+        Write-Host ("{0}: {1} (exit {2}, {3}s)" -f $h.name, $row.verdict, $row.exit, $row.seconds) -ForegroundColor $colour
+
+        if (-not $useFixtures) {
+            # Reap anything the harness left behind, before the next one's gate
+            # refuses over it. A harness that tore down cleanly makes this a
+            # no-op.
+            Stop-WinttyStartedAfter -Since $script:CurrentStamp -ExePath $ExePath
+            $script:CurrentStamp = $null
+            Start-Sleep -Milliseconds 800
+        }
+        if ($StopOnFindings -and $row.verdict -eq 'findings') {
+            Write-Host 'stopping at the first findings (-StopOnFindings)' -ForegroundColor Yellow
+            break
+        }
+    }
+}
+finally {
+    # Ctrl-C on a 40-minute run that holds the foreground is not an edge case.
+    # Without this the harness that was in flight keeps its window, and every
+    # later run refuses over it. Only reachable with a stamp set, so it can
+    # never bind $null to the mandatory -Since.
+    if ($script:CurrentStamp) {
+        Stop-WinttyStartedAfter -Since $script:CurrentStamp -ExePath $ExePath
+    }
+}
+
+# ---- self-test assertions -------------------------------------------------
+# The fixtures exit each way on purpose; what is under test here is the
+# runner. attempts is half the point: a product finding that gets retried is
+# a regression this suite would hide, and a retry that does not actually
+# re-run the harness is a retry that proves nothing.
+if ($SelfTest) {
+    $expect = @(
+        @{ name = 'st-pass';       verdict = 'pass';     attempts = 1; why = 'a clean harness runs once' }
+        @{ name = 'st-findings';   verdict = 'findings'; attempts = 1; why = 'findings are a result, never retried' }
+        @{ name = 'st-cannot-run'; verdict = 'harness';  attempts = 2; why = 'a harness that could not run is retried' }
+        @{ name = 'st-throws';     verdict = 'harness';  attempts = 2; why = 'an unhandled throw is a harness failure, not a pass' }
+        @{ name = 'st-flaky';      verdict = 'pass';     attempts = 2; why = 'the retry re-runs rather than replaying the first verdict' }
+        @{ name = 'st-no-outdir';  verdict = 'pass';     attempts = 1; why = '-OutDir is omitted and -Seed is passed through' }
+        @{ name = 'st-product-throw'; verdict = 'findings'; attempts = 1; why = 'a thrown PRODUCT_FAIL leaves with 2, not the retryable 1' }
+        @{ name = 'st-unknown-code'; verdict = 'error';    attempts = 1; why = 'an exit code outside the convention is not a pass' }
+        @{ name = 'st-hangs';      verdict = 'harness';  attempts = 2; why = 'a wedged harness is killed at its budget and treated as retryable' }
+    )
+    $bad = @()
+    # One row per harness and nothing else. A harness's console output
+    # leaking into the result set is not cosmetic: it inflates the pass
+    # count that gets reported and fills summary.json with printed lines.
+    if ($rows.Count -ne $expect.Count) {
+        $bad += "collected $($rows.Count) result(s) for $($expect.Count) harnesses; something other than verdicts is in the result set"
+    }
+    foreach ($e in $expect) {
+        $got = $rows | Where-Object { $_.name -eq $e.name } | Select-Object -First 1
+        if (-not $got) { $bad += "$($e.name): did not run at all"; continue }
+        if ($got.verdict -ne $e.verdict) {
+            $bad += "$($e.name): verdict $($got.verdict), expected $($e.verdict) - $($e.why)"
+        }
+        if ($got.attempts -ne $e.attempts) {
+            $bad += "$($e.name): $($got.attempts) attempt(s), expected $($e.attempts) - $($e.why)"
+        }
+    }
+    # The aggregate matters as much as the rows, and it is checked by calling
+    # the same Get-SuiteOutcome the real run exits on - not by re-deriving it
+    # here. This fixture set holds two findings, four that could not run (an
+    # exit code outside the convention, and one that had to be killed) and
+    # three passes, so every branch of the roll-up has a witness.
+    $outcome = Get-SuiteOutcome -Rows $rows -SelectedCount $selected.Count
+    if ($outcome.exit -ne 2) {
+        $bad += "aggregate exit is $($outcome.exit), expected 2 (findings outrank harness failures)"
+    }
+    if ($outcome.findings.Count -ne 2) {
+        $bad += "roll-up counted $($outcome.findings.Count) findings, expected 2"
+    }
+
+    # The trap that maps PRODUCT_FAIL to 2 must not cost the cleanup: that is
+    # where XDG_CONFIG_HOME is restored and where the process sweep lives.
+    $ptDir = Join-Path $OutRoot 'st-product-throw'
+    if (-not (Test-Path (Join-Path $ptDir 'finally-ran.txt'))) {
+        $bad += 'st-product-throw exited 2 without running its finally, so a real harness would leak its config dir and its window'
+    }
+    if ($outcome.broken.Count -ne 4) {
+        $bad += "roll-up counted $($outcome.broken.Count) harness failures, expected 4"
+    }
+    if ($outcome.notRun -ne 0) {
+        $bad += "roll-up counted $($outcome.notRun) not reached, expected 0"
+    }
+
+    # Everything above inspects objects in this process. The two lines that
+    # actually end a real run - the report block and `exit $outcome.exit` -
+    # are only reached by a run that does not stop to assert, so run one and
+    # read its process exit code. The fixtures hold a findings, so 2.
+    # Not $Args: that is an automatic variable, and shadowing it in a function
+    # makes the splat below behave in ways that are not worth debugging.
+    function Invoke-Inner {
+        param([string]$Name, [string[]]$Extra)
+        # The space is deliberate. Start-Process does not quote its argument
+        # array, so a path containing one silently turns into two arguments
+        # and pwsh prints its usage instead of running the harness. Nothing
+        # would notice until someone checked the repo out under a path with a
+        # space in it.
+        $root = Join-Path $OutRoot "inner $Name"
+        $argv = @('-NoProfile', '-File', $PSCommandPath, '-SelfTestInner', '-OutRoot', $root) + $Extra
+        & pwsh @argv | Out-Null
+        return @{ exit = $LASTEXITCODE; root = $root }
+    }
+
+    $full = Invoke-Inner -Name 'full' -Extra @()
+    if ($full.exit -ne 2) {
+        $bad += "a real run over the same fixtures exited $($full.exit), expected 2"
+    }
+    if (-not (Test-Path (Join-Path $full.root 'summary.json'))) {
+        $bad += 'a real run over the same fixtures wrote no summary.json'
+    }
+
+    # The filters are refused under -SelfTest, so without these child runs
+    # nothing ever exercises Split-List, the -Only typo check, or the three
+    # Where-Object filters. An inverted -Skip is silent in the safe-looking
+    # direction: it runs more than you asked for and still reports.
+    $onlyClean = Invoke-Inner -Name 'only-clean' -Extra @('-Only', 'st-pass,st-no-outdir')
+    if ($onlyClean.exit -ne 0) {
+        $bad += "-Only over two clean fixtures exited $($onlyClean.exit), expected 0 - the filter ran more than it was asked for"
+    }
+    $onlyFindings = Invoke-Inner -Name 'only-findings' -Extra @('-Only', 'st-findings')
+    if ($onlyFindings.exit -ne 2) {
+        $bad += "-Only st-findings exited $($onlyFindings.exit), expected 2"
+    }
+    $skipped = Invoke-Inner -Name 'skip' -Extra @('-Only', 'st-pass,st-findings', '-Skip', 'st-findings')
+    if ($skipped.exit -ne 0) {
+        $bad += "-Skip st-findings exited $($skipped.exit), expected 0 - the skip did not take"
+    }
+    $typo = Invoke-Inner -Name 'typo' -Extra @('-Only', 'st-pass,st-nope')
+    if ($typo.exit -ne 1) {
+        $bad += "-Only with an unknown name exited $($typo.exit), expected 1 - a typo must not silently shrink the run"
+    }
+
+    Write-Host ''
+    if ($bad.Count -gt 0) {
+        Write-Host 'SELFTEST FAILED' -ForegroundColor Red
+        $bad | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+        exit 1
+    }
+    Write-Host ("SELFTEST OK  {0} exit paths classified correctly, and a real run over them exits 2" -f $expect.Count) -ForegroundColor Green
+    exit 0
+}
+
+# ---- report ---------------------------------------------------------------
+$outcome  = Get-SuiteOutcome -Rows $rows -SelectedCount $selected.Count
+$findings = $outcome.findings
+$broken   = $outcome.broken
+$notRun   = $outcome.notRun
+
+$summary = [ordered]@{
+    exe              = $ExePath
+    seed             = $Seed
+    selected         = @($selected | ForEach-Object { $_.name })
+    findings         = @($findings | ForEach-Object { $_.name })
+    couldNotRun      = @($broken | ForEach-Object { $_.name })
+    skippedAfterStop = $notRun
+    results          = $rows
+}
+$summary | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutRoot 'summary.json') -Encoding utf8
+
+Write-Host ''
+$rows | ForEach-Object { [pscustomobject]$_ } | Format-Table name, verdict, exit, attempts, seconds -AutoSize
+Write-Host "summary -> $(Join-Path $OutRoot 'summary.json')"
+
+if ($broken.Count -gt 0) {
+    Write-Host ("{0} harness(es) could not run, so nothing is known about the area they cover: {1}" -f
+        $broken.Count, (($broken | ForEach-Object { $_.name }) -join ', ')) -ForegroundColor Yellow
+}
+if ($notRun -gt 0) {
+    Write-Host ("{0} harness(es) were not reached after -StopOnFindings" -f $notRun) -ForegroundColor Yellow
+}
+
+if ($findings.Count -gt 0) {
+    Write-Host ("FINDINGS in {0} harness(es): {1}" -f $findings.Count, (($findings | ForEach-Object { $_.name }) -join ', ')) -ForegroundColor Red
+} elseif ($outcome.exit -eq 0) {
+    Write-Host ("PASS  {0} harness(es), 0 findings" -f @($rows).Count) -ForegroundColor Green
+}
+exit $outcome.exit

--- a/windows/scripts/lib/fuzz-selftest/README.md
+++ b/windows/scripts/lib/fuzz-selftest/README.md
@@ -1,0 +1,26 @@
+# fuzz-suite self-test fixtures
+
+Stand-ins for real harnesses, one per exit path the runner has to tell
+apart. They ignore the exe they are handed, so `fuzz-suite.ps1 -SelfTest`
+needs no build, no window and no interactive desktop.
+
+| fixture | what it pins down |
+|---|---|
+| `pass.ps1` | a clean run is one attempt |
+| `findings.ps1` | exit 2 is a result, never retried |
+| `cannot-run.ps1` | exit 1 is retried |
+| `throws.ps1` | an unhandled throw is a harness failure, not a pass |
+| `flaky.ps1` | the retry re-runs rather than replaying the first verdict |
+| `no-outdir.ps1` | a harness that takes no `-OutDir` is called correctly, and `-Seed` reaches it |
+| `product-throw.ps1` | a thrown `PRODUCT_FAIL` leaves with 2 *and* still runs its `finally` |
+| `unknown-code.ps1` | an exit code outside the convention is not a pass |
+| `hangs.ps1` | a wedged harness is killed at its budget rather than hanging the run |
+
+Most take `-ExePath` and `-OutDir` like a real harness; `no-outdir.ps1`
+deliberately takes `-Seed` and no `-OutDir`, which is the point of it.
+
+They exist because the failure this suite is most likely to have is the one
+that looks like success: a runner that reports green for a harness that
+found defects, could not start, or never ran at all. That is not a
+hypothetical - `vtabs-visual-qa.ps1` marked a step OK whenever the
+sub-script did not throw, and a sub-script that exits 2 does not throw.

--- a/windows/scripts/lib/fuzz-selftest/cannot-run.ps1
+++ b/windows/scripts/lib/fuzz-selftest/cannot-run.ps1
@@ -1,0 +1,6 @@
+#requires -Version 7
+# The harness could not run. Retryable: nothing was learned about the product.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+Add-Content -Path (Join-Path $OutDir 'attempts.txt') -Value 'x'
+Write-Host 'selftest: cannot run'
+exit 1

--- a/windows/scripts/lib/fuzz-selftest/findings.ps1
+++ b/windows/scripts/lib/fuzz-selftest/findings.ps1
@@ -1,0 +1,7 @@
+#requires -Version 7
+# Product findings. Must NOT be retried: re-running a real defect until it
+# passes is how a flaky-looking regression gets buried.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+Add-Content -Path (Join-Path $OutDir 'attempts.txt') -Value 'x'
+Write-Host 'selftest: findings'
+exit 2

--- a/windows/scripts/lib/fuzz-selftest/flaky.ps1
+++ b/windows/scripts/lib/fuzz-selftest/flaky.ps1
@@ -1,0 +1,13 @@
+#requires -Version 7
+# Fails to start once, then runs. Proves a retry actually re-runs rather
+# than replaying the first verdict.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+# Beside the run directory, not inside it: the runner preserves a failed
+# attempt by renaming its directory, so a marker kept in $OutDir would vanish
+# between attempts and this fixture would never recover.
+$marker = Join-Path (Split-Path -Parent $OutDir) 'flaky.seen'
+Add-Content -Path (Join-Path $OutDir 'attempts.txt') -Value 'x'
+if (Test-Path $marker) { Write-Host 'selftest: flaky recovered'; exit 0 }
+Set-Content -Path $marker -Value 'seen'
+Write-Host 'selftest: flaky first attempt'
+exit 1

--- a/windows/scripts/lib/fuzz-selftest/hangs.ps1
+++ b/windows/scripts/lib/fuzz-selftest/hangs.ps1
@@ -1,0 +1,7 @@
+#requires -Version 7
+# Never returns. A harness that wedges holding the foreground is the worst
+# case for a runner without a timeout: the run stops dead and the desktop is
+# unusable until someone finds the window.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+Write-Host 'selftest: hanging on purpose'
+while ($true) { Start-Sleep -Seconds 5 }

--- a/windows/scripts/lib/fuzz-selftest/no-outdir.ps1
+++ b/windows/scripts/lib/fuzz-selftest/no-outdir.ps1
@@ -1,0 +1,7 @@
+#requires -Version 7
+# A harness that takes no -OutDir, like vtabs-morph-fuzz.ps1 and
+# splash-single-instance-race.ps1. Binding -OutDir to it would fail.
+param([string]$ExePath, [int]$Seed = 0)
+if ($Seed -ne 4242) { Write-Host "selftest: expected -Seed 4242, got $Seed"; exit 1 }
+Write-Host 'selftest: no-outdir ok'
+exit 0

--- a/windows/scripts/lib/fuzz-selftest/pass.ps1
+++ b/windows/scripts/lib/fuzz-selftest/pass.ps1
@@ -1,0 +1,5 @@
+#requires -Version 7
+# Clean run.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+Write-Host 'selftest: clean'
+exit 0

--- a/windows/scripts/lib/fuzz-selftest/product-throw.ps1
+++ b/windows/scripts/lib/fuzz-selftest/product-throw.ps1
@@ -1,0 +1,30 @@
+#requires -Version 7
+# Mirrors the shape every mouse-fuzz-* harness has: a script-scope trap, a
+# try/finally that restores the environment and sweeps, and a PRODUCT_FAIL
+# thrown from inside the try.
+#
+# Two things must hold, and both have been wrong here before. The run has to
+# leave with 2, because a product defect that leaves with 1 is retried and
+# then reported as an area nothing is known about. And the finally has to run
+# anyway, because that is where XDG_CONFIG_HOME goes back and where the
+# process sweep lives.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+$ErrorActionPreference = 'Stop'
+
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
+
+try {
+    Write-Host 'selftest: product-throw running'
+    throw 'PRODUCT_FAIL: the thing under test did not do the thing'
+}
+finally {
+    # The self-test asserts this file exists, so a trap that skipped the
+    # finally would be caught rather than assumed.
+    Set-Content -Path (Join-Path $OutDir 'finally-ran.txt') -Value 'cleanup happened'
+}

--- a/windows/scripts/lib/fuzz-selftest/throws.ps1
+++ b/windows/scripts/lib/fuzz-selftest/throws.ps1
@@ -1,0 +1,5 @@
+#requires -Version 7
+# An unhandled terminating error, which is how a gate refusal surfaces in
+# every harness that puts Assert-NoWintty above its try.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+throw 'selftest: unhandled'

--- a/windows/scripts/lib/fuzz-selftest/unknown-code.ps1
+++ b/windows/scripts/lib/fuzz-selftest/unknown-code.ps1
@@ -1,0 +1,7 @@
+#requires -Version 7
+# An exit code outside the convention. A harness killed by Ctrl-C or dying on
+# an access violation returns one of these, and the runner must file it as
+# something it does not understand rather than as a pass.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+Write-Host 'selftest: exiting 3, which means nothing in this convention'
+exit 3

--- a/windows/scripts/lib/wintty-process.ps1
+++ b/windows/scripts/lib/wintty-process.ps1
@@ -52,17 +52,22 @@ function Stop-WinttyStartedAfter {
         [Parameter(Mandatory)][datetime]$Since,
         # Optional, and worth passing whenever the caller knows which exe it
         # launched: start time alone will also match an instance the
-        # developer opened while the run was in flight.
+        # developer opened while the run was in flight. Omit it to mean that
+        # deliberately; passing $null or '' is treated as a filter that could
+        # not be built, and sweeps nothing.
         [string]$ExePath,
         [int]$TimeoutMs = 3000
     )
 
+    # Three cases, and the distinction matters: a caller that omitted -ExePath
+    # is knowingly sweeping on time alone, but a caller that PASSED something
+    # empty or unresolvable meant to filter and failed to. Treating those the
+    # same is a fail-open: an unreadable path swept nothing while $null swept
+    # everything, which is backwards.
     $full = $null
-    if ($ExePath) {
+    if ($PSBoundParameters.ContainsKey('ExePath')) {
+        if ([string]::IsNullOrWhiteSpace($ExePath)) { return }
         $full = (Resolve-Path -LiteralPath $ExePath -ErrorAction SilentlyContinue)?.Path
-        # A path the caller supplied but that does not resolve means the
-        # filter cannot be applied. Sweep nothing rather than quietly
-        # widening to every process started since the stamp.
         if (-not $full) { return }
     }
 

--- a/windows/scripts/mouse-fuzz-confirm-always.ps1
+++ b/windows/scripts/mouse-fuzz-confirm-always.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -295,7 +309,7 @@ try {
 finally {
     if ($null -ne $proc) {
         $proc.Refresh()
-        if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        if (-not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     }
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }

--- a/windows/scripts/mouse-fuzz-dialogs.ps1
+++ b/windows/scripts/mouse-fuzz-dialogs.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing

--- a/windows/scripts/mouse-fuzz-ime-cjk.ps1
+++ b/windows/scripts/mouse-fuzz-ime-cjk.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -452,7 +466,7 @@ try {
 finally {
     if ($null -ne $proc) {
         $proc.Refresh()
-        if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        if (-not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     }
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }

--- a/windows/scripts/mouse-fuzz-inspector.ps1
+++ b/windows/scripts/mouse-fuzz-inspector.ps1
@@ -6,6 +6,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -514,8 +528,13 @@ Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
 
 Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 
+# All of these are defects in the build under test, so they are 2, not 1.
+# They used to exit 1, which under the suite convention means "the harness
+# could not run" -- a code the runners retry and then report as unknown
+# coverage. A real inspector regression was therefore retried and, if it
+# passed the second time, buried.
 if (-not $alive -or $crashGrew) { exit 2 }
-if ($noticeOpen -or -not $renderOk -or -not $closedOk) { exit 1 }
-if (-not $tabDismissOk) { Write-Host 'PRODUCT_FAIL: inspector survived tab switch'; exit 1 }
+if ($noticeOpen -or -not $renderOk -or -not $closedOk) { exit 2 }
+if (-not $tabDismissOk) { Write-Host 'PRODUCT_FAIL: inspector survived tab switch'; exit 2 }
 if ($tabCount -lt 2) { Write-Host "WARN: tabCount=$tabCount (UIA count may flake on AOT; dismissOk=$tabDismissOk)" }
 exit 0

--- a/windows/scripts/mouse-fuzz-jumplist.ps1
+++ b/windows/scripts/mouse-fuzz-jumplist.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -461,12 +475,14 @@ finally {
     if ($null -ne $proc) {
         $proc.Refresh()
         if (-not $proc.HasExited) {
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
         }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    # After the env restores, not before: a throw in the sweep would otherwise
+    # abandon them and leave the shell pointed at a temp profile.
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 }
 
 $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc -gt $crashStamp)

--- a/windows/scripts/mouse-fuzz-kitty.ps1
+++ b/windows/scripts/mouse-fuzz-kitty.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -475,7 +489,7 @@ try {
 finally {
     if ($null -ne $proc) {
         $proc.Refresh()
-        if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        if (-not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     }
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }

--- a/windows/scripts/mouse-fuzz-loop.ps1
+++ b/windows/scripts/mouse-fuzz-loop.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing

--- a/windows/scripts/mouse-fuzz-mica-dpi.ps1
+++ b/windows/scripts/mouse-fuzz-mica-dpi.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -495,13 +509,15 @@ finally {
     if ($null -ne $proc) {
         $proc.Refresh()
         if (-not $proc.HasExited) {
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
             Start-Sleep -Milliseconds 300
         }
     }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    # After the env restores, not before: a throw in the sweep would otherwise
+    # abandon them and leave the shell pointed at a temp profile.
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 }
 
 $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc -gt $crashStamp)
@@ -520,145 +536,4 @@ $result | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
 if ($crashGrew -or $dpi -eq 0 -or -not $perMonitorV2) { exit 2 }
 if ($styleAfterFrosted -ne 'frosted' -or $styleAfterCrystal -ne 'crystal' -or $paletteBackdropAfter -ne 'opaque') { exit 2 }
-exit 0
-
-try {
-    $env:XDG_CONFIG_HOME = $tempXdg
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
-    Start-Sleep -Milliseconds 400
-    $proc = Start-Process -FilePath $ExePath -PassThru -WorkingDirectory (Split-Path $ExePath)
-    $pid32 = [uint32]$proc.Id
-    $main = Wait-Ready $proc
-    Start-Sleep -Seconds 2
-    $main = @(Get-WinUiWindows $pid32) | Select-Object -First 1
-    $hwnd64 = [int64]$main.Hwnd64
-    Write-Host "hwnd=$hwnd64 pid=$pid32 title=$($main.Title)"
-    Shot $hwnd64 '00-launch'
-
-    Invoke-PaletteCommand $hwnd64 $pid32 'open config' 'Open Config'
-    $settings = Wait-SettingsWindow $pid32 $hwnd64
-    $settingsHwnd = [int64]$settings.Hwnd64
-    $settingsTitle = $settings.Title
-    Write-Host "settings hwnd=$settingsHwnd title=$settingsTitle"
-    Shot $settingsHwnd '01-settings-open'
-    Shot-Pid $pid32 '01b-all'
-
-    $sroot = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($settingsHwnd))
-    # Keybindings last: ItemsSource of internal row types can kill the UI thread.
-    $nav = @(
-        @{ Name = 'Appearance'; Shot = '02-appearance' },
-        @{ Name = 'Profiles'; Shot = '03-profiles' },
-        @{ Name = 'Colors'; Shot = '04-colors' },
-        @{ Name = 'Terminal'; Shot = '05-terminal' },
-        @{ Name = 'Advanced'; Shot = '06-advanced' },
-        @{ Name = 'Raw Editor'; Shot = '07-raw' },
-        @{ Name = 'General'; Shot = '08-general' }
-    )
-    foreach ($n in $nav) {
-        $proc.Refresh(); if ($proc.HasExited) { throw "PRODUCT_FAIL died before $($n.Name) exit=$($proc.ExitCode)" }
-        $sroot = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($settingsHwnd))
-        Select-Nav $sroot $pid32 $n.Name
-        $pages += $n.Name
-        Shot $settingsHwnd $n.Shot
-    }
-
-    $sroot = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($settingsHwnd))
-    $vtabCards = @(
-        'Vertical tab width',
-        'Pin vertical tabs expanded',
-        'Expand vertical tabs on hover'
-    )
-    $script:vtabFound = @()
-    foreach ($name in $vtabCards) {
-        if ($null -ne (Find-Name $sroot $name)) { $script:vtabFound += $name }
-        else { Write-Host "HARVEST_MISS: settings card '$name'" }
-    }
-    Write-Host "vtabCards=$($script:vtabFound -join ',')/$($vtabCards.Count)"
-
-    $sroot = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($settingsHwnd))
-    $search = Find-Name $sroot 'Search settings'
-    if ($null -eq $search) {
-        $editCt = [System.Windows.Automation.ControlType]::Edit
-        $cond = New-Object System.Windows.Automation.PropertyCondition(
-            [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
-        $search = $sroot.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    }
-    if ($null -ne $search) {
-        try {
-            $vp = $search.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
-            $vp.SetValue('font')
-            Write-Host "search font"
-            Start-Sleep -Milliseconds 800
-            Shot $settingsHwnd '09-search-font'
-            $pages += 'search:font'
-            # Nav while _pendingQuery is set is a no-op (results pane stays).
-            # Clear via ValuePattern so Keybindings actually constructs.
-            $vp.SetValue('')
-            Write-Host "search cleared"
-            [MzMD]::Key($settingsHwnd, 0x1B)
-            Start-Sleep -Milliseconds 500
-            Shot $settingsHwnd '09b-search-cleared'
-        } catch { Write-Host "search set failed: $_" }
-    } else {
-        Write-Host "HARVEST_MISS: no Search settings box"
-    }
-
-    try {
-        $sroot = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($settingsHwnd))
-        Select-Nav $sroot $pid32 'Keybindings'
-        # Loaded → ApplyFilter → ItemsSource can kill the UI thread after Select returns.
-        Start-Sleep -Seconds 2
-        $proc.Refresh()
-        if ($proc.HasExited -or $null -eq [MzMD]::RectOf($settingsHwnd)) {
-            $keybindKilled = $true
-            Write-Host "PRODUCT_FAIL: died after Keybindings nav (ItemsSource ABI)"
-        } else {
-            $pages += 'Keybindings'
-            Shot $settingsHwnd '10-keybindings'
-        }
-    } catch {
-        $proc.Refresh()
-        $keybindKilled = $true
-        Write-Host "keybindings nav: $_ killed=$($proc.HasExited)"
-    }
-
-    $proc.Refresh()
-    if (-not $proc.HasExited -and -not $keybindKilled) {
-        try {
-            $sroot = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($settingsHwnd))
-            $close = Find-Name $sroot 'Close'
-            if ($null -ne $close) { Invoke-El $close $pid32 'Close Wintty Settings' }
-            else { Write-Host "HARVEST_MISS: no Close on Settings" }
-        } catch { Write-Host "close settings: $_" }
-        Start-Sleep -Milliseconds 400
-        if ($null -ne [MzMD]::RectOf($hwnd64)) { Shot $hwnd64 '11-after-settings-close' }
-        else { Write-Host "main hwnd gone after settings close" }
-    }
-}
-finally {
-    if ($null -ne $proc) {
-        $proc.Refresh()
-        if (-not $proc.HasExited) {
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
-            Start-Sleep -Milliseconds 300
-        }
-    }
-    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
-    if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }
-    else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
-}
-
-$crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc -gt $crashStamp)
-$result = @{
-    aliveAtEnd = $false
-    keybindKilled = $keybindKilled
-    crashGrew = $crashGrew
-    settingsTitle = $settingsTitle
-    pages = $pages
-    vtabCards = $script:vtabFound
-    xdg = $tempXdg
-}
-$result | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
-Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
-if ($keybindKilled -or $crashGrew -or ($script:vtabFound.Count -lt 3)) { exit 2 }
 exit 0

--- a/windows/scripts/mouse-fuzz-osc-paste.ps1
+++ b/windows/scripts/mouse-fuzz-osc-paste.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -443,7 +457,7 @@ try {
 finally {
     if ($null -ne $proc) {
         $proc.Refresh()
-        if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        if (-not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     }
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }

--- a/windows/scripts/mouse-fuzz-probe.ps1
+++ b/windows/scripts/mouse-fuzz-probe.ps1
@@ -12,6 +12,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing

--- a/windows/scripts/mouse-fuzz-remain-title.ps1
+++ b/windows/scripts/mouse-fuzz-remain-title.ps1
@@ -8,6 +8,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -290,7 +304,7 @@ try {
 finally {
     if ($null -ne $proc) {
         $proc.Refresh()
-        if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        if (-not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     }
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }

--- a/windows/scripts/mouse-fuzz-remain.ps1
+++ b/windows/scripts/mouse-fuzz-remain.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing

--- a/windows/scripts/mouse-fuzz-settings.ps1
+++ b/windows/scripts/mouse-fuzz-settings.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -416,7 +430,7 @@ finally {
     if ($null -ne $proc) {
         $proc.Refresh()
         if (-not $proc.HasExited) {
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
             Start-Sleep -Milliseconds 300
         }
     }

--- a/windows/scripts/mouse-fuzz-tab-colors.ps1
+++ b/windows/scripts/mouse-fuzz-tab-colors.ps1
@@ -4,7 +4,22 @@ param(
     [Parameter(Mandatory)][string]$ExePath,
     [Parameter(Mandatory)][string]$OutDir
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -580,6 +595,7 @@ theme = Catppuccin Mocha
 no-color-override = strip
 '@ | Set-Content (Join-Path $tempXdg 'wintty\config.wintty') -Encoding utf8
 
+$script:FatalWasProduct = $null
 $origXdg = $env:XDG_CONFIG_HOME
 $origNoColor = $env:NO_COLOR
 $proc = $null
@@ -599,6 +615,12 @@ function Add-Phase([string]$name, [scriptblock]$body) {
         throw
     }
 }
+# Above the try, so the refusal message survives: with the gate inside, the
+# sweep in the finally would bind a null stamp to a mandatory [datetime] and
+# that binding error would replace it, taking the env restores with it.
+Assert-NoWintty -Context 'The tab-color fuzz'
+$script:WinttyStamp = Get-WinttyLaunchStamp
+
 try {
     Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
     $env:XDG_CONFIG_HOME = $tempXdg
@@ -719,11 +741,19 @@ catch {
         try { Shot $hwnd64 'fail-state' } catch { }
     }
     $result.phases += [ordered]@{ name = 'fatal'; ok = $false; error = "$_" }
+    # Which kind of failure it was decides the exit code. A HARVEST_MISS - a
+    # menu item the script could not find, a click the window refused - is a
+    # run that judged nothing, and filing it as a product finding means it is
+    # never retried and shows up as a defect in the build.
+    $script:FatalWasProduct = ("$_" -like 'PRODUCT_FAIL*')
 }
 finally {
-    # Only this run's process. `Get-Process Wintty | Stop-Process` also
-    # kills the developer's real session on the same desktop.
-    if ($null -ne $proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    # Only this run's processes. `Get-Process Wintty | Stop-Process` also
+    # kills the developer's real session on the same desktop. Kill the tree:
+    # the shell runs as a child and outlives a kill on the parent alone.
+    if ($null -ne $proc -and -not $proc.HasExited) {
+        try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
+    }
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
     if ($null -ne $origNoColor) { $env:NO_COLOR = $origNoColor }
@@ -731,10 +761,16 @@ finally {
     if ($null -ne $tempXdg -and (Test-Path $tempXdg)) {
         Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
     }
+    # After the env restores, not before: a throw in the sweep would otherwise
+    # abandon them and leave the shell pointed at a temp profile.
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 }
 
 $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir 'result.json')
 $fail = @($result.phases | Where-Object { -not $_.ok })
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
-if ($fail.Count -gt 0) { exit 2 }
-exit 0
+if ($fail.Count -eq 0) { exit 0 }
+# A phase that failed without a fatal error is a real assertion failing; a
+# fatal PRODUCT_FAIL is too. Anything else got in the way of the run.
+if ($null -eq $script:FatalWasProduct -or $script:FatalWasProduct) { exit 2 }
+exit 1

--- a/windows/scripts/mouse-fuzz-undo-osc.ps1
+++ b/windows/scripts/mouse-fuzz-undo-osc.ps1
@@ -7,6 +7,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -407,7 +421,7 @@ try {
 finally {
     if ($null -ne $proc) {
         $proc.Refresh()
-        if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        if (-not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     }
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }

--- a/windows/scripts/mouse-fuzz-vertical-tabs.ps1
+++ b/windows/scripts/mouse-fuzz-vertical-tabs.ps1
@@ -6,6 +6,20 @@ param(
 )
 . (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# A PRODUCT_FAIL throw is a defect in the build under test, so it has to leave
+# with 2. Thrown, it escapes to pwsh and becomes exit 1 - "the harness could
+# not run" - which the suite retries and then reports as an area nothing is
+# known about. Every finally below still runs: exit from a trap unwinds
+# through them, and `break` rethrows anything that is not a product failure so
+# a genuine harness failure still leaves with 1.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
 Add-Type -AssemblyName System.Drawing
@@ -295,7 +309,7 @@ try {
 finally {
     if ($null -ne $proc) {
         $proc.Refresh()
-        if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+        if (-not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     }
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($originalXdgSet) { $env:XDG_CONFIG_HOME = $originalXdg }

--- a/windows/scripts/mouse-smoke-run.ps1
+++ b/windows/scripts/mouse-smoke-run.ps1
@@ -71,7 +71,9 @@ try {
     $exited = $proc.WaitForExit($TimeoutMs)
     if (-not $exited) {
         Write-Error "TIMEOUT after ${TimeoutMs}ms - killing process"
-        try { Stop-Process -Id $proc.Id -Force }
+        # Kill the tree: the TUI runs as a child and would outlive a kill on
+        # the parent alone, and an orphan does not trip Assert-NoWintty.
+        try { $proc.Kill($true); [void]$proc.WaitForExit(3000) }
         catch [System.InvalidOperationException] {}
         exit 2
     }

--- a/windows/scripts/release-smoke.ps1
+++ b/windows/scripts/release-smoke.ps1
@@ -8,8 +8,33 @@ param(
 $ErrorActionPreference = 'Stop'
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
 Push-Location $repo
-Assert-NoWintty
-$script:WinttyStamp = Get-WinttyLaunchStamp
+# Before the builds, not after: a ReleaseFast libghostty plus a Release shell
+# is minutes of work to then be told to close a window, and dotnet cannot
+# overwrite a locked Wintty.exe anyway.
+Assert-NoWintty -Context 'The release smoke'
+
+# One entry per launch, each with its own stamp. A single stamp taken at
+# script start would be minutes stale by the time anything launches, and
+# every Wintty the developer opened while the builds ran would look like
+# this run's.
+$script:Launched = @()
+
+function Invoke-LaunchSmoke {
+    param([Parameter(Mandatory)][string]$Exe, [Parameter(Mandatory)][string]$Label)
+
+    $since = Get-WinttyLaunchStamp
+    $script:Launched += [pscustomobject]@{ Since = $since; Exe = $Exe }
+    $proc = Start-Process -FilePath $Exe -PassThru -WorkingDirectory (Split-Path $Exe)
+    Start-Sleep -Seconds 3
+    $proc.Refresh()
+    if ($proc.HasExited) { throw "$Label Wintty exited early code=$($proc.ExitCode)" }
+    # Kill the tree: the shell runs as a child and a wedged one outlives a
+    # Stop-Process on the parent alone.
+    try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
+    Stop-WinttyStartedAfter -Since $since -ExePath $Exe
+    Write-Host "$Label launch ok"
+}
+
 try {
     Write-Host '== build-dll-release (ReleaseFast libghostty) =='
     just build-dll-release
@@ -26,12 +51,7 @@ try {
     if (-not $SkipLaunch) {
         Write-Host '== launch Release smoke (3s) =='
         Start-Sleep -Milliseconds 400
-        $proc = Start-Process -FilePath $releaseExe -PassThru -WorkingDirectory (Split-Path $releaseExe)
-        Start-Sleep -Seconds 3
-        $proc.Refresh()
-        if ($proc.HasExited) { throw "Release Wintty exited early code=$($proc.ExitCode)" }
-        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
-        Write-Host 'release launch ok'
+        Invoke-LaunchSmoke -Exe $releaseExe -Label 'release'
     }
 
     if (-not $SkipAot) {
@@ -52,19 +72,19 @@ try {
         Write-Host "aot publish ok: $pubExe"
         if (-not $SkipLaunch) {
             Write-Host '== launch NativeAOT smoke (3s) =='
-            Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $releaseExe
             Start-Sleep -Milliseconds 400
-            $proc = Start-Process -FilePath $pubExe -PassThru -WorkingDirectory (Split-Path $pubExe)
-            Start-Sleep -Seconds 3
-            $proc.Refresh()
-            if ($proc.HasExited) { throw "NativeAOT Wintty exited early code=$($proc.ExitCode)" }
-            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
-            Write-Host 'aot launch ok'
+            Invoke-LaunchSmoke -Exe $pubExe -Label 'aot'
         }
     }
 
     @{ releaseExe = $releaseExe; ok = $true } | ConvertTo-Json | Write-Output
 }
 finally {
+    # A throw between Start-Process and the kill above leaves a smoke window
+    # on the desktop for the next harness to refuse over. Sweeping per
+    # recorded launch is a no-op when the happy path already reaped it.
+    foreach ($l in $script:Launched) {
+        Stop-WinttyStartedAfter -Since $l.Since -ExePath $l.Exe
+    }
     Pop-Location
 }

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -50,6 +50,7 @@ param(
     # throwaway dir when a controlled config matters more than stability.
     [switch]$IsolatedConfig
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir 'shots') | Out-Null
 
@@ -593,9 +594,9 @@ $script:Iter = 0
 $script:ExitCode = 0
 # Set before the try so a throw that precedes their real assignment cannot
 # leave the teardown sweep with a null filter, which matches every process
-# rather than none.
+# rather than none, or bind $null to Stop-WinttyStartedAfter's mandatory
+# -Since and replace the in-flight exception with a binding error.
 $script:ExeFull = $null
-$script:PreExisting = @()
 $script:StartedAt = $null
 $result = [ordered]@{
     seed = $Seed; iterations = $Iterations; ops = @()
@@ -612,27 +613,21 @@ try {
 
     # Never kill by name: developers keep builds from several worktrees open
     # at once, and force-killing every Wintty takes down work this run has
-    # nothing to do with. Refuse instead.
+    # nothing to do with. Refuse instead. lib/wintty-process.ps1 carries the
+    # rule and the reasoning; the short version is that crash.log is shared
+    # per user rather than per exe path, and this harness reports every byte
+    # the file gains during a run as a defect in the build under test.
     #
-    # The reason is not single-instance -- that mutex is keyed on a hash of
-    # the exe path (SingleInstanceNames.For), so another worktree's build
-    # would not absorb this launch. It is that crash.log is shared: it lives
-    # at %LOCALAPPDATA%\<StateDirName>\crash.log, per user rather than per
-    # exe path, and XDG_CONFIG_HOME does not move it. This harness attributes
-    # every byte the file gains to the run, as a product finding. Any other
-    # instance crashing during a run would therefore be reported as a defect
-    # in the build under test.
+    # The gate sits inside the try, unlike the other harnesses, because the
+    # catch below records the refusal as a harness finding and prints it in
+    # the harness's own voice. That is only safe because the sweep in the
+    # finally is guarded on $script:StartedAt: an unguarded call would bind
+    # $null to a mandatory [datetime] and replace this message with a
+    # parameter-binding error.
+    Assert-NoWintty -Context 'The search fuzz'
     $script:ExeFull = (Resolve-Path $ExePath).Path
-    $script:PreExisting = @(Get-Process Wintty -ErrorAction SilentlyContinue |
-        Select-Object -ExpandProperty Id)
-    if ($script:PreExisting.Count -gt 0) {
-        throw ("close the running Wintty first (pid: $($script:PreExisting -join ', ')). " +
-               'It shares crash.log with the build under test, so its crashes ' +
-               'would be reported as defects in this run, and this harness ' +
-               'will not kill instances it did not start')
-    }
 
-    $script:StartedAt = Get-Date
+    $script:StartedAt = Get-WinttyLaunchStamp
     $script:Proc = Start-Process -FilePath $script:ExeFull -PassThru -WorkingDirectory (Split-Path -Parent $script:ExeFull)
     $pid32 = [uint32]$script:Proc.Id
     $main = Wait-Ready $script:Proc
@@ -1110,42 +1105,47 @@ finally {
     $result.checks = $script:Checks
     $result.findings = @($script:Findings)
     $result.failed = $script:Findings.Count
+    # Decide the verdict before any cleanup runs. It used to be computed at
+    # the very bottom of this block, after the sweep and the env restores, so
+    # anything throwing on the way down left $script:ExitCode at its initial
+    # 0 - a clean PASS with findings already recorded. Nothing below this
+    # point can change what the run found, so nothing below it should be able
+    # to change what the run reports.
+    #
+    # 2 means the product is broken, 1 means the run never got far enough to
+    # judge it and should be retried rather than filed. Same numbering as the
+    # rest of the harnesses.
+    $product = @($script:Findings | Where-Object { $_.kind -ne 'harness' })
+    if ($script:Findings.Count -eq 0) { $script:ExitCode = 0 }
+    elseif ($product.Count -gt 0) { $script:ExitCode = 2 }
+    else { $script:ExitCode = 1 }
+
     # A run that never got to assert anything has nothing to record, and
     # writing it would overwrite the last real run's results.
     if ($script:Checks -gt 0) {
         $result | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $OutDir "run-$Seed.json") -Encoding utf8
     }
 
-    # Tear down only what this run started, and fail closed on anything the
-    # sweep cannot positively identify: an unreadable path or start time is a
-    # reason to leave a process alone, never a reason to kill it. Process.Path
-    # returns null rather than throwing when the process cannot be opened, so
-    # the null checks are the real guard here.
+    # Tear down only what this run started. The handle covers the launch
+    # itself; the sweep is the backstop for anything else that came up from
+    # the same exe during the run, and is a no-op when there is nothing.
     #
-    # $script:PreExisting is empty on every path that reaches a launch (the
-    # gate refuses otherwise); it is only non-empty on the refusal path, where
-    # it is exactly what stops this sweep touching the developer's instances.
-    if (-not $KeepOpen) {
-        if ($script:Proc) {
-            try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill($true) } } catch { }
-            try { [void]$script:Proc.WaitForExit(3000) } catch { }
-        }
-        if ($script:ExeFull -and $script:StartedAt) {
-            foreach ($p in @(Get-Process Wintty -ErrorAction SilentlyContinue)) {
-                if ($script:PreExisting -contains $p.Id) { continue }
-                $path = try { $p.Path } catch { $null }
-                if ([string]::IsNullOrEmpty($path) -or $path -ne $script:ExeFull) { continue }
-                # Without this a same-build window the developer opened while
-                # the run was going gets killed with it.
-                $started = try { $p.StartTime } catch { $null }
-                if ($null -eq $started -or $started -lt $script:StartedAt) { continue }
-                try { $p.Kill($true); [void]$p.WaitForExit(3000) } catch { }
-            }
-        }
+    # The stamp guard is what keeps a refusal readable. Reaching the finally
+    # with $script:StartedAt still $null means the run never launched, so
+    # there is nothing to sweep; calling anyway would bind $null to a
+    # mandatory [datetime] and replace whatever threw with a binding error.
+    if (-not $KeepOpen -and $script:Proc) {
+        try { $script:Proc.Refresh(); if (-not $script:Proc.HasExited) { $script:Proc.Kill($true) } } catch { }
+        try { [void]$script:Proc.WaitForExit(3000) } catch { }
     }
     if ($IsolatedConfig) {
         if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
         else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    }
+    # After the restore, not before: a throw here would otherwise abandon it
+    # and leave the shell pointed at a temp profile.
+    if (-not $KeepOpen -and $script:StartedAt) {
+        Stop-WinttyStartedAfter -Since $script:StartedAt -ExePath $script:ExeFull
     }
     Start-Sleep -Milliseconds 500
     if (-not $KeepOpen) { Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue }
@@ -1160,15 +1160,6 @@ finally {
         }
     }
 
-    # Distinct exit codes so a caller can tell the two failures apart, using
-    # the same numbering as verified-input-probe.ps1, mouse-fuzz-loop.ps1 and
-    # mouse-fuzz-probe.ps1: 2 means the product is broken, 1 means the run
-    # never got far enough to judge it and should be retried rather than
-    # filed.
-    $product = @($script:Findings | Where-Object { $_.kind -ne 'harness' })
-    if ($script:Findings.Count -eq 0) { $script:ExitCode = 0 }
-    elseif ($product.Count -gt 0) { $script:ExitCode = 2 }
-    else { $script:ExitCode = 1 }
 }
 
 exit $script:ExitCode

--- a/windows/scripts/splash-single-instance-race.ps1
+++ b/windows/scripts/splash-single-instance-race.ps1
@@ -32,6 +32,10 @@
     is on the order of 30-40ms, so a splash shown for less than that would
     be missed.
 
+    Exit codes follow the rest of the harnesses: 0 clean, 2 the race
+    reproduced, 1 nothing was measured (every iteration inconclusive, or a
+    Wintty was already running from this exe).
+
 .PARAMETER ExePath
     Wintty.exe to test. Defaults to the x64 Debug build.
 
@@ -383,6 +387,7 @@ if ($skipped -gt 0) {
     Write-Host "$skipped/$Iterations iteration(s) were INCONCLUSIVE and are not scored." -ForegroundColor Yellow
 }
 if ($scored.Count -eq 0) {
+    # Stays 1: nothing was measured, so nothing is known about the product.
     Write-Host "FAIL: no iteration produced a usable measurement." -ForegroundColor Red
     exit 1
 }
@@ -391,7 +396,7 @@ if ($expectSecondarySplash) {
     $bad = @($scored | Where-Object { $_.SplashSightings -eq 0 })
     if ($bad.Count -gt 0) {
         Write-Host "FAIL: an independent launch was denied its splash in $($bad.Count)/$($scored.Count) scored iteration(s)." -ForegroundColor Red
-        exit 1
+        exit 2
     }
     Write-Host "PASS: the independent launch showed its splash in all $($scored.Count) scored iteration(s)." -ForegroundColor Green
     exit 0
@@ -400,7 +405,7 @@ if ($expectSecondarySplash) {
 $bad = @($scored | Where-Object { $_.SplashSightings -gt 0 })
 if ($bad.Count -gt 0) {
     Write-Host "FAIL: the secondary put a splash on screen in $($bad.Count)/$($scored.Count) scored iteration(s)." -ForegroundColor Red
-    exit 1
+    exit 2
 }
 
 Write-Host "PASS: no secondary showed a splash in any of $($scored.Count) scored iteration(s)." -ForegroundColor Green

--- a/windows/scripts/vtabs-layout-switch-capture.ps1
+++ b/windows/scripts/vtabs-layout-switch-capture.ps1
@@ -3,6 +3,7 @@ param(
     [string]$ExePath = (Join-Path $PSScriptRoot '..\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'),
     [string]$OutDir = (Join-Path $PSScriptRoot ("vtabs-layout-switch/run-" + (Get-Date -Format 'yyyyMMdd-HHmmss')))
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
@@ -90,6 +91,13 @@ theme = Catppuccin Mocha
 
 $origXdg = $env:XDG_CONFIG_HOME
 $env:XDG_CONFIG_HOME = $tempXdg
+# vtabs-visual-qa.ps1 runs this first and mouse-fuzz-tab-colors.ps1 second,
+# and tab-colors now refuses when a Wintty is up. Without a gate and a sweep
+# here, a window this script fails to reap makes the next step refuse rather
+# than run.
+Assert-NoWintty -Context 'The layout-switch capture'
+$script:WinttyStamp = Get-WinttyLaunchStamp
+
 try {
     $proc = Start-Process -FilePath $ExePath -PassThru
     $dl = (Get-Date).AddSeconds(45)
@@ -137,9 +145,10 @@ try {
 finally {
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg } else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
     if ($proc -and -not $proc.HasExited) {
-        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
         try { $proc.WaitForExit(3000) } catch {}
     }
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
 }
 Write-Host "OUT=$OutDir"

--- a/windows/scripts/vtabs-morph-filmstrip.ps1
+++ b/windows/scripts/vtabs-morph-filmstrip.ps1
@@ -22,6 +22,7 @@ param(
     # so it is where the strip lagging behind the ghost shows up.
     [switch]$Pinned
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
@@ -151,6 +152,11 @@ theme = Catppuccin Mocha
 $origXdg = $env:XDG_CONFIG_HOME
 $env:XDG_CONFIG_HOME = $tempXdg
 $proc = $null
+# Same policy as the rest of the directory: refuse rather than fight another
+# instance for the foreground, and reap only what this run started.
+Assert-NoWintty -Context 'The morph filmstrip capture'
+$script:WinttyStamp = Get-WinttyLaunchStamp
+
 try {
     $proc = Start-Process -FilePath $ExePath -PassThru
     $dl = (Get-Date).AddSeconds(45)
@@ -224,12 +230,13 @@ try {
 }
 finally {
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg } else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
+    # The dying process can still hold handles under the temp dir; an
+    # immediate delete leaks the GUID dir silently, hence the wait.
     if ($proc -and -not $proc.HasExited) {
-        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
-        # The dying process can still hold handles under the temp dir; an
-        # immediate delete leaks the GUID dir silently.
-        try { $proc.WaitForExit(3000) } catch {}
+        try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
     }
     Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
+    # Last, so a throw here cannot abandon the restore or the cleanup above.
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 }
 Write-Host "OUT=$OutDir"

--- a/windows/scripts/vtabs-morph-fuzz.ps1
+++ b/windows/scripts/vtabs-morph-fuzz.ps1
@@ -17,7 +17,20 @@ param(
     [int]$Iterations = 60,
     [switch]$StartHorizontal
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
+
+# Same convention as the mouse-fuzz harnesses: a PRODUCT_FAIL leaves with 2,
+# anything else is a run that could not judge the product and leaves with 1
+# for the runner to retry. FOREGROUND_MISS and a missing trace are the latter
+# - a stolen foreground says nothing about the build.
+trap {
+    if ("$_" -like 'PRODUCT_FAIL*') {
+        Write-Host "$_" -ForegroundColor Red
+        exit 2
+    }
+    break
+}
 if ($Seed -eq 0) { $Seed = Get-Random -Minimum 1 -Maximum 999999 }
 $rng = [System.Random]::new($Seed)
 Write-Host "seed=$Seed iterations=$Iterations"
@@ -185,6 +198,12 @@ $proc = $null
 $actions = @{}
 $chordMisses = 0
 $failures = New-Object System.Collections.Generic.List[string]
+# Above the try so a refusal keeps its own message: with the gate inside, the
+# sweep in the finally would bind a null stamp to a mandatory [datetime] and
+# that error would replace it, taking the env restores with it.
+Assert-NoWintty -Context 'The layout-morph fuzz'
+$script:WinttyStamp = Get-WinttyLaunchStamp
+
 try {
     $proc = Start-Process -FilePath $ExePath -PassThru
     $hwnd = [IntPtr]::Zero
@@ -192,7 +211,7 @@ try {
     while ((Get-Date) -lt $dl) {
         Start-Sleep -Milliseconds 300
         $proc.Refresh()
-        if ($proc.HasExited) { throw "exit $($proc.ExitCode)" }
+        if ($proc.HasExited) { throw "PRODUCT_FAIL: exited during startup, code $($proc.ExitCode)" }
         $hwnd = [MFz]::FindWin([uint32]$proc.Id)
         if ($hwnd -ne [IntPtr]::Zero) { break }
     }
@@ -218,9 +237,9 @@ try {
     }
 
     for ($i = 0; $i -lt $Iterations; $i++) {
-        if (-not [MFz]::IsWindow($hwnd)) { throw "window gone at iteration $i" }
+        if (-not [MFz]::IsWindow($hwnd)) { throw "PRODUCT_FAIL: window gone at iteration $i" }
         $proc.Refresh()
-        if ($proc.HasExited) { throw "process exited at iteration $i (code $($proc.ExitCode))" }
+        if ($proc.HasExited) { throw "PRODUCT_FAIL: process exited at iteration $i (code $($proc.ExitCode))" }
 
         $roll = $rng.Next(100)
         if ($roll -lt 45) {
@@ -343,8 +362,9 @@ try {
     Start-Sleep -Milliseconds 1200
 }
 finally {
-    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    if ($proc -and -not $proc.HasExited) { try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { } }
     Start-Sleep -Milliseconds 600
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
     if ($null -ne $origTrace) { $env:WINTTY_MORPH_TRACE = $origTrace }
@@ -389,6 +409,8 @@ Write-Host ''
 if ($failures.Count -gt 0) {
     $failures | ForEach-Object { Write-Host "FAIL: $_" }
     Write-Host "reproduce with: -Seed $Seed"
-    exit 1
+    # 2, not 1: these are layout-switch defects, and 1 is reserved for a run
+    # that never got to assert anything.
+    exit 2
 }
 Write-Host "PASS (seed $Seed)"

--- a/windows/scripts/vtabs-switcher-capture.ps1
+++ b/windows/scripts/vtabs-switcher-capture.ps1
@@ -10,6 +10,7 @@ param(
     [int]$TabCount = 14,
     [switch]$Vertical
 )
+. (Join-Path $PSScriptRoot 'lib/wintty-process.ps1')
 $ErrorActionPreference = 'Stop'
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
@@ -149,6 +150,11 @@ theme = Catppuccin Mocha
 $origXdg = $env:XDG_CONFIG_HOME
 $env:XDG_CONFIG_HOME = $tempXdg
 $proc = $null
+# Same policy as the rest of the directory: refuse rather than fight another
+# instance for the foreground, and reap only what this run started.
+Assert-NoWintty -Context 'The switcher capture'
+$script:WinttyStamp = Get-WinttyLaunchStamp
+
 try {
     $proc = Start-Process -FilePath $ExePath -PassThru
     $hwnd = [IntPtr]::Zero
@@ -245,11 +251,12 @@ try {
 }
 finally {
     if ($proc -and -not $proc.HasExited) {
-        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
-        try { $proc.WaitForExit(3000) } catch {}
+        try { $proc.Kill($true); [void]$proc.WaitForExit(3000) } catch { }
     }
     if ($null -ne $origXdg) { $env:XDG_CONFIG_HOME = $origXdg }
     else { Remove-Item Env:XDG_CONFIG_HOME -ErrorAction SilentlyContinue }
     Remove-Item -Recurse -Force $tempXdg -ErrorAction SilentlyContinue
+    # Last, so a throw here cannot abandon the restore or the cleanup above.
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
 }
 Write-Host "OUT=$OutDir"

--- a/windows/scripts/vtabs-visual-qa.ps1
+++ b/windows/scripts/vtabs-visual-qa.ps1
@@ -14,16 +14,37 @@ if (-not (Test-Path $ExePath)) { throw "missing exe: $ExePath" }
 
 $results = [ordered]@{ outRoot = $OutRoot; steps = @() }
 
-function Step([string]$name, [scriptblock]$body) {
+# A step used to be judged on whether its body threw. A sub-script that
+# exits 2 does not throw, so a run that found real defects printed all
+# green - the exact failure this file was being trusted not to have. The
+# exit code is the verdict; the catch is only for the harness never
+# starting.
+# NoVerdict is for the capture scripts, which produce frames for a human and
+# never call exit; whatever native command ran last inside them is what
+# $LASTEXITCODE would be read from, so reading it would invent a verdict.
+function Step([string]$name, [scriptblock]$body, [switch]$NoVerdict) {
     Write-Host "`n=== $name ===" -ForegroundColor Cyan
     $dir = Join-Path $OutRoot $name
     New-Item -ItemType Directory -Force -Path $dir | Out-Null
     try {
+        $global:LASTEXITCODE = 0
         & $body $dir
-        $results.steps += [ordered]@{ name = $name; ok = $true }
-        Write-Host "OK $name" -ForegroundColor Green
+        if ($NoVerdict) {
+            $results.steps += [ordered]@{ name = $name; ok = $true; exit = $null; verdict = 'captured' }
+            Write-Host "OK $name (captured, no verdict)" -ForegroundColor Green
+            Start-Sleep -Milliseconds 400
+            return
+        }
+        $code = $LASTEXITCODE
+        $verdict = switch ($code) { 0 { 'pass' } 2 { 'findings' } 1 { 'harness' } default { 'error' } }
+        $results.steps += [ordered]@{ name = $name; ok = ($code -eq 0); exit = $code; verdict = $verdict }
+        if ($code -eq 0) {
+            Write-Host "OK $name" -ForegroundColor Green
+        } else {
+            Write-Host "$verdict $name (exit $code)" -ForegroundColor Red
+        }
     } catch {
-        $results.steps += [ordered]@{ name = $name; ok = $false; error = $_.Exception.Message }
+        $results.steps += [ordered]@{ name = $name; ok = $false; exit = $null; verdict = 'harness'; error = $_.Exception.Message }
         Write-Host "FAIL $name : $($_.Exception.Message)" -ForegroundColor Red
     }
     # Each sub-script owns and tears down the process it started. A blanket
@@ -35,7 +56,7 @@ function Step([string]$name, [scriptblock]$body) {
 Step 'layout-switch-capture' {
     param($dir)
     & (Join-Path $PSScriptRoot 'vtabs-layout-switch-capture.ps1') -ExePath $ExePath -OutDir $dir
-}
+} -NoVerdict
 
 Step 'mouse-fuzz-tab-colors' {
     param($dir)
@@ -55,6 +76,10 @@ Step 'mouse-fuzz-loop' {
 $summaryPath = Join-Path $OutRoot 'summary.json'
 $results | ConvertTo-Json -Depth 5 | Set-Content $summaryPath
 Write-Host "`nOUT=$OutRoot"
-$fail = @($results.steps | Where-Object { -not $_.ok })
-if ($fail.Count -gt 0) { exit 2 }
+# Same numbering as the harnesses themselves: findings outrank a harness
+# that could not run, and a step that could not run is not a pass.
+$findings = @($results.steps | Where-Object { $_.verdict -eq 'findings' })
+$broken = @($results.steps | Where-Object { -not $_.ok -and $_.verdict -ne 'findings' })
+if ($findings.Count -gt 0) { exit 2 }
+if ($broken.Count -gt 0) { exit 1 }
 exit 0


### PR DESCRIPTION
The harnesses in `windows/scripts/` knew how to drive Wintty and judge what they
saw; nothing ran them in a known order or kept their verdicts apart.

`just fuzz` does, over a manifest of 19 with tags, runtimes, and a line per
harness saying what a pass from it actually rules out. `just fuzz-list` prints
those, and several harnesses check far less than their names suggest.

## The 0/2/1 split was not real yet

The harnesses signal defects by throwing, and an unhandled throw makes
`pwsh -File` return 1 - "the harness could not run", the code a runner retries
and then reports as untested. **56 `throw "PRODUCT_FAIL: ..."` sites across 16
harnesses** were on the wrong side of that line. Each script now opens with:

```powershell
trap {
    if ("$_" -like 'PRODUCT_FAIL*') { Write-Host "$_"; exit 2 }
    break
}
```

`exit` from a trap still unwinds the `finally` blocks, so the config restore and
the process sweep survive; a fixture asserts that half specifically.
`HARVEST_MISS` and `FOREGROUND_MISS` stay 1 on purpose - a refused click is
usually another app taking the foreground, not a defect.

## Three runners were green while failing

- `vtabs-visual-qa.ps1` judged a step on whether its body threw. A sub-script
  that exits 2 does not throw.
- `aot-fuzz.ps1` retried every non-zero exit and kept the last attempt.
- `mouse-fuzz-inspector.ps1` exited 1 for four product conditions, one printing
  `PRODUCT_FAIL` on its way out. `vtabs-morph-fuzz.ps1` and
  `splash-single-instance-race.ps1` did the same.

## What keeps the suite honest

`just fuzz-selftest` runs nine fixtures that exit 0, 1, 2 and 3 on purpose, plus
ones that throw, hang, and fail once then work, asserting verdict and attempt
count for each. Two things make it worth trusting:

- it asserts against the same `Get-SuiteOutcome` the real run exits on, not a
  copy of those rules - an earlier version checked a copy, so neutering the
  shipped roll-up left it green;
- it spawns a child run through the ordinary report path and asserts the real
  process exit code, since everything else happens before the lines that end a
  run.

Every fix is mutation-tested: retrying findings, treating 2 as a pass, inverting
`-Skip`, forcing the final `exit` to 0, dropping the argument quoting, removing
the trap - each one turns it red.

## Process handling

- `aot-fuzz` swept with no `-ExePath` on a stamp stale by tens of minutes: it
  would tree-kill a window opened mid-run.
- The suite took one stamp for the whole 40 minutes; now one per harness.
- `lib/wintty-process.ps1` failed **open** on a null `-ExePath` while failing
  closed on an unreadable one.
- 15 parent-only kills orphaned their ConPTY shells, which do not trip the gate
  and simply accumulate.
- `vtabs-morph-fuzz` and three capture scripts launched Wintty with no gate.

## Also

`search-fuzz` folded onto the helper - its pre-existing-pid allowlist was dead
code - and its verdict is now computed before cleanup, so a throw on the way out
cannot turn findings into a pass. A per-harness timeout, because a wedged
harness held the desktop indefinitely. `release-smoke` given per-launch stamps
and a tree kill. 133 lines of unreachable code dropped from `mouse-fuzz-mica-dpi`
that the manifest was implicitly vouching for.

## Test plan

- [x] `just fuzz-selftest` green, and red for every mutation listed above
- [x] All 17 trapped harnesses still exit 1 on a non-product error
- [x] Self-test green from a path containing a space (the quoting regression)
- [x] Manifest integrity: missing script, unclassified script, and a renamed
      harness parameter each refuse
- [x] With an instance running, the suite, `search-fuzz` and `tab-colors` exit 1,
      name its pid, and leave it alive
- [x] `-Tag smoke` green end to end against a fresh build after the trap went in:
      search, probe, loop, vertical-tabs, 0 findings. That run exercised the
      retry path for real - `search` first exited 1 with "no TerminalControl
      exposed to UIA" (the window was up before its UIA tree was) and passed on
      the retry, with attempt 1's artifacts kept beside the successful run

