### PR TITLE
terminal/osc: stop reserving 2KB for OSCs that write tens of bytes

### DIFF
--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -615,9 +615,21 @@ pub const Parser = struct {
     }
 
     const Capture = struct {
+        /// Where captured bytes go. This points into `backing`, so promotion
+        /// moves it: anything holding a copy across a `writeByte` is left
+        /// pointing at an abandoned union member, which is a type confusion
+        /// rather than a truncation. Parsers that write the trailing NUL
+        /// through this pointer directly are all on `.fixed` captures, which
+        /// never promote. Go through `writeByte` if that ever stops being true.
         writer: *std.Io.Writer,
         backing: Backing,
         max_bytes: usize,
+
+        /// Allocator used to move the capture off the parser's inline
+        /// buffer once that buffer fills. Null pins the capture to the
+        /// inline buffer for its whole life: either it was requested
+        /// fixed, or no allocator was available to begin with.
+        alloc: ?Allocator,
 
         const Backing = union(enum) {
             fixed: std.Io.Writer,
@@ -634,22 +646,62 @@ pub const Parser = struct {
                 .backing = .{ .fixed = .fixed(buf) },
                 .writer = &new.*.?.backing.fixed,
                 .max_bytes = buf.len,
+                .alloc = null,
             };
         }
 
+        /// A capture that may grow up to max_bytes, but starts in the
+        /// parser's inline buffer and only reaches for the allocator when
+        /// that fills. Reserving up front instead would charge every OSC
+        /// that can grow the price of the rare one that does: the keys
+        /// that dominate this traffic are shell integration ones sent on
+        /// every prompt, tens of bytes each.
         pub inline fn allocating(
             new: *?Capture,
             alloc: Allocator,
+            buf: []u8,
             max_bytes: usize,
-        ) error{OutOfMemory}!void {
+        ) void {
             new.* = .{
-                .backing = .{ .allocating = try std.Io.Writer.Allocating.initCapacity(
-                    alloc,
-                    @min(MAX_BUF, max_bytes),
-                ) },
-                .writer = &new.*.?.backing.allocating.writer,
+                .backing = .{ .fixed = .fixed(buf) },
+                .writer = &new.*.?.backing.fixed,
                 .max_bytes = max_bytes,
+                .alloc = alloc,
             };
+        }
+
+        /// Move a capture that has filled the parser's inline buffer onto
+        /// the heap, copying what it holds so far. Safe against the buffer
+        /// it copies from: that memory belongs to the parser, not to the
+        /// backing union being overwritten here.
+        fn promote(self: *Capture, alloc: Allocator) error{WriteFailed}!void {
+            // Overwriting an allocating backing would drop its buffer on the
+            // floor without deinit. Unreachable from the one call site, and
+            // asserted rather than commented because the cost of it becoming
+            // reachable is a silent leak of up to max_bytes.
+            assert(self.backing == .fixed);
+
+            const buffered = self.writer.buffered();
+
+            // Callers reject the write before this point once max_bytes is
+            // reached, so max_bytes is strictly greater than what we hold and
+            // the capacity below always has room for it.
+            assert(self.max_bytes > buffered.len);
+            const capacity = @min(self.max_bytes, @max(buffered.len *| 2, 1));
+            var heap = std.Io.Writer.Allocating.initCapacity(
+                alloc,
+                capacity,
+            ) catch return error.WriteFailed;
+
+            // The memcpy needs the capacity, not max_bytes. Asserting the
+            // quantity the copy actually depends on: in ReleaseFast a broken
+            // invariant here is an out of bounds write, not a panic.
+            assert(heap.writer.buffer.len >= buffered.len);
+            @memcpy(heap.writer.buffer[0..buffered.len], buffered);
+            heap.writer.end = buffered.len;
+
+            self.backing = .{ .allocating = heap };
+            self.writer = &self.backing.allocating.writer;
         }
 
         /// Append one byte without permitting the backing allocation to grow
@@ -659,7 +711,17 @@ pub const Parser = struct {
             if (self.writer.buffered().len >= self.max_bytes) return error.WriteFailed;
 
             switch (self.backing) {
-                .fixed => {},
+                .fixed => {
+                    const w = &self.backing.fixed;
+                    if (w.end >= w.buffer.len) {
+                        // The inline buffer is full. A capture that may grow
+                        // moves to the heap here. One that may not falls
+                        // through to the writer and fails there, which is the
+                        // ceiling a fixed capture has always had.
+                        if (self.alloc) |alloc| try self.promote(alloc);
+                    }
+                },
+
                 .allocating => |*w| {
                     if (w.writer.end >= w.writer.buffer.len) {
                         const new_capacity = @min(
@@ -692,9 +754,10 @@ pub const Parser = struct {
     };
 
     /// Begin capturing trailing data. All inputs to next from this point
-    /// forward will be captured into the `self.capture.writer` buffer
-    /// which may be backed by either a fixed size or allocating buffer
-    /// depending on mode.
+    /// forward will be captured into the `self.capture.writer` buffer.
+    /// Both modes start in `self.buffer`; `.allocating` additionally
+    /// carries the allocator that lets it outgrow that buffer, while
+    /// `.fixed` stops there.
     ///
     /// Get the trailing data using `capture.trailing()`. Do not access
     /// the writer directly.
@@ -720,13 +783,9 @@ pub const Parser = struct {
                 Capture.allocating(
                     &self.capture,
                     alloc,
+                    &self.buffer,
                     self.max_allocating_bytes,
-                ) catch {
-                    // The allocator failed for some reason, fall back to a fixed buffer
-                    // and hope that it's big enough.
-                    self.captureTrailing(.fixed);
-                    return;
-                };
+                );
             },
         }
     }
@@ -750,8 +809,8 @@ pub const Parser = struct {
                 // budget looked exactly like one that was never sent.
                 error.WriteFailed => {
                     log.warn(
-                        "OSC sequence exceeded the capture limit and was dropped, state={s} captured={d}",
-                        .{ @tagName(self.state), cap.trailing().len },
+                        "OSC sequence was dropped, state={s} captured={d} limit={d}",
+                        .{ @tagName(self.state), cap.trailing().len, cap.max_bytes },
                     );
                     self.state = .invalid;
                 },
@@ -1109,5 +1168,126 @@ test "Parser allocating capture limit includes parser-added bytes" {
 
     const cap = &p.capture.?;
     try testing.expectEqual(@as(usize, 4), cap.trailing().len);
-    try testing.expectEqual(@as(usize, 4), cap.writer.buffer.len);
+
+    // A budget this small is exhausted long before the inline buffer is,
+    // so the bound is enforced without the capture ever reaching the heap.
+    try testing.expect(cap.backing == .fixed);
+}
+
+test "Parser allocating captures do not allocate below the inline buffer" {
+    const testing = std.testing;
+
+    // Nearly all of this traffic is short: shell integration keys emitted on
+    // every prompt, a drag-and-drop query, a clipboard write of a few words.
+    // Reserving for the rare image-sized payload charged all of them a malloc
+    // and a free apiece.
+    const inputs = [_][]const u8{
+        "52;c;YWJjZA==",
+        "66;s=2;hello",
+        "72;t=q",
+        "1337;CurrentDir=/home/user",
+        "5522;type=read:loc=primary",
+    };
+
+    for (inputs) |input| {
+        var failing: std.testing.FailingAllocator = .init(testing.allocator, .{});
+        var p: Parser = .init(failing.allocator());
+        defer p.deinit();
+
+        for (input) |ch| p.next(ch);
+        _ = p.end('\x1b');
+
+        // Both halves are load-bearing. The allocation count is the point of
+        // the change; `alloc != null` is what stops the test passing vacuously
+        // if one of these regressed to a plain fixed capture, which allocates
+        // nothing for a quite different reason.
+        try testing.expect(p.capture.?.backing == .fixed);
+        try testing.expect(p.capture.?.alloc != null);
+        try testing.expectEqual(@as(usize, 0), failing.allocations);
+    }
+}
+
+test "Parser allocating captures survive a failed promotion intact" {
+    const testing = std.testing;
+
+    // Fail the first allocation, which is the promotion itself: nothing before
+    // it allocates. The capture must be left exactly as it was, because
+    // promote mutates only after initCapacity has succeeded.
+    var failing: std.testing.FailingAllocator = .init(
+        testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    var p: Parser = .init(failing.allocator());
+    defer p.deinit();
+
+    for ("1337;") |ch| p.next(ch);
+    for (0..Parser.MAX_BUF + 1) |_| p.next('a');
+
+    // Dropped whole rather than truncated. A partial base64 payload reaching a
+    // decoder would be worse than no payload at all.
+    try testing.expect(p.state == .invalid);
+    try testing.expect(p.end('\x1b') == null);
+
+    const cap = &p.capture.?;
+    try testing.expect(cap.backing == .fixed);
+    try testing.expectEqual(@as(usize, Parser.MAX_BUF), cap.trailing().len);
+}
+
+test "Parser allocating captures reach the heap only once the inline buffer fills" {
+    const testing = std.testing;
+    const prefixes = [_][]const u8{ "52;", "66;", "72;", "1337;", "5522;" };
+
+    for (prefixes) |prefix| {
+        var failing: std.testing.FailingAllocator = .init(testing.allocator, .{});
+        var p: Parser = .init(failing.allocator());
+        defer p.deinit();
+
+        for (prefix) |ch| p.next(ch);
+        for (0..Parser.MAX_BUF) |_| p.next('a');
+
+        // Exactly full is still free. The byte after it is the seam.
+        const cap = &p.capture.?;
+        try testing.expectEqual(@as(usize, Parser.MAX_BUF), cap.trailing().len);
+        try testing.expect(cap.backing == .fixed);
+        try testing.expectEqual(@as(usize, 0), failing.allocations);
+
+        p.next('b');
+        try testing.expect(p.state != .invalid);
+        try testing.expect(cap.backing == .allocating);
+        try testing.expectEqual(@as(usize, 1), failing.allocations);
+
+        // The promotion copy must carry every byte across, in order.
+        const data = cap.trailing();
+        try testing.expectEqual(@as(usize, Parser.MAX_BUF + 1), data.len);
+        try testing.expect(mem.allEqual(u8, data[0..Parser.MAX_BUF], 'a'));
+        try testing.expectEqual(@as(u8, 'b'), data[Parser.MAX_BUF]);
+    }
+}
+
+test "Parser allocating captures truncate at the default ceiling" {
+    const testing = std.testing;
+
+    // Deliberately the real ceiling rather than a reduced one. The tests
+    // above prove the arithmetic at a cheap limit but say nothing about
+    // which limit production runs with.
+    var p: Parser = .init(testing.allocator);
+    defer p.deinit();
+    try testing.expectEqual(Parser.MAX_ALLOCATING_BUF, p.max_allocating_bytes);
+
+    const prefix = "File=inline=1:";
+    for ("1337;") |ch| p.next(ch);
+    for (prefix) |ch| p.next(ch);
+    for (0..Parser.MAX_ALLOCATING_BUF - prefix.len) |_| p.next('A');
+
+    const cap = &p.capture.?;
+    try testing.expectEqual(Parser.State.@"1337", p.state);
+    try testing.expectEqual(Parser.MAX_ALLOCATING_BUF, cap.trailing().len);
+
+    // One byte past the ceiling drops the sequence whole. next() warns about
+    // it because the symptom is otherwise silent: no command, no image, no
+    // error anywhere downstream.
+    p.next('A');
+    try testing.expectEqual(Parser.State.invalid, p.state);
+    try testing.expectEqual(Parser.MAX_ALLOCATING_BUF, cap.trailing().len);
+    try testing.expect(p.end('\x1b') == null);
 }

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -908,6 +908,20 @@ test "OSC: 1337: a File payload survives at any size an image needs" {
     try expectFilePayloadSurvives(alloc, alloc, 512 * 1024);
 }
 
+test "OSC: 1337: a File payload survives across the capture growth boundary" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // The capture starts in the parser's inline buffer and moves to the heap
+    // on the byte that overflows it, so that byte is where an off-by-one
+    // would land. The options block is captured too, and `parse` appends a
+    // NUL, so the seam sits below MAX_BUF by those amounts rather than at it.
+    const overhead = "File=inline=1:".len;
+    try expectFilePayloadSurvives(alloc, alloc, Parser.MAX_BUF - overhead - 1);
+    try expectFilePayloadSurvives(alloc, alloc, Parser.MAX_BUF - overhead);
+    try expectFilePayloadSurvives(alloc, alloc, Parser.MAX_BUF - overhead + 1);
+}
+
 test "OSC: 1337: without an allocator File= keeps the fixed-buffer ceiling" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
Closes # 681.

The allocating capture reserved `@min(MAX_BUF, max_bytes)` on entry, so every OSC that *can* grow paid for the rare one that *does*. OSC 1337 is mostly shell integration keys, `SetMark` and `CurrentDir` and friends, tens of bytes each and sent on every prompt; `File=` is the exception. That was a 2KB malloc and free per prompt for a buffer only images need.

The parser already carries an inline `buffer: [MAX_BUF]u8` that fixed captures write into for free. An allocating capture now starts there too and moves to the heap on the byte that overflows it. Short payloads allocate nothing; image payloads pay one promotion copy and then the existing bounded doubling.

This applies to all five allocating OSCs, not just 1337, because they all had the same eager reservation and all cleared the same safety check. OSC 52 was paying 2KB to carry a two word clipboard write.

The change hinged on whether starting in the shared inline buffer aliases anything, and it does not:

- The only writers of `Parser.buffer` in `src/terminal/` are the two Valgrind poisons in `init`/`reset`, both outside any active capture, and `captureTrailing` itself.
- OSC 1337 parses nothing before the capture opens. The `;` right after `1337` starts it, so `File=`, `MultipartFile=` and every key are captured, and `parsers/iterm2.zig` reads `cap.trailing()` afterwards. There is no slice held across a write.
- The other four allocating parsers have the same shape: write the NUL sentinel, then take `trailing()`, then slice.

Unchanged: the 8MB ceiling and its per byte enforcement, the overflow log, and `.fixed` semantics. The two modes stay distinct, carried by whether the capture holds an allocator. The old OOM fallback to a fixed buffer is gone because there is no eager allocation left to fail; a promotion that cannot allocate lands on `error.WriteFailed`, which is the ceiling a fixed capture always had.

Tests cover the thing that is otherwise invisible: a `FailingAllocator` proves a short sequence on all five prefixes performs zero allocations and stays on the fixed backing. `MAX_BUF` bytes still allocates nothing; one more byte allocates exactly once and the copy is verified byte for byte, which is where an off by one in the seam would land. `expectFilePayloadSurvives` gains five lengths around the boundary, including the case where the payload fills the inline buffer exactly and it is the parser's own NUL sentinel that triggers promotion.

One existing test changed meaning rather than behaviour. It asserted `cap.writer.buffer.len == 4` under `max_allocating_bytes = 4`, which was a claim about allocation size; with no allocation to size, that number is now 2048. It asserts `backing == .fixed` instead, which is the same invariant stated more strongly.

Full `zig build test` green, `zig fmt --check` clean on both files.
