### PR TITLE
windows: stop the tab layout switch crashing on a closed window

### DIFF
--- a/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
@@ -10,85 +11,115 @@ namespace Ghostty.Tests.Wiring;
 /// 340ms after it starts, and nothing cancels it when the window goes away in
 /// between. Closing the last tab closes the window, and a storyboard that has
 /// already begun still raises Completed, so the callback can run against a
-/// window whose HWND is gone.
-///
-/// <c>Window.AppWindow</c> is null at that point. The chrome work the callback
-/// does reaches <c>AppWindow.TitleBar</c>, so without a guard it throws
-/// NullReferenceException on the UI thread, which is unhandled and takes the
-/// process down. Four such crashes were recorded in crash.log with this exact
-/// stack before the guard was added:
+/// window that is tearing down. crash.log recorded four NullReferenceExceptions
+/// with this stack before the gate was added:
 ///
 ///   ApplyButtonColors -> ApplyCaptionButtonChrome -> RefreshTabHostChrome
 ///   -> AnimateTabLayoutTo's completion -> LayoutCoordinator.FinishSwitch
 ///
-/// These are wiring guards. They prove the null checks are still on the path a
-/// dead window takes; whether the window actually survives a switch is only
-/// observable on a live UI.
+/// The gate is _isClosed, not a null AppWindow. AppWindow survives into
+/// OnClosedAsync, so it goes null strictly later than teardown starts, and in
+/// that gap the theme manager is disposed and panes are being freed. These
+/// tests pin the earlier signal deliberately, because a later one leaves the
+/// gap open.
+///
+/// These are wiring guards. They prove the gate is on the path a closing
+/// window takes; whether the window survives a switch is only observable live.
 /// </summary>
 public class TabLayoutSwitchWiringTests
 {
     private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
 
-    [Fact]
-    public void SwitchCompletion_BailsOutWhenTheWindowIsGone()
+    /// <summary>
+    /// The lambda passed as <c>onCompleted:</c>, found by argument name rather
+    /// than by being the only lambda present, so adding another callback to
+    /// the method does not turn this into an unreadable sequence error.
+    /// </summary>
+    private static ParenthesizedLambdaExpressionSyntax SwitchCompletion()
     {
         var animate = Window().Method("AnimateTabLayoutTo");
+        var arg = animate.DescendantNodes()
+            .OfType<ArgumentSyntax>()
+            .Single(a => a.NameColon?.Name.Identifier.Text == "onCompleted");
+        return Assert.IsType<ParenthesizedLambdaExpressionSyntax>(arg.Expression);
+    }
 
-        // The completion lambda handed to LayoutCoordinator.Animate.
-        var completion = animate.DescendantNodes()
-            .OfType<ParenthesizedLambdaExpressionSyntax>()
-            .Single();
+    private static bool ReturnsEarly(IfStatementSyntax guard) =>
+        guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any();
 
-        var guard = completion.DescendantNodes()
+    [Fact]
+    public void SwitchCompletion_BailsOutOnceTeardownHasStarted()
+    {
+        var completion = SwitchCompletion();
+        var statements = completion.Block!.Statements;
+
+        // Identity, not a substring: `if (_isClosed) return;` and nothing that
+        // merely mentions the field. An inverted or dead condition is a
+        // different syntax shape and does not match.
+        var guard = statements
             .OfType<IfStatementSyntax>()
-            .FirstOrDefault(s => s.Condition.ToString().Contains("AppWindow"));
+            .FirstOrDefault(s => s.Condition is IdentifierNameSyntax { Identifier.Text: "_isClosed" });
 
         Assert.True(
             guard is not null,
-            "the layout-switch completion must check AppWindow before touching window chrome");
+            "the layout-switch completion must return early once _isClosed is set; "
+            + "a null AppWindow is a strictly later signal and leaves the teardown gap open");
+        Assert.True(ReturnsEarly(guard!), "the teardown gate must return, not just log");
 
-        // A guard that does not return leaves the crash in place.
-        Assert.Contains("return", guard!.Statement.ToString());
+        // Order matters rather than position: everything below the gate is
+        // what touches disposed state.
+        var guardIndex = statements.IndexOf(guard!);
+        var refreshIndex = statements
+            .TakeWhile(s => !s.DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>()
+                .Any(i => i.Expression.ToString() == "RefreshTabHostChrome"))
+            .Count();
 
-        // And it has to come first: the calls below it are what crash.
-        var firstStatement = completion.Block!.Statements.First();
-        Assert.Same(guard, firstStatement);
+        Assert.True(refreshIndex < statements.Count, "expected a RefreshTabHostChrome call to guard");
+        Assert.True(guardIndex < refreshIndex, "the teardown gate must precede the chrome work");
     }
 
     [Fact]
