### PR TITLE
windows: what the first full fuzz run turned up

### DIFF
--- a/justfile
+++ b/justfile
@@ -152,9 +152,15 @@ splash-race args="": _no-wintty-running build-win
 # without this the developer pays a full zig + dotnet build only to be told
 # to close a window -- or gets an MSB file-in-use error that hides the real
 # reason. Prerequisites run in the order listed.
+#
+# The trailing `exit 0` is load-bearing. `pwsh -Command` exits 1 if the script
+# produced ANY error, and Get-Process finding no match is an error even under
+# -ErrorAction SilentlyContinue or Ignore. Without it this recipe refused
+# unconditionally - including when the desktop was clear - and took every
+# recipe that depends on it down with it.
 [windows]
 _no-wintty-running:
-    $p = @(Get-Process Wintty -ErrorAction SilentlyContinue); if ($p.Count -gt 0) { Write-Host ("close the running Wintty first (pid: " + ($p.Id -join ', ') + ")") -ForegroundColor Red; exit 1 }
+    $p = @(Get-Process Wintty -ErrorAction SilentlyContinue); if ($p.Count -gt 0) { Write-Host ("close the running Wintty first (pid: " + ($p.Id -join ', ') + ")") -ForegroundColor Red; exit 1 }; exit 0
 
 # Fuzz in-pane scrollback search against a real oracle: the harness reads the
 # terminal's own UIA text document, counts matches itself, and compares every

--- a/justfile
+++ b/justfile
@@ -145,7 +145,7 @@ test-win:
 # Pass extra args through, e.g. `just splash-race "-SecondaryFeatureOff"`.
 [windows]
 splash-race args="": _no-wintty-running build-win
-    pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}
+    pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}; exit $LASTEXITCODE
 
 # Checked before the builds, not after: the harnesses refuse to run while a
 # Wintty is open, and dotnet build cannot overwrite a locked Wintty.exe, so
@@ -175,7 +175,7 @@ _no-wintty-running:
 search-fuzz args="": _no-wintty-running build-dll build-win
     pwsh -NoProfile -File windows/scripts/search-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
-        -OutDir windows/scripts/search-fuzz {{args}}
+        -OutDir windows/scripts/search-fuzz {{args}}; exit $LASTEXITCODE
 
 # Real windows and real input, so it needs an interactive desktop and holds
 # the foreground for the duration - about 40 minutes budgeted for everything,
@@ -185,20 +185,25 @@ search-fuzz args="": _no-wintty-running build-dll build-win
 # Exit codes: 0 clean, 2 product findings, 1 one or more harnesses could not
 # run (so their area is untested, not proven good).
 #
+# `; exit $LASTEXITCODE` is not decoration. The recipe body runs under
+# `pwsh -Command`, which collapses ANY non-zero child exit to 1 - so without
+# it a product finding (2) and a harness that could not run (1) arrive here
+# identical, which is the whole distinction these harnesses exist to make.
+#
 # Args pass through, e.g. `just fuzz "-Tag smoke"` or `just fuzz "-Only search"`.
 #
 # Run every GUI fuzz harness against the Debug build.
 [windows]
 fuzz args="": _no-wintty-running build-dll build-win
     pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 \
-        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe {{args}}
+        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe {{args}}; exit $LASTEXITCODE
 
 # No build, no desktop.
 #
 # List the suite: what it runs, what each harness catches, what it costs.
 [windows]
 fuzz-list:
-    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -List
+    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -List; exit $LASTEXITCODE
 
 # Runs the suite runner against fixtures that exit 0, 1, 2 and 3 on purpose,
 # plus ones that throw, hang, and fail once then work. About a minute, no
@@ -207,7 +212,7 @@ fuzz-list:
 # Prove the suite still tells a product finding from a harness that broke.
 [windows]
 fuzz-selftest:
-    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -SelfTest
+    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -SelfTest; exit $LASTEXITCODE
 
 # === Upstream Sync ===
 

--- a/justfile
+++ b/justfile
@@ -145,7 +145,7 @@ test-win:
 # Pass extra args through, e.g. `just splash-race "-SecondaryFeatureOff"`.
 [windows]
 splash-race args="": _no-wintty-running build-win
-    pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}; exit $LASTEXITCODE
+    pwsh -NoProfile -File windows/scripts/splash-single-instance-race.ps1 {{args}}; exit ($LASTEXITCODE ?? 1)
 
 # Checked before the builds, not after: the harnesses refuse to run while a
 # Wintty is open, and dotnet build cannot overwrite a locked Wintty.exe, so
