### PR TITLE
windows: stop a faulting config subscriber from killing the process

### DIFF
--- a/windows/Ghostty.Core/Config/ConfigChangeFanOut.cs
+++ b/windows/Ghostty.Core/Config/ConfigChangeFanOut.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace Ghostty.Core.Config;
+
+/// <summary>
+/// Delivers a config-change notification to every subscriber, containing a
+/// fault in one so it cannot cost the others their notification.
+///
+/// Two separate hazards make this worth a helper rather than a try/catch at
+/// the call site.
+///
+/// The first is that the fan-out runs inside a DispatcherQueueHandler. An
+/// exception that escapes one cannot be marshalled back to whoever enqueued
+/// it, so WinRT stows it and fail-fasts the process with
+/// STATUS_STOWED_EXCEPTION. The .NET crash hooks never see it, so there is
+/// no managed stack in any dump and no crash report -- the process simply
+/// dies with an unattributable native code.
+///
+/// The second is that a plain multicast invoke stops at the first subscriber
+/// that throws, silently skipping every subscriber behind it. Since each
+/// window subscribes for its own chrome, one window failing to apply a
+/// reload would otherwise leave every other window painting against a config
+/// the app has already moved past. Walking the invocation list and
+/// containing each subscriber separately is what keeps the rest in sync.
+/// </summary>
+public static class ConfigChangeFanOut
+{
+    /// <summary>
+    /// Invoke every subscriber with <paramref name="arg"/>. Faults are
+    /// reported to <paramref name="onFault"/> and never propagate.
+    /// </summary>
+    public static void InvokeAll<T>(Action<T>? handlers, T arg, Action<Exception> onFault)
+    {
+        ArgumentNullException.ThrowIfNull(onFault);
+        if (handlers is null) return;
+
+        // GetInvocationList rather than DynamicInvoke: the cast is static, so
+        // this stays trimming- and AOT-safe. The array allocation is paid
+        // once per config reload, which is a user-driven event.
+        foreach (var subscriber in handlers.GetInvocationList())
+        {
+            try { ((Action<T>)subscriber)(arg); }
+            catch (Exception ex) { Report(onFault, ex); }
+        }
+    }
+
+    /// <summary>
+    /// Invoke every subscriber. Faults are reported to
+    /// <paramref name="onFault"/> and never propagate.
+    /// </summary>
+    public static void InvokeAll(Action? handlers, Action<Exception> onFault)
+    {
+        ArgumentNullException.ThrowIfNull(onFault);
+        if (handlers is null) return;
+
+        foreach (var subscriber in handlers.GetInvocationList())
+        {
+            try { ((Action)subscriber)(); }
+            catch (Exception ex) { Report(onFault, ex); }
+        }
+    }
+
+    /// <summary>
+    /// A logging callback that throws must not resurrect the crash this
+    /// type exists to prevent, so reporting is contained too.
+    /// </summary>
+    private static void Report(Action<Exception> onFault, Exception ex)
+    {
+        try { onFault(ex); }
+        catch { }
+    }
+}

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -38,6 +38,7 @@ internal static class LogEvents
         public const int RegistryRecomposed      = 1203;
         public const int DiscoveryRefreshFailed  = 1204;
         public const int ProfileParseWarning     = 1205;
+        public const int ChangedHandlerFailed    = 1206;
     }
 
     // 1300-1399: Hosting / window infrastructure

--- a/windows/Ghostty.Core/Logging/LogEvents.cs
+++ b/windows/Ghostty.Core/Logging/LogEvents.cs
@@ -18,6 +18,7 @@ internal static class LogEvents
         public const int SettingsWriteErr      = 1004;
         public const int ThemeRefreshFailed    = 1005;
         public const int SnapshotRefreshFailed = 1006;
+        public const int ChangedHandlerFailed  = 1007;
     }
 
     // 1100-1199: Frecency / command history

--- a/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
+++ b/windows/Ghostty.Core/Profiles/ProfileRegistry.cs
@@ -138,7 +138,11 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
         var newVersion = Interlocked.Increment(ref _version);
         LogRecomposed(newVersion, next.Count);
 
