### PR TITLE
Clear the palette selection with the list it points into

### DIFF
--- a/windows/Ghostty.Core/Commands/PaletteSelection.cs
+++ b/windows/Ghostty.Core/Commands/PaletteSelection.cs
@@ -17,10 +17,14 @@ public static class PaletteSelection
     /// The item <paramref name="delta"/> steps away from
     /// <paramref name="current"/>, clamped to the ends of the list.
     ///
-    /// A null or no-longer-present <paramref name="current"/> resolves to the
-    /// first item, in either direction: pressing Up in a list nothing is
-    /// selected in should land somewhere, and the top is the only end both
-    /// keys agree on.
+    /// A null <paramref name="current"/> resolves to the first item, in
+    /// either direction: pressing Up in a list nothing is selected in
+    /// should land somewhere, and the top is the only end both keys agree
+    /// on. So does one the list does not contain, which is a fallback
+    /// rather than a promise - equality here is whatever the item type
+    /// defines, and a record carrying a delegate does not compare equal to
+    /// itself across a rebuild. Callers pass a selection taken from the
+    /// list they are stepping through, so it does not arise.
     /// </summary>
     public static T? Step<T>(IReadOnlyList<T> items, T? current, int delta)
         where T : class
@@ -31,9 +35,11 @@ public static class PaletteSelection
         var index = IndexOf(items, current);
         if (index < 0) return items[0];
 
-        // Widened before the clamp. A large delta from a paging binding
-        // overflows int arithmetic and lands on the first item, which is the
-        // opposite end from the one the caller asked for.
+        // Widened before the clamp. Every caller passes plus or minus one
+        // today, so this is not reachable; it is here because the failure it
+        // prevents is silent and the opposite of what was asked for. A delta
+        // large enough to overflow wraps negative and clamps to the FIRST
+        // item, so a Page Down would jump to the top of the list.
         var next = Math.Clamp((long)index + delta, 0, items.Count - 1);
         return items[(int)next];
     }

--- a/windows/Ghostty.Core/Commands/PaletteSelection.cs
+++ b/windows/Ghostty.Core/Commands/PaletteSelection.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ghostty.Core.Commands;
+
+/// <summary>
+/// Which item in a palette list is current, after an arrow key or after the
+/// list underneath the selection was rebuilt.
+///
+/// Here rather than in the view model because that is what makes the rules
+/// testable at all: the view model lives in the WinUI project, which the
+/// test assembly cannot reference.
+/// </summary>
+public static class PaletteSelection
+{
+    /// <summary>
+    /// The item <paramref name="delta"/> steps away from
+    /// <paramref name="current"/>, clamped to the ends of the list.
+    ///
+    /// A null or no-longer-present <paramref name="current"/> resolves to the
+    /// first item, in either direction: pressing Up in a list nothing is
+    /// selected in should land somewhere, and the top is the only end both
+    /// keys agree on.
+    /// </summary>
+    public static T? Step<T>(IReadOnlyList<T> items, T? current, int delta)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        if (items.Count == 0) return null;
+
+        var index = IndexOf(items, current);
+        if (index < 0) return items[0];
+
+        // Widened before the clamp. A large delta from a paging binding
+        // overflows int arithmetic and lands on the first item, which is the
+        // opposite end from the one the caller asked for.
+        var next = Math.Clamp((long)index + delta, 0, items.Count - 1);
+        return items[(int)next];
+    }
+
+    /// <summary>
+    /// The selection for a freshly built list: its first item, or none when
+    /// it is empty.
+    ///
+    /// Exists so that "a list and the selection into it are set together" is
+    /// one call rather than a convention. Assigning the selection only when
+    /// the list turned out non-empty leaves the previous one in place behind
+    /// a query that matched nothing, and Enter then runs a command that is
+    /// not on screen.
+    /// </summary>
+    public static T? SelectTop<T>(IReadOnlyList<T> items) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        return items.Count > 0 ? items[0] : null;
+    }
+
+    private static int IndexOf<T>(IReadOnlyList<T> items, T? value) where T : class
+    {
+        if (value is null) return -1;
+
+        var comparer = EqualityComparer<T>.Default;
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (comparer.Equals(items[i], value)) return i;
+        }
+        return -1;
+    }
+}