@@ -153,11 +153,18 @@ splash-race args="": _no-wintty-running build-win
 # to close a window -- or gets an MSB file-in-use error that hides the real
 # reason. Prerequisites run in the order listed.
 #
-# The trailing `exit 0` is load-bearing. `pwsh -Command` exits 1 if the script
-# produced ANY error, and Get-Process finding no match is an error even under
-# -ErrorAction SilentlyContinue or Ignore. Without it this recipe refused
-# unconditionally - including when the desktop was clear - and took every
-# recipe that depends on it down with it.
+# The trailing `exit 0` is load-bearing, and the reason is narrower than it
+# looks: `pwsh -Command` returns the success of the LAST STATEMENT EXECUTED.
+# `Get-Process Wintty` finding no match leaves $? false even under
+# -ErrorAction SilentlyContinue or Ignore, and an `if` that is not taken does
+# not reset it - so the recipe fell off its end in the failed state, on a clear
+# desktop, with no message, because the pid list only prints on the branch that
+# was not taken.
+#
+# It does not mask a `throw`, which never reaches the exit, but it does mask a
+# trailing non-terminating error. Treat this as a convenience gate only: the
+# authority is Assert-NoWintty in lib/wintty-process.ps1, which every harness
+# calls for itself.
 [windows]
 _no-wintty-running:
     $p = @(Get-Process Wintty -ErrorAction SilentlyContinue); if ($p.Count -gt 0) { Write-Host ("close the running Wintty first (pid: " + ($p.Id -join ', ') + ")") -ForegroundColor Red; exit 1 }; exit 0
@@ -175,7 +182,7 @@ _no-wintty-running:
 search-fuzz args="": _no-wintty-running build-dll build-win
     pwsh -NoProfile -File windows/scripts/search-fuzz.ps1 \
         -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe \
-        -OutDir windows/scripts/search-fuzz {{args}}; exit $LASTEXITCODE
+        -OutDir windows/scripts/search-fuzz {{args}}; exit ($LASTEXITCODE ?? 1)
 
 # Real windows and real input, so it needs an interactive desktop and holds
 # the foreground for the duration - about 40 minutes budgeted for everything,
@@ -185,10 +192,13 @@ search-fuzz args="": _no-wintty-running build-dll build-win
 # Exit codes: 0 clean, 2 product findings, 1 one or more harnesses could not
 # run (so their area is untested, not proven good).
 #
-# `; exit $LASTEXITCODE` is not decoration. The recipe body runs under
-# `pwsh -Command`, which collapses ANY non-zero child exit to 1 - so without
-# it a product finding (2) and a harness that could not run (1) arrive here
-# identical, which is the whole distinction these harnesses exist to make.
+# `; exit ($LASTEXITCODE ?? 1)` is not decoration. The recipe body runs under
+# `pwsh -Command`, which reports the last statement's success as 0 or 1 - so
+# without it a product finding (2) and a harness that could not run (1) arrive
+# here identical, which is the whole distinction these harnesses exist to make.
+# The `?? 1` carries its own weight: $LASTEXITCODE is only assigned by a native
+# command that actually ran, so a pwsh that fails to launch would otherwise
+# `exit $null`, which is `exit 0` - a clean fuzz run that never happened.
 #
 # Args pass through, e.g. `just fuzz "-Tag smoke"` or `just fuzz "-Only search"`.
 #
@@ -196,14 +206,18 @@ search-fuzz args="": _no-wintty-running build-dll build-win
 [windows]
 fuzz args="": _no-wintty-running build-dll build-win
     pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 \
-        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe {{args}}; exit $LASTEXITCODE
+        -ExePath windows/Ghostty/bin/x64/Debug/net10.0-windows10.0.19041.0/Wintty.exe {{args}}; exit ($LASTEXITCODE ?? 1)
+
+# Alias for `just fuzz`, for when that is what the fingers type.
+[windows]
+fuzzy args="": (fuzz args)
 
 # No build, no desktop.
 #
 # List the suite: what it runs, what each harness catches, what it costs.
 [windows]
 fuzz-list:
-    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -List; exit $LASTEXITCODE
+    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -List; exit ($LASTEXITCODE ?? 1)
 
 # Runs the suite runner against fixtures that exit 0, 1, 2 and 3 on purpose,
 # plus ones that throw, hang, and fail once then work. About a minute, no
