### PR TITLE
Put the tier layer merge under -SelfTest

### DIFF
--- a/windows/scripts/README.md
+++ b/windows/scripts/README.md
@@ -94,7 +94,7 @@ throws, one that throws `PRODUCT_FAIL` from inside a `try`/`finally`, one
 that fails once and then works, one that hangs forever, and one that
 classifies its own failure to establish a corpus as the retryable 1 rather
 than a finding. It asserts the verdict *and* the attempt count for each. It
-takes about a minute, needs no build or desktop, and is safe to run with
+takes a minute and a half, needs no build or desktop, and is safe to run with
 Wintty open.
 
 Two details make it worth trusting rather than just running:

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -189,6 +189,18 @@ $NotInSuite = [ordered]@{
     'fuzz-tier-harnesses.ps1'       = 'the tier layer manifest, not a harness; read below'
 }
 
+# Everything this file ships beside itself, as paths relative to this directory:
+# the harnesses above plus everything deliberately outside them. Integrity check
+# 2 is what makes that an inventory rather than a claim - a script sitting here
+# in neither collection fails every invocation, -List included. Taken while both
+# are still literals, because the tier merge below appends a tier's own scripts
+# to both and those are not what this file ships. Normalised exactly the way
+# check 2 normalises, so the two cannot drift apart.
+$BaseScripts = @(
+    @($Harnesses  | ForEach-Object { ($_.script -replace '/', '\').TrimStart('.\') }) +
+    @($NotInSuite.Keys | ForEach-Object { ([string]$_ -replace '/', '\').TrimStart('.\') })
+)
+
 # ---- tier layer -----------------------------------------------------------
 # A tier build ships the harnesses above PLUS its own, because a tier is the
 # thing it was built on plus what it adds. The base set is not optional for a
@@ -219,6 +231,16 @@ if (Test-Path $TierManifestPath) {
     $declared = & $TierManifestPath
     if ($null -eq $declared) {
         Write-Host "tier layer: $TierManifestPath returned nothing" -ForegroundColor Red
+        exit 1
+    }
+
+    # More than one object out of one file is what an overlay that appended
+    # rather than replaced leaves behind, and what keeping both sides of a merge
+    # conflict produces. Member enumeration hides it rather than failing: across
+    # an array .layer stringifies to the names joined and .harnesses to both
+    # sets, so everything merges under a layer named after neither of them.
+    if ($declared -is [array]) {
+        Write-Host ("tier layer: $TierManifestPath emitted $($declared.Count) objects; it must emit exactly one") -ForegroundColor Red
         exit 1
     }
 
@@ -266,6 +288,21 @@ if (Test-Path $TierManifestPath) {
             }
         }
 
+        # Present but empty, for the three that are read as text. An empty name
+        # is a blank row in -List that neither -Only nor -Skip can select, and
+        # an OutDir that resolves to the run root. An empty script slips both
+        # the path guard below and integrity check 1 - Test-Path on the
+        # directory itself succeeds - and surfaces only as check 3 saying
+        # nothing declares -ExePath, which reads as a broken harness rather
+        # than a broken manifest. An empty oracle is a harness claiming a pass
+        # rules something out without saying what, and the header above is
+        # explicit that those strings were already wrong here once.
+        foreach ($key in @('name', 'script', 'oracle')) {
+            if ($entry.Contains($key) -and -not "$($entry[$key])".Trim()) {
+                $tierProblems += "tier harness has an empty '$key': $($entry.name)"
+            }
+        }
+
         # minutes is the dangerous one, so it is coerced here rather than trusted.
         # It reaches [math]::Max(180, $_ * 60 * 4) in the run loop, and a string
         # multiplies by REPEATING - '2' * 60 is a 60-character string - which then
@@ -284,7 +321,11 @@ if (Test-Path $TierManifestPath) {
 
         # A null or empty tags list passes a key-presence check and then quietly
         # excludes the harness from every -Tag run, which is how CI invokes this.
-        if (-not @($entry.tags | Where-Object { $_ })) {
+        # Whitespace counts as empty here: only '' is falsy in PowerShell, so a
+        # bare truthiness test keeps '  ' - and Split-List trims the caller's
+        # -Tag values and drops the blanks, so no -Tag argument can ever reach a
+        # tag like that. It selects nothing, exactly like the empty list does.
+        if (-not @($entry.tags | Where-Object { "$_".Trim() })) {
             $tierProblems += "tier harness '$($entry.name)' declares no tags, so no -Tag run would ever select it"
         }
 
@@ -319,8 +360,41 @@ if (Test-Path $TierManifestPath) {
     # the run, and the only escapes were patching this file, which is what the
     # layer exists to avoid, or declaring it a harness, which is worse.
     if ($declared.notInSuite) {
-        foreach ($name in $declared.notInSuite.Keys) {
-            $NotInSuite[[string]$name] = [string]$declared.notInSuite[$name]
+        # Normalised the same way a harness entry is, and for the same reason.
+        # This is the other half of the same manifest and arrives the same two
+        # ways, but a PSCustomObject has no .Keys at all - so the foreach ran
+        # over $null and did nothing, and the run then died at integrity check 2
+        # telling the tier author to classify a file they had classified.
+        $declaredNotInSuite = [ordered]@{}
+        if ($declared.notInSuite -is [System.Collections.IDictionary]) {
+            foreach ($k in $declared.notInSuite.Keys) { $declaredNotInSuite[[string]$k] = [string]$declared.notInSuite[$k] }
+        } elseif ($declared.notInSuite -is [array] -or $declared.notInSuite -is [string]) {
+            # The reason is not decoration: it is the only place a tier says why
+            # a script of its own is not a harness. A bare list also reads as an
+            # object whose properties are Length and Rank, so left to the branch
+            # below it would classify those and nothing else.
+            $tierProblems += 'tier notInSuite must be written as name = reason pairs, not a list of names'
+        } else {
+            foreach ($prop in $declared.notInSuite.PSObject.Properties) { $declaredNotInSuite[[string]$prop.Name] = [string]$prop.Value }
+        }
+
+        # This is the one door in the merge that lets a tier tell check 2 to look
+        # away, so it is the one place a lenient read would undo the strict one.
+        $claimedScripts = @($Harnesses | ForEach-Object { ($_.script -replace '/', '\').TrimStart('.\') })
+        foreach ($name in $declaredNotInSuite.Keys) {
+            # Check 2 compares against a leaf name, so anything carrying a
+            # separator excuses nothing while reading as though it did.
+            if (-not $name.Trim() -or $name -match '[\\/]') {
+                $tierProblems += "tier notInSuite names something that is not a plain file name: '$name'"
+                continue
+            }
+            # Excusing a script the manifest also names is the silent shrink
+            # again, arriving through the only door a tier can open by itself.
+            if ($claimedScripts -contains $name) {
+                $tierProblems += "tier notInSuite excuses '$name', which the manifest also names as a harness script"
+                continue
+            }
+            $NotInSuite[$name] = $declaredNotInSuite[$name]
         }
     }
 
@@ -607,12 +681,17 @@ $all = if ($useFixtures) { @($SelfTestHarnesses) } else { @($Harnesses) }
 
 # The assertions are written against the whole fixture set at exactly one
 # retry, so anything that would change either is refused rather than
-# silently ignored.
+# silently ignored. -OutRoot is refused for a different reason: the tier layer
+# cases below run out of a copy of this directory placed under it, and two
+# self-tests sharing one root rewrite each other's manifest in the window
+# between the copy and the child launch. The default stamp is per-second, so
+# that is two runs started in the same second, not a contrived collision.
 if ($SelfTest -and ($Tag -or $Only -or $Skip -or
                     $PSBoundParameters.ContainsKey('Retries') -or
                     $PSBoundParameters.ContainsKey('Seed') -or
+                    $PSBoundParameters.ContainsKey('OutRoot') -or
                     $StopOnFindings)) {
-    Write-Host '-SelfTest asserts against the whole fixture set at one retry; it takes no filters, -Retries, -Seed or -StopOnFindings' -ForegroundColor Red
+    Write-Host '-SelfTest asserts against the whole fixture set at one retry, under an output root of its own; it takes no filters, -Retries, -Seed, -OutRoot or -StopOnFindings' -ForegroundColor Red
     exit 1
 }
 
@@ -835,10 +914,28 @@ if ($SelfTest) {
     # read is text and none of it is built, a copy is enough.
     $LayerRoot = Join-Path $OutRoot 'layer-scripts'
     New-Item -ItemType Directory -Force -Path $LayerRoot | Out-Null
-    # A tier checkout has a real manifest sitting here. Copying it would give
-    # every case below a second layer, the case that asserts what an ABSENT
-    # manifest does included - on exactly the builds that ship one.
-    Copy-Item -Path (Join-Path $PSScriptRoot '*.ps1') -Destination $LayerRoot -Exclude 'fuzz-tier-harnesses.ps1'
+    # Copied from the inventory by name rather than swept up by a glob. A tier
+    # checkout has the tier's own scripts sitting here too, and a glob takes
+    # those while deliberately leaving behind the one file that classifies them
+    # - so every case below would fail integrity check 2 on exactly the builds
+    # the layer exists for.
+    foreach ($rel in $BaseScripts) {
+        # The manifest is the one name left behind. A tier checkout has a real
+        # one sitting here, and copying it would give every case below a second
+        # layer, the case that asserts what an ABSENT manifest does included -
+        # on exactly the builds that ship one.
+        if ($rel -eq 'fuzz-tier-harnesses.ps1') { continue }
+        $src = Join-Path $PSScriptRoot $rel
+        # $NotInSuite classifies names, and nothing checks that the file behind
+        # one is still there: check 2 only looks the other way. A stale entry is
+        # its silence, not a reason to fail the self-test.
+        if (-not (Test-Path -LiteralPath $src)) { continue }
+        $dest = Join-Path $LayerRoot $rel
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
+        Copy-Item -LiteralPath $src -Destination $dest -Force
+    }
+    # lib/ wholesale, because it carries wintty-process.ps1 - dot-sourced before
+    # anything else runs - and every fixture the self-test harnesses name.
     Copy-Item -Path (Join-Path $PSScriptRoot 'lib') -Destination $LayerRoot -Recurse -Force
 
     # Read off this run rather than written down here, so adding a base harness
@@ -858,11 +955,27 @@ exit 0
     $script:LayerInjected = @()
     $script:LayerCases = 0
 
+    # Puts the copy back the way the last case found it. A case injects onto a
+    # relative path, and a path it names may be one the copy legitimately
+    # carries - pass.ps1 and tier-runner.ps1 are both plausible base names - so
+    # what was there is restored rather than deleted. Deleting it instead
+    # mutates the tree under test for every case that follows, which is how a
+    # case comes to pass for a reason nobody wrote down.
+    function Reset-LayerInjection {
+        foreach ($p in $script:LayerInjected) {
+            if ($null -eq $p.was) { Remove-Item -LiteralPath $p.path -Force -ErrorAction SilentlyContinue }
+            else { [System.IO.File]::WriteAllBytes($p.path, $p.was) }
+        }
+        $script:LayerInjected = @()
+    }
+
     # One child run over the copy. The manifest and whatever scripts a case
-    # needs on disk are placed fresh and taken away again on the next call, so
-    # no case inherits what another left behind and the order they are written
-    # in does not matter. -List is the whole run: the merge and all three
-    # integrity checks happen before it, and none of them needs a desktop.
+    # needs on disk are placed fresh and undone again on the next call, so no
+    # case inherits what another left behind and the order they are written in
+    # does not matter. That last part needs the sweep after the final assertion
+    # too: undoing on the way in leaves the last injecting case's files sitting
+    # there. -List is the whole run: the merge and all three integrity checks
+    # happen before it, and none of them needs a desktop.
     function Invoke-Layer {
         param(
             [Parameter(Mandatory)][string]$Case,
@@ -870,8 +983,7 @@ exit 0
             [hashtable]$Inject = @{},
             [string[]]$Extra = @('-List')
         )
-        foreach ($p in $script:LayerInjected) { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
-        $script:LayerInjected = @()
+        Reset-LayerInjection
         $script:LayerCases++
 
         $manifestPath = Join-Path $LayerRoot 'fuzz-tier-harnesses.ps1'
@@ -884,8 +996,11 @@ exit 0
         foreach ($rel in $Inject.Keys) {
             $dest = Join-Path $OutRoot $rel
             New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
+            # Whatever was there first, so the sweep can put it back rather than
+            # delete a file it did not create. $null means there was nothing.
+            $was = if (Test-Path -LiteralPath $dest) { [System.IO.File]::ReadAllBytes($dest) } else { $null }
             Set-Content -LiteralPath $dest -Value $Inject[$rel] -Encoding utf8
-            $script:LayerInjected += $dest
+            $script:LayerInjected += @{ path = $dest; was = $was }
         }
 
         $argv = @('-NoProfile', '-File', (Join-Path $LayerRoot 'fuzz-suite.ps1')) + $Extra
@@ -929,8 +1044,11 @@ exit 0
     Assert-Layer -Run (Invoke-Layer -Case 'pscustomobject' -Manifest 'pscustomobject.ps1') -Exit 0 `
         -Says @("layers: base ($baseCount) + pro (1)")
 
-    # '2' and '2.6' coerce to 2 and 3, so a layer that took them as text moves
-    # the total by 4.6 and one that coerced them moves it by 5.
+    # -List's minutes total is the only place a coerced value looks different
+    # from the text it came from, so this pins .NET's rounding of '2.6' to 3 for
+    # want of any other signal. Nobody chose that rounding and nothing depends
+    # on it: if the coercion ever changes, this number follows it rather than
+    # the other way round.
     Assert-Layer -Run (Invoke-Layer -Case 'minutes-string' -Manifest 'minutes-string.ps1') -Exit 0 `
         -Says @("layers: base ($baseCount) + pro (2)",
                 "$($baseCount + 2) harnesses, about $($baseMinutes + 5) minutes for a full run")
@@ -938,12 +1056,26 @@ exit 0
     Assert-Layer -Run (Invoke-Layer -Case 'minutes-bad' -Manifest 'minutes-bad.ps1') -Exit 1 `
         -Says @("tier harness 'st-tier' has a non-numeric minutes: soon")
 
+    # All three in one manifest, because the guard collects them: an empty list,
+    # a null one, and one holding only blanks. The last is the only one a bare
+    # truthiness test does not see, so without it the filter doing the work is
+    # unpinned and could be dropped.
     Assert-Layer -Run (Invoke-Layer -Case 'tags-missing' -Manifest 'tags-missing.ps1') -Exit 1 `
         -Says @("tier harness 'st-tier-empty' declares no tags",
-                "tier harness 'st-tier-null' declares no tags")
+                "tier harness 'st-tier-null' declares no tags",
+                "tier harness 'st-tier-blank' declares no tags")
 
+    # One entry per required key, each short a different one. The loop collects
+    # every problem before it exits, so seven assertions cost one child run - and
+    # a key quietly dropped from the list is otherwise invisible.
     Assert-Layer -Run (Invoke-Layer -Case 'missing-key' -Manifest 'missing-key.ps1') -Exit 1 `
-        -Says @("tier harness is missing 'oracle': st-tier")
+        -Says @("tier harness is missing 'name':",
+                "tier harness is missing 'script': st-tier-no-script",
+                "tier harness is missing 'tags': st-tier-no-tags",
+                "tier harness is missing 'outDir': st-tier-no-outdir",
+                "tier harness is missing 'seed': st-tier-no-seed",
+                "tier harness is missing 'minutes': st-tier-no-minutes",
+                "tier harness is missing 'oracle': st-tier-no-oracle")
 
     # The target is made to exist and to declare what the manifest passes it, so
     # checks 1 and 3 have nothing to say and only the path guard can refuse it.
@@ -976,14 +1108,59 @@ exit 0
     Assert-Layer -Run (Invoke-Layer -Case 'no-harnesses' -Manifest 'no-harnesses.ps1') -Exit 1 `
         -Says @("tier layer: expected an object with 'layer' and 'harnesses'")
 
+    # The other arm of that same check, which nothing else reaches: a manifest
+    # with harnesses and no layer name merges them and then has no name to print,
+    # so -List reports a suite bigger than the base set as base-only. That is
+    # this whole feature's failure mode wearing its own clothes, so the case
+    # pins the silence as well as the exit.
+    Assert-Layer -Run (Invoke-Layer -Case 'no-layer' -Manifest 'no-layer.ps1') -Exit 1 `
+        -Says @("tier layer: expected an object with 'layer' and 'harnesses'") `
+        -Silent @('layers: base only')
+
     Assert-Layer -Run (Invoke-Layer -Case 'returns-nothing' -Manifest 'returns-nothing.ps1') -Exit 1 `
         -Says @('fuzz-tier-harnesses.ps1 returned nothing')
+
+    # The opposite of returns-nothing, and the one the pipeline hides: two
+    # objects out of one file read as a single manifest whose layer name is both
+    # names joined. -RequireLayer refuses that; a run without it did not.
+    Assert-Layer -Run (Invoke-Layer -Case 'two-objects' -Manifest 'two-objects.ps1') -Exit 1 `
+        -Says @('emitted 2 objects; it must emit exactly one')
 
     # A tier ships runners and assets of its own, and until the layer could
     # classify them the choices were patching this file or calling one a harness.
     Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite' -Manifest 'not-in-suite.ps1' `
                                     -Inject @{ 'layer-scripts/tier-runner.ps1' = $LayerStub }) -Exit 0 `
         -Says @("layers: base ($baseCount) + pro (1)")
+
+    # The same classification written as a PSCustomObject. Unnormalised it is a
+    # no-op with no message of its own: the run dies at check 2 naming the very
+    # file the manifest classified, which sends the tier author looking at the
+    # half that was right.
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-object' -Manifest 'not-in-suite-object.ps1' `
+                                    -Inject @{ 'layer-scripts/tier-runner.ps1' = $LayerStub }) -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)") `
+        -Silent @('tier-runner.ps1 is in this directory')
+
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-list' -Manifest 'not-in-suite-list.ps1') -Exit 1 `
+        -Says @('tier notInSuite must be written as name = reason pairs, not a list of names')
+
+    # notInSuite is the only thing in the merge that tells check 2 to look away,
+    # so what it may excuse is the merge's own business.
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-harness' -Manifest 'not-in-suite-harness.ps1') -Exit 1 `
+        -Says @("tier notInSuite excuses 'search-fuzz.ps1', which the manifest also names as a harness script")
+
+    # Present and empty, which a key-presence check takes for declared.
+    Assert-Layer -Run (Invoke-Layer -Case 'empty-value' -Manifest 'empty-value.ps1') -Exit 1 `
+        -Says @("tier harness has an empty 'name':",
+                "tier harness has an empty 'script': st-tier-empty-script",
+                "tier harness has an empty 'oracle': st-tier-empty-oracle")
+
+    # Refused by integrity check 1 rather than by the merge, which is why it is
+    # asserted end to end: the merge reads the manifest strictly so that a tier
+    # cannot shrink the suite quietly, and a script the tier declared but never
+    # shipped is that same event whichever check happens to catch it.
+    Assert-Layer -Run (Invoke-Layer -Case 'script-missing' -Manifest 'script-missing.ps1') -Exit 1 `
+        -Says @('manifest names a script that does not exist: st-tier -> lib/fuzz-selftest/never-shipped.ps1')
 
     # -RequireLayer is a tier's assertion that its overlay landed. An absent
     # manifest and a wrong one are the same event from here, and both leave a
@@ -1000,6 +1177,12 @@ exit 0
     Assert-Layer -Run (Invoke-Layer -Case 'require-match' -Manifest 'valid.ps1' `
                                     -Extra @('-List', '-RequireLayer', 'pro')) -Exit 0 `
         -Says @("layers: base ($baseCount) + pro (1)")
+
+    # What makes the order-independence above a property rather than an accident
+    # of which cases happen to come last. The copy goes with it: it is most of a
+    # megabyte, and nothing under fuzz-out/ is ever pruned.
+    Reset-LayerInjection
+    Remove-Item -Recurse -Force -LiteralPath $LayerRoot -ErrorAction SilentlyContinue
 
     Write-Host ''
     if ($bad.Count -gt 0) {

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -189,16 +189,26 @@ $NotInSuite = [ordered]@{
     'fuzz-tier-harnesses.ps1'       = 'the tier layer manifest, not a harness; read below'
 }
 
+# The one place a script path is put into the form the checks compare. Every
+# collection compared that way is built through here - the inventory below, the
+# tier's claimed scripts, and both halves of integrity check 2. The rule used to
+# be copied into each of them, so an edit to one was silent in the others, and
+# they already differed: check 2 read $NotInSuite raw while the inventory
+# normalised it.
+function ConvertTo-ScriptKey {
+    param([string]$Path)
+    return ($Path -replace '/', '\').TrimStart('.\')
+}
+
 # Everything this file ships beside itself, as paths relative to this directory:
 # the harnesses above plus everything deliberately outside them. Integrity check
 # 2 is what makes that an inventory rather than a claim - a script sitting here
 # in neither collection fails every invocation, -List included. Taken while both
 # are still literals, because the tier merge below appends a tier's own scripts
-# to both and those are not what this file ships. Normalised exactly the way
-# check 2 normalises, so the two cannot drift apart.
+# to both and those are not what this file ships.
 $BaseScripts = @(
-    @($Harnesses  | ForEach-Object { ($_.script -replace '/', '\').TrimStart('.\') }) +
-    @($NotInSuite.Keys | ForEach-Object { ([string]$_ -replace '/', '\').TrimStart('.\') })
+    @($Harnesses  | ForEach-Object { ConvertTo-ScriptKey $_.script }) +
+    @($NotInSuite.Keys | ForEach-Object { ConvertTo-ScriptKey ([string]$_) })
 )
 
 # ---- tier layer -----------------------------------------------------------
@@ -239,8 +249,12 @@ if (Test-Path $TierManifestPath) {
     # conflict produces. Member enumeration hides it rather than failing: across
     # an array .layer stringifies to the names joined and .harnesses to both
     # sets, so everything merges under a layer named after neither of them.
+    # Phrased as a collection rather than a count, because the count can be one:
+    # a manifest ending `,@( @{...} )` emits a single-element array, and telling
+    # its author it emitted one object when it must emit exactly one is not a
+    # diagnosis. What is wrong is the wrapper, at any length.
     if ($declared -is [array]) {
-        Write-Host ("tier layer: $TierManifestPath emitted $($declared.Count) objects; it must emit exactly one") -ForegroundColor Red
+        Write-Host ("tier layer: $TierManifestPath emitted a collection of $($declared.Count); it must emit exactly one object") -ForegroundColor Red
         exit 1
     }
 
@@ -321,11 +335,18 @@ if (Test-Path $TierManifestPath) {
 
         # A null or empty tags list passes a key-presence check and then quietly
         # excludes the harness from every -Tag run, which is how CI invokes this.
-        # Whitespace counts as empty here: only '' is falsy in PowerShell, so a
-        # bare truthiness test keeps '  ' - and Split-List trims the caller's
-        # -Tag values and drops the blanks, so no -Tag argument can ever reach a
-        # tag like that. It selects nothing, exactly like the empty list does.
-        if (-not @($entry.tags | Where-Object { "$_".Trim() })) {
+        # Put through the same trim-and-drop rule Split-List applies to the
+        # caller's -Tag values, and STORED that way rather than only tested that
+        # way: selection compares -Tag against the value as stored, so a tag of
+        # ' tier ' listed as a real one while no -Tag argument could reach it -
+        # Split-List trims the caller's side down to 'tier' and the two never
+        # meet. Testing the normalised list also settles the values that are not
+        # strings: they are compared as strings anyway, so a tag of 0 is exactly
+        # as selectable as '0' and is kept.
+        if ($entry.Contains('tags')) {
+            $entry.tags = @($entry.tags | ForEach-Object { "$_".Trim() } | Where-Object { $_ })
+        }
+        if (-not $entry.tags) {
             $tierProblems += "tier harness '$($entry.name)' declares no tags, so no -Tag run would ever select it"
         }
 
@@ -359,15 +380,23 @@ if (Test-Path $TierManifestPath) {
     # harnesses. A tier shipping its own had no way to say so: check 2 refuses
     # the run, and the only escapes were patching this file, which is what the
     # layer exists to avoid, or declaring it a harness, which is worse.
-    if ($declared.notInSuite) {
+    # Presence, not truthiness. An empty list is falsy, so `notInSuite = @()`
+    # skipped this block entirely and reached integrity check 2 instead, where
+    # the tier author is told to classify a script rather than told that the
+    # classification they wrote is the wrong shape.
+    if ($null -ne $declared.notInSuite) {
         # Normalised the same way a harness entry is, and for the same reason.
         # This is the other half of the same manifest and arrives the same two
         # ways, but a PSCustomObject has no .Keys at all - so the foreach ran
         # over $null and did nothing, and the run then died at integrity check 2
         # telling the tier author to classify a file they had classified.
+        # The names are trimmed on the way in, not on the way out: check 2
+        # compares against a bare leaf name, so a key stored with padding
+        # excuses nothing while passing every check below - the same wrong-blame
+        # failure by the door this normalisation left open.
         $declaredNotInSuite = [ordered]@{}
         if ($declared.notInSuite -is [System.Collections.IDictionary]) {
-            foreach ($k in $declared.notInSuite.Keys) { $declaredNotInSuite[[string]$k] = [string]$declared.notInSuite[$k] }
+            foreach ($k in $declared.notInSuite.Keys) { $declaredNotInSuite[([string]$k).Trim()] = [string]$declared.notInSuite[$k] }
         } elseif ($declared.notInSuite -is [array] -or $declared.notInSuite -is [string]) {
             # The reason is not decoration: it is the only place a tier says why
             # a script of its own is not a harness. A bare list also reads as an
@@ -375,16 +404,16 @@ if (Test-Path $TierManifestPath) {
             # below it would classify those and nothing else.
             $tierProblems += 'tier notInSuite must be written as name = reason pairs, not a list of names'
         } else {
-            foreach ($prop in $declared.notInSuite.PSObject.Properties) { $declaredNotInSuite[[string]$prop.Name] = [string]$prop.Value }
+            foreach ($prop in $declared.notInSuite.PSObject.Properties) { $declaredNotInSuite[([string]$prop.Name).Trim()] = [string]$prop.Value }
         }
 
         # This is the one door in the merge that lets a tier tell check 2 to look
         # away, so it is the one place a lenient read would undo the strict one.
-        $claimedScripts = @($Harnesses | ForEach-Object { ($_.script -replace '/', '\').TrimStart('.\') })
+        $claimedScripts = @($Harnesses | ForEach-Object { ConvertTo-ScriptKey $_.script })
         foreach ($name in $declaredNotInSuite.Keys) {
             # Check 2 compares against a leaf name, so anything carrying a
             # separator excuses nothing while reading as though it did.
-            if (-not $name.Trim() -or $name -match '[\\/]') {
+            if (-not $name -or $name -match '[\\/]') {
                 $tierProblems += "tier notInSuite names something that is not a plain file name: '$name'"
                 continue
             }
@@ -392,6 +421,14 @@ if (Test-Path $TierManifestPath) {
             # again, arriving through the only door a tier can open by itself.
             if ($claimedScripts -contains $name) {
                 $tierProblems += "tier notInSuite excuses '$name', which the manifest also names as a harness script"
+                continue
+            }
+            # The reason is the whole point of the pairs form refused above: it
+            # is the only place a tier says why a script of its own is not a
+            # harness. An empty one is the list form again, spelled differently,
+            # and the same argument that rejects an empty oracle applies to it.
+            if (-not $declaredNotInSuite[$name].Trim()) {
+                $tierProblems += "tier notInSuite gives no reason for '$name'; the reason is why the script is not a harness"
                 continue
             }
             $NotInSuite[$name] = $declaredNotInSuite[$name]
@@ -627,10 +664,11 @@ foreach ($h in @($Harnesses) + @($SelfTestHarnesses)) {
 # so a leaf comparison was equivalent until a tier could name one in a
 # subdirectory; after that, naming lib/pro/x.ps1 excuses an unrelated x.ps1
 # sitting here unclassified, which is the check's whole purpose.
-$claimed = @(@($Harnesses) | ForEach-Object { ($_.script -replace '/', '\').TrimStart('.\') })
+$claimed = @(@($Harnesses) | ForEach-Object { ConvertTo-ScriptKey $_.script })
+$excused = @($NotInSuite.Keys | ForEach-Object { ConvertTo-ScriptKey ([string]$_) })
 foreach ($f in Get-ChildItem -Path $PSScriptRoot -Filter '*.ps1' -File) {
     if ($claimed -contains $f.Name) { continue }
-    if ($NotInSuite.Contains($f.Name)) { continue }
+    if ($excused -contains $f.Name) { continue }
     $problems += "$($f.Name) is in this directory but neither in the manifest nor in `$NotInSuite; classify it"
 }
 
@@ -680,18 +718,20 @@ $useFixtures = $SelfTest -or $SelfTestInner
 $all = if ($useFixtures) { @($SelfTestHarnesses) } else { @($Harnesses) }
 
 # The assertions are written against the whole fixture set at exactly one
-# retry, so anything that would change either is refused rather than
-# silently ignored. -OutRoot is refused for a different reason: the tier layer
-# cases below run out of a copy of this directory placed under it, and two
-# self-tests sharing one root rewrite each other's manifest in the window
-# between the copy and the child launch. The default stamp is per-second, so
-# that is two runs started in the same second, not a contrived collision.
+# retry with one seed, so anything that would change any of the three is
+# refused rather than silently ignored: an assertion that still runs against a
+# selection it was not written for reports on something nobody asked about.
+# -OutRoot is NOT among them. It was, on the grounds that the tier cases below
+# run a child out of a copy of this directory placed under the root and two
+# self-tests sharing one root rewrite each other's manifest between the copy
+# and the child launch - but that argument indicts the DEFAULT root, which is
+# stamped per second, and refusing the override removed the only way to give
+# two runs distinct roots. The root is made unique below instead.
 if ($SelfTest -and ($Tag -or $Only -or $Skip -or
                     $PSBoundParameters.ContainsKey('Retries') -or
                     $PSBoundParameters.ContainsKey('Seed') -or
-                    $PSBoundParameters.ContainsKey('OutRoot') -or
                     $StopOnFindings)) {
-    Write-Host '-SelfTest asserts against the whole fixture set at one retry, under an output root of its own; it takes no filters, -Retries, -Seed, -OutRoot or -StopOnFindings' -ForegroundColor Red
+    Write-Host '-SelfTest asserts against the whole fixture set at one retry and one seed; it takes no filters, -Retries, -Seed or -StopOnFindings' -ForegroundColor Red
     exit 1
 }
 
@@ -716,6 +756,15 @@ if ($selected.Count -eq 0) {
     Write-Host 'no harness matched the filters; run with -List to see the manifest' -ForegroundColor Red
     exit 1
 }
+
+# A root of its own per process, so two self-tests cannot collide however the
+# root was chosen. Every path this run writes hangs off here - the per-fixture
+# output directories, the child runs' roots, and the copy of this directory the
+# tier cases run out of - and sharing that last one means a run rewriting the
+# manifest another is about to read. Applied to the root rather than to the
+# copy alone because the collision is the root's, and applied here rather than
+# to the default because the default is not the only way to arrive at one.
+if ($SelfTest) { $OutRoot = Join-Path $OutRoot "selftest-$PID" }
 
 New-Item -ItemType Directory -Force -Path $OutRoot | Out-Null
 
@@ -904,6 +953,32 @@ if ($SelfTest) {
         $bad += "-Only with an unknown name exited $($typo.exit), expected 1 - a typo must not silently shrink the run"
     }
 
+    # The refusal that keeps everything above meaning what it says: the
+    # expectations are written for the whole fixture set, so a filter that got
+    # through would leave them asserting against a selection nobody chose. It
+    # cannot be reached from this process - this one is already past it - so a
+    # child is run for real. The message is checked as well as the exit code,
+    # because a run whose filter took would leave with 1 as well, by failing
+    # these very assertions.
+    #
+    # The child is told what it is, and skips this block. Its whole job is to
+    # be refused before it starts, so if the refusal ever stopped refusing the
+    # child would reach this line and start a -SelfTest of its own, and that
+    # one another, without end. A self-test that takes the machine down when a
+    # guard breaks is worse than one that misses.
+    if (-not $env:WINTTY_FUZZ_SELFTEST_REFUSAL_CHILD) {
+        $env:WINTTY_FUZZ_SELFTEST_REFUSAL_CHILD = '1'
+        try {
+            $refused = (& pwsh -NoProfile -File $PSCommandPath -SelfTest -Only st-pass | Out-String)
+            $refusedExit = $LASTEXITCODE
+        } finally {
+            Remove-Item Env:WINTTY_FUZZ_SELFTEST_REFUSAL_CHILD -ErrorAction SilentlyContinue
+        }
+        if ($refusedExit -ne 1 -or -not $refused.Contains('it takes no filters')) {
+            $bad += "-SelfTest with -Only exited $refusedExit without refusing the filter; every expectation above would have run against one fixture"
+        }
+    }
+
     # ---- tier layer -------------------------------------------------------
     # The merge reads a manifest found by presence beside this runner, and the
     # checks it feeds read $PSScriptRoot rather than anything a caller can pass
@@ -912,31 +987,52 @@ if ($SelfTest) {
     # runs included. Giving the child a different $PSScriptRoot is the only way
     # to hand those checks a directory of our own, and since everything they
     # read is text and none of it is built, a copy is enough.
-    $LayerRoot = Join-Path $OutRoot 'layer-scripts'
-    New-Item -ItemType Directory -Force -Path $LayerRoot | Out-Null
-    # Copied from the inventory by name rather than swept up by a glob. A tier
-    # checkout has the tier's own scripts sitting here too, and a glob takes
-    # those while deliberately leaving behind the one file that classifies them
-    # - so every case below would fail integrity check 2 on exactly the builds
-    # the layer exists for.
-    foreach ($rel in $BaseScripts) {
-        # The manifest is the one name left behind. A tier checkout has a real
-        # one sitting here, and copying it would give every case below a second
-        # layer, the case that asserts what an ABSENT manifest does included -
-        # on exactly the builds that ship one.
-        if ($rel -eq 'fuzz-tier-harnesses.ps1') { continue }
-        $src = Join-Path $PSScriptRoot $rel
-        # $NotInSuite classifies names, and nothing checks that the file behind
-        # one is still there: check 2 only looks the other way. A stale entry is
-        # its silence, not a reason to fail the self-test.
-        if (-not (Test-Path -LiteralPath $src)) { continue }
-        $dest = Join-Path $LayerRoot $rel
-        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
-        Copy-Item -LiteralPath $src -Destination $dest -Force
+    # Copies a suite directory from the inventory by name rather than sweeping
+    # it up with a glob. A tier checkout has the tier's own scripts sitting
+    # beside the base ones, and a glob takes those while deliberately leaving
+    # behind the one file that classifies them - so every case below would fail
+    # integrity check 2 on exactly the builds the layer exists for.
+    #
+    # A function taking a source root rather than four lines reading
+    # $PSScriptRoot, because that is the difference between something the
+    # self-test can hand a tier checkout and something it can only ever run
+    # against this one, where a glob and the inventory name the same files.
+    function Copy-SuiteScripts {
+        param(
+            [Parameter(Mandatory)][string]$From,
+            [Parameter(Mandatory)][string]$To,
+            [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Inventory
+        )
+        New-Item -ItemType Directory -Force -Path $To | Out-Null
+        foreach ($rel in $Inventory) {
+            # The manifest is the one name left behind. A tier checkout has a
+            # real one sitting there, and copying it would give every case below
+            # a second layer, the case that asserts what an ABSENT manifest does
+            # included - on exactly the builds that ship one.
+            if ($rel -eq 'fuzz-tier-harnesses.ps1') { continue }
+            $src = Join-Path $From $rel
+            # $NotInSuite classifies names, and nothing checks that the file
+            # behind one is still there: check 2 only looks the other way. A
+            # stale entry is its silence, not a reason to fail the self-test.
+            if (-not (Test-Path -LiteralPath $src)) { continue }
+            $dest = Join-Path $To $rel
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
+            Copy-Item -LiteralPath $src -Destination $dest -Force
+        }
+        # lib/ wholesale, because it carries wintty-process.ps1 - dot-sourced
+        # before anything else runs - and every fixture the harnesses name.
+        Copy-Item -Path (Join-Path $From 'lib') -Destination $To -Recurse -Force
     }
-    # lib/ wholesale, because it carries wintty-process.ps1 - dot-sourced before
-    # anything else runs - and every fixture the self-test harnesses name.
-    Copy-Item -Path (Join-Path $PSScriptRoot 'lib') -Destination $LayerRoot -Recurse -Force
+
+    # Everything the tier cases create lives under one directory, the copy and
+    # the files injected beside it alike, so the sweep at the end is one removal
+    # rather than a list that has to be kept in step with the cases. The cases
+    # name paths relative to this, and two of them turn on where the copy sits
+    # inside it: one climbs out of the copy, one names a sibling whose full path
+    # opens with the copy's.
+    $LayerSandbox = Join-Path $OutRoot 'layer'
+    $LayerRoot = Join-Path $LayerSandbox 'layer-scripts'
+    Copy-SuiteScripts -From $PSScriptRoot -To $LayerRoot -Inventory $BaseScripts
 
     # Read off this run rather than written down here, so adding a base harness
     # is not a self-test failure. What is under test is that a layer adds
@@ -957,8 +1053,8 @@ exit 0
 
     # Puts the copy back the way the last case found it. A case injects onto a
     # relative path, and a path it names may be one the copy legitimately
-    # carries - pass.ps1 and tier-runner.ps1 are both plausible base names - so
-    # what was there is restored rather than deleted. Deleting it instead
+    # carries - the last case below injects over gen-bell.ps1, which it does -
+    # so what was there is restored rather than deleted. Deleting it instead
     # mutates the tree under test for every case that follows, which is how a
     # case comes to pass for a reason nobody wrote down.
     function Reset-LayerInjection {
@@ -991,10 +1087,11 @@ exit 0
         if ($Manifest) {
             Copy-Item -LiteralPath (Join-Path $PSScriptRoot "lib/fuzz-selftest/layers/$Manifest") -Destination $manifestPath
         }
-        # Rooted at $OutRoot rather than at the copy, so a case can put a file
-        # somewhere only a script path that climbs out of the directory reaches.
+        # Rooted at the sandbox rather than at the copy, so a case can put a
+        # file somewhere only a script path that climbs out of the copy reaches
+        # - and so the sweep at the end takes those directories with it.
         foreach ($rel in $Inject.Keys) {
-            $dest = Join-Path $OutRoot $rel
+            $dest = Join-Path $LayerSandbox $rel
             New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
             # Whatever was there first, so the sweep can put it back rather than
             # delete a file it did not create. $null means there was nothing.
@@ -1065,6 +1162,16 @@ exit 0
                 "tier harness 'st-tier-null' declares no tags",
                 "tier harness 'st-tier-blank' declares no tags")
 
+    # The other half of the same rule, and the half a guard that only TESTS the
+    # trimmed value leaves open: a padded tag is declared, is listed, and is
+    # still unreachable, because selection compares -Tag against what was
+    # stored. -List joins the tags with a comma, so 'tier,x' appears only if the
+    # padding came off on the way in - unnormalised it reads ' tier ,x'. The
+    # numeric tag rides along to show a value that is not a string survives:
+    # tags are compared as text either way.
+    Assert-Layer -Run (Invoke-Layer -Case 'tags-padded' -Manifest 'tags-padded.ps1') -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (2)", 'tier,x')
+
     # One entry per required key, each short a different one. The loop collects
     # every problem before it exits, so seven assertions cost one child run - and
     # a key quietly dropped from the list is otherwise invisible.
@@ -1088,6 +1195,15 @@ exit 0
     Assert-Layer -Run (Invoke-Layer -Case 'script-sibling' -Manifest 'script-sibling.ps1' `
                                     -Inject @{ 'layer-scriptsX/escape.ps1' = $LayerStub }) -Exit 1 `
         -Says @("tier harness 'st-tier' names a script outside this directory: ../layer-scriptsX/escape.ps1")
+
+    # The other thing that reduction does, and the half a subdirectory case
+    # cannot reach: a leading './' has to come off before a leaf comparison can
+    # match, or a tier naming its own harness the way a path beside the runner
+    # is usually written is told to classify the script it just declared.
+    Assert-Layer -Run (Invoke-Layer -Case 'script-relative' -Manifest 'script-relative.ps1' `
+                                    -Inject @{ 'layer-scripts/tier-relative.ps1' = $LayerStub }) -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)") `
+        -Silent @('tier-relative.ps1 is in this directory')
 
     # The manifest names lib/fuzz-selftest/pass.ps1 and an unrelated pass.ps1
     # sits at the top level. Comparing leaves rather than relative paths reads
@@ -1124,7 +1240,13 @@ exit 0
     # objects out of one file read as a single manifest whose layer name is both
     # names joined. -RequireLayer refuses that; a run without it did not.
     Assert-Layer -Run (Invoke-Layer -Case 'two-objects' -Manifest 'two-objects.ps1') -Exit 1 `
-        -Says @('emitted 2 objects; it must emit exactly one')
+        -Says @('emitted a collection of 2; it must emit exactly one object')
+
+    # The same wrapper holding one object, which is what a message that counts
+    # them cannot describe: it must be refused, and told apart from the manifest
+    # it is wrapping.
+    Assert-Layer -Run (Invoke-Layer -Case 'one-object-collection' -Manifest 'one-object-collection.ps1') -Exit 1 `
+        -Says @('emitted a collection of 1; it must emit exactly one object')
 
     # A tier ships runners and assets of its own, and until the layer could
     # classify them the choices were patching this file or calling one a harness.
@@ -1141,8 +1263,34 @@ exit 0
         -Says @("layers: base ($baseCount) + pro (1)") `
         -Silent @('tier-runner.ps1 is in this directory')
 
+    # The same classification with padding on the name. Stored as it arrives it
+    # excuses nothing, and the run dies at check 2 naming the file the manifest
+    # classified - so the assertion is the silence as much as the exit.
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-padded' -Manifest 'not-in-suite-padded.ps1' `
+                                    -Inject @{ 'layer-scripts/tier-runner.ps1' = $LayerStub }) -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)") `
+        -Silent @('tier-runner.ps1 is in this directory')
+
     Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-list' -Manifest 'not-in-suite-list.ps1') -Exit 1 `
         -Says @('tier notInSuite must be written as name = reason pairs, not a list of names')
+
+    # The list form with nothing in it. Read for truthiness rather than for
+    # presence it is not the list form at all: it is skipped, and the run dies
+    # at check 2 about a script instead of here about the shape.
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-empty' -Manifest 'not-in-suite-empty.ps1') -Exit 1 `
+        -Says @('tier notInSuite must be written as name = reason pairs, not a list of names')
+
+    # Names check 2 could never act on: one carrying a separator, which it
+    # compares leaves against, and one that is blank. Nothing else in the set
+    # gives the plain-file-name guard anything to refuse.
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-path' -Manifest 'not-in-suite-path.ps1') -Exit 1 `
+        -Says @("tier notInSuite names something that is not a plain file name: 'lib/tier-runner.ps1'",
+                "tier notInSuite names something that is not a plain file name: ''")
+
+    # The pairs form with an empty reason, which is the list form spelled the
+    # long way round.
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite-empty-reason' -Manifest 'not-in-suite-empty-reason.ps1') -Exit 1 `
+        -Says @("tier notInSuite gives no reason for 'tier-runner.ps1'")
 
     # notInSuite is the only thing in the merge that tells check 2 to look away,
     # so what it may excuse is the merge's own business.
@@ -1178,11 +1326,72 @@ exit 0
                                     -Extra @('-List', '-RequireLayer', 'pro')) -Exit 0 `
         -Says @("layers: base ($baseCount) + pro (1)")
 
+    # What the copy does that a glob does not, which is the whole reason it is
+    # written by name. The difference only shows against a tier checkout - a
+    # directory holding the tier's own scripts and the manifest that classifies
+    # them - and a copy of THIS directory can never be one, so the source tree
+    # is staged rather than found. A glob over it takes two files the inventory
+    # does not name: the tier's own harness, which then fails check 2 in the
+    # copy, and the tier manifest, which gives every case above a second layer.
+    # The inventory also names one file that is not there, because $NotInSuite
+    # classifies names and nothing prunes an entry whose file has gone.
+    $stagedTier = Join-Path $LayerSandbox 'tier-checkout'
+    $stagedCopy = Join-Path $LayerSandbox 'tier-checkout-copy'
+    New-Item -ItemType Directory -Force -Path (Join-Path $stagedTier 'lib') | Out-Null
+    foreach ($f in @('fuzz-suite.ps1', 'gen-bell.ps1', 'fuzz-tier-harnesses.ps1', 'tier-only.ps1')) {
+        Set-Content -LiteralPath (Join-Path $stagedTier $f) -Value "# $f" -Encoding utf8
+    }
+    Set-Content -LiteralPath (Join-Path $stagedTier 'lib/wintty-process.ps1') -Value '# dot-sourced' -Encoding utf8
+    Copy-SuiteScripts -From $stagedTier -To $stagedCopy `
+                      -Inventory @('fuzz-suite.ps1', 'gen-bell.ps1', 'fuzz-tier-harnesses.ps1', 'deleted-since.ps1')
+    $script:LayerCases++
+    foreach ($want in @('fuzz-suite.ps1', 'gen-bell.ps1', 'lib\wintty-process.ps1')) {
+        if (-not (Test-Path -LiteralPath (Join-Path $stagedCopy $want))) {
+            $bad += "layer/tier-checkout: the copy left behind $want, which the inventory names"
+        }
+    }
+    foreach ($unwanted in @('tier-only.ps1', 'fuzz-tier-harnesses.ps1')) {
+        if (Test-Path -LiteralPath (Join-Path $stagedCopy $unwanted)) {
+            $bad += "layer/tier-checkout: the copy carried $unwanted, which only a glob over a tier checkout takes"
+        }
+    }
+
+    # Injected over a file the copy legitimately carries, which is what the
+    # sweep's restore branch exists for and what nothing else reaches: every
+    # other case names a path the copy does not already hold, so deleting and
+    # restoring are indistinguishable. Last on purpose - nothing resets after
+    # it, so the sweep below is the only thing that can put the file back.
+    Assert-Layer -Run (Invoke-Layer -Case 'injection-over-a-copied-file' -Manifest 'valid.ps1' `
+                                    -Inject @{ 'layer-scripts/gen-bell.ps1' = $LayerStub }) -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)")
+
+    # Read through Test-Path rather than straight: a sweep that deleted the file
+    # is one of the two things under test here, and a read that throws over it
+    # ends the self-test with no verdict instead of with this one.
+    function Get-LayerFileText {
+        param([Parameter(Mandatory)][string]$Path)
+        if (-not (Test-Path -LiteralPath $Path)) { return '' }
+        return (Get-Content -Raw -LiteralPath $Path).Trim()
+    }
+    $genBellCopy = Join-Path $LayerRoot 'gen-bell.ps1'
+    $genBellSource = Get-LayerFileText (Join-Path $PSScriptRoot 'gen-bell.ps1')
+    if (-not $genBellSource) {
+        $bad += 'layer/injection-over-a-copied-file: gen-bell.ps1 is not in this directory any more, so the case injects over nothing and asserts nothing; point it at another script the inventory names'
+    }
+    if ((Get-LayerFileText $genBellCopy) -ne $LayerStub.Trim()) {
+        $bad += 'layer/injection-over-a-copied-file: the injection never landed, so the restore below proves nothing'
+    }
+
     # What makes the order-independence above a property rather than an accident
-    # of which cases happen to come last. The copy goes with it: it is most of a
-    # megabyte, and nothing under fuzz-out/ is ever pruned.
+    # of which cases happen to come last, asserted rather than asserted about:
+    # the case above is the only one whose leavings a later case would inherit,
+    # and this is the only thing that undoes them. The sandbox goes with it - it
+    # is most of a megabyte, and nothing under fuzz-out/ is ever pruned.
     Reset-LayerInjection
-    Remove-Item -Recurse -Force -LiteralPath $LayerRoot -ErrorAction SilentlyContinue
+    if ((Get-LayerFileText $genBellCopy) -ne $genBellSource) {
+        $bad += 'the final sweep left gen-bell.ps1 injected or deleted rather than restored, so a case after it would run against a copy missing a script'
+    }
+    Remove-Item -Recurse -Force -LiteralPath $LayerSandbox -ErrorAction SilentlyContinue
 
     Write-Host ''
     if ($bad.Count -gt 0) {

--- a/windows/scripts/fuzz-suite.ps1
+++ b/windows/scripts/fuzz-suite.ps1
@@ -61,7 +61,9 @@
     A tier build adds its own harnesses by dropping fuzz-tier-harnesses.ps1
     beside this runner; they append to the base set, so a tier runs what it was
     built on plus what it adds. Absent means base-only. -RequireLayer makes that
-    absence an error for a build that should have one.
+    absence an error for a build that should have one. -SelfTest covers that
+    merge from a copy of this directory rather than from this one, because a
+    fixture manifest placed here would be found by every other run from it.
 
     Three integrity checks run on every invocation, including -List, and all
     are free: the manifest cannot name a script that is gone, a script cannot
@@ -823,13 +825,189 @@ if ($SelfTest) {
         $bad += "-Only with an unknown name exited $($typo.exit), expected 1 - a typo must not silently shrink the run"
     }
 
+    # ---- tier layer -------------------------------------------------------
+    # The merge reads a manifest found by presence beside this runner, and the
+    # checks it feeds read $PSScriptRoot rather than anything a caller can pass
+    # in. So a fixture manifest cannot be dropped into windows/scripts: it would
+    # change every other invocation from that directory, this run's own child
+    # runs included. Giving the child a different $PSScriptRoot is the only way
+    # to hand those checks a directory of our own, and since everything they
+    # read is text and none of it is built, a copy is enough.
+    $LayerRoot = Join-Path $OutRoot 'layer-scripts'
+    New-Item -ItemType Directory -Force -Path $LayerRoot | Out-Null
+    # A tier checkout has a real manifest sitting here. Copying it would give
+    # every case below a second layer, the case that asserts what an ABSENT
+    # manifest does included - on exactly the builds that ship one.
+    Copy-Item -Path (Join-Path $PSScriptRoot '*.ps1') -Destination $LayerRoot -Exclude 'fuzz-tier-harnesses.ps1'
+    Copy-Item -Path (Join-Path $PSScriptRoot 'lib') -Destination $LayerRoot -Recurse -Force
+
+    # Read off this run rather than written down here, so adding a base harness
+    # is not a self-test failure. What is under test is that a layer adds
+    # exactly its own and leaves the base half alone; a base manifest that
+    # silently shrinks is already integrity check 2's job.
+    $baseSet     = @($Harnesses | Where-Object { $_.layer -eq 'base' })
+    $baseCount   = $baseSet.Count
+    $baseMinutes = ($baseSet | ForEach-Object { $_.minutes } | Measure-Object -Sum).Sum
+
+    # Nothing runs these. Only the param block is read, by integrity check 3.
+    $LayerStub = @'
+#requires -Version 7
+param([string]$ExePath, [Parameter(Mandatory)][string]$OutDir)
+exit 0
+'@
+    $script:LayerInjected = @()
+    $script:LayerCases = 0
+
+    # One child run over the copy. The manifest and whatever scripts a case
+    # needs on disk are placed fresh and taken away again on the next call, so
+    # no case inherits what another left behind and the order they are written
+    # in does not matter. -List is the whole run: the merge and all three
+    # integrity checks happen before it, and none of them needs a desktop.
+    function Invoke-Layer {
+        param(
+            [Parameter(Mandatory)][string]$Case,
+            [string]$Manifest,
+            [hashtable]$Inject = @{},
+            [string[]]$Extra = @('-List')
+        )
+        foreach ($p in $script:LayerInjected) { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+        $script:LayerInjected = @()
+        $script:LayerCases++
+
+        $manifestPath = Join-Path $LayerRoot 'fuzz-tier-harnesses.ps1'
+        Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
+        if ($Manifest) {
+            Copy-Item -LiteralPath (Join-Path $PSScriptRoot "lib/fuzz-selftest/layers/$Manifest") -Destination $manifestPath
+        }
+        # Rooted at $OutRoot rather than at the copy, so a case can put a file
+        # somewhere only a script path that climbs out of the directory reaches.
+        foreach ($rel in $Inject.Keys) {
+            $dest = Join-Path $OutRoot $rel
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
+            Set-Content -LiteralPath $dest -Value $Inject[$rel] -Encoding utf8
+            $script:LayerInjected += $dest
+        }
+
+        $argv = @('-NoProfile', '-File', (Join-Path $LayerRoot 'fuzz-suite.ps1')) + $Extra
+        $text = (& pwsh @argv | Out-String)
+        return @{ case = $Case; exit = $LASTEXITCODE; text = [string]$text }
+    }
+
+    # Both halves are the assertion. Every refusal in the merge leaves with 1,
+    # so a case reading the exit code alone would pass while some other guard
+    # did the refusing - and a guard whose body was gutted still has its shape.
+    function Assert-Layer {
+        param(
+            [Parameter(Mandatory)]$Run,
+            [Parameter(Mandatory)][int]$Exit,
+            [string[]]$Says = @(),
+            [string[]]$Silent = @()
+        )
+        if ($Run.exit -ne $Exit) {
+            $script:bad += "layer/$($Run.case): exited $($Run.exit), expected $Exit"
+        }
+        foreach ($s in $Says) {
+            if (-not $Run.text.Contains($s)) { $script:bad += "layer/$($Run.case): said nothing about: $s" }
+        }
+        foreach ($s in $Silent) {
+            if ($Run.text.Contains($s)) { $script:bad += "layer/$($Run.case): said what it must not: $s" }
+        }
+    }
+
+    # No manifest, which is what a public build runs. This is the property most
+    # likely to rot without anyone noticing, because nothing downstream can tell
+    # a base-only run from the tier run it was supposed to be.
+    Assert-Layer -Run (Invoke-Layer -Case 'base-only') -Exit 0 `
+        -Says @("$baseCount harnesses, about $baseMinutes minutes for a full run",
+                'layers: base only (no tier manifest beside this runner)') `
+        -Silent @('layers: base (')
+
+    Assert-Layer -Run (Invoke-Layer -Case 'valid' -Manifest 'valid.ps1') -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)",
+                "$($baseCount + 1) harnesses, about $($baseMinutes + 1) minutes for a full run")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'pscustomobject' -Manifest 'pscustomobject.ps1') -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)")
+
+    # '2' and '2.6' coerce to 2 and 3, so a layer that took them as text moves
+    # the total by 4.6 and one that coerced them moves it by 5.
+    Assert-Layer -Run (Invoke-Layer -Case 'minutes-string' -Manifest 'minutes-string.ps1') -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (2)",
+                "$($baseCount + 2) harnesses, about $($baseMinutes + 5) minutes for a full run")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'minutes-bad' -Manifest 'minutes-bad.ps1') -Exit 1 `
+        -Says @("tier harness 'st-tier' has a non-numeric minutes: soon")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'tags-missing' -Manifest 'tags-missing.ps1') -Exit 1 `
+        -Says @("tier harness 'st-tier-empty' declares no tags",
+                "tier harness 'st-tier-null' declares no tags")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'missing-key' -Manifest 'missing-key.ps1') -Exit 1 `
+        -Says @("tier harness is missing 'oracle': st-tier")
+
+    # The target is made to exist and to declare what the manifest passes it, so
+    # checks 1 and 3 have nothing to say and only the path guard can refuse it.
+    Assert-Layer -Run (Invoke-Layer -Case 'script-escapes' -Manifest 'script-escapes.ps1' `
+                                    -Inject @{ 'layer-escape/escape.ps1' = $LayerStub }) -Exit 1 `
+        -Says @("tier harness 'st-tier' names a script outside this directory: ../layer-escape/escape.ps1")
+
+    # A sibling directory whose full path opens with this one's. A prefix test
+    # that stops short of the separator reads it as inside.
+    Assert-Layer -Run (Invoke-Layer -Case 'script-sibling' -Manifest 'script-sibling.ps1' `
+                                    -Inject @{ 'layer-scriptsX/escape.ps1' = $LayerStub }) -Exit 1 `
+        -Says @("tier harness 'st-tier' names a script outside this directory: ../layer-scriptsX/escape.ps1")
+
+    # The manifest names lib/fuzz-selftest/pass.ps1 and an unrelated pass.ps1
+    # sits at the top level. Comparing leaves rather than relative paths reads
+    # the first as classifying the second.
+    Assert-Layer -Run (Invoke-Layer -Case 'leaf-collision' -Manifest 'leaf-collision.ps1' `
+                                    -Inject @{ 'layer-scripts/pass.ps1' = $LayerStub }) -Exit 1 `
+        -Says @('pass.ps1 is in this directory but neither in the manifest nor in $NotInSuite')
+
+    Assert-Layer -Run (Invoke-Layer -Case 'duplicate-name' -Manifest 'duplicate-name.ps1') -Exit 1 `
+        -Says @("tier harness 'st-tier' is declared twice in the tier manifest")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'base-collision' -Manifest 'base-collision.ps1') -Exit 1 `
+        -Says @("tier harness 'search' collides with a base harness of the same name")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'reserved-layer' -Manifest 'reserved-layer.ps1') -Exit 1 `
+        -Says @("tier layer: 'base' is the name this runner gives its own harnesses")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'no-harnesses' -Manifest 'no-harnesses.ps1') -Exit 1 `
+        -Says @("tier layer: expected an object with 'layer' and 'harnesses'")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'returns-nothing' -Manifest 'returns-nothing.ps1') -Exit 1 `
+        -Says @('fuzz-tier-harnesses.ps1 returned nothing')
+
+    # A tier ships runners and assets of its own, and until the layer could
+    # classify them the choices were patching this file or calling one a harness.
+    Assert-Layer -Run (Invoke-Layer -Case 'not-in-suite' -Manifest 'not-in-suite.ps1' `
+                                    -Inject @{ 'layer-scripts/tier-runner.ps1' = $LayerStub }) -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)")
+
+    # -RequireLayer is a tier's assertion that its overlay landed. An absent
+    # manifest and a wrong one are the same event from here, and both leave a
+    # summary shape-identical to the oss run nobody asked for.
+    Assert-Layer -Run (Invoke-Layer -Case 'require-missing' -Extra @('-List', '-RequireLayer', 'pro')) -Exit 1 `
+        -Says @("-RequireLayer 'pro' but no tier manifest sits beside this runner")
+
+    Assert-Layer -Run (Invoke-Layer -Case 'require-mismatch' -Manifest 'valid.ps1' `
+                                    -Extra @('-List', '-RequireLayer', 'enterprise')) -Exit 1 `
+        -Says @("-RequireLayer 'enterprise' but the manifest declares 'pro'")
+
+    # The matching case, because a -RequireLayer that refused everything would
+    # satisfy both of the two above.
+    Assert-Layer -Run (Invoke-Layer -Case 'require-match' -Manifest 'valid.ps1' `
+                                    -Extra @('-List', '-RequireLayer', 'pro')) -Exit 0 `
+        -Says @("layers: base ($baseCount) + pro (1)")
+
     Write-Host ''
     if ($bad.Count -gt 0) {
         Write-Host 'SELFTEST FAILED' -ForegroundColor Red
         $bad | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
         exit 1
     }
-    Write-Host ("SELFTEST OK  {0} exit paths classified correctly, and a real run over them exits 2" -f $expect.Count) -ForegroundColor Green
+    Write-Host ("SELFTEST OK  {0} exit paths classified correctly, {1} tier layer cases, and a real run over them exits 2" -f $expect.Count, $script:LayerCases) -ForegroundColor Green
     exit 0
 }
 

--- a/windows/scripts/lib/fuzz-selftest/README.md
+++ b/windows/scripts/lib/fuzz-selftest/README.md
@@ -40,12 +40,14 @@ overlay would drop beside the runner as `fuzz-tier-harnesses.ps1`.
 | `minutes-string.ps1` | `minutes` as text coerces to `Int32` before the timeout arithmetic reads it |
 | `minutes-bad.ps1` | `minutes` no arithmetic can use is refused |
 | `tags-missing.ps1` | empty, null and all-blank `tags` are each refused, not just an absent key |
+| `tags-padded.ps1` | a padded tag is stored trimmed, so `-Tag` can reach what `-List` shows; a numeric one is kept |
 | `missing-key.ps1` | one entry per required key, each short a different one, so shortening the list is visible |
 | `empty-value.ps1` | a key that is present and empty is not a declared key |
 | `script-missing.ps1` | a `script` the tier declared and never shipped is refused, by integrity check 1 |
 | `script-escapes.ps1` | a `script` that climbs out of the directory is refused |
 | `script-sibling.ps1` | so is one in a sibling directory whose path opens with the same characters |
 | `leaf-collision.ps1` | naming a subdirectory script does not classify a same-leaf script at the top level |
+| `script-relative.ps1` | a `script` written as `./name.ps1` is reduced to the leaf the same check compares |
 | `duplicate-name.ps1` | the same name twice inside one layer is refused |
 | `base-collision.ps1` | a name the base set already uses is refused |
 | `reserved-layer.ps1` | the layer cannot call itself `base` |
@@ -53,10 +55,15 @@ overlay would drop beside the runner as `fuzz-tier-harnesses.ps1`.
 | `no-layer.ps1` | so is harnesses with no layer name, which would otherwise merge and report as base-only |
 | `returns-nothing.ps1` | a manifest that emits no object at all is refused |
 | `two-objects.ps1` | so is one that emits two, which member enumeration otherwise reads as a single merged layer |
+| `one-object-collection.ps1` | a leading comma wraps one object in a collection, which is refused as the wrapper it is |
 | `not-in-suite.ps1` | a layer can classify a runner of its own without patching the suite |
 | `not-in-suite-object.ps1` | the same classification written as a custom object is read, not silently ignored |
 | `not-in-suite-list.ps1` | a list of names rather than name = reason pairs is refused |
 | `not-in-suite-harness.ps1` | a layer cannot excuse a script its own manifest names as a harness |
+| `not-in-suite-padded.ps1` | a padded name is stored trimmed, so it excuses the file it names |
+| `not-in-suite-path.ps1` | a name carrying a separator, or a blank one, excuses nothing and is refused |
+| `not-in-suite-empty-reason.ps1` | the pairs form with an empty reason is the list form spelled the long way round |
+| `not-in-suite-empty.ps1` | an empty collection is read as the list form rather than skipped |
 
 The self-test runs these against a copy of `windows/scripts`, because the
 manifest is discovered by presence: a fixture placed in the real directory

--- a/windows/scripts/lib/fuzz-selftest/README.md
+++ b/windows/scripts/lib/fuzz-selftest/README.md
@@ -26,3 +26,33 @@ that looks like success: a runner that reports green for a harness that
 found defects, could not start, or never ran at all. That is not a
 hypothetical - `vtabs-visual-qa.ps1` marked a step OK whenever the
 sub-script did not throw, and a sub-script that exits 2 does not throw.
+
+## `layers/`
+
+Tier layer manifests, one per thing the merge in `fuzz-suite.ps1` has to
+refuse or accept. They are not harnesses: each emits the object a tier
+overlay would drop beside the runner as `fuzz-tier-harnesses.ps1`.
+
+| fixture | what it pins down |
+|---|---|
+| `valid.ps1` | a well-formed layer merges, and the run names both counts |
+| `pscustomobject.ps1` | an entry written as a custom object normalises rather than crashing |
+| `minutes-string.ps1` | `minutes` as text coerces to `Int32` before the timeout arithmetic reads it |
+| `minutes-bad.ps1` | `minutes` no arithmetic can use is refused |
+| `tags-missing.ps1` | empty and null `tags` are both refused, not just an absent key |
+| `missing-key.ps1` | an entry short of a key the runner reads later is refused |
+| `script-escapes.ps1` | a `script` that climbs out of the directory is refused |
+| `script-sibling.ps1` | so is one in a sibling directory whose path opens with the same characters |
+| `leaf-collision.ps1` | naming a subdirectory script does not classify a same-leaf script at the top level |
+| `duplicate-name.ps1` | the same name twice inside one layer is refused |
+| `base-collision.ps1` | a name the base set already uses is refused |
+| `reserved-layer.ps1` | the layer cannot call itself `base` |
+| `no-harnesses.ps1` | a layer with nothing to run under it is refused |
+| `returns-nothing.ps1` | a manifest that emits no object at all is refused |
+| `not-in-suite.ps1` | a layer can classify a runner of its own without patching the suite |
+
+The self-test runs these against a copy of `windows/scripts`, because the
+manifest is discovered by presence: a fixture placed in the real directory
+would be picked up by every other invocation from it, including a concurrent
+one, and the case that asserts what an ABSENT manifest does could not exist
+at all.

--- a/windows/scripts/lib/fuzz-selftest/README.md
+++ b/windows/scripts/lib/fuzz-selftest/README.md
@@ -39,8 +39,10 @@ overlay would drop beside the runner as `fuzz-tier-harnesses.ps1`.
 | `pscustomobject.ps1` | an entry written as a custom object normalises rather than crashing |
 | `minutes-string.ps1` | `minutes` as text coerces to `Int32` before the timeout arithmetic reads it |
 | `minutes-bad.ps1` | `minutes` no arithmetic can use is refused |
-| `tags-missing.ps1` | empty and null `tags` are both refused, not just an absent key |
-| `missing-key.ps1` | an entry short of a key the runner reads later is refused |
+| `tags-missing.ps1` | empty, null and all-blank `tags` are each refused, not just an absent key |
+| `missing-key.ps1` | one entry per required key, each short a different one, so shortening the list is visible |
+| `empty-value.ps1` | a key that is present and empty is not a declared key |
+| `script-missing.ps1` | a `script` the tier declared and never shipped is refused, by integrity check 1 |
 | `script-escapes.ps1` | a `script` that climbs out of the directory is refused |
 | `script-sibling.ps1` | so is one in a sibling directory whose path opens with the same characters |
 | `leaf-collision.ps1` | naming a subdirectory script does not classify a same-leaf script at the top level |
@@ -48,8 +50,13 @@ overlay would drop beside the runner as `fuzz-tier-harnesses.ps1`.
 | `base-collision.ps1` | a name the base set already uses is refused |
 | `reserved-layer.ps1` | the layer cannot call itself `base` |
 | `no-harnesses.ps1` | a layer with nothing to run under it is refused |
+| `no-layer.ps1` | so is harnesses with no layer name, which would otherwise merge and report as base-only |
 | `returns-nothing.ps1` | a manifest that emits no object at all is refused |
+| `two-objects.ps1` | so is one that emits two, which member enumeration otherwise reads as a single merged layer |
 | `not-in-suite.ps1` | a layer can classify a runner of its own without patching the suite |
+| `not-in-suite-object.ps1` | the same classification written as a custom object is read, not silently ignored |
+| `not-in-suite-list.ps1` | a list of names rather than name = reason pairs is refused |
+| `not-in-suite-harness.ps1` | a layer cannot excuse a script its own manifest names as a harness |
 
 The self-test runs these against a copy of `windows/scripts`, because the
 manifest is discovered by presence: a fixture placed in the real directory

--- a/windows/scripts/lib/fuzz-selftest/layers/base-collision.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/base-collision.ps1
@@ -1,0 +1,8 @@
+#requires -Version 7
+# A name the base set already uses.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'search'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/duplicate-name.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/duplicate-name.ps1
@@ -1,0 +1,10 @@
+#requires -Version 7
+# The same name twice inside one layer. -Only and -Skip match on name, so one
+# of the two would be unreachable and which one would depend on order.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/empty-value.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/empty-value.ps1
@@ -1,0 +1,12 @@
+#requires -Version 7
+# Keys that are present and empty, which a key-presence check accepts. Kept
+# apart from missing-key.ps1 because an entry cannot both omit a key and hold an
+# empty value for it, and a fixture named for one holding the other reads wrong.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = '';                     script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-empty-script'; script = '';                           tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-empty-oracle'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = $null }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/leaf-collision.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/leaf-collision.ps1
@@ -1,0 +1,10 @@
+#requires -Version 7
+# Names a script in a subdirectory whose leaf matches an unclassified script
+# sitting at the top level. Comparing leaves rather than relative paths would
+# read this as classifying that one.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/minutes-bad.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/minutes-bad.ps1
@@ -1,0 +1,9 @@
+#requires -Version 7
+# minutes that no arithmetic can use. Left alone it reaches the run loop's
+# timeout arithmetic and throws out of the foreach that has no catch.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 'soon'; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/minutes-string.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/minutes-string.ps1
@@ -1,8 +1,11 @@
 #requires -Version 7
 # minutes as text, which is what a hand-written manifest tends to produce.
-# '2.6' rather than another '2' so the coerced value reads differently from
-# the text it came from: -List is the only output that shows minutes at all,
-# so a string that renders the same either way would assert nothing.
+# '2.6' rather than another '2' so the coerced value reads differently from the
+# text it came from: -List is the only output that shows minutes at all, so a
+# string that renders the same either way would assert nothing. That makes the
+# assertion downstream a pin on the platform's own rounding rather than on a
+# rule anyone here decided; it is used because it is the only signal, not
+# because 2.6 minutes rounding up matters to anything.
 @{
     layer = 'pro'
     harnesses = @(

--- a/windows/scripts/lib/fuzz-selftest/layers/minutes-string.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/minutes-string.ps1
@@ -1,0 +1,12 @@
+#requires -Version 7
+# minutes as text, which is what a hand-written manifest tends to produce.
+# '2.6' rather than another '2' so the coerced value reads differently from
+# the text it came from: -List is the only output that shows minutes at all,
+# so a string that renders the same either way would assert nothing.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier-a'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = '2';   oracle = 'fixture' }
+        @{ name = 'st-tier-b'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = '2.6'; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/missing-key.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/missing-key.ps1
@@ -1,8 +1,20 @@
 #requires -Version 7
-# An entry short of one key the runner reads later without checking again.
+# One entry per key the runner reads later without checking again, each short a
+# different one. The loop collects every missing key before the run exits, so
+# covering all seven costs one child run rather than seven - and a key dropped
+# from the list it checks is invisible against a fixture that omits only one.
+#
+# The entry with no name is the one worth keeping honest about: the message
+# names the offender, and that one has nothing to name itself with.
 @{
     layer = 'pro'
     harnesses = @(
-        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1 }
+        @{                             script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-no-script';                                        tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-no-tags';    script = 'lib/fuzz-selftest/pass.ps1';                   outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-no-outdir';  script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier');                 seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-no-seed';    script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true;                minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-no-minutes'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false;              oracle = 'fixture' }
+        @{ name = 'st-tier-no-oracle';  script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1                     }
     )
 }

--- a/windows/scripts/lib/fuzz-selftest/layers/missing-key.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/missing-key.ps1
@@ -1,0 +1,8 @@
+#requires -Version 7
+# An entry short of one key the runner reads later without checking again.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1 }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/no-harnesses.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/no-harnesses.ps1
@@ -1,0 +1,3 @@
+#requires -Version 7
+# A layer name and nothing to run under it.
+@{ layer = 'pro' }

--- a/windows/scripts/lib/fuzz-selftest/layers/no-layer.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/no-layer.ps1
@@ -1,0 +1,9 @@
+#requires -Version 7
+# Harnesses and no name to run them under. This is the sharper half of the shape
+# check: the merge takes the harness, nothing downstream has a layer name to
+# print, and -List reports a suite one bigger than the base set as "base only".
+@{
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-empty-reason.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-empty-reason.ps1
@@ -1,0 +1,12 @@
+#requires -Version 7
+# The pairs form with nothing in the second half. A bare list of names is
+# refused because the reason is the only place a tier says why a script of its
+# own is not a harness; an empty reason says exactly as much, and an empty
+# oracle is refused a few lines earlier on the same argument.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = @{ 'tier-runner.ps1' = '' }
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-empty.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-empty.ps1
@@ -1,0 +1,12 @@
+#requires -Version 7
+# An empty collection, which is the list form with nothing in it. Read for
+# truthiness rather than presence it is skipped entirely, so a tier that wrote
+# its classifications the wrong shape was told to classify a script rather than
+# told the shape was wrong.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = @()
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-harness.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-harness.ps1
@@ -1,0 +1,11 @@
+#requires -Version 7
+# notInSuite excusing a script the manifest itself names as a harness. This is
+# the one door a tier can open on the unclassified-script check, so a lenient
+# read of it hands back the silent shrink the strict read exists to stop.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = @{ 'search-fuzz.ps1' = 'not ours to excuse' }
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-list.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-list.ps1
@@ -1,0 +1,11 @@
+#requires -Version 7
+# notInSuite written as a list of names rather than name = reason pairs. Read
+# through PSObject.Properties an array answers with Length, Rank and the rest,
+# so it classifies nothing while looking like it classified something.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = @('tier-runner.ps1')
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-object.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-object.ps1
@@ -1,0 +1,11 @@
+#requires -Version 7
+# notInSuite written the other way a manifest reasonably gets written. A
+# PSCustomObject has no .Keys, so an unnormalised read is a silent no-op and the
+# run dies at the unclassified-script check naming the file this classifies.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = [pscustomobject]@{ 'tier-runner.ps1' = 'a runner the tier ships; not a harness' }
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-padded.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-padded.ps1
@@ -1,0 +1,13 @@
+#requires -Version 7
+# A classification whose name carries padding. It passes every check in the
+# merge, goes into the collection padded, and the unclassified-script check then
+# compares a bare leaf name against it and misses - so the run dies blaming the
+# tier for a file it classified, which is the failure normalising the pairs was
+# added to remove, arriving through the door normalising left open.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = @{ 'tier-runner.ps1 ' = 'a runner the tier ships; not a harness' }
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-path.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite-path.ps1
@@ -1,0 +1,15 @@
+#requires -Version 7
+# Names the unclassified-script check cannot act on. It compares leaf names, so
+# one carrying a separator excuses nothing while reading as though it did, and a
+# blank one excuses nothing at all. Both are accepted in silence without the
+# plain-file-name guard, and the run then fails somewhere else or not at all.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = @{
+        'lib/tier-runner.ps1' = 'a runner the tier keeps in a subdirectory'
+        '   '                 = 'nothing at all'
+    }
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/not-in-suite.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/not-in-suite.ps1
@@ -1,0 +1,12 @@
+#requires -Version 7
+# A layer that ships a runner of its own beside the harnesses and classifies
+# it. Without notInSuite the only ways to keep that script from failing the
+# unclassified-script check were patching the runner, which is what the layer
+# exists to avoid, or calling it a harness, which is worse.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+    notInSuite = @{ 'tier-runner.ps1' = 'a runner the tier ships; not a harness' }
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/one-object-collection.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/one-object-collection.ps1
@@ -1,0 +1,12 @@
+#requires -Version 7
+# The wrapper, at length one. A leading comma emits the manifest inside an
+# array, which is a collection whatever it holds - and a message that counts the
+# objects tells this author it emitted one object when it must emit exactly one.
+,@(
+    @{
+        layer = 'pro'
+        harnesses = @(
+            @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        )
+    }
+)

--- a/windows/scripts/lib/fuzz-selftest/layers/pscustomobject.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/pscustomobject.ps1
@@ -1,0 +1,11 @@
+#requires -Version 7
+# The same layer written the other way a manifest reasonably gets written.
+# A PSCustomObject answers neither .Contains() nor an assignment to a property
+# it does not already have, so an entry that arrives as one has to be
+# normalised before anything else touches it.
+@{
+    layer = 'pro'
+    harnesses = @(
+        [pscustomobject]@{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/reserved-layer.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/reserved-layer.ps1
@@ -1,0 +1,9 @@
+#requires -Version 7
+# The layer name the runner gives its own harnesses. Taking it would make the
+# base and tier counts in the summary indistinguishable.
+@{
+    layer = 'base'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/returns-nothing.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/returns-nothing.ps1
@@ -1,0 +1,3 @@
+#requires -Version 7
+# A manifest that emits no object at all, which is what a tier overlay that
+# placed an empty or half-written file leaves behind.

--- a/windows/scripts/lib/fuzz-selftest/layers/script-escapes.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/script-escapes.ps1
@@ -1,0 +1,11 @@
+#requires -Version 7
+# A script that climbs out of the directory the suite covers. The target is
+# made to exist and to declare the parameters the manifest passes it, so the
+# integrity checks downstream have nothing to say about it: only the guard on
+# the resolved path can refuse this one.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = '../layer-escape/escape.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/script-missing.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/script-missing.ps1
@@ -1,0 +1,10 @@
+#requires -Version 7
+# A script the tier declares and did not ship. The merge itself has nothing to
+# say about it - the path is inside the directory and the entry is well formed -
+# so what refuses it is integrity check 1, on the merged manifest.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/never-shipped.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/script-relative.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/script-relative.ps1
@@ -1,0 +1,12 @@
+#requires -Version 7
+# A script named the way a path beside the runner is often written. The
+# unclassified-script check compares bare leaf names, so './tier-relative.ps1'
+# has to be reduced to one before it can match the file on disk - taken as it
+# is written it classifies nothing, and the run dies telling the tier author to
+# classify a script their own manifest names as a harness.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = './tier-relative.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/script-sibling.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/script-sibling.ps1
@@ -1,0 +1,10 @@
+#requires -Version 7
+# A script in a sibling directory whose full path opens with this directory's,
+# character for character. A prefix test that stops before the separator reads
+# it as inside; only one that requires the separator refuses it.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = '../layer-scriptsX/escape.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/tags-missing.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/tags-missing.ps1
@@ -1,9 +1,13 @@
 #requires -Version 7
-# Both ways a tags list passes a key-presence check and still selects nothing.
+# Every way a tags list passes a key-presence check and still selects nothing.
+# The blank one is the case a plain truthiness test cannot see: only '' is falsy
+# in PowerShell, so '  ' survives a bare `Where-Object { $_ }` while no -Tag
+# argument can ever match it.
 @{
     layer = 'pro'
     harnesses = @(
-        @{ name = 'st-tier-empty'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @();   outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
-        @{ name = 'st-tier-null';  script = 'lib/fuzz-selftest/pass.ps1'; tags = $null; outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-empty'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @();          outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-null';  script = 'lib/fuzz-selftest/pass.ps1'; tags = $null;        outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-blank'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('', '  '); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
     )
 }

--- a/windows/scripts/lib/fuzz-selftest/layers/tags-missing.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/tags-missing.ps1
@@ -1,0 +1,9 @@
+#requires -Version 7
+# Both ways a tags list passes a key-presence check and still selects nothing.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier-empty'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @();   outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-null';  script = 'lib/fuzz-selftest/pass.ps1'; tags = $null; outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/tags-padded.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/tags-padded.ps1
@@ -1,0 +1,13 @@
+#requires -Version 7
+# Tags that a truthiness test reads as declared and no -Tag argument can reach.
+# Split-List trims the caller's side, so ' tier ' listed as a real tag while
+# `-Tag ' tier '` arrived as 'tier' and matched nothing - the very condition the
+# no-tags guard's message describes, passing the guard. The numeric one is here
+# because the fix compares tags as text: 0 is as selectable as '0', so it stays.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier-padded';  script = 'lib/fuzz-selftest/pass.ps1'; tags = @(' tier ', 'x'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+        @{ name = 'st-tier-numeric'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @(0);             outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/two-objects.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/two-objects.ps1
@@ -1,0 +1,17 @@
+#requires -Version 7
+# Two manifests in one file: an overlay that appended rather than replaced, or a
+# merge conflict resolved by keeping both sides. Member enumeration across the
+# array reads it as one manifest whose layer name is both names joined and whose
+# harnesses are both sets, so it merges rather than refusing.
+@{
+    layer = 'common'
+    harnesses = @(
+        @{ name = 'st-tier-common'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier-pro'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}

--- a/windows/scripts/lib/fuzz-selftest/layers/valid.ps1
+++ b/windows/scripts/lib/fuzz-selftest/layers/valid.ps1
@@ -1,0 +1,8 @@
+#requires -Version 7
+# A well-formed tier layer: the base set plus one harness of its own.
+@{
+    layer = 'pro'
+    harnesses = @(
+        @{ name = 'st-tier'; script = 'lib/fuzz-selftest/pass.ps1'; tags = @('tier'); outDir = $true; seed = $false; minutes = 1; oracle = 'fixture' }
+    )
+}


### PR DESCRIPTION
`fuzz-suite.ps1` says its own most likely defect is the one that looks like
success. That is what `-SelfTest` is for, and the tier layer merge shipped with
none of it - every behaviour verified by hand, and three of them were defects
review caught after the first hand check passed.

## Why a copy of the directory

The manifest is found by presence at `Join-Path $PSScriptRoot 'fuzz-tier-harnesses.ps1'`,
and the checks it feeds read `$PSScriptRoot` too. So a fixture cannot be dropped
into `windows/scripts`: it would change every other invocation from there,
including this run's own children.

A `-TierManifestPath` parameter would have been smaller, and the security
objection to it is not real - the runner already executes every script its
manifest names. It was rejected on coverage. The leaf-collision case needs an
unclassified `pass.ps1` at the top level of the scanned directory to prove a
tier naming `lib/x/pass.ps1` does not excuse it, and that file is exactly what
cannot be committed. Covering it would have taken a second seam for the scan
directory, at which point the seam is larger than the copy.

The copy excludes any real `fuzz-tier-harnesses.ps1`. On a tier checkout one is
sitting there, and copying it would give every case a second layer - including
the case that asserts what an absent manifest does, on the builds that ship one.

## What is asserted

19 cases, each pinning the exit code and the message. Both halves matter: every
refusal in the merge leaves with 1, so an exit-only oracle passes while some
other guard does the refusing. Two mutations demonstrated exactly that.

The base-only case is pinned too - counts and the absence of the
`layers: base (` line. Nothing downstream can tell a base-only run from the tier
run it was supposed to be, so that is the property most likely to rot unnoticed.

Counts come off the run rather than being written down, so adding a base harness
is not a self-test failure.

## Verification

`-SelfTest` green at exit 0: 11 exit paths plus 19 layer cases, 1m22s, no build
and no desktop. Base-only `-List` unchanged at 19 harnesses.

20 mutations, one at a time, all caught. Mutations 15 and 16 still exited 1 and
were caught by message alone.

## One correction to the issue

"byte-identical to before the feature existed" is not achievable: the merge
itself added the `layer` column and the trailing `layers:` line, so base-only
output already differs by construction. The case pins the honest version of that
property instead.
