### PR TITLE
settings: stop the custom-shader box wiping the shader it never read

### DIFF
--- a/windows/Ghostty.Tests/Settings/SettingsWriteBackSeedingTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsWriteBackSeedingTests.cs
@@ -1,47 +1,48 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
 using System.Xml.Linq;
-using Microsoft.CodeAnalysis.CSharp;
+using Ghostty.Tests.Wiring;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
 namespace Ghostty.Tests.Settings;
 
 // A settings control that writes to the config file on LostFocus has to be
-// seeded from the config file first.
+// seeded from the config file first, AND has to write only when the value
+// actually changed.
 //
 // Blur is not an edit. It fires on every pass through the page: tabbing
-// through, clicking elsewhere, closing the window. So a box that writes
-// unconditionally on blur writes whatever it is currently showing -- and a box
-// that was never seeded is showing nothing. AppearancePage's custom-shader box
-// was the one page control with no seed, so opening Appearance and moving focus
-// past it wrote `custom-shader = ` and dropped a configured shader.
+// through, clicking elsewhere, closing the window. Both halves matter and both
+// have shipped broken:
 //
-// Nothing catches that at runtime: the write is a legitimate config edit, the
-// file stays valid, and the terminal just quietly stops using the shader.
+//   - Unseeded. AppearancePage's custom-shader box was the one page control
+//     with no seed, so opening Appearance and moving focus past it wrote
+//     `custom-shader = ` and dropped a configured shader.
+//   - Unconditional. AdvancedPage's quake-key box wrote on every blur, and
+//     SetValue APPENDS a key the file does not have, so simply visiting
+//     Advanced materialised `quick-terminal-key = ` the user never set.
 //
-// The markup is parsed as XML rather than text-scanned, so a handler named
-// inside an XML comment does not count, and the code-behind is parsed with
-// Roslyn rather than grepped, so the word "ShaderPathBox.Text" in a comment
-// does not satisfy the check.
+// Nothing catches either at runtime: the write is a legitimate config edit, the
+// file stays valid, and the setting just quietly becomes something else.
+//
+// The markup is parsed as XML, so a handler named inside an XML comment does
+// not count, and the code-behind is parsed with Roslyn, so the control name
+// appearing in a comment does not count as a seed.
+//
+// What this does NOT see: a LostFocus handler attached in code-behind rather
+// than in markup, and a seed written through a property other than Text.
 public class SettingsWriteBackSeedingTests
 {
     private const string PagePrefix = "Ghostty.Tests.Settings.Pages.";
-
-    // The WinUI project's sources are already embedded under this prefix,
-    // keeping their directory in the name, so the code-behind is reached by
-    // suffix rather than by adding a second glob that would collide with it.
-    private const string SourcePrefix = "Ghostty.Tests.Interop.Sources.Ghostty.";
 
     private static readonly XNamespace XamlNamespace =
         "http://schemas.microsoft.com/winfx/2006/xaml";
 
     [Fact]
-    public void EveryLostFocusWriteBackControlIsSeededInItsCodeBehind()
+    public void EveryLostFocusWriteBackControlIsSeededAndGuarded()
     {
         var controls = WriteBackControls();
 
@@ -53,24 +54,32 @@ public class SettingsWriteBackSeedingTests
             "found no LostFocus write-back controls in the settings pages; the " +
             "scan is broken, not the pages");
 
-        var unseeded = new List<string>();
+        var problems = new List<string>();
         foreach (var control in controls)
         {
-            var assigned = AssignedControlProperties(control.Page);
-            if (!assigned.Contains(control.Name + ".Text"))
+            var source = SourceFor(control.Page);
+
+            if (!AssignedControlProperties(source).Contains(control.Name + ".Text"))
             {
-                unseeded.Add(
+                problems.Add(
                     $"  {control.Page}: {control.Name} writes the config on " +
-                    $"{control.Handler} but nothing assigns {control.Name}.Text");
+                    $"{control.Handler} but nothing assigns {control.Name}.Text, so " +
+                    "the first blur writes whatever it is showing, which is nothing");
+            }
+
+            if (!ComparesSomething(source, control.Handler))
+            {
+                problems.Add(
+                    $"  {control.Page}: {control.Handler} writes without comparing " +
+                    "the value to anything, so every pass through the page rewrites " +
+                    "the key -- and appends it if the file does not have it");
             }
         }
 
         Assert.True(
-            unseeded.Count == 0,
-            "settings controls that write on blur without being seeded first. " +
-            "Moving focus past one of these writes what it happens to be " +
-            "showing, which for an unseeded box is nothing:\n" +
-            string.Join("\n", unseeded));
+            problems.Count == 0,
+            "settings controls that write on blur without being seeded first, or " +
+            "without checking whether anything changed:\n" + string.Join("\n", problems));
     }
 
     private sealed record WriteBackControl(string Page, string Name, string Handler);
