### PR TITLE
windows: cancel the tab layout switch instead of catching where it lands

### DIFF
--- a/windows/Ghostty.Tests/Wiring/ShellSource.cs
+++ b/windows/Ghostty.Tests/Wiring/ShellSource.cs
@@ -108,13 +108,17 @@ internal static class SyntaxQueries
     /// </summary>
     public static List<InvocationExpressionSyntax> Calls(this SyntaxNode node, string target) =>
         node.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(i => Callee(i) == target)
+            .Where(i => i.CalleeText() == target)
             .ToList();
 
-    // A null-conditional call parses with the receiver hoisted out, so the
-    // callee on its own reads as ".TryEnqueue". Put the receiver back so a
-    // test can name the call the way the source spells it.
-    private static string Callee(InvocationExpressionSyntax call)
+    /// <summary>
+    /// The callee the way the source spells it, receiver included. A
+    /// null-conditional call parses with the receiver hoisted out, so the
+    /// callee on its own reads as ".TryEnqueue"; put the receiver back so a
+    /// test can name the call as written. Keeping the receiver is what lets a
+    /// test tell `_switchStoryboard.Stop` from a Stop on anything else.
+    /// </summary>
+    public static string CalleeText(this InvocationExpressionSyntax call)
     {
         if (call.Expression is MemberBindingExpressionSyntax
             && call.Ancestors().OfType<ConditionalAccessExpressionSyntax>().FirstOrDefault() is { } conditional)

--- a/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
+++ b/windows/Ghostty.Tests/Wiring/TabLayoutSwitchWiringTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -8,10 +9,10 @@ namespace Ghostty.Tests.Wiring;
 
 /// <summary>
 /// The horizontal/vertical tab switch lands on a completion callback about
-/// 340ms after it starts, and nothing cancels it when the window goes away in
-/// between. Closing the last tab closes the window, and a storyboard that has
-/// already begun still raises Completed, so the callback can run against a
-/// window that is tearing down. crash.log recorded four NullReferenceExceptions
+/// 340ms after it starts, and nothing cancelled it when the window went away
+/// in between. Closing the last tab closes the window, and a storyboard that
+/// has already begun still raises Completed, so the callback ran against a
+/// window that was tearing down. crash.log recorded four NullReferenceExceptions
 /// with this stack before the gate was added:
 ///
 ///   ApplyButtonColors -> ApplyCaptionButtonChrome -> RefreshTabHostChrome
@@ -23,12 +24,21 @@ namespace Ghostty.Tests.Wiring;
 /// tests pin the earlier signal deliberately, because a later one leaves the
 /// gap open.
 ///
+/// That gate is only the last thing the completion reaches, though, so the
+/// switch is now cancelled at the source instead and the gate stays as the
+/// backstop. LayoutCoordinator.CancelSwitch is where the reasoning lives --
+/// what a switch still has in the air, why the landing cannot simply be
+/// fast-forwarded, and what is deliberately left alone. The tests below pin
+/// both halves, because either alone is one edit away from being the only one.
+///
 /// These are wiring guards. They prove the gate is on the path a closing
 /// window takes; whether the window survives a switch is only observable live.
 /// </summary>
 public class TabLayoutSwitchWiringTests
 {
     private static ShellSource Window() => ShellSource.Load("Ghostty.MainWindow.xaml.cs");
+
+    private static ShellSource Coordinator() => ShellSource.Load("Shell.LayoutCoordinator.cs");
 
     /// <summary>
     /// The lambda passed as <c>onCompleted:</c>, found by argument name rather
@@ -47,24 +57,70 @@ public class TabLayoutSwitchWiringTests
     private static bool ReturnsEarly(IfStatementSyntax guard) =>
         guard.Statement.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any();
 
+    /// <summary><c>if (_isClosed) return;</c> and nothing that merely mentions
+    /// the field: an inverted or dead condition is a different syntax shape and
+    /// does not match.</summary>
+    private static bool IsClosedGuard(StatementSyntax statement) =>
+        statement is IfStatementSyntax
+        {
+            Condition: IdentifierNameSyntax { Identifier.Text: "_isClosed" }
+        } guard
+        && ReturnsEarly(guard);
+
+    /// <summary>
+    /// <c>_switchStoryboard = null;</c> as a statement in its own right. The
+    /// field means "a switch is in flight", so every path that ends one has to
+    /// clear it -- the landing, and the Begin that threw before there was ever
+    /// anything to land.
+    /// </summary>
+    private static bool ClearsTheStoryboard(StatementSyntax statement) =>
+        statement is ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax assignment }
+        && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+        && assignment.Left.ToString() == "_switchStoryboard"
+        && assignment.Right.ToString() == "null";
+
+    /// <summary><c>if (_switchStoryboard is not null)</c> and nothing looser:
+    /// an inverted test, or a condition that merely mentions the field, is a
+    /// different syntax shape and does not match.</summary>
+    private static bool IsSwitchInFlightGuard(StatementSyntax statement)
+    {
+        if (statement is not IfStatementSyntax guard) return false;
+        if (guard.Condition is not IsPatternExpressionSyntax test) return false;
+        if (test.Expression is not IdentifierNameSyntax { Identifier.Text: "_switchStoryboard" }) return false;
+        if (test.Pattern is not UnaryPatternSyntax negated || !negated.IsKind(SyntaxKind.NotPattern)) return false;
+        return negated.Pattern is ConstantPatternSyntax constant
+            && constant.Expression.IsKind(SyntaxKind.NullLiteralExpression);
+    }
+
+    /// <summary>
+    /// CancelSwitch's one <c>if (_switchStoryboard is not null)</c> statement.
+    /// Everything that reads the field lives inside it, and so does the trace
+    /// line, whose at-most-once property is that block and nothing else.
+    /// </summary>
+    private static IfStatementSyntax SwitchInFlightGuard(MethodDeclarationSyntax cancel)
+    {
+        var found = cancel.Body!.Statements.Where(IsSwitchInFlightGuard).ToList();
+        Assert.True(
+            found.Count == 1,
+            "CancelSwitch must reach _switchStoryboard through exactly one "
+            + "`if (_switchStoryboard is not null)` block: a bare _switchStoryboard.Stop() faults on "
+            + "every close with no switch in flight, and a trace line outside the block reports a "
+            + "cancel for a switch that already emitted its end");
+        return (IfStatementSyntax)found[0];
+    }
+
     [Fact]
     public void SwitchCompletion_BailsOutOnceTeardownHasStarted()
     {
         var completion = SwitchCompletion();
         var statements = completion.Block!.Statements;
 
-        // Identity, not a substring: `if (_isClosed) return;` and nothing that
-        // merely mentions the field. An inverted or dead condition is a
-        // different syntax shape and does not match.
-        var guard = statements
-            .OfType<IfStatementSyntax>()
-            .FirstOrDefault(s => s.Condition is IdentifierNameSyntax { Identifier.Text: "_isClosed" });
+        var guard = statements.FirstOrDefault(IsClosedGuard);
 
         Assert.True(
             guard is not null,
             "the layout-switch completion must return early once _isClosed is set; "
             + "a null AppWindow is a strictly later signal and leaves the teardown gap open");
-        Assert.True(ReturnsEarly(guard!), "the teardown gate must return, not just log");
 
         // Order matters rather than position: everything below the gate is
         // what touches disposed state.
@@ -121,5 +177,380 @@ public class TabLayoutSwitchWiringTests
         Assert.True(guardIndex < statements.Count, "expected an AppWindow guard");
         Assert.True(cacheIndex < statements.Count, "expected a _lastButtonColors assignment");
         Assert.True(guardIndex < cacheIndex, "the guard must run before any state is mutated");
+    }
+
+    [Fact]
+    public void WindowTeardown_CancelsTheLayoutSwitch()
+    {
+        var statements = Window().Method("OnClosedAsync").Body!.Statements;
+
+        var cancelIndex = statements
+            .TakeWhile(s => !s.Calls("_layout.CancelSwitch").Any())
+            .Count();
+        Assert.True(
+            cancelIndex < statements.Count,
+            "OnClosedAsync must cancel an in-flight layout switch; the 340ms landing outlives the close");
+
+        // Unconditionally. A call is found anywhere inside the statement that
+        // holds it, so `if (IsQuickTerminal) { _layout.CancelSwitch(); }` reads
+        // as a cancel while every regular window closes without one.
+        Assert.True(
+            statements[cancelIndex] is ExpressionStatementSyntax
+            {
+                Expression: InvocationExpressionSyntax { ArgumentList.Arguments.Count: 0 } call
+            }
+            && call.Expression.ToString() == "_layout.CancelSwitch",
+            "the cancel must be a statement of OnClosedAsync itself, not nested inside a condition");
+
+        // Anchored at both ends. _isClosed is what makes the completion inert
+        // if one is already queued, so it has to be set first; the theme
+        // manager is the first disposal in the method and the first state a
+        // landing switch would read through RefreshTabHostChrome.
+        var gateIndex = statements
+            .TakeWhile(s => !s.DescendantNodesAndSelf()
+                .OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                          && a.Left.ToString() == "_isClosed"
+                          && a.Right.ToString() == "true"))
+            .Count();
+        var disposeIndex = statements
+            .TakeWhile(s => !s.Calls("_themeManager.Dispose").Any())
+            .Count();
+
+        // Both have to exist, or TakeWhile silently returns the full count and
+        // the comparison passes while pinning nothing.
+        Assert.True(gateIndex < statements.Count, "expected OnClosedAsync to set _isClosed");
+        Assert.True(disposeIndex < statements.Count, "expected the theme manager to be disposed on close");
+        Assert.True(
+            gateIndex < cancelIndex,
+            "_isClosed must be set before the cancel, so a completion already queued this frame is turned away too");
+        Assert.True(
+            cancelIndex < disposeIndex,
+            "the switch must be cancelled before the state its landing reads is disposed");
+    }
+
+    [Fact]
+    public void CancelSwitch_StopsTheStoryboardAndRunsNoEndStateWork()
+    {
+        var cancel = Coordinator().Method("CancelSwitch");
+        var statements = cancel.Body!.Statements;
+
+        var guard = SwitchInFlightGuard(cancel);
+        var guarded = Assert.IsType<BlockSyntax>(guard.Statement).Statements;
+        var guardIndex = statements.IndexOf(guard);
+
+        // Stop is one half of the defence: a stopped Storyboard does not raise
+        // Completed at all, so the landing never gets scheduled. Reached only
+        // through the block above -- a switch is in flight on a minority of
+        // closes, and the field is null on all the rest.
+        Assert.Single(cancel.Calls("_switchStoryboard.Stop"));
+        Assert.True(
+            guarded.Any(s => s.Calls("_switchStoryboard.Stop").Any()),
+            "the Stop must sit inside the null-checked block, not above it");
+
+        // Clearing the field is the other half, and the one Stop cannot
+        // provide: a Completed already queued in the same frame as the Stop
+        // still runs, and only the identity check in Animate turns it away.
+        // Pinned on its own because deleting this line leaves every other
+        // assertion in this test green.
+        Assert.True(
+            guarded.Any(ClearsTheStoryboard),
+            "CancelSwitch must clear _switchStoryboard inside the null-checked block");
+
+        // The storyboard block and both releases have to run before the early
+        // return: that return is taken when no active-tab morph is in flight,
+        // and a switch can stop a storyboard, reveal the pane or park an icon
+        // ghost with no morph staged at all.
+        var earlyExit = statements
+            .TakeWhile(s => !s.DescendantNodesAndSelf().OfType<ReturnStatementSyntax>().Any())
+            .Count();
+        Assert.True(earlyExit < statements.Count, "expected CancelSwitch to return early when no morph is staged");
+        Assert.True(
+            guardIndex < earlyExit,
+            "the storyboard must be stopped and cleared before CancelSwitch's early return");
+
+        // Stopping the switch storyboard releases one of the three things a
+        // switch has in the air. The pane reveal is a Composition InsetClip
+        // animation the compositor keeps driving against the pane host while
+        // the window disposes its leaves, and the icon ghost stays parked on
+        // the morph layer with both real badges left transparent. Neither is a
+        // XAML storyboard, so neither is reachable by Stop.
+        //
+        // CancelPaneReveal, not FinishPaneReveal: only the clip has to come
+        // off here. See CancelSwitch's summary for why the margin stays put.
+        //
+        // Each has to be a statement of CancelSwitch itself. A call is found
+        // anywhere beneath the statement holding it, so `if (_iconGhost is not
+        // null) FinishIconGhost();` reads as a release while any other shape
+        // of that condition skips it.
+        foreach (var release in new[] { "FinishIconGhost", "CancelPaneReveal" })
+        {
+            Assert.Single(cancel.Calls(release));
+            var index = statements.TakeWhile(s => !s.Calls(release).Any()).Count();
+            Assert.True(index < statements.Count, $"CancelSwitch must call {release}");
+            Assert.True(
+                statements[index] is ExpressionStatementSyntax
+                {
+                    Expression: InvocationExpressionSyntax { ArgumentList.Arguments.Count: 0 } call
+                }
+                && call.Expression.ToString() == release,
+                $"{release} must be a statement of CancelSwitch itself, not nested inside a condition");
+            Assert.True(
+                index < earlyExit,
+                $"{release} must run before CancelSwitch's early return, which is taken when no morph is in flight");
+        }
+
+        // What this method may call, spelled the way the source spells it so
+        // that a bare "Stop" cannot stand in for a Stop on another receiver.
+        //
+        // An allow-list rather than a list of forbidden names. Snap,
+        // FinishSwitch and FinishActiveTabMorph are the three that must never
+        // appear -- they walk both tab hosts, the vertical title bar and the
+        // pane host, which is the tree a closing window is disposing -- but
+        // naming only those waves through an inlined copy of Snap's body, a
+        // RefreshTabHostChrome, or the same work under a name invented later.
+        // Adding an entry here is meant to cost a decision, weighed against
+        // what this method's summary says it is allowed to touch.
+        var allowed = new[]
+        {
+            "MorphTrace",
+            "_switchStoryboard.Stop",
+            "_morphStoryboard?.Stop",
+            "FinishIconGhost",
+            "CancelPaneReveal",
+        };
+        var unexpected = cancel.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Select(SyntaxQueries.CalleeText)
+            .Where(n => !allowed.Contains(n, StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        Assert.True(
+            unexpected.Count == 0,
+            "CancelSwitch must run no end-state work, found: " + string.Join(", ", unexpected));
+
+        // A morph still waiting for its destination holds a LayoutUpdated
+        // handler on the morph root and a deadline on
+        // CompositionTarget.Rendering. Rendering is a thread-level event, so a
+        // pending handler keeps the closed window's whole tree alive until the
+        // thread renders again -- the leak CancelStripPriming already exists
+        // to close, reachable by a second route.
+        //
+        // Right-hand sides too: `_morphRoot.LayoutUpdated -= null;` detaches
+        // nothing and satisfies a check that reads only the event name.
+        var detached = cancel.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(a => a.IsKind(SyntaxKind.SubtractAssignmentExpression))
+            .Select(a => (Event: a.Left.ToString(), Handler: a.Right.ToString()))
+            .ToList();
+        Assert.Contains(("_morphRoot.LayoutUpdated", "morph.Waiting"), detached);
+        Assert.Contains(("CompositionTarget.Rendering", "morph.WaitingDeadline"), detached);
+    }
+
+    [Fact]
+    public void CancelSwitch_LeavesATraceTheFuzzOracleCanPair()
+    {
+        var cancel = Coordinator().Method("CancelSwitch");
+
+        // Animate emits SWITCH begin and FinishSwitch emits SWITCH end, and
+        // the morph fuzz harness fails the run when those two counts differ.
+        // A cancelled switch never reaches FinishSwitch, so without a line of
+        // its own every close landing inside a switch reads as a switch that
+        // never finished.
+        var traced = cancel.Calls("MorphTrace").Select(c => c.Arg(0)).ToList();
+        Assert.Single(traced);
+        Assert.StartsWith("\"SWITCH cancel", traced[0], StringComparison.Ordinal);
+
+        // The harness reads any ghosts= above zero as a leaked ghost, and a
+        // cancel deliberately leaves the morph ghost on a tree about to be
+        // destroyed, so the line must not carry one.
+        Assert.DoesNotContain("ghosts=", traced[0], StringComparison.Ordinal);
+
+        // Inside the null-checked block, which is the whole of what makes the
+        // line at most one per switch rather than one per close. Emitted
+        // unconditionally, a window closed with no switch in flight still
+        // reports a cancel, and the harness subtracts it from a begin its own
+        // end already answered: a healthy run fails the oracle.
+        var guarded = Assert.IsType<BlockSyntax>(SwitchInFlightGuard(cancel).Statement).Statements;
+        Assert.True(
+            guarded.Any(s => s.Calls("MorphTrace").Any()),
+            "the SWITCH cancel line must sit inside the `_switchStoryboard is not null` block, "
+            + "which is what keeps a close with no switch in flight from emitting one");
+    }
+
+    [Fact]
+    public void Animate_ClearsTheStoryboardWhenBeginThrows()
+    {
+        var animate = Coordinator().Method("Animate");
+
+        // Found by what the try attempts rather than by being the first one:
+        // Animate has a second try below for the morph storyboard, and "the
+        // first try in the method" swaps silently the day their order changes.
+        var attempts = animate.DescendantNodes()
+            .OfType<TryStatementSyntax>()
+            .Where(t => t.Block.Calls("sb.Begin").Any())
+            .ToList();
+        Assert.True(attempts.Count == 1, "expected one try around sb.Begin in Animate");
+        var catches = attempts[0].Catches;
+        Assert.True(catches.Count == 1, "expected one catch on the try around sb.Begin");
+        var handler = catches[0].Block.Statements;
+
+        var clearIndex = handler.TakeWhile(s => !ClearsTheStoryboard(s)).Count();
+        var finishIndex = handler.TakeWhile(s => !s.Calls("FinishSwitch").Any()).Count();
+
+        // Nothing is in flight after a Begin that threw, and the field claims
+        // otherwise until this line runs. Left set, it holds a storyboard that
+        // never began for the life of the window: the close then stops it and
+        // emits a SWITCH cancel for a switch the fallback below already
+        // finished and counted, so a healthy run fails the fuzz oracle.
+        Assert.True(
+            clearIndex < handler.Count,
+            "the catch around sb.Begin must clear _switchStoryboard; a storyboard that never began "
+            + "is not a switch in flight, and the close would emit a cancel for one already ended");
+        Assert.True(finishIndex < handler.Count, "expected the catch to land the switch without animating it");
+        Assert.True(
+            clearIndex < finishIndex,
+            "the field must be cleared before FinishSwitch, which invokes onCompleted and can stage the "
+            + "next switch; clearing after that would null the storyboard that switch just registered");
+    }
+
+    [Fact]
+    public void SwitchCompleted_CannotLandAfterACancel()
+    {
+        var coordinator = Coordinator();
+        coordinator.Field("_switchStoryboard");
+
+        var animate = coordinator.Method("Animate");
+        var body = animate.Body!.Statements;
+
+        // Position, not just presence. Moved into the Completed lambda or into
+        // the catch below sb.Begin, the assignment is still a descendant of
+        // Animate -- and from the catch no live switch ever registers, so every
+        // completion trips the identity check below, FinishSwitch never runs
+        // and _switching latches for the life of the window.
+        static bool StagesTheStoryboard(StatementSyntax statement) =>
+            statement is ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax assignment }
+            && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+            && assignment.Left.ToString() == "_switchStoryboard"
+            && assignment.Right.ToString() == "sb";
+
+        var stageIndex = body.TakeWhile(s => !StagesTheStoryboard(s)).Count();
+        var wiringIndex = body
+            .TakeWhile(s => !s.DescendantNodesAndSelf()
+                .OfType<AssignmentExpressionSyntax>()
+                .Any(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                          && a.Left.ToString() == "sb.Completed"))
+            .Count();
+
+        Assert.True(
+            stageIndex < body.Count,
+            "Animate must stage `_switchStoryboard = sb` as a statement of its own body");
+        Assert.True(wiringIndex < body.Count, "expected Animate to attach a Completed handler to sb");
+        Assert.True(
+            stageIndex < wiringIndex,
+            "the storyboard must be staged before the handler that reads it is attached");
+
+        var completed = animate.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Single(a => a.IsKind(SyntaxKind.AddAssignmentExpression)
+                         && a.Left.ToString() == "sb.Completed");
+        var statements = Assert
+            .IsType<ParenthesizedLambdaExpressionSyntax>(completed.Right)
+            .Block!.Statements;
+
+        // Identity against the field CancelSwitch clears, matched as syntax
+        // rather than text: a condition rewritten to a constant, or one that
+        // logs instead of returning, is a different shape and does not match.
+        //
+        // Exactly two operands, and exactly these two. Without that,
+        // ReferenceEquals(_switchStoryboard, _switchStoryboard) reads as a
+        // guard and never returns, so a cancelled switch lands anyway; and
+        // ReferenceEquals(_switchStoryboard, null) reads as a guard and always
+        // returns, so the layout toggle is dead for the window's life.
+        static bool IsStaleStoryboardGuard(StatementSyntax statement)
+        {
+            if (statement is not IfStatementSyntax guard) return false;
+            if (guard.Condition is not PrefixUnaryExpressionSyntax negation
+                || !negation.IsKind(SyntaxKind.LogicalNotExpression)) return false;
+            if (negation.Operand is not InvocationExpressionSyntax call
+                || call.Expression.ToString() != "ReferenceEquals") return false;
+            var operands = call.ArgumentList.Arguments.Select(a => a.ToString()).ToList();
+            return operands.Count == 2
+                && operands.Contains("_switchStoryboard")
+                && operands.Contains("sb")
+                && ReturnsEarly(guard);
+        }
+
+        // The field is non-null exactly while a switch is in flight, so the
+        // landing has to clear it (ClearsTheStoryboard, shared with the
+        // Begin-threw path above). Left set, a close an hour later would Stop
+        // a long-finished storyboard and release its hold values across both
+        // tab hosts, the title bar and the icon transforms, mid-teardown -- by
+        // the one method whose premise is that touching that tree is the
+        // hazard.
+        var guardIndex = statements.TakeWhile(s => !IsStaleStoryboardGuard(s)).Count();
+        var clearIndex = statements.TakeWhile(s => !ClearsTheStoryboard(s)).Count();
+        var finishIndex = statements
+            .TakeWhile(s => !s.Calls("FinishSwitch").Any())
+            .Count();
+
+        // All three have to exist, or TakeWhile silently returns the full count
+        // and the comparisons pass while pinning nothing.
+        Assert.True(
+            guardIndex < statements.Count,
+            "the Completed handler must bail unless its storyboard is still the current one; "
+            + "Stop does not recall a completion already queued this frame");
+        Assert.True(
+            clearIndex < statements.Count,
+            "the landing must clear _switchStoryboard; nothing else does on the normal path");
+        Assert.True(finishIndex < statements.Count, "expected the Completed handler to call FinishSwitch");
+        Assert.True(guardIndex < clearIndex, "the identity check must run before the field is cleared");
+        Assert.True(
+            clearIndex < finishIndex,
+            "the field must be cleared before FinishSwitch, which invokes onCompleted and can stage the "
+            + "next switch; clearing after that would null the storyboard that switch just registered");
+    }
+
+    [Fact]
+    public void NudgeWindowForImpact_StopsOnTeardownAcrossItsAwaits()
+    {
+        var method = Window().Method("NudgeWindowForImpact");
+
+        var awaits = method.DescendantNodes().OfType<AwaitExpressionSyntax>().ToList();
+
+        // Load-bearing: with no awaits the per-await loop below proves nothing
+        // and passes. The gate matters precisely because this method resumes
+        // on later dispatcher turns.
+        Assert.NotEmpty(awaits);
+
+        // Control flow, not source order. A gate that merely sits later in the
+        // file -- moved out of the loop to below it, say -- satisfies every
+        // await by position while the window is moved again on the turn after
+        // it closed. The gate has to be the next statement executed.
+        foreach (var suspension in awaits)
+        {
+            var suspending = suspension.FirstAncestorOrSelf<StatementSyntax>();
+            Assert.True(suspending is not null, "every await sits inside a statement");
+            var block = suspending!.Parent as BlockSyntax;
+            Assert.True(
+                block is not null,
+                "the awaiting statement must sit in a block, so the gate can be the statement after it");
+
+            var next = block!.Statements.IndexOf(suspending!) + 1;
+            Assert.True(
+                next < block.Statements.Count && IsClosedGuard(block.Statements[next]),
+                "the statement right after each await must be the _isClosed gate; the window can close "
+                + "while the nudge is suspended and the next step moves it again");
+        }
+
+        // And once before it starts, as a statement of the method itself: an
+        // entry gate nested inside some other branch is not one.
+        var entry = method.Body!.Statements.FirstOrDefault(IsClosedGuard);
+        Assert.True(
+            entry is not null,
+            "the impact nudge keeps moving AppWindow after teardown starts unless it is gated on _isClosed");
+        Assert.True(
+            entry!.SpanStart < awaits[0].SpanStart,
+            "the nudge must also bail before it starts moving an already-closing window");
     }
 }

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -1021,10 +1021,14 @@ public sealed partial class MainWindow : Window
         _titleBar.ApplyForCurrentMode();
         _layout.Animate(vertical, onCompleted: () =>
         {
-            // The switch lands about 340ms after it starts, and nothing
-            // cancels it if the window goes away in between: closing the last
-            // tab closes the window, and a storyboard that has already begun
-            // still raises Completed.
+            // Belt to CancelSwitch's braces. OnClosedAsync cancels the
+            // switch at the source before anything is disposed -- see
+            // LayoutCoordinator.CancelSwitch for why the landing is the
+            // hazard -- so on a closing window the callback below should not
+            // run at all. This gate stays because it is the only defence that
+            // does not depend on the coordinator: a completion queued in the
+            // same frame as the stop, or a landing site added outside the
+            // coordinator's cancel path, still arrives here.
             //
             // Gated on _isClosed rather than on AppWindow, which is the same
             // reasoning as the other teardown gates in this file. AppWindow
@@ -1419,7 +1423,14 @@ public sealed partial class MainWindow : Window
         // before the first await below, so no theme callback fires after
         // teardown begins.
         _isClosed = true;
+        // Both cancels drop work already scheduled against the tree that is
+        // about to be torn down: a pending rendering-frame handler, and a
+        // layout switch still in flight (see LayoutCoordinator.CancelSwitch
+        // for what that switch is still holding). Nothing is disposed yet at
+        // this point, so cancelling here is the last moment both are still
+        // cheap and safe.
         _layout.CancelStripPriming();
+        _layout.CancelSwitch();
         _themeManager.Dispose();
 
         // Close the inspector window before any surface/host teardown below.
@@ -2067,9 +2078,14 @@ public sealed partial class MainWindow : Window
     /// put it and bails otherwise: the awaited delays give the user ~80ms
     /// to start dragging (or a snap assist to move the window), and a
     /// blind restore would teleport the window back over their move.
+    ///
+    /// The same delays are why _isClosed is re-checked after each one rather
+    /// than only on entry: the shake outlives its own first turn, and the
+    /// window can be closed underneath it while it is suspended.
     /// </summary>
     private async void NudgeWindowForImpact(double dx, double dy)
     {
+        if (_isClosed) return;
         if (IsQuickTerminal) return;
         if (AppWindow?.Presenter is not Microsoft.UI.Windowing.OverlappedPresenter
             { State: Microsoft.UI.Windowing.OverlappedPresenterState.Restored }) return;
@@ -2088,6 +2104,10 @@ public sealed partial class MainWindow : Window
                     origin.Y + (int)(dy * amplitude));
                 AppWindow.Move(expected);
                 await System.Threading.Tasks.Task.Delay(26);
+                // Placed after the await, not at the top of the loop, so the
+                // final delay is covered too: the restore below is a move
+                // against a window that may have been closed during it.
+                if (_isClosed) return;
             }
             if (AppWindow.Position == expected)
                 AppWindow.Move(origin);

--- a/windows/Ghostty/Shell/LayoutCoordinator.cs
+++ b/windows/Ghostty/Shell/LayoutCoordinator.cs
@@ -111,6 +111,12 @@ internal sealed class LayoutCoordinator
     private readonly Func<TabModel?> _activeTab;
 
     private bool _switching;
+    // The Storyboard staged by the most recent switch, non-null exactly while
+    // that switch is in flight: Animate stages it, and the Completed handler
+    // and the Begin failure path both clear it. Teardown has to be able to
+    // stop it, and its own Completed handler checks it to find out whether it
+    // is still the switch the coordinator cares about. See CancelSwitch.
+    private Storyboard? _switchStoryboard;
     // When true (quake window with a single tab), the strip + vertical
     // title bar are forced hidden regardless of layout mode, leaving only
     // the pane host. Snap and Animate both honor it so the layout toggle
@@ -369,8 +375,24 @@ internal sealed class LayoutCoordinator
                 0, 0, -outgoingOffset.X, -outgoingOffset.Y, incoming: false);
         }
 