-    public void ApplyButtonColors_ChecksAppWindowBeforeDereferencingIt()
+    public void ApplyButtonColors_ChecksBothHalvesBeforeDereferencing()
     {
         var method = Window().Method("ApplyButtonColors");
 
-        var guard = method.DescendantNodes()
+        // The crash line reads AppWindow.TitleBar, which faults whether
+        // AppWindow or TitleBar is null, so the check has to cover both. A
+        // plain `AppWindow is null` test leaves the second half live.
+        var guard = method.Body!.Statements
             .OfType<IfStatementSyntax>()
-            .FirstOrDefault(s => s.Condition.ToString().Contains("AppWindow"));
+            .FirstOrDefault(s =>
+                s.Condition is IsPatternExpressionSyntax pattern &&
+                pattern.Expression.ToString().Contains("AppWindow?.TitleBar"));
 
         Assert.True(
             guard is not null,
-            "ApplyButtonColors dereferences AppWindow.TitleBar and must check it first");
-        Assert.Contains("return", guard!.Statement.ToString());
+            "ApplyButtonColors must check AppWindow?.TitleBar, covering a null window and a null title bar");
+        Assert.True(ReturnsEarly(guard!), "the guard must return");
     }
 
     [Fact]
-    public void ApplyButtonColors_DoesNotRecordColoursItNeverApplied()
+    public void ApplyButtonColors_GuardsBeforeMutatingState()
     {
         var method = Window().Method("ApplyButtonColors");
         var statements = method.Body!.Statements;
 
         var guardIndex = statements
-            .TakeWhile(s => s is not IfStatementSyntax i || !i.Condition.ToString().Contains("AppWindow"))
+            .TakeWhile(s => s is not IfStatementSyntax i ||
+                            !i.Condition.ToString().Contains("AppWindow"))
             .Count();
 
-        // _lastButtonColors is the no-op cache: writing it on a path that
-        // applies nothing makes the next real call skip those writes, so the
-        // window would keep stale caption colours after the guard stops firing.
         var cacheIndex = statements
-            .TakeWhile(s => !s.ToString().Contains("_lastButtonColors ="))
+            .TakeWhile(s => !s.DescendantNodesAndSelf()
+                .OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.Left.ToString() == "_lastButtonColors"))
             .Count();
 
-        Assert.True(
-            guardIndex < cacheIndex,
-            "the AppWindow guard must run before _lastButtonColors is updated");
+        // Both have to exist, or TakeWhile silently returns the full count and
+        // the comparison passes while pinning nothing.
+        Assert.True(guardIndex < statements.Count, "expected an AppWindow guard");
+        Assert.True(cacheIndex < statements.Count, "expected a _lastButtonColors assignment");
+        Assert.True(guardIndex < cacheIndex, "the guard must run before any state is mutated");
     }
 }

