### PR TITLE
windows: make the command palette speak to a screen reader

### DIFF
--- a/windows/Ghostty.Core/Accessibility/CommandPaletteAnnouncer.cs
+++ b/windows/Ghostty.Core/Accessibility/CommandPaletteAnnouncer.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// What the command palette tells a screen reader: how the mode label is
+/// named, and which result-count changes are worth speaking.
+///
+/// Pure and deterministic so the wording and the repeat suppression can be
+/// exercised without a live UIA tree; the control only forwards whatever
+/// comes back out of here to the announcer.
+/// </summary>
+public sealed class CommandPaletteAnnouncer
+{
+    private string? _lastStatus;
+
+    /// <summary>
+    /// Accessible name for the mode label, whose own text ("Search" /
+    /// "Command") is the value the user needs.
+    ///
+    /// The value cannot simply be the name: a bare "Search" collides with
+    /// the command titled the same on a find-by-name, which is how the
+    /// mode label started absorbing clicks meant for the list row. Naming
+    /// it after the field instead ("Palette mode") swaps one defect for a
+    /// worse one, because an explicit name replaces the text a reader
+    /// would otherwise speak, so the mode itself goes silent. Carrying
+    /// both keeps the value audible and the string unambiguous.
+    /// </summary>
+    public static string ModeAccessibleName(string? modeLabel) =>
+        string.IsNullOrWhiteSpace(modeLabel)
+            ? "Palette mode"
+            : modeLabel.Trim() + " mode";
+
+    /// <summary>
+    /// The result count to speak, or null when there is nothing new to
+    /// say. Repeats are dropped because the palette recomputes its status
+    /// on every keystroke and most keystrokes leave the count alone;
+    /// hearing "12 commands" again after each letter buries the row title
+    /// that is spoken alongside it.
+    /// </summary>
+    public string? StatusChanged(string? statusText)
+    {
+        if (string.IsNullOrWhiteSpace(statusText)) return null;
+        if (string.Equals(statusText, _lastStatus, StringComparison.Ordinal)) return null;
+        _lastStatus = statusText;
+        return statusText;
+    }
+
+    /// <summary>
+    /// Forget the last spoken status, so reopening the palette on the same
+    /// count says it again instead of opening in silence.
+    /// </summary>
+    public void Reset() => _lastStatus = null;
+}

--- a/windows/Ghostty.Core/Accessibility/CommandPaletteAnnouncer.cs
+++ b/windows/Ghostty.Core/Accessibility/CommandPaletteAnnouncer.cs
@@ -4,15 +4,16 @@ namespace Ghostty.Core.Accessibility;
 
 /// <summary>
 /// What the command palette tells a screen reader: how the mode label is
-/// named, and which result-count changes are worth speaking.
+/// named, and which result counts are worth speaking, and when.
 ///
-/// Pure and deterministic so the wording and the repeat suppression can be
-/// exercised without a live UIA tree; the control only forwards whatever
-/// comes back out of here to the announcer.
+/// Pure and deterministic so the wording, the repeat suppression and the
+/// hold-until-focus rule can be exercised without a live UIA tree; the
+/// control only publishes whatever comes back out of here.
 /// </summary>
 public sealed class CommandPaletteAnnouncer
 {
-    private string? _lastStatus;
+    private string? _lastSpoken;
+    private bool _awaitingFocus;
 
     /// <summary>
     /// Accessible name for the mode label, whose own text ("Search" /
@@ -32,23 +33,48 @@ public sealed class CommandPaletteAnnouncer
             : modeLabel.Trim() + " mode";
 
     /// <summary>
-    /// The result count to speak, or null when there is nothing new to
-    /// say. Repeats are dropped because the palette recomputes its status
-    /// on every keystroke and most keystrokes leave the count alone;
-    /// hearing "12 commands" again after each letter buries the row title
-    /// that is spoken alongside it.
+    /// The palette has opened but focus has not reached it yet.
+    ///
+    /// Everything the view model raises while opening lands before the
+    /// host moves focus into the search box, and a reader flushes what it
+    /// is holding when focus moves. Speaking the count there means
+    /// speaking it into the gap, and worse, banking it: the identical
+    /// count arriving after focus would then be suppressed as a repeat.
+    /// So the count is held, unrecorded, until <see cref="Focused"/>.
     /// </summary>
-    public string? StatusChanged(string? statusText)
+    public void Opening()
     {
-        if (string.IsNullOrWhiteSpace(statusText)) return null;
-        if (string.Equals(statusText, _lastStatus, StringComparison.Ordinal)) return null;
-        _lastStatus = statusText;
-        return statusText;
+        _lastSpoken = null;
+        _awaitingFocus = true;
     }
 
     /// <summary>
-    /// Forget the last spoken status, so reopening the palette on the same
-    /// count says it again instead of opening in silence.
+    /// Focus has landed in the palette. Returns the result count to speak,
+    /// or null when it has already been spoken.
     /// </summary>
-    public void Reset() => _lastStatus = null;
+    public string? Focused(string? statusText)
+    {
+        _awaitingFocus = false;
+        return Speak(statusText);
+    }
+
+    /// <summary>
+    /// A new result count. Returns what to speak, or null when there is
+    /// nothing new to say.
+    ///
+    /// Repeats are dropped because the palette recomputes its status on
+    /// every keystroke and most keystrokes leave the count alone; hearing
+    /// "12 commands" again after each letter buries the row title that is
+    /// spoken alongside it.
+    /// </summary>
+    public string? StatusChanged(string? statusText) =>
+        _awaitingFocus ? null : Speak(statusText);
+
+    private string? Speak(string? statusText)
+    {
+        if (string.IsNullOrWhiteSpace(statusText)) return null;
+        if (string.Equals(statusText, _lastSpoken, StringComparison.Ordinal)) return null;
+        _lastSpoken = statusText;
+        return statusText;
+    }
 }