+        _switchStoryboard = sb;
         sb.Completed += (_, _) =>
         {
+            // A cancelled switch must not land; see CancelSwitch for why the
+            // landing is the hazard, and why stopping the storyboard alone
+            // does not settle it.
+            if (!ReferenceEquals(_switchStoryboard, sb)) return;
+
+            // Cleared here rather than in FinishSwitch: FinishSwitch invokes
+            // onCompleted, which legitimately stages the next switch when a
+            // layout change arrived mid-flight, and clearing after that would
+            // null the storyboard that switch just registered. Left set, the
+            // field outlives the switch by the life of the window, and
+            // CancelSwitch would Stop a long-finished storyboard -- releasing
+            // its hold values across the whole chrome tree during teardown,
+            // which is the one thing that method exists to avoid.
+            _switchStoryboard = null;
+
             // Only a staged flight has anything to slam into: a waiting
             // morph whose destination never realized parks the ghost and
             // stages no storyboard, and the fallback paths below
@@ -391,6 +413,9 @@ internal sealed class LayoutCoordinator
         }
         catch (Exception)
         {
+            // Nothing is in flight after a Begin that threw, and FinishSwitch
+            // below can stage the next switch through onCompleted.
+            _switchStoryboard = null;
             FinishSwitch(verticalTabs, onCompleted);
             return;
         }
