### PR TITLE
windows: give palette rows an accessible name, hide the IME sink from UIA

### DIFF
--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Linq;
 using System.ComponentModel;
+using Ghostty.Accessibility;
 using Ghostty.Commands;
 using Ghostty.Core.Config;
 using Ghostty.Core.Windows;
 using Ghostty.Services;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -295,6 +297,14 @@ internal sealed partial class CommandPaletteControl : UserControl
         {
             ResultsList.SelectedIndex = idx;
             ResultsList.ScrollIntoView(ResultsList.Items[idx]);
+
+            // Arrowing the palette never moves focus: OnSearchKeyDown handles
+            // Up/Down and marks them handled, so the list is never focused and
+            // its selection-changed event goes unannounced. Without this the
+            // row names below are invisible on the one path a screen-reader
+            // user actually takes through the palette. Announce is gated on a
+            // listener existing, so nobody else pays for it.
+            UiaAnnouncer.Announce(SearchBox, _vm.SelectedCommand.Title, "palette-selection");
         }
     }
 
@@ -323,6 +333,38 @@ internal sealed partial class CommandPaletteControl : UserControl
         ContainerContentChangingEventArgs args)
     {
         if (args.Item is not CommandItem item) return;
+
+        // Name the container before anything below can bail out. Without this
+        // the row's UIA name falls back to CommandItem.ToString(), so a screen
+        // reader announces the whole record - id, description, category, the
+        // Execute delegate - for every command in the list, and any automation
+        // client looking a command up by name finds nothing.
+        AutomationProperties.SetName(args.ItemContainer, item.Title);
+        // Clear rather than skip when there is no description. Containers are
+        // recycled - SyncFilteredCommands clears and refills the list on every
+        // keystroke - and a local value set on one item outlives it, so a row
+        // with no description would keep reading the previous row's. Name is
+        // safe because it is written unconditionally; HelpText was not.
+        // ClearValue, not an empty string: UIA reports "" as present-but-blank.
+        if (!string.IsNullOrEmpty(item.Description))
+        {
+            AutomationProperties.SetHelpText(args.ItemContainer, item.Description);
+        }
+        else
+        {
+            args.ItemContainer.ClearValue(AutomationProperties.HelpTextProperty);
+        }
+        // The key-cap is rendered in the last column, so a sighted user can see
+        // the command is bound. AcceleratorKey is the property Narrator reads
+        // for that; folding it into the name would just make every row longer.
+        if (item.Shortcut is { } binding)
+        {
+            AutomationProperties.SetAcceleratorKey(args.ItemContainer, FormatKeyBinding(binding));
+        }
+        else
+        {
+            args.ItemContainer.ClearValue(AutomationProperties.AcceleratorKeyProperty);
+        }
 
         // Phase 0 fires synchronously during measure; grab the template root.
         // Children are indexed by column order in the DataTemplate:

--- a/windows/scripts/mouse-fuzz-dialogs.ps1
+++ b/windows/scripts/mouse-fuzz-dialogs.ps1
@@ -303,11 +303,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzD]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"

--- a/windows/scripts/mouse-fuzz-ime-cjk.ps1
+++ b/windows/scripts/mouse-fuzz-ime-cjk.ps1
@@ -330,11 +330,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzIC]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"

--- a/windows/scripts/mouse-fuzz-inspector.ps1
+++ b/windows/scripts/mouse-fuzz-inspector.ps1
@@ -326,11 +326,14 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzI]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window": the terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette, so FindFirst(Edit) typed into the sink and
+    # the palette never filtered.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: palette Edit" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Start-Sleep -Milliseconds 350

--- a/windows/scripts/mouse-fuzz-jumplist.ps1
+++ b/windows/scripts/mouse-fuzz-jumplist.ps1
@@ -267,11 +267,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzD]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"