--- a/windows/Ghostty.Core/Accessibility/CommandRowAutomation.cs
+++ b/windows/Ghostty.Core/Accessibility/CommandRowAutomation.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Ghostty.Core.Accessibility;
+
+/// <summary>
+/// The automation properties one command-palette row carries.
+///
+/// Absent values are null rather than empty, because the two are not the
+/// same to UIA: an empty string reads as present-but-blank, and the row
+/// containers are recycled, so a value that is merely blanked leaves the
+/// previous row's still in place on the next item to reuse the container.
+/// Null is the signal to clear the property outright.
+/// </summary>
+public readonly record struct CommandRowAutomation(
+    string Name,
+    string? HelpText,
+    string? AcceleratorKey)
+{
+    /// <summary>
+    /// Decide the three properties for a row from its item's fields.
+    /// <paramref name="shortcut"/> is the already-formatted key-cap text,
+    /// or null when the command has no binding.
+    /// </summary>
+    public static CommandRowAutomation For(string? title, string? description, string? shortcut) =>
+        new(
+            // Without a name the row falls back to the item's ToString(),
+            // which is the whole record: id, description, category and the
+            // Execute delegate, read out for every command in the list.
+            title ?? string.Empty,
+            Present(description),
+            // The key-cap is rendered in its own column so a sighted user
+            // can see the command is bound; AcceleratorKey is where a
+            // reader looks for that. Folding it into the name would only
+            // make every row longer.
+            Present(shortcut));
+
+    private static string? Present(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/windows/Ghostty.Tests/Accessibility/CommandPaletteAnnouncerTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/CommandPaletteAnnouncerTests.cs
@@ -32,17 +32,19 @@ public class CommandPaletteAnnouncerTests
         Assert.Equal("Palette mode", CommandPaletteAnnouncer.ModeAccessibleName(label));
     }
 
+    // ── Repeat suppression ───────────────────────────────────────────────
+
     [Fact]
     public void StatusChanged_SpeaksTheFirstCount()
     {
-        var a = new CommandPaletteAnnouncer();
+        var a = Live();
         Assert.Equal("12 commands", a.StatusChanged("12 commands"));
     }
 
     [Fact]
     public void StatusChanged_DropsAnUnchangedCount()
     {
-        var a = new CommandPaletteAnnouncer();
+        var a = Live();
         a.StatusChanged("12 commands");
         Assert.Null(a.StatusChanged("12 commands"));
     }
@@ -50,7 +52,7 @@ public class CommandPaletteAnnouncerTests
     [Fact]
     public void StatusChanged_SpeaksAgainWhenTheCountMoves()
     {
-        var a = new CommandPaletteAnnouncer();
+        var a = Live();
         a.StatusChanged("12 commands");
         Assert.Equal("3 commands", a.StatusChanged("3 commands"));
         Assert.Equal("1 command", a.StatusChanged("1 command"));
@@ -62,7 +64,7 @@ public class CommandPaletteAnnouncerTests
         // Typing ">" flips the palette to command mode. The count wording
         // changes with it, so the switch is audible even though nothing
         // announces the mode label directly.
-        var a = new CommandPaletteAnnouncer();
+        var a = Live();
         a.StatusChanged("3 commands");
         Assert.Equal("3 actions", a.StatusChanged("3 actions"));
     }
@@ -73,14 +75,13 @@ public class CommandPaletteAnnouncerTests
     [InlineData("  ")]
     public void StatusChanged_SaysNothingForAnEmptyStatus(string? status)
     {
-        var a = new CommandPaletteAnnouncer();
-        Assert.Null(a.StatusChanged(status));
+        Assert.Null(Live().StatusChanged(status));
     }
 
     [Fact]
     public void StatusChanged_EmptyStatusDoesNotPoisonTheNextRealOne()
     {
-        var a = new CommandPaletteAnnouncer();
+        var a = Live();
         a.StatusChanged("5 commands");
         a.StatusChanged("");
         // The blank was never spoken, so the count that follows it is only
@@ -89,12 +90,80 @@ public class CommandPaletteAnnouncerTests
         Assert.Equal("6 commands", a.StatusChanged("6 commands"));
     }
 
+    // ── Hold until focus ─────────────────────────────────────────────────
+
     [Fact]
-    public void Reset_MakesAReopenSpeakTheSameCountAgain()
+    public void Opening_HoldsEveryCountRaisedBeforeFocusArrives()
+    {
+        // The view model raises IsOpen, then the filter results, then the
+        // count, and only after all of that does the host move focus into
+        // the palette. Anything spoken in that window is spoken into a
+        // focus change.
+        var a = new CommandPaletteAnnouncer();
+        a.Opening();
+        Assert.Null(a.StatusChanged("12 commands"));
+        Assert.Null(a.StatusChanged("12 commands"));
+    }
+
+    [Fact]
+    public void Focused_SpeaksTheCountThatWasHeld()
     {
         var a = new CommandPaletteAnnouncer();
+        a.Opening();
         a.StatusChanged("12 commands");
-        a.Reset();
-        Assert.Equal("12 commands", a.StatusChanged("12 commands"));
+        Assert.Equal("12 commands", a.Focused("12 commands"));
+    }
+
+    [Fact]
+    public void Opening_DoesNotBankTheHeldCountAsAlreadySpoken()
+    {
+        // The regression this exists for: recording the count while
+        // holding it would make the identical count arriving after focus
+        // look like a repeat, and the palette would open in silence.
+        var a = new CommandPaletteAnnouncer();
+        a.Opening();
+        a.StatusChanged("12 commands");
+        Assert.NotNull(a.Focused("12 commands"));
+    }
+
+    [Fact]
+    public void Reopening_OnTheSameCountSpeaksItAgain()
+    {
+        var a = new CommandPaletteAnnouncer();
+        a.Opening();
+        a.Focused("12 commands");
+        a.Opening();
+        Assert.Equal("12 commands", a.Focused("12 commands"));
+    }
+
+    [Fact]
+    public void AfterFocus_TypingResumesNormalSuppression()
+    {
+        var a = new CommandPaletteAnnouncer();
+        a.Opening();
+        a.Focused("12 commands");
+        Assert.Null(a.StatusChanged("12 commands"));
+        Assert.Equal("2 commands", a.StatusChanged("2 commands"));
+    }
+
+    [Fact]
+    public void Focused_SaysNothingWhenTheCountIsAlreadySpoken()
+    {
+        // Focus can land in the search box again without a reopen (the
+        // user clicks back into it). That is not new information.
+        var a = new CommandPaletteAnnouncer();
+        a.Opening();
+        a.Focused("12 commands");
+        Assert.Null(a.Focused("12 commands"));
+    }
+
+    // An announcer that has already been through an open/focus cycle, i.e.
+    // one for a palette the user is typing in.
+    private static CommandPaletteAnnouncer Live()
+    {
+        var a = new CommandPaletteAnnouncer();
+        a.Opening();
+        a.Focused("seed");
+        return a;
     }
 }

