### PR TITLE
windows: stop flashing a console at launch, and tell the editions apart

### DIFF
--- a/dist/windows/IconGen.Tests/CliTests.cs
+++ b/dist/windows/IconGen.Tests/CliTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Ghostty.IconGen.Tests;
@@ -17,6 +18,46 @@ public class CliTests
     {
         var options = Cli.Parse(new[] { "--channel", "nightly", "--out", "out" });
         Assert.Equal(Channel.Nightly, options.Channel);
+    }
+
+    // Compared by name rather than by the enum: Edition is internal, so a
+    // public [Theory] signature cannot name it.
+    [Theory]
+    [InlineData("none", "None")]
+    [InlineData("pro", "Pro")]
+    [InlineData("enterprise", "Enterprise")]
+    [InlineData("legacy", "Legacy")]
+    [InlineData("oss", "Oss")]
+    public void ParsesEachEdition(string value, string expected)
+    {
+        var options = Cli.Parse(new[] { "--channel", "stable", "--out", "out", "--edition", value });
+        Assert.Equal(expected, options.Edition.ToString());
+    }
+
+    // The default is what every build in this repo gets, and Cli.cs states
+    // it as a requirement: an invocation with no --edition has to keep
+    // producing the unmarked mark it produced before editions existed.
+    [Fact]
+    public void EditionDefaultsToNoneWhenAbsent()
+    {
+        var options = Cli.Parse(new[] { "--channel", "stable", "--out", "out" });
+        Assert.Equal("None", options.Edition.ToString());
+    }
+
+    // A typo must not fall back to the flagship mark: that would ship one
+    // flavour's icon under another flavour's name, silently.
+    [Fact]
+    public void UnknownEditionThrows()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Cli.Parse(new[] { "--channel", "stable", "--out", "out", "--edition", "platinum" }));
+    }
+
+    [Fact]
+    public void EditionWithoutValueThrows()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Cli.Parse(new[] { "--channel", "stable", "--out", "out", "--edition" }));
     }
 
     [Fact]

--- a/dist/windows/IconGen.Tests/MonogramBandTests.cs
+++ b/dist/windows/IconGen.Tests/MonogramBandTests.cs
@@ -23,9 +23,16 @@ public class MonogramBandTests
     {
         using var masters = MasterRasters.Load(RepoRoot);
         using var icon = masters.Get(256);
+        using var reference = masters.Get(256);
 
-        int ghostBottom = LowestLitRow(icon);
-        int bandTop = 256 - (int)Math.Round(256 * EditionBrand.BandHeightFraction);
+        int ghostBottom = LowestLitRow(reference);
+
+        // Derived from what Apply actually painted, not recomputed from the
+        // constant. Recomputing tested the arithmetic in this file against
+        // itself and would have passed through any change to Apply's own
+        // geometry - an inset, a different rounding, padding.
+        MonogramBand.Apply(icon, EditionBrand.For(Edition.Pro));
+        int bandTop = TopmostChangedRow(reference, icon);
 
         Assert.True(
             bandTop > ghostBottom,
@@ -122,17 +129,38 @@ public class MonogramBandTests
         using var masters = MasterRasters.Load(RepoRoot);
         using var icon = masters.Get(size);
 
-        MonogramBand.Apply(icon, EditionBrand.For(Edition.Pro));
+        // Tint first, exactly as BrandMasters does. The band samples its
+        // fill off the artwork, so testing on an un-tinted master exercises
+        // a colour combination that never ships - and that sampled colour
+        // is what the ink threshold below has to stay clear of.
+        var brand = EditionBrand.For(Edition.Pro);
+        TierTint.Apply(icon, brand);
+        MonogramBand.Apply(icon, brand);
 
         int bandHeight = Math.Max(2, (int)Math.Round(size * EditionBrand.BandHeightFraction));
         int bandTop = size - bandHeight;
 
+        // Skip the band's own top rule. It is a 25%-black wash over the
+        // fill, so on a dark enough screen colour it satisfies any loose
+        // "is this dark?" predicate and would be counted as glyph ink -
+        // which would let the 256 px case pass for the wrong reason and
+        // the small cases fail for one.
+        int rule = Math.Max(1, (int)Math.Round(size / 256.0 * 4));
+        int scanTop = bandTop + rule;
+
+        // Distance to the actual ink colour rather than a dark-ish
+        // threshold, so the test tracks the constant the drawing uses.
+        var inkColour = Color.FromArgb(0xFF, 0x12, 0x16, 0x1B);
         int ink = 0;
-        for (int y = bandTop; y < size; y++)
+        for (int y = scanTop; y < size; y++)
             for (int x = 0; x < size; x++)
             {
                 var c = icon.GetPixel(x, y);
-                if (c.A > 200 && c.R < 60 && c.G < 60 && c.B < 70) ink++;
+                if (c.A <= 200) continue;
+                int distance = Math.Abs(c.R - inkColour.R)
+                    + Math.Abs(c.G - inkColour.G)
+                    + Math.Abs(c.B - inkColour.B);
+                if (distance <= 40) ink++;
             }
 
         if (expectLetters)
@@ -141,6 +169,24 @@ public class MonogramBandTests
             Assert.True(ink == 0,
                 $"Expected no monogram ink at {size} px (band is {bandHeight} px tall, "
                 + $"below the {EditionBrand.MinLegibleBandPx} px legibility floor); found {ink}.");
+    }
+
+    /// <summary>
+    /// The first row the band actually repainted. Asking the output rather
+    /// than the constant is what makes the caller a test of
+    /// <see cref="MonogramBand.Apply"/> instead of a test of arithmetic
+    /// copied out of it.
+    /// </summary>
+    private static int TopmostChangedRow(Bitmap before, Bitmap after)
+    {
+        for (int y = 0; y < before.Height; y++)
+            for (int x = 0; x < before.Width; x++)
+                if (before.GetPixel(x, y).ToArgb() != after.GetPixel(x, y).ToArgb())
+                    return y;
+
+        throw new InvalidOperationException(
+            "MonogramBand.Apply changed nothing, so there is no band to place. "
+            + "Either the brand was neutral or the band stopped drawing.");
     }
 
     private static int LowestLitRow(Bitmap icon)

--- a/dist/windows/IconGen.Tests/MonogramBandTests.cs
+++ b/dist/windows/IconGen.Tests/MonogramBandTests.cs
@@ -1,0 +1,179 @@
+using System.Drawing;
+using Xunit;
+
+namespace Ghostty.IconGen.Tests;
+
+public class MonogramBandTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    /// <summary>
+    /// The constraint the band exists under: it must sit below the mark,
+    /// not on top of it.
+    ///
+    /// Measured against the shipping artwork rather than asserted against
+    /// the constant, so that redrawing the icon with a longer ghost fails
+    /// this instead of silently shipping a band across its feet. The
+    /// failure message carries both numbers because the fix is either a
+    /// smaller band or a redrawn master, and which one depends on how far
+    /// apart they are.
+    /// </summary>
+    [Fact]
+    public void BandNeverReachesTheGhost()
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(256);
+
+        int ghostBottom = LowestLitRow(icon);
+        int bandTop = 256 - (int)Math.Round(256 * EditionBrand.BandHeightFraction);
+
+        Assert.True(
+            bandTop > ghostBottom,
+            $"The monogram band starts at y={bandTop} but the ghost's lowest lit row "
+            + $"is y={ghostBottom}, so the band would cover the bottom of the mark. "
+            + $"Either lower EditionBrand.BandHeightFraction (currently "
+            + $"{EditionBrand.BandHeightFraction}) or raise the ghost in the master.");
+    }
+
+    /// <summary>
+    /// The plate is a rounded square and the band runs to the bottom
+    /// edge, so a plain rectangle fill squares off the bottom corners.
+    /// The corner pixel is transparent in the master and has to stay
+    /// transparent afterwards.
+    /// </summary>
+    [Fact]
+    public void BandKeepsThePlatesRoundedCorners()
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(256);
+
+        var cornerBefore = icon.GetPixel(1, 254);
+        Assert.True(cornerBefore.A < 40,
+            $"Test assumes the master's bottom-left corner is transparent; got alpha "
+            + $"{cornerBefore.A}. If the plate is no longer rounded this test is moot.");
+
+        MonogramBand.Apply(icon, EditionBrand.For(Edition.Pro));
+
+        var cornerAfter = icon.GetPixel(1, 254);
+        Assert.True(cornerAfter.A < 40,
+            $"The band squared off the plate's rounded corner: alpha went from "
+            + $"{cornerBefore.A} to {cornerAfter.A}.");
+    }
+
+    [Fact]
+    public void BandCoversTheBottomBandAndNothingAbove()
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(256);
+
+        var before = Snapshot(icon);
+        MonogramBand.Apply(icon, EditionBrand.For(Edition.Pro));
+
+        int bandTop = 256 - (int)Math.Round(256 * EditionBrand.BandHeightFraction);
+
+        for (int y = 0; y < bandTop; y++)
+            for (int x = 0; x < 256; x++)
+                Assert.Equal(before[x, y], icon.GetPixel(x, y).ToArgb());
+
+        int changed = 0;
+        for (int y = bandTop; y < 256; y++)
+            for (int x = 0; x < 256; x++)
+                if (before[x, y] != icon.GetPixel(x, y).ToArgb()) changed++;
+
+        Assert.True(changed > 1000, $"Expected the band to repaint its rows; {changed} pixels changed.");
+    }
+
+    /// <summary>
+    /// The flagship carries no monogram, so a mark on an icon means "this
+    /// is an edition". If this ever draws, every icon gains furniture and
+    /// the signal is gone.
+    /// </summary>
+    [Fact]
+    public void FlagshipIsLeftAlone()
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(256);
+
+        var before = Snapshot(icon);
+        MonogramBand.Apply(icon, EditionBrand.For(Edition.None));
+
+        for (int y = 0; y < 256; y++)
+            for (int x = 0; x < 256; x++)
+                Assert.Equal(before[x, y], icon.GetPixel(x, y).ToArgb());
+    }
+
+    /// <summary>
+    /// At 16 and 32 px the band is two to five pixels tall. Letters there
+    /// are a smudge that reads as a rendering fault, so the band is drawn
+    /// plain and those sizes lean entirely on the hue, as intended. By
+    /// 256 px the letters are the whole point.
+    ///
+    /// Asserted on the presence of letter ink rather than on a colour
+    /// count: the plate's curved edge yields many partial-alpha variants
+    /// of the one band colour, so counting distinct values measures
+    /// anti-aliasing, not glyphs.
+    /// </summary>
+    [Theory]
+    [InlineData(16, false)]
+    [InlineData(32, false)]
+    [InlineData(256, true)]
+    public void LettersAppearOnlyWhereTheyCanBeRead(int size, bool expectLetters)
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(size);
+
+        MonogramBand.Apply(icon, EditionBrand.For(Edition.Pro));
+
+        int bandHeight = Math.Max(2, (int)Math.Round(size * EditionBrand.BandHeightFraction));
+        int bandTop = size - bandHeight;
+
+        int ink = 0;
+        for (int y = bandTop; y < size; y++)
+            for (int x = 0; x < size; x++)
+            {
+                var c = icon.GetPixel(x, y);
+                if (c.A > 200 && c.R < 60 && c.G < 60 && c.B < 70) ink++;
+            }
+
+        if (expectLetters)
+            Assert.True(ink > 40, $"Expected monogram ink at {size} px; found {ink} dark pixels.");
+        else
+            Assert.True(ink == 0,
+                $"Expected no monogram ink at {size} px (band is {bandHeight} px tall, "
+                + $"below the {EditionBrand.MinLegibleBandPx} px legibility floor); found {ink}.");
+    }
+
+    private static int LowestLitRow(Bitmap icon)
+    {
+        // The ghost is the only near-white, opaque thing on the icon; the
+        // bezel is a mid silver and the screen is saturated.
+        for (int y = icon.Height - 1; y >= 0; y--)
+        {
+            int lit = 0;
+            for (int x = 0; x < icon.Width; x++)
+            {
+                var c = icon.GetPixel(x, y);
+                if (c.A > 128 && c.R > 200 && c.G > 200 && c.B > 200) lit++;
+            }
+            if (lit >= 3) return y;
+        }
+        throw new InvalidOperationException("No lit ghost rows found in the master.");
+    }
+
+    private static int[,] Snapshot(Bitmap bitmap)
+    {
+        var pixels = new int[bitmap.Width, bitmap.Height];
+        for (int y = 0; y < bitmap.Height; y++)
+            for (int x = 0; x < bitmap.Width; x++)
+                pixels[x, y] = bitmap.GetPixel(x, y).ToArgb();
+        return pixels;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "images", "icons")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new DirectoryNotFoundException("repo root with images/icons not found");
+    }
+}