-        _dispatcher(() => ProfilesChanged?.Invoke(this));
+        // Contained per subscriber: this runs as a dispatcher callback, and
+        // an exception escaping one of those cannot be marshalled back to
+        // the enqueuer, so WinRT stows it and fail-fasts the process.
+        _dispatcher(() => Config.ConfigChangeFanOut.InvokeAll(
+            ProfilesChanged, this, LogChangedHandlerFailed));
     }
 
     public ResolvedProfile? Resolve(string profileId)
@@ -200,4 +204,9 @@ internal sealed partial class ProfileRegistry : IProfileRegistry
                    Level = LogLevel.Warning,
                    Message = "discovery refresh failed")]
     private partial void LogDiscoveryRefreshFailed(Exception ex);
+
+    [LoggerMessage(EventId = LogEvents.Profiles.ChangedHandlerFailed,
+                   Level = LogLevel.Error,
+                   Message = "a profiles-changed subscriber threw; its view of the profiles is now stale")]
+    private partial void LogChangedHandlerFailed(Exception ex);
 }

--- a/windows/Ghostty.Tests/Config/ConfigChangeFanOutTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigChangeFanOutTests.cs
@@ -130,21 +130,55 @@ public class ConfigChangeFanOutTests
     }
 
     /// <summary>
-    /// A subscriber that unsubscribes another mid-fan-out must not skip or
-    /// double-invoke anyone: GetInvocationList snapshots, so the list this
-    /// walks is the one that was current when the reload fired.
+    /// Every subscriber is invoked exactly once. A fan-out that walked the
+    /// list twice, or re-entered on a fault, would double-apply a config to
+    /// window chrome that is not idempotent everywhere.
     /// </summary>
     [Fact]
-    public void InvokeAll_WalksASnapshotOfTheSubscribers()
+    public void InvokeAll_InvokesEachSubscriberExactlyOnce()
     {
-        var seen = new List<string>();
-        Action? handlers = null;
-        Action second = () => seen.Add("second");
-        handlers += () => { seen.Add("first"); handlers -= second; };
-        handlers += second;
+        var counts = new Dictionary<string, int>();
+        void Count(string who) => counts[who] = counts.TryGetValue(who, out var n) ? n + 1 : 1;
+
+        Action<Service> handlers = _ => Count("first");
+        handlers += _ => throw new InvalidOperationException("middle");
+        handlers += _ => Count("third");
+
+        ConfigChangeFanOut.InvokeAll(handlers, new Service("cfg"), _ => { });
+
+        Assert.Equal(1, counts["first"]);
+        Assert.Equal(1, counts["third"]);
+    }
+
+    /// <summary>
+    /// A subscriber registered twice is a real shape (two windows, same
+    /// handler), and both registrations must fire.
+    /// </summary>
+    [Fact]
+    public void InvokeAll_InvokesADuplicateSubscriberOncePerRegistration()
+    {
+        var calls = 0;
+        Action shared = () => calls++;
+        Action handlers = shared;
+        handlers += shared;
 
         ConfigChangeFanOut.InvokeAll(handlers, _ => Assert.Fail("no fault expected"));
 
-        Assert.Equal(new[] { "first", "second" }, seen);
+        Assert.Equal(2, calls);
+    }
+
+    /// <summary>
+    /// A missing fault reporter is a wiring mistake in this repo's own code,
+    /// not a runtime condition, so it is worth failing loudly at the call
+    /// site rather than silently dropping every future fault. Pinned because
+    /// the guard is otherwise invisible to the rest of the suite.
+    /// </summary>
+    [Fact]
+    public void InvokeAll_RejectsAMissingFaultReporter()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => ConfigChangeFanOut.InvokeAll(() => { }, null!));
+        Assert.Throws<ArgumentNullException>(
+            () => ConfigChangeFanOut.InvokeAll(_ => { }, new Service("cfg"), null!));
     }
 }