--- a/windows/Ghostty.Tests/Accessibility/CommandPaletteAnnouncerTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/CommandPaletteAnnouncerTests.cs
@@ -1,0 +1,100 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class CommandPaletteAnnouncerTests
+{
+    [Theory]
+    [InlineData("Search", "Search mode")]
+    [InlineData("Command", "Command mode")]
+    public void ModeAccessibleName_CarriesTheMode(string label, string expected)
+    {
+        Assert.Equal(expected, CommandPaletteAnnouncer.ModeAccessibleName(label));
+    }
+
+    [Fact]
+    public void ModeAccessibleName_IsNeverTheBareModeWord()
+    {
+        // A name equal to a command title makes a find-by-name land on the
+        // header label instead of the row, which is what put the fuzz
+        // harness's click on the wrong element.
+        Assert.NotEqual("Search", CommandPaletteAnnouncer.ModeAccessibleName("Search"));
+        Assert.NotEqual("Command", CommandPaletteAnnouncer.ModeAccessibleName("Command"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ModeAccessibleName_FallsBackWhenThereIsNoMode(string? label)
+    {
+        Assert.Equal("Palette mode", CommandPaletteAnnouncer.ModeAccessibleName(label));
+    }
+
+    [Fact]
+    public void StatusChanged_SpeaksTheFirstCount()
+    {
+        var a = new CommandPaletteAnnouncer();
+        Assert.Equal("12 commands", a.StatusChanged("12 commands"));
+    }
+
+    [Fact]
+    public void StatusChanged_DropsAnUnchangedCount()
+    {
+        var a = new CommandPaletteAnnouncer();
+        a.StatusChanged("12 commands");
+        Assert.Null(a.StatusChanged("12 commands"));
+    }
+
+    [Fact]
+    public void StatusChanged_SpeaksAgainWhenTheCountMoves()
+    {
+        var a = new CommandPaletteAnnouncer();
+        a.StatusChanged("12 commands");
+        Assert.Equal("3 commands", a.StatusChanged("3 commands"));
+        Assert.Equal("1 command", a.StatusChanged("1 command"));
+    }
+
+    [Fact]
+    public void StatusChanged_SpeaksTheModeSwitchToActions()
+    {
+        // Typing ">" flips the palette to command mode. The count wording
+        // changes with it, so the switch is audible even though nothing
+        // announces the mode label directly.
+        var a = new CommandPaletteAnnouncer();
+        a.StatusChanged("3 commands");
+        Assert.Equal("3 actions", a.StatusChanged("3 actions"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void StatusChanged_SaysNothingForAnEmptyStatus(string? status)
+    {
+        var a = new CommandPaletteAnnouncer();
+        Assert.Null(a.StatusChanged(status));
+    }
+
+    [Fact]
+    public void StatusChanged_EmptyStatusDoesNotPoisonTheNextRealOne()
+    {
+        var a = new CommandPaletteAnnouncer();
+        a.StatusChanged("5 commands");
+        a.StatusChanged("");
+        // The blank was never spoken, so the count that follows it is only
+        // a repeat if it repeats what was actually spoken.
+        Assert.Null(a.StatusChanged("5 commands"));
+        Assert.Equal("6 commands", a.StatusChanged("6 commands"));
+    }
+
+    [Fact]
+    public void Reset_MakesAReopenSpeakTheSameCountAgain()
+    {
+        var a = new CommandPaletteAnnouncer();
+        a.StatusChanged("12 commands");
+        a.Reset();
+        Assert.Equal("12 commands", a.StatusChanged("12 commands"));
+    }
+}

--- a/windows/Ghostty.Tests/Accessibility/CommandRowAutomationTests.cs
+++ b/windows/Ghostty.Tests/Accessibility/CommandRowAutomationTests.cs
@@ -1,0 +1,68 @@
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Accessibility;
+
+public class CommandRowAutomationTests
+{
+    [Fact]
+    public void Name_IsTheTitle()
+    {
+        Assert.Equal("Copy to Clipboard", Row(title: "Copy to Clipboard").Name);
+    }
+
+    [Fact]
+    public void HelpText_IsTheDescription()
+    {
+        Assert.Equal("Copy the selection", Row(description: "Copy the selection").HelpText);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void HelpText_IsNullWhenThereIsNoDescription(string? description)
+    {
+        // Null, not empty. The caller clears the property on null; an
+        // empty string would be set, and UIA reads a set-but-empty
+        // property as present, which on a recycled container leaves the
+        // previous row's description in place.
+        Assert.Null(Row(description: description).HelpText);
+    }
+
+    [Fact]
+    public void AcceleratorKey_IsTheFormattedShortcut()
+    {
+        Assert.Equal("Ctrl+Shift+P", Row(shortcut: "Ctrl+Shift+P").AcceleratorKey);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AcceleratorKey_IsNullWhenTheCommandHasNoBinding(string? shortcut)
+    {
+        Assert.Null(Row(shortcut: shortcut).AcceleratorKey);
+    }
+
+    [Fact]
+    public void ShortcutIsNotFoldedIntoTheName()
+    {
+        // It belongs on AcceleratorKey; repeating it in the name is what
+        // makes every row long to listen to.
+        var row = Row(title: "Copy to Clipboard", shortcut: "Ctrl+Shift+C");
+        Assert.DoesNotContain("Ctrl", row.Name);
+    }
+
+    [Fact]
+    public void DescriptionIsNotFoldedIntoTheName()
+    {
+        var row = Row(title: "Copy to Clipboard", description: "Copy the selection");
+        Assert.Equal("Copy to Clipboard", row.Name);
+    }
+
+    private static CommandRowAutomation Row(
+        string? title = "Some Command",
+        string? description = null,
+        string? shortcut = null)
+        => CommandRowAutomation.For(title, description, shortcut);
+}

--- a/windows/Ghostty.Tests/Commands/CommandPaletteAutomationTests.cs
+++ b/windows/Ghostty.Tests/Commands/CommandPaletteAutomationTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Ghostty.Core.Accessibility;
+using Xunit;
+
+namespace Ghostty.Tests.Commands;
+
+/// <summary>
+/// The palette's spoken names live in XAML, where no C# type can hold them.
+/// These parse the markup rather than grep it: an attribute is only set if
+/// it is an attribute of the element that needs it, and a substring match
+/// would pass on a name sitting on the wrong element, inside a comment, or
+/// on an element that was since renamed.
+/// </summary>
+public class CommandPaletteAutomationTests
+{
+    private const string Xaml = "Ghostty.Tests.Commands.CommandPaletteControl.xaml";
+    private static readonly XNamespace X = "http://schemas.microsoft.com/winfx/2006/xaml";
+    private static readonly XName AutomationName = "AutomationProperties.Name";
+
+    [Fact]
+    public void Palette_RootIsNamed()
+    {
+        var root = Markup().Root!;
+        Assert.Equal("UserControl", root.Name.LocalName);
+        Assert.Equal("Command palette", (string?)root.Attribute(AutomationName));
+    }
+
+    [Fact]
+    public void SearchBox_IsNamedAndKeepsItsAutomationId()
+    {
+        // x:Name is the AutomationId every mouse-fuzz harness locates the
+        // palette by; renaming it breaks them, and it is not spoken.
+        var box = Named("SearchBox");
+        Assert.Equal("TextBox", box.Name.LocalName);
+        Assert.Equal("Search commands", (string?)box.Attribute(AutomationName));
+        // PlaceholderText is not a substitute: it is not the UIA name, and
+        // it is gone from the visual once the user types.
+        Assert.NotEqual(
+            (string?)box.Attribute("PlaceholderText"),
+            (string?)box.Attribute(AutomationName));
+    }
+
+    [Fact]
+    public void ResultsList_IsNamed()
+    {
+        var list = Named("ResultsList");
+        Assert.Equal("ListView", list.Name.LocalName);
+        Assert.False(string.IsNullOrWhiteSpace((string?)list.Attribute(AutomationName)));
+    }
+
+    [Fact]
+    public void PinButton_IsNamed()
+    {
+        // Its only content is a glyph, so without a name a reader has
+        // nothing but the private-use codepoint to speak.
+        var pin = Named("PinButton");
+        Assert.False(string.IsNullOrWhiteSpace((string?)pin.Attribute(AutomationName)));
+    }
+
+    [Fact]
+    public void ModeLabel_SeedNameMatchesItsSeedText()
+    {
+        // The markup carries the starting mode; code-behind rewrites both
+        // on every mode change. If the two drift, the palette opens
+        // announcing a mode it is not in.
+        var label = Named("ModeLabel");
+        var text = (string?)label.Attribute("Text");
+        Assert.Equal(
+            CommandPaletteAnnouncer.ModeAccessibleName(text),
+            (string?)label.Attribute(AutomationName));
+    }
+
+    [Fact]
+    public void Palette_HasNoSilentLiveRegion()
+    {
+        // A LiveSetting on its own announces nothing: WinUI raises no
+        // automation event when a TextBlock's Text is assigned, so the
+        // live region was dead markup. Status goes through UiaAnnouncer.
+        var withLiveSetting = Markup().Descendants()
+            .Where(e => e.Attribute("AutomationProperties.LiveSetting") is not null)
+            .ToList();
+        Assert.Empty(withLiveSetting);
+        Assert.Null(Markup().Descendants()
+            .FirstOrDefault(e => (string?)e.Attribute(X + "Name") == "LiveAnnouncer"));
+    }
+
+    [Fact]
+    public void CodeBehind_RoutesStatusThroughTheSharedAnnouncer()
+    {
+        var source = ReadEmbedded("CommandPaletteControl.xaml.cs");
+        Assert.Contains("UiaAnnouncer.Announce(SearchBox, text, \"palette-status\")", source);
+        // The dead live region must not come back alongside it.
+        Assert.DoesNotContain("LiveAnnouncer", source);
+    }
+
+    [Fact]
+    public void MainWindow_CapturesTheFocusedSurfaceByWalkingToIt()
+    {
+        // TerminalControl hands focus straight to its ImeSink TextBox, so
+        // the focused element is never the TerminalControl and a cast to
+        // it always yielded null - the palette's focus restore was dead.
+        var terminal = ReadEmbedded("TerminalControl.xaml.cs");
+        Assert.Contains("ImeSink.Focus(FocusState.Programmatic)", terminal);
+
+        var main = ReadEmbedded("MainWindow.xaml.cs");
+        Assert.DoesNotContain("GetFocusedElement(Content.XamlRoot) as Controls.TerminalControl", main);
+        Assert.Contains("_previousFocusSurface = FocusedTerminal();", main);
+        Assert.Contains("if (node is Controls.TerminalControl terminal) return terminal;", main);
+    }
+
+    private static XElement Named(string name) =>
+        Markup().Descendants().Single(e => (string?)e.Attribute(X + "Name") == name);
+
+    private static XDocument Markup()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(Xaml);
+        Assert.NotNull(stream);
+        return XDocument.Load(stream!);
+    }
+
+    private static string ReadEmbedded(string suffix)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var name = asm.GetManifestResourceNames()
+            .Single(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        using var stream = asm.GetManifestResourceStream(name);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty.Tests/Commands/CommandPaletteAutomationTests.cs
+++ b/windows/Ghostty.Tests/Commands/CommandPaletteAutomationTests.cs
@@ -1,32 +1,46 @@
 using System;
-using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
 using Ghostty.Core.Accessibility;
+using Ghostty.Tests.Wiring;
 using Xunit;
 
 namespace Ghostty.Tests.Commands;
 
 /// <summary>
-/// The palette's spoken names live in XAML, where no C# type can hold them.
-/// These parse the markup rather than grep it: an attribute is only set if
-/// it is an attribute of the element that needs it, and a substring match
-/// would pass on a name sitting on the wrong element, inside a comment, or
-/// on an element that was since renamed.
+/// The palette's spoken names live in XAML, where no C# type can hold
+/// them. These parse the markup rather than search it: an attribute is
+/// only set if it is an attribute of the element that needs it, and a
+/// substring match would pass on a name sitting on the wrong element,
+/// inside a comment, or on an element that was since renamed.
 /// </summary>
 public class CommandPaletteAutomationTests
 {
     private const string Xaml = "Ghostty.Tests.Commands.CommandPaletteControl.xaml";
     private static readonly XNamespace X = "http://schemas.microsoft.com/winfx/2006/xaml";
     private static readonly XName AutomationName = "AutomationProperties.Name";
+    private static readonly XName LiveSetting = "AutomationProperties.LiveSetting";
 
     [Fact]
     public void Palette_RootIsNamed()
     {
         var root = Markup().Root!;
         Assert.Equal("UserControl", root.Name.LocalName);
-        Assert.Equal("Command palette", (string?)root.Attribute(AutomationName));
+        Assert.False(string.IsNullOrWhiteSpace((string?)root.Attribute(AutomationName)));
+    }
+
+    [Fact]
+    public void Palette_RootNameIsNotACasingVariantOfTheMenuItem()
+    {
+        // The pane context menu offers "Command Palette", and four fuzz
+        // harnesses invoke it by that name. Find-by-name is case-sensitive
+        // today, so a root named "Command palette" only happens not to
+        // collide; a name that differs by more than casing does not have
+        // to rely on that.
+        var name = (string?)Markup().Root!.Attribute(AutomationName);
+        Assert.NotEqual("Command Palette", name, StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -75,42 +89,42 @@ public class CommandPaletteAutomationTests
     }
 
     [Fact]
-    public void Palette_HasNoSilentLiveRegion()
+    public void StatusLabel_IsTheLiveRegion()
     {
-        // A LiveSetting on its own announces nothing: WinUI raises no
-        // automation event when a TextBlock's Text is assigned, so the
-        // live region was dead markup. Status goes through UiaAnnouncer.
-        var withLiveSetting = Markup().Descendants()
-            .Where(e => e.Attribute("AutomationProperties.LiveSetting") is not null)
-            .ToList();
-        Assert.Empty(withLiveSetting);
-        Assert.Null(Markup().Descendants()
-            .FirstOrDefault(e => (string?)e.Attribute(X + "Name") == "LiveAnnouncer"));
+        // The footer count is the only feedback that a query matched
+        // nothing, and it has to reach a reader whose focus never leaves
+        // the search box.
+        var status = Named("StatusLabel");
+        Assert.Equal("Polite", (string?)status.Attribute(LiveSetting));
     }
 
     [Fact]
-    public void CodeBehind_RoutesStatusThroughTheSharedAnnouncer()
+    public void EveryLiveRegion_HasSomethingRaisingItsChange()
     {
-        var source = ReadEmbedded("CommandPaletteControl.xaml.cs");
-        Assert.Contains("UiaAnnouncer.Announce(SearchBox, text, \"palette-status\")", source);
-        // The dead live region must not come back alongside it.
-        Assert.DoesNotContain("LiveAnnouncer", source);
+        // The defect this replaces: a LiveSetting was declared on a hidden
+        // TextBlock and nothing ever raised LiveRegionChanged for it, so
+        // assigning its text announced precisely nothing. Live regions are
+        // not banned; silent ones are.
+        var code = ShellSource.Load("Controls.CommandPalette.CommandPaletteControl.xaml.cs");
+        var raised = code.Method("PublishStatus")
+            .Calls("UiaAnnouncer.RaiseLiveRegionChanged")
+            .Select(c => c.Arg(0))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var declared = LiveRegions();
+        Assert.NotEmpty(declared);
+        foreach (var element in declared)
+        {
+            var name = (string?)element.Attribute(X + "Name");
+            Assert.False(
+                string.IsNullOrEmpty(name),
+                $"a <{element.Name.LocalName}> declares LiveSetting with no x:Name, so no code can raise it");
+            Assert.Contains(name!, raised);
+        }
     }
 
-    [Fact]
-    public void MainWindow_CapturesTheFocusedSurfaceByWalkingToIt()
-    {
-        // TerminalControl hands focus straight to its ImeSink TextBox, so
-        // the focused element is never the TerminalControl and a cast to
-        // it always yielded null - the palette's focus restore was dead.
-        var terminal = ReadEmbedded("TerminalControl.xaml.cs");
-        Assert.Contains("ImeSink.Focus(FocusState.Programmatic)", terminal);
-
-        var main = ReadEmbedded("MainWindow.xaml.cs");
-        Assert.DoesNotContain("GetFocusedElement(Content.XamlRoot) as Controls.TerminalControl", main);
-        Assert.Contains("_previousFocusSurface = FocusedTerminal();", main);
-        Assert.Contains("if (node is Controls.TerminalControl terminal) return terminal;", main);
-    }
+    private static List<XElement> LiveRegions() =>
+        Markup().Descendants().Where(e => e.Attribute(LiveSetting) is not null).ToList();
 
     private static XElement Named(string name) =>
         Markup().Descendants().Single(e => (string?)e.Attribute(X + "Name") == name);
@@ -121,16 +135,5 @@ public class CommandPaletteAutomationTests
         using var stream = asm.GetManifestResourceStream(Xaml);
         Assert.NotNull(stream);
         return XDocument.Load(stream!);
-    }
-
-    private static string ReadEmbedded(string suffix)
-    {
-        var asm = Assembly.GetExecutingAssembly();
-        var name = asm.GetManifestResourceNames()
-            .Single(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
-        using var stream = asm.GetManifestResourceStream(name);
-        Assert.NotNull(stream);
-        using var reader = new StreamReader(stream!);
-        return reader.ReadToEnd();
     }
 }

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -122,6 +122,14 @@
     <EmbeddedResource Include="..\Ghostty\Controls\Search\SearchBarControl.xaml"
                       Link="Search\SearchBarControl.xaml"
                       LogicalName="Ghostty.Tests.Search.SearchBarControl.xaml" />
+    <!--
+      The palette's XAML, for CommandPaletteAutomationTests. The names it
+      checks are the ones a screen reader speaks; nothing in C# can assert
+      they are still on the elements.
+    -->
+    <EmbeddedResource Include="..\Ghostty\Controls\CommandPalette\CommandPaletteControl.xaml"
+                      Link="Commands\CommandPaletteControl.xaml"
+                      LogicalName="Ghostty.Tests.Commands.CommandPaletteControl.xaml" />
     <EmbeddedResource Include="..\Ghostty\Settings\CheatSheetDialog.xaml"
                       Link="Settings\CheatSheetDialog.xaml"
                       LogicalName="Ghostty.Tests.Settings.CheatSheetDialog.xaml" />

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -37,6 +37,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!--
+      The compiler as a library, for the wiring guards. The WinUI half of
+      the shell cannot be loaded into a test host, so what those tests can
+      reach is its source; parsing it is the difference between asserting
+      the code does something and asserting a string appears somewhere in
+      the file, which a mutation that keeps the string and drops the
+      behaviour walks straight through.
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/windows/Ghostty.Tests/Wiring/CommandPaletteWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CommandPaletteWiringTests.cs
@@ -1,0 +1,210 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The palette's accessibility decisions are unit-tested in
+/// CommandPaletteAnnouncerTests and CommandRowAutomationTests. What those
+/// cannot reach is the wiring: the WinUI half never loads in a test host,
+/// so whether a handler still calls the decision it was handed is only
+/// answerable from the parsed source.
+///
+/// These guard that wiring. They do not prove a screen reader speaks, and
+/// they are not a substitute for the behaviour tests next door.
+/// </summary>
+public class CommandPaletteWiringTests
+{
+    private static ShellSource Palette() =>
+        ShellSource.Load("Controls.CommandPalette.CommandPaletteControl.xaml.cs");
+
+    private static ShellSource MainWindow() => ShellSource.Load("MainWindow.xaml.cs");
+
+    // -- Status announcement ---------------------------------------------
+
+    [Fact]
+    public void StatusChange_IsPublished()
+    {
+        var call = Palette().Case("OnViewModelPropertyChanged", "StatusText").Call("PublishStatus");
+        // Publishing anything other than the announcer's verdict would
+        // either speak on every keystroke or on none of them.
+        Assert.Equal("_announcer.StatusChanged(_vm.StatusText)", call.Arg(0));
+    }
+
+    [Fact]
+    public void PublishStatus_RaisesTheLiveRegionOnTheStatusLabel()
+    {
+        var method = Palette().Method("PublishStatus");
+        Assert.Equal("StatusLabel", method.Call("UiaAnnouncer.RaiseLiveRegionChanged").Arg(0));
+        // It must not go back to a notification from the search box: those
+        // are discarded by the row title raised from there right after.
+        Assert.Empty(method.Calls("UiaAnnouncer.Announce"));
+    }
+
+    [Fact]
+    public void PublishStatus_GuardsOnTheVerdictAndNothingElse()
+    {
+        // The escape this closes: keeping the call and neutering it with a
+        // condition that is never true.
+        var conditions = Palette().Method("PublishStatus").DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .Select(s => s.Condition.ToString())
+            .ToList();
+        Assert.Equal(new[] { "_vm is null", "toSpeak is null" }, conditions);
+    }
+
+    [Fact]
+    public void Open_ArmsTheAnnouncerRatherThanSpeaking()
+    {
+        var section = Palette().Case("OnViewModelPropertyChanged", "IsOpen");
+        Assert.Single(section.Calls("_announcer.Opening"));
+        // Speaking here would land before focus reaches the palette, and
+        // would bank the count so the post-focus one is suppressed.
+        Assert.Empty(section.Calls("PublishStatus"));
+    }
+
+    [Fact]
+    public void FocusSearchBox_SpeaksTheHeldCountAfterFocusLands()
+    {
+        var method = Palette().Method("FocusSearchBox");
+        Assert.Single(method.Calls("SearchBox.Focus"));
+        Assert.Equal("_announcer.Focused(_vm.StatusText)", method.Call("PublishStatus").Arg(0));
+        // In a later turn of the queue, not alongside the focus call: a
+        // reader flushes what it is holding when focus moves.
+        Assert.Single(method.Calls("DispatcherQueue?.TryEnqueue"));
+    }
+
+    [Fact]
+    public void ToggleCommandPalette_MovesFocusIntoThePaletteOnOpen()
+    {
+        // FocusSearchBox is what releases the held count, so an open that
+        // stops calling it is an open that never speaks.
+        Assert.Single(MainWindow().Method("ToggleCommandPalette")
+            .Calls("CommandPaletteUI.FocusSearchBox"));
+    }
+
+    [Fact]
+    public void Announcer_IsPerControl()
+    {
+        // A static announcer would share its already-spoken state across
+        // every window, so opening the palette in a second window would
+        // find the count banked and stay silent.
+        var (_, field) = Palette().Field("_announcer");
+        Assert.DoesNotContain(field.Modifiers, m => m.IsKind(SyntaxKind.StaticKeyword));
+        Assert.Contains(field.Modifiers, m => m.IsKind(SyntaxKind.ReadOnlyKeyword));
+    }
+
+    // -- Mode label ------------------------------------------------------
+
+    [Fact]
+    public void SetModeLabel_WritesBothTheTextAndTheName()
+    {
+        var method = Palette().Method("SetModeLabel");
+        var name = method.Call("AutomationProperties.SetName");
+        Assert.Equal("ModeLabel", name.Arg(0));
+        Assert.Equal("CommandPaletteAnnouncer.ModeAccessibleName(modeLabel)", name.Arg(1));
+        Assert.Contains(
+            method.DescendantNodes().OfType<AssignmentExpressionSyntax>(),
+            a => a.ToString() == "ModeLabel.Text = modeLabel");
+    }
+
+    [Fact]
+    public void ModeChange_GoesThroughSetModeLabel()
+    {
+        // Assigning ModeLabel.Text directly would leave the stale name in
+        // place, which is the original defect.
+        var palette = Palette();
+        Assert.Single(palette.Case("OnViewModelPropertyChanged", "ModeLabel").Calls("SetModeLabel"));
+        Assert.Single(palette.Method("SyncAll").Calls("SetModeLabel"));
+        // And nowhere else may write the text on its own.
+        Assert.Empty(palette.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "ModeLabel.Text"
+                && a.Ancestors().OfType<MethodDeclarationSyntax>()
+                    .All(m => m.Identifier.ValueText != "SetModeLabel")));
+    }
+
+    // -- Row automation --------------------------------------------------
+
+    [Fact]
+    public void EveryRow_IsNamedFromTheRowDecision()
+    {
+        var method = Palette().Method("OnContainerContentChanging");
+        var name = method.Call("AutomationProperties.SetName");
+        Assert.Equal("args.ItemContainer", name.Arg(0));
+        Assert.Equal("row.Name", name.Arg(1));
+        Assert.Single(method.Calls("CommandRowAutomation.For"));
+    }
+
+    [Fact]
+    public void AbsentRowProperties_AreClearedNotBlanked()
+    {
+        var targets = Palette().Method("OnContainerContentChanging")
+            .Calls("SetOrClear").Select(c => c.Arg(1)).ToList();
+        Assert.Equal(
+            new[]
+            {
+                "AutomationProperties.HelpTextProperty",
+                "AutomationProperties.AcceleratorKeyProperty",
+            },
+            targets);
+
+        // And SetOrClear has to actually clear. A recycled container keeps
+        // the previous row's value otherwise.
+        Assert.Single(Palette().Method("SetOrClear").Calls("target.ClearValue"));
+    }
+
+    // -- Focus restore ---------------------------------------------------
+
+    [Fact]
+    public void FocusedTerminal_WalksUpFromTheFocusedElement()
+    {
+        // The focused element is the terminal's IME sink, never the
+        // TerminalControl, so a cast can only ever yield null. The walk is
+        // the fix; a body that just returns null is the regression.
+        var method = MainWindow().Method("FocusedTerminal");
+        Assert.Single(method.Calls("FocusManager.GetFocusedElement"));
+        Assert.Single(method.Calls("VisualTreeHelper.GetParent"));
+        Assert.Single(method.DescendantNodes().OfType<WhileStatementSyntax>());
+        Assert.Contains(
+            method.DescendantNodes().OfType<DeclarationPatternSyntax>(),
+            p => p.Type.ToString() == "Controls.TerminalControl");
+    }
+
+    [Fact]
+    public void PaletteOpen_CapturesTheSurfaceByWalking()
+    {
+        var main = MainWindow();
+        Assert.Single(main.Method("ToggleCommandPalette").Calls("FocusedTerminal"));
+        // No cast anywhere may claim the focused element is a terminal.
+        Assert.Empty(main.Root.DescendantNodes().OfType<BinaryExpressionSyntax>()
+            .Where(b => b.IsKind(SyntaxKind.AsExpression)
+                && b.Right.ToString() == "Controls.TerminalControl"));
+    }
+
+    [Fact]
+    public void RestorePaletteFocus_FocusesTheCapturedSurfaceThenFallsBack()
+    {
+        var method = MainWindow().Method("RestorePaletteFocus");
+        Assert.Single(method.Calls("_previousFocusSurface?.Focus"));
+        Assert.Single(method.Calls("FocusActiveLeaf"));
+        // Deferred: this runs inside the Popup teardown, where WinUI is
+        // still moving focus itself.
+        Assert.Single(method.Calls("DispatcherQueue.TryEnqueue"));
+    }
+
+    [Fact]
+    public void BothClosePaths_GoThroughTheRestore()
+    {
+        // The toggle and the light-dismiss handler. Neither may go back to
+        // poking the captured surface directly, which is how the restore
+        // ends up happening in only one of them.
+        var main = MainWindow();
+        Assert.Equal(2, main.Root.Calls("RestorePaletteFocus").Count);
+        Assert.Empty(main.Root.Calls("_previousFocusSurface?.Focus")
+            .Where(c => c.Ancestors().OfType<MethodDeclarationSyntax>()
+                .All(m => m.Identifier.ValueText != "RestorePaletteFocus")));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/CommandPaletteWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/CommandPaletteWiringTests.cs
@@ -167,10 +167,21 @@ public class CommandPaletteWiringTests
         var method = MainWindow().Method("FocusedTerminal");
         Assert.Single(method.Calls("FocusManager.GetFocusedElement"));
         Assert.Single(method.Calls("VisualTreeHelper.GetParent"));
-        Assert.Single(method.DescendantNodes().OfType<WhileStatementSyntax>());
+        var loop = Assert.Single(method.DescendantNodes().OfType<WhileStatementSyntax>());
         Assert.Contains(
             method.DescendantNodes().OfType<DeclarationPatternSyntax>(),
             p => p.Type.ToString() == "Controls.TerminalControl");
+
+        // Asserting the walk exists is not enough on its own: an
+        // unconditional `return null;` in front of it leaves every check
+        // above satisfied while the walk never runs. Guarding the ones that
+        // are reachable is the whole point, so require that nothing returns
+        // before the loop except from inside a conditional -- which is what
+        // the XamlRoot guard is.
+        var earlyReturns = method.Body!.Statements
+            .TakeWhile(s => s != loop)
+            .OfType<ReturnStatementSyntax>();
+        Assert.Empty(earlyReturns);
     }
 
     [Fact]

--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// One WinUI source file, parsed.
+///
+/// The shell assembly cannot be loaded into a test host, so a test that
+/// wants to know whether a handler still calls something has only the
+/// source to go on. Parsing it rather than searching it is the whole
+/// point: a mutation that keeps a literal and drops the behaviour (an
+/// `if (false && ...)`, a method rewritten to `return null;`) walks
+/// straight through a substring match and changes the syntax tree.
+///
+/// These are wiring guards, not behaviour tests. They prove a call site
+/// is still shaped the way the fix left it. Whether a screen reader then
+/// speaks is only observable on a live UIA tree.
+/// </summary>
+internal sealed class ShellSource
+{
+    private readonly CompilationUnitSyntax _root;
+
+    private ShellSource(CompilationUnitSyntax root) => _root = root;
+
+    /// <summary>
+    /// Load an embedded shell source by its dotted path tail, e.g.
+    /// "Controls.CommandPalette.CommandPaletteControl.xaml.cs".
+    ///
+    /// The tail must include enough directories to be unique: the
+    /// resource names keep the source's folders, and a bare file name
+    /// would start matching two files the day a second MainWindow.xaml.cs
+    /// or TerminalControl.xaml.cs appears somewhere else in the tree.
+    /// </summary>
+    public static ShellSource Load(string dottedTail)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var matches = asm.GetManifestResourceNames()
+            .Where(n => Normalize(n).EndsWith("." + dottedTail, StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            matches.Count == 1,
+            $"expected exactly one embedded source ending in '{dottedTail}', found {matches.Count}: "
+                + string.Join(", ", matches));
+
+        using var stream = asm.GetManifestResourceStream(matches[0])!;
+        using var reader = new StreamReader(stream);
+        var tree = CSharpSyntaxTree.ParseText(reader.ReadToEnd());
+        return new ShellSource((CompilationUnitSyntax)tree.GetRoot());
+    }
+
+    // MSBuild substitutes the host's directory separator into the logical
+    // name, so neither "\" nor "/" can be assumed. Fold both to dots.
+    private static string Normalize(string resourceName) =>
+        resourceName.Replace('\\', '.').Replace('/', '.');
+
+    /// <summary>The whole parsed file.</summary>
+    public SyntaxNode Root => _root;
+
+    /// <summary>The one method with this name in the file.</summary>
+    public MethodDeclarationSyntax Method(string name)
+    {
+        var found = _root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.ValueText == name)
+            .ToList();
+        Assert.True(found.Count == 1, $"expected one method named '{name}', found {found.Count}");
+        return found[0];
+    }
+
+    /// <summary>The one field with this name in the file.</summary>
+    public (VariableDeclaratorSyntax Variable, FieldDeclarationSyntax Field) Field(string name)
+    {
+        var found = _root.DescendantNodes().OfType<FieldDeclarationSyntax>()
+            .SelectMany(f => f.Declaration.Variables.Select(v => (Variable: v, Field: f)))
+            .Where(x => x.Variable.Identifier.ValueText == name)
+            .ToList();
+        Assert.True(found.Count == 1, $"expected one field named '{name}', found {found.Count}");
+        return found[0];
+    }
+
+    /// <summary>
+    /// The switch section inside <paramref name="method"/> whose labels
+    /// mention <paramref name="label"/>.
+    /// </summary>
+    public SwitchSectionSyntax Case(string method, string label)
+    {
+        var found = Method(method).DescendantNodes().OfType<SwitchSectionSyntax>()
+            .Where(s => s.Labels.ToString().Contains(label, StringComparison.Ordinal))
+            .ToList();
+        Assert.True(found.Count == 1, $"expected one '{label}' case in {method}, found {found.Count}");
+        return found[0];
+    }
+}
+
+internal static class SyntaxQueries
+{
+    /// <summary>
+    /// Every call to <paramref name="target"/> under <paramref name="node"/>,
+    /// matched on the parsed callee expression rather than on text: a call
+    /// that is present only inside a comment or a string is not one.
+    /// </summary>
+    public static List<InvocationExpressionSyntax> Calls(this SyntaxNode node, string target) =>
+        node.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => Callee(i) == target)
+            .ToList();
+
+    // A null-conditional call parses with the receiver hoisted out, so the
+    // callee on its own reads as ".TryEnqueue". Put the receiver back so a
+    // test can name the call the way the source spells it.
+    private static string Callee(InvocationExpressionSyntax call)
+    {
+        if (call.Expression is MemberBindingExpressionSyntax
+            && call.Ancestors().OfType<ConditionalAccessExpressionSyntax>().FirstOrDefault() is { } conditional)
+        {
+            return conditional.Expression + "?" + call.Expression;
+        }
+        return call.Expression.ToString();
+    }
+
+    /// <summary>The one call to <paramref name="target"/>.</summary>
+    public static InvocationExpressionSyntax Call(this SyntaxNode node, string target)
+    {
+        var found = node.Calls(target);
+        Assert.True(found.Count == 1, $"expected one call to '{target}', found {found.Count}");
+        return found[0];
+    }
+
+    /// <summary>The literal source of one argument of a call.</summary>
+    public static string Arg(this InvocationExpressionSyntax call, int index)
+    {
+        Assert.True(
+            call.ArgumentList.Arguments.Count > index,
+            $"'{call.Expression}' has {call.ArgumentList.Arguments.Count} arguments, wanted index {index}");
+        return call.ArgumentList.Arguments[index].ToString();
+    }
+}

--- a/windows/Ghostty/Accessibility/UiaAnnouncer.cs
+++ b/windows/Ghostty/Accessibility/UiaAnnouncer.cs
@@ -38,6 +38,32 @@ internal static class UiaAnnouncer
     }
 
     /// <summary>
+    /// Re-read <paramref name="source"/> as a live region.
+    ///
+    /// Declaring AutomationProperties.LiveSetting on an element announces
+    /// nothing on its own: WinUI raises no automation event when the text
+    /// under it is assigned, so the client is never told to look again.
+    /// This is the missing half.
+    ///
+    /// Separate from <see cref="Announce"/> on purpose. Notifications are
+    /// queued per source element and MostRecent discards the ones still
+    /// pending from that element, so state raised alongside a stream of
+    /// notifications from the same place loses every race. A live region
+    /// is a different element and a different event class, so the two
+    /// coexist instead of overwriting each other.
+    /// </summary>
+    internal static void RaiseLiveRegionChanged(FrameworkElement? source)
+    {
+        if (source is null) return;
+        if (!AnyoneListening()) return;
+
+        var peer = FrameworkElementAutomationPeer.FromElement(source)
+            ?? FrameworkElementAutomationPeer.CreatePeerForElement(source)
+            ?? new FrameworkElementAutomationPeer(source);
+        peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+    }
+
+    /// <summary>
     /// Whether anything is listening. Gated like TerminalAutomationPeer's
     /// raises: crossing the UIA boundary with nobody advised is work for
     /// nothing. There is no AutomationEvents.Notification to ask

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
@@ -23,7 +23,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:Ghostty.Converters"
-    AutomationProperties.Name="Command palette"
+    AutomationProperties.Name="Command palette overlay"
     Width="560"
     HorizontalAlignment="Center"
     VerticalAlignment="Top">
@@ -307,9 +307,19 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <!-- Status text: "N commands" / "N actions" -->
+                <!--
+                    Status text: "N commands" / "N actions". Also the
+                    palette's live region: it is the only feedback that a
+                    query matched nothing, and the palette never moves
+                    focus off the search box, so a reader that speaks only
+                    what it is focused on would never reach it. Polite so
+                    it lands after the row title rather than cutting it
+                    off. Code-behind raises the change; a LiveSetting on
+                    its own is silent.
+                -->
                 <TextBlock x:Name="StatusLabel"
                            Grid.Column="0"
+                           AutomationProperties.LiveSetting="Polite"
                            FontSize="{StaticResource CaptionTextBlockFontSize}"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            VerticalAlignment="Center"/>
@@ -322,15 +332,6 @@
                            VerticalAlignment="Center"
                            Text="↑↓ navigate   ↵ run   Esc close"/>
             </Grid>
-
-            <!--
-                There is deliberately no hidden live-region TextBlock here.
-                A LiveSetting alone announces nothing: the change has to be
-                pushed as a UIA event, and a zero-size zero-opacity element
-                is a poor thing to push one from. Status goes through
-                UiaAnnouncer from the focused search box instead, which is
-                the one mechanism the rest of the app already uses.
-            -->
         </Grid>
     </Border>
 </UserControl>

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml
@@ -23,6 +23,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:Ghostty.Converters"
+    AutomationProperties.Name="Command palette"
     Width="560"
     HorizontalAlignment="Center"
     VerticalAlignment="Top">
@@ -222,13 +223,15 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <!-- Mode label: "Search" or "Command". Accessible name is
-                     distinct so it cannot steal UIA Find-Name from a command
-                     titled Search. -->
+                <!-- Mode label: "Search" or "Command". The accessible name
+                     carries the mode and stays distinct from a bare mode
+                     word, so it cannot steal UIA Find-Name from a command
+                     titled Search. Code-behind keeps it in step with Text;
+                     see CommandPaletteAnnouncer.ModeAccessibleName. -->
                 <TextBlock x:Name="ModeLabel"
                            Grid.Column="0"
                            Text="Search"
-                           AutomationProperties.Name="Palette mode"
+                           AutomationProperties.Name="Search mode"
                            FontSize="{StaticResource CaptionTextBlockFontSize}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            VerticalAlignment="Center"/>
@@ -240,6 +243,7 @@
                               Padding="0"
                               Background="Transparent"
                               BorderThickness="0"
+                              AutomationProperties.Name="Keep palette open"
                               ToolTipService.ToolTip="Keep open after executing a command (Pin)"
                               Checked="OnPinChecked"
                               Unchecked="OnPinUnchecked">
@@ -250,11 +254,15 @@
                 </ToggleButton>
             </Grid>
 
-            <!-- ── Row 1: Search box ── -->
+            <!-- ── Row 1: Search box ──
+                 PlaceholderText is not the UIA name: it is spoken only as
+                 help text by some readers and by none once the box has
+                 content, so the box needs a name of its own. -->
             <TextBox x:Name="SearchBox"
                      Grid.Row="1"
                      Margin="8,0"
                      Padding="8,10"
+                     AutomationProperties.Name="Search commands"
                      PlaceholderText="Search commands or type &gt; for actions..."
                      Background="Transparent"
                      BorderThickness="0"
@@ -272,6 +280,7 @@
             <!-- ── Row 3: Results list ── -->
             <ListView x:Name="ResultsList"
                       Grid.Row="3"
+                      AutomationProperties.Name="Command results"
                       MaxHeight="320"
                       SelectionMode="Single"
                       IsItemClickEnabled="True"
@@ -315,20 +324,13 @@
             </Grid>
 
             <!--
-                Hidden live region for screen-reader announcements.
-                Sits outside the visual layout at z-order 0 with
-                Width/Height=0 so it consumes no space.
-                AutomationProperties.LiveSetting=Polite ensures
-                changes are announced after the user finishes their
-                current interaction, not immediately (which would be
-                Assertive).
+                There is deliberately no hidden live-region TextBlock here.
+                A LiveSetting alone announces nothing: the change has to be
+                pushed as a UIA event, and a zero-size zero-opacity element
+                is a poor thing to push one from. Status goes through
+                UiaAnnouncer from the focused search box instead, which is
+                the one mechanism the rest of the app already uses.
             -->
-            <TextBlock x:Name="LiveAnnouncer"
-                       Grid.Row="0" Grid.RowSpan="6"
-                       Width="0" Height="0"
-                       Opacity="0"
-                       IsHitTestVisible="False"
-                       AutomationProperties.LiveSetting="Polite"/>
         </Grid>
     </Border>
 </UserControl>

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -59,6 +59,7 @@ internal sealed partial class CommandPaletteControl : UserControl
     public CommandPaletteControl()
     {
         InitializeComponent();
+        LinkSearchBoxToResults();
         // Configure() runs during MainWindow init, before this control
         // is in the visual tree. Parent-walk to the Popup may not
         // resolve yet, so re-apply on Loaded to guarantee the Popup's
@@ -68,6 +69,13 @@ internal sealed partial class CommandPaletteControl : UserControl
     }
 
     private void OnPaletteLoaded(object sender, RoutedEventArgs e) => ApplyTheme();
+
+    // Up/Down are handled in OnSearchKeyDown and marked handled, so focus
+    // never leaves the search box while the user walks the list. That is
+    // the case ControlledPeers exists for: it tells a reader which element
+    // the box it is sitting in drives, so the list is reachable at all.
+    private void LinkSearchBoxToResults() =>
+        AutomationProperties.GetControlledPeers(SearchBox).Add(ResultsList);
 
     // ── Public API ────────────────────────────────────────────────────────────
 
@@ -169,6 +177,18 @@ internal sealed partial class CommandPaletteControl : UserControl
     public void FocusSearchBox()
     {
         SearchBox.Focus(FocusState.Programmatic);
+
+        // The result count is published only now, and in a follow-up turn
+        // of the queue rather than alongside the focus call. Everything
+        // the view model raises while opening is already queued ahead of
+        // this, and a reader flushes what it is holding when focus moves,
+        // so a count published any earlier is a count published into the
+        // gap. Focused() is what holds it back until here.
+        DispatcherQueue?.TryEnqueue(() =>
+        {
+            if (_vm is null) return;
+            PublishStatus(_announcer.Focused(_vm.StatusText));
+        });
     }
 
     /// <summary>
@@ -228,16 +248,12 @@ internal sealed partial class CommandPaletteControl : UserControl
             switch (e.PropertyName)
             {
                 case nameof(CommandPaletteViewModel.IsOpen):
-                    // Announce on open rather than waiting for StatusText:
-                    // reopening on the count it closed on raises nothing,
-                    // because the ViewModel suppresses same-value changes,
-                    // and the user would land in a palette that never said
-                    // how much it was offering.
-                    if (_vm.IsOpen)
-                    {
-                        _announcer.Reset();
-                        AnnounceStatus(_vm.StatusText);
-                    }
+                    // Arm the announcer before any of the counts this open
+                    // is about to raise reach it. Reopening on the count it
+                    // closed on raises no StatusText at all, because the
+                    // view model suppresses same-value changes, so the open
+                    // itself has to be what speaks.
+                    if (_vm.IsOpen) _announcer.Opening();
                     break;
 
                 case nameof(CommandPaletteViewModel.ModeLabel):
@@ -265,22 +281,28 @@ internal sealed partial class CommandPaletteControl : UserControl
                     break;
 
                 case nameof(CommandPaletteViewModel.StatusText):
-                    StatusLabel.Text = _vm.StatusText;
-                    AnnounceStatus(_vm.StatusText);
+                    PublishStatus(_announcer.StatusChanged(_vm.StatusText));
                     break;
             }
         });
     }
 
-    // The footer count is the only feedback that a query matched nothing,
-    // and the palette never moves focus off the search box, so a reader
-    // that only speaks what it is focused on would never reach it. Raise
-    // it from the search box for the same reason the bell announcement
-    // rides the focused element: that is where a reader is listening.
-    private void AnnounceStatus(string statusText)
+    // Put the current count on screen, and speak it when the announcer
+    // says this one is worth speaking.
+    //
+    // The count rides the footer label as a live region rather than a
+    // notification from the search box. Notifications are queued per
+    // source element and MostRecent discards whatever is still pending
+    // from that element, so a count raised from the search box is
+    // discarded by the row title raised from the search box immediately
+    // after it - which is every keystroke. A live region is a different
+    // element and a different event class, so the two stop colliding.
+    private void PublishStatus(string? toSpeak)
     {
-        if (_announcer.StatusChanged(statusText) is { } text)
-            UiaAnnouncer.Announce(SearchBox, text, "palette-status");
+        if (_vm is null) return;
+        StatusLabel.Text = _vm.StatusText;
+        if (toSpeak is null) return;
+        UiaAnnouncer.RaiseLiveRegionChanged(StatusLabel);
     }
 
     // Keep the spoken name in step with the visible text. An explicit
@@ -375,37 +397,17 @@ internal sealed partial class CommandPaletteControl : UserControl
     {
         if (args.Item is not CommandItem item) return;
 
-        // Name the container before anything below can bail out. Without this
-        // the row's UIA name falls back to CommandItem.ToString(), so a screen
-        // reader announces the whole record - id, description, category, the
-        // Execute delegate - for every command in the list, and any automation
-        // client looking a command up by name finds nothing.
-        AutomationProperties.SetName(args.ItemContainer, item.Title);
-        // Clear rather than skip when there is no description. Containers are
-        // recycled - SyncFilteredCommands clears and refills the list on every
-        // keystroke - and a local value set on one item outlives it, so a row
-        // with no description would keep reading the previous row's. Name is
-        // safe because it is written unconditionally; HelpText was not.
-        // ClearValue, not an empty string: UIA reports "" as present-but-blank.
-        if (!string.IsNullOrEmpty(item.Description))
-        {
-            AutomationProperties.SetHelpText(args.ItemContainer, item.Description);
-        }
-        else
-        {
-            args.ItemContainer.ClearValue(AutomationProperties.HelpTextProperty);
-        }
-        // The key-cap is rendered in the last column, so a sighted user can see
-        // the command is bound. AcceleratorKey is the property Narrator reads
-        // for that; folding it into the name would just make every row longer.
-        if (item.Shortcut is { } binding)
-        {
-            AutomationProperties.SetAcceleratorKey(args.ItemContainer, FormatKeyBinding(binding));
-        }
-        else
-        {
-            args.ItemContainer.ClearValue(AutomationProperties.AcceleratorKeyProperty);
-        }
+        // Name the container before anything below can bail out; the
+        // decision of what each property should hold (and which of them
+        // are absent for this item) is CommandRowAutomation's.
+        var row = CommandRowAutomation.For(
+            item.Title,
+            item.Description,
+            item.Shortcut is { } binding ? FormatKeyBinding(binding) : null);
+
+        AutomationProperties.SetName(args.ItemContainer, row.Name);
+        SetOrClear(args.ItemContainer, AutomationProperties.HelpTextProperty, row.HelpText);
+        SetOrClear(args.ItemContainer, AutomationProperties.AcceleratorKeyProperty, row.AcceleratorKey);
 
         // Phase 0 fires synchronously during measure; grab the template root.
         // Children are indexed by column order in the DataTemplate:
@@ -485,6 +487,19 @@ internal sealed partial class CommandPaletteControl : UserControl
                 shortcutBorder.Visibility = Visibility.Collapsed;
             }
         }
+    }
+
+    // Containers are recycled - SyncFilteredCommands clears and refills the
+    // list on every keystroke - and a local value set for one item outlives
+    // it, so an absent value has to be cleared rather than blanked: UIA
+    // reports an empty string as present-but-blank, which leaves the next
+    // row reading the previous row's text.
+    private static void SetOrClear(DependencyObject target, DependencyProperty property, string? value)
+    {
+        if (value is null)
+            target.ClearValue(property);
+        else
+            target.SetValue(property, value);
     }
 
     // ── UI → ViewModel ────────────────────────────────────────────────────────

--- a/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
+++ b/windows/Ghostty/Controls/CommandPalette/CommandPaletteControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.ComponentModel;
 using Ghostty.Accessibility;
 using Ghostty.Commands;
+using Ghostty.Core.Accessibility;
 using Ghostty.Core.Config;
 using Ghostty.Core.Windows;
 using Ghostty.Services;
@@ -49,6 +50,11 @@ internal sealed partial class CommandPaletteControl : UserControl
     // chrome (#236). Created in Configure() and disposed on Unloaded.
     // Null until Configure runs, which happens once during MainWindow init.
     private WindowThemeManager? _themeManager;
+
+    // Decides the mode label's accessible name and which result counts are
+    // worth speaking. Stateful across keystrokes (it suppresses repeats),
+    // so it lives with the control rather than being created per update.
+    private readonly CommandPaletteAnnouncer _announcer = new();
 
     public CommandPaletteControl()
     {
@@ -221,8 +227,21 @@ internal sealed partial class CommandPaletteControl : UserControl
 
             switch (e.PropertyName)
             {
+                case nameof(CommandPaletteViewModel.IsOpen):
+                    // Announce on open rather than waiting for StatusText:
+                    // reopening on the count it closed on raises nothing,
+                    // because the ViewModel suppresses same-value changes,
+                    // and the user would land in a palette that never said
+                    // how much it was offering.
+                    if (_vm.IsOpen)
+                    {
+                        _announcer.Reset();
+                        AnnounceStatus(_vm.StatusText);
+                    }
+                    break;
+
                 case nameof(CommandPaletteViewModel.ModeLabel):
-                    ModeLabel.Text = _vm.ModeLabel;
+                    SetModeLabel(_vm.ModeLabel);
                     UpdateFooterHints();
                     break;
 
@@ -247,17 +266,39 @@ internal sealed partial class CommandPaletteControl : UserControl
 
                 case nameof(CommandPaletteViewModel.StatusText):
                     StatusLabel.Text = _vm.StatusText;
-                    LiveAnnouncer.Text = _vm.StatusText;
+                    AnnounceStatus(_vm.StatusText);
                     break;
             }
         });
+    }
+
+    // The footer count is the only feedback that a query matched nothing,
+    // and the palette never moves focus off the search box, so a reader
+    // that only speaks what it is focused on would never reach it. Raise
+    // it from the search box for the same reason the bell announcement
+    // rides the focused element: that is where a reader is listening.
+    private void AnnounceStatus(string statusText)
+    {
+        if (_announcer.StatusChanged(statusText) is { } text)
+            UiaAnnouncer.Announce(SearchBox, text, "palette-status");
+    }
+
+    // Keep the spoken name in step with the visible text. An explicit
+    // AutomationProperties.Name replaces the text a reader would derive
+    // from the TextBlock, so leaving a fixed name here reads the field and
+    // never the mode.
+    private void SetModeLabel(string modeLabel)
+    {
+        ModeLabel.Text = modeLabel;
+        AutomationProperties.SetName(
+            ModeLabel, CommandPaletteAnnouncer.ModeAccessibleName(modeLabel));
     }
 
     private void SyncAll()
     {
         if (_vm is null) return;
 
-        ModeLabel.Text = _vm.ModeLabel;
+        SetModeLabel(_vm.ModeLabel);
         PinButton.IsChecked = _vm.IsPinned;
         SearchBox.Text = _vm.SearchText;
         StatusLabel.Text = _vm.StatusText;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -3354,17 +3354,29 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Hand focus back to whichever surface the palette was opened from.
-    /// Falls back to the active leaf when that surface is gone (a palette
-    /// command can close the very pane it was opened over) or was never
-    /// captured, because leaving focus on a dismissed popup strands a
-    /// keyboard user with nowhere to type.
+    /// Hand focus back to whichever surface the palette was opened from,
+    /// because leaving it on a dismissed popup strands a keyboard user
+    /// with nowhere to type.
+    ///
+    /// Deferred rather than immediate: this runs inside the Popup's own
+    /// teardown, where WinUI is still moving focus itself, so a
+    /// synchronous call here is one the framework can overwrite on its
+    /// way out. The fallback already went through the queue; the primary
+    /// path has to take the same turn or the two disagree about when they
+    /// happen.
+    ///
+    /// The fallback covers a palette opened while focus sat outside any
+    /// terminal, and a captured surface that will no longer take focus.
+    /// Executing a command does not arrive here at all: that path
+    /// early-returns out of Popup.Closed on the close state, and the
+    /// command itself decides where focus belongs.
     /// </summary>
-    private void RestorePaletteFocus()
-    {
-        if (_previousFocusSurface?.Focus(FocusState.Programmatic) == true) return;
-        FocusActiveLeaf();
-    }
+    private void RestorePaletteFocus() =>
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_previousFocusSurface?.Focus(FocusState.Programmatic) == true) return;
+            FocusActiveLeaf();
+        });
 
     private void ToggleCommandPalette()
     {

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -815,7 +815,7 @@ public sealed partial class MainWindow : Window
                 _commandPaletteVm.Close();
                 SetCommandPaletteOpenOnAllTerminals(false);
                 if (wasOpen)
-                    _previousFocusSurface?.Focus(FocusState.Programmatic);
+                    RestorePaletteFocus();
             }
             finally
             {
@@ -3329,6 +3329,43 @@ public sealed partial class MainWindow : Window
         FocusActiveLeaf();
     }
 