@@ -212,7 +226,7 @@ fuzz-list:
 # Prove the suite still tells a product finding from a harness that broke.
 [windows]
 fuzz-selftest:
-    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -SelfTest; exit $LASTEXITCODE
+    pwsh -NoProfile -File windows/scripts/fuzz-suite.ps1 -SelfTest; exit ($LASTEXITCODE ?? 1)
 
 # === Upstream Sync ===
 

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -324,6 +324,15 @@ function Invoke-Harness {
             Remove-Item -Recurse -Force $kept -ErrorAction SilentlyContinue
             try { Move-Item -LiteralPath $out -Destination $kept -ErrorAction Stop } catch { }
             New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+            # Reap before retrying, not just between harnesses. A harness that
+            # failed halfway often left its window up, and the retry's own gate
+            # then refuses over it - so the retry was guaranteed to fail and
+            # the whole area got reported as untested. Seen for real: dialogs'
+            # retry refused over a pid its first attempt had leaked.
+            if ($script:CurrentStamp) {
+                Stop-WinttyStartedAfter -Since $script:CurrentStamp -ExePath $Exe
+            }
             Start-Sleep -Seconds 2
         }
         $argv = @('-NoProfile', '-File', $scriptPath, '-ExePath', $Exe)

--- a/windows/scripts/mouse-fuzz-remain.ps1
+++ b/windows/scripts/mouse-fuzz-remain.ps1
@@ -339,6 +339,7 @@ Write-Host "hwnd=$hwnd64 pid=$pid32 title=$($main.Title)"
 Shot $hwnd64 '00-launch'
 
 $overview = $false
+$script:OverviewMissed = $false
 try {
     Invoke-PaletteCommand $hwnd64 $pid32 'show all' 'Show all tabs'
     Start-Sleep -Milliseconds 800
@@ -355,6 +356,13 @@ try {
     }
 } catch {
     Write-Host "overview: $_"
+    # Distinguish "the overview did not open" from "this harness never got to
+    # ask". A HARVEST_MISS or FOREGROUND_MISS is the click never landing, and
+    # reporting that as a product finding is how a flaky click becomes a bug
+    # report against the build.
+    if ("$_" -like '*HARVEST_MISS*' -or "$_" -like '*FOREGROUND_MISS*') {
+        $script:OverviewMissed = $true
+    }
 }
 
 $rename = $false
@@ -500,6 +508,16 @@ $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc
     quake = [bool]$quake
 } | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
+# $overview is false both when the overview genuinely did not open and when
+# the harness never reached it - the run that prompted this logged
+# "HARVEST_MISS: grid context not Wintty" and then reported exit 2, a product
+# finding, for a click that never landed. A miss is a run that judged nothing,
+# so it leaves with 1.
+if ($script:OverviewMissed) {
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
+    Write-Host 'the tab overview could not be reached, so nothing is known about it'
+    exit 1
+}
 if ($proc.HasExited -or $crashGrew -or -not $overview) {
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     exit 2

--- a/windows/scripts/mouse-fuzz-remain.ps1
+++ b/windows/scripts/mouse-fuzz-remain.ps1
@@ -220,13 +220,13 @@ function Invoke-El($el, [uint32]$ProcId, [string]$what, [int64]$MainHwnd = 0) {
     $inside = $rc -and $x -ge $rc.L -and $x -le $rc.R -and $y -ge $rc.T -and $y -le $rc.B
     if (-not $inside) {
         Write-Host "bounds outside hwnd for $what at $x,$y; Enter"
-        if ($MainHwnd -eq 0) { throw "HARVEST_MISS: empty/outside bounds for $what at $x,$y" }
+        if ($MainHwnd -eq 0) { throw "FOREGROUND_MISS: empty/outside bounds for $what at $x,$y" }
         [MzD]::Key($MainHwnd, 0x0D)
         Start-Sleep -Milliseconds 400
         return
     }
     $hit = [MzD]::ClickScreen($ProcId, $x, $y, $false)
-    if (-not $hit.Ok) { throw "HARVEST_MISS: $what click $($hit.Why) class=$($hit.HitClass) at $x,$y" }
+    if (-not $hit.Ok) { throw "FOREGROUND_MISS: $what click $($hit.Why) class=$($hit.HitClass) at $x,$y" }
     Write-Host "click $what $x,$y"
     Start-Sleep -Milliseconds 400
 }
@@ -235,7 +235,7 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzD]::P($MainHwnd))
     $rc = [MzD]::RectOf($MainHwnd)
     $hit = [MzD]::ClickScreen($ProcId, $rc.L + 400, $rc.T + 280, $true)
