### PR TITLE
deps: bump zioshade to v0.7.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -89,25 +89,14 @@
         .zlib = .{ .path = "./pkg/zlib", .lazy = true },
 
         // Shader translation: zioshade is a pure-Zig GLSL -> SPIR-V ->
-        // HLSL/MSL/GLSL cross compiler. It replaces the glslang and
-        // spirv-cross C++ packages, so custom shader compilation is
-        // in-process with no C++ dependencies.
-        // Pinned to the v0.5.0 tag. It carries a broad silent-wrong hunt across
-        // all four backends (~17 bug classes), honest errors instead of
-        // placeholder output for unknown types, self-loop lowering, and a C ABI
-        // fix that matters here: caller-owned buffers now come from a
-        // process-global mutex-guarded allocator, so they may be freed from any
-        // thread. Previously they came from a threadlocal allocator, so
-        // compiling on a worker and freeing on the main thread handed an
-        // allocator a pointer it never produced.
-        // Note for anyone diffing generated shader text: v0.5.0 mangles
-        // identifiers that used to collide, so output for unchanged input can
-        // differ from v0.4.0. That is a correctness fix, not a regression.
-        // `zioshade_status_t` also gained ZIOSHADE_ERR_UNSUPPORTED (8), an
-        // additive change; keep a default branch when switching over it.
+        // HLSL/MSL/GLSL/WGSL cross compiler, used in-process so shader
+        // compilation carries no C++ dependencies.
+        // Note for anyone diffing generated shader text: output can differ
+        // between zioshade versions on unchanged input (lowering and
+        // identifier fixes); regenerate any golden outputs.
         .zioshade = .{
-            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.5.0.tar.gz",
-            .hash = "zioshade-0.5.0-8s3a2t1NSAALg56PbAKbTaDxBDPyUOQ-VR3zKsnPDmky",
+            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
+            .hash = "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8",
             .lazy = true,
         },
 

--- a/build.zig.zon.json
+++ b/build.zig.zon.json
@@ -174,10 +174,10 @@
     "url": "git+https://github.com/zigimg/zigimg#d695acd97c02e57bb151e8f659d1280f5cd6ca70",
     "hash": "sha256-0IYATQldT6eJxRR2T/2CsIYZuzomqjvmdVyjmsjguyE="
   },
-  "zioshade-0.5.0-8s3a2t1NSAALg56PbAKbTaDxBDPyUOQ-VR3zKsnPDmky": {
+  "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8": {
     "name": "zioshade",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.5.0.tar.gz",
-    "hash": "sha256-XLb0+v/41M6n4Dh6NPrg474mCspJ4JLvpyvC1aptQ40="
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
+    "hash": "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4="
   },
   "N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o": {
     "name": "zlib",

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -422,11 +422,11 @@ in
       };
     }
     {
-      name = "zioshade-0.5.0-8s3a2t1NSAALg56PbAKbTaDxBDPyUOQ-VR3zKsnPDmky";
+      name = "zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8";
       path = fetchZigArtifact {
         name = "zioshade";
-        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.5.0.tar.gz";
-        hash = "sha256-XLb0+v/41M6n4Dh6NPrg474mCspJ4JLvpyvC1aptQ40=";
+        url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz";
+        hash = "sha256-AB8U+6tn9L+GGqTeTtBN+m3bc11GnrnEcREOTRPXmG4=";
         unpack = false;
       };
     }

--- a/build.zig.zon.txt
+++ b/build.zig.zon.txt
@@ -34,4 +34,4 @@ https://deps.files.ghostty.org/zig_objc-c8de82ff80281215ad92900866dab7103a8efa8b
 https://deps.files.ghostty.org/zlib-1220fed0c74e1019b3ee29edae2051788b080cd96e90d56836eea857b0b966742efb.tar.gz
 https://github.com/ghostty-org/zig-gobject/releases/download/0.10.0-2026-07-28-36-1/ghostty-gobject-0.10.0-2026-07-28-36-1.tar.zst
 https://github.com/vancluever/arocc/archive/ecbc5c799574e0da2758a961b12efa586007f03c.tar.gz
-https://github.com/zioShade/zioshade/archive/refs/tags/v0.5.0.tar.gz
+https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz

--- a/flatpak/zig-packages.json
+++ b/flatpak/zig-packages.json
@@ -217,8 +217,8 @@
   },
   {
     "type": "archive",
-    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.5.0.tar.gz",
-    "dest": "vendor/p/zioshade-0.5.0-8s3a2t1NSAALg56PbAKbTaDxBDPyUOQ-VR3zKsnPDmky",
-    "sha256": "5cb6f4fafff8d4cea7e0387a34fae0e3be260aca49e092efa72bc2d5aa6d438d"
+    "url": "https://github.com/zioShade/zioshade/archive/refs/tags/v0.7.0.tar.gz",
+    "dest": "vendor/p/zioshade-0.7.0-8s3a2hNSTgDA_8j-r4WhyCbfEuhsD6TGlETxwat8Xzz8",
+    "sha256": "001f14fbab67f4bf861aa4de4ed04dfa6ddb735d469eb9c471110e4d13d7986e"
   }
 ]


### PR DESCRIPTION
One-line pin bump plus the comment block refreshed with what the two releases actually change.

**What it buys over v0.5.0**
- GraphicsFuzz corpus: **0 invalid-output on all four backends** (v0.5.0 baseline was GLSL 54 / MSL 47 / HLSL 46 / WGSL 5)
- Render-only silent-wrong classes fixed: MSL switch-merge shadow phis, HLSL break-to-loop-merge emitted as continue, WGSL dropped back-edge phi updates and hardcoded depth in depth-only fragments
- New verification channels inherited by the pin: WebGPU CTS round-trip harness (1613 CTS-authored shaders, 1597 valid, 0 invalid, 0 crash) and a D3D12 WARP render gate for HLSL (full corpus: 1374 render-match, 5 diffs all proven benign fp-contraction via dxc -Gis recompile)
- zioshade CI now builds and passes its full suite on Zig 0.15.2 and 0.16; dependencies are vendored, so the fetch cannot flake on archive 503s anymore

**Compatibility notes**
- Generated shader text can differ from v0.5.0 on unchanged input (loop/phi lowering and identifier fixes). Correctness fixes, not regressions; regenerate any pinned golden outputs.
- C ABI: no changes flagged in the 0.6.0/0.7.0 changelogs; the ZIOSHADE_ERR_UNSUPPORTED default-branch handling from v0.5.0 still applies.

Windows CI on this PR is the gate; nothing else in wintty is touched.