--- a/windows/scripts/mouse-fuzz-kitty.ps1
+++ b/windows/scripts/mouse-fuzz-kitty.ps1
@@ -322,11 +322,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzKT]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"

--- a/windows/scripts/mouse-fuzz-mica-dpi.ps1
+++ b/windows/scripts/mouse-fuzz-mica-dpi.ps1
@@ -277,10 +277,27 @@ function Dump-NamesMatching($root, [string]$needle) {
     }
 }
 
-function Select-ComboItem($root, [uint32]$ProcId, [string]$card, [string]$item) {
+# AutomationId first, proximity only as a fallback. Locating a control by how
+# close it sits to a label works right up until the layout moves: this failed
+# on its second pass over 'Backdrop preset' after the first one changed the
+# backdrop and reflowed the page. The combos carry x:Name, which WinUI exposes
+# as the AutomationId, so there is a stable handle to use instead.
+function Find-ComboById($root, [string]$automationId) {
+    if ([string]::IsNullOrEmpty($automationId)) { return $null }
+    $cond = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, $automationId)
+    return $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
+}
+
+function Select-ComboItem($root, [uint32]$ProcId, [string]$card, [string]$item, [string]$AutomationId) {
     $named = Find-Name $root $card
     Show-El $named
-    $combo = Find-ComboNearName $root $card
+    $combo = Find-ComboById $root $AutomationId
+    if ($null -ne $combo) {
+        Write-Host "combo by id '$AutomationId'"
+    } else {
+        $combo = Find-ComboNearName $root $card
+    }
     if ($null -eq $combo) { throw "HARVEST_MISS: ComboBox near '$card'" }
     Show-El $combo
     $r = $combo.Current.BoundingRectangle
@@ -354,11 +371,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"
@@ -470,7 +492,7 @@ try {
     }
     if ($appearanceCards.Count -lt 3) { throw "PRODUCT_FAIL: missing appearance cards $($appearanceCards -join ',')" }
 
-    Select-ComboItem $sroot $pid32 'Backdrop preset' 'Frosted (Acrylic)'
+    Select-ComboItem $sroot $pid32 'Backdrop preset' 'Frosted (Acrylic)' -AutomationId 'BackgroundStyleCombo'
     Start-Sleep -Milliseconds 400
     $styleAfterFrosted = Read-ConfigKey $configPath 'background-style'
     Write-Host "styleAfterFrosted=$styleAfterFrosted"
@@ -478,7 +500,7 @@ try {
     if ($styleAfterFrosted -ne 'frosted') { throw "PRODUCT_FAIL: expected background-style=frosted got '$styleAfterFrosted'" }
 
     $sroot = [System.Windows.Automation.AutomationElement]::FromHandle([MzMD]::P($settingsHwnd))
-    Select-ComboItem $sroot $pid32 'Backdrop preset' 'Crystal (Zero blur)'
+    Select-ComboItem $sroot $pid32 'Backdrop preset' 'Crystal (Zero blur)' -AutomationId 'BackgroundStyleCombo'
     Start-Sleep -Milliseconds 400
     $styleAfterCrystal = Read-ConfigKey $configPath 'background-style'
     Write-Host "styleAfterCrystal=$styleAfterCrystal"

--- a/windows/scripts/mouse-fuzz-osc-paste.ps1
+++ b/windows/scripts/mouse-fuzz-osc-paste.ps1
@@ -322,11 +322,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzOP]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"

--- a/windows/scripts/mouse-fuzz-settings.ps1
+++ b/windows/scripts/mouse-fuzz-settings.ps1
@@ -240,11 +240,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzS]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"