@@ -102,34 +111,33 @@ public class SettingsWriteBackSeedingTests
         return found;
     }
 
-    // The left-hand sides of every assignment in the page's code-behind, as
+    // Parsed once per page. ShellSource does the resource-by-suffix lookup, the
+    // exactly-one assert, and the separator normalisation MSBuild's logical
+    // names need; reimplementing those here drifted from it once already.
+    private static readonly Dictionary<string, ShellSource> SourceCache = new(StringComparer.Ordinal);
+
+    private static ShellSource SourceFor(string pageXamlName)
+    {
+        if (SourceCache.TryGetValue(pageXamlName, out var cached)) return cached;
+
+        var source = ShellSource.Load("Settings.Pages." + pageXamlName + ".cs");
+
+        // Parsed with no preprocessor symbols, so a conditionally-compiled
+        // region would make the file this reads a different program from the
+        // one that ships. Same guard the sibling parity test carries.
+        Assert.DoesNotContain("#if", source.Root.ToFullString(), StringComparison.Ordinal);
+
+        SourceCache[pageXamlName] = source;
+        return source;
+    }
+
+    // The left-hand sides of every assignment in the page, as
     // "Control.Property". Roslyn rather than a string search: a mention in a
     // comment or in a nameof() is not a seed.
-    private static HashSet<string> AssignedControlProperties(string pageXamlName)
+    private static HashSet<string> AssignedControlProperties(ShellSource source)
     {
-        var assembly = Assembly.GetExecutingAssembly();
-        var suffix = pageXamlName + ".cs";
-        var matches = assembly.GetManifestResourceNames()
-            .Where(n => n.StartsWith(SourcePrefix, StringComparison.Ordinal)
-                        && n.EndsWith(suffix, StringComparison.Ordinal))
-            .ToList();
-
-        // Exactly one, not "the first". Two pages of the same name in different
-        // directories would otherwise be checked against whichever the resource
-        // order happened to put first.
-        Assert.True(
-            matches.Count == 1,
-            $"expected exactly one embedded source ending in {suffix}, found " +
-            $"{matches.Count}: {string.Join(", ", matches)}");
-
-        using var stream = assembly.GetManifestResourceStream(matches[0]);
-        Assert.NotNull(stream);
-
-        using var reader = new StreamReader(stream!);
-        var root = CSharpSyntaxTree.ParseText(reader.ReadToEnd()).GetRoot();
-
         var assigned = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var assignment in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        foreach (var assignment in source.Root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
         {
             if (assignment.Left is MemberAccessExpressionSyntax
                 {
@@ -142,6 +150,14 @@ public class SettingsWriteBackSeedingTests
 
         return assigned;
     }
+
+    // Whether the handler compares anything at all. Deliberately loose: what it
+    // rules out is the shape that shipped twice, a handler whose only guard is
+    // `_loading` and which then writes whatever it is holding.
+    private static bool ComparesSomething(ShellSource source, string handlerName) =>
+        source.Method(handlerName).DescendantNodes()
+            .OfType<BinaryExpressionSyntax>()
+            .Any(b => b.OperatorToken.Text is "==" or "!=");
 
     private static List<(string Page, XDocument Document)> PageDocuments()
     {

--- a/windows/Ghostty.Tests/Settings/SettingsWriteBackSeedingTests.cs
+++ b/windows/Ghostty.Tests/Settings/SettingsWriteBackSeedingTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Ghostty.Tests.Settings;
+
+// A settings control that writes to the config file on LostFocus has to be
+// seeded from the config file first.
+//
+// Blur is not an edit. It fires on every pass through the page: tabbing
+// through, clicking elsewhere, closing the window. So a box that writes
+// unconditionally on blur writes whatever it is currently showing -- and a box
+// that was never seeded is showing nothing. AppearancePage's custom-shader box
+// was the one page control with no seed, so opening Appearance and moving focus
+// past it wrote `custom-shader = ` and dropped a configured shader.
+//
+// Nothing catches that at runtime: the write is a legitimate config edit, the
+// file stays valid, and the terminal just quietly stops using the shader.
+//
+// The markup is parsed as XML rather than text-scanned, so a handler named
+// inside an XML comment does not count, and the code-behind is parsed with
+// Roslyn rather than grepped, so the word "ShaderPathBox.Text" in a comment
+// does not satisfy the check.
+public class SettingsWriteBackSeedingTests
+{
+    private const string PagePrefix = "Ghostty.Tests.Settings.Pages.";
+
+    // The WinUI project's sources are already embedded under this prefix,
+    // keeping their directory in the name, so the code-behind is reached by
+    // suffix rather than by adding a second glob that would collide with it.
+    private const string SourcePrefix = "Ghostty.Tests.Interop.Sources.Ghostty.";
+
+    private static readonly XNamespace XamlNamespace =
+        "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    [Fact]
+    public void EveryLostFocusWriteBackControlIsSeededInItsCodeBehind()
+    {
+        var controls = WriteBackControls();
+
+        // If the scan finds nothing, every assertion below holds vacuously.
+        // There is at least one such control in the tree and there has been
+        // since the quake key box.
+        Assert.True(
+            controls.Count > 0,
+            "found no LostFocus write-back controls in the settings pages; the " +
+            "scan is broken, not the pages");
+
+        var unseeded = new List<string>();
+        foreach (var control in controls)
+        {
+            var assigned = AssignedControlProperties(control.Page);
+            if (!assigned.Contains(control.Name + ".Text"))
+            {
+                unseeded.Add(
+                    $"  {control.Page}: {control.Name} writes the config on " +
+                    $"{control.Handler} but nothing assigns {control.Name}.Text");
+            }
+        }
+
+        Assert.True(
+            unseeded.Count == 0,
+            "settings controls that write on blur without being seeded first. " +
+            "Moving focus past one of these writes what it happens to be " +
+            "showing, which for an unseeded box is nothing:\n" +
+            string.Join("\n", unseeded));
+    }
+
+    private sealed record WriteBackControl(string Page, string Name, string Handler);
+
+    private static List<WriteBackControl> WriteBackControls()
+    {
+        var found = new List<WriteBackControl>();
+        foreach (var (page, document) in PageDocuments())
+        {
+            foreach (var element in document.Descendants())
+            {
+                var handler = element.Attribute("LostFocus")?.Value;
+                if (handler is null) continue;
+
+                var name = element.Attribute(XamlNamespace + "Name")?.Value;
+
+                // A handler on an unnamed control cannot be checked from here,
+                // and it also cannot be seeded by name from the code-behind, so
+                // it is a defect in its own right rather than something to skip.
+                Assert.False(
+                    string.IsNullOrEmpty(name),
+                    $"{page}: a {element.Name.LocalName} handles LostFocus " +
+                    $"({handler}) but has no x:Name, so nothing can seed it");
+
+                found.Add(new WriteBackControl(page, name!, handler));
+            }
+        }
+
+        return found;
+    }
+
+    // The left-hand sides of every assignment in the page's code-behind, as
+    // "Control.Property". Roslyn rather than a string search: a mention in a
+    // comment or in a nameof() is not a seed.
+    private static HashSet<string> AssignedControlProperties(string pageXamlName)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var suffix = pageXamlName + ".cs";
+        var matches = assembly.GetManifestResourceNames()
+            .Where(n => n.StartsWith(SourcePrefix, StringComparison.Ordinal)
+                        && n.EndsWith(suffix, StringComparison.Ordinal))
+            .ToList();
+
+        // Exactly one, not "the first". Two pages of the same name in different
+        // directories would otherwise be checked against whichever the resource
+        // order happened to put first.
+        Assert.True(
+            matches.Count == 1,
+            $"expected exactly one embedded source ending in {suffix}, found " +
+            $"{matches.Count}: {string.Join(", ", matches)}");
+
+        using var stream = assembly.GetManifestResourceStream(matches[0]);
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        var root = CSharpSyntaxTree.ParseText(reader.ReadToEnd()).GetRoot();
+
+        var assigned = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var assignment in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.Left is MemberAccessExpressionSyntax
+                {
+                    Expression: IdentifierNameSyntax identifier,
+                } member)
+            {
+                assigned.Add(identifier.Identifier.ValueText + "." + member.Name.Identifier.ValueText);
+            }
+        }
+
+        return assigned;
+    }
+
+    private static List<(string Page, XDocument Document)> PageDocuments()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var pages = new List<(string, XDocument)>();
+
+        foreach (var resource in assembly.GetManifestResourceNames()
+                     .Where(n => n.StartsWith(PagePrefix, StringComparison.Ordinal)
+                                 && n.EndsWith(".xaml", StringComparison.Ordinal)))
+        {
+            using var stream = assembly.GetManifestResourceStream(resource);
+            Assert.NotNull(stream);
+
+            var page = resource[PagePrefix.Length..];
+            try
+            {
+                pages.Add((page, XDocument.Load(stream)));
+            }
+            catch (XmlException ex)
+            {
+                Assert.Fail($"{page} is not well-formed XML: {ex.Message}");
+            }
+        }
+
+        Assert.True(pages.Count > 0, "no settings page XAML is embedded; see Ghostty.Tests.csproj");
+        return pages;
+    }
+}

--- a/windows/Ghostty/Settings/Pages/AdvancedPage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AdvancedPage.xaml.cs
@@ -27,6 +27,7 @@ internal sealed partial class AdvancedPage : Page
         HighContrastToggle.IsOn = _configService.WindowsHighContrast;
         SelectComboByTag(LogLevelCombo, _configService.LogLevel);
         LogFilterBox.Text = _configService.LogFilter ?? string.Empty;
+        _logFilterWritten = LogFilterBox.Text.Trim();
 
         if (_cs is null) return;
 
@@ -36,7 +37,19 @@ internal sealed partial class AdvancedPage : Page
 
         var quake = _cs.GetRawFileValue("quick-terminal-key");
         QuakeKeyBox.Text = string.IsNullOrWhiteSpace(quake) ? string.Empty : quake;
+        _quakeKeyWritten = QuakeKeyBox.Text.Trim();
     }
