### PR TITLE
Stop the solution and the branding step building IconGen at once

### DIFF
--- a/windows/Ghostty/Ghostty.csproj
+++ b/windows/Ghostty/Ghostty.csproj
@@ -136,6 +136,53 @@
     <ApplicationIcon>$(GeneratedBrandingDir)wintty.ico</ApplicationIcon>
   </PropertyGroup>
 
+  <!--
+    Build-order only, not a reference: IconGen is a tool this project shells
+    out to, and nothing here links against it.
+
+    Without it the solution build and this project's Exec build IconGen at the
+    same time. IconGen is a project in Ghostty.sln and IconGen.Tests references
+    it, so MSBuild is already building it when GenerateBrandingAssets runs a
+    `dotnet run` on the same project. That inner run is a separate process with
+    its own MSBuild instance, sharing no build graph and no locking, so both
+    write one obj\ and whichever loses reports:
+
+      error MSB3501: Could not read lines from file
+      "obj\Release\net10.0-windows\IconGen.csproj.FileListAbsolute.txt".
+      The process cannot access the file ... used by another process.
+
+    It is a scheduling race, so it survives plenty of green builds and then
+    takes a whole tier build down. A single green build is not evidence that it
+    is fixed.
+
+    Ordering the two is the fix, and it only works because GenerateBrandingAssets
+    hooks AfterTargets="ResolveProjectReferences" (see that target). MSBuild
+    builds one project node per global-property set and every in-graph requester
+    shares it, so once this project's reference has resolved, IconGen's in-graph
+    build is finished for IconGen.Tests too, and the Exec is the only writer left.
+    The inner `dotnet run` still re-enters MSBuild and restores; that is fine
+    once nothing else is in there with it.
+
+    GlobalPropertiesToRemove="RuntimeIdentifier" is not decoration. A
+    ReferenceOutputAssembly="false" reference is dropped from NuGet's restore
+    graph, so IconGen never gets a RID-specific assets target; without this,
+    a RID publish with restore suppressed (windows/scripts/release-smoke.ps1)
+    fails NETSDK1047 on IconGen's assets file and cannot self-repair.
+
+    Redirecting the tool run to its own obj\ instead does NOT work. Overriding
+    BaseIntermediateOutputPath stops the SDK excluding the default obj\ from
+    its compile glob, and IconGen then fails CS0579 on duplicate assembly
+    attributes from the two generated AssemblyInfo.cs files.
+
+    SkipGetTargetFrameworkProperties because the TFMs differ and there is no
+    assembly to reconcile.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\dist\windows\IconGen\IconGen.csproj"
+                      ReferenceOutputAssembly="false"
+                      GlobalPropertiesToRemove="RuntimeIdentifier" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
@@ -652,8 +699,17 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    AfterTargets, not BeforeBuild. BeforeBuild is the first entry of
+    $(BuildDependsOn) and ResolveProjectReferences sits under CoreBuild, so a
+    branding step hooked on BeforeBuild runs BEFORE the ProjectReference below
+    has built IconGen - which is the whole point of having it. PrepareResources
+    is the backstop: ApplicationIcon is handed to csc during CoreCompile, and
+    the Content copies happen later still, so this is early enough for both.
+  -->
   <Target Name="GenerateBrandingAssets"
-          BeforeTargets="BeforeBuild"
+          AfterTargets="ResolveProjectReferences"
+          BeforeTargets="PrepareResources"
           Inputs="@(IconGenSource);..\Ghostty.Core\Shell\LaunchIconAssets.cs;..\Ghostty.Core\Shell\LaunchIconMetrics.cs;@(IconGenMaster);$(BrandingStamp)"
           Outputs="$(GeneratedBrandingDir)wintty.ico;$(GeneratedBrandingDir)wintty-settings.ico;$(GeneratedBrandingDir)wintty-inspector.ico;$(GeneratedBrandingDir)AppIcon.scale-100.png;$(GeneratedBrandingDir)AppIcon.scale-150.png;$(GeneratedBrandingDir)AppIcon.scale-200.png;$(GeneratedBrandingDir)AppIcon.scale-400.png;$(GeneratedBrandingDir)SplashIcon.scale-100.png;$(GeneratedBrandingDir)SplashIcon.scale-150.png;$(GeneratedBrandingDir)SplashIcon.scale-200.png;$(GeneratedBrandingDir)SplashIcon.scale-400.png">
     <MakeDir Directories="$(GeneratedBrandingDir)" />


### PR DESCRIPTION
`IconGen` is a project in `Ghostty.sln`, and `IconGen.Tests` references it, so a
solution build is already building it when `GenerateBrandingAssets` shells out
to a `dotnet run` on the same project. The inner run is a **separate process
with its own MSBuild instance** - no shared build graph, no shared locking - so
both write one `obj\` and whichever loses reports:

```
error MSB3501: Could not read lines from file
"obj\Release\net10.0-windows\IconGen.csproj.FileListAbsolute.txt".
The process cannot access the file ... used by another process.
```

It is a scheduling race, so it survives plenty of green builds first: the same
invocation failed on one tier and succeeded on the next one minutes later.

## Three changes, and the first is what makes the other two mean anything

**`GenerateBrandingAssets` moves off `BeforeTargets="BeforeBuild"`.** `BeforeBuild`
is the first entry of `$(BuildDependsOn)` and `ResolveProjectReferences` sits
under `CoreBuild`, so a branding step hooked there runs *before* any
`ProjectReference` has been built. `AfterTargets="ResolveProjectReferences"` is
what actually orders the two; `PrepareResources` is the backstop, since
`ApplicationIcon` reaches csc during `CoreCompile`.

**A build-order-only `ProjectReference`.** Nothing links against IconGen, so
`ReferenceOutputAssembly="false"` and nothing flows into this project's compile
set, assets file, deps.json, bin or publish output. MSBuild builds one node per
global-property set and every in-graph requester shares it, so once this
reference resolves, IconGen is finished for `IconGen.Tests` too.

**`GlobalPropertiesToRemove="RuntimeIdentifier"`.** Such a reference is dropped
from NuGet's restore graph, so IconGen never gets a RID-specific assets target;
without this, a RID publish with restore suppressed
(`windows/scripts/release-smoke.ps1`) fails `NETSDK1047` and cannot self-repair.

Redirecting the tool run to its own `obj\` instead does **not** work, and the
comment says so, because it is the obvious next thing to try: overriding
`BaseIntermediateOutputPath` stops the SDK excluding the default `obj\` from its
compile glob, and IconGen then fails `CS0579` on duplicate assembly attributes.

## Verification

By ordering, not by a green run, because a green run proves nothing about a
race. Temporary markers in both projects, clean `obj\`, parallel solution build:

```
MARKER: TOOL BUILD START
MARKER: TOOL BUILD END
MARKER: GENBRAND
```

An earlier revision of this PR put `GENBRAND` between START and END - it did not
fix the race and it introduced the `NETSDK1047` regression above. Both are
fixed and both were re-checked: the RID resolve now exits 0, and the branding
step produced its icons on the marker run.

## How it surfaced

Checking whether per-tier icons were produced at all. They were not, for one
tier: pro's `Branding` directory existed with **zero** icons because IconGen had
died on the lock.