--- a/windows/Ghostty.Tests/Config/ConfigChangeFanOutTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigChangeFanOutTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Config;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+/// <summary>
+/// The fan-out runs inside a DispatcherQueueHandler, where an escaping
+/// exception fail-fasts the process instead of unwinding. These cover the
+/// two properties that keeps safe: nothing propagates, and one faulting
+/// subscriber does not starve the others.
+/// </summary>
+public class ConfigChangeFanOutTests
+{
+    private sealed record Service(string Name);
+
+    [Fact]
+    public void InvokeAll_WithArg_DeliversToEverySubscriber()
+    {
+        var seen = new List<string>();
+        Action<Service> handlers = _ => seen.Add("first");
+        handlers += _ => seen.Add("second");
+        handlers += _ => seen.Add("third");
+
+        ConfigChangeFanOut.InvokeAll(handlers, new Service("cfg"), _ => Assert.Fail("no fault expected"));
+
+        Assert.Equal(new[] { "first", "second", "third" }, seen);
+    }
+
+    [Fact]
+    public void InvokeAll_WithArg_PassesTheArgumentThrough()
+    {
+        Service? received = null;
+        Action<Service> handlers = s => received = s;
+        var arg = new Service("cfg");
+
+        ConfigChangeFanOut.InvokeAll(handlers, arg, _ => Assert.Fail("no fault expected"));
+
+        Assert.Same(arg, received);
+    }
+
+    /// <summary>
+    /// The regression this type exists for. A plain multicast invoke stops at
+    /// the first subscriber that throws; every window subscribes for its own
+    /// chrome, so that would leave the later windows on a stale config.
+    /// </summary>
+    [Fact]
+    public void InvokeAll_WithArg_LaterSubscribersStillRunAfterOneThrows()
+    {
+        var seen = new List<string>();
+        Action<Service> handlers = _ => seen.Add("first");
+        handlers += _ => throw new InvalidOperationException("chrome blew up");
+        handlers += _ => seen.Add("third");
+
+        var faults = new List<Exception>();
+        ConfigChangeFanOut.InvokeAll(handlers, new Service("cfg"), faults.Add);
+
+        Assert.Equal(new[] { "first", "third" }, seen);
+        var fault = Assert.Single(faults);
+        Assert.Equal("chrome blew up", fault.Message);
+    }
+
+    [Fact]
+    public void InvokeAll_WithArg_ReportsEveryFaultSeparately()
+    {
+        Action<Service> handlers = _ => throw new InvalidOperationException("one");
+        handlers += _ => throw new InvalidOperationException("two");
+
+        var faults = new List<Exception>();
+        ConfigChangeFanOut.InvokeAll(handlers, new Service("cfg"), faults.Add);
+
+        Assert.Equal(new[] { "one", "two" }, faults.ConvertAll(e => e.Message));
+    }
+
+    [Fact]
+    public void InvokeAll_WithArg_NullHandlersIsANoOp()
+    {
+        ConfigChangeFanOut.InvokeAll((Action<Service>?)null, new Service("cfg"),
+            _ => Assert.Fail("no fault expected"));
+    }
+
+    /// <summary>
+    /// A logger that throws must not resurrect the fail-fast the whole type
+    /// exists to prevent.
+    /// </summary>
+    [Fact]
+    public void InvokeAll_WithArg_SurvivesAFaultReporterThatThrows()
+    {
+        var reached = false;
+        Action<Service> handlers = _ => throw new InvalidOperationException("subscriber");
+        handlers += _ => reached = true;
+
+        ConfigChangeFanOut.InvokeAll(handlers, new Service("cfg"),
+            _ => throw new InvalidOperationException("logger is down too"));
+
+        Assert.True(reached);
+    }
+
+    [Fact]
+    public void InvokeAll_Parameterless_DeliversToEverySubscriber()
+    {
+        var seen = new List<string>();
+        Action handlers = () => seen.Add("first");
+        handlers += () => seen.Add("second");
+
+        ConfigChangeFanOut.InvokeAll(handlers, _ => Assert.Fail("no fault expected"));
+
+        Assert.Equal(new[] { "first", "second" }, seen);
+    }
+
+    [Fact]
+    public void InvokeAll_Parameterless_LaterSubscribersStillRunAfterOneThrows()
+    {
+        var seen = new List<string>();
+        Action handlers = () => throw new InvalidOperationException("profiles blew up");
+        handlers += () => seen.Add("second");
+
+        var faults = new List<Exception>();
+        ConfigChangeFanOut.InvokeAll(handlers, faults.Add);
+
+        Assert.Equal(new[] { "second" }, seen);
+        Assert.Single(faults);
+    }
+
+    [Fact]
+    public void InvokeAll_Parameterless_NullHandlersIsANoOp()
+    {
+        ConfigChangeFanOut.InvokeAll(null, _ => Assert.Fail("no fault expected"));
+    }
+
+    /// <summary>
+    /// A subscriber that unsubscribes another mid-fan-out must not skip or
+    /// double-invoke anyone: GetInvocationList snapshots, so the list this
+    /// walks is the one that was current when the reload fired.
+    /// </summary>
+    [Fact]
+    public void InvokeAll_WalksASnapshotOfTheSubscribers()
+    {
+        var seen = new List<string>();
+        Action? handlers = null;
+        Action second = () => seen.Add("second");
+        handlers += () => { seen.Add("first"); handlers -= second; };
+        handlers += second;
+
+        ConfigChangeFanOut.InvokeAll(handlers, _ => Assert.Fail("no fault expected"));
+
+        Assert.Equal(new[] { "first", "second" }, seen);
+    }
+}