+
+    // Blur is not an edit: it fires on tab-through, on a click elsewhere, on
+    // the window closing. Writing unconditionally meant every pass through this
+    // page rewrote both keys, and for a file with no quick-terminal-key line
+    // SetValue APPENDS, so simply visiting Advanced materialised
+    // `quick-terminal-key = ` that the user never set.
+    //
+    // Seeded values are trimmed to match what the handlers write, or a file
+    // value with trailing space would look changed on the first blur.
+    private string _quakeKeyWritten = string.Empty;
+    private string _logFilterWritten = string.Empty;
 
     private void SingleInstanceToggle_Toggled(object sender, RoutedEventArgs e)
     {
@@ -58,6 +71,8 @@ internal sealed partial class AdvancedPage : Page
     {
         if (_loading) return;
         var raw = QuakeKeyBox.Text?.Trim() ?? string.Empty;
+        if (raw == _quakeKeyWritten) return;
+        _quakeKeyWritten = raw;
         Ghostty.App.ConfigWriteScheduler?.Schedule("quick-terminal-key", raw);
     }
 
@@ -74,9 +89,10 @@ internal sealed partial class AdvancedPage : Page
     private void LogFilterBox_LostFocus(object sender, RoutedEventArgs e)
     {
         if (_loading) return;
-        Ghostty.App.ConfigWriteScheduler?.Schedule(
-            "log-filter",
-            LogFilterBox.Text?.Trim() ?? string.Empty);
+        var filter = LogFilterBox.Text?.Trim() ?? string.Empty;
+        if (filter == _logFilterWritten) return;
+        _logFilterWritten = filter;
+        Ghostty.App.ConfigWriteScheduler?.Schedule("log-filter", filter);
     }
 
     private static void SelectComboByTag(ComboBox combo, string tag)

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -67,6 +67,17 @@ internal sealed partial class AppearancePage : Page
             // NoColorOverride is already normalized to one of notify/strip/keep.
             SelectComboByTag(NoColorOverrideCombo, cs.NoColorOverride);
 
+            // Read from the file rather than from the merged config: this box
+            // edits what is written down, and a default the user never set
+            // would be written back the moment the box loses focus.
+            //
+            // custom-shader is repeatable and this getter returns the first
+            // entry, so a config with two shaders shows only the first. The
+            // dirty check in ShaderPath_LostFocus is what keeps the second one:
+            // passing through the box without editing it writes nothing.
+            ShaderPathBox.Text = cs.GetRawFileValue("custom-shader");
+            _shaderPathWritten = ShaderPathBox.Text;
+
             BlurFollowsOpacityToggle.IsOn = cs.BackgroundBlurFollowsOpacity;
             if (cs.IsConfiguredInFile("background-tint-color"))
             {
@@ -257,9 +268,20 @@ internal sealed partial class AppearancePage : Page
             OnValueChanged("window-theme", item.Tag?.ToString() ?? "auto");
     }
 
+    // The last value this page put in the file, or seeded from it. Blur fires
+    // on every pass through the page, including tab-through and the window
+    // closing, so an unconditional write here rewrote custom-shader every time
+    // - and while the box was never seeded, it rewrote it to empty, silently
+    // dropping a configured shader.
+    private string _shaderPathWritten = string.Empty;
+
     private void ShaderPath_LostFocus(object sender, RoutedEventArgs e)
     {
-        if (sender is TextBox tb) OnValueChanged("custom-shader", tb.Text);
+        if (sender is not TextBox tb) return;
+        var value = tb.Text ?? string.Empty;
+        if (value == _shaderPathWritten) return;
+        _shaderPathWritten = value;
+        OnValueChanged("custom-shader", value);
     }
 
     private void BackgroundStyle_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
+++ b/windows/Ghostty/Settings/Pages/AppearancePage.xaml.cs
@@ -8,6 +8,7 @@ using Ghostty.Core.DirectWrite;
 using Ghostty.Core.Settings;
 using Ghostty.Logging;
 using Ghostty.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -67,16 +68,7 @@ internal sealed partial class AppearancePage : Page
             // NoColorOverride is already normalized to one of notify/strip/keep.
             SelectComboByTag(NoColorOverrideCombo, cs.NoColorOverride);
 
-            // Read from the file rather than from the merged config: this box
-            // edits what is written down, and a default the user never set
-            // would be written back the moment the box loses focus.
-            //
-            // custom-shader is repeatable and this getter returns the first
-            // entry, so a config with two shaders shows only the first. The
-            // dirty check in ShaderPath_LostFocus is what keeps the second one:
-            // passing through the box without editing it writes nothing.
-            ShaderPathBox.Text = cs.GetRawFileValue("custom-shader");
-            _shaderPathWritten = ShaderPathBox.Text;
+            SeedShaderPath();
 
             BlurFollowsOpacityToggle.IsOn = cs.BackgroundBlurFollowsOpacity;
             if (cs.IsConfiguredInFile("background-tint-color"))
@@ -268,6 +260,24 @@ internal sealed partial class AppearancePage : Page
             OnValueChanged("window-theme", item.Tag?.ToString() ?? "auto");
     }
 