@@ -521,6 +546,96 @@ internal sealed class LayoutCoordinator
     }
 
     private EventHandler<object>? _primingFrame;
+
+    /// <summary>
+    /// Drop an in-flight layout switch on window teardown without running any
+    /// of the end-state work it was going to run.
+    ///
+    /// A switch lands on its Storyboard's Completed handler roughly 340ms
+    /// after it starts, and the landing goes through Snap, which touches both
+    /// tab hosts, the vertical title bar and the pane host. A closing window
+    /// is disposing exactly that tree, so the landing has to be dropped rather
+    /// than fast-forwarded: calling FinishSwitch here would run the work this
+    /// method exists to prevent. This is the one place that reasoning is
+    /// written down; the Completed handler, the window's completion callback
+    /// and the wiring tests point here rather than repeat it.
+    ///
+    /// Two defences against the landing, because they cover different things.
+    /// Stopping the storyboard means Completed is never raised at all;
+    /// clearing the field the handler checks its identity against covers a
+    /// Completed that was already queued in the same frame as the Stop, which
+    /// the Stop cannot recall.
+    ///
+    /// Then release the rest of what a switch has in the air, none of which
+    /// the switch Storyboard drives:
+    ///
+    /// - The pane reveal is a Composition InsetClip on the pane host's visual
+    ///   with a key-frame animation sweeping its left inset, plus a shifted
+    ///   margin. The compositor keeps driving that against the pane host while
+    ///   the window goes on to dispose its leaves and its host: the same leak,
+    ///   reached through the composition tree instead of a XAML event.
+    /// - The icon ghost is an Image parked on the morph layer, with both real
+    ///   badges left at Opacity 0 behind it.
+    /// - A morph still waiting for its destination holds a LayoutUpdated
+    ///   handler on the morph root and a deadline on
+    ///   CompositionTarget.Rendering. Rendering is a thread-level event, so a
+    ///   pending handler keeps the closed window's whole tree alive until the
+    ///   thread renders again -- the leak CancelStripPriming exists to close,
+    ///   reachable by a second route.
+    ///
+    /// CancelPaneReveal and FinishIconGhost are safe here where FinishSwitch
+    /// is not: between them they touch the pane host's clip, the morph layer
+    /// and the Opacity of the two icon badges, none of it disposed at this
+    /// point and none of it a call into a tab host, the theme manager or
+    /// libghostty. The reveal is released through CancelPaneReveal rather
+    /// than FinishPaneReveal because only the clip has to go: putting the
+    /// pane host's margin back invalidates measure on a tree whose panes are
+    /// about to be freed, to restore a layout nobody will see. The morph's own
+    /// restoration is deliberately skipped -- FinishActiveTabMorph puts
+    /// opacity back on tab elements nobody will see again and asks the
+    /// vertical host to unsuppress its selection row, which is the tree-walking
+    /// this avoids. Only its handlers come off.
+    ///
+    /// Leaves _switching latched true, which is load-bearing rather than
+    /// merely harmless: between here and the config/settings unsubscribes
+    /// further down the closing path, a settings toggle or a debounced config
+    /// reload can still reach the window's layout entry point, and the latch is
+    /// what parks it as a pending target instead of starting a switch on a
+    /// window that is closing.
+    /// </summary>
+    public void CancelSwitch()
+    {
+        if (_switchStoryboard is not null)
+        {
+            // Pairs with the SWITCH begin line this switch emitted: the fuzz
+            // harness counts begins against ends, and a cancelled switch never
+            // reaches FinishSwitch to emit an end. No ghost count on the line
+            // -- the harness reads any ghosts= above zero as a leak, and a
+            // cancel deliberately leaves the morph ghost on a tree that is
+            // about to be destroyed.
+            MorphTrace("SWITCH cancel");
+            _switchStoryboard.Stop();
+            _switchStoryboard = null;
+        }
+
+        FinishIconGhost();
+        CancelPaneReveal();
+
+        _morphStoryboard?.Stop();
+        _morphStoryboard = null;
+        if (_morph is not { } morph) return;
+        if (morph.Waiting is not null)
+        {
+            _morphRoot.LayoutUpdated -= morph.Waiting;
+            morph.Waiting = null;
+        }
+        if (morph.WaitingDeadline is not null)
+        {
+            CompositionTarget.Rendering -= morph.WaitingDeadline;
+            morph.WaitingDeadline = null;
+        }
+        _morph = null;
+    }
 
     /// <summary>
     /// A realized element can still sit scrolled out of the strip's
