### PR TITLE
Point the AppUserModelId registration at the icon we already ship

### DIFF
--- a/windows/Ghostty.Core/Windows/AppUserModelRegistration.cs
+++ b/windows/Ghostty.Core/Windows/AppUserModelRegistration.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using Microsoft.Win32;
+
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// Corrects the icon and the name behind this process's AUMID.
+///
+/// <c>HKCU\Software\Classes\AppUserModelId\&lt;aumid&gt;</c> is this app's notification identity.
+/// We do not create it deliberately: it is a side effect of
+/// <c>AppNotificationManager.Register()</c>, which fills it in and leaves
+///
+/// <list type="bullet">
+/// <item>an <c>IconUri</c> pointing at a 16x16 PNG it generates under
+/// <c>%LOCALAPPDATA%\Microsoft\WindowsAppSDK</c>, sized for a toast payload,</item>
+/// <item>a <c>DisplayName</c> derived from the exe basename, which comes out as the bare product
+/// name for every flavour - so a machine with several installed shows the same name several
+/// times, with nothing to say which is which.</item>
+/// </list>
+///
+/// Nothing has to be generated to fix either. The deployed <c>Assets\wintty.ico</c> already
+/// carries eight images up to 256x256, and it is rasterised per edition, so pointing at it also
+/// stops every flavour sharing one mark - on this machine seven of the eight registered PNGs were
+/// byte-identical.
+/// </summary>
+/// <remarks>
+/// Scope, measured rather than assumed: the Start menu does NOT read this key. Pointing a
+/// registration at a deliberately different icon and name, restarting Explorer, and searching
+/// Start produced no change at all - Start takes both from the shortcut. So this corrects the
+/// notification identity and makes no claim about Start.
+///
+/// Two ordering constraints, and both are why this is a call at a particular moment rather than
+/// something an installer could do once.
+///
+/// It must run AFTER <c>Register()</c>. Register rewrites <c>IconUri</c> on every launch, not only
+/// on the first, so a value written before it - or written once at install time - is silently
+/// reverted the next time the app starts. Re-applying on each launch is the point.
+///
+/// It must run after the process AUMID is set, because the key it corrects is the one
+/// <c>Register()</c> chose from that identity. Passing the AUMID in rather than reading it back
+/// keeps this honest: it writes to the identity the caller names, so it cannot quietly correct
+/// some other flavour's key.
+/// </remarks>
+internal static class AppUserModelRegistration
+{
+    /// <summary>The icon deployed beside the exe, relative to the app directory.</summary>
+    private const string IconRelativePath = @"Assets\wintty.ico";
+
+    /// <summary>
+    /// The multi-resolution icon deployed beside the running exe. Per-edition: the build
+    /// rasterises this one, so a Pro install points at the Pro mark.
+    /// </summary>
+    public static string DeployedIconPath =>
+        Path.Combine(AppContext.BaseDirectory, IconRelativePath);
+
+    /// <summary>
+    /// Point <paramref name="aumid"/>'s registration at <paramref name="iconPath"/> and at
+    /// <paramref name="displayName"/>.
+    ///
+    /// Returns whether anything was written. Never throws: a wrong icon in All apps is a cosmetic
+    /// defect, and taking startup down over it would be a much worse one.
+    /// </summary>
+    public static bool Apply(string aumid, string displayName, string iconPath)
+    {
+        if (string.IsNullOrWhiteSpace(aumid)) return false;
+
+        try
+        {
+            // Subkey rather than an interpolated path: an AUMID containing a backslash would
+            // otherwise silently write one level deeper, under a key nothing reads.
+            using var classes = Registry.CurrentUser.OpenSubKey(
+                @"Software\Classes\AppUserModelId", writable: true);
+            if (classes is null) return false;
+
+            // Open rather than create. The key is Register()'s to make; if it is absent then
+            // registration did not happen, and writing an icon into a key with no CustomActivator
+            // would leave a registration that looks complete and activates nothing.
+            using var key = classes.OpenSubKey(aumid, writable: true);
+            if (key is null) return false;
+
+            // Only when it is really there. Writing a path that does not resolve is worse than
+            // leaving the toast PNG: Start would have nothing to fall back to.
+            if (!string.IsNullOrWhiteSpace(iconPath) && File.Exists(iconPath))
+                key.SetValue("IconUri", iconPath, RegistryValueKind.String);
+
+            if (!string.IsNullOrWhiteSpace(displayName))
+                key.SetValue("DisplayName", displayName, RegistryValueKind.String);
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/windows/Ghostty.Tests.Windows/AppUserModelRegistrationTests.cs
+++ b/windows/Ghostty.Tests.Windows/AppUserModelRegistrationTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using Ghostty.Core.Windows;
+using Microsoft.Win32;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// Writes to the real registry, under an AUMID unique to the run, and removes it afterwards.
+/// The behaviour under test IS the registry write, so a fake would only restate the code.
+/// </summary>
+public sealed class AppUserModelRegistrationTests : IDisposable
+{
+    private const string Root = @"Software\Classes\AppUserModelId";
+
+    private readonly string _aumid = "Ghostty.Tests." + Guid.NewGuid().ToString("N");
+    private readonly string _iconPath = Path.Combine(
+        Path.GetTempPath(), "wintty-aumid-test-" + Guid.NewGuid().ToString("N") + ".ico");
+
+    public void Dispose()
+    {
+        try
+        {
+            using var classes = Registry.CurrentUser.OpenSubKey(Root, writable: true);
+            classes?.DeleteSubKeyTree(_aumid, throwOnMissingSubKey: false);
+        }
+        catch (Exception) { }
+
+        try { if (File.Exists(_iconPath)) File.Delete(_iconPath); } catch (Exception) { }
+    }
+
+    private RegistryKey CreateRegistration()
+    {
+        using var classes = Registry.CurrentUser.CreateSubKey(Root, writable: true)!;
+        var key = classes.CreateSubKey(_aumid, writable: true)!;
+        // What Register() leaves behind, and what this code has to correct.
+        key.SetValue("IconUri", @"C:\nowhere\toast-sized.png", RegistryValueKind.String);
+        key.SetValue("DisplayName", "Wintty", RegistryValueKind.String);
+        return key;
+    }
+
+    private void WriteIcon() => File.WriteAllBytes(_iconPath, new byte[] { 0, 0, 1, 0, 1, 0 });
+
+    [Fact]
+    public void ItReplacesTheToastIconAndTheName()
+    {
+        using (CreateRegistration()) { }
+        WriteIcon();
+
+        Assert.True(AppUserModelRegistration.Apply(_aumid, "Wintty Pro", _iconPath));
+
+        using var key = Registry.CurrentUser.OpenSubKey($@"{Root}\{_aumid}")!;
+        Assert.Equal(_iconPath, key.GetValue("IconUri"));
+        Assert.Equal("Wintty Pro", key.GetValue("DisplayName"));
+    }
+
+    /// <summary>
+    /// Register() rewrites IconUri on every launch, so this has to be able to run repeatedly and
+    /// land on the same answer. A first-run-only guard would leave the toast PNG in place from the
+    /// second launch onward, which is the failure that makes an install-time fix impossible.
+    /// </summary>
+    [Fact]
+    public void ItIsIdempotentAcrossRelaunches()
+    {
+        using (CreateRegistration()) { }
+        WriteIcon();
+
+        Assert.True(AppUserModelRegistration.Apply(_aumid, "Wintty Pro", _iconPath));
+
+        // Register() runs again and clobbers it.
+        using (var key = Registry.CurrentUser.OpenSubKey($@"{Root}\{_aumid}", writable: true)!)
+        {
+            key.SetValue("IconUri", @"C:\nowhere\toast-sized.png", RegistryValueKind.String);
+            key.SetValue("DisplayName", "Wintty", RegistryValueKind.String);
+        }
+
+        Assert.True(AppUserModelRegistration.Apply(_aumid, "Wintty Pro", _iconPath));
+
+        using var after = Registry.CurrentUser.OpenSubKey($@"{Root}\{_aumid}")!;
+        Assert.Equal(_iconPath, after.GetValue("IconUri"));
+        Assert.Equal("Wintty Pro", after.GetValue("DisplayName"));
+    }
+
+    /// <summary>
+    /// A missing icon leaves IconUri alone rather than writing a path that resolves to nothing.
+    /// A broken path is worse than the small icon: Start has nothing left to fall back to.
+    /// </summary>
+    [Fact]
+    public void AMissingIconLeavesTheExistingOneAlone()
+    {
+        using (CreateRegistration()) { }
+
+        Assert.True(AppUserModelRegistration.Apply(_aumid, "Wintty Pro", _iconPath));
+
+        using var key = Registry.CurrentUser.OpenSubKey($@"{Root}\{_aumid}")!;
+        Assert.Equal(@"C:\nowhere\toast-sized.png", key.GetValue("IconUri"));
+        Assert.Equal("Wintty Pro", key.GetValue("DisplayName"));
+    }
+
+    /// <summary>
+    /// No key means Register() did not run. Creating one here would leave a registration carrying
+    /// an icon and a name but no CustomActivator - complete to look at, and activating nothing.
+    /// </summary>
+    [Fact]
+    public void ItDoesNotCreateAKeyRegisterNeverMade()
+    {
+        WriteIcon();
+
+        Assert.False(AppUserModelRegistration.Apply(_aumid, "Wintty Pro", _iconPath));
+        Assert.Null(Registry.CurrentUser.OpenSubKey($@"{Root}\{_aumid}"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ItRefusesAnEmptyAumid(string aumid)
+    {
+        Assert.False(AppUserModelRegistration.Apply(aumid, "Wintty Pro", _iconPath));
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/AppUserModelIconWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/AppUserModelIconWiringTests.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using Ghostty.Tests.Wiring;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Where the AppUserModelId correction sits in startup, which is the whole of whether it works.
+///
+/// <c>AppNotificationManager.Register()</c> rewrites the key's <c>IconUri</c> with a 16x16 toast
+/// PNG on EVERY launch, not only the first. So the correction is not a thing that is true or false
+/// about the code, it is a thing that is true or false about the ORDER: run it before Register()
+/// and it is silently reverted, run it after and it holds. That ordering cannot be observed from a
+/// unit test of the writer, and the symptom of getting it wrong - an upscaled icon in a Start list
+/// - is invisible in every automated check we have.
+///
+/// <c>App</c> lives in the WinUI project, which this assembly cannot reference, so this parses the
+/// source the way the other wiring guards do.
+/// </summary>
+public class AppUserModelIconWiringTests
+{
+    private const string ShellFile = "App.xaml.cs";
+
+    private static BlockSyntax Launched() =>
+        ShellSource.Load(ShellFile).Method("OnLaunched").Body!;
+
+    private static int IndexOf(BlockSyntax body, string call) =>
+        body.Statements.ToList().FindIndex(s => s.Calls(call).Count > 0);
+
+    [Fact]
+    public void StartupCorrectsTheAppUserModelRegistration()
+    {
+        Launched().Call("Ghostty.Core.Windows.AppUserModelRegistration.Apply");
+    }
+
+    /// <summary>
+    /// After Register(), because Register() overwrites what this writes.
+    /// </summary>
+    [Fact]
+    public void TheCorrectionRunsAfterTheToastRegistration()
+    {
+        var body = Launched();
+
+        var register = IndexOf(
+            body, "Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register");
+        var apply = IndexOf(body, "Ghostty.Core.Windows.AppUserModelRegistration.Apply");
+
+        Assert.True(register >= 0, "OnLaunched no longer registers for toast notifications");
+        Assert.True(apply >= 0, "OnLaunched no longer corrects the AppUserModelId registration");
+        Assert.True(
+            apply > register,
+            $"the correction is at statement {apply}, at or above Register() at {register}. "
+                + "Register() rewrites IconUri with the toast-sized PNG on every launch, so a "
+                + "correction that runs first is reverted before the user ever sees it.");
+    }
+
+    /// <summary>
+    /// And after the process AUMID is set, since the key being corrected is the one Register()
+    /// derived from that identity. A reorder here would correct another flavour's registration.
+    /// </summary>
+    [Fact]
+    public void TheCorrectionRunsAfterTheProcessIdentityIsSet()
+    {
+        var body = Launched();
+
+        var identity = IndexOf(body, "Windows.Win32.PInvoke.SetCurrentProcessExplicitAppUserModelID");
+        var apply = IndexOf(body, "Ghostty.Core.Windows.AppUserModelRegistration.Apply");
+
+        Assert.True(identity >= 0, "OnLaunched no longer sets an explicit AUMID");
+        Assert.True(apply > identity, "the correction runs before the process identity is set");
+    }
+
+    /// <summary>
+    /// It corrects the identity this process actually answers to.
+    ///
+    /// Passing the AUMID in rather than having the writer read it back is what keeps the two in
+    /// step; a literal here would be a second place the AUMID is spelled, and the shell merges
+    /// installs that share one.
+    /// </summary>
+    [Fact]
+    public void TheCorrectionNamesTheSameIdentityTheProcessSet()
+    {
+        var body = Launched();
+
+        var identityArg = body
+            .Call("Windows.Win32.PInvoke.SetCurrentProcessExplicitAppUserModelID").Arg(0);
+        var appliedArg = body.Call("Ghostty.Core.Windows.AppUserModelRegistration.Apply").Arg(0);
+
+        Assert.Equal(identityArg, appliedArg);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -454,6 +454,18 @@ public partial class App : Application
             Ghostty.Logging.StaticLoggers.App.LogToastRegisterFailed(ex);
         }
 
+        // Immediately after Register(), never before: it writes a 16x16 toast PNG over IconUri on
+        // EVERY launch, so anything written earlier is reverted rather than kept. This is the
+        // notification identity only - Start was tested and takes its icon and name from the
+        // shortcut, not from this key.
+        if (!Ghostty.Core.Windows.AppUserModelRegistration.Apply(
+                AppUserModelId,
+                Ghostty.Core.AppIdentity.ProductName,
+                Ghostty.Core.Windows.AppUserModelRegistration.DeployedIconPath))
+        {
+            Ghostty.Logging.StaticLoggers.App.LogAppUserModelIconFailed(AppUserModelId);
+        }
+
         // Read the activation this process was started for, before the
         // single-instance gate below acts on it. Position is load-bearing: a
         // secondary forwards its launch and exits at that gate, so anything
@@ -1847,6 +1859,13 @@ internal static partial class AppLogExtensions
                    Message = "Removed {Count} superseded AppUserModelId registration(s)")]
     internal static partial void LogStaleAumidRemoved(
         this ILogger<App> logger, int count);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.AppUserModelIconFailed,
+                   Level = LogLevel.Warning,
+                   Message = "Could not point the AppUserModelId registration for {Aumid} at the "
+                             + "full-resolution icon")]
+    internal static partial void LogAppUserModelIconFailed(
+        this ILogger<App> logger, string aumid);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Notifications.ActivationFailed,
                    Level = LogLevel.Warning,

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -14,6 +14,7 @@ internal static class LogEvents
         public const int ToastRegisterFailed = 2002;
         public const int TrayInitFailed      = 2003;
         public const int StaleAumidRemoved   = 2004;
+        public const int AppUserModelIconFailed = 2005;
     }
 
     // 2100-2199: Clipboard


### PR DESCRIPTION
Start's All apps list takes an AUMID-keyed entry's icon and name from
`HKCU\Software\Classes\AppUserModelId\<aumid>`, not from the shortcut. That key
is a side effect of `AppNotificationManager.Register()`, which leaves an
`IconUri` pointing at a 16x16 toast PNG and a `DisplayName` derived from the exe
basename.

Verified on this machine before writing anything: every registered flavour reads
`DisplayName = Wintty`, every registered PNG is 16x16, and seven of the eight on
disk are byte-identical - so the flavours are indistinguishable in toasts as well
as in Start.

Nothing needs generating. `Assets\wintty.ico` ships beside the exe with eight
images up to 256x256 and is rasterised per edition. `AppIdentity.ProductName` is
already per-flavour, so it is the right source for the name and adds no second
place to spell it.

## The ordering is the fix

`Register()` rewrites `IconUri` on **every** launch, so a value written before it
- or written once by an installer - is reverted at the next start. This runs
immediately after `Register()` and re-applies each launch, and after the process
AUMID is set, since the key is the one `Register()` derived from that identity.

It opens rather than creates the key: no key means `Register()` did not run, and
an icon in a key with no `CustomActivator` is a registration that looks complete
and activates nothing. A missing icon file leaves `IconUri` alone, because a path
resolving to nothing is worse than a small icon.

## Tests

Split the way the risk does. `Ghostty.Tests.Windows` covers the write against the
real registry under a per-run AUMID, including the relaunch case that makes an
install-time fix impossible. The ordering is invisible from there, so
`Ghostty.Tests` parses `App.xaml.cs`. Three mutations, each caught by its guard:
the call moved above `Register()`, the AUMID replaced with a literal, and the
call dropped.

Both suites green: 2312 and 34.

## Scope

Deliberately not in the tiered build - every flavour has the defect, oss included,
and `AppIdentity.AumId` is already per-flavour wherever a flavour is built.

## What this does not do

It has no visible effect until a shortcut carries the AUMID. Two of the four
installed here now do; the other two carry none, which is tracked separately.

The acceptance step in the issue - install, open All apps, confirm full fidelity -
still wants a human eye on an idle desktop, and has not been done.
