### PR TITLE
terminal/kitty: lower the frame rate of a long GIF instead of cutting it short

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ default: test build-dll
 # === Testing ===
 
 # Run all Zig tests
-test: test-lib-vt test-full
+test: test-lib-vt test-full test-pkg
 
 # Test libghostty-vt (fastest feedback loop)
 test-lib-vt:
@@ -28,6 +28,20 @@ test-lib-vt:
 # Full Zig test suite
 test-full:
     zig build test -Dapp-runtime=none --summary all
+
+# Tests that live in the vendored packages rather than in src/.
+#
+# `zig build test` roots at src/main.zig and the packages under pkg/ are
+# separate builds, so nothing reachable from that root ever compiles their test
+# blocks. A wrong assertion in pkg/wuffs/src/gif.zig passes the whole suite
+# here. CI does run them, in the test-pkg-linux job, which is a required check,
+# so this closes a local gap rather than a total one.
+#
+# The list mirrors that job's matrix, which is only wuffs. Eight other packages
+# under pkg/ carry test blocks; why CI covers just this one is that job's
+# business, and duplicating a different list here would leave two to maintain.
+test-pkg:
+    cd pkg/wuffs && zig build test --summary all
 
 # Cross-platform sanity check (on demand)
 # Uses the cross-platform-test Claude Code skill for native SSH-based testing.

--- a/pkg/wuffs/src/gif.zig
+++ b/pkg/wuffs/src/gif.zig
@@ -9,31 +9,107 @@ const mul = std.math.mul;
 
 const log = std.log.scoped(.wuffs_gif);
 
-/// The largest number of frames decodeAnimated will compose from one GIF.
+/// The largest number of frames decodeAnimated will decode from one GIF.
+///
+/// Every frame is decoded and disposed whether or not it is kept, so this
+/// bounds decode time rather than memory. An upper bound and not the ceiling
+/// itself: maximum_decode_bytes lowers it as the canvas grows.
 pub const maximum_frames: usize = 1024;
+
+/// How many times a frame writes the whole canvas in the worst case: the
+/// snapshot before a restore-to-previous frame draws, the decode, the restore.
+/// Canvas-sized writes each decoded frame can cost: the decode itself, the
+/// restore-previous snapshot taken before it, the restore afterwards, and the
+/// dupe kept when the frame is retained. Not every frame pays all four, so
+/// this is the ceiling rather than the typical cost.
+const canvas_passes_per_frame: usize = 4;
+
+/// The most composition work decodeAnimated will do, counted in bytes written
+/// across the canvas.
+///
+/// Bounding the frame count bounds memory but not time: a file of a few tens
+/// of kilobytes can declare a huge canvas and a thousand one-pixel frames,
+/// which allocates almost nothing and touches hundreds of gigabytes. This is
+/// roughly a quarter of a second of memory traffic, about where the old
+/// budget/size frame ceiling put it before decimation took that bound away.
+///
+/// In bytes rather than frames, so the ceiling falls as the canvas grows: the
+/// full maximum_frames up to 256x256, 32 frames at 1080p, one frame at the
+/// storage budget. For a large canvas it binds well before the frame count, so
+/// a long large-canvas animation is still cut short, and decimation cannot
+/// help there: covering a whole loop means decoding every frame of it.
+///
+/// The floor of one frame is outside this budget: a single frame at the still
+/// ceiling costs four passes over 400MB whatever this says, because a file with
+/// one frame has to decode that frame. That is what the ceiling this replaced
+/// also did, so it is not a widening.
+pub const maximum_decode_bytes: usize = 1024 * 1024 * 1024;
 
 /// The largest canvas edge decodeAnimated will animate, matching the
 /// dimension the kitty layer accepts.
 ///
 /// Checked against the header before anything is allocated. A byte budget
-/// alone does not cover this: a canvas can satisfy any total while still
-/// being an absurd shape, and the layer that would reject the shape only
-/// looks after the decode is done.
+/// alone does not cover this: a canvas can satisfy any total while still being
+/// an absurd shape, and the layer that would reject the shape only looks once
+/// the decode is done.
 pub const maximum_dimension: u32 = 10000;
 
-/// The most memory decodeAnimated will commit to composed frames, and the
-/// largest canvas it will animate.
+/// The most memory decodeAnimated will commit to composed frames.
 ///
-/// Both bounds are needed and neither is redundant. A GIF states its canvas
-/// in four bytes and each frame costs width * height * 4 once composed, so
-/// bounding the frame count alone still lets a file a few tens of kilobytes
-/// long ask for terabytes. Every limit the caller applies, including the
-/// image storage limit, is checked against frames this function has already
-/// allocated, so the bound has to live here to be worth anything.
+/// A GIF states its canvas in four bytes and each frame costs
+/// width * height * 4 once composed, so a file a few tens of kilobytes long
+/// can ask for terabytes. Every limit the caller applies is checked against
+/// frames this function has already allocated, so the bound has to live here.
 ///
-/// Matched to the 400MB per-image ceiling the kitty layer enforces, so a
-/// still image that would have been accepted before is accepted now.
-pub const maximum_animation_bytes: usize = 400 * 1024 * 1024;
+/// Matched to the default kitty image storage limit, which is what animation
+/// frames are charged against, rather than to the larger per-image ceiling:
+/// budgeting past the storage limit only moves the truncation up a layer. The
+/// caller stays the final authority even so, because that limit is
+/// user-configurable and the store is shared with every other image, neither
+/// of which is visible from here. A store configured smaller, or busy with
+/// other images, can still refuse frames this decoded; a store configured
+/// larger just gets fewer frames than it could have held.
+pub const maximum_animation_bytes: usize = 320 * 1000 * 1000;
+
+/// The largest canvas decodeAnimated will decode at all.
+///
+/// Separate from the frame budget because they answer different questions.
+/// The frame budget says how many composed frames may be retained; this says
+/// how large one frame may be. Every GIF comes through here, so testing the
+/// frame budget alone would refuse a still image larger than it, which the
+/// layer above is willing to hold and which decoded fine before frames were
+/// budgeted at all.
+///
+/// Matched to the per-image ceiling that layer enforces, so this is never the
+/// binding limit in practice; it is here so that lowering the frame budget
+/// cannot silently narrow the still path with it.
+pub const maximum_still_bytes: usize = 400 * 1024 * 1024;
+
+comptime {
+    // A still is allowed to be larger than the whole frame budget, by the
+    // floor of one frame. The reverse would mean a canvas that fits the frame
+    // budget but is refused outright, which is never what is wanted.
+    std.debug.assert(maximum_still_bytes >= maximum_animation_bytes);
+}
+
+/// The bounds a decode runs within.
+///
+/// Separate from the constants above only so the tests can drive the
+/// decimation and both decode ceilings with a fixture that costs bytes rather
+/// than one that costs hundreds of megabytes.
+const Limits = struct {
+    /// The most memory committed to retained frames.
+    animation_bytes: usize = maximum_animation_bytes,
+
+    /// The most frames decoded, retained or not.
+    decode_limit: usize = maximum_frames,
+
+    /// The most bytes written across the canvas while decoding.
+    decode_bytes: usize = maximum_decode_bytes,
+
+    /// The largest canvas accepted at all, animated or not.
+    still_bytes: usize = maximum_still_bytes,
+};
 
 /// A decoded GIF animation. Every frame is composed to the full canvas, so
 /// any single frame can be displayed without replaying the ones before it.