-    if (-not $hit.Ok) { throw "HARVEST_MISS: grid context $($hit.Why) class=$($hit.HitClass)" }
+    if (-not $hit.Ok) { throw "FOREGROUND_MISS: grid context $($hit.Why) class=$($hit.HitClass)" }
     Start-Sleep -Milliseconds 300
     $pal = $null
     $dl = (Get-Date).AddMilliseconds(1200)
@@ -251,7 +251,7 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
         Write-Host "palette miss, grid dismiss ok=$($dismiss.Ok)"
         Start-Sleep -Milliseconds 300
         $hit = [MzD]::ClickScreen($ProcId, $rc.L + 400, $rc.T + 280, $true)
-        if (-not $hit.Ok) { throw "HARVEST_MISS: grid context retry $($hit.Why) class=$($hit.HitClass)" }
+        if (-not $hit.Ok) { throw "FOREGROUND_MISS: grid context retry $($hit.Why) class=$($hit.HitClass)" }
         Start-Sleep -Milliseconds 300
         $dl = (Get-Date).AddMilliseconds(1200)
         while ((Get-Date) -lt $dl -and $null -eq $pal) {
@@ -267,11 +267,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzD]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"
@@ -318,7 +323,7 @@ function Open-TabMenu([int64]$MainHwnd, [uint32]$ProcId) {
     $rc = [MzD]::RectOf($MainHwnd)
     $x = $rc.L + 80; $y = $rc.T + 16
     $hit = [MzD]::ClickScreen($ProcId, $x, $y, $true)
-    if (-not $hit.Ok) { throw "HARVEST_MISS: tab context $($hit.Why) class=$($hit.HitClass) at $x,$y" }
+    if (-not $hit.Ok) { throw "FOREGROUND_MISS: tab context $($hit.Why) class=$($hit.HitClass) at $x,$y" }
     Start-Sleep -Milliseconds 400
     return [System.Windows.Automation.AutomationElement]::FromHandle([MzD]::P($MainHwnd))
 }
@@ -340,6 +345,7 @@ Shot $hwnd64 '00-launch'
 
 $overview = $false
 $script:OverviewMissed = $false
+$script:OverviewBroke = $false
 try {
     Invoke-PaletteCommand $hwnd64 $pid32 'show all' 'Show all tabs'
     Start-Sleep -Milliseconds 800
@@ -356,12 +362,20 @@ try {
     }
 } catch {
     Write-Host "overview: $_"
-    # Distinguish "the overview did not open" from "this harness never got to
-    # ask". A HARVEST_MISS or FOREGROUND_MISS is the click never landing, and
-    # reporting that as a product finding is how a flaky click becomes a bug
-    # report against the build.
-    if ("$_" -like '*HARVEST_MISS*' -or "$_" -like '*FOREGROUND_MISS*') {
+    # Distinguish "the overview did not open" from "the click never landed".
+    # Only the latter is a run that judged nothing. A HARVEST_MISS here means a
+    # named control was absent - no Command Palette entry, no Edit in the
+    # palette, no 'Show all tabs' after filtering - and that is a defect, so it
+    # must keep falling through to the exit-2 path below.
+    if ("$_" -like '*FOREGROUND_MISS*') {
         $script:OverviewMissed = $true
+    } else {
+        # Everything else thrown in here is evidence about the build: a named
+        # control that was not there, or a window rect that collapsed. It can
+        # be thrown AFTER $overview was already set true - the screenshot below
+        # the check is one such path - so a separate flag is needed; keying
+        # only off $overview would let it pass.
+        $script:OverviewBroke = $true
     }
 }
 
@@ -437,7 +451,7 @@ if ($null -ne $el) {
 
 $rc = [MzD]::RectOf($hwnd64)
 $menuHit = [MzD]::ClickScreen($pid32, $rc.L + 400, $rc.T + 280, $true)
-if (-not $menuHit.Ok) { throw "HARVEST_MISS: pane menu $($menuHit.Why) class=$($menuHit.HitClass)" }
+if (-not $menuHit.Ok) { throw "FOREGROUND_MISS: pane menu $($menuHit.Why) class=$($menuHit.HitClass)" }
 Start-Sleep -Milliseconds 500
 $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzD]::P($hwnd64))
 $zoomPane = $null -ne (Find-Name $root 'Zoom Pane')