--- a/windows/Ghostty.Tests/Commands/PaletteSelectionTests.cs
+++ b/windows/Ghostty.Tests/Commands/PaletteSelectionTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using Ghostty.Core.Commands;
+using Xunit;
+
+namespace Ghostty.Tests.Commands;
+
+/// <summary>
+/// The palette's selection rules, which used to live inline in the view
+/// model and so could not be exercised at all: the view model is in the
+/// WinUI project, which this assembly cannot reference.
+///
+/// The bug behind <see cref="PaletteSelection.SelectTop"/> was real. A query
+/// matching nothing left the previously selected command selected, and
+/// ExecuteSelectedCommand guards only against null, so Enter ran a command
+/// that was not on screen.
+/// </summary>
+public class PaletteSelectionTests
+{
+    private sealed record Row(string Name);
+
+    private static readonly List<Row> Three =
+        [new Row("a"), new Row("b"), new Row("c")];
+
+    [Fact]
+    public void Step_FromNothing_SelectsTheFirstItemInEitherDirection()
+    {
+        // Up and Down disagree about which end is "next" but agree that a
+        // list with no selection should end up selecting something.
+        Assert.Equal(Three[0], PaletteSelection.Step(Three, null, -1));
+        Assert.Equal(Three[0], PaletteSelection.Step(Three, null, +1));
+    }
+
+    [Theory]
+    [InlineData(0, +1, 1)]
+    [InlineData(1, +1, 2)]
+    [InlineData(2, -1, 1)]
+    [InlineData(1, -1, 0)]
+    public void Step_MovesOne(int from, int delta, int expected)
+    {
+        Assert.Equal(Three[expected], PaletteSelection.Step(Three, Three[from], delta));
+    }
+
+    [Theory]
+    [InlineData(2, +1, 2)]
+    [InlineData(0, -1, 0)]
+    public void Step_ClampsAtTheEnds(int from, int delta, int expected)
+    {
+        // Not a wrap. Arrowing past the end of a palette list stays put
+        // rather than jumping to the far end under the user's fingers.
+        Assert.Equal(Three[expected], PaletteSelection.Step(Three, Three[from], delta));
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, 2)]
+    [InlineData(int.MinValue, 0)]
+    public void Step_ClampsWithoutOverflowing(int delta, int expected)
+    {
+        // index + delta in int arithmetic wraps, and a wrapped negative
+        // clamps to the FIRST item, the opposite end from the one asked for.
+        // Only reachable from a paging binding, which is exactly the caller
+        // that would pass a large delta.
+        Assert.Equal(Three[expected], PaletteSelection.Step(Three, Three[1], delta));
+    }
+
+    [Fact]
+    public void Step_OnAnEmptyList_SelectsNothing()
+    {
+        // An empty list has to end with nothing selected, not with the
+        // previous selection surviving into it.
+        Assert.Null(PaletteSelection.Step(new List<Row>(), Three[1], +1));
+        Assert.Null(PaletteSelection.Step(new List<Row>(), null, -1));
+    }
+
+    [Fact]
+    public void Step_FromAnItemThatIsGone_SelectsTheFirst()
+    {
+        Assert.Equal(Three[0], PaletteSelection.Step(Three, new Row("gone"), +1));
+    }
+
+    [Fact]
+    public void SelectTop_TakesTheFirstOrNothing()
+    {
+        // The point is that it has no non-assigning branch.
+        Assert.Equal(Three[0], PaletteSelection.SelectTop(Three));
+        Assert.Null(PaletteSelection.SelectTop(new List<Row>()));
+    }
+
+    [Fact]
+    public void BothRejectANullList()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => PaletteSelection.Step<Row>(null!, null, +1));
+        Assert.Throws<ArgumentNullException>(
+            () => PaletteSelection.SelectTop<Row>(null!));
+    }
+}