@@ -971,6 +1086,39 @@ internal sealed class LayoutCoordinator
         Microsoft.UI.Xaml.Hosting.ElementCompositionPreview
             .GetElementVisual(_paneHost).Clip = null;
         _paneHost.Margin = saved;
+    }
+
+    /// <summary>
+    /// Release the reveal on a window that is closing: drop the clip, leave
+    /// the margin shifted.
+    ///
+    /// The clip is the half that has to go. Its left inset is swept by a
+    /// key-frame animation the compositor owns, so no Storyboard.Stop reaches
+    /// it and it would go on running against the pane host after the window
+    /// is gone. Restoring the margin is the half that must not run: it is
+    /// cosmetic on a window nobody will see again, and writing it invalidates
+    /// measure on a tree whose panes are about to be freed, which is the work
+    /// CancelSwitch exists to avoid.
+    ///
+    /// Guarded the way StartPaneReveal guards the same composition calls, and
+    /// for a second reason here: the only caller runs before the first await
+    /// of the window's async void Closed handler, where a COM teardown race
+    /// would come back as an unhandled exception on the UI thread.
+    /// </summary>
+    private void CancelPaneReveal()
+    {
+        if (_savedPaneMargin is null) return;
+        _savedPaneMargin = null;
+        try
+        {
+            Microsoft.UI.Xaml.Hosting.ElementCompositionPreview
+                .GetElementVisual(_paneHost).Clip = null;
+        }
+        catch (Exception)
+        {
+            // Composition refused, or the visual is already gone. Either way
+            // there is nothing left to release.
+        }
     }
 
     /// <summary>Non-null exactly while a pane reveal is in flight.</summary>