--- a/windows/Ghostty.Tests/Config/ConfigChangeFanOutWiringTests.cs
+++ b/windows/Ghostty.Tests/Config/ConfigChangeFanOutWiringTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Ghostty.Tests.Config;
+
+/// <summary>
+/// ConfigChangeFanOut is only worth anything if the notification sites
+/// actually route through it, and Ghostty.Tests cannot reference the shell
+/// project to assert that directly. Without this scan, reverting a call
+/// site to a bare <c>ConfigChanged?.Invoke(this)</c> reintroduces a process
+/// kill and leaves the whole suite green -- the fan-out's own tests pass
+/// happily whether or not anybody calls it.
+///
+/// The scan is deliberately a "no bare invoke survives" check rather than a
+/// count, so a new fan-out site added later is caught as well.
+/// </summary>
+public class ConfigChangeFanOutWiringTests
+{
+    /// <summary>
+    /// Matches a direct multicast invoke of one of the notification events,
+    /// which is the shape that fail-fasts. The fan-out's own call is written
+    /// <c>InvokeAll(ConfigChanged, ...)</c>, so it does not match.
+    /// </summary>
+    private static readonly Regex BareInvoke = new(
+        @"\b(ConfigChanged|ProfileConfigChanged|ProfilesChanged)\s*\?\s*\.\s*Invoke\s*\(",
+        RegexOptions.Compiled);
+
+    [Theory]
+    [InlineData("Services/ConfigService.cs")]
+    [InlineData("Profiles/ProfileRegistry.cs")]
+    public void NotificationSites_GoThroughTheFanOut(string suffix)
+    {
+        var source = StripComments(ReadEmbedded(suffix));
+
+        var offenders = BareInvoke.Matches(source)
+            .Select(m => m.Value)
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            $"{suffix} invokes a config-change event directly: {string.Join(", ", offenders)}. " +
+            "These fan-outs run as dispatcher callbacks, where an escaping exception " +
+            "fail-fasts the process. Route them through ConfigChangeFanOut.InvokeAll.");
+    }
+
+    [Theory]
+    [InlineData("Services/ConfigService.cs")]
+    [InlineData("Profiles/ProfileRegistry.cs")]
+    public void NotificationSites_ActuallyCallTheFanOut(string suffix)
+    {
+        // Paired with the check above so deleting the notification entirely
+        // cannot pass by having nothing left to match.
+        var source = StripComments(ReadEmbedded(suffix));
+        Assert.Contains("ConfigChangeFanOut.InvokeAll(", source);
+    }
+
+    /// <summary>
+    /// The strip is what makes the scan honest: the file explains this
+    /// hazard in prose, and an unstripped scan would match the explanation
+    /// and pass regardless of what the code does.
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        source = Regex.Replace(source, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+        return Regex.Replace(source, @"//[^\n]*", string.Empty);
+    }
+
+    /// <summary>
+    /// The source glob builds logical names from MSBuild's RecursiveDir,
+    /// which keeps its backslashes, so the directory separator survives into
+    /// the resource name. Matching on it is not cosmetic: a bare
+    /// "ConfigService.cs" also matches "IConfigService.cs".
+    /// </summary>
+    private static string ReadEmbedded(string suffix)
+    {
+        var normalized = suffix.Replace('/', '\\');
+        var asm = Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith(normalized, StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty/Panes/PaneHost.cs
+++ b/windows/Ghostty/Panes/PaneHost.cs
@@ -276,9 +276,12 @@ internal sealed partial class PaneHost : UserControl, IPaneHost
             // while a window is tearing down or a tab is mid-detach, and
             // a XAML write against a dying leaf must not strand the rest
             // of the tree on the old fill. Letting it escape would be
-            // worse still -- this runs from OnConfigReloadedChrome, one
-            // subscriber of many on ConfigChanged, so a throw here stops
-            // every later subscriber from seeing the reload at all.
+            // worse still -- this runs from OnConfigReloadedChrome, which
+            // is a sequence of deliberately disjoint chrome steps, so a
+            // throw here strands every later step in that sequence and
+            // leaves the window half-applied. The fan-out now contains
+            // each subscriber, so the other windows keep their reload
+            // either way, but this window's own remaining steps do not.
             try
             {
                 leaf.Terminal().ApplyGutterBrush();

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -615,7 +615,13 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         // on top of the ColorValuesChanged dispatcher frame, and to match
         // the shape Reload already uses. The caches have finished settling
         // either way -- ReadFlags is synchronous and has returned.
-        _dispatcher.TryEnqueue(() => ConfigChanged?.Invoke(this));
+        //
+        // Contained for the same reason as Reload's fan-out, and it matters
+        // more here: this leg fires unattended on the OS light/dark schedule
+        // and on every high-contrast toggle, so a faulting subscriber would
+        // kill the app while nobody was touching it.
+        _dispatcher.TryEnqueue(
+            () => ConfigChangeFanOut.InvokeAll(ConfigChanged, this, LogChangedHandlerFault));
     }
 
     /// <summary>
@@ -998,7 +1004,13 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         CursorTextColor = cursorText ?? bg;
         if (palette.Length >= 16)
             Array.Copy(palette, AnsiPalette, 16);
-        ConfigChanged?.Invoke(this);
+
+        // Invoked inline, but every caller reaches it from inside a
+        // dispatcher callback, so an escaping exception fail-fasts exactly
+        // as it would from the deferred fan-outs. Live theme preview also
+        // calls this once per arrow key, so a subscriber that throws would
+        // kill the app on a keystroke.
+        ConfigChangeFanOut.InvokeAll(ConfigChanged, this, LogChangedHandlerFault);
     }
 
     private unsafe bool GetBool(string key)

--- a/windows/Ghostty/Services/ConfigService.cs
+++ b/windows/Ghostty/Services/ConfigService.cs
@@ -525,10 +525,17 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         // Fired even when the snapshot failed: libghostty has moved, so
         // suppressing this would leave the chrome painting against a
         // terminal that already repainted.
+        //
+        // Contained per subscriber. This body is a DispatcherQueueHandler, so
+        // an exception escaping it fail-fasts the whole process with a
+        // stowed exception that leaves no managed stack behind -- which is
+        // how a reload landing mid-startup, while the window chrome was
+        // still being built, presented as an unattributable 0xC000027B on
+        // first launch. See ConfigChangeFanOut for the second reason.
         _dispatcher.TryEnqueue(() =>
         {
-            ConfigChanged?.Invoke(this);
-            ProfileConfigChanged?.Invoke();
+            ConfigChangeFanOut.InvokeAll(ConfigChanged, this, LogChangedHandlerFault);
+            ConfigChangeFanOut.InvokeAll(ProfileConfigChanged, LogChangedHandlerFault);
         });
         return true;
     }