+    /// <summary>
+    /// The terminal that owns keyboard focus, or null when focus is
+    /// elsewhere in the window.
+    ///
+    /// FocusManager reports the innermost focused element, which is never
+    /// the TerminalControl: its GotFocus handler immediately hands focus
+    /// on to the zero-size ImeSink TextBox so WinUI will surface IME
+    /// composition (a UserControl never does). A direct cast to
+    /// TerminalControl therefore always yielded null, which is why the
+    /// palette's focus restore did nothing at all. Walk up to the owning
+    /// surface instead, the way SearchBarControl.ContainsFocus does.
+    /// </summary>
+    private Controls.TerminalControl? FocusedTerminal()
+    {
+        if (Content?.XamlRoot is null) return null;
+        var node = FocusManager.GetFocusedElement(Content.XamlRoot) as DependencyObject;
+        while (node is not null)
+        {
+            if (node is Controls.TerminalControl terminal) return terminal;
+            node = VisualTreeHelper.GetParent(node);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Hand focus back to whichever surface the palette was opened from.
+    /// Falls back to the active leaf when that surface is gone (a palette
+    /// command can close the very pane it was opened over) or was never
+    /// captured, because leaving focus on a dismissed popup strands a
+    /// keyboard user with nowhere to type.
+    /// </summary>
+    private void RestorePaletteFocus()
+    {
+        if (_previousFocusSurface?.Focus(FocusState.Programmatic) == true) return;
+        FocusActiveLeaf();
+    }
+
     private void ToggleCommandPalette()
     {
         if (_commandPaletteVm is not { } vm) return;
@@ -3341,13 +3378,13 @@ public sealed partial class MainWindow : Window
                 vm.Close();
                 CommandPalettePopup.IsOpen = false;
                 SetCommandPaletteOpenOnAllTerminals(false);
-                _previousFocusSurface?.Focus(FocusState.Programmatic);
+                RestorePaletteFocus();
             }
             finally { _paletteCloseState = PaletteCloseState.Idle; }
         }
         else
         {
-            _previousFocusSurface = FocusManager.GetFocusedElement(Content.XamlRoot) as Controls.TerminalControl;
+            _previousFocusSurface = FocusedTerminal();
 
             var windowWidth = AppWindow.Size.Width;
             var paletteWidth = Math.Min(600, windowWidth * 0.9);


### PR DESCRIPTION
Naming the palette rows left four gaps around them.

**The mode label announced its own label.** It carried an explicit `AutomationProperties.Name`, and an explicit name replaces the one a reader derives from the text, so it always said "Palette mode" and never which mode. The name now carries the value ("Search mode" / "Command mode"), not the bare mode word, which would collide with a command actually titled "Search".

**Focus restore was dead.** It captured the focused element and cast it to `TerminalControl`, but the terminal moves focus to a hidden 1x1 `TextBox` to surface IME composition, so the cast always yielded null and both restore sites were no-ops. It now walks up the visual tree to the owning terminal, and falls back to the active leaf when the palette command closed the very pane the palette was opened over.

**The status live region never announced.** `LiveSetting` only declares how to announce; something has to raise the event, and assigning `Text` raises nothing. Status now goes through the existing `UiaAnnouncer` from the search box, where focus actually sits, with repeat suppression so an unchanged count is not re-spoken on every keystroke. The dead `LiveAnnouncer` element is gone.

**Nothing in the palette was named.** The root, search box, results list and pin button now have names. Every `x:Name` is unchanged, so the `SearchBox` AutomationId that the fuzz harnesses locate by still resolves.

## Verified

`Ghostty.Tests` 2215 passed, `Ghostty.Tests.Windows` 28 passed. The automation test parses the XAML with `XDocument` rather than scanning it as text, so a name on the wrong element or inside a comment cannot pass it. Reverting the mode name and the focus cast turns it red.

## Not verified

No screen reader was run. This claims the events are raised and the names are set, not that a given reader voices them a given way. The focus walk needs a live focus tree, so it has no unit test.