@@ -508,17 +522,21 @@ $crashGrew = (Test-Path $crashPath) -and ((Get-Item $crashPath).LastWriteTimeUtc
     quake = [bool]$quake
 } | ConvertTo-Json | Set-Content (Join-Path $OutDir 'result.json')
 Write-Host (Get-Content (Join-Path $OutDir 'result.json') -Raw)
-# $overview is false both when the overview genuinely did not open and when
-# the harness never reached it - the run that prompted this logged
-# "HARVEST_MISS: grid context not Wintty" and then reported exit 2, a product
-# finding, for a click that never landed. A miss is a run that judged nothing,
-# so it leaves with 1.
+# Order matters. A dead process or a grown crash.log is evidence about the
+# build no matter what else happened, so it is checked first; letting the
+# missed-click branch preempt it would report a crash as "could not run" and
+# hand it to the runner to retry, where a clean second attempt buries it.
+if ($proc.HasExited -or $crashGrew) {
+    Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
+    exit 2
+}
+# Only now: a click that never landed says nothing about the overview.
 if ($script:OverviewMissed) {
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     Write-Host 'the tab overview could not be reached, so nothing is known about it'
     exit 1
 }
-if ($proc.HasExited -or $crashGrew -or -not $overview) {
+if (-not $overview -or $script:OverviewBroke) {
     Stop-WinttyStartedAfter -Since $script:WinttyStamp -ExePath $ExePath
     exit 2
 }


### PR DESCRIPTION
Running `just fuzz` for real, which none of #647, #648 or #649 had done - every
run in all three went at the `.ps1` files directly, including the verification
sections those PRs were written around.

## 1. The gate refused on a clear desktop

`just fuzz`, `just search-fuzz` and `just splash-race` were all unusable, with
no message explaining it - the pid list only prints on the branch not taken.

`pwsh -Command` returns the success of the **last statement executed**.
`Get-Process Wintty` finding no match leaves `$?` false even under
`-ErrorAction SilentlyContinue` or `Ignore`, and a not-taken `if` does not reset
it, so the recipe fell off its end in the failed state. A trailing `exit 0`
fixes it.

## 2. Every recipe collapsed the exit code to 1

Recipe bodies run under `pwsh -Command`, so a product finding (2) and a harness
that could not run (1) arrived identical - the distinction the suite exists to
make, lost at the layer the README points people at.

`; exit ($LASTEXITCODE ?? 1)`. The `?? 1` is not cosmetic: `$LASTEXITCODE` is
only assigned by a native command that actually ran, so a pwsh that fails to
launch would `exit $null`, which is `exit 0` - a clean fuzz run that never
happened.

## 3. The suite never swept between retry attempts

A harness that failed halfway left its window up, and the retry's own gate then
refused over it, so the retry could not succeed. Seen for real: `dialogs`' retry
refused over pid 51064, leaked by its own first attempt.

## 4. `remain` filed a miss as a finding

It reported exit 2 for a tab overview it never reached, gating on `$overview`
being false - which is also what a genuine failure to open looks like.

## Review fixes on top

Reviewers found two regressions in my own fix for 4, both of the kind that turn
a real defect into a green run:

- The missed-click branch **preempted the crash check**. `$proc.HasExited` and
  `$crashGrew` are evidence about the build whatever else happened, so a crash
  after a missed click was reported as "could not run" - which the runner
  retries, and a clean second attempt buries. Product evidence is checked first
  now.
- The catch matched `HARVEST_MISS`, which had come to mean two different things.
  "The control is not there" - a missing Command Palette entry, no Edit in the
  palette, a collapsed window rect - is a **finding**, and this demoted all of
  them to a retryable 1. Click misses are retagged `FOREGROUND_MISS`, only that
  is retryable, and a throw arriving after `$overview` was already true no
  longer escapes.

Also carries the `just fuzzy` alias.

## Test plan

- [x] Gate: clear desktop exits 0; with an instance running it prints the pid
      and exits 1
- [x] A suite run reporting findings returns 2 through `just`, and returned 1
      before; a launch failure now returns 1, and returned 0 before
- [x] `just fuzz-selftest` green
- [x] Every changed script parses
- [ ] The full suite has not been re-run since these fixes