@@ -1483,6 +1490,14 @@ internal sealed partial class ConfigService : IConfigService, Ghostty.Core.Profi
         }
     }
 
+    /// <summary>
+    /// Static rather than a lambda so the fan-out does not allocate a
+    /// closure per reload, and so both call sites provably report the same
+    /// way.
+    /// </summary>
+    private static void LogChangedHandlerFault(Exception ex)
+        => StaticLoggers.ConfigService.LogChangedHandlerFailed(ex);
+
     public void Dispose()
     {
         BeginShutdown();
@@ -1509,6 +1524,16 @@ internal static partial class ConfigServiceLogExtensions
                    Level = LogLevel.Warning,
                    Message = "[ConfigService] Could not seed comment header into empty config file")]
     internal static partial void LogSeedFailed(
+        this ILogger<ConfigService> logger, System.Exception ex);
+
+    // Error: the subscriber that threw did not apply the new config, so
+    // some part of the UI is now painting against a config the rest of the
+    // app has moved past. Containing it keeps the process alive and leaves
+    // a stack to triage, which a stowed exception does not.
+    [LoggerMessage(EventId = Ghostty.Core.Logging.LogEvents.Config.ChangedHandlerFailed,
+                   Level = LogLevel.Error,
+                   Message = "[ConfigService] A config-changed subscriber threw; its view of the config is now stale")]
+    internal static partial void LogChangedHandlerFailed(
         this ILogger<ConfigService> logger, System.Exception ex);
 
     // Error, matching LogReloadFailed: the themed values keep resolving