--- a/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
+++ b/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using Ghostty.Tests.Wiring;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Commands;
+
+/// <summary>
+/// That the view model uses the rules rather than reimplementing them.
+///
+/// The view model is in the WinUI project, which this assembly cannot
+/// reference, so the source is all there is. Parsed rather than searched,
+/// for the reason <see cref="ShellSource"/> gives.
+/// </summary>
+public class PaletteSelectionWiringTests
+{
+    private const string ViewModel = "Commands.CommandPaletteViewModel.cs";
+
+    /// <summary>
+    /// The selection is only ever set from the list as a whole, via SelectTop
+    /// or Step. Indexing the list by hand is what needed a surrounding
+    /// <c>if (Count &gt; 0)</c>, and that guard is what left a stale command
+    /// selected behind a query matching nothing - Enter then ran a command
+    /// with nothing on screen to show which.
+    /// </summary>
+    [Fact]
+    public void TheCommandListIsNeverIndexedByHand()
+    {
+        var indexed = ShellSource.Load(ViewModel).Root
+            .DescendantNodes().OfType<ElementAccessExpressionSyntax>()
+            .Where(e => e.Expression.ToString() == "FilteredCommands")
+            .Select(e => e.ToString())
+            .ToList();
+
+        Assert.True(indexed.Count == 0,
+            "FilteredCommands is indexed directly, which needs a count guard around it "
+            + "and leaves the selection stale when the guard skips the assignment: "
+            + string.Join(", ", indexed));
+    }
+
+    /// <summary>
+    /// Every path that rebuilds or empties the list sets the selection in the
+    /// same breath. Asserted as "the two always travel together" rather than
+    /// by naming today's paths, because the defect is a path that forgets.
+    /// </summary>
+    [Fact]
+    public void EveryAssignmentToTheListIsMatchedBySelectTop()
+    {
+        var vm = ShellSource.Load(ViewModel);
+
+        var listWrites = vm.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Count(a => a.Left.ToString() == "FilteredCommands");
+        var selectTops = vm.Root.Calls("PaletteSelection.SelectTop").Count;
+
+        Assert.True(listWrites == selectTops,
+            $"FilteredCommands is assigned {listWrites} times but SelectTop is called "
+            + $"{selectTops} times. A path that rebuilds the list without setting the "
+            + "selection into it leaves the previous selection live and runnable.");
+    }
+}

--- a/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
+++ b/windows/Ghostty.Tests/Commands/PaletteSelectionWiringTests.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using Ghostty.Tests.Wiring;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -17,44 +19,91 @@ public class PaletteSelectionWiringTests
     private const string ViewModel = "Commands.CommandPaletteViewModel.cs";
 
     /// <summary>
-    /// The selection is only ever set from the list as a whole, via SelectTop
-    /// or Step. Indexing the list by hand is what needed a surrounding
-    /// <c>if (Count &gt; 0)</c>, and that guard is what left a stale command
-    /// selected behind a query matching nothing - Enter then ran a command
-    /// with nothing on screen to show which.
+    /// The bug was not "the assignment is missing", it was "the assignment
+    /// is conditional". So the thing to forbid is a condition, not an
+    /// absence: any test on the list standing between the palette and its
+    /// selection puts back the case where the list empties and the
+    /// selection does not.
+    ///
+    /// `??=` counts as conditional for the same reason - it assigns only
+    /// when the previous selection was null, which is precisely the stale
+    /// selection this is trying to clear.
     /// </summary>
     [Fact]
-    public void TheCommandListIsNeverIndexedByHand()
+    public void TheSelectionIsNeverAssignedConditionallyOnTheList()
     {
-        var indexed = ShellSource.Load(ViewModel).Root
-            .DescendantNodes().OfType<ElementAccessExpressionSyntax>()
-            .Where(e => e.Expression.ToString() == "FilteredCommands")
-            .Select(e => e.ToString())
+        var guarded = ShellSource.Load(ViewModel).Root
+            .DescendantNodes().OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.Left.ToString() == "SelectedCommand")
+            .Where(a => !a.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || a.Ancestors().Any(n =>
+                    (n is IfStatementSyntax i
+                        && i.Condition.ToString().Contains("FilteredCommands"))
+                    || (n is ConditionalExpressionSyntax c
+                        && c.Condition.ToString().Contains("FilteredCommands"))))
+            .Select(a => a.ToString())
             .ToList();
 
-        Assert.True(indexed.Count == 0,
-            "FilteredCommands is indexed directly, which needs a count guard around it "
-            + "and leaves the selection stale when the guard skips the assignment: "
-            + string.Join(", ", indexed));
+        Assert.True(guarded.Count == 0,
+            "SelectedCommand is assigned under a test on FilteredCommands, or with a "
+            + "compound assignment. Either way the empty case skips it and the previous "
+            + "selection stays live and runnable: " + string.Join("; ", guarded));
     }
 
     /// <summary>