--- a/windows/scripts/vtabs-morph-fuzz.ps1
+++ b/windows/scripts/vtabs-morph-fuzz.ps1
@@ -11,6 +11,15 @@
 # SWITCH end line must report ghosts=0 and morph=null. A ghost left parked on
 # the morph layer is the artifact this whole change exists to remove, so it
 # is the thing worth asserting.
+#
+# Every switch also has to be accounted for. A SWITCH begin is answered by a
+# SWITCH end, or by a SWITCH cancel when the window closed while the switch
+# was still in the air -- closing cancels the switch instead of landing it, so
+# counting begins against ends alone would report a graceful close as a switch
+# that never finished. No run of this harness reaches that cancel, though: it
+# keeps the strip above three tabs and kills the process at the end rather than
+# closing the window, so the cancel term keeps the oracle honest for a graceful
+# close rather than recording one this harness drove.
 param(
     [string]$ExePath = (Join-Path $PSScriptRoot '..\Ghostty\bin\x64\Debug\net10.0-windows10.0.19041.0\Wintty.exe'),
     [int]$Seed = 0,
@@ -384,12 +393,14 @@ $immediate = @($lines | Where-Object { $_ -like 'MORPH immediate*' }).Count
 $deferred = @($lines | Where-Object { $_ -like 'MORPH deferred*' }).Count
 $waiting = @($lines | Where-Object { $_ -like 'MORPH waiting*' }).Count
 $none = @($lines | Where-Object { $_ -like 'MORPH none*' }).Count
+$cancels = @($lines | Where-Object { $_ -like 'SWITCH cancel*' }).Count
 $leaked = @($lines | Where-Object { $_ -match 'ghosts=[1-9]|morph=LEAKED' })
 
 Write-Host ''
 Write-Host "chord misses   : $chordMisses"
 Write-Host "switches begun : $begins"
 Write-Host "switches ended : $ends"
+Write-Host "switches cancel: $cancels"
 Write-Host "morph immediate: $immediate"
 Write-Host "morph deferred : $deferred  (waited: $waiting)"
 Write-Host "morph none     : $none"
@@ -398,8 +409,10 @@ if ($leaked.Count -gt 0) {
     $failures.Add("$($leaked.Count) switch(es) ended with a ghost still on the morph layer")
     $leaked | Select-Object -First 8 | ForEach-Object { Write-Host "  LEAK: $_" }
 }
-if ($begins -ne $ends) {
-    $failures.Add("switch begin/end mismatch: $begins vs $ends (a switch never finished)")
+if ($begins -ne ($ends + $cancels)) {
+    $failures.Add(
+        "switch begin/end mismatch: $begins begun vs $ends ended + $cancels cancelled " +
+        '(a switch never finished)')
 }
 if ($immediate -eq 0 -and $begins -gt 0) {
     $failures.Add('no switch ever staged a morph immediately')


### PR DESCRIPTION
Closes # 683.

# 674 gated the switch's `onCompleted` callback on `_isClosed`. That is the right place but the last one the completion handler reaches: `FinishSwitch` calls `Snap` before invoking the callback, so the end-state authority still ran on a tearing-down window, and the impact nudge fired after it. Nothing was known to crash there; the point is that gating one landing site leaves the class open.

`CancelSwitch` stops the switch at the source, beside `CancelStripPriming` on the closing path where nothing has been disposed yet. It stops the storyboard and makes the handler inert by identity. Both, deliberately: `Stop()` does not raise `Completed` in WinUI 3, but a completion already queued in the same frame is not something `Stop` can recall.

That `Stop()` behaviour is worth stating because the documentation does not. `Storyboard.Stop` has no Remarks at all, neither does `Timeline.Completed`, and WPF differs. It is settled from the WinUI 3 sources: `StopPrivate` sets `m_fIsStopped` before any tick, `ComputeStateImpl` skips stopped storyboards, `FinalizeIteration` clears the flag that gates the fire, and `DetachDCompCompletedHandlerOnStop` removes the composition-side signal with a comment saying why.

**Review found the first version cancelled only one of the three things a switch has in the air, and the one it missed was the only one running off the UI thread.** The pane reveal is not a XAML storyboard: it is a Composition `InsetClip` with a keyframe animation the compositor drives for the full 340ms, so `Stop` cannot reach it. Toggling out of vertical tabs and closing within 340ms left it running against the pane host while `DisposeAllLeaves()` freed the panes underneath. That is the same leak class this PR is about, arriving through the composition tree instead of `CompositionTarget.Rendering`, and before this PR `Snap` had been cleaning it up. The icon ghost was also left parked with both badges at zero opacity. Cancel now finishes both, before the early return that would otherwise skip them when a reveal ran with no morph staged. `FinishActiveTabMorph` stays out because it restores tab element opacity and unsuppresses the selection row.

**The storyboard field is now cleared where the switch ends, not only on cancel.** Otherwise closing a window an hour after a switch landed would `Stop` a long-finished storyboard and release its hold values across the whole chrome tree during teardown, which is precisely what the method exists not to do.

**The fuzz harness would have reported a false failure.** It pairs `SWITCH begin` against `SWITCH end` and exits 2 on a mismatch; a cancel emitted nothing, so any graceful close inside a switch read as a stuck switch. Latent only because the harness kills rather than closes. Cancel now emits its own line and the oracle counts it.

**Most of the tests accepted implementations that did nothing.** They took the left-hand side of an event detach without its handler (so `-= null` passed), allowed a guard comparing the field against itself, checked that an await had a guard somewhere later in the file rather than next to it, and forbade one spelling of `Snap` while `SnapStripColumn` walks the same teardown. Rewritten, and three of the demonstrated wrong implementations were re-applied to confirm the new tests reject them: deleting the field clear, the tautological guard, and a cancel that calls `SnapStripColumn`. Each fails exactly one test.

One reviewer claim did not hold and was not acted on: `var origin = AppWindow.Position;` was said to sit outside the `try` in `NudgeWindowForImpact`. It is inside it, in this commit and its parent.

Pre-existing teardown exposures found during review are filed separately as # 689; none were introduced here.

Full suite 2224 + 44 passing, solution builds with no errors, fuzz script parses clean.