--- a/dist/windows/IconGen.Tests/TierTintTests.cs
+++ b/dist/windows/IconGen.Tests/TierTintTests.cs
@@ -31,11 +31,42 @@ public class TierTintTests
 
         TierTint.Apply(icon, EditionBrand.For(Edition.Pro));
 
+        // Exact equality is the wrong assertion, and finding out why is the
+        // point of testing this by chroma. A pure grey (chroma 0) has HSL
+        // saturation 0 and the gate skips it outright. A near-white with a
+        // few counts of chroma computes a saturation near 1.0, because the
+        // HSL denominator collapses as lightness approaches 1 - so the gate
+        // does rotate it, by a hue it barely has. The visible result is
+        // nothing; the bytes move.
+        //
+        // So: pure greys must be untouched, and everything else near-grey
+        // must stay visually identical. The bound is the measured worst case
+        // plus headroom, not a guess - the largest single-channel move over
+        // the whole master is 12/255, on a bezel corner pixel. A regression
+        // that actually recoloured the ghost is nowhere near this: rotating
+        // a genuinely saturated pixel moves channels by 100 or more.
+        int worst = 0;
+        (int X, int Y) worstAt = (0, 0);
         foreach (var (x, y, before) in neutrals)
         {
             var after = icon.GetPixel(x, y);
-            Assert.Equal(before.ToArgb(), after.ToArgb());
+            int shift = Math.Max(Math.Abs(before.R - after.R),
+                Math.Max(Math.Abs(before.G - after.G), Math.Abs(before.B - after.B)));
+            if (shift > worst) { worst = shift; worstAt = (x, y); }
+
+            if (before.R == before.G && before.G == before.B)
+            {
+                Assert.True(before.ToArgb() == after.ToArgb(),
+                    $"A pure grey at ({x},{y}) moved: {before} -> {after}. The "
+                    + "saturation gate must skip these outright.");
+            }
         }
+
+        Assert.True(worst <= 16,
+            $"A near-neutral pixel moved by {worst}/255 at {worstAt}, which is more "
+            + "than the rounding the hue rotation can account for. The ghost and the "
+            + "bezel are the brand: if they shift, the five editions stop looking "
+            + "like one product.");
     }
 
     [Fact]
@@ -56,7 +87,13 @@ public class TierTintTests
     [Fact]
     public void EditionsLandOnDistinctHues()
     {
-        var editions = new[] { Edition.Pro, Edition.Enterprise, Edition.Legacy, Edition.Oss };
+        // None is in the set on purpose: the flagship is what an edition
+        // shortcut sits next to in the Start menu, so "distinct from each
+        // other" is only half the requirement.
+        var editions = new[]
+        {
+            Edition.None, Edition.Pro, Edition.Enterprise, Edition.Legacy, Edition.Oss,
+        };
         var seen = new List<(Edition Edition, Color Colour)>();
 
         using var masters = MasterRasters.Load(RepoRoot);
@@ -92,20 +129,28 @@ public class TierTintTests
         Assert.Equal(before.ToArgb(), icon.GetPixel(30, 128).ToArgb());
     }
 
+    /// <summary>
+    /// Near-grey by chroma, deliberately NOT by the HSL saturation
+    /// <see cref="TierTint"/> gates on.
+    ///
+    /// The first version of this test recomputed that same saturation with
+    /// a tighter cutoff, which made it a strict subset of what the gate
+    /// already skips: it could only fail if the gate inverted, never if
+    /// the gate's threshold moved or its formula changed. Chroma is an
+    /// independent measure, so this now fails when the ghost actually
+    /// starts moving.
+    ///
+    /// It also happens to be the honest measure here. HSL saturation is 1.0
+    /// for any pixel whose max channel is 255 and whose lightness is above
+    /// 0.5, so a near-white (245,247,255) reads as fully saturated - which
+    /// is why "the ghost is low-saturation" was never quite the right
+    /// description of why it survives.
+    /// </summary>
     private static bool IsNeutral(Color c)
     {
         int max = Math.Max(c.R, Math.Max(c.G, c.B));
         int min = Math.Min(c.R, Math.Min(c.G, c.B));
-        if (max == 0) return true;
-        // Mirrors TierTint's cutoff closely enough to select the same
-        // pixels without reaching into its internals.
-        double lightness = (max + min) / 510.0;
-        double delta = (max - min) / 255.0;
-        if (delta == 0) return true;
-        double saturation = lightness > 0.5
-            ? delta / (2.0 - (max + min) / 255.0)
-            : delta / ((max + min) / 255.0);
-        return saturation < 0.12;
+        return max - min <= 12;
     }
 
     private static string FindRepoRoot()

--- a/dist/windows/IconGen.Tests/TierTintTests.cs
+++ b/dist/windows/IconGen.Tests/TierTintTests.cs
@@ -1,0 +1,118 @@
+using System.Drawing;
+using Xunit;
+
+namespace Ghostty.IconGen.Tests;
+
+public class TierTintTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    /// <summary>
+    /// The whole reason the tint is gated on saturation: the ghost is
+    /// the brand, and it has to survive every edition unchanged. If this
+    /// fails, the five editions stop looking like one product.
+    /// </summary>
+    [Fact]
+    public void TheGhostAndTheBezelKeepTheirColour()
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(256);
+
+        var neutrals = new List<(int X, int Y, Color Before)>();
+        for (int y = 0; y < 256; y++)
+            for (int x = 0; x < 256; x++)
+            {
+                var c = icon.GetPixel(x, y);
+                if (c.A > 200 && IsNeutral(c)) neutrals.Add((x, y, c));
+            }
+
+        Assert.True(neutrals.Count > 500,
+            $"Expected the master to contain neutral ghost/bezel pixels; found {neutrals.Count}.");
+
+        TierTint.Apply(icon, EditionBrand.For(Edition.Pro));
+
+        foreach (var (x, y, before) in neutrals)
+        {
+            var after = icon.GetPixel(x, y);
+            Assert.Equal(before.ToArgb(), after.ToArgb());
+        }
+    }
+
+    [Fact]
+    public void TheScreenActuallyMoves()
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(256);
+
+        // A point inside the screen, above the band and below the ghost's
+        // head, chosen so it is screen rather than mark.
+        var before = icon.GetPixel(30, 128);
+        TierTint.Apply(icon, EditionBrand.For(Edition.Pro));
+        var after = icon.GetPixel(30, 128);
+
+        Assert.NotEqual(before.ToArgb(), after.ToArgb());
+    }
+
+    [Fact]
+    public void EditionsLandOnDistinctHues()
+    {
+        var editions = new[] { Edition.Pro, Edition.Enterprise, Edition.Legacy, Edition.Oss };
+        var seen = new List<(Edition Edition, Color Colour)>();
+
+        using var masters = MasterRasters.Load(RepoRoot);
+        foreach (var edition in editions)
+        {
+            using var icon = masters.Get(256);
+            TierTint.Apply(icon, EditionBrand.For(edition));
+            seen.Add((edition, icon.GetPixel(30, 128)));
+        }
+
+        for (int i = 0; i < seen.Count; i++)
+            for (int j = i + 1; j < seen.Count; j++)
+            {
+                int distance = Math.Abs(seen[i].Colour.R - seen[j].Colour.R)
+                    + Math.Abs(seen[i].Colour.G - seen[j].Colour.G)
+                    + Math.Abs(seen[i].Colour.B - seen[j].Colour.B);
+                Assert.True(distance > 60,
+                    $"{seen[i].Edition} and {seen[j].Edition} render the screen too close "
+                    + $"together (channel distance {distance}); they will not be tellable "
+                    + "apart in a taskbar.");
+            }
+    }
+
+    [Fact]
+    public void FlagshipIsLeftAlone()
+    {
+        using var masters = MasterRasters.Load(RepoRoot);
+        using var icon = masters.Get(256);
+
+        var before = icon.GetPixel(30, 128);
+        TierTint.Apply(icon, EditionBrand.For(Edition.None));
+
+        Assert.Equal(before.ToArgb(), icon.GetPixel(30, 128).ToArgb());
+    }
+
+    private static bool IsNeutral(Color c)
+    {
+        int max = Math.Max(c.R, Math.Max(c.G, c.B));
+        int min = Math.Min(c.R, Math.Min(c.G, c.B));
+        if (max == 0) return true;
+        // Mirrors TierTint's cutoff closely enough to select the same
+        // pixels without reaching into its internals.
+        double lightness = (max + min) / 510.0;
+        double delta = (max - min) / 255.0;
+        if (delta == 0) return true;
+        double saturation = lightness > 0.5
+            ? delta / (2.0 - (max + min) / 255.0)
+            : delta / ((max + min) / 255.0);
+        return saturation < 0.12;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "images", "icons")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new DirectoryNotFoundException("repo root with images/icons not found");
+    }
+}