+    // Read from the file rather than from the merged config: this box edits
+    // what is written down, and a default the user never set would be written
+    // back the moment the box loses focus.
+    //
+    // custom-shader is repeatable and this is one box, so a config with several
+    // entries can only show one of them. It shows the FIRST, and writing sets
+    // the whole list to just that value, so what the box displays is always
+    // what the setting is. Reading the first and writing the last -- which is
+    // where SetValue lands -- would leave the entry the user was looking at
+    // untouched and destroy one they never saw.
+    private void SeedShaderPath()
+    {
+        var values = _editor.GetRepeatableValues("custom-shader");
+        ShaderPathBox.Text = values.Length > 0 ? values[0] : string.Empty;
+        _shaderPathWritten = ShaderPathBox.Text;
+        _shaderPathExtraEntries = values.Length > 1;
+    }
+
     // The last value this page put in the file, or seeded from it. Blur fires
     // on every pass through the page, including tab-through and the window
     // closing, so an unconditional write here rewrote custom-shader every time
@@ -275,13 +285,40 @@ internal sealed partial class AppearancePage : Page
     // dropping a configured shader.
     private string _shaderPathWritten = string.Empty;
 
+    // Whether the file had more custom-shader lines than this box can show. Only
+    // used to log that writing collapses them, since the box cannot represent
+    // them and silently dropping them would be worse unexplained.
+    private bool _shaderPathExtraEntries;
+
     private void ShaderPath_LostFocus(object sender, RoutedEventArgs e)
     {
+        if (_loading) return;
         if (sender is not TextBox tb) return;
+
         var value = tb.Text ?? string.Empty;
         if (value == _shaderPathWritten) return;
+
+        if (_shaderPathExtraEntries)
+        {
+            StaticLoggers.SettingsConfigWriter.LogInformation(
+                "custom-shader had more entries than the Appearance box can show; " +
+                "editing it collapses them to the one shown");
+        }
+
+        var values = value.Length > 0 ? new[] { value } : System.Array.Empty<string>();
+        var result = _writer.Write(
+            () => _editor.SetRepeatableValues("custom-shader", values),
+            "custom-shader");
+
+        // Only on success. Advancing unconditionally meant a write that failed
+        // -- the file locked by a sync client or an editor -- left the guard
+        // holding a value the file does not have, so every retry from this page
+        // read as "unchanged" and was suppressed for the life of the window.
+        if (!result.WriteSucceeded) return;
+
         _shaderPathWritten = value;
-        OnValueChanged("custom-shader", value);
+        _shaderPathExtraEntries = false;
+        if (result.Reloaded) _expectingOwnReloads++;
     }
 
     private void BackgroundStyle_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -439,6 +476,13 @@ internal sealed partial class AppearancePage : Page
                 .Select(p => new Controls.Settings.GradientPointModel(
                     p.X, p.Y, p.Color, p.Radius))
                 .ToList());