@@ -41,7 +117,8 @@ pub const AnimatedImageData = struct {
     width: u32,
     height: u32,
 
-    /// The frames in display order, at least one.
+    /// The frames in display order, at least one. Not necessarily every
+    /// frame the file holds; see decodeAnimated.
     frames: []Frame,
 
     /// How many times the animation should play in total. Zero means play
@@ -58,11 +135,22 @@ pub const AnimatedImageData = struct {
         /// width * height * 4 bytes of RGBA.
         data: []u8,
 
-        /// The delay the file declares, in milliseconds. A declared zero is
-        /// reported as zero: what a zero delay ought to mean is a policy
-        /// question, and the answer differs between the GIF and kitty
-        /// models, so it belongs to the caller rather than here.
+        /// How long the frame is shown, in milliseconds. If the animation was
+        /// decimated this covers the frames it stands in for, which is what
+        /// keeps one loop the length the file asks for.
+        ///
+        /// A declared zero is reported as zero: what a zero delay ought to
+        /// mean differs between the GIF and kitty models, so the answer
+        /// belongs to the caller.
         delay_ms: u32,
+
+        /// How many of the frames this one stands in for declared no delay,
+        /// itself included.
+        ///
+        /// A caller that substitutes a gap for a zero delay needs the count,
+        /// because zero delays fold into zero: without it a decimated
+        /// animation gets one gap where the file asked for several.
+        zero_delay_frames: u32,
     };
 
     pub fn deinit(self: *AnimatedImageData, alloc: Allocator) void {
@@ -80,12 +168,22 @@ pub const AnimatedImageData = struct {
 /// area be restored afterwards. wuffs reports the rectangle, blend and
 /// disposal per frame but composes nothing across frames, so this keeps one
 /// canvas, decodes each frame into it, snapshots the result, and then applies
-/// the disposal the file asked for before moving on.
+/// the disposal the file asked for before moving on. Composing eagerly is what
+/// lets the caller treat frames as independent images.
 ///
-/// Composing eagerly is what lets the caller treat frames as independent
-/// images. It costs width * height * 4 per frame, which is the same shape the
-/// kitty animation model already stores.
+/// An animation whose frames do not all fit in maximum_animation_bytes is
+/// decimated, not cut short: every kth frame is kept and the delays in between
+/// are folded into it, so the caller gets the whole loop at a lower frame rate
+/// rather than the opening of it repeating forever.
 pub fn decodeAnimated(alloc: Allocator, data: []const u8) Error!AnimatedImageData {
+    return decodeAnimatedLimited(alloc, data, .{});
+}
+
+fn decodeAnimatedLimited(
+    alloc: Allocator,
+    data: []const u8,
+    limits: Limits,
+) Error!AnimatedImageData {
     const decoder_buf = try alloc.alloc(u8, c.sizeof__wuffs_gif__decoder());
     defer alloc.free(decoder_buf);
 
@@ -145,19 +243,37 @@ pub fn decodeAnimated(alloc: Allocator, data: []const u8) Error!AnimatedImageDat
         @sizeOf(c.wuffs_base__color_u32_argb_premul),
     );
 
-    if (size > maximum_animation_bytes) {
+    // Rejected against the still ceiling, not the frame budget. Every GIF comes
+    // through here now, including single-frame ones, so testing the frame
+    // budget would refuse a still image that the layer above is willing to hold
+    // and that decoded fine before there was a frame budget at all.
+    if (size > limits.still_bytes) {
         log.warn(
             "gif canvas {d} is larger than the maximum allowed ({d})",
-            .{ size, maximum_animation_bytes },
+            .{ size, limits.still_bytes },
         );
         return error.Overflow;
     }
 
-    // How many frames the budget affords. Checked before anything is
-    // allocated, because the canvas alone is already the size of one frame.
-    const frame_limit = @min(
-        maximum_frames,
-        @max(@as(usize, 1), maximum_animation_bytes / @max(size, 1)),
+    // How many composed frames the budget affords, computed before anything is
+    // allocated because the canvas alone is already one frame. The floor of one
+    // is what lets a still image larger than the frame budget through: that one
+    // frame is the image itself, charged as an image rather than as animation
+    // frames, and the layer above applies its own ceiling to it.
+    const frame_capacity = @max(
+        @as(usize, 1),
+        limits.animation_bytes / @max(size, 1),
+    );
+
+    // How many frames may be decoded at all. Storage is met by lowering the
+    // frame rate, which costs nothing in time; time can only be met by
+    // decoding fewer frames, so this is the one ceiling that still truncates.
+    const decode_ceiling = @min(
+        limits.decode_limit,
+        @max(
+            @as(usize, 1),
+            limits.decode_bytes / (@max(size, 1) * canvas_passes_per_frame),
+        ),
     );
 
     // The canvas every frame is decoded into and disposed from. Zeroed so
@@ -201,11 +317,17 @@ pub fn decodeAnimated(alloc: Allocator, data: []const u8) Error!AnimatedImageDat
         frames.deinit(alloc);
     }
 
-    // Whether the file ran out before the budget did, which is the only case
-    // where the caller is seeing the whole animation.
+    // Frames whose index is a multiple of this one are retained. It doubles
+    // whenever the retained set fills the budget, so it cannot be chosen up
+    // front: a GIF declares its frame count nowhere.
+    var stride: usize = 1;
+
+    // Whether the file ran out before the decode ceiling did, which is now
+    // the only case where frames are lost off the end.
     var complete = false;
 
-    while (frames.items.len < frame_limit) {
+    var index: usize = 0;
+    while (index < decode_ceiling) : (index += 1) {
         var frame_config: c.wuffs_base__frame_config = undefined;
         const status = c.wuffs_gif__decoder__decode_frame_config(
             decoder,
@@ -250,12 +372,43 @@ pub fn decodeAnimated(alloc: Allocator, data: []const u8) Error!AnimatedImageDat
             try check(log, &frame_status);
         }
 
-        const snapshot = try alloc.dupe(u8, canvas);
-        errdefer alloc.free(snapshot);
-        try frames.append(alloc, .{
-            .data = snapshot,
-            .delay_ms = flicksToMs(duration),
-        });
+        const keep = keep: {
+            if (index % stride != 0) break :keep false;
+            if (frames.items.len < frame_capacity) break :keep true;
+
+            // The budget is full and the file is not done, so halve what is
+            // retained and carry on at twice the stride. The frame in hand
+            // was on the old stride but may not be on the new one, so the
+            // test has to run again rather than being assumed.
+            decimate(alloc, &frames);
+            stride *= 2;
+            break :keep index % stride == 0 and frames.items.len < frame_capacity;
+        };
+
+        // The retained delays always sum to the delays of every frame decoded
+        // so far, so one loop still takes the time the file asks for. A frame
+        // that is not retained shows as the retained frame before it staying
+        // up for longer, which is where its delay goes. Folding into the next
+        // retained frame instead would hold the same total but start every
+        // retained frame early by the delays it absorbed.
+        const delay_ms = flicksToMs(duration);
+        if (keep) {
+            const snapshot = try alloc.dupe(u8, canvas);
+            errdefer alloc.free(snapshot);
+            try frames.append(alloc, .{
+                .data = snapshot,
+                .delay_ms = delay_ms,
+                .zero_delay_frames = @intFromBool(delay_ms == 0),
+            });
+        } else {
+            // Index zero is a multiple of every stride and arrives to an empty
+            // list, so it is always retained and there is always a frame here
+            // to fold into. Saturating, because a total past 49 days does not
+            // fit in the u32 a frame carries.
+            const last = &frames.items[frames.items.len - 1];
+            last.delay_ms +|= delay_ms;
+            if (delay_ms == 0) last.zero_delay_frames +|= 1;
+        }
 
         switch (disposal) {
             c.WUFFS_BASE__ANIMATION_DISPOSAL__RESTORE_BACKGROUND => clearRect(
@@ -277,8 +430,14 @@ pub fn decodeAnimated(alloc: Allocator, data: []const u8) Error!AnimatedImageDat
     }
     if (!complete) {
         log.warn(
-            "gif stopped at {d} frames ({d} bytes); the rest are dropped",
-            .{ frames.items.len, frames.items.len * size },
+            "gif stopped at the {d} frame decode ceiling; the rest are dropped",
+            .{decode_ceiling},
+        );
+    }
+    if (stride > 1) {
+        log.info(
+            "gif animation reduced to one frame in {d} ({d} of {d}) to fit {d} bytes",
+            .{ stride, frames.items.len, index, limits.animation_bytes },
         );
     }
 
@@ -288,6 +447,36 @@ pub fn decodeAnimated(alloc: Allocator, data: []const u8) Error!AnimatedImageDat
         .frames = try frames.toOwnedSlice(alloc),
         .loop_count = c.wuffs_gif__decoder__num_animation_loops(decoder),
     };
+}
+
+/// Halve the retained frames in place, folding each dropped frame's delay
+/// into the frame that now stands in for it.
+///
+/// Every odd position is freed and its delay added to the even position
+/// before it. An odd count leaves its last frame alone: that frame sits at an
+/// even position, so the retained set stays exactly the frames whose index is
+/// a multiple of the doubled stride, with no gap in the middle.
+///
+/// The write cursor never passes the read cursor, so no buffer is ever owned
+/// by two entries, and shrinking at the end keeps the caller's errdefer off
+/// freed pointers.
+fn decimate(
+    alloc: Allocator,
+    frames: *std.ArrayListUnmanaged(AnimatedImageData.Frame),
+) void {
+    var kept: usize = 0;
+    var i: usize = 0;
+    while (i < frames.items.len) : (i += 2) {
+        var frame = frames.items[i];
+        if (i + 1 < frames.items.len) {
+            frame.delay_ms +|= frames.items[i + 1].delay_ms;
+            frame.zero_delay_frames +|= frames.items[i + 1].zero_delay_frames;
+            alloc.free(frames.items[i + 1].data);
+        }
+        frames.items[kept] = frame;
+        kept += 1;
+    }
+    frames.shrinkRetainingCapacity(kept);
 }
 
 /// Zero the frame's rectangle, which is what restore-to-background means for
@@ -310,8 +499,7 @@ fn clearRect(
 /// wuffs reports durations in flicks. Truncating toward zero matches the
 /// centisecond granularity GIF actually stores.
 fn flicksToMs(duration: c.wuffs_base__flicks) u32 {
-    // Flicks are signed. GIF never yields a negative duration, but clamping
-    // costs nothing and is better than aborting if one ever appears.
+    // Flicks are signed, and clamping a negative one costs nothing.
     const ticks: u64 = @intCast(@max(duration, 0));
     const ms = ticks / (c.WUFFS_BASE__FLICKS_PER_SECOND / 1000);
     return std.math.cast(u32, ms) orelse std.math.maxInt(u32);
@@ -488,6 +676,7 @@ test "gif animated: frames, delays and loop count" {
     // display any of them without knowing about the others.
     for (anim.frames) |frame| {
         try std.testing.expectEqual(@as(usize, 2 * 2 * 4), frame.data.len);
+        try std.testing.expectEqual(@as(u32, 0), frame.zero_delay_frames);
     }
 
     // Solid red, then green, then blue.
@@ -511,9 +700,8 @@ test "gif animated: a finite loop count counts total plays" {
 
 test "gif animated: a zero delay is reported as zero" {
     // The decoder stays faithful to the file. Substituting a default gap is
-    // the caller's decision, because zero has a meaning in the kitty
-    // animation model (gapless, skipped during playback) that a GIF frame
-    // never intends.
+    // the caller's decision, because zero means gapless in the kitty animation
+    // model, which a GIF frame never intends.
     const alloc = std.testing.allocator;
     var anim = try decodeAnimated(alloc, @embedFile("anim-nodelay.gif"));
     defer anim.deinit(alloc);
@@ -521,9 +709,14 @@ test "gif animated: a zero delay is reported as zero" {
     try std.testing.expectEqual(@as(usize, 2), anim.frames.len);
     try std.testing.expectEqual(@as(u32, 0), anim.frames[0].delay_ms);
     try std.testing.expectEqual(@as(u32, 0), anim.frames[1].delay_ms);
+    try std.testing.expectEqual(@as(u32, 1), anim.frames[0].zero_delay_frames);
+    try std.testing.expectEqual(@as(u32, 1), anim.frames[1].zero_delay_frames);
 }
 
-test "gif animated: disposal composes each frame onto the canvas" {
+test "gif animated: a file from a real encoder decodes to distinct frames" {
+    // Every frame of this fixture overwrites the whole canvas opaquely, so it
+    // says nothing about composition. What it covers is bytes a real encoder
+    // produced rather than the ones testGif writes.
     const alloc = std.testing.allocator;
     var anim = try decodeAnimated(alloc, @embedFile("anim-dispose.gif"));
     defer anim.deinit(alloc);
@@ -535,30 +728,65 @@ test "gif animated: disposal composes each frame onto the canvas" {
         try std.testing.expectEqual(@as(usize, 4 * 4 * 4), frame.data.len);
     }
 
-    // The frames differ from one another; a composer that returned the same
-    // canvas for every frame, or that never advanced, would pass the length
-    // checks above but not this.
     try std.testing.expect(!std.mem.eql(u8, anim.frames[0].data, anim.frames[1].data));
     try std.testing.expect(!std.mem.eql(u8, anim.frames[1].data, anim.frames[2].data));
 }
 
-test "gif animated: an absurd canvas is rejected from the header" {
-    // A GIF89a header declaring a 30000x30000 logical screen, then nothing.
-    // The canvas is four bytes of the file, so this is the cheap way to ask
-    // for 3.6GB; it has to be refused before anything is allocated.
+test "gif animated: an absurd canvas shape is rejected from the header" {
+    // A GIF89a header declaring a 20000x1 logical screen, then nothing. That
+    // is 80KB composed, inside every byte budget, so only the dimension check
+    // can refuse it.
     const header = [_]u8{
         'G', 'I', 'F', '8', '9', 'a',
-        0x30, 0x75, // width 30000
-        0x30, 0x75, // height 30000
+        0x20, 0x4e, // width 20000
+        0x01, 0x00, // height 1
         0x00, 0x00,
         0x00,
-        0x3B, // trailer
+        0x3b, // trailer
     };
 
     try std.testing.expectError(
         error.Overflow,
         decodeAnimated(std.testing.allocator, &header),
     );
+}
+
+test "gif animated: a canvas past the still ceiling is rejected from the header" {
+    // The canvas is four bytes of the file, so an oversized one has to be
+    // refused before anything is allocated. Driven through the limit rather
+    // than through a large header because the dimension check binds first for
+    // every canvas the production ceiling would reject: 10000x10000, the
+    // largest shape that check allows, composes to just under it.
+    const header = [_]u8{
+        'G', 'I', 'F', '8', '9', 'a',
+        0x10, 0x27, // width 10000
+        0x10, 0x27, // height 10000
+        0x00, 0x00,
+        0x00,
+        0x3b, // trailer
+    };
+
+    try std.testing.expectError(error.Overflow, decodeAnimatedLimited(
+        std.testing.allocator,
+        &header,
+        .{ .still_bytes = 400 * 1000 * 1000 - 1 },
+    ));
+}
+
+test "gif animated: a still larger than the frame budget still decodes" {
+    // Every GIF routes through this decoder, so the frame budget must not be
+    // what decides whether a single-frame image is accepted. One frame past
+    // that budget is the image itself, and the layer above charges it as an
+    // image and applies its own ceiling.
+    const alloc = std.testing.allocator;
+    const data = try testAnimation(alloc, &[_]u16{10});
+    defer alloc.free(data);
+
+    // A 2x2 canvas is 16 bytes; a budget of 1 cannot hold a single frame.
+    var anim = try decodeAnimatedLimited(alloc, data, .{ .animation_bytes = 1 });
+    defer anim.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), anim.frames.len);
 }
 
 test "gif animated: a single-frame gif yields one frame" {
@@ -568,6 +796,618 @@ test "gif animated: a single-frame gif yields one frame" {
 
     try std.testing.expectEqual(@as(usize, 1), anim.frames.len);
     try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0, 255 }, anim.frames[0].data);
+}
+
+/// The colour table the generated fixtures use. Eight entries, so a frame can
+/// name a colour and still have a spare index to declare transparent.
+const test_palette = [_]u8{
+    0xff, 0x00, 0x00, // 0 red
+    0x00, 0xff, 0x00, // 1 green
+    0x00, 0x00, 0xff, // 2 blue
+    0xff, 0xff, 0xff, // 3 white
+    0xff, 0xff, 0x00, // 4 yellow
+    0x00, 0xff, 0xff, // 5 cyan
+    0xff, 0x00, 0xff, // 6 magenta
+    0x00, 0x00, 0x00, // 7 the entry frames declare transparent
+};
+
+/// One frame of a generated fixture, in colour table indices.
+const TestFrame = struct {
+    /// The delay in centiseconds, which is the unit GIF stores.
+    delay_cs: u16 = 0,
+
+    /// GIF disposal method: 1 leaves the canvas alone, 2 restores the
+    /// background, 3 restores what was under the frame before it drew.
+    disposal: u3 = 1,
+
+    /// The colour table entry that is transparent, or null for an opaque
+    /// frame. An opaque frame overwrites its rectangle; a transparent one
+    /// blends over whatever is under it.
+    transparent: ?u8 = null,
+
+    left: u16 = 0,
+    top: u16 = 0,
+    width: u16,
+    height: u16,
+
+    /// One colour table index per pixel, row major, width * height long.
+    pixels: []const u8,
+
+    /// A local colour table shaped like test_palette, or null to use the
+    /// global one.
+    palette: ?[]const u8 = null,
+};
+
+fn appendU16(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    value: u16,
+) Allocator.Error!void {
+    try out.append(alloc, @as(u8, @truncate(value)));
+    try out.append(alloc, @as(u8, @intCast(value >> 8)));
+}
+
+/// Append a frame's image data, coded as literals so no compressor is needed:
+/// a clear code, one nine bit code per pixel, then end of information. A
+/// minimum code size of eight keeps every code nine bits wide until 254 more
+/// have been added to the table, which no fixture here comes near.
+fn appendImageData(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    pixels: []const u8,
+) Allocator.Error!void {
+    try out.append(alloc, 8);
+
+    var data: std.ArrayListUnmanaged(u8) = .empty;
+    defer data.deinit(alloc);
+
+    const Packer = struct {
+        alloc: Allocator,
+        data: *std.ArrayListUnmanaged(u8),
+        acc: u32 = 0,
+        bits: u5 = 0,
+
+        fn push(self: *@This(), code: u16) Allocator.Error!void {
+            self.acc |= @as(u32, code) << self.bits;
+            self.bits += 9;
+            while (self.bits >= 8) {
+                try self.data.append(self.alloc, @as(u8, @truncate(self.acc)));
+                self.acc >>= 8;
+                self.bits -= 8;
+            }
+        }
+
+        fn flush(self: *@This()) Allocator.Error!void {
+            if (self.bits > 0) {
+                try self.data.append(self.alloc, @as(u8, @truncate(self.acc)));
+            }
+        }
+    };
+
+    var packer: Packer = .{ .alloc = alloc, .data = &data };
+    try packer.push(256);
+    for (pixels) |pixel| try packer.push(pixel);
+    try packer.push(257);
+    try packer.flush();
+
+    var i: usize = 0;
+    while (i < data.items.len) {
+        const len = @min(@as(usize, 255), data.items.len - i);
+        try out.append(alloc, @as(u8, @intCast(len)));
+        try out.appendSlice(alloc, data.items[i..][0..len]);
+        i += len;
+    }
+    try out.append(alloc, 0x00);
+}
+
+/// Build a GIF from frames described in colour table indices.
+///
+/// The checked-in fixtures are three frames that each overwrite the whole
+/// canvas, which is neither long enough to watch the retained set halve nor
+/// dependent enough to tell a composed canvas from a fresh one.
+fn testGif(
+    alloc: Allocator,
+    width: u16,
+    height: u16,
+    frames: []const TestFrame,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(alloc);
+
+    // Header and logical screen, with an eight entry global colour table,
+    // background index zero and square pixels.
+    try out.appendSlice(alloc, "GIF89a");
+    try appendU16(alloc, &out, width);
+    try appendU16(alloc, &out, height);
+    try out.appendSlice(alloc, "\x82\x00\x00");
+    try out.appendSlice(alloc, &test_palette);
+
+    // NETSCAPE, zero repeats, which means loop forever.
+    try out.appendSlice(alloc, "\x21\xff\x0bNETSCAPE2.0\x03\x01\x00\x00\x00");
+
+    for (frames) |frame| {
+        // Graphic control: disposal, transparency and delay.
+        try out.appendSlice(alloc, "\x21\xf9\x04");
+        try out.append(alloc, (@as(u8, frame.disposal) << 2) |
+            @as(u8, @intFromBool(frame.transparent != null)));
+        try appendU16(alloc, &out, frame.delay_cs);
+        try out.append(alloc, frame.transparent orelse 0);
+        try out.append(alloc, 0x00);
+
+        // Image descriptor, with a local colour table only where the frame
+        // asked for one.
+        try out.append(alloc, 0x2c);
+        try appendU16(alloc, &out, frame.left);
+        try appendU16(alloc, &out, frame.top);
+        try appendU16(alloc, &out, frame.width);
+        try appendU16(alloc, &out, frame.height);
+        if (frame.palette) |palette| {
+            try out.append(alloc, 0x82);
+            try out.appendSlice(alloc, palette);
+        } else {
+            try out.append(alloc, 0x00);
+        }
+
+        try appendImageData(alloc, &out, frame.pixels);
+    }
+
+    try out.append(alloc, 0x3b);
+    return out.toOwnedSlice(alloc);
+}
+
+/// Write the RGBA bytes a canvas of these colour table indices decodes to.
+/// Null is a pixel no frame ever painted, which stays transparent.
+fn testCanvas(indices: []const ?u8, out: []u8) void {
+    for (indices, 0..) |index, i| {
+        const pixel = out[i * 4 ..][0..4];
+        if (index) |entry| {
+            @memcpy(pixel[0..3], test_palette[@as(usize, entry) * 3 ..][0..3]);
+            pixel[3] = 0xff;
+        } else {
+            @memset(pixel, 0);
+        }
+    }
+}
+
+/// Build a GIF of one 2x2 frame per entry in `delays_cs`, each frame a flat
+/// shade of its own so a test can name the frames that were kept.
+fn testAnimation(alloc: Allocator, delays_cs: []const u16) ![]u8 {
+    const flat = [_]u8{ 0, 0, 0, 0 };
+
+    const palettes = try alloc.alloc([test_palette.len]u8, delays_cs.len);
+    defer alloc.free(palettes);
+
+    const frames = try alloc.alloc(TestFrame, delays_cs.len);
+    defer alloc.free(frames);
+
+    for (delays_cs, palettes, frames, 0..) |delay, *palette, *frame, i| {
+        // All four pixels use entry zero, so the frame is a flat shade the
+        // tests can name: the shade is the frame's own number, one based.
+        palette.* = test_palette;
+        const shade: u8 = @intCast(i + 1);
+        palette[0] = shade;
+        palette[1] = shade;
+        palette[2] = shade;
+
+        frame.* = .{
+            .width = 2,
+            .height = 2,
+            .pixels = &flat,
+            .delay_cs = delay,
+            .palette = palette,
+        };
+    }
+
+    return testGif(alloc, 2, 2, frames);
+}
+
+/// Sixteen frame delays a centisecond apart, which GIF stores exactly and
+/// which decode to 10, 20 ... 160ms, or 1360ms for a whole loop. Distinct
+/// values, so a fold that dropped or double counted one would show up in the
+/// total.
+fn testRampDelays() [16]u16 {
+    var delays: [16]u16 = undefined;
+    for (&delays, 0..) |*delay, i| delay.* = @intCast(i + 1);
+    return delays;
+}
+
+/// Five frames of a 4x4 canvas, two of which restore what was under them.
+/// Every frame's correct pixels depend on the frames before it, so a decode
+/// that skipped one frame's composition, its snapshot or its restore comes out
+/// different from that point on.
+fn testRestorePreviousGif(alloc: Allocator) ![]u8 {
+    const red_canvas = [_]u8{0} ** 16;
+    const blue_square = [_]u8{2} ** 4;
+    const green_row = [_]u8{1} ** 4;
+    const yellow_square = [_]u8{4} ** 4;
+    const cyan_square = [_]u8{5} ** 4;
+
+    return testGif(alloc, 4, 4, &.{
+        .{ .width = 4, .height = 4, .pixels = &red_canvas, .delay_cs = 10 },
+        .{
+            .width = 2,
+            .height = 2,
+            .pixels = &blue_square,
+            .disposal = 3,
+            .delay_cs = 20,
+        },
+        .{ .width = 4, .height = 1, .pixels = &green_row, .delay_cs = 30 },
+        .{
+            .left = 1,
+            .top = 1,
+            .width = 2,
+            .height = 2,
+            .pixels = &yellow_square,
+            .disposal = 3,
+            .delay_cs = 40,
+        },
+        .{
+            .left = 2,
+            .top = 2,
+            .width = 2,
+            .height = 2,
+            .pixels = &cyan_square,
+            .delay_cs = 50,
+        },
+    });
+}
+
+test "gif animated: frames compose onto one canvas" {
+    // Partial rectangles, a transparent index and a restore-to-background
+    // disposal, so a decode that started each frame from a fresh canvas, that
+    // overwrote where it should have blended, or that skipped the disposal
+    // produces different pixels here.
+    const alloc = std.testing.allocator;
+
+    const red_canvas = [_]u8{0} ** 16;
+    const green_square = [_]u8{1} ** 4;
+    const blue_checker = [_]u8{ 2, 7, 7, 2 };
+    const yellow_square = [_]u8{4} ** 4;
+    const cyan_pixel = [_]u8{ 7, 7, 7, 5 } ++ ([_]u8{7} ** 12);
+
+    const data = try testGif(alloc, 4, 4, &.{
+        .{ .width = 4, .height = 4, .pixels = &red_canvas, .delay_cs = 10 },
+        .{
+            .left = 1,
+            .top = 1,
+            .width = 2,
+            .height = 2,
+            .pixels = &green_square,
+            .delay_cs = 20,
+        },
+        .{
+            .width = 2,
+            .height = 2,
+            .pixels = &blue_checker,
+            .transparent = 7,
+            .disposal = 2,
+            .delay_cs = 30,
+        },
+        .{
+            .left = 2,
+            .top = 2,
+            .width = 2,
+            .height = 2,
+            .pixels = &yellow_square,
+            .delay_cs = 40,
+        },
+        .{
+            .width = 4,
+            .height = 4,
+            .pixels = &cyan_pixel,
+            .transparent = 7,
+            .delay_cs = 50,
+        },
+    });
+    defer alloc.free(data);
+
+    var anim = try decodeAnimated(alloc, data);
+    defer anim.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 5), anim.frames.len);
+
+    var expected: [4 * 4 * 4]u8 = undefined;
+
+    // Green over the middle of the red canvas, so the ring of red around it
+    // can only have come from the frame before.
+    const frame_two = [_]?u8{ 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0 };
+    testCanvas(&frame_two, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[1].data);
+
+    // Two blue pixels and two transparent ones over the top left corner: the
+    // transparent pair leaves the red and green underneath showing.
+    const frame_three = [_]?u8{ 2, 0, 0, 0, 0, 2, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0 };
+    testCanvas(&frame_three, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[2].data);
+
+    // That frame asked for its rectangle to go back to the background, which
+    // leaves those four pixels transparent under the yellow square.
+    const frame_four = [_]?u8{ null, null, 0, 0, null, null, 1, 0, 0, 1, 4, 4, 0, 0, 4, 4 };
+    testCanvas(&frame_four, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[3].data);
+
+    // The last frame is transparent but for one pixel, so it is the canvas as
+    // it stood with a single cyan pixel painted into it.
+    const frame_five = [_]?u8{ null, null, 0, 5, null, null, 1, 0, 0, 1, 4, 4, 0, 0, 4, 4 };
+    testCanvas(&frame_five, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[4].data);
+}
+
+test "gif animated: restore to previous is undone before the next frame" {
+    // The snapshot has to be taken before the frame draws and put back after
+    // it, or the frames that follow inherit pixels the file never meant to
+    // keep. No checked-in fixture asks for this disposal at all.
+    const alloc = std.testing.allocator;
+    const data = try testRestorePreviousGif(alloc);
+    defer alloc.free(data);
+
+    var anim = try decodeAnimated(alloc, data);
+    defer anim.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 5), anim.frames.len);
+
+    var expected: [4 * 4 * 4]u8 = undefined;
+
+    // The frame itself is still composed onto the canvas.
+    const frame_two = [_]?u8{ 2, 2, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    testCanvas(&frame_two, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[1].data);
+
+    // And gone by the next one, which paints its row onto the canvas as it
+    // stood before the blue square drew.
+    const frame_three = [_]?u8{ 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    testCanvas(&frame_three, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[2].data);
+
+    const frame_four = [_]?u8{ 1, 1, 1, 1, 0, 4, 4, 0, 0, 4, 4, 0, 0, 0, 0, 0 };
+    testCanvas(&frame_four, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[3].data);
+
+    // The second restore has to put back the green row, which is what was
+    // under that frame, and not the all red canvas the first restore saved.
+    const frame_five = [_]?u8{ 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 5, 5, 0, 0, 5, 5 };
+    testCanvas(&frame_five, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, anim.frames[4].data);
+}
+
+test "gif animated: decimation preserves the total duration" {
+    const alloc = std.testing.allocator;
+    const delays = testRampDelays();
+    const data = try testAnimation(alloc, &delays);
+    defer alloc.free(data);
+
+    // Room for four frames against sixteen, so the retained set halves
+    // twice on the way through.
+    var anim = try decodeAnimatedLimited(alloc, data, .{
+        .animation_bytes = 4 * 2 * 2 * 4,
+    });
+    defer anim.deinit(alloc);
+
+    var total: u32 = 0;
+    for (anim.frames) |frame| total += frame.delay_ms;
+
+    // One loop takes as long as the file asks for. Truncating to the first
+    // four frames would leave 100ms of the 1360.
+    try std.testing.expectEqual(@as(u32, 1360), total);
+
+    // And the memory is inside the budget it was decimated to fit.
+    try std.testing.expect(anim.frames.len * 2 * 2 * 4 <= 4 * 2 * 2 * 4);
+}
+
+test "gif animated: decimation covers the animation end to end" {
+    const alloc = std.testing.allocator;
+    const delays = testRampDelays();
+    const data = try testAnimation(alloc, &delays);
+    defer alloc.free(data);
+
+    var anim = try decodeAnimatedLimited(alloc, data, .{
+        .animation_bytes = 4 * 2 * 2 * 4,
+    });
+    defer anim.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 4), anim.frames.len);
+
+    // Frames 1, 5, 9 and 13 of the sixteen, by the shade each carries. The
+    // first frame is still the first frame, which the kitty layer relies on
+    // when it peels it off to use as the image; the last is within one
+    // stride of the end rather than a quarter of the way in.
+    const shades = [_]u8{ 1, 5, 9, 13 };
+    for (anim.frames, &shades) |frame, shade| {
+        try std.testing.expectEqualSlices(
+            u8,
+            &[_]u8{ shade, shade, shade, 255 },
+            frame.data[0..4],
+        );
+    }
+
+    // Each retained frame carries the delays of the three it stands in for,
+    // so it comes up at the moment it would have without decimation.
+    const expected = [_]u32{ 100, 260, 420, 580 };
+    for (anim.frames, &expected) |frame, delay_ms| {
+        try std.testing.expectEqual(delay_ms, frame.delay_ms);
+    }
+}
+
+test "gif animated: halving an odd count carries the last frame forward" {
+    // A retained set of three halves to the first and the third, which is the
+    // only branch of decimate no other test reaches: every other one starts
+    // from an even count.
+    const alloc = std.testing.allocator;
+    const delays = testRampDelays();
+    const data = try testAnimation(alloc, &delays);
+    defer alloc.free(data);
+
+    // Room for three frames against sixteen, so every halving runs on an odd
+    // count.
+    var anim = try decodeAnimatedLimited(alloc, data, .{
+        .animation_bytes = 3 * 2 * 2 * 4,
+    });
+    defer anim.deinit(alloc);
+
+    // Frames 1 and 9 of the sixteen, holding the delays of frames 1 to 8 and 9
+    // to 16. A halving that folded the odd last frame into the one before it
+    // instead would retain frames 1, 9 and 13, at the same total duration.
+    try std.testing.expectEqual(@as(usize, 2), anim.frames.len);
+    const shades = [_]u8{ 1, 9 };
+    for (anim.frames, &shades) |frame, shade| {
+        try std.testing.expectEqualSlices(
+            u8,
+            &[_]u8{ shade, shade, shade, 255 },
+            frame.data[0..4],
+        );
+    }
+    try std.testing.expectEqual(@as(u32, 360), anim.frames[0].delay_ms);
+    try std.testing.expectEqual(@as(u32, 1000), anim.frames[1].delay_ms);
+}
+
+test "gif animated: a budget of one frame still spans the whole loop" {
+    // A single frame fills the budget on its own, so nothing but the first
+    // frame survives and it holds the whole duration: a still image shown for
+    // the length of the animation rather than a fragment looping fast.
+    const alloc = std.testing.allocator;
+    const delays = testRampDelays();
+    const data = try testAnimation(alloc, &delays);
+    defer alloc.free(data);
+
+    var anim = try decodeAnimatedLimited(alloc, data, .{
+        .animation_bytes = 2 * 2 * 4,
+    });
+    defer anim.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), anim.frames.len);
+    try std.testing.expectEqual(@as(u32, 1360), anim.frames[0].delay_ms);
+    try std.testing.expectEqualSlices(
+        u8,
+        &.{ 1, 1, 1, 255 },
+        anim.frames[0].data[0..4],
+    );
+}
+
+test "gif animated: an animation inside the budget is untouched" {
+    const alloc = std.testing.allocator;
+    const data = @embedFile("anim3.gif");
+
+    var full = try decodeAnimated(alloc, data);
+    defer full.deinit(alloc);
+
+    // Exactly enough room for all three frames. Decimating one step early
+    // would halve an animation that fits.
+    var fitted = try decodeAnimatedLimited(alloc, data, .{
+        .animation_bytes = 3 * 2 * 2 * 4,
+    });
+    defer fitted.deinit(alloc);
+
+    try std.testing.expectEqual(full.frames.len, fitted.frames.len);
+    for (full.frames, fitted.frames) |expected, actual| {
+        try std.testing.expectEqual(expected.delay_ms, actual.delay_ms);
+        try std.testing.expectEqualSlices(u8, expected.data, actual.data);
+    }
+}
+
+test "gif animated: a skipped frame is still composed and disposed" {
+    // Decimation skips the snapshot and nothing else: the frame is still
+    // decoded and disposed, so a retained frame has to come out byte for byte
+    // the same as it does when nothing is dropped.
+    const alloc = std.testing.allocator;
+    const data = try testRestorePreviousGif(alloc);
+    defer alloc.free(data);
+
+    var full = try decodeAnimated(alloc, data);
+    defer full.deinit(alloc);
+
+    // Room for two of the five frames. The set halves at index two and again
+    // at index four, so index three arrives at a stride of two: skipped
+    // outright rather than retained and dropped later.
+    var fitted = try decodeAnimatedLimited(alloc, data, .{
+        .animation_bytes = 2 * 4 * 4 * 4,
+    });
+    defer fitted.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 5), full.frames.len);
+    try std.testing.expectEqual(@as(usize, 2), fitted.frames.len);
+    try std.testing.expectEqualSlices(
+        u8,
+        full.frames[0].data,
+        fitted.frames[0].data,
+    );
+    try std.testing.expectEqualSlices(
+        u8,
+        full.frames[4].data,
+        fitted.frames[1].data,
+    );
+
+    // The dropped delays went to the frame left on screen in their place.
+    try std.testing.expectEqual(
+        @as(u32, 100 + 200 + 300 + 400),
+        fitted.frames[0].delay_ms,
+    );
+    try std.testing.expectEqual(@as(u32, 500), fitted.frames[1].delay_ms);
+}
+
+test "gif animated: decimating zero delays keeps the loop the same length" {
+    // Zero delays fold into zero, so the count is the only thing stopping a
+    // caller substituting a single gap where the file asked for four.
+    const alloc = std.testing.allocator;
+    const delays = [_]u16{0} ** 16;
+    const data = try testAnimation(alloc, &delays);
+    defer alloc.free(data);
+
+    var anim = try decodeAnimatedLimited(alloc, data, .{
+        .animation_bytes = 4 * 2 * 2 * 4,
+    });
+    defer anim.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 4), anim.frames.len);
+    for (anim.frames) |frame| {
+        try std.testing.expectEqual(@as(u32, 0), frame.delay_ms);
+        try std.testing.expectEqual(@as(u32, 4), frame.zero_delay_frames);
+    }
+}
+
+test "gif animated: the decode ceiling still truncates" {
+    // Decimation answers the byte budget, so the decode ceiling is the one
+    // bound that can still cost frames off the end. It also logs, which this
+    // cannot observe.
+    const alloc = std.testing.allocator;
+    const delays = testRampDelays();
+    const data = try testAnimation(alloc, &delays);
+    defer alloc.free(data);
+
+    var anim = try decodeAnimatedLimited(alloc, data, .{ .decode_limit = 3 });
+    defer anim.deinit(alloc);
+
+    // The frames that were decoded are untouched: the byte budget was never
+    // the constraint, so nothing was folded into anything.
+    try std.testing.expectEqual(@as(usize, 3), anim.frames.len);
+    try std.testing.expectEqual(@as(u32, 10), anim.frames[0].delay_ms);
+    try std.testing.expectEqual(@as(u32, 20), anim.frames[1].delay_ms);
+    try std.testing.expectEqual(@as(u32, 30), anim.frames[2].delay_ms);
+}
+
+test "gif animated: the decode ceiling counts every pass over the canvas" {
+    // The budget below is four frames of a 2x2 canvas at four passes each, so
+    // a ceiling counting one pass per frame would decode sixteen and one
+    // counting three would decode five.
+    const alloc = std.testing.allocator;
+    const delays = testRampDelays();
+    const data = try testAnimation(alloc, &delays);
+    defer alloc.free(data);
+
+    var anim = try decodeAnimatedLimited(alloc, data, .{
+        .decode_bytes = 4 * 2 * 2 * 4 * canvas_passes_per_frame,
+    });
+    defer anim.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 4), anim.frames.len);
+    try std.testing.expectEqual(@as(u32, 10), anim.frames[0].delay_ms);
+    try std.testing.expectEqual(@as(u32, 40), anim.frames[3].delay_ms);
+
+    // A budget too small for a single frame still decodes one. A file with one
+    // frame has to decode that frame, so the floor sits outside this budget and
+    // is bounded by the still ceiling instead.
+    var one = try decodeAnimatedLimited(alloc, data, .{ .decode_bytes = 1 });
+    defer one.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), one.frames.len);
 }
 
 test "gif_decode_000000" {

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -1152,7 +1152,7 @@ fn attachGifAnimation(
         // is already the right size and the decoder is done with it.
         anim.frames.append(alloc, .{
             .data = frame.data,
-            .gap_ms = gifGap(frame.delay_ms),
+            .gap_ms = gifGap(frame.delay_ms, frame.zero_delay_frames),
         }) catch {
             storage.releaseAnimationBytes(frame_len);
             break;
@@ -1163,7 +1163,10 @@ fn attachGifAnimation(
     if (taken == 0) return;
 
     const anim = img.animation.?;
-    anim.root_gap_ms = gifGap(decoded.root_delay_ms);
+    anim.root_gap_ms = gifGap(
+        decoded.root_delay_ms,
+        decoded.root_zero_delay_frames,
+    );
     anim.max_loops = decoded.loop_count;
     anim.state = .running;
     anim.frame_shown_at_ms = null;
@@ -1176,8 +1179,20 @@ fn attachGifAnimation(
 /// specific meaning in the kitty model: the frame is gapless and gets skipped
 /// during playback. Passing zero through would silently drop those frames, so
 /// an unspecified delay takes the same default a kitty frame would.
-fn gifGap(delay_ms: u32) u32 {
-    return if (delay_ms == 0) animation.default_gap_ms else delay_ms;
+///
+/// A decimated decode hands back one frame standing in for several, so the
+/// default is owed once per source frame that declared nothing, not once per
+/// frame that arrives here.
+fn gifGap(delay_ms: u32, zero_delay_frames: u32) u32 {
+    // A frame always stands in for at least itself, so no delay and no count
+    // is one frame that declared nothing. Decoders behind the sys seam are
+    // not obliged to count.
+    const unspecified = if (delay_ms == 0 and zero_delay_frames == 0)
+        1
+    else
+        zero_delay_frames;
+
+    return delay_ms +| unspecified *| animation.default_gap_ms;
 }
 
 const EncodeableError = Image.Error || Allocator.Error;
@@ -1362,11 +1377,27 @@ test "kittygfx an animated gif actually plays once placed" {
     try testing.expectEqualSlices(u8, root, img.renderData().bytes().?);
 }
 
-test "gif gap substitutes the default only for an unspecified delay" {
+test "gif gap substitutes the default for every unspecified delay" {
     const testing = std.testing;
-    try testing.expectEqual(animation.default_gap_ms, gifGap(0));
-    try testing.expectEqual(@as(u32, 1), gifGap(1));
-    try testing.expectEqual(@as(u32, 5000), gifGap(5000));
+
+    // Undecimated, which is what every frame of an animation inside the
+    // decoder's budget looks like: one default gap for a frame that declared
+    // nothing, exactly its own delay for a frame that declared one.
+    try testing.expectEqual(animation.default_gap_ms, gifGap(0, 1));
+    try testing.expectEqual(@as(u32, 1), gifGap(1, 0));
+    try testing.expectEqual(@as(u32, 5000), gifGap(5000, 0));
+
+    // Decimated: a frame standing in for four that all declared nothing holds
+    // the screen as long as those four did, instead of a quarter as long.
+    try testing.expectEqual(4 * animation.default_gap_ms, gifGap(0, 4));
+    try testing.expectEqual(
+        100 + 2 * animation.default_gap_ms,
+        gifGap(100, 2),
+    );
+
+    // A decoder behind the sys seam that reports no count still gets the
+    // substitution it got before there was one.
+    try testing.expectEqual(animation.default_gap_ms, gifGap(0, 0));
 }
 
 test "kittygfx query validates image data" {

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -766,6 +766,7 @@ pub const LoadingImage = struct {
 
         const first = result.frames[0].data;
         const first_delay_ms = result.frames[0].delay_ms;
+        const first_zero_delay_frames = result.frames[0].zero_delay_frames;
         if (first.len > max_size) {
             log.warn("gif image too large size={} max_size={}", .{ first.len, max_size });
             return error.InvalidData;
@@ -800,6 +801,7 @@ pub const LoadingImage = struct {
             .frames = tail,
             .loop_count = result.loop_count,
             .root_delay_ms = first_delay_ms,
+            .root_zero_delay_frames = first_zero_delay_frames,
         };
     }
 };
@@ -1108,6 +1110,7 @@ test "image load: an animated gif keeps its remaining frames" {
     try testing.expectEqual(@as(u32, 50), anim.frames[0].delay_ms);
     try testing.expectEqual(@as(u32, 30), anim.frames[1].delay_ms);
     try testing.expectEqual(@as(u32, 100), anim.root_delay_ms);
+    try testing.expectEqual(@as(u32, 0), anim.root_zero_delay_frames);
     try testing.expectEqual(@as(u32, 0), anim.loop_count);
     for (anim.frames) |frame| {
         try testing.expectEqual(@as(usize, 2 * 2 * 4), frame.data.len);

--- a/src/terminal/sys.zig
+++ b/src/terminal/sys.zig
@@ -83,6 +83,10 @@ pub const Animation = struct {
     /// itself, which would otherwise lose that frame's timing.
     root_delay_ms: u32 = 0,
 
+    /// zero_delay_frames of the frame that preceded `frames`, filled in by
+    /// the same caller and for the same reason.
+    root_zero_delay_frames: u32 = 0,
+
     pub const Frame = struct {
         data: []u8,
 
@@ -90,6 +94,14 @@ pub const Animation = struct {
         /// passed through as zero; substituting a default is the caller's
         /// policy decision.
         delay_ms: u32,
+
+        /// How many source frames this one stands in for declared no delay.
+        ///
+        /// A decoder that drops frames folds their delays into the frame that
+        /// replaces them, and zeros fold into zero, so a caller substituting
+        /// a default gap needs a count rather than a flag. Decoders that
+        /// return every frame may leave this zero.
+        zero_delay_frames: u32 = 0,
     };
 
     pub fn deinit(self: *Animation, alloc: Allocator) void {
@@ -190,6 +202,7 @@ fn decodeGifFramesWuffs(
     for (result.frames, frames) |src, *dst| dst.* = .{
         .data = src.data,
         .delay_ms = src.delay_ms,
+        .zero_delay_frames = src.zero_delay_frames,
     };
 
     // The buffers now belong to `frames`, so release only the outer slice.


### PR DESCRIPTION
Closes # 682.

`decodeAnimated` met its memory budget by stopping, which keeps the first N frames and discards the tail. That does not degrade an animation so much as replace it with a different one: a spinner needing two hundred frames to come back round plays the first hundred and twenty and loops there, rotating part way and snapping back forever. The dropped delays went with the dropped frames, so the loop was also the wrong length.

It now keeps every k-th frame and folds the delays of the frames in between into the one that is kept. A GIF declares its frame count nowhere in the header, so the stride cannot be chosen up front: when the retained set fills the budget it is halved in place, the freed delays are added to the frames before them, and the stride doubles. Delays fold backwards, not forwards, because forwards holds the same total but starts every retained frame early by the delays it absorbed and strands the tail with no frame left to take them.

Three things review found that are worth reading, since two of them were mine and wrong.

**The storage budget was above the limit that actually governs frames.** It was matched to the per-image ceiling, but animation frames are charged against the kitty store's `total_limit`, and the attach path handles a failed reservation by dropping the tail. The store cannot evict the image the frames belong to, so budgeting past it only relocated this PR's own bug one layer up. The decoder now stops at the store's default. The caller is still the final authority, since that limit is configurable and the store is shared.

Lowering it then needed a still ceiling to go with it, which review caught: every GIF routes through this decoder now, so testing the frame budget alone would have refused a large single-frame image that the layer above is willing to hold and that decoded fine before frames were budgeted at all. How many frames may be retained and how large one frame may be are separate questions and now have separate limits.

**The decode-work bound I added was five times looser than the one it replaced.** The old frame ceiling was `budget / size`, which limited work as a side effect; I lost that when splitting storage from work, and my replacement both undercounted (a restore-previous frame costs three canvas passes, not one) and allowed 2GB. A 1024x1024 GIF went from 100 frames decoded to 512. It is now counted in canvas passes and set so the worst case lands just under what it replaced, about a gigabyte of traffic whatever the shape, roughly a quarter second. A second pass found the count was still one short: the snapshot kept for each retained frame is a fourth canvas-sized write. For a large canvas this binds well before the frame count, so a long large-canvas animation is still cut short; decimation cannot avoid that, because preserving the loop means decoding every frame of it.

**Zero-delay GIFs played faster after decimation.** A declared zero is reported as zero and the caller substitutes a default gap, so folding zeros produced zero: sixteen frames at 640ms became four at 160ms, breaking the whole point of the change. Frames now carry how many of their sources declared zero and the substitution multiplies by it, which is exactly the old behaviour for an undecimated animation.

**The fixtures could not see most of what they claimed.** The skipped-frame test never entered the skip branch, and the file it used is three mutually independent full-canvas opaque overwrites, so an implementation that never composed or disposed at all passed it. The absurd-canvas test used a shape that also failed the byte check, so deleting the dimension check left it green. Nothing anywhere used restore-previous. Frames are now generated with partial rects, a transparent index and a chosen disposal, and every expected pixel was derived by hand and cross-checked against Pillow rather than read off the implementation.

**Correction to an earlier version of this PR:** I claimed these tests were run by "not `just test`, not the sync-verify ladder, not CI", and that wuffs was the only package under `pkg/` with test blocks. Both were wrong. CI runs them via the `test-pkg-linux` job as a required check, and eight other packages have test blocks; my grep only looked one level deep. The local gap is real and `just test-pkg` closes it, mirroring that CI job's matrix, which is only wuffs. I first wrote a reason for why the others are excluded and that was wrong too, in the same way: their system-library links are gated behind `systemIntegrationOption` and build vendored sources by default. The recipe now mirrors the matrix and does not speculate about why CI chose it.

`just test-pkg` 30 passing, `zig build test` green, `zig fmt --check` clean.