--- a/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Wiring;
+
+/// <summary>
+/// The horizontal/vertical tab switch lands on a completion callback about
+/// 340ms after it starts, and nothing cancels it when the window goes away in
+/// between. Closing the last tab closes the window, and a storyboard that has
+/// already begun still raises Completed, so the callback can run against a
+/// window whose HWND is gone.
+///
+/// <c>Window.AppWindow</c> is null at that point. The chrome work the callback
+/// does reaches <c>AppWindow.TitleBar</c>, so without a guard it throws
+/// NullReferenceException on the UI thread, which is unhandled and takes the
+/// process down. Four such crashes were recorded in crash.log with this exact
+/// stack before the guard was added:
+///
+///   ApplyButtonColors -> ApplyCaptionButtonChrome -> RefreshTabHostChrome
+///   -> AnimateTabLayoutTo's completion -> LayoutCoordinator.FinishSwitch
+///
+/// These are wiring guards. They prove the null checks are still on the path a
+/// dead window takes; whether the window actually survives a switch is only
+/// observable on a live UI.
+/// </summary>
+public class TabLayoutSwitchWiringTests
+{
+    private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+
+    [Fact]
+    public void SwitchCompletion_BailsOutWhenTheWindowIsGone()
+    {
+        var animate = Window().Method("AnimateTabLayoutTo");
+
+        // The completion lambda handed to LayoutCoordinator.Animate.
+        var completion = animate.DescendantNodes()
+            .OfType<ParenthesizedLambdaExpressionSyntax>()
+            .Single();
+
+        var guard = completion.DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .FirstOrDefault(s => s.Condition.ToString().Contains("AppWindow"));
+
+        Assert.True(
+            guard is not null,
+            "the layout-switch completion must check AppWindow before touching window chrome");
+
+        // A guard that does not return leaves the crash in place.
+        Assert.Contains("return", guard!.Statement.ToString());
+
+        // And it has to come first: the calls below it are what crash.
+        var firstStatement = completion.Block!.Statements.First();
+        Assert.Same(guard, firstStatement);
+    }
+
+    [Fact]
+    public void ApplyButtonColors_ChecksAppWindowBeforeDereferencingIt()
+    {
+        var method = Window().Method("ApplyButtonColors");
+
+        var guard = method.DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .FirstOrDefault(s => s.Condition.ToString().Contains("AppWindow"));
+
+        Assert.True(
+            guard is not null,
+            "ApplyButtonColors dereferences AppWindow.TitleBar and must check it first");
+        Assert.Contains("return", guard!.Statement.ToString());
+    }
+
+    [Fact]
+    public void ApplyButtonColors_DoesNotRecordColoursItNeverApplied()
+    {
+        var method = Window().Method("ApplyButtonColors");
+        var statements = method.Body!.Statements;
+
+        var guardIndex = statements
+            .TakeWhile(s => s is not IfStatementSyntax i || !i.Condition.ToString().Contains("AppWindow"))
+            .Count();
+
+        // _lastButtonColors is the no-op cache: writing it on a path that
+        // applies nothing makes the next real call skip those writes, so the
+        // window would keep stale caption colours after the guard stops firing.
+        var cacheIndex = statements
+            .TakeWhile(s => !s.ToString().Contains("_lastButtonColors ="))
+            .Count();
+
+        Assert.True(
+            guardIndex < cacheIndex,
+            "the AppWindow guard must run before _lastButtonColors is updated");
+    }
+}

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1024,11 +1024,19 @@ public sealed partial class MainWindow : Window
             // The switch lands about 340ms after it starts, and nothing
             // cancels it if the window goes away in between: closing the last
             // tab closes the window, and a storyboard that has already begun
-            // still raises Completed. Window.AppWindow is null once the HWND
-            // is gone, so the chrome work below would take an unhandled
-            // NullReferenceException on the UI thread and take the process
-            // with it.
-            if (AppWindow is null) return;
+            // still raises Completed.
+            //
+            // Gated on _isClosed rather than on AppWindow, which is the same
+            // reasoning as the other teardown gates in this file. AppWindow
+            // survives into OnClosedAsync (it reads AppWindow.Presenter and
+            // the window geometry there), so it goes null strictly later than
+            // teardown begins. In that gap the theme manager is already
+            // disposed and the panes are being torn down, and the work below
+            // reaches both: RefreshTabHostChrome asks the theme manager for
+            // the element theme, and the focus call touches a leaf that
+            // DisposeAllLeaves may already have freed. AppWindow going null is
+            // only the loudest symptom, not the earliest.
+            if (_isClosed) return;
 
             RefreshTabHostChrome();
             if (vertical)