+
+            // The shader box has to move with the file too. Leaving it alone
+            // would not merely show a stale value: _shaderPathWritten would go
+            // on describing a write this page made before the external edit
+            // undid it, so re-committing the displayed value would read as
+            // unchanged and be suppressed.
+            SeedShaderPath();
         }
         finally
         {


### PR DESCRIPTION
`ShaderPathBox` on Settings > Appearance was the only control never seeded from config, and its `LostFocus` handler wrote unconditionally.

Blur is not an edit. It fires on tab-through, on a click elsewhere, on the window closing. So opening Appearance and moving focus past the box wrote whatever it was showing, which was nothing, and `custom-shader = ` replaced a configured shader. Nothing catches that at runtime: the write is a legitimate config edit, the file stays valid, and the terminal quietly stops using the shader.

## The fix, after review

Review found the first attempt got three things wrong.

**Read and write went to opposite ends of the file.** `GetRawFileValue` returns the **first** entry of a repeatable key; `SetValue` rewrites the **last**. So editing a box showing entry one destroyed entry two and left entry one alone -- and the comment claimed the opposite. The box now seeds with `GetRepeatableValues` and writes the whole list, so what it displays is what the setting is. Collapsing several entries into one is still a loss, but a visible one, and it is logged.

**The guard advanced before the write landed.** `SettingsConfigWriter` catches `IOException`/`UnauthorizedAccessException` and reports them in `WriteSucceeded`, which nobody read. A locked file left the guard holding a value the file did not have, so every retry from that page read as "unchanged" and was suppressed for the life of the window -- strictly worse than the unconditional write it replaced. It advances on success only now, the way `RawEditorPage` already did.

**The guard went stale on an external edit.** `OnConfigChanged` re-seeded only the gradient editor, and `SettingsWindow` caches page instances. After an edit through the raw editor, the box kept describing a write the file no longer had, and re-committing the displayed value was suppressed. It re-seeds there too, guard and display together.

## The other half of the same defect

`AdvancedPage` was seeded but wrote unconditionally, and `SetValue` **appends** a key the file does not have -- so simply visiting Advanced materialised `quick-terminal-key = ` the user never set. Both its boxes compare first now, against a trimmed seed so a file value with trailing space does not look changed on the first blur.

## Test

`SettingsWriteBackSeedingTests` asserts both halves: every `LostFocus` write-back control is assigned in its code-behind, and its handler compares the value to something. Markup parsed as XML, code-behind parsed with Roslyn, a page carrying `#if` refused, and `ShellSource` reused for the resource lookup rather than a second copy (which had already drifted by dropping the separator normalisation).

Verified with both negative controls run together: deleting the seed fails the Appearance box, deleting the dirty check fails the Advanced handler, each with its own message.

2220 passed / 1 skipped; Ghostty.Tests.Windows 44 passed / 12 skipped.