-    /// Every path that rebuilds or empties the list sets the selection in the
-    /// same breath. Asserted as "the two always travel together" rather than
-    /// by naming today's paths, because the defect is a path that forgets.
+    /// Every method that rebuilds or empties the list also sets the
+    /// selection into it. Paired per method rather than counted over the
+    /// file: two totals can agree while the pairing is wrong, and a global
+    /// tally also fails on the harmless direction, which teaches whoever
+    /// hits it to rebalance the counter instead of trusting it.
     /// </summary>
     [Fact]
-    public void EveryAssignmentToTheListIsMatchedBySelectTop()
+    public void EveryMethodThatWritesTheListAlsoSetsTheSelection()
     {
-        var vm = ShellSource.Load(ViewModel);
+        var offenders = ShellSource.Load(ViewModel).Root
+            .DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .Where(m => m.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.Left.ToString().EndsWith("FilteredCommands", System.StringComparison.Ordinal)))
+            .Where(m => !m.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.Left.ToString() == "SelectedCommand"))
+            .Select(m => m.Identifier.ValueText)
+            .ToList();
 
-        var listWrites = vm.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>()
-            .Count(a => a.Left.ToString() == "FilteredCommands");
-        var selectTops = vm.Root.Calls("PaletteSelection.SelectTop").Count;
+        Assert.True(offenders.Count == 0,
+            "These methods assign FilteredCommands without setting SelectedCommand. The "
+            + "selection then points into a list that no longer contains it, and Enter "
+            + "runs a command that is not on screen: " + string.Join(", ", offenders));
+    }
 
-        Assert.True(listWrites == selectTops,
-            $"FilteredCommands is assigned {listWrites} times but SelectTop is called "
-            + $"{selectTops} times. A path that rebuilds the list without setting the "
-            + "selection into it leaves the previous selection live and runnable.");
+    /// <summary>
+    /// A method emptied to `{ }` passes every guard above and takes the
+    /// whole Step unit-test suite with it, since nothing else calls it.
+    /// </summary>
+    [Fact]
+    public void BothMoversStillGoThroughStep()
+    {
+        Assert.Equal(2, ShellSource.Load(ViewModel).Root.Calls("PaletteSelection.Step").Count);
+    }
+
+    /// <summary>
+    /// The parser runs with no preprocessor symbols, so a disabled `#if`
+    /// region is trivia and every guard above looks straight through it.
+    /// This file has a live `#if DEMO` block, so a demo path that touched
+    /// the list would ship unguarded in DEMO builds.
+    /// </summary>
+    [Fact]
+    public void NoDisabledRegionTouchesTheList()
+    {
+        var hidden = ShellSource.Load(ViewModel).Root
+            .DescendantTrivia()
+            .Where(t => t.IsKind(SyntaxKind.DisabledTextTrivia))
+            .Select(t => t.ToString())
+            .Where(t => t.Contains("FilteredCommands"))
+            .ToList();
+
+        Assert.True(hidden.Count == 0,
+            "A conditionally compiled region assigns FilteredCommands. It is trivia to "
+            + "the parser, so the guards in this file cannot see it: "
+            + string.Join("\n", hidden));
     }
 }

--- a/windows/Ghostty/Commands/CommandPaletteViewModel.cs
+++ b/windows/Ghostty/Commands/CommandPaletteViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Ghostty.Core.Commands;
 
 namespace Ghostty.Commands;
 
@@ -153,6 +154,7 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
         IsPinned = false;
         Mode = PaletteMode.Search;
         FilteredCommands = [];
+        SelectedCommand = PaletteSelection.SelectTop(FilteredCommands);
         GhostText = null;
     }
 
@@ -236,8 +238,11 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
             ? "1 command"
             : $"{FilteredCommands.Count} commands";
 
-        if (FilteredCommands.Count > 0)
-            SelectedCommand = FilteredCommands[0];
+        // Assigned for the empty case too. Assigning only when the list came
+        // back non-empty leaves the previous selection live behind a query
+        // that matched nothing, and ExecuteSelectedCommand guards only
+        // against null - so Enter runs a command that is not on screen.
+        SelectedCommand = PaletteSelection.SelectTop(FilteredCommands);
     }
 
     private void ApplyCommandLineFilter(string input)