--- a/dist/windows/IconGen/Cli.cs
+++ b/dist/windows/IconGen/Cli.cs
@@ -6,7 +6,7 @@ internal enum Channel
     Nightly,
 }
 
-internal sealed record Options(Channel Channel, string OutputDir);
+internal sealed record Options(Channel Channel, string OutputDir, Edition Edition);
 
 internal static class Cli
 {
@@ -14,6 +14,11 @@ internal static class Cli
     {
         Channel? channel = null;
         string? outputDir = null;
+        // Optional, and defaulting to the unmarked mark: this repo builds
+        // one product, and the editions are selected by the tier repo that
+        // packages them. A missing --edition has to keep producing exactly
+        // what it produced before editions existed.
+        var edition = Edition.None;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -35,6 +40,21 @@ internal static class Cli
                         throw new ArgumentException("--out requires a value");
                     outputDir = args[++i];
                     break;
+                case "--edition":
+                    if (i + 1 >= args.Length)
+                        throw new ArgumentException("--edition requires a value");
+                    edition = args[++i].ToLowerInvariant() switch
+                    {
+                        "none" => Edition.None,
+                        "pro" => Edition.Pro,
+                        "enterprise" => Edition.Enterprise,
+                        "legacy" => Edition.Legacy,
+                        "oss" => Edition.Oss,
+                        var other => throw new ArgumentException(
+                            $"Unknown edition '{other}'. Expected 'none', 'pro', "
+                            + "'enterprise', 'legacy' or 'oss'."),
+                    };
+                    break;
             }
         }
 
@@ -43,6 +63,6 @@ internal static class Cli
         if (outputDir is null)
             throw new ArgumentException("--out is required");
 
-        return new Options(channel.Value, outputDir);
+        return new Options(channel.Value, outputDir, edition);
     }
 }

--- a/dist/windows/IconGen/Edition.cs
+++ b/dist/windows/IconGen/Edition.cs
@@ -1,0 +1,89 @@
+namespace Ghostty.IconGen;
+
+/// <summary>
+/// Which product edition an icon is being generated for. Editions install
+/// side by side, so their shortcuts sit next to each other in the Start
+/// menu, the taskbar and Alt-Tab, and have to be tellable apart there.
+/// </summary>
+internal enum Edition
+{
+    /// <summary>The unmarked flagship mark. What every build produced
+    /// before editions existed, and still the default.</summary>
+    None,
+    Pro,
+    Enterprise,
+    Legacy,
+    Oss,
+}
+
+/// <summary>
+/// How one edition differs from the flagship mark.
+///
+/// Two cues, deliberately, because each covers the other's blind spot:
+/// hue is the only one that survives at 16 px, where the band is a
+/// couple of pixels of mush; the band is the only one that survives
+/// greyscale, a Windows high-contrast theme, or a user who cannot
+/// separate amber from graphite. Either alone leaves a real user unable
+/// to pick their shortcut.
+/// </summary>
+/// <param name="HueShiftDegrees">Rotation applied to the screen behind
+/// the mark. Only saturated pixels move (see <see cref="TierTint"/>), so
+/// the silver bezel and the white ghost keep their colour and the family
+/// still reads as one product.</param>
+/// <param name="SaturationScale">Multiplier on saturation. This is what
+/// separates two editions that would otherwise land on neighbouring
+/// hues: Legacy is a muted gold rather than a second amber, and Oss is
+/// near-graphite.</param>
+/// <param name="Monogram">Letters for the band, or empty for no band.
+/// The flagship is deliberately unmarked so that carrying a mark means
+/// "this is an edition" rather than every icon carrying furniture.</param>
+internal sealed record EditionBrand(
+    double HueShiftDegrees,
+    double SaturationScale,
+    string Monogram)
+{
+    /// <summary>
+    /// Fraction of the icon height the monogram band occupies.
+    ///
+    /// 0.15 is not a taste choice. The ghost's lowest lit row in the
+    /// shipping 256 px master is y=213, which is 83.2 percent down, so a
+    /// band starting at 85 percent clears the mark with a few pixels to
+    /// spare. A taller band looks better in isolation and starts eating
+    /// the ghost's body, which is the thing this must not do.
+    /// <see cref="MonogramBandTests.BandNeverReachesTheGhost"/> holds
+    /// this to the real artwork rather than to this comment, and
+    /// <see cref="HazardStripe.BandHeightFraction"/> is the same value so
+    /// the nightly stripe and the edition band cannot disagree about
+    /// where "the band" is.
+    /// </summary>
+    public const double BandHeightFraction = 0.15;
+
+    /// <summary>
+    /// Below this band height in pixels the letters stop being letters.
+    /// A three-glyph monogram needs roughly this much to keep its
+    /// counters open; under it the band is drawn as a plain bar, which
+    /// carries the edition's colour honestly instead of rendering mush
+    /// that reads as damage.
+    /// </summary>
+    public const int MinLegibleBandPx = 7;
+
+    public static EditionBrand For(Edition edition) => edition switch
+    {
+        // Amber. The largest move off the base indigo, because Pro is the
+        // edition most often installed next to the flagship.
+        Edition.Pro => new EditionBrand(160, 1.05, "PRO"),
+
+        // Teal. Far enough from both amber and the base blue to survive
+        // being in the same taskbar as either.
+        Edition.Enterprise => new EditionBrand(-62, 1.0, "ENT"),
+
+        // Muted gold. The hue alone sits close to Pro's amber, so the
+        // saturation drop is doing as much work here as the rotation.
+        Edition.Legacy => new EditionBrand(172, 0.55, "LTS"),
+
+        // Near-graphite. The open-source build reads as the plain one.
+        Edition.Oss => new EditionBrand(0, 0.15, "OSS"),
+
+        _ => new EditionBrand(0, 1.0, string.Empty),
+    };
+}

