### PR TITLE
terminal/osc: let OSC 1337 carry a payload larger than 2KB

### DIFF
--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -743,7 +743,18 @@ pub const Parser = struct {
             cap.writeByte(c) catch |err| switch (err) {
                 // We have overflowed our buffer or had some other error, set the
                 // state to invalid so that we discard any further input.
-                error.WriteFailed => self.state = .invalid,
+                //
+                // Logged because the symptom is otherwise invisible: the
+                // sequence never becomes a command, so whatever it carried
+                // just fails to happen. An inline image that exceeds the
+                // budget looked exactly like one that was never sent.
+                error.WriteFailed => {
+                    log.warn(
+                        "OSC sequence exceeded the capture limit and was dropped, state={s} captured={d}",
+                        .{ @tagName(self.state), cap.trailing().len },
+                    );
+                    self.state = .invalid;
+                },
             };
             return;
         }
@@ -1040,7 +1051,7 @@ test {
 
 test "Parser allocating captures have a hard limit" {
     const testing = std.testing;
-    const prefixes = [_][]const u8{ "52;", "66;", "72;", "5522;" };
+    const prefixes = [_][]const u8{ "52;", "66;", "72;", "1337;", "5522;" };
     const limit = Parser.MAX_BUF + 1;
 
     for (prefixes) |prefix| {
@@ -1058,6 +1069,30 @@ test "Parser allocating captures have a hard limit" {
         p.next('a');
         try testing.expectEqual(Parser.State.invalid, p.state);
         try testing.expectEqual(@as(usize, limit), cap.trailing().len);
+        try testing.expectEqual(@as(usize, limit), cap.writer.buffer.len);
+    }
+}
+
+test "Parser allocating captures stay within the limit through end" {
+    const testing = std.testing;
+
+    // Terminating a sequence that already filled the budget must not grow the
+    // allocation. Parsers append a NUL sentinel at this point, and one that
+    // writes it around the capture reallocates past the limit here.
+    const prefixes = [_][]const u8{ "52;", "66;", "72;", "1337;", "5522;" };
+    const limit = Parser.MAX_BUF + 1;
+
+    for (prefixes) |prefix| {
+        var p: Parser = .init(testing.allocator);
+        defer p.deinit();
+        p.max_allocating_bytes = limit;
+
+        for (prefix) |ch| p.next(ch);
+        for (0..limit) |_| p.next('a');
+
+        _ = p.end('\x1b');
+
+        const cap = &p.capture.?;
         try testing.expectEqual(@as(usize, limit), cap.writer.buffer.len);
     }
 }

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -919,7 +919,13 @@ pub const Parser = struct {
 
             .@"1337",
             => switch (c) {
-                ';' => self.captureTrailing(.fixed),
+                // Allocating, like OSC 52 and 72, because File= carries a
+                // base64 image and the fixed buffer is 2048 bytes. Anything
+                // larger was dropped without a command ever being produced,
+                // so an inline image simply failed to appear with nothing
+                // logged anywhere. Falls back to the fixed buffer when no
+                // allocator is available.
+                ';' => self.captureTrailing(.allocating),
                 else => self.state = .invalid,
             },
 

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -876,10 +876,20 @@ fn filePayloadSurvives(alloc: std.mem.Allocator, len: usize) !bool {
     return std.mem.eql(u8, payload, cmd.iterm2_image_transmit.payload);
 }
 
-test "OSC: 1337: a File payload within the capture limit survives intact" {
+test "OSC: 1337: a File payload survives at any size an image needs" {
     const testing = std.testing;
+
+    // Small enough for the fixed capture either way.
     try testing.expect(try filePayloadSurvives(testing.allocator, 1024));
     try testing.expect(try filePayloadSurvives(testing.allocator, 2000));
+
+    // Past the fixed buffer. A 2.4KB GIF is about 3.2KB of base64, and it
+    // used to vanish here with no error at all: the sequence never became a
+    // command, so nothing downstream knew an image had been sent.
+    try testing.expect(try filePayloadSurvives(testing.allocator, 4096));
+
+    // A photograph rather than an icon.
+    try testing.expect(try filePayloadSurvives(testing.allocator, 512 * 1024));
 }
 
 test "OSC: 1337: test File with extra options before inline=1" {

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -154,7 +154,11 @@ pub fn parse(parser: *Parser, _: ?u8) ?*Command {
         parser.state = .invalid;
         return null;
     };
-    cap.writer.writeByte(0) catch {
+    // Through the capture, not the raw writer: the capture is what enforces
+    // max_allocating_bytes, and this sentinel is a byte like any other. Going
+    // around it lets a sequence that already filled the budget grow the
+    // allocation past it, which is the whole thing the budget exists to stop.
+    cap.writeByte(0) catch {
         parser.state = .invalid;
         return null;
     };
@@ -856,40 +860,72 @@ test "OSC: 1337: test File inline=1 produces iterm2_image_transmit" {
     try testing.expect(tx.hints.preserve_aspect_ratio);
 }
 
-/// Feed a File= payload of the given length and report whether the command
-/// survived, so the size at which inline images start disappearing is a
-/// measured number rather than a guess.
-fn filePayloadSurvives(alloc: std.mem.Allocator, len: usize) !bool {
+/// Feed a File= payload of the given length and assert it comes back byte for
+/// byte, so the size at which inline images start disappearing is a measured
+/// number rather than a guess.
+///
+/// `capture_alloc` is what the parser gets: null exercises the fixed-buffer
+/// fallback, which is what a parser built without an allocator falls back to.
+fn expectFilePayloadSurvives(
+    alloc: std.mem.Allocator,
+    capture_alloc: ?std.mem.Allocator,
+    len: usize,
+) !void {
+    const testing = std.testing;
+
     const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     const payload = try alloc.alloc(u8, len);
     defer alloc.free(payload);
     for (payload, 0..) |*b, i| b.* = alphabet[i % alphabet.len];
 
-    var p: Parser = .init(alloc);
+    var p: Parser = .init(capture_alloc);
     defer p.deinit();
 
     for ("1337;File=inline=1:") |ch| p.next(ch);
     for (payload) |ch| p.next(ch);
 
-    const cmd = p.end('\x1b') orelse return false;
-    if (cmd.* != .iterm2_image_transmit) return false;
-    return std.mem.eql(u8, payload, cmd.iterm2_image_transmit.payload);
+    const cmd = p.end('\x1b') orelse {
+        std.log.err("File= payload of {d} bytes produced no command", .{len});
+        return error.TestExpectedCommand;
+    };
+    try testing.expect(cmd.* == .iterm2_image_transmit);
+    try testing.expectEqualStrings(payload, cmd.iterm2_image_transmit.payload);
 }
 
 test "OSC: 1337: a File payload survives at any size an image needs" {
     const testing = std.testing;
+    const alloc = testing.allocator;
 
-    // Small enough for the fixed capture either way.
-    try testing.expect(try filePayloadSurvives(testing.allocator, 1024));
-    try testing.expect(try filePayloadSurvives(testing.allocator, 2000));
+    try expectFilePayloadSurvives(alloc, alloc, 1024);
+    try expectFilePayloadSurvives(alloc, alloc, 2000);
 
     // Past the fixed buffer. A 2.4KB GIF is about 3.2KB of base64, and it
     // used to vanish here with no error at all: the sequence never became a
     // command, so nothing downstream knew an image had been sent.
-    try testing.expect(try filePayloadSurvives(testing.allocator, 4096));
+    try expectFilePayloadSurvives(alloc, alloc, 4096);
 
     // A photograph rather than an icon.
-    try testing.expect(try filePayloadSurvives(testing.allocator, 512 * 1024));
+    try expectFilePayloadSurvives(alloc, alloc, 512 * 1024);
+}
+
+test "OSC: 1337: without an allocator File= keeps the fixed-buffer ceiling" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // A parser built without an allocator falls back to the fixed buffer, so
+    // small images still work and large ones still do not. Pinned so the
+    // fallback is a known limitation rather than a surprise.
+    try expectFilePayloadSurvives(alloc, null, 1024);
+
+    const payload = try alloc.alloc(u8, Parser.MAX_BUF + 1);
+    defer alloc.free(payload);
+    @memset(payload, 'A');
+
+    var p: Parser = .init(null);
+    defer p.deinit();
+    for ("1337;File=inline=1:") |ch| p.next(ch);
+    for (payload) |ch| p.next(ch);
+    try testing.expect(p.end('\x1b') == null);
 }
 
 test "OSC: 1337: test File with extra options before inline=1" {


### PR DESCRIPTION
Stacked on #672. Merge that first.

An inline image sent over OSC 1337 `File=` vanished if it was any bigger than a tiny icon. A 335 byte PNG displayed; a 2.4KB GIF displayed nothing, with no error logged and nothing anywhere indicating an image had been sent.

The capture backing OSC 1337 was the 2048 byte fixed buffer, so a longer sequence overflowed and the parser dropped it before it became a command. Base64 inflates by a third, putting the real ceiling around 1.5KB of image, which is smaller than a 32x32 PNG icon.

OSC 52 and 72 already capture through the allocator for exactly this reason, and this is the stronger case: a clipboard payload can be small, an image never is. The allocating path falls back to the fixed buffer when no allocator is present, so nothing regresses where one is absent, and the existing 8MB allocating ceiling still bounds it.

This is what stood between the animated GIF work and anything visible on screen. With it, a 240x120 four-frame GIF renders and animates through its full loop in the real app. Sampling a strip across the image every 230ms captures the authored cycle twice:

```
b1  red     bar x=70     b6  red     bar x=70   <- looped
b2  green   bar x=120    b7  green   bar x=120
b3  blue    bar x=170    b8  blue    bar x=170
b4  yellow  bar x=220    b9  yellow  bar x=220
```

Those are the exact colours and the 50px-per-frame movement the fixture was generated with.

The test measures the boundary rather than asserting a magic number: it feeds payloads of 1KB, 2KB, 4KB and 512KB and requires each to come back byte-identical. The 4KB case failed before this change.