--- a/windows/scripts/mouse-fuzz-undo-osc.ps1
+++ b/windows/scripts/mouse-fuzz-undo-osc.ps1
@@ -298,11 +298,16 @@ function Open-Palette([int64]$MainHwnd, [uint32]$ProcId) {
 
 function Set-PaletteFilter([int64]$MainHwnd, [string]$text) {
     $root = [System.Windows.Automation.AutomationElement]::FromHandle([MzUO]::P($MainHwnd))
-    $editCt = [System.Windows.Automation.ControlType]::Edit
+    # By AutomationId, not "the first Edit under the window". The terminal
+    # keeps a 1x1 IME sink TextBox focused whenever a pane has focus, and it
+    # sorts ahead of the palette in the tree - so FindFirst(Edit) returned the
+    # sink, SetValue typed into it, and the palette never filtered. The list
+    # then still held every command, so the lookup below failed on a command
+    # that was present the whole time.
     $cond = New-Object System.Windows.Automation.PropertyCondition(
-        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $editCt)
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty, 'SearchBox')
     $edit = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
-    if ($null -eq $edit) { throw "HARVEST_MISS: no Edit in palette" }
+    if ($null -eq $edit) { throw "HARVEST_MISS: no SearchBox in palette" }
     $vp = $edit.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern)
     $vp.SetValue($text)
     Write-Host "filter '$text'"


### PR DESCRIPTION
Stacked on #650.

Found by driving the command palette from automation and dumping what UIA
actually exposes.

## Palette rows had no accessible name

Every row's UIA name was `CommandItem.ToString()`:

```
name="CommandItem { Id = pane:NextTab, Title = Next Tab, Description = Switch to
the next tab, ... Execute = System.Action`1[...] }"
```

Narrator reads that for all 38 commands, so **the command palette is unusable
with a screen reader**, and no automation client can find a command by name.

- `AutomationProperties.Name` = the title, `HelpText` = the description, set at
  the top of the existing `OnContainerContentChanging` so it lands before the
  template checks that bail out on phase-0 layouts.
- `HelpText` is **cleared** when an item has no description. Containers are
  recycled and the list is refilled on every keystroke, so a value set for one
  row outlived it and the next row read a description that was not its own.
- `AcceleratorKey` carries the shortcut, which is rendered on screen but was
  otherwise unreachable.
- The selection is announced via the existing `UiaAnnouncer`. Arrowing the
  palette never moves focus - `OnSearchKeyDown` handles Up/Down and marks them
  handled - so the list is never focused and its selection event is never
  announced. Naming rows without this is invisible on the one path a
  screen-reader user takes.

## The IME sink change was withdrawn

The first version hid `ImeSink` from UIA with `AccessibilityView="Raw"`. Review
killed it, and both objections check out:

- `OnGotFocus` routes focus to the sink whenever **any pane** is focused, so it
  is not a composition-time element, it is the resting focus of the app - and
  UIA requires a focusable element to be in the control view.
- The terminal's own text provider cannot cover for it: `dumpTextLocked` reads
  `screens.active`, while preedit lives on `renderer_state` and never reaches
  the screen. Hiding the sink would have removed the only UIA object holding
  the composition string.

That was to fix a harness problem which has a harness-side fix, and the
harness-side fix is better anyway.

## Ten harnesses stopped guessing

They grabbed the palette box with `FindFirst(ControlType.Edit)` and got the IME
sink, which sorts ahead of the palette - so `SetValue` typed into the sink, the
palette never filtered, and the lookup then failed on a command that was present
the whole time. They now ask for `AutomationId = 'SearchBox'`.

Same shape as `mouse-fuzz-mica-dpi`, which located a combo by pixel proximity to
its label and broke once the first selection reflowed the page; it now uses
`BackgroundStyleCombo`.

## Test plan

- [x] UIA dump before and after: `FindFirst(Edit)` returns `SearchBox`, rows
      read `Paste from Clipboard`, filtering drops 37 realized items to 2
- [x] Solution builds clean
- [x] A/B against a build without the change, 4 runs each way, ruling it out of
      an unrelated startup crash (identical `0xC000027B` both sides)
- [ ] The palette harnesses have not been re-run end to end since
- [ ] No screen-reader pass. The naming and announcement are code-verified only