@@ -245,6 +250,7 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
         if (_autoCompleter is null)
         {
             FilteredCommands = [];
+            SelectedCommand = PaletteSelection.SelectTop(FilteredCommands);
             GhostText = null;
             StatusText = "No autocomplete available";
             return;
@@ -281,8 +287,7 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
             ? "1 action"
             : $"{FilteredCommands.Count} actions";
 
-        if (FilteredCommands.Count > 0)
-            SelectedCommand = FilteredCommands[0];
+        SelectedCommand = PaletteSelection.SelectTop(FilteredCommands);
     }
 
     public void AcceptAutocomplete()
@@ -291,21 +296,11 @@ internal partial class CommandPaletteViewModel : INotifyPropertyChanged
         SearchText += GhostText;
     }
 
-    public void MoveSelectionUp()
-    {
-        if (FilteredCommands.Count == 0) return;
-        var idx = SelectedCommand is not null ? FilteredCommands.IndexOf(SelectedCommand) : 0;
-        idx = Math.Max(0, idx - 1);
-        SelectedCommand = FilteredCommands[idx];
-    }
+    public void MoveSelectionUp() =>
+        SelectedCommand = PaletteSelection.Step(FilteredCommands, SelectedCommand, -1);
 
-    public void MoveSelectionDown()
-    {
-        if (FilteredCommands.Count == 0) return;
-        var idx = SelectedCommand is not null ? FilteredCommands.IndexOf(SelectedCommand) : -1;
-        idx = Math.Min(FilteredCommands.Count - 1, idx + 1);
-        SelectedCommand = FilteredCommands[idx];
-    }
+    public void MoveSelectionDown() =>
+        SelectedCommand = PaletteSelection.Step(FilteredCommands, SelectedCommand, +1);
 
     // ── INotifyPropertyChanged ───────────────────────────────────────────────
 


### PR DESCRIPTION
Type a query the command palette matches nothing for, press Enter, and it runs a command. Which one depends on frecency, so it is whatever you have been using most - New Window, Close Tab, Toggle Quake.

`ApplyFilter` assigns `SelectedCommand` only when the filtered list came back non-empty. `ExecuteSelectedCommand` guards only against null. So an empty result leaves the previous selection live and runnable, with nothing on screen to show which command it is. `ApplyCommandLineFilter` has the same shape twice, and `Close` leaves a selection behind for the next open.

## Shape

The rules move to `Ghostty.Core` as `PaletteSelection`. Not tidying: the view model is in the WinUI project, which `Ghostty.Tests` cannot reference, so anything decided inline there cannot be unit-tested at all - the workaround elsewhere in this repo is a source-level copy of the class under test.

`SelectTop` has no non-assigning branch, which is the whole fix. Assigning "only when non-empty" IS the bug, so a helper that cannot express it is what stops it coming back.

`Step` absorbs the two movers unchanged, and gains one thing they lacked: the index arithmetic is widened before the clamp. `int.MaxValue` as a delta wraps negative and clamps to the FIRST item, the opposite end from the one asked for. Only reachable from a paging binding, which is exactly the caller that would pass a large delta.

Two wiring guards over the parsed view model, since the assignments themselves are not reachable from a test: the list is never indexed by hand (indexing is what needs the count guard that skips the assignment), and every assignment to the list is matched by a `SelectTop` call.

## Where this came from

Found while fixing the sessions picker in the tiered build, where the same defect is sharper: entering sessions mode empties the command list on purpose, so Enter with no sessions ran a command every time rather than only after a fruitless search. That fix needs a session concept this repo does not have and stays in the tier; this is the half that belongs here, and it is live here today.

The tier currently carries `PaletteSelection` as an overlay so the fix could ship without waiting on a pin bump. Once this lands, that overlay drops and the tier keeps only its own `Reconcile` - which exists because a session row's age is recomputed on every load, so full value equality reports every survivor as gone. That is a session-shaped problem and does not belong here.

## Draft

Marked draft until the build and test run locally; builds on this machine are serialised and one is in flight. I will mark it ready with the numbers.