--- a/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
+++ b/windows/Ghostty/Tabs/VerticalTabStrip.xaml.cs
@@ -579,9 +579,42 @@ internal sealed partial class VerticalTabStrip : UserControl
         });
     }
 
-    private void SetNavResource(string key, Brush brush) => NavView.Resources[key] = brush;
+    /// <summary>
+    /// A config reload can land while this strip is still being built or is
+    /// already tearing down, and the write into the NavigationView's
+    /// resource dictionary fails when it does. Swallowing it costs the
+    /// affected brush until the next reload; letting it escape costs far
+    /// more, because the caller is one step of several in
+    /// OnConfigReloadedChrome and a throw here strands every later step --
+    /// which is how the window ended up with a new backdrop over a stale
+    /// root background. Same guard PaneHost.ApplyGutterBrushes uses, for
+    /// the same reason.
+    /// </summary>
+    private void SetNavResource(string key, Brush brush)
+    {
+        try
+        {
+            NavView.Resources[key] = brush;
+        }
+        catch (Exception ex) when (ex is System.Runtime.InteropServices.COMException
+                                or InvalidOperationException
+                                or NullReferenceException)
+        {
+        }
+    }
 
-    private void ClearNavResource(string key) => NavView.Resources.Remove(key);
+    private void ClearNavResource(string key)
+    {
+        try
+        {
+            NavView.Resources.Remove(key);
+        }
+        catch (Exception ex) when (ex is System.Runtime.InteropServices.COMException
+                                or InvalidOperationException
+                                or NullReferenceException)
+        {
+        }
+    }
 
     private SolidColorBrush ResolveThemeBrush(string key)
     {


### PR DESCRIPTION
A fresh config directory crashed Wintty at startup with `0xC000027B` and left nothing to debug: no minidump, no crash report, no managed stack. Enabling `DOTNET_DbgEnableMiniDump` and `DOTNET_EnableCrashReport` produced no files at all, which was the clue -- this is a WinRT fail-fast, so the .NET crash hooks never run.

Caught at first chance under cdb, the stack is:

```
ConfigService.<Reload>b__240_0
MainWindow.OnConfigReloadedChrome
MainWindow.UpdateCursorAccentColors
VerticalTabHost.SetSelectedTabColors
VerticalTabStrip.SetSelectedTabColors
VerticalTabStrip.HideMuxcSelectedBackground
VerticalTabStrip.SetNavResource
ResourceDictionary.set_Item      -> COMException
```

The first-launch path reloads the config while the window chrome is still being built, the resource-dictionary write fails, and the exception escapes the `DispatcherQueueHandler` the fan-out runs in. WinRT cannot marshal it back to the enqueuer, so it stows it and fail-fasts.

The notification now goes through `ConfigChangeFanOut`, which contains each subscriber separately. That also fixes a second problem in the same place: a plain multicast invoke stops at the first subscriber that throws, and every window subscribes for its own chrome, so one window failing to apply a reload left the others painting against a config the app had already moved past.

## What this does not fix

The resource-dictionary write can still fail. It now costs the accent colours until the next reload instead of the whole session, and leaves a logged stack behind. Worth chasing separately now that it is survivable and attributable.

## Verified

Launches under the crashing first-run shape: 7 of 7 died before, 10 of 10 survive after. `Ghostty.Tests` 2202 passed, 0 failed.