### PR TITLE
Remove the AppUserModelId registration the rename left behind

### DIFF
--- a/windows/Ghostty.Core/Windows/StaleAppUserModelRegistrations.cs
+++ b/windows/Ghostty.Core/Windows/StaleAppUserModelRegistrations.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace Ghostty.Core.Windows;
+
+/// <summary>
+/// Removes the notification identities this app used to answer to and no longer does.
+///
+/// <c>HKCU\Software\Classes\AppUserModelId\&lt;aumid&gt;</c> is created as a side effect of
+/// <c>AppNotificationManager.Register()</c>, and nothing ever removes it. What is left behind is a
+/// <c>CustomActivator</c> naming a COM class no running build claims, so the registration can
+/// never produce a notification again and nothing will ever say so.
+///
+/// It does NOT clean up the row Windows shows in Settings &gt; System &gt; Notifications. That list is
+/// driven by the notification platform's own database, which is a separate store: on the machine
+/// this was found on, the key below was already gone while its row and its <c>NotificationHandler</c>
+/// record both remained, and another identity had a record there with no key at all. Removing the
+/// key stops it being read; it does not tidy the list.
+/// </summary>
+/// <remarks>
+/// The whole risk here is deleting a key that something still uses, so the rule is that removal is
+/// driven by <see cref="Superseded"/>, an explicit list, and never by the shape of a name. Matching
+/// the AUMID namespace instead would take out a sibling flavour that happens to be installed:
+/// Wintty ships several, they differ only by AUMID, and the one being removed would go quiet with
+/// nothing to say why.
+///
+/// An entry earns its place on that list only by being impossible for a build that exists to use.
+/// "Old" is not enough. <c>com.deblasis.wintty</c> and the tier names derived from it look
+/// abandoned on a machine carrying the release AUMIDs, but they are the DEFAULT that
+/// <c>_WinttyAumId</c> falls back to, so any public or untiered build registers under them, and
+/// this must leave them alone.
+/// </remarks>
+[SupportedOSPlatform("windows")]
+internal static class StaleAppUserModelRegistrations
+{
+    private const string Root = @"Software\Classes\AppUserModelId";
+
+    /// <summary>
+    /// The identities that are provably dead, listed one by one.
+    ///
+    /// <c>com.deblasis.ghostty</c> is dead because the AUMID was a hardcoded literal for as long as
+    /// it said "ghostty": the product was renamed to Wintty, the constant moved to
+    /// <c>com.deblasis.wintty</c>, and the per-tier <c>_WinttyAumId</c> override that lets flavours
+    /// differ arrived only after that move. So no build ever registered under
+    /// <c>com.deblasis.ghostty</c> plus a tier suffix, and no build that can be produced today
+    /// registers under the bare name either.
+    /// </summary>
+    public static readonly ImmutableArray<string> Superseded = ["com.deblasis.ghostty"];
+
+    /// <summary>
+    /// Remove the <see cref="Superseded"/> registrations. Returns how many keys were deleted.
+    ///
+    /// Two identities are held back rather than one. <paramref name="currentAumid"/> is what the
+    /// caller set on the process, and <see cref="AppIdentity.AumId"/> is what this build was
+    /// compiled with. Today they are the same constant and a wiring test keeps the one call site
+    /// that way, so the second is redundant from here - it is there for the second call site, which
+    /// would otherwise be able to delete the registration behind every notification this build
+    /// sends by passing a string that is merely plausible.
+    /// </summary>
+    public static int RemoveSuperseded(string currentAumid) =>
+        RemoveSuperseded(Superseded, [currentAumid, AppIdentity.AumId]);
+
+    /// <summary>
+    /// The same, over caller-supplied lists, so a test can exercise this against keys it owns.
+    /// Nothing in <paramref name="live"/> is removed whatever <paramref name="superseded"/> says.
+    ///
+    /// Never throws. An orphaned row in a settings list is a cosmetic defect, and a registry hive
+    /// can be locked down or redirected in ways this cannot anticipate; neither is worth a startup
+    /// failure.
+    /// </summary>
+    public static int RemoveSuperseded(IReadOnlyList<string> superseded, IReadOnlyList<string> live)
+    {
+        try
+        {
+            using var classes = Registry.CurrentUser.OpenSubKey(Root, writable: true);
+            if (classes is null) return 0;
+
+            var removed = 0;
+            foreach (var aumid in superseded)
+            {
+                if (string.IsNullOrWhiteSpace(aumid)) continue;
+
+                // A separator is not whitespace, and a name made only of them fixes up to the
+                // empty string - at which point DeleteSubKeyTree deletes the key the handle is
+                // open on, which here is the whole AppUserModelId hive: every desktop app on the
+                // machine loses its notification identity. The existence probe below does not
+                // catch it either, because OpenSubKey(@"\") returns the parent. A legal AUMID
+                // never contains one, so refuse the whole class rather than the one spelling.
+                if (aumid.Contains('\\') || aumid.Contains('/')) continue;
+
+                if (IsLive(aumid, live)) continue;
+
+                // Per entry, so one key the user cannot write does not cost the rest of the list.
+                try
+                {
+                    // Existence checked first because DeleteSubKeyTree cannot report the
+                    // difference between having removed something and having found nothing, and
+                    // the second launch onward will always be the second case.
+                    bool present;
+                    using (var existing = classes.OpenSubKey(aumid)) present = existing is not null;
+                    if (!present) continue;
+
+                    classes.DeleteSubKeyTree(aumid, throwOnMissingSubKey: false);
+                    removed++;
+                }
+                catch { /* One key that cannot be opened or deleted; the rest of the list still can. */ }
+            }
+
+            return removed;
+        }
+        catch
+        {
+            // The hive can be locked down or redirected in ways this cannot anticipate, and a
+            // dangling activator entry is not worth failing a launch over.
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Whether an entry names an identity that is in use, in which case it is left alone whatever
+    /// the superseded list says. Compared case-insensitively, because registry key names are.
+    /// </summary>
+    private static bool IsLive(string aumid, IReadOnlyList<string> live)
+    {
+        foreach (var identity in live)
+            if (string.Equals(aumid, identity, StringComparison.OrdinalIgnoreCase)) return true;
+
+        return false;
+    }
+}

--- a/windows/Ghostty.Tests.Windows/StaleAppUserModelRegistrationsTests.cs
+++ b/windows/Ghostty.Tests.Windows/StaleAppUserModelRegistrationsTests.cs
@@ -1,0 +1,246 @@
+using System;
+using Ghostty.Core;
+using Ghostty.Core.Windows;
+using Microsoft.Win32;
+using Xunit;
+
+namespace Ghostty.Tests.Windows;
+
+/// <summary>
+/// Deleting from the real registry is the behaviour, so these use it, under AUMIDs unique to the
+/// run and removed again afterwards.
+///
+/// No test here names a real identity to the remover, and that is deliberate rather than tidiness:
+/// the shipped <see cref="StaleAppUserModelRegistrations.Superseded"/> list, and the AUMIDs the
+/// installed flavours answer to, are keys on the machine running the tests. A test run must not be
+/// the thing that cleans a developer's shell up, and a mutation of the code under test must not be
+/// able to make it one. What the shipped list contains is asserted on the list itself, without
+/// going near a key.
+/// </summary>
+public sealed class StaleAppUserModelRegistrationsTests : IDisposable
+{
+    private const string Root = @"Software\Classes\AppUserModelId";
+
+    private readonly string _orphan = "Ghostty.Tests.Orphan." + Guid.NewGuid().ToString("N");
+    private readonly string _keeper = "Ghostty.Tests.Keeper." + Guid.NewGuid().ToString("N");
+    private readonly string _current = "Ghostty.Tests.Current." + Guid.NewGuid().ToString("N");
+
+    public void Dispose()
+    {
+        try
+        {
+            using var classes = Registry.CurrentUser.OpenSubKey(Root, writable: true);
+            if (classes is null) return;
+
+            classes.DeleteSubKeyTree(_orphan, throwOnMissingSubKey: false);
+            classes.DeleteSubKeyTree(_keeper, throwOnMissingSubKey: false);
+            classes.DeleteSubKeyTree(_current, throwOnMissingSubKey: false);
+        }
+        catch (Exception) { }
+    }
+
+    /// <summary>What Register() leaves behind, which is what has to be removed.</summary>
+    private static void CreateRegistration(string aumid)
+    {
+        using var classes = Registry.CurrentUser.CreateSubKey(Root, writable: true)!;
+        using var key = classes.CreateSubKey(aumid, writable: true)!;
+        key.SetValue(
+            "CustomActivator", "{" + Guid.NewGuid().ToString("D") + "}", RegistryValueKind.String);
+        key.SetValue("DisplayName", "Wintty", RegistryValueKind.String);
+    }
+
+    private static bool Exists(string aumid)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey($@"{Root}\{aumid}");
+        return key is not null;
+    }
+
+    [Fact]
+    public void ItRemovesAListedRegistration()
+    {
+        CreateRegistration(_orphan);
+
+        Assert.Equal(1, StaleAppUserModelRegistrations.RemoveSuperseded([_orphan], [_current]));
+        Assert.False(Exists(_orphan));
+    }
+
+    /// <summary>
+    /// The listed name is the only thing that decides. A key that merely looks like one of ours -
+    /// same namespace, same product, one suffix apart - is a sibling flavour's live notification
+    /// identity, and removing it would silence an app the user did not touch.
+    /// </summary>
+    [Fact]
+    public void ItLeavesAnUnlistedRegistrationAlone()
+    {
+        CreateRegistration(_orphan);
+        CreateRegistration(_keeper);
+
+        Assert.Equal(1, StaleAppUserModelRegistrations.RemoveSuperseded([_orphan], [_current]));
+        Assert.True(Exists(_keeper));
+    }
+
+    /// <summary>
+    /// The live identity wins over the list. That guard, not the list, is what protects the running
+    /// process: a list that named this identity would otherwise delete the registration behind
+    /// every toast this build sends, and the app would go quiet with the key gone until the next
+    /// launch recreated it.
+    /// </summary>
+    [Fact]
+    public void ItRefusesToRemoveALiveIdentity()
+    {
+        CreateRegistration(_current);
+
+        Assert.Equal(0, StaleAppUserModelRegistrations.RemoveSuperseded([_current], [_current]));
+        Assert.True(Exists(_current));
+    }
+
+    /// <summary>
+    /// Every live identity, not just the first. The shipped call names two - the AUMID the process
+    /// was given and the one the build was compiled with - so a guard that stopped at one would
+    /// leave the other unprotected.
+    /// </summary>
+    [Fact]
+    public void ItRefusesToRemoveAnyOfSeveralLiveIdentities()
+    {
+        CreateRegistration(_current);
+        CreateRegistration(_keeper);
+
+        Assert.Equal(
+            0,
+            StaleAppUserModelRegistrations.RemoveSuperseded(
+                [_current, _keeper], [_current, _keeper]));
+        Assert.True(Exists(_current));
+        Assert.True(Exists(_keeper));
+    }
+
+    /// <summary>
+    /// Registry key names are case-insensitive, so a guard that is not would compare unequal to the
+    /// very key it is protecting.
+    /// </summary>
+    [Fact]
+    public void TheLiveGuardIgnoresCase()
+    {
+        CreateRegistration(_current);
+
+        Assert.Equal(
+            0,
+            StaleAppUserModelRegistrations.RemoveSuperseded(
+                [_current.ToUpperInvariant()], [_current]));
+        Assert.True(Exists(_current));
+    }
+
+    /// <summary>
+    /// This runs on every launch, so all but the first run finds nothing to do. Already gone has to
+    /// be a quiet zero rather than a throw or a phantom removal.
+    /// </summary>
+    [Fact]
+    public void ItIsIdempotentOnceTheKeyIsGone()
+    {
+        CreateRegistration(_orphan);
+
+        Assert.Equal(1, StaleAppUserModelRegistrations.RemoveSuperseded([_orphan], [_current]));
+        Assert.Equal(0, StaleAppUserModelRegistrations.RemoveSuperseded([_orphan], [_current]));
+        Assert.False(Exists(_orphan));
+    }
+
+    [Fact]
+    public void AnAbsentKeyIsNotAnError()
+    {
+        Assert.Equal(0, StaleAppUserModelRegistrations.RemoveSuperseded([_orphan], [_current]));
+    }
+
+    /// <summary>
+    /// A name the registry cannot use is not an error either. Whether it is rejected outright or
+    /// simply matches nothing is the registry's business; what matters is that nothing propagates
+    /// out of a call made on the startup path.
+    /// </summary>
+    [Fact]
+    public void AnUnusableNameIsNotAnError()
+    {
+        Assert.Equal(
+            0,
+            StaleAppUserModelRegistrations.RemoveSuperseded([new string('x', 300)], [_current]));
+    }
+
+    /// <summary>
+    /// A bad entry cannot take the rest of the list with it, or one addition would quietly turn the
+    /// cleanup off for everything listed after it.
+    /// </summary>
+    [Fact]
+    public void ABadEntryDoesNotStopTheRest()
+    {
+        CreateRegistration(_orphan);
+
+        Assert.Equal(
+            1,
+            StaleAppUserModelRegistrations.RemoveSuperseded(
+                ["", "   ", @"\", "/", @"\\", @"\some	hing", new string('x', 300), _orphan],
+                [_current]));
+        Assert.False(Exists(_orphan));
+    }
+
+    /// <summary>
+    /// A name made only of separators must not reach DeleteSubKeyTree.
+    ///
+    /// It fixes up to the empty string, and DeleteSubKeyTree("") deletes the key the handle is open
+    /// on - here the whole AppUserModelId hive, taking every desktop app's notification identity
+    /// with it. Whitespace filtering does not catch it and neither does the existence probe, since
+    /// OpenSubKey(@"\") returns the parent rather than null. Proven against a throwaway hive
+    /// before the guard existed.
+    /// </summary>
+    [Theory]
+    [InlineData(@"\")]
+    [InlineData("/")]
+    [InlineData(@"\\")]
+    [InlineData(@"\   ")]
+    public void ASeparatorEntryLeavesTheContainingKeyAlone(string aumid)
+    {
+        CreateRegistration(_orphan);
+
+        Assert.Equal(0, StaleAppUserModelRegistrations.RemoveSuperseded([aumid], [_current]));
+
+        using var classes = Registry.CurrentUser.OpenSubKey(Root);
+        Assert.NotNull(classes);
+        Assert.True(Exists(_orphan), "the containing key was deleted");
+    }
+
+    /// <summary>
+    /// What the app actually ships. The danger is not the code, it is somebody adding a name to the
+    /// list that a build still answers to, and no behaviour test can catch that.
+    /// </summary>
+    [Fact]
+    public void TheShippedListNamesOnlyTheRenamedIdentity()
+    {
+        Assert.Equal(new[] { "com.deblasis.ghostty" }, StaleAppUserModelRegistrations.Superseded);
+    }
+
+    /// <summary>
+    /// Stated separately from the exact list above, because this is the constraint that survives
+    /// the list growing.
+    ///
+    /// Both families, not one. An untiered or public build registers under com.deblasis.wintty;
+    /// every RELEASE build registers under ShipDigital.&lt;pack id&gt;, which wintty-release composes in
+    /// builds/_common/patches from the resolved pack id. The first version of this guard named only
+    /// the default family, so the one every shipped flavour actually uses was the one it did not
+    /// cover - and comparing against AppIdentity.AumId does not close that, because it is the single
+    /// variant this assembly happened to compile as.
+    ///
+    /// The failure it exists to stop: retire a flavour, add its AUMID here, and every other flavour
+    /// deletes that one's registration on launch. Its toasts die until it is next started, which
+    /// depends on the order the user opens things.
+    /// </summary>
+    [Theory]
+    [InlineData("com.deblasis.wintty")]
+    [InlineData("ShipDigital.")]
+    public void TheShippedListNamesNothingInALiveIdentityFamily(string family)
+    {
+        foreach (var aumid in StaleAppUserModelRegistrations.Superseded)
+        {
+            Assert.False(
+                aumid.StartsWith(family, StringComparison.OrdinalIgnoreCase),
+                $"'{aumid}' is in the '{family}' AUMID family, which builds that can be installed "
+                    + "today still register under");
+            Assert.NotEqual(AppIdentity.AumId, aumid, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/windows/Ghostty.Tests/Wiring/StaleAppUserModelWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/StaleAppUserModelWiringTests.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// Where the superseded-registration cleanup sits in startup.
+///
+/// It has to be on the launch path at all: nothing else ever removes an AppUserModelId key, so a
+/// call site that gets dropped leaves the orphaned rows in Settings &gt; Notifications forever, and
+/// no unit test of the remover can tell.
+///
+/// It also has to run before <c>Register()</c>. Register() recreates the key for this process's
+/// identity, so a cleanup that runs first is recoverable if the list is ever wrong and one that
+/// runs after is not. That is a fact about the ORDER, invisible to a test of the remover itself.
+///
+/// <c>App</c> lives in the WinUI project, which this assembly cannot reference, so this parses the
+/// source the way the other wiring guards do.
+/// </summary>
+public class StaleAppUserModelWiringTests
+{
+    private const string ShellFile = "App.xaml.cs";
+    private const string Removal =
+        "Ghostty.Core.Windows.StaleAppUserModelRegistrations.RemoveSuperseded";
+    private const string Register =
+        "Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register";
+    private const string SetIdentity =
+        "Windows.Win32.PInvoke.SetCurrentProcessExplicitAppUserModelID";
+
+    private static BlockSyntax Launched() =>
+        ShellSource.Load(ShellFile).Method("OnLaunched").Body!;
+
+    private static int IndexOf(BlockSyntax body, string call) =>
+        body.Statements.ToList().FindIndex(s => s.Calls(call).Count > 0);
+
+    [Fact]
+    public void StartupRemovesSupersededRegistrations()
+    {
+        Launched().Call(Removal);
+    }
+
+    [Fact]
+    public void TheRemovalRunsBeforeTheToastRegistration()
+    {
+        var body = Launched();
+
+        var register = IndexOf(body, Register);
+        var removal = IndexOf(body, Removal);
+
+        Assert.True(register >= 0, "OnLaunched no longer registers for toast notifications");
+        Assert.True(removal >= 0, "OnLaunched no longer removes superseded registrations");
+        Assert.True(
+            removal < register,
+            $"the removal is at statement {removal}, at or below Register() at {register}. "
+                + "Register() is what recreates this process's own key, so running the removal "
+                + "first is what keeps a wrong entry in the list from costing this launch its "
+                + "notifications.");
+    }
+
+    /// <summary>
+    /// It names the identity this process answers to, and names it by reading the same constant
+    /// the process was given rather than spelling the AUMID a second time. The remover refuses to
+    /// delete what it is told is current, so an argument that drifts is the one way that guard
+    /// stops guarding anything.
+    /// </summary>
+    [Fact]
+    public void TheRemovalNamesTheSameIdentityTheProcessSet()
+    {
+        var body = Launched();
+
+        var identityArg = body.Call(SetIdentity).Arg(0);
+        var removalArg = body.Call(Removal).Arg(0);
+
+        Assert.Equal(identityArg, removalArg);
+    }
+}

--- a/windows/Ghostty/App.xaml.cs
+++ b/windows/Ghostty/App.xaml.cs
@@ -403,6 +403,21 @@ public partial class App : Application
         // once ProfileRegistry is live so pinned profiles appear.
         RebuildJumpList();
 
+        // Before Register(), not after. Register() is what (re)creates the key for the identity
+        // below, so a removal that runs first cannot leave this process without a registration
+        // even if the superseded list one day named something still in use; run it afterwards and
+        // that same mistake costs every toast until the next launch.
+        // Recorded rather than discarded. This deletes registry keys, unattended, on every
+        // launch; if it ever removes one it should not, the log line is the only way anyone
+        // reconstructs why notifications stopped.
+        // On one line because the wiring guard matches the callee as source text, and a wrapped
+        // qualified name stops matching. Worth knowing before reformatting it.
+        var staleRemoved = Ghostty.Core.Windows.StaleAppUserModelRegistrations.RemoveSuperseded(AppUserModelId);
+        if (staleRemoved > 0)
+        {
+            Ghostty.Logging.StaticLoggers.App.LogStaleAumidRemoved(staleRemoved);
+        }
+
         // Register for toast notifications. Unpackaged apps must call
         // Register() so AppNotificationManager wires up the COM activator
         // under the AUMID before any Show(); without it Show() throws. The
@@ -1826,6 +1841,12 @@ internal static partial class AppLogExtensions
                    Message = "Failed to register for toast notifications")]
     internal static partial void LogToastRegisterFailed(
         this ILogger<App> logger, System.Exception ex);
+
+    [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Startup.StaleAumidRemoved,
+                   Level = LogLevel.Information,
+                   Message = "Removed {Count} superseded AppUserModelId registration(s)")]
+    internal static partial void LogStaleAumidRemoved(
+        this ILogger<App> logger, int count);
 
     [LoggerMessage(EventId = Ghostty.Logging.LogEvents.Notifications.ActivationFailed,
                    Level = LogLevel.Warning,

--- a/windows/Ghostty/Logging/LogEvents.cs
+++ b/windows/Ghostty/Logging/LogEvents.cs
@@ -13,6 +13,7 @@ internal static class LogEvents
         public const int JumpListFailed = 2001;
         public const int ToastRegisterFailed = 2002;
         public const int TrayInitFailed      = 2003;
+        public const int StaleAumidRemoved   = 2004;
     }
 
     // 2100-2199: Clipboard


### PR DESCRIPTION

Renaming the product from ghostty to wintty changed the AUMID, and the old
registration was never removed. It is still in HKCU on a machine that has run
both, still carrying a live CustomActivator, and Windows shows it as its own
app.

Removal is driven by an explicit list, never by the shape of a name. Matching
the AUMID namespace would take out a sibling flavour that happens to be
installed: Wintty ships several, they differ only by AUMID, and the one removed
would go quiet with nothing to say why. A mutation that derived a prefix from
the list did exactly that during development, against a real key.

One entry earns its place. `com.deblasis.ghostty` is dead because the AUMID was
a hardcoded literal for as long as it said "ghostty": the constant moved to
`com.deblasis.wintty` before the per-tier `_WinttyAumId` override existed, so no
build ever registered under the old name plus a tier suffix, and none that can
be produced today registers under the bare name.

The `com.deblasis.wintty*` family is deliberately left alone. It reads as
abandoned on a machine carrying the release AUMIDs, but it is the DEFAULT
`_WinttyAumId` falls back to, so any public or untiered build registers there.
Old is not the same as dead.

Two identities are held back rather than one: the AUMID the caller set on the
process, and the one this build was compiled with. They agree today, and the
second costs nothing if they always do, but a caller passing the wrong string
would otherwise delete the registration behind every notification this build
sends.

Runs before Register(), which is what recreates this process's own key - so a
list that is ever wrong is recoverable on the next launch rather than costing
that launch its notifications.

## What this does not do

It does not remove the row Windows shows in Settings. Those come from the
notification platform's own database, which is a separate store: after the
`com.deblasis.ghostty` registry key was gone, its handler was still present in
`wpndatabase.db`, and `com.deblasis.wintty` has a handler there with no registry
key at all. Removing the key stops it being read; it does not tidy the list.
Filed separately.