--- a/dist/windows/IconGen/Edition.cs
+++ b/dist/windows/IconGen/Edition.cs
@@ -52,11 +52,13 @@ internal sealed record EditionBrand(
     /// the ghost's body, which is the thing this must not do.
     /// <see cref="MonogramBandTests.BandNeverReachesTheGhost"/> holds
     /// this to the real artwork rather than to this comment, and
-    /// <see cref="HazardStripe.BandHeightFraction"/> is the same value so
-    /// the nightly stripe and the edition band cannot disagree about
-    /// where "the band" is.
+    /// Taken from <see cref="HazardStripe.BandHeightFraction"/> rather
+    /// than repeated, so the nightly stripe and the edition band cannot
+    /// disagree about where "the band" is. It was two literals and the
+    /// comment claimed they could not drift, which was not something
+    /// anything enforced.
     /// </summary>
-    public const double BandHeightFraction = 0.15;
+    public const double BandHeightFraction = HazardStripe.BandHeightFraction;
 
     /// <summary>
     /// Below this band height in pixels the letters stop being letters.

--- a/dist/windows/IconGen/MonogramBand.cs
+++ b/dist/windows/IconGen/MonogramBand.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
@@ -25,8 +24,13 @@ internal static class MonogramBand
     {
         if (string.IsNullOrEmpty(brand.Monogram)) return;
 
-        Debug.Assert(bitmap.Width == bitmap.Height,
-            "MonogramBand.Apply expects a square bitmap.");
+        // Thrown rather than asserted: the branding target runs this
+        // tool with -c Release, where Debug.Assert compiles away and a
+        // wrong pixel format would silently round-trip through a
+        // converted buffer instead of failing the build.
+        if (bitmap.Width != bitmap.Height)
+            throw new InvalidOperationException(
+                "MonogramBand.Apply expects a square bitmap.");
 
         int size = bitmap.Width;
         int bandHeight = (int)Math.Round(size * EditionBrand.BandHeightFraction);

--- a/dist/windows/IconGen/MonogramBand.cs
+++ b/dist/windows/IconGen/MonogramBand.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Drawing.Text;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.IconGen;
+
+/// <summary>
+/// Draws the edition monogram across the bottom band of an icon.
+///
+/// The band is held to <see cref="EditionBrand.BandHeightFraction"/> so
+/// it stays below the mark; see that constant for the measurement it
+/// comes from. Below <see cref="EditionBrand.MinLegibleBandPx"/> the
+/// letters are dropped and a plain bar is drawn instead, because a
+/// three-glyph monogram rendered into four pixels is not a small
+/// monogram, it is a smudge that reads as a rendering fault.
+/// </summary>
+internal static class MonogramBand
+{
+    private static readonly Color BandInk = Color.FromArgb(0xFF, 0x12, 0x16, 0x1B);
+
+    public static void Apply(Bitmap bitmap, EditionBrand brand)
+    {
+        if (string.IsNullOrEmpty(brand.Monogram)) return;
+
+        Debug.Assert(bitmap.Width == bitmap.Height,
+            "MonogramBand.Apply expects a square bitmap.");
+
+        int size = bitmap.Width;
+        int bandHeight = (int)Math.Round(size * EditionBrand.BandHeightFraction);
+        if (bandHeight < 2) bandHeight = 2;
+        int bandTop = size - bandHeight;
+
+        // The band's colour is the edition's own hue, taken from the icon
+        // it is being drawn on rather than from a second table that could
+        // drift away from the tint.
+        var bandColour = SampleScreenColour(bitmap, brand);
+
+        // The plate has rounded corners and the band runs to the bottom
+        // edge, so a plain rectangle would square off the two bottom
+        // corners. Snapshot the alpha, draw, then put the alpha back:
+        // the band ends up clipped to whatever silhouette the master
+        // actually has, with no second copy of the corner radius to keep
+        // in step.
+        var alpha = SnapshotAlpha(bitmap, bandTop, bandHeight);
+
+        using (var g = Graphics.FromImage(bitmap))
+        {
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            g.CompositingQuality = CompositingQuality.HighQuality;
+            g.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
+
+            using (var brush = new SolidBrush(bandColour))
+                g.FillRectangle(brush, 0, bandTop, size, bandHeight);
+
+            // A hairline along the top edge so the band reads as a
+            // deliberate layer rather than the screen changing colour
+            // halfway down.
+            int rule = Math.Max(1, (int)Math.Round(size / 256.0 * 4));
+            using (var shade = new SolidBrush(Color.FromArgb(0x40, 0, 0, 0)))
+                g.FillRectangle(shade, 0, bandTop, size, rule);
+
+            if (bandHeight >= EditionBrand.MinLegibleBandPx)
+                DrawMonogram(g, brand.Monogram, size, bandTop, bandHeight);
+        }
+
+        RestoreAlpha(bitmap, bandTop, bandHeight, alpha);
+    }
+
+    private static void DrawMonogram(Graphics g, string text, int size, int bandTop, int bandHeight)
+    {
+        // Fitted to the band rather than to a fixed point size, so the
+        // monogram occupies the same proportion of every master instead
+        // of drifting between 32 px and 1024 px.
+        float emSize = bandHeight * 0.72f;
+
+        using var font = new Font(
+            FontFamily.GenericSansSerif, emSize, FontStyle.Bold, GraphicsUnit.Pixel);
+        using var brush = new SolidBrush(BandInk);
+        using var format = new StringFormat
+        {
+            Alignment = StringAlignment.Center,
+            LineAlignment = StringAlignment.Center,
+        };
+
+        var layout = new RectangleF(0, bandTop, size, bandHeight);
+        g.DrawString(text, font, brush, layout, format);
+    }
+
+    /// <summary>
+    /// The band's fill, derived from the icon's own screen so it tracks
+    /// whatever <see cref="TierTint"/> did. Sampled from a row above the
+    /// band and lightened, which keeps the band related to the screen
+    /// while staying separable from it.
+    /// </summary>
+    private static Color SampleScreenColour(Bitmap bitmap, EditionBrand brand)
+    {
+        int size = bitmap.Width;
+        int y = (int)Math.Round(size * 0.62);
+        int x = (int)Math.Round(size * 0.5);
+        var sampled = bitmap.GetPixel(Math.Clamp(x, 0, size - 1), Math.Clamp(y, 0, size - 1));
+
+        // A fully desaturated edition would otherwise get a grey band on
+        // a grey screen; nudge the lightness so the edge survives.
+        int lift = brand.SaturationScale < 0.3 ? 70 : 46;
+        return Color.FromArgb(
+            0xFF,
+            Math.Clamp(sampled.R + lift, 0, 255),
+            Math.Clamp(sampled.G + lift, 0, 255),
+            Math.Clamp(sampled.B + lift, 0, 255));
+    }
+
+    private static byte[] SnapshotAlpha(Bitmap bitmap, int bandTop, int bandHeight)
+    {
+        var rect = new Rectangle(0, bandTop, bitmap.Width, bandHeight);
+        var data = bitmap.LockBits(rect, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+        try
+        {
+            int count = bitmap.Width * bandHeight;
+            var pixels = new int[count];
+            Marshal.Copy(data.Scan0, pixels, 0, count);
+
+            var alpha = new byte[count];
+            for (int i = 0; i < count; i++)
+                alpha[i] = (byte)((pixels[i] >> 24) & 0xFF);
+            return alpha;
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+    }
+
+    private static void RestoreAlpha(Bitmap bitmap, int bandTop, int bandHeight, byte[] alpha)
+    {
+        var rect = new Rectangle(0, bandTop, bitmap.Width, bandHeight);
+        var data = bitmap.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+        try
+        {
+            int count = bitmap.Width * bandHeight;
+            var pixels = new int[count];
+            Marshal.Copy(data.Scan0, pixels, 0, count);
+
+            for (int i = 0; i < count; i++)
+            {
+                int drawn = (pixels[i] >> 24) & 0xFF;
+                int keep = Math.Min(drawn, alpha[i]);
+                pixels[i] = (keep << 24) | (pixels[i] & 0x00FFFFFF);
+            }
+
+            Marshal.Copy(pixels, 0, data.Scan0, count);
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+    }
+}

--- a/dist/windows/IconGen/Program.cs
+++ b/dist/windows/IconGen/Program.cs
@@ -17,7 +17,14 @@ internal static class Program
             var options = Cli.Parse(args);
             Directory.CreateDirectory(options.OutputDir);
 
-            using var masters = MasterRasters.Load(repoRoot);
+            using var loaded = MasterRasters.Load(repoRoot);
+
+            // Edition first, channel second. The nightly stripe and the
+            // edition band want the same bottom band, and a nightly build
+            // of an edition needs to read as nightly before it reads as
+            // that edition - a dev build shipped as if it were stable is
+            // the more expensive confusion.
+            using var masters = BrandMasters(loaded, EditionBrand.For(options.Edition));
 
             if (options.Channel == Channel.Nightly)
             {
@@ -61,6 +68,20 @@ internal static class Program
             Console.Error.WriteLine($"IconGen failed: {ex.Message}");
             return 1;
         }
+    }
+
+    private static MasterRasters BrandMasters(MasterRasters original, EditionBrand brand)
+    {
+        // Caller disposes the returned instance.
+        var dict = new Dictionary<int, System.Drawing.Bitmap>();
+        foreach (var px in original.Sizes)
+        {
+            var bitmap = original.Get(px); // MasterRasters.Get clones
+            TierTint.Apply(bitmap, brand);
+            MonogramBand.Apply(bitmap, brand);
+            dict[px] = bitmap;
+        }
+        return MasterRasters.FromDictionary(dict);
     }
 
     private static MasterRasters StripeMasters(MasterRasters original)

--- a/dist/windows/IconGen/Program.cs
+++ b/dist/windows/IconGen/Program.cs
@@ -23,8 +23,19 @@ internal static class Program
             // edition band want the same bottom band, and a nightly build
             // of an edition needs to read as nightly before it reads as
             // that edition - a dev build shipped as if it were stable is
-            // the more expensive confusion.
-            using var masters = BrandMasters(loaded, EditionBrand.For(options.Edition));
+            // the more expensive confusion. One consequence worth knowing:
+            // on a nightly edition build the stripe covers the monogram, so
+            // those icons carry the hue cue alone.
+            //
+            // The unmarked flagship skips branding entirely rather than
+            // running two no-op transforms over a clone. That is not just
+            // saved work: it keeps the default path byte-identical to what
+            // this tool produced before editions existed, which Cli.cs
+            // states as a requirement and which an extra Bitmap round-trip
+            // would quietly put at risk.
+            var brand = EditionBrand.For(options.Edition);
+            using var branded = IsNeutral(brand) ? null : BrandMasters(loaded, brand);
+            var masters = branded ?? loaded;
 
             if (options.Channel == Channel.Nightly)
             {
@@ -69,6 +80,16 @@ internal static class Program
             return 1;
         }
     }
+
+    /// <summary>
+    /// Whether this brand changes nothing, so the masters can be used as
+    /// loaded. Asks the brand rather than the <see cref="Edition"/> so a
+    /// future edition that happens to be neutral takes the same path.
+    /// </summary>
+    private static bool IsNeutral(EditionBrand brand)
+        => brand.HueShiftDegrees == 0
+           && brand.SaturationScale == 1.0
+           && string.IsNullOrEmpty(brand.Monogram);
 
     private static MasterRasters BrandMasters(MasterRasters original, EditionBrand brand)
     {

--- a/dist/windows/IconGen/TierTint.cs
+++ b/dist/windows/IconGen/TierTint.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+
+namespace Ghostty.IconGen;
+
+/// <summary>
+/// Rotates the hue of an icon's saturated pixels, leaving its neutral
+/// ones alone.
+///
+/// The selectivity is the point. The shipping mark is a saturated screen
+/// behind a near-white ghost inside a near-neutral silver bezel, so a
+/// rotation gated on saturation recolours the screen and its glow while
+/// the ghost and the bezel come through untouched. That is what keeps
+/// five editions looking like one product rather than five apps, and it
+/// means no mask or per-region artwork has to be maintained alongside
+/// the masters.
+/// </summary>
+internal static class TierTint
+{
+    /// <summary>
+    /// Saturation below which a pixel is treated as neutral and left as
+    /// it is. The bezel's silver and the ghost's white sit well under
+    /// this; the screen and the glow sit well over it. Anti-aliased
+    /// pixels along the ghost's edge land in between and move only
+    /// partially, which is what stops the edge from banding.
+    /// </summary>
+    private const double NeutralSaturationCutoff = 0.18;
+
+    public static void Apply(Bitmap bitmap, EditionBrand brand)
+    {
+        if (brand.HueShiftDegrees == 0 && brand.SaturationScale == 1.0)
+            return;
+
+        Debug.Assert(bitmap.PixelFormat == PixelFormat.Format32bppArgb,
+            "TierTint.Apply expects 32bpp ARGB; the masters load as ARGB.");
+
+        var rect = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+        var data = bitmap.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+        try
+        {
+            int count = bitmap.Width * bitmap.Height;
+            var pixels = new int[count];
+            Marshal.Copy(data.Scan0, pixels, 0, count);
+
+            for (int i = 0; i < count; i++)
+            {
+                int argb = pixels[i];
+                int a = (argb >> 24) & 0xFF;
+                if (a == 0) continue; // Outside the plate; nothing to recolour.
+
+                int r = (argb >> 16) & 0xFF;
+                int g = (argb >> 8) & 0xFF;
+                int b = argb & 0xFF;
+
+                RgbToHsl(r, g, b, out double h, out double s, out double l);
+                if (s < NeutralSaturationCutoff) continue;
+
+                h = (h + brand.HueShiftDegrees) % 360.0;
+                if (h < 0) h += 360.0;
+                s = Math.Clamp(s * brand.SaturationScale, 0.0, 1.0);
+
+                HslToRgb(h, s, l, out r, out g, out b);
+                pixels[i] = (a << 24) | (r << 16) | (g << 8) | b;
+            }
+
+            Marshal.Copy(pixels, 0, data.Scan0, count);
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+    }
+
+    private static void RgbToHsl(int r8, int g8, int b8, out double h, out double s, out double l)
+    {
+        double r = r8 / 255.0, g = g8 / 255.0, b = b8 / 255.0;
+        double max = Math.Max(r, Math.Max(g, b));
+        double min = Math.Min(r, Math.Min(g, b));
+        double delta = max - min;
+
+        l = (max + min) / 2.0;
+
+        if (delta == 0)
+        {
+            h = 0;
+            s = 0;
+            return;
+        }
+
+        s = l > 0.5 ? delta / (2.0 - max - min) : delta / (max + min);
+
+        if (max == r) h = ((g - b) / delta + (g < b ? 6.0 : 0.0)) * 60.0;
+        else if (max == g) h = ((b - r) / delta + 2.0) * 60.0;
+        else h = ((r - g) / delta + 4.0) * 60.0;
+    }
+
+    private static void HslToRgb(double h, double s, double l, out int r8, out int g8, out int b8)
+    {
+        if (s == 0)
+        {
+            r8 = g8 = b8 = (int)Math.Round(l * 255.0);
+            return;
+        }
+
+        double q = l < 0.5 ? l * (1.0 + s) : l + s - l * s;
+        double p = 2.0 * l - q;
+        double hk = h / 360.0;
+
+        r8 = Channel(p, q, hk + 1.0 / 3.0);
+        g8 = Channel(p, q, hk);
+        b8 = Channel(p, q, hk - 1.0 / 3.0);
+
+        static int Channel(double p, double q, double t)
+        {
+            if (t < 0) t += 1.0;
+            if (t > 1) t -= 1.0;
+
+            double v =
+                t < 1.0 / 6.0 ? p + (q - p) * 6.0 * t :
+                t < 1.0 / 2.0 ? q :
+                t < 2.0 / 3.0 ? p + (q - p) * (2.0 / 3.0 - t) * 6.0 :
+                p;
+
+            return (int)Math.Clamp(Math.Round(v * 255.0), 0, 255);
+        }
+    }
+}

--- a/dist/windows/IconGen/TierTint.cs
+++ b/dist/windows/IconGen/TierTint.cs
@@ -21,9 +21,15 @@ internal static class TierTint
     /// <summary>
     /// Saturation below which a pixel is treated as neutral and left as
     /// it is. The bezel's silver and the ghost's white sit well under
-    /// this; the screen and the glow sit well over it. Anti-aliased
-    /// pixels along the ghost's edge land in between and move only
-    /// partially, which is what stops the edge from banding.
+    /// this; the screen and the glow sit well over it.
+    ///
+    /// HSL saturation, not chroma, and the difference matters at the top
+    /// end: for any pixel whose brightest channel is 255 the denominator
+    /// collapses as lightness approaches 1, so a near-white carrying a
+    /// few counts of colour computes a saturation close to 1.0 and is
+    /// rotated rather than skipped. It is rotated by a hue it barely has,
+    /// so the result moves by at most 12/255 on the shipping master - not
+    /// visible, and measured by TierTintTests rather than assumed.
     /// </summary>
     private const double NeutralSaturationCutoff = 0.18;
 

--- a/dist/windows/IconGen/TierTint.cs
+++ b/dist/windows/IconGen/TierTint.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
@@ -33,8 +32,13 @@ internal static class TierTint
         if (brand.HueShiftDegrees == 0 && brand.SaturationScale == 1.0)
             return;
 
-        Debug.Assert(bitmap.PixelFormat == PixelFormat.Format32bppArgb,
-            "TierTint.Apply expects 32bpp ARGB; the masters load as ARGB.");
+        // Thrown rather than asserted: the branding target runs this
+        // tool with -c Release, where Debug.Assert compiles away and a
+        // wrong pixel format would silently round-trip through a
+        // converted buffer instead of failing the build.
+        if (bitmap.PixelFormat != PixelFormat.Format32bppArgb)
+            throw new InvalidOperationException(
+                "TierTint.Apply expects 32bpp ARGB; the masters load as ARGB.");
 
         var rect = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
         var data = bitmap.LockBits(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);

--- a/dist/windows/cli-shim/main.zig
+++ b/dist/windows/cli-shim/main.zig
@@ -60,18 +60,79 @@ pub fn main(init: std.process.Init) !u8 {
     const term = try child.wait(io);
     return switch (term) {
         .exited => |code| code,
-        // Signalled, stopped or unknown: the child did not exit on its
-        // own terms, and reporting 0 would tell a script it succeeded.
-        else => 1,
+        // The child did not exit on its own terms, and reporting 0 would
+        // tell a script it succeeded. Listed rather than caught by an
+        // `else` so a new Term variant is a compile error here.
+        .signal, .stopped, .unknown => 1,
     };
 }
 
+/// Every bare-word subcommand the app accepts without a `+`.
+///
+/// A copy, and it has to be: this binary decides whether to wait before
+/// the app has run, so it cannot ask. The copy is pinned to the original
+/// by CliShimParityTests, which parses this array out of this file and
+/// compares it with `CliAliases.Actions` - the same technique
+/// CliAliasParityTests already uses to pin that table to the Action enum
+/// in src/cli/ghostty.zig. Keep the marker comments; the test finds the
+/// array by them.
+// wintty:aliases:begin
+const aliases = [_][]const u8{
+    "boo",
+    "crash-report",
+    "edit-config",
+    "explain-config",
+    "help",
+    "list-actions",
+    "list-colors",
+    "list-fonts",
+    "list-keybinds",
+    "list-themes",
+    "list-themes-tui",
+    "new-tab",
+    "new-window",
+    "show-config",
+    "show-face",
+    "ssh",
+    "ssh-cache",
+    "toggle-quick-terminal",
+    "validate-config",
+    "version",
+};
+// wintty:aliases:end
+
 /// Whether this invocation is a CLI action rather than a launch.
 ///
-/// The `+verb` spelling is libghostty's own, and Program.cs dispatches
-/// on exactly the same test, so the two agree on what counts without
-/// this binary needing to know any of the verbs.
+/// Mirrors what Program.MainImpl treats as a command: a `+verb`, one of
+/// the bare-word aliases above, the version spellings it intercepts
+/// directly, and a help request. Getting this wrong in the permissive
+/// direction returns the prompt before the output, which is the symptom
+/// this binary exists to remove; getting it wrong the other way holds a
+/// shell until the user closes a terminal window. The first is annoying
+/// and the second is broken, so anything uncertain stays out.
 fn isCliAction(argv: []const []const u8) bool {
     if (argv.len < 2) return false;
-    return std.mem.startsWith(u8, argv[1], "+");
+    const first = argv[1];
+
+    if (std.mem.startsWith(u8, first, "+")) return true;
+
+    // `version` and `help` are in the alias table; these two are not,
+    // and Program.MainImpl intercepts them before libghostty sees argv.
+    if (std.mem.eql(u8, first, "--version") or std.mem.eql(u8, first, "-v")) return true;
+
+    for (aliases) |alias| {
+        if (std.mem.eql(u8, first, alias)) return true;
+    }
+
+    // Help, with the same `-e` rule the C# side applies: -e hands the
+    // rest of the line to a child command, so a help flag after it
+    // belongs to that command and this is a launch.
+    for (argv[1..]) |arg| {
+        if (std.mem.eql(u8, arg, "-e")) return false;
+        if (std.mem.eql(u8, arg, "--help") or
+            std.mem.eql(u8, arg, "-h") or
+            std.mem.eql(u8, arg, "/?")) return true;
+    }
+
+    return false;
 }

--- a/dist/windows/cli-shim/main.zig
+++ b/dist/windows/cli-shim/main.zig
@@ -1,0 +1,77 @@
+//! Console launcher for the GUI Wintty binary.
+//!
+//! Wintty.exe is a GUI-subsystem binary so that launching it from the
+//! Start menu or Explorer does not flash a loader-created console before
+//! the splash. Windows decides whether a shell waits for a process from
+//! that subsystem byte and nothing else, so `wintty +version` typed at a
+//! prompt returns to the prompt immediately and prints afterwards, which
+//! reads as a hang or a lost command.
+//!
+//! One binary cannot have both. This is the other half: a console-
+//! subsystem launcher that forwards its arguments to the real
+//! executable, lets it inherit the console it was given, waits for it,
+//! and exits with its exit code. `code.cmd` and `wt.exe` are the same
+//! pattern.
+//!
+//! It lives one directory below the app so that both can be called
+//! `wintty` without colliding on a case-insensitive filesystem.
+
+const std = @import("std");
+
+const app_name = "Wintty.exe";
+
+pub fn main(init: std.process.Init) !u8 {
+    const io = init.io;
+    const arena = init.arena.allocator();
+
+    const exe_dir = try std.process.executableDirPathAlloc(io, arena);
+    const app_path = try std.fs.path.join(arena, &.{ exe_dir, "..", app_name });
+
+    const args = try init.minimal.args.toSlice(arena);
+    if (args.len == 0) return 1;
+
+    // argv[0] becomes the real executable; everything the caller typed
+    // after our own name passes through untouched, so quoting and flags
+    // reach libghostty's CLI exactly as written.
+    const argv = try arena.alloc([]const u8, args.len);
+    argv[0] = app_path;
+    for (args[1..], 1..) |arg, i| argv[i] = arg;
+
+    // stdin, stdout and stderr all default to .inherit, which is the
+    // entire point of this binary: the child writes to the console this
+    // process was handed rather than to one of its own.
+    var child = std.process.spawn(io, .{ .argv = argv }) catch |err| {
+        std.debug.print(
+            "wintty: cannot start {s}: {s}\n",
+            .{ app_path, @errorName(err) },
+        );
+        return 1;
+    };
+
+    // Wait for a CLI action, get out of the way for a launch.
+    //
+    // `wintty +show-config` is a command and the shell has to wait for
+    // it, which is this binary's whole reason to exist. `wintty` on its
+    // own opens a terminal window, and holding the calling shell hostage
+    // until the user closes that window would make the launcher worse
+    // than calling the GUI binary directly.
+    if (!isCliAction(argv)) return 0;
+
+    const term = try child.wait(io);
+    return switch (term) {
+        .exited => |code| code,
+        // Signalled, stopped or unknown: the child did not exit on its
+        // own terms, and reporting 0 would tell a script it succeeded.
+        else => 1,
+    };
+}
+
+/// Whether this invocation is a CLI action rather than a launch.
+///
+/// The `+verb` spelling is libghostty's own, and Program.cs dispatches
+/// on exactly the same test, so the two agree on what counts without
+/// this binary needing to know any of the verbs.
+fn isCliAction(argv: []const []const u8) bool {
+    if (argv.len < 2) return false;
+    return std.mem.startsWith(u8, argv[1], "+");
+}

--- a/windows/Ghostty.Tests/Cli/CliShimParityTests.cs
+++ b/windows/Ghostty.Tests/Cli/CliShimParityTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Cli;
+using Xunit;
+
+namespace Ghostty.Tests.Cli;
+
+// Pins the console shim's alias table to CliAliases.Actions.
+//
+// dist/windows/cli-shim decides whether the calling shell waits for
+// Wintty.exe, and it has to decide before the app runs, so it carries its
+// own copy of the subcommand list. A third copy of a table that already
+// rots (see CliAliasParityTests) needs its own guard: when the two drift,
+// `wintty <alias>` returns to the prompt and prints over it, and
+// `wintty validate-config && deploy` proceeds regardless of the result,
+// because the shim's non-waiting branch always exits 0.
+//
+// Same technique as CliAliasParityTests: the zig source is embedded by
+// Ghostty.Tests.csproj rather than read from disk, so the test does not
+// depend on where the assembly runs from.
+public class CliShimParityTests
+{
+    private const string ShimResource = "Ghostty.Tests.Cli.Shim.main.zig";
+
+    // The shim brackets its table with these so this test finds the array
+    // and not, say, a doc comment listing the same words.
+    private const string TableOpen = "// wintty:aliases:begin";
+    private const string TableClose = "// wintty:aliases:end";
+
+    private static readonly Regex EntryPattern = new(
+        @"^\s*""(?<name>[^""]+)"",\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+
+    [Fact]
+    public void ShimAliasTableMatchesCliAliases()
+    {
+        var shim = ReadShimSource();
+        var declared = ParseAliasTable(shim);
+
+        Assert.True(declared.Count > 0,
+            $"No alias entries found between {TableOpen} and {TableClose}. If the "
+            + "shim's table moved or the markers were removed, this test cannot "
+            + "pin anything and must be repaired rather than deleted.");
+
+        var expected = CliAliases.Actions.OrderBy(a => a, StringComparer.Ordinal).ToList();
+        var actual = declared.OrderBy(a => a, StringComparer.Ordinal).ToList();
+
+        var missing = expected.Except(actual, StringComparer.Ordinal).ToList();
+        var extra = actual.Except(expected, StringComparer.Ordinal).ToList();
+
+        Assert.True(
+            missing.Count == 0 && extra.Count == 0,
+            "dist/windows/cli-shim/main.zig's alias table has drifted from "
+            + "CliAliases.Actions.\n"
+            + $"  missing from the shim: {Fmt(missing)}\n"
+            + $"  present only in the shim: {Fmt(extra)}\n"
+            + "A subcommand missing from the shim means the shell stops waiting "
+            + "for it: its output lands after the prompt and its exit code is "
+            + "reported as 0.");
+    }
+
+    // The two version spellings the shim special-cases are the ones
+    // Program.MainImpl intercepts on top of the alias table. If that
+    // interception grows a spelling, the shim needs it too.
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("-v")]
+    public void ShimCoversTheVersionSpellingsProgramIntercepts(string spelling)
+    {
+        var shim = ReadShimSource();
+        Assert.Contains($"\"{spelling}\"", shim, StringComparison.Ordinal);
+    }
+
+    private static string Fmt(IReadOnlyCollection<string> items)
+        => items.Count == 0 ? "(none)" : string.Join(", ", items);
+
+    private static List<string> ParseAliasTable(string source)
+    {
+        var open = source.IndexOf(TableOpen, StringComparison.Ordinal);
+        var close = source.IndexOf(TableClose, StringComparison.Ordinal);
+        Assert.True(open >= 0 && close > open,
+            $"Could not locate {TableOpen}/{TableClose} in the shim source.");
+
+        var body = source[(open + TableOpen.Length)..close];
+        return EntryPattern.Matches(body)
+            .Select(m => m.Groups["name"].Value)
+            .ToList();
+    }
+
+    private static string ReadShimSource()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(ShimResource);
+        Assert.True(stream is not null,
+            $"Embedded resource {ShimResource} not found. Check the "
+            + "EmbeddedResource entry for dist/windows/cli-shim/main.zig in "
+            + "Ghostty.Tests.csproj.");
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty.Tests/Ghostty.Tests.csproj
+++ b/windows/Ghostty.Tests/Ghostty.Tests.csproj
@@ -114,6 +114,15 @@
                       Link="Cli\Actions\ghostty.zig"
                       LogicalName="Ghostty.Tests.Cli.Actions.ghostty.zig" />
     <!--
+      The console shim's copy of the same alias table, for
+      CliShimParityTests. The shim decides whether the shell waits before
+      the app runs, so it cannot ask CliAliases at runtime and carries a
+      copy; this pins the copy.
+    -->
+    <EmbeddedResource Include="..\..\dist\windows\cli-shim\main.zig"
+                      Link="Cli\Shim\main.zig"
+                      LogicalName="Ghostty.Tests.Cli.Shim.main.zig" />
+    <!--
       Every settings page, for SettingsCardConfigKeyParityTests. A wildcard
       rather than a file list: a page added later is picked up without anyone
       remembering this entry, which is the failure mode the other blocks above

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -330,8 +330,8 @@ public partial class App : Application
 
     private static void LogUnhandled(string tag, string detail)
     {
-        // stderr mirror for terminal launches (Program.Main's
-        // FreeConsole gate keeps the console attached in that case).
+        // stderr mirror for terminal launches (Program.MainImpl attaches
+        // to the launching terminal's console, so there is one to write to).
         try
         {
             Console.Error.WriteLine($"{AppIdentity.LogTag} {tag}:");

--- a/windows/Ghostty/Cli/CliActions.cs
+++ b/windows/Ghostty/Cli/CliActions.cs
@@ -6,9 +6,10 @@ namespace Ghostty.Cli;
 
 /// <summary>
 /// Handlers for <c>+</c>-prefixed CLI actions intercepted before the
-/// libghostty CLI dispatcher in <see cref="Program"/>. Console
-/// inheritance is provided by Wintty.exe being a console-subsystem app
-/// (see Program.cs comments) - no AttachConsole plumbing is needed.
+/// libghostty CLI dispatcher in <see cref="Program"/>. Wintty is a
+/// GUI-subsystem binary, so the console these write to is the one
+/// <c>Program.AttachToParentConsole</c> borrows from the launching
+/// terminal.
 /// </summary>
 internal static class CliActions
 {

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -1,6 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!--
+      WinExe, not Exe: a console-subsystem binary makes the loader put a
+      console window on screen before managed code runs, which Explorer and
+      the Start menu show as a flash before the splash. UseWinUI does not
+      trigger the SDK's WinExe output inference (only UseWPF and
+      UseWindowsForms do), so this has to be spelled out. Program.MainImpl
+      attaches to the launching terminal's console explicitly so the `+`
+      CLI actions keep their stdio.
+    -->
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <!--
@@ -545,6 +554,31 @@
     Inputs for the same reason as IconGen's own sources: IconGen
     compiles them, so editing one changes what it writes.
   -->
+  <!--
+    The console launcher. Wintty.exe is GUI-subsystem so Explorer does not
+    flash a console at it; that also means a shell does not wait for it, so
+    `wintty +version` needs a console-subsystem binary in front of it. See
+    dist/windows/cli-shim/main.zig.
+
+    Built with zig rather than as a second .NET project because a .NET
+    console app would drag a runtime (or 70 MB of self-contained payload)
+    behind a program whose whole job is CreateProcess plus WaitForSingleObject.
+    zig is already a hard build dependency for libghostty, so this adds a
+    compiler invocation and no new toolchain.
+
+    It lands in a bin/ subdirectory because the app it launches is also
+    called wintty, and a case-insensitive filesystem will not hold both in
+    one directory.
+  -->
+  <Target Name="BuildCliShim"
+          AfterTargets="Build"
+          Inputs="..\..\dist\windows\cli-shim\main.zig"
+          Outputs="$(OutDir)bin\wintty.exe">
+    <MakeDir Directories="$(OutDir)bin" />
+    <Exec Command="zig build-exe &quot;$(MSBuildThisFileDirectory)..\..\dist\windows\cli-shim\main.zig&quot; -O ReleaseSmall --name wintty -femit-bin=&quot;$(OutDir)bin\wintty.exe&quot;"
+          WorkingDirectory="$(MSBuildThisFileDirectory)" />
+  </Target>
+
   <Target Name="GenerateBrandingAssets"
           BeforeTargets="BeforeBuild"
           Inputs="@(IconGenSource);..\Ghostty.Core\Shell\LaunchIconAssets.cs;..\Ghostty.Core\Shell\LaunchIconMetrics.cs;@(IconGenMaster);$(BrandingStamp)"

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -94,12 +94,22 @@
     <Channel Condition="'$(Channel)' == '' and '$(Configuration)' == 'Debug'">Nightly</Channel>
     <Channel Condition="'$(Channel)' == ''">Stable</Channel>
     <!--
-      Channel is part of the path so a switch (e.g. -p:Channel=Nightly
+      Which edition's mark to generate: none, pro, enterprise, legacy or
+      oss. This repo builds one product, so the default has to be the
+      unmarked mark; the tier repo that packages the editions sets this
+      per tier. See dist/windows/IconGen/Edition.cs for what each value
+      does to the icon.
+    -->
+    <IconEdition Condition="'$(IconEdition)' == ''">none</IconEdition>
+    <!--
+      Channel and edition are part of the path so a switch (e.g. -p:Channel=Nightly
       after a Stable build) cannot serve the stale variant from the
       previous build: MSBuild only skips GenerateBrandingAssets when its
       declared Outputs exist AND are newer than its Inputs, and keeping
       each channel in its own directory makes "does wintty.ico exist?"
-      channel-aware.
+      channel-aware. Edition sits below channel in the same path for the
+      same reason: two editions built in one tree would otherwise
+      overwrite each other's files.
 
       That is not enough on its own, because the two consumers of these
       files are timestamp-driven and have no channel in their own paths.
@@ -112,15 +122,17 @@
       is what forces the regeneration when the channel changes.
     -->
     <GeneratedBrandingRoot>$(BaseIntermediateOutputPath)$(Platform)\$(Configuration)\$(TargetFramework)\Branding\</GeneratedBrandingRoot>
-    <GeneratedBrandingDir>$(GeneratedBrandingRoot)$(Channel)\</GeneratedBrandingDir>
+    <GeneratedBrandingDir>$(GeneratedBrandingRoot)$(Channel)\$(IconEdition)\</GeneratedBrandingDir>
     <BrandingStamp>$(GeneratedBrandingRoot)last-invocation.txt</BrandingStamp>
     <!--
       One definition, used to run the tool and to stamp what was run.
       Stamping the whole command rather than just the channel keeps the
       guard honest: any future argument that changes what IconGen writes
-      changes the stamp too, without anyone having to remember.
+      changes the stamp too, without anyone having to remember. The
+      edition argument is one such, and it needed nothing added here to
+      be covered.
     -->
-    <IconGenCommand>dotnet run --project ..\..\dist\windows\IconGen --no-launch-profile -c Release -- --channel $(Channel) --out "$(GeneratedBrandingDir.TrimEnd('\'))"</IconGenCommand>
+    <IconGenCommand>dotnet run --project ..\..\dist\windows\IconGen --no-launch-profile -c Release -- --channel $(Channel) --edition $(IconEdition) --out "$(GeneratedBrandingDir.TrimEnd('\'))"</IconGenCommand>
     <ApplicationIcon>$(GeneratedBrandingDir)wintty.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -582,13 +582,74 @@
     called wintty, and a case-insensitive filesystem will not hold both in
     one directory.
   -->
+  <!--
+    Target triple for the shim, from $(Platform). Without it zig builds for
+    the host, so an ARM64 package produced on an x64 agent gets an x64 shim
+    beside an ARM64 Wintty.exe. `baseline` because zig otherwise targets the
+    building machine's CPU features, which is how a CI box with AVX-512
+    ships a binary that faults on a user's older chip.
+  -->
+  <PropertyGroup>
+    <CliShimTarget Condition="'$(Platform)' == 'ARM64'">aarch64-windows</CliShimTarget>
+    <CliShimTarget Condition="'$(Platform)' == 'x86'">x86-windows</CliShimTarget>
+    <CliShimTarget Condition="'$(CliShimTarget)' == ''">x86_64-windows</CliShimTarget>
+  <!--
+    The whole command, stamped and listed in Inputs, so a change to the
+    target, the optimisation mode or the zig version regenerates the shim.
+    Listing only main.zig meant none of those did. Same device as
+    $(BrandingStamp) above, and for the same reason.
+  -->
+  </PropertyGroup>
+
+  <!--
+    $(OutDir) is not set while the project body is being evaluated, so the
+    command and the stamp path are built here, inside a target, where it
+    is. Defining them in a PropertyGroup above silently produced
+    -femit-bin="bin\wintty.exe" relative to the project directory and a
+    stamp nothing ever read, which made the target skip on every ordinary
+    build. Properties set inside a target stay set for the rest of it, so
+    BuildCliShim below sees both.
+  -->
+  <Target Name="StampCliShimInvocation" BeforeTargets="BuildCliShim">
+    <PropertyGroup>
+      <CliShimStamp>$(OutDir)bin\last-invocation.txt</CliShimStamp>
+      <CliShimCommand>zig build-exe "$(MSBuildThisFileDirectory)..\..\dist\windows\cli-shim\main.zig" -target $(CliShimTarget) -mcpu baseline -O ReleaseSmall --subsystem console --name wintty -femit-bin="$(OutDir)bin\wintty.exe"</CliShimCommand>
+    </PropertyGroup>
+    <MakeDir Directories="$(OutDir)bin" />
+    <WriteLinesToFile File="$(CliShimStamp)" Lines="$(CliShimCommand)"
+                      Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
+
   <Target Name="BuildCliShim"
           AfterTargets="Build"
-          Inputs="..\..\dist\windows\cli-shim\main.zig"
+          Inputs="..\..\dist\windows\cli-shim\main.zig;$(OutDir)bin\last-invocation.txt"
           Outputs="$(OutDir)bin\wintty.exe">
     <MakeDir Directories="$(OutDir)bin" />
-    <Exec Command="zig build-exe &quot;$(MSBuildThisFileDirectory)..\..\dist\windows\cli-shim\main.zig&quot; -O ReleaseSmall --name wintty -femit-bin=&quot;$(OutDir)bin\wintty.exe&quot;"
-          WorkingDirectory="$(MSBuildThisFileDirectory)" />
+    <!--
+      The console subsystem is requested explicitly in the command above
+      rather than left to zig's inference. That subsystem byte is the only
+      reason this binary exists, so inferring it would make the feature
+      depend on a compiler default.
+    -->
+    <Exec Command="$(CliShimCommand)" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+  </Target>
+
+  <!--
+    Publish does not copy arbitrary $(OutDir) content, only items the SDK
+    resolved, so the shim built above reaches bin\ and stops there. The MSI
+    harvest and the Velopack pack step both read $(PublishDir)\** (see the
+    comment above the WiX target), so without this the shipped installer
+    contains no shim at all and every packaged build has the console
+    behaviour this feature was written to fix. Dev builds run out of
+    $(OutDir) and look fine, which is what makes the gap easy to miss.
+
+    Same shape as CopyXamlResourcesForAot below, which exists for the
+    identical reason.
+  -->
+  <Target Name="CopyCliShimForPublish" AfterTargets="Publish">
+    <Copy SourceFiles="$(OutDir)bin\wintty.exe"
+          DestinationFolder="$(PublishDir)bin"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="GenerateBrandingAssets"

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -78,6 +78,9 @@ public static partial class Program
     private static partial IntPtr GetStdHandle(int nStdHandle);
 
     [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial uint GetFileType(IntPtr hFile);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool SetStdHandle(int nStdHandle, IntPtr hHandle);
 
@@ -122,6 +125,7 @@ public static partial class Program
     private const uint GENERIC_WRITE = 0x40000000;
     private const uint FILE_SHARE_WRITE = 0x00000002;
     private const uint OPEN_EXISTING = 3;
+    private const uint FILE_TYPE_UNKNOWN = 0x0000;
 
     /// <summary>
     /// Attach to the launching terminal's console, when there is one.
@@ -135,15 +139,29 @@ public static partial class Program
     /// </summary>
     private static void AttachToParentConsole()
     {
+        // Snapshot the three handles BEFORE attaching, and decide from the
+        // snapshot. AllocConsole is documented to initialise the standard
+        // handles; AttachConsole's documentation is silent on whether it
+        // does the same. If it does, reading them afterwards would see
+        // handles Windows had just created, conclude the caller had
+        // already bound them, and skip the bind - which is the correct
+        // outcome by accident for a terminal launch and the wrong one for
+        // `wintty +version > out.txt`, whose redirected handle is what the
+        // guard exists to preserve. Reading first is correct either way
+        // and costs three calls.
+        var inheritedOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        var inheritedErr = GetStdHandle(STD_ERROR_HANDLE);
+        var inheritedIn = GetStdHandle(STD_INPUT_HANDLE);
+
         if (!AttachConsole(ATTACH_PARENT_PROCESS))
             return;
 
         // CONOUT$ is opened for read as well as write because the console
         // screen-buffer queries behind isTty and the interactive TUI need
         // read access on the handle, not just the ability to write to it.
-        BindStandardHandle(STD_OUTPUT_HANDLE, "CONOUT$", GENERIC_READ | GENERIC_WRITE);
-        BindStandardHandle(STD_ERROR_HANDLE, "CONOUT$", GENERIC_READ | GENERIC_WRITE);
-        BindStandardHandle(STD_INPUT_HANDLE, "CONIN$", GENERIC_READ | GENERIC_WRITE);
+        BindStandardHandle(STD_OUTPUT_HANDLE, inheritedOut, "CONOUT$", GENERIC_READ | GENERIC_WRITE);
+        BindStandardHandle(STD_ERROR_HANDLE, inheritedErr, "CONOUT$", GENERIC_READ | GENERIC_WRITE);
+        BindStandardHandle(STD_INPUT_HANDLE, inheritedIn, "CONIN$", GENERIC_READ | GENERIC_WRITE);
     }
 
     /// <summary>
@@ -156,11 +174,22 @@ public static partial class Program
     /// terminal instead of where the caller asked for it, so an existing
     /// handle always wins.
     /// </summary>
-    private static void BindStandardHandle(int stdHandle, string device, uint access)
+    private static void BindStandardHandle(int stdHandle, IntPtr inherited, string device, uint access)
     {
-        var existing = GetStdHandle(stdHandle);
-        if (existing != IntPtr.Zero && existing != InvalidHandleValue)
+        // "Not null and not INVALID_HANDLE_VALUE" is not the same as "a
+        // handle this process can actually use": a launcher can hand a GUI
+        // child a stale or non-inheritable value in STARTUPINFO, and
+        // skipping the bind on one of those sends every CLI diagnostic
+        // nowhere, silently - the exact failure this method exists to
+        // remove. GetFileType answers the real question and costs one
+        // call. See the remarks on WriteConsole below, which is the same
+        // lesson learned somewhere else in this file.
+        if (inherited != IntPtr.Zero
+            && inherited != InvalidHandleValue
+            && GetFileType(inherited) != FILE_TYPE_UNKNOWN)
+        {
             return;
+        }
 
         var handle = CreateFileW(
             device,
@@ -521,10 +550,13 @@ public static partial class Program
         // architecture: ghostty_init parses argv, ghostty_cli_run_action
         // runs the action (if any). If no action, we start the WinUI app.
         //
-        // The project uses Exe (console) subsystem so that CLI actions
-        // inherit the terminal's console handles natively. This lets
-        // Zig's isTty() return true and the Vaxis interactive TUI work.
-        // For GUI mode we detach from the console immediately.
+        // The console these actions write to comes from
+        // AttachToParentConsole above, not from the subsystem: this is a
+        // WinExe binary, so the loader gives it no console and there is
+        // nothing to detach from on the way into the GUI. The handles are
+        // real console handles when the caller had a terminal, which is
+        // what lets Zig's isTty() return true and the Vaxis interactive
+        // TUI work.
         //
         // The StartsWith('+') half of the gate is deliberately unchanged
         // and deliberately not narrowed to known actions: `+bogus` and

--- a/windows/Ghostty/Program.cs
+++ b/windows/Ghostty/Program.cs
@@ -70,14 +70,9 @@ public static partial class Program
         ManagedUnhandled = 3,
     }
 
-    [LibraryImport("kernel32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool FreeConsole();
-
     [LibraryImport("kernel32.dll", SetLastError = true)]
-    private static partial uint GetConsoleProcessList(
-        [Out] uint[] lpdwProcessList,
-        uint dwProcessCount);
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool AttachConsole(int dwProcessId);
 
     [LibraryImport("kernel32.dll", SetLastError = true)]
     private static partial IntPtr GetStdHandle(int nStdHandle);
@@ -119,6 +114,66 @@ public static partial class Program
     private const uint FILE_SHARE_READ = 0x00000001;
     private const uint CREATE_ALWAYS = 2;
     private const uint FILE_ATTRIBUTE_NORMAL = 0x80;
+
+    private const int ATTACH_PARENT_PROCESS = -1;
+    private const int STD_INPUT_HANDLE = -10;
+    private const int STD_OUTPUT_HANDLE = -11;
+    private const uint GENERIC_READ = 0x80000000;
+    private const uint GENERIC_WRITE = 0x40000000;
+    private const uint FILE_SHARE_WRITE = 0x00000002;
+    private const uint OPEN_EXISTING = 3;
+
+    /// <summary>
+    /// Attach to the launching terminal's console, when there is one.
+    ///
+    /// Wintty is a GUI-subsystem binary so that Explorer and the Start menu
+    /// do not flash a loader-created console before the splash. The cost is
+    /// that the process starts with no console at all, which would leave
+    /// every <c>wintty +action</c> printing into the void. Attaching to the
+    /// parent gives those handles back, and failing to attach is the
+    /// ordinary Explorer case rather than an error.
+    /// </summary>
+    private static void AttachToParentConsole()
+    {
+        if (!AttachConsole(ATTACH_PARENT_PROCESS))
+            return;
+
+        // CONOUT$ is opened for read as well as write because the console
+        // screen-buffer queries behind isTty and the interactive TUI need
+        // read access on the handle, not just the ability to write to it.
+        BindStandardHandle(STD_OUTPUT_HANDLE, "CONOUT$", GENERIC_READ | GENERIC_WRITE);
+        BindStandardHandle(STD_ERROR_HANDLE, "CONOUT$", GENERIC_READ | GENERIC_WRITE);
+        BindStandardHandle(STD_INPUT_HANDLE, "CONIN$", GENERIC_READ | GENERIC_WRITE);
+    }
+
+    /// <summary>
+    /// Point one standard handle at a console device, but only if Windows
+    /// left it unset.
+    ///
+    /// A redirected launch (<c>wintty +version &gt; out.txt</c>, or a pipe)
+    /// arrives with a real file or pipe handle already in STARTUPINFO.
+    /// Overwriting that with CONOUT$ would quietly send the output to the
+    /// terminal instead of where the caller asked for it, so an existing
+    /// handle always wins.
+    /// </summary>
+    private static void BindStandardHandle(int stdHandle, string device, uint access)
+    {
+        var existing = GetStdHandle(stdHandle);
+        if (existing != IntPtr.Zero && existing != InvalidHandleValue)
+            return;
+
+        var handle = CreateFileW(
+            device,
+            access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            IntPtr.Zero,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            IntPtr.Zero);
+
+        if (handle != InvalidHandleValue)
+            SetStdHandle(stdHandle, handle);
+    }
 
     /// <summary>
     /// Persistent GPU diagnostic log path.  Survives reboot so we can
@@ -297,7 +352,8 @@ public static partial class Program
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // A handle this process may not write to, a pipe with no reader, a
-            // locked log file, a console handle FreeConsole invalidated.
+            // locked log file, a console handle that went away with the
+            // terminal that owned it.
             //
             // Not dropped on the floor: when the console refuses writes and the
             // GPU log is unavailable too, a debugger is the only channel left,
@@ -398,6 +454,13 @@ public static partial class Program
         // App's static constructor used to register this same assembly
         // again, so a `+action` run that found no action and fell through to
         // the GUI died in that static constructor rather than starting.
+        // Borrow the launching terminal's console before anything reads a
+        // standard handle. A GUI-subsystem process starts with none, so the
+        // capture below would otherwise bind _terminalStderr to a handle
+        // that goes nowhere and every CLI diagnostic would vanish on
+        // exactly the launches that have a human watching.
+        AttachToParentConsole();
+
         // Before anything can write to Console.Error and bind it to whatever
         // GetStdHandle returns at that moment. See _terminalStderr.
         _terminalStderr = Console.Error;
@@ -552,28 +615,12 @@ public static partial class Program
         // Menu launch has. InitGhostty tees its fatal line to the terminal.
         InitGhostty();
 
-        // Detach from the console before starting WinUI, but ONLY
-        // when we are the console's sole owner. Explorer / Start
-        // Menu allocates a fresh console for a console-subsystem app
-        // and briefly flashes it; that's the console we want to
-        // close. A terminal launch (bash, cmd, pwsh) shares the
-        // terminal's console with us, and FreeConsole would detach
-        // us from that shared console and silently drop every
-        // Console.Error.WriteLine below (which is how we lose
-        // startup diagnostics and the unhandled-exception dump).
-        //
-        // GetConsoleProcessList returns >= 2 in the shared case (the
-        // parent terminal process counts), exactly 1 in the solo
-        // case, and 0 if the probe fails (no attached console). The
-        // `<= 1` guard treats a probe failure as solo, which matches
-        // the pre-gating behavior and never worse.
-        var consoleProcesses = new uint[4];
-        var consoleProcessCount = GetConsoleProcessList(
-            consoleProcesses,
-            (uint)consoleProcesses.Length);
-        if (consoleProcessCount <= 1)
-            FreeConsole();
-
+        // No console to detach from on the way into the GUI. A shortcut
+        // launch never had one, and a terminal launch is attached to the
+        // caller's console on purpose, so Console.Error diagnostics and the
+        // unhandled-exception mirror still reach whoever started it from a
+        // shell. The gate that used to live here existed because a
+        // console-subsystem binary was handed a console it did not want.
         return StartGui();
     }
 
@@ -685,7 +732,7 @@ public static partial class Program
 
             // Terminal first, and each in its own try: a human is watching
             // that one, and a throw from the log write (disk full, or a
-            // handle FreeConsole invalidated) must not take it down with it.
+            // handle whose terminal has gone) must not take it down with it.
             // Neither may escape either - this method exits with InitFailed,
             // and an exception here would unwind into Main's handler and
             // turn that into ManagedUnhandled, which is the other code the


### PR DESCRIPTION
Two changes, both about what a user sees when they pick Wintty out of the Start menu.

**The console flash.** Wintty.exe is linked console-subsystem, so the loader puts a real console on screen before any managed code runs and the app only tears it down once startup gets far enough to know it should. The subsystem byte reads 3 on every edition. The cause is `<OutputType>Exe</OutputType>`, which never got promoted because the SDK's WinExe inference fires for UseWPF and UseWindowsForms but not for UseWinUI.

WinExe alone would break the CLI, since a GUI-subsystem process starts with no console. MainImpl now attaches to the launching terminal's console before any standard handle is read, which has to happen before the `_terminalStderr` capture or that binds to a handle going nowhere. CONOUT$ is opened for read as well as write, because the screen-buffer queries behind isTty need read access on the handle; and a handle Windows already populated is never replaced, so `wintty +version > out.txt` still lands in the file.

Windows still will not wait for a GUI-subsystem process, so `dist/windows/cli-shim` is a console launcher that forwards argv, inherits the console, waits, and returns the exit code. It waits only for `+` verbs, so a bare `wintty` still returns immediately. In zig because a .NET console app would drag a runtime behind CreateProcess plus WaitForSingleObject.

**Edition icons.** Five flavours install side by side carrying the same mark, so their shortcuts are indistinguishable in the Start menu, the taskbar and Alt-Tab. IconGen gains a per-edition hue shift plus a monogram band, both rather than either: hue is the only cue that survives 16 px, the band the only one that survives greyscale and high contrast.

The tint is gated on saturation, so the screen recolours while the ghost and bezel come through untouched. The band is held to the bottom 15 percent because the ghost's lowest lit row in the 256 px master is 83.2 percent down; `MonogramBandTests` measures that against the real artwork rather than trusting the constant. `--edition` defaults to none, so output here is unchanged and the tier repo selects.

Verified: 38 IconGen tests green, subsystem byte now 2, shim builds and returns `+version` with exit 0, redirection to a file still honoured, icons generate per edition.

Note two things this deliberately does not include, because `windows` already had them and did them better: the `+list-themes` flag swallowing, and skipping the stderr redirect for CLI actions.