### PR TITLE
windows: verify the search fuzz corpus actually landed

### DIFF
--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -91,9 +91,11 @@ work leaned on.
 `just fuzz-selftest` runs the suite's own runner against fixtures in
 `lib/fuzz-selftest/` that exit 0, 1, 2 and 3 on purpose, plus one that
 throws, one that throws `PRODUCT_FAIL` from inside a `try`/`finally`, one
-that fails once and then works, and one that hangs forever. It asserts the
-verdict *and* the attempt count for each. It takes about a minute, needs no
-build or desktop, and is safe to run with Wintty open.
+that fails once and then works, one that hangs forever, and one that
+classifies its own failure to establish a corpus as the retryable 1 rather
+than a finding. It asserts the verdict *and* the attempt count for each. It
+takes about a minute, needs no build or desktop, and is safe to run with
+Wintty open.
 
 Two details make it worth trusting rather than just running:
 
@@ -244,6 +246,12 @@ and note two prerequisites:
 2. A foreground guard on every send. A bare `SetForegroundWindow` loses to any
    app that repaints often; attach to the current foreground thread's input
    queue first, then set foreground, bring to top and set focus.
+3. Nothing typed in the moment after XAML hands focus over. Closing the search
+   bar returns focus to the terminal asynchronously, and the first character
+   after it lands nowhere - `search-fuzz.ps1` typed `$a='ZQ'+'XW'; ...` after
+   an Escape and the shell received it without the `$`. Wait for the handoff,
+   spend a sacrificial first character, and read back what landed. The
+   foreground guard does not cover this: the foreground was never lost.
 
 Do not sniff the shell prompt to decide the shell is ready - a themed prompt
 looks nothing like `PS >`. Ask it instead, and wait for the answer to appear

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -177,6 +177,7 @@ $SelfTestHarnesses = @(
     [ordered]@{ name = 'st-no-outdir';  script = 'lib/fuzz-selftest/no-outdir.ps1';  tags = @('selftest'); outDir = $false; seed = $true;  minutes = 0; oracle = 'fixture' }
     [ordered]@{ name = 'st-product-throw'; script = 'lib/fuzz-selftest/product-throw.ps1'; tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
     [ordered]@{ name = 'st-unknown-code';  script = 'lib/fuzz-selftest/unknown-code.ps1';  tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-seed-unverified'; script = 'lib/fuzz-selftest/seed-unverified.ps1'; tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
     # Deliberately short budget: the point is the runaway guard, not the wait.
     [ordered]@{ name = 'st-hangs';         script = 'lib/fuzz-selftest/hangs.ps1';         tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; timeoutSeconds = 2; oracle = 'fixture' }
 )
@@ -545,6 +546,7 @@ if ($SelfTest) {
         @{ name = 'st-product-throw'; verdict = 'findings'; attempts = 1; why = 'a thrown PRODUCT_FAIL leaves with 2, not the retryable 1' }
         @{ name = 'st-unknown-code'; verdict = 'error';    attempts = 1; why = 'an exit code outside the convention is not a pass' }
         @{ name = 'st-hangs';      verdict = 'harness';  attempts = 2; why = 'a wedged harness is killed at its budget and treated as retryable' }
+        @{ name = 'st-seed-unverified'; verdict = 'harness'; attempts = 2; why = 'a harness that could not establish its own corpus leaves with 1, not the never-retried 2' }
     )
     $bad = @()
     # One row per harness and nothing else. A harness's console output
@@ -565,9 +567,10 @@ if ($SelfTest) {
     }
     # The aggregate matters as much as the rows, and it is checked by calling
     # the same Get-SuiteOutcome the real run exits on - not by re-deriving it
-    # here. This fixture set holds two findings, four that could not run (an
-    # exit code outside the convention, and one that had to be killed) and
-    # three passes, so every branch of the roll-up has a witness.
+    # here. This fixture set holds two findings, five that could not run (an
+    # exit code outside the convention, one that had to be killed, and one
+    # that classified its own failure as retryable) and three passes, so
+    # every branch of the roll-up has a witness.
     $outcome = Get-SuiteOutcome -Rows $rows -SelectedCount $selected.Count
     if ($outcome.exit -ne 2) {
         $bad += "aggregate exit is $($outcome.exit), expected 2 (findings outrank harness failures)"
@@ -582,8 +585,17 @@ if ($SelfTest) {
     if (-not (Test-Path (Join-Path $ptDir 'finally-ran.txt'))) {
         $bad += 'st-product-throw exited 2 without running its finally, so a real harness would leak its config dir and its window'
     }
-    if ($outcome.broken.Count -ne 4) {
-        $bad += "roll-up counted $($outcome.broken.Count) harness failures, expected 4"
+    if ($outcome.broken.Count -ne 5) {
+        $bad += "roll-up counted $($outcome.broken.Count) harness failures, expected 5"
+    }
+
+    # Same reason as st-product-throw: the verdict must not cost the cleanup.
+    # A seeding failure aborts a real run from the middle of its op loop, and
+    # that is exactly when leaving the app up would make the next harness
+    # refuse to start.
+    $suDir = Join-Path $OutRoot 'st-seed-unverified'
+    if (-not (Test-Path (Join-Path $suDir 'finally-ran.txt'))) {
+        $bad += 'st-seed-unverified exited without running its finally, so a real harness would leave its window up'
     }
     if ($outcome.notRun -ne 0) {
         $bad += "roll-up counted $($outcome.notRun) not reached, expected 0"

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -28,11 +28,17 @@
     until it passes is how a regression gets buried.
 
     That split only works because each harness leaves with the right code.
-    They signal defects by throwing, and an unhandled throw makes pwsh return
-    1, so every one of them opens with a trap that maps a PRODUCT_FAIL throw
-    to 2 and lets anything else through as 1. HARVEST_MISS and
-    FOREGROUND_MISS stay 1 on purpose: a refused click is usually another app
-    taking the foreground, not a defect.
+    Most signal defects by throwing, and an unhandled throw makes pwsh return
+    1, so they open with a trap that maps a PRODUCT_FAIL throw to 2 and lets
+    anything else through as 1. HARVEST_MISS and FOREGROUND_MISS stay 1 on
+    purpose: a refused click is usually another app taking the foreground,
+    not a defect.
+
+    search-fuzz.ps1 reaches the same split the other way, and the difference
+    matters when reading its exits: it records findings with a kind, and its
+    tail exits 2 when any finding is not a harness one, 1 when they all are.
+    A harness that cannot establish the corpus its oracle measures against
+    leaves with 1 through that path, not 2.
 
     Each harness also gets a wall-clock budget - four times its manifest
     estimate, floor three minutes - after which it is killed and recorded as
@@ -178,6 +184,7 @@ $SelfTestHarnesses = @(
     [ordered]@{ name = 'st-product-throw'; script = 'lib/fuzz-selftest/product-throw.ps1'; tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
     [ordered]@{ name = 'st-unknown-code';  script = 'lib/fuzz-selftest/unknown-code.ps1';  tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
     [ordered]@{ name = 'st-seed-unverified'; script = 'lib/fuzz-selftest/seed-unverified.ps1'; tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
+    [ordered]@{ name = 'st-seed-readback'; script = 'lib/fuzz-selftest/seed-readback-cases.ps1'; tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; oracle = 'fixture' }
     # Deliberately short budget: the point is the runaway guard, not the wait.
     [ordered]@{ name = 'st-hangs';         script = 'lib/fuzz-selftest/hangs.ps1';         tags = @('selftest'); outDir = $true; seed = $false; minutes = 0; timeoutSeconds = 2; oracle = 'fixture' }
 )
@@ -547,6 +554,7 @@ if ($SelfTest) {
         @{ name = 'st-unknown-code'; verdict = 'error';    attempts = 1; why = 'an exit code outside the convention is not a pass' }
         @{ name = 'st-hangs';      verdict = 'harness';  attempts = 2; why = 'a wedged harness is killed at its budget and treated as retryable' }
         @{ name = 'st-seed-unverified'; verdict = 'harness'; attempts = 2; why = 'a harness that could not establish its own corpus leaves with 1, not the never-retried 2' }
+        @{ name = 'st-seed-readback'; verdict = 'pass'; attempts = 1; why = 'the seed read-back rules decide whether a run has a real corpus, so they are exercised rather than assumed' }
     )
     $bad = @()
     # One row per harness and nothing else. A harness's console output
@@ -569,7 +577,7 @@ if ($SelfTest) {
     # the same Get-SuiteOutcome the real run exits on - not by re-deriving it
     # here. This fixture set holds two findings, five that could not run (an
     # exit code outside the convention, one that had to be killed, and one
-    # that classified its own failure as retryable) and three passes, so
+    # that classified its own failure as retryable) and four passes, so
     # every branch of the roll-up has a witness.
     $outcome = Get-SuiteOutcome -Rows $rows -SelectedCount $selected.Count
     if ($outcome.exit -ne 2) {

--- a/windows/scripts/lib/fuzz-selftest/README.md
+++ b/windows/scripts/lib/fuzz-selftest/README.md
@@ -15,6 +15,7 @@ needs no build, no window and no interactive desktop.
 | `product-throw.ps1` | a thrown `PRODUCT_FAIL` leaves with 2 *and* still runs its `finally` |
 | `unknown-code.ps1` | an exit code outside the convention is not a pass |
 | `hangs.ps1` | a wedged harness is killed at its budget rather than hanging the run |
+| `seed-unverified.ps1` | a harness that could not establish its own corpus leaves with 1 out of a catch and a classification, and still runs its `finally` |
 
 Most take `-ExePath` and `-OutDir` like a real harness; `no-outdir.ps1`
 deliberately takes `-Seed` and no `-OutDir`, which is the point of it.

--- a/windows/scripts/lib/fuzz-selftest/README.md
+++ b/windows/scripts/lib/fuzz-selftest/README.md
@@ -16,6 +16,7 @@ needs no build, no window and no interactive desktop.
 | `unknown-code.ps1` | an exit code outside the convention is not a pass |
 | `hangs.ps1` | a wedged harness is killed at its budget rather than hanging the run |
 | `seed-unverified.ps1` | a harness that could not establish its own corpus leaves with 1 out of a catch and a classification, and still runs its `finally` |
+| `seed-readback-cases.ps1` | the seed read-back rules themselves: a rising count is landing, an unreadable sample is not a miss |
 
 Most take `-ExePath` and `-OutDir` like a real harness; `no-outdir.ps1`
 deliberately takes `-Seed` and no `-OutDir`, which is the point of it.

--- a/windows/scripts/lib/fuzz-selftest/seed-readback-cases.ps1
+++ b/windows/scripts/lib/fuzz-selftest/seed-readback-cases.ps1
@@ -1,0 +1,65 @@
+#requires -Version 7
+# Exercises the seed read-back rules directly, with no window and no build.
+#
+# seed-unverified.ps1 next door pins what the RUNNER does with a harness that
+# could not establish its corpus. This pins the decision that gets it there.
+# Without it, Test-SeedLanded could be replaced by `return 'landed'` and the
+# whole self-test would stay green while the harness went back to measuring
+# its oracle against text it never typed - which is the bug the read-back was
+# added to fix.
+#
+# Exits 2 rather than 1 on a failure: a rule here being wrong is a defect in
+# shipped logic, not a harness that could not run, and it must not be retried
+# until it passes.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '../seed-readback.ps1')
+
+$fails = @()
+
+function Check([string]$name, $expected, $actual) {
+    if ($expected -ne $actual) { $script:fails += "$name : expected '$expected', got '$actual'" }
+}
+
+# The line was typed: one more copy than before.
+Check 'rise-is-landed' 'landed' (Test-SeedLanded 'prompt> ' 'prompt>  echo ZQXW' 'echo ZQXW')
+
+# The emit op retypes the same line every few iterations, so an older copy is
+# already in the scrollback. Presence is not the question; the count rising is.
+Check 'same-count-is-missing' 'missing' `
+    (Test-SeedLanded 'old echo ZQXW' 'old echo ZQXW' 'echo ZQXW')
+
+# The case this file exists for. Get-TerminalText answers '' on any UIA fault,
+# and a baseline of '' counts zero occurrences - which turns the question back
+# into bare presence and blesses a send that landed nothing.
+Check 'unreadable-before' 'unreadable' (Test-SeedLanded '' 'old echo ZQXW' 'echo ZQXW')
+Check 'unreadable-after'  'unreadable' (Test-SeedLanded 'prompt> ' '' 'echo ZQXW')
+
+# A partly typed line does not contain the whole needle.
+Check 'truncated-is-missing' 'missing' (Test-SeedLanded 'prompt> ' 'prompt>  echo ZQX' 'echo ZQXW')
+
+# The read-back is ordinal on purpose: a line that came back in a different
+# case did not come back.
+Check 'case-change-is-missing' 'missing' `
+    (Test-SeedLanded 'prompt> ' 'prompt>  ECHO ZQXW' 'echo ZQXW')
+
+# Nothing to verify is not a failure to verify.
+Check 'empty-text-is-landed' 'landed' (Test-SeedLanded 'a' 'a' '')
+
+# The oracle's own counter: non-overlapping, and case-folding by default.
+Check 'count-non-overlapping' 2 (Measure-Occurrences 'aaaa' 'aa')
+Check 'count-folds-case'      2 (Measure-Occurrences 'ZqXw zqxw' 'ZQXW')
+Check 'count-ordinal-strict'  1 `
+    (Measure-Occurrences 'ZQXW zqxw' 'ZQXW' ([StringComparison]::Ordinal))
+
+Set-Content -Path (Join-Path $OutDir 'finally-ran.txt') -Value 'cases ran'
+
+if ($fails.Count -gt 0) {
+    $fails | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+    Write-Host "seed read-back rules: $($fails.Count) case(s) wrong" -ForegroundColor Red
+    exit 2
+}
+
+Write-Host 'seed read-back rules: all cases hold'
+exit 0

--- a/windows/scripts/lib/fuzz-selftest/seed-unverified.ps1
+++ b/windows/scripts/lib/fuzz-selftest/seed-unverified.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7
+# Mirrors search-fuzz.ps1's tail rather than a real harness's trap: findings
+# are collected with a kind, the verdict is derived from those kinds in the
+# finally, and the script exits on it.
+#
+# The case being pinned is a seed line that could not be read back. The
+# harness never established the corpus every oracle count is measured
+# against, so it knows nothing about the product and must leave with the
+# retryable 1 - filing that as a defect would put a broken harness in front
+# of real findings. cannot-run.ps1 covers a literal `exit 1`; this covers a 1
+# that comes out of a throw, a catch and a classification, which is where it
+# can go wrong: the same throw reaching a PRODUCT_FAIL trap would leave with
+# 2 and never be retried.
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+$ErrorActionPreference = 'Stop'
+
+$findings = [System.Collections.Generic.List[object]]::new()
+$code = 0
+
+try {
+    Write-Host 'selftest: seed line could not be read back'
+    throw 'the seed payload never landed on the input row'
+}
+catch {
+    $findings.Add([pscustomobject]@{ kind = 'harness'; detail = $_.Exception.Message })
+}
+finally {
+    $product = @($findings | Where-Object { $_.kind -ne 'harness' })
+    if ($findings.Count -eq 0) { $code = 0 }
+    elseif ($product.Count -gt 0) { $code = 2 }
+    else { $code = 1 }
+
+    # The self-test asserts this file, so a tail that skipped the cleanup is
+    # caught rather than assumed. In the real harness this is where the app
+    # is taken back down and XDG_CONFIG_HOME is restored, and a seeding
+    # failure aborts the run from the middle of the op loop.
+    Set-Content -Path (Join-Path $OutDir 'finally-ran.txt') -Value 'cleanup happened'
+}
+
+exit $code

--- a/windows/scripts/lib/seed-readback.ps1
+++ b/windows/scripts/lib/seed-readback.ps1
@@ -1,0 +1,61 @@
+#requires -Version 7
+# Deciding whether a line the harness typed actually reached the terminal.
+#
+# Lives here rather than inside search-fuzz.ps1 so it can be exercised without
+# a window, a build or an interactive desktop. These rules decide whether a
+# run's corpus is real, and a run measuring its oracle against a corpus that
+# was never typed reports findings that are not there and passes over ones
+# that are - which is worth testing directly rather than only through a GUI
+# harness that cannot run in CI.
+
+# Non-overlapping occurrence count. The default folds case because that is what
+# the search oracle needs: search is ASCII case-insensitive
+# (src/terminal/search/sliding_window.zig uses std.ascii.indexOfIgnoreCase) and
+# the sliding window advances past each hit the same way. The seed read-back
+# passes Ordinal instead - a line that came back in a different case did not
+# come back.
+function Measure-Occurrences([string]$haystack, [string]$needle,
+                             [StringComparison]$comparison = [StringComparison]::OrdinalIgnoreCase) {
+    if ([string]::IsNullOrEmpty($needle)) { return 0 }
+    $n = 0; $i = 0
+    while ($true) {
+        $j = $haystack.IndexOf($needle, $i, $comparison)
+        if ($j -lt 0) { break }
+        $n++; $i = $j + $needle.Length
+    }
+    return $n
+}
+
+# Did this send put one more copy of the seed line into the document?
+#
+# Returns 'landed', 'missing' or 'unreadable'. The third is not a nicety.
+# Get-TerminalText turns any UIA fault into an empty string, so without it an
+# unreadable BEFORE silently rewrites the question from "did the count rise"
+# into "is the text present anywhere" - and the emit op retypes the same line
+# every few iterations, so from the second one on the answer to that question
+# is always yes and a send that landed nothing reads as success. An empty
+# document is a fault in practice: the shell has printed a prompt by the time
+# anything is seeded, and the document is untrimmed.
+#
+# Equality against a row is not on offer. The shell owns that row and repaints
+# it with a prompt in front and syntax colours over the top, and a long line
+# wraps; a check that fired on a legitimate repaint would be worse than no
+# check, because it would be switched off. A rising containment count is the
+# strongest thing that survives all of that.
+#
+# What it does NOT catch, stated because the previous wording claimed
+# otherwise: a doubled first or last character still contains the needle, and
+# so does the whole payload typed twice. A PSReadLine inline prediction can
+# also draw the rest of a matching history entry into the grid before it is
+# typed, which is why the harness turns prediction off rather than relying on
+# this to notice.
+function Test-SeedLanded([string]$before, [string]$after, [string]$text) {
+    if ([string]::IsNullOrEmpty($text)) { return 'landed' }
+    if ([string]::IsNullOrEmpty($before) -or [string]::IsNullOrEmpty($after)) { return 'unreadable' }
+
+    $ord = [StringComparison]::Ordinal
+    if ((Measure-Occurrences $after $text $ord) -gt (Measure-Occurrences $before $text $ord)) {
+        return 'landed'
+    }
+    return 'missing'
+}

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -12,6 +12,14 @@
     Search is ASCII case-insensitive (src/terminal/search/sliding_window.zig
     uses std.ascii.indexOfIgnoreCase), so the oracle folds case the same way.
 
+    The corpus the oracle reads is typed into a live shell, so every seeding
+    send is read back off the input row before Enter commits it. A dropped
+    character there is silent and moves the answer for every later count
+    rather than failing one check, so a line that cannot be read back ends
+    the run as a harness failure - the corpus was never established, and a
+    harness that could not build its own premise has nothing to say about
+    the product.
+
     Failures are recorded and the run continues: one broken invariant should
     not hide the rest.
 
@@ -411,13 +419,17 @@ function Get-FocusedName {
 
 # ---- oracle ---------------------------------------------------------------
 
-# Non-overlapping, ASCII-case-insensitive occurrence count, matching the way
-# the sliding window advances past each hit.
-function Measure-Occurrences([string]$haystack, [string]$needle) {
+# Non-overlapping occurrence count. The default folds case because that is
+# what the oracle needs: search is ASCII case-insensitive, and the sliding
+# window advances past each hit the same way. The seed read-back passes
+# Ordinal instead - a line that came back in a different case did not come
+# back.
+function Measure-Occurrences([string]$haystack, [string]$needle,
+                             [StringComparison]$comparison = [StringComparison]::OrdinalIgnoreCase) {
     if ([string]::IsNullOrEmpty($needle)) { return 0 }
     $n = 0; $i = 0
     while ($true) {
-        $j = $haystack.IndexOf($needle, $i, [StringComparison]::OrdinalIgnoreCase)
+        $j = $haystack.IndexOf($needle, $i, $comparison)
         if ($j -lt 0) { break }
         $n++; $i = $j + $needle.Length
     }
@@ -552,6 +564,121 @@ function Clear-Needle {
     # Select-all then Backspace: shorter and less racy than N backspaces.
     Send-Chord @([SFz]::VK_CONTROL) ([SFz]::VK_A) 120
     Send-Chord @() ([SFz]::VK_BACK) 250
+}
+
+# ---- seeding --------------------------------------------------------------
+#
+# A seed line is typed into a live shell, and a character it loses on the way
+# is invisible: nothing throws, the shell just runs something else. The corpus
+# is what every oracle count is measured against, so a lost character does not
+# fail one check, it moves the answer for the rest of the run - a false pass
+# and a false finding are equally reachable from there.
+#
+# The needle path already refuses to trust a send (see 'needle-box-drift': it
+# reads the box back and compares). These three helpers are the same
+# discipline where there is no box to read, only the terminal document.
+
+# How many times a seed line is retyped before the run gives up on it.
+$script:SeedAttempts = 3
+
+# The first character after the search bar closes gets eaten. Escape tears the
+# bar down and XAML hands focus back to the terminal asynchronously, so a
+# keystroke that arrives mid-handoff lands nowhere: a run that typed
+# "$a='ZQ'+'XW'; ..." straight after Escape reached the shell as
+# "a='ZQ'+'XW'; ...", one dropped '$', and the pipeline behind it then ran
+# against a variable nobody set.
+#
+# The needle box is the only element that can be named positively here, so the
+# gate is "the bar is gone and focus has left it" rather than "the terminal has
+# focus" - TerminalControl's UIA name is not stable enough to wait on.
+function Wait-ShellFocus([int]$timeoutMs = 3000) {
+    $dl = (Get-Date).AddMilliseconds($timeoutMs)
+    while ((Get-Date) -lt $dl) {
+        if (-not (Test-SearchBarOpen (Get-Root)) -and (Get-FocusedName) -ne 'Search scrollback') {
+            # UIA reports the handoff slightly before the island will take a
+            # keystroke, so the settle is on top of the wait, not instead of it.
+            Start-Sleep -Milliseconds 250
+            return $true
+        }
+        Start-Sleep -Milliseconds 120
+    }
+    return $false
+}
+
+# True when the send put one more copy of the seed line into the document.
+#
+# Equality against a row is not on offer: the shell owns that row and repaints
+# it with a prompt in front, a PSReadLine prediction in grey behind the cursor
+# and syntax colours over the top, and a long line wraps. Containment is the
+# strongest check that survives all of those, and it still catches every
+# dropped, doubled or reordered character in the typed text itself, which is
+# the failure being guarded. A check that fires on a legitimate repaint would
+# be worse than no check at all, because it would be switched off.
+#
+# Containment of the *document* is not enough on its own: the emit op retypes
+# the same line every few iterations, so from the second one on the scrollback
+# already holds a copy and a bare containment check would pass on what the
+# previous iteration echoed, whatever this send did. The count has to go up.
+#
+# The document unwraps soft wraps (Screen.selectionString passes unwrap = true),
+# so a wrapped input line rejoins and the ordinal count sees it whole. The
+# newline-stripped second look is only for the case where it does not: it
+# tolerates a row boundary landing inside the typed text, and nothing else.
+#
+# The one way this can say "no" about a send that worked is scrollback that
+# evicted an older copy in the same window, leaving the count level. That
+# needs a scrollback-limit small enough for a run to fill, which the default
+# config used here is not; and the cost of a false no is a retype, not a
+# wrong verdict.
+function Test-SeedLanded([string]$before, [string]$after, [string]$text) {
+    if ([string]::IsNullOrEmpty($text)) { return $true }
+    if ([string]::IsNullOrEmpty($after)) { return $false }
+    $ord = [StringComparison]::Ordinal
+    if ((Measure-Occurrences $after $text $ord) -gt (Measure-Occurrences $before $text $ord)) { return $true }
+    $flatBefore = $before -replace "`r", '' -replace "`n", ''
+    $flatAfter  = $after  -replace "`r", '' -replace "`n", ''
+    return (Measure-Occurrences $flatAfter $text $ord) -gt (Measure-Occurrences $flatBefore $text $ord)
+}
+
+# Type a line that becomes corpus and prove it landed, before Enter commits it.
+# Reading back afterwards is too late: by then the shell has echoed, executed
+# and scrolled, and a mangled line has become output that cannot be told apart
+# from the output that was wanted.
+#
+# The leading space is a sacrificial first character, not decoration. PowerShell
+# ignores leading whitespace, so if the handoff above still eats one keystroke
+# the payload is untouched; the read-back is what decides the outcome either
+# way, and it never looks at the space.
+#
+# Returns $false when the line could not be established. That is a harness
+# problem, not a product one: the corpus the run needs was never built, so the
+# run has nothing to say about the search. Callers throw, which the outer catch
+# records as a 'harness' finding and the verdict below turns into exit 1.
+function Send-SeedText([string]$text, [string]$dumpPath) {
+    for ($try = 1; $try -le $script:SeedAttempts; $try++) {
+        if (-not (Wait-ShellFocus)) {
+            Write-Host "  seed: focus never left the search bar (attempt $try of $script:SeedAttempts)" -ForegroundColor Yellow
+            Press-Escape
+            continue
+        }
+        # Sampled after the focus wait, not before it: the wait can spend
+        # three seconds, and anything the shell printed in them belongs to
+        # the baseline rather than to this send.
+        $before = Get-TerminalText (Get-Term)
+        Send-Text (' ' + $text) 30
+        Start-Sleep -Milliseconds 400
+        $doc = Get-TerminalText (Get-Term)
+        # Overwritten per attempt on purpose: a failure throws straight away,
+        # so the file left behind is the read-back that failed.
+        if ($dumpPath) { $doc | Set-Content $dumpPath -Encoding utf8 }
+        if (Test-SeedLanded $before $doc $text) { return $true }
+        Write-Host "  seed: the input row does not hold the typed line (attempt $try of $script:SeedAttempts), retyping" -ForegroundColor Yellow
+        # Drop whatever did land, including the continuation prompt a dropped
+        # quote leaves behind, so the retry starts from a bare line instead of
+        # appending to a broken one.
+        Clear-CommandLine
+    }
+    return $false
 }
 
 # Poll until the counter stops changing, so assertions never race the
@@ -712,9 +839,9 @@ try {
     # string. Reset the line before committing to the payload.
     Clear-CommandLine
 
-    Send-Text $payload 30
-    Start-Sleep -Milliseconds 400
-    (Get-TerminalText (Get-Term)) | Set-Content (Join-Path $OutDir 'doc-typed.txt') -Encoding utf8
+    if (-not (Send-SeedText $payload (Join-Path $OutDir 'doc-typed.txt'))) {
+        throw "the seed payload never landed on the input row after $script:SeedAttempts attempts, see doc-typed.txt"
+    }
     Send-Chord @() ([SFz]::VK_RETURN) 400
     Start-Sleep -Seconds 3
 
@@ -1056,7 +1183,10 @@ try {
                 $before = Get-CounterParts (Get-Counter (Get-Root))
                 $needleBox = Get-NeedleText (Get-Root)
                 Press-Escape
-                Send-Text ('$a=' + "'ZQ'+'XW'; 1..12 | % { `"`$a extra `$_`" }") 30
+                $emit = '$a=' + "'ZQ'+'XW'; 1..12 | % { `"`$a extra `$_`" }"
+                if (-not (Send-SeedText $emit (Join-Path $OutDir 'doc-emit.txt'))) {
+                    throw "the emit payload never landed on the input row after $script:SeedAttempts attempts, see doc-emit.txt"
+                }
                 Send-Chord @() ([SFz]::VK_RETURN) 400
                 Start-Sleep -Seconds 3
                 $doc = Get-TerminalText (Get-Term)

--- a/windows/scripts/search-fuzz.ps1
+++ b/windows/scripts/search-fuzz.ps1
@@ -418,23 +418,14 @@ function Get-FocusedName {
 }
 
 # ---- oracle ---------------------------------------------------------------
+#
+# The occurrence count and the seed read-back rules are shared with the
+# self-test, which exercises them with no window. See lib/seed-readback.ps1.
+. (Join-Path $PSScriptRoot 'lib/seed-readback.ps1')
 
-# Non-overlapping occurrence count. The default folds case because that is
-# what the oracle needs: search is ASCII case-insensitive, and the sliding
-# window advances past each hit the same way. The seed read-back passes
-# Ordinal instead - a line that came back in a different case did not come
-# back.
-function Measure-Occurrences([string]$haystack, [string]$needle,
-                             [StringComparison]$comparison = [StringComparison]::OrdinalIgnoreCase) {
-    if ([string]::IsNullOrEmpty($needle)) { return 0 }
-    $n = 0; $i = 0
-    while ($true) {
-        $j = $haystack.IndexOf($needle, $i, $comparison)
-        if ($j -lt 0) { break }
-        $n++; $i = $j + $needle.Length
-    }
-    return $n
-}
+
+# Measure-Occurrences and Test-SeedLanded live in lib/seed-readback.ps1, so
+# the read-back rules can be tested without a window. See the dot-source above.
 
 # Both haystacks unwrap soft wraps: the UIA document comes from
 # Screen.selectionString with unwrap = true, and the search window builds its
@@ -591,53 +582,44 @@ $script:SeedAttempts = 3
 # The needle box is the only element that can be named positively here, so the
 # gate is "the bar is gone and focus has left it" rather than "the terminal has
 # focus" - TerminalControl's UIA name is not stable enough to wait on.
+# Returns 'ok', 'bar-open' or 'timeout'. Which of the two failures it is
+# decides who owns it: a search bar that never closed is a product defect this
+# harness asserts on by name elsewhere, and reporting that as a harness problem
+# would suppress the very regression the run exists to find.
+#
+# The gate is negative - "the bar is gone and focus has left it" - because the
+# needle box is the only element that can be named positively here;
+# TerminalControl's UIA name is not stable enough to wait on. That makes it a
+# weak signal, not a strong one: FocusedElement is system-wide, so another app
+# satisfies it, and Get-FocusedName answers '<none>' on a UIA fault. The
+# read-back below is what actually decides whether a send worked.
 function Wait-ShellFocus([int]$timeoutMs = 3000) {
     $dl = (Get-Date).AddMilliseconds($timeoutMs)
     while ((Get-Date) -lt $dl) {
-        if (-not (Test-SearchBarOpen (Get-Root)) -and (Get-FocusedName) -ne 'Search scrollback') {
-            # UIA reports the handoff slightly before the island will take a
-            # keystroke, so the settle is on top of the wait, not instead of it.
-            Start-Sleep -Milliseconds 250
-            return $true
+        if (-not (Test-SearchBarOpen (Get-Root))) {
+            if ((Get-FocusedName) -ne 'Search scrollback') {
+                # UIA reports the handoff slightly before the island will take
+                # a keystroke, so the settle is on top of the wait.
+                Start-Sleep -Milliseconds 250
+                return 'ok'
+            }
         }
         Start-Sleep -Milliseconds 120
     }
-    return $false
+    if (Test-SearchBarOpen (Get-Root)) { return 'bar-open' }
+    return 'timeout'
 }
 
-# True when the send put one more copy of the seed line into the document.
-#
-# Equality against a row is not on offer: the shell owns that row and repaints
-# it with a prompt in front, a PSReadLine prediction in grey behind the cursor
-# and syntax colours over the top, and a long line wraps. Containment is the
-# strongest check that survives all of those, and it still catches every
-# dropped, doubled or reordered character in the typed text itself, which is
-# the failure being guarded. A check that fires on a legitimate repaint would
-# be worse than no check at all, because it would be switched off.
-#
-# Containment of the *document* is not enough on its own: the emit op retypes
-# the same line every few iterations, so from the second one on the scrollback
-# already holds a copy and a bare containment check would pass on what the
-# previous iteration echoed, whatever this send did. The count has to go up.
-#
-# The document unwraps soft wraps (Screen.selectionString passes unwrap = true),
-# so a wrapped input line rejoins and the ordinal count sees it whole. The
-# newline-stripped second look is only for the case where it does not: it
-# tolerates a row boundary landing inside the typed text, and nothing else.
-#
-# The one way this can say "no" about a send that worked is scrollback that
-# evicted an older copy in the same window, leaving the count level. That
-# needs a scrollback-limit small enough for a run to fill, which the default
-# config used here is not; and the cost of a false no is a retype, not a
-# wrong verdict.
-function Test-SeedLanded([string]$before, [string]$after, [string]$text) {
-    if ([string]::IsNullOrEmpty($text)) { return $true }
-    if ([string]::IsNullOrEmpty($after)) { return $false }
-    $ord = [StringComparison]::Ordinal
-    if ((Measure-Occurrences $after $text $ord) -gt (Measure-Occurrences $before $text $ord)) { return $true }
-    $flatBefore = $before -replace "`r", '' -replace "`n", ''
-    $flatAfter  = $after  -replace "`r", '' -replace "`n", ''
-    return (Measure-Occurrences $flatAfter $text $ord) -gt (Measure-Occurrences $flatBefore $text $ord)
+# Re-arm the XAML island the way startup does. A retry that only retypes
+# repeats whatever swallowed the first attempt: the island does not take focus
+# from the window merely being foreground (see SFz.Click), and Clear-CommandLine
+# goes through the same input path that just failed.
+function Restore-IslandFocus {
+    $rc = [SFz]::RectOf($script:Hwnd64)
+    if ($null -eq $rc) { return $false }
+    $ok = [SFz]::Click($script:Pid32, [int]($rc.L + $rc.W / 2), [int]($rc.T + $rc.Hh * 0.7))
+    Start-Sleep -Milliseconds 300
+    return $ok
 }
 
 # Type a line that becomes corpus and prove it landed, before Enter commits it.
@@ -654,11 +636,19 @@ function Test-SeedLanded([string]$before, [string]$after, [string]$text) {
 # problem, not a product one: the corpus the run needs was never built, so the
 # run has nothing to say about the search. Callers throw, which the outer catch
 # records as a 'harness' finding and the verdict below turns into exit 1.
+# Returns 'ok', 'bar-open' or 'unverified'. 'bar-open' is handed back rather
+# than retried: the caller files it as the product defect it is.
 function Send-SeedText([string]$text, [string]$dumpPath) {
+    # A dump from a previous run reads as evidence about this one, and OutDir
+    # is reused. Clear it so its presence means this attempt wrote it.
+    if ($dumpPath -and (Test-Path $dumpPath)) { Remove-Item $dumpPath -Force }
+
     for ($try = 1; $try -le $script:SeedAttempts; $try++) {
-        if (-not (Wait-ShellFocus)) {
-            Write-Host "  seed: focus never left the search bar (attempt $try of $script:SeedAttempts)" -ForegroundColor Yellow
-            Press-Escape
+        $focus = Wait-ShellFocus
+        if ($focus -eq 'bar-open') { return 'bar-open' }
+        if ($focus -ne 'ok') {
+            Write-Host "  seed: focus never settled after the bar closed (attempt $try of $script:SeedAttempts)" -ForegroundColor Yellow
+            [void](Restore-IslandFocus)
             continue
         }
         # Sampled after the focus wait, not before it: the wait can spend
@@ -666,19 +656,33 @@ function Send-SeedText([string]$text, [string]$dumpPath) {
         # the baseline rather than to this send.
         $before = Get-TerminalText (Get-Term)
         Send-Text (' ' + $text) 30
-        Start-Sleep -Milliseconds 400
-        $doc = Get-TerminalText (Get-Term)
-        # Overwritten per attempt on purpose: a failure throws straight away,
-        # so the file left behind is the read-back that failed.
+
+        # Polled rather than slept. The peer serves its document from a 500ms
+        # cache (TerminalAutomationPeer.ScreenTextCacheMs), so any fixed settle
+        # shorter than that can read a snapshot taken before the last
+        # characters were typed and call a good send a miss - which costs a
+        # retype every time, and three in a row abort a healthy run.
+        $verdict = 'unreadable'
+        $doc = ''
+        $deadline = (Get-Date).AddMilliseconds(2500)
+        do {
+            Start-Sleep -Milliseconds 200
+            $doc = Get-TerminalText (Get-Term)
+            $verdict = Test-SeedLanded $before $doc $text
+        } while ($verdict -ne 'landed' -and (Get-Date) -lt $deadline)
+
         if ($dumpPath) { $doc | Set-Content $dumpPath -Encoding utf8 }
-        if (Test-SeedLanded $before $doc $text) { return $true }
-        Write-Host "  seed: the input row does not hold the typed line (attempt $try of $script:SeedAttempts), retyping" -ForegroundColor Yellow
+        if ($verdict -eq 'landed') { return 'ok' }
+
+        Write-Host "  seed: the input row does not hold the typed line ($verdict, attempt $try of $script:SeedAttempts), retyping" -ForegroundColor Yellow
         # Drop whatever did land, including the continuation prompt a dropped
         # quote leaves behind, so the retry starts from a bare line instead of
-        # appending to a broken one.
+        # appending to a broken one, then re-arm the island: retyping through
+        # the input path that just failed is not a different attempt.
         Clear-CommandLine
+        [void](Restore-IslandFocus)
     }
-    return $false
+    return 'unverified'
 }
 
 # Poll until the counter stops changing, so assertions never race the
@@ -757,6 +761,7 @@ try {
     $script:StartedAt = Get-WinttyLaunchStamp
     $script:Proc = Start-Process -FilePath $script:ExeFull -PassThru -WorkingDirectory (Split-Path -Parent $script:ExeFull)
     $pid32 = [uint32]$script:Proc.Id
+    $script:Pid32 = $pid32
     $main = Wait-Ready $script:Proc
     $script:Hwnd64 = [int64]$main.Hwnd64
     [void][SFz]::Focus([SFz]::P($script:Hwnd64))
@@ -839,8 +844,21 @@ try {
     # string. Reset the line before committing to the payload.
     Clear-CommandLine
 
-    if (-not (Send-SeedText $payload (Join-Path $OutDir 'doc-typed.txt'))) {
-        throw "the seed payload never landed on the input row after $script:SeedAttempts attempts, see doc-typed.txt"
+    # Inline prediction renders the rest of a matching history entry into the
+    # grid as soon as the typed prefix matches it, and those are real cells the
+    # read-back counts. A run whose payload is already in history would then
+    # verify text it had not finished typing, while Enter commits only what was
+    # typed. Default is HistoryAndPlugin on 7.2+, and the default (non-isolated)
+    # run loads the user's profile, so it has to be turned off rather than
+    # assumed off.
+    Send-Text 'Set-PSReadLineOption -PredictionSource None' 30
+    Send-Chord @() ([SFz]::VK_RETURN) 400
+    Start-Sleep -Milliseconds 800
+    Clear-CommandLine
+
+    $seeded = Send-SeedText $payload (Join-Path $OutDir 'doc-typed.txt')
+    if ($seeded -ne 'ok') {
+        throw "the seed payload never landed on the input row ($seeded) after $script:SeedAttempts attempts, see doc-typed.txt"
     }
     Send-Chord @() ([SFz]::VK_RETURN) 400
     Start-Sleep -Seconds 3
@@ -1184,8 +1202,24 @@ try {
                 $needleBox = Get-NeedleText (Get-Root)
                 Press-Escape
                 $emit = '$a=' + "'ZQ'+'XW'; 1..12 | % { `"`$a extra `$_`" }"
-                if (-not (Send-SeedText $emit (Join-Path $OutDir 'doc-emit.txt'))) {
-                    throw "the emit payload never landed on the input row after $script:SeedAttempts attempts, see doc-emit.txt"
+                # The initial seed clears the row first and this has to as
+                # well: anything already sitting there is prefixed to the
+                # payload, and "leftover + line" still contains the line, so
+                # the read-back would bless a command the shell cannot run.
+                Clear-CommandLine
+                $seeded = Send-SeedText $emit (Join-Path $OutDir 'doc-emit.txt')
+                if ($seeded -eq 'bar-open') {
+                    # Escape not closing the bar is a product defect this
+                    # harness names elsewhere. Record it BEFORE the throw: the
+                    # verdict is derived from every finding, so this is what
+                    # keeps a live regression at exit 2 instead of being
+                    # filed as a harness failure and retried until it is
+                    # reported as a broken harness.
+                    [void](Assert-That $false 'esc-did-not-close' `
+                        'Escape left the search bar open, so the emit payload could not be typed' @{})
+                }
+                if ($seeded -ne 'ok') {
+                    throw "the emit payload never landed on the input row ($seeded), see doc-emit.txt"
                 }
                 Send-Chord @() ([SFz]::VK_RETURN) 400
                 Start-Sleep -Seconds 3


### PR DESCRIPTION
The harness seeded its corpus by synthesizing keystrokes and never checked what arrived. A dropped character made the corpus differ from what the harness believed it had typed, and every oracle count after that was computed against the wrong text -- so a run could report a finding that was not there, or pass over one that was. Either way the verdict is worthless, which defeats the point of having an oracle.

Observed: `$a='ZQ'+'XW'; ...` arrived as `a='ZQ'+'XW'; ...` and the shell reported `a=ZQ+XW: The term 'a=ZQ+XW' is not recognized`.

The drop is a focus race. Escape tears down the search bar and XAML hands focus back to the terminal asynchronously; the first keystroke arriving mid-handoff lands nowhere. The existing foreground guard cannot see it, because the foreground was never lost -- the loss is inside the app, at the XAML focus boundary.

Now: wait for the handoff to finish before the first character, prefix the line with a sacrificial space so one more eaten keystroke cannot corrupt the payload, and read the terminal document back before Enter to confirm the line arrived, retrying a bounded number of times. A send that never verifies ends the run at exit 1, the harness-could-not-run code, not 2 -- the corpus was never established, so nothing is known about the product.

Two details worth flagging:

The read-back requires the occurrence **count to rise**, not merely that the text is present. The same line is retyped every few iterations and the previous copy is still in the scrollback, so a presence check would have passed on the previous iteration's echo regardless of what the current send did.

The check is containment, not equality. The shell owns the input row and repaints it with a prompt in front, a prediction suffix behind the cursor, and syntax colouring; equality would fire on all three.

## Verified

Self-test exits 0 across all 10 classified exit paths, including the new fixture for this failure. Breaking that fixture on purpose (classifying the seeding failure as a product finding) turns the self-test red, so it catches the regression it exists for. 17 asserts cover the read-back logic, lifted from the shipped script by AST so they cannot drift from it.

## Not verified

No desktop was available, so the real harness was never run. This proves detection, not the fix: a drop now ends the run at exit 1 instead of silently corrupting the corpus, but whether the settle and the sacrificial space make the run green rather than red is unmeasured.