@@ -2269,17 +2277,21 @@ public sealed partial class MainWindow : Window
         Windows.UI.Color? hoverBg, Windows.UI.Color? hoverFg,
         Windows.UI.Color? pressedBg, Windows.UI.Color? pressedFg)
     {
-        // A closed window has no AppWindow. Callers reach here from animation
-        // completions that outlive the window, so this is checked before the
-        // cache is written: recording colours we never applied would make a
-        // later call skip the real writes as no-ops.
-        if (AppWindow is not { } appWindow) return;
+        // Defence in depth for callers that outlive the window: the animation
+        // completion that produced the crashes has its own teardown gate now,
+        // but this is reachable from several places and only needs the title
+        // bar to be there.
+        //
+        // Both halves are checked because the crash stack cannot distinguish
+        // them: it points at the line that reads AppWindow.TitleBar, which
+        // faults whether AppWindow or TitleBar is the null one. Nothing is
+        // mutated before the check, so a skipped call leaves no trace.
+        if (AppWindow?.TitleBar is not { } tb) return;
 
         var prev = _lastButtonColors;
         _lastButtonColors = new CaptionColors(
             bg, fg, inactiveBg, inactiveFg, hoverBg, hoverFg, pressedBg, pressedFg);
 
-        var tb = appWindow.TitleBar;
         if (prev.Bg != bg) tb.ButtonBackgroundColor = bg;
         if (prev.InactiveBg != inactiveBg) tb.ButtonInactiveBackgroundColor = inactiveBg;
         if (prev.HoverBg != hoverBg) tb.ButtonHoverBackgroundColor = hoverBg;

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1021,6 +1021,15 @@ public sealed partial class MainWindow : Window
         _titleBar.ApplyForCurrentMode();
         _layout.Animate(vertical, onCompleted: () =>
         {
+            // The switch lands about 340ms after it starts, and nothing
+            // cancels it if the window goes away in between: closing the last
+            // tab closes the window, and a storyboard that has already begun
+            // still raises Completed. Window.AppWindow is null once the HWND
+            // is gone, so the chrome work below would take an unhandled
+            // NullReferenceException on the UI thread and take the process
+            // with it.
+            if (AppWindow is null) return;
+
             RefreshTabHostChrome();
             if (vertical)
                 _verticalTabHost.SyncSelectionFromManager();
@@ -2260,11 +2269,17 @@ public sealed partial class MainWindow : Window
         Windows.UI.Color? hoverBg, Windows.UI.Color? hoverFg,
         Windows.UI.Color? pressedBg, Windows.UI.Color? pressedFg)
     {
+        // A closed window has no AppWindow. Callers reach here from animation
+        // completions that outlive the window, so this is checked before the
+        // cache is written: recording colours we never applied would make a
+        // later call skip the real writes as no-ops.
+        if (AppWindow is not { } appWindow) return;
+
         var prev = _lastButtonColors;
         _lastButtonColors = new CaptionColors(
             bg, fg, inactiveBg, inactiveFg, hoverBg, hoverFg, pressedBg, pressedFg);
 
-        var tb = AppWindow.TitleBar;
+        var tb = appWindow.TitleBar;
         if (prev.Bg != bg) tb.ButtonBackgroundColor = bg;
         if (prev.InactiveBg != inactiveBg) tb.ButtonInactiveBackgroundColor = inactiveBg;
         if (prev.HoverBg != hoverBg) tb.ButtonHoverBackgroundColor = hoverBg;


### PR DESCRIPTION
Switching between horizontal and vertical tabs takes the process down. `crash.log` has it four times, always the same stack:

```
ApplyButtonColors -> ApplyCaptionButtonChrome -> RefreshTabHostChrome
  -> AnimateTabLayoutTo's completion -> LayoutCoordinator.FinishSwitch
```

The switch lands on a completion callback about 340ms after it starts, and nothing cancels it in between. Closing the last tab closes the window, and a storyboard that has already begun still raises `Completed`, so the callback can run against a window whose HWND is gone. `Window.AppWindow` is null from that point, and the callback's first act is to repaint chrome, which reaches `AppWindow.TitleBar`. The NullReferenceException is on the UI thread, where nothing catches it.

The same file already treats a null `AppWindow` as reachable a few hundred lines up, reading the presenter through `AppWindow?.`. This path never got the same treatment.

Two guards, because they fail differently. The completion callback returns early so no chrome work runs on a dead window. `ApplyButtonColors` checks for itself, since other callers reach it, and it checks *before* writing `_lastButtonColors`: that field is a no-op cache, so recording colours that were never applied would make the next real call skip those writes and leave stale caption colours.

Tests parse the syntax tree rather than the text, matching the existing wiring tests. They assert the guard exists, returns, is the first statement in the callback, and precedes the cache write. I verified all three fail with the guards removed.

Worth knowing: this was found from `%LOCALAPPDATA%\Wintty\crash.log`, not from WER. The WER record only says `0xc000027b` in `Microsoft.UI.Xaml.dll` with no managed frames, so the crash log is the only place the actual cause appears.