### PR TITLE
config: expand ~ where the paths are actually resolved

### DIFF
--- a/src/config/path.zig
+++ b/src/config/path.zig
@@ -158,12 +158,17 @@ pub const Path = union(enum) {
         var buf: [std.fs.max_path_bytes]u8 = undefined;
 
         // Check if the path starts with a tilde and expand it to the
-        // home directory on Linux/macOS. We explicitly look for "~/"
-        // because we don't support alternate users such as "~alice/"
-        if (std.mem.startsWith(u8, path, "~/")) expand: {
-            // Windows isn't supported yet
-            if (comptime builtin.os.tag == .windows) break :expand;
-
+        // home directory. We explicitly look for "~/" because we don't
+        // support alternate users such as "~alice/".
+        //
+        // Windows included. It used to break out of this block, on the
+        // grounds that `~/` is not a Windows idiom -- true of Windows, and
+        // untrue of Ghostty configs, where every documented example is
+        // written that way. Left unexpanded the path fell through to the
+        // relative branch and resolved under the config directory, so a
+        // config carried over from macOS or Linux had paths that could
+        // never resolve and said nothing about why.
+        if (std.mem.startsWith(u8, path, "~/")) {
             var environ_map = try global.environMap();
             defer environ_map.deinit();
 

--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -106,8 +106,14 @@ pub fn expandHome(
     return switch (builtin.os.tag) {
         .linux, .freebsd, .macos => try expandHomeUnix(io, environ_map, path, buf),
 
-        // `~/` is not an idiom generally used on Windows
-        .windows => return path,
+        // `~/` is not an idiom Windows itself uses, but it is the idiom
+        // every Ghostty config example is written in, so a config carried
+        // over from macOS or Linux is full of them. Left unexpanded they
+        // become a relative path that cannot exist, and the option silently
+        // does nothing: a custom-shader at `~/shader.glsl` reports only
+        // "check the path". Both separators are accepted because a config
+        // written on Windows will use the backslash.
+        .windows => try expandHomeWindows(environ_map, path, buf),
 
         // iOS doesn't have a user-writable home directory
         .ios => return path,
@@ -134,6 +140,69 @@ fn expandHomeUnix(
     @memcpy(buf[home_dir.len..expanded_len], rest);
 
     return buf[0..expanded_len];
+}
+
+fn expandHomeWindows(
+    environ_map: *const std.process.Environ.Map,
+    path: []const u8,
+    buf: []u8,
+) ExpandError![]const u8 {
+    if (!std.mem.startsWith(u8, path, "~/") and
+        !std.mem.startsWith(u8, path, "~\\")) return path;
+
+    // homeWindows writes into `buf` and returns a slice of it, so the rest of
+    // the path is appended in place after it, exactly as the Unix path does.
+    const home_dir: []const u8 = (homeWindows(environ_map, buf) catch
+        return error.HomeDetectionFailed) orelse
+        return error.HomeDetectionFailed;
+
+    const rest = path[1..]; // Skip the ~
+    const expanded_len = home_dir.len + rest.len;
+    if (expanded_len > buf.len) return Error.BufferTooSmall;
+    @memcpy(buf[home_dir.len..expanded_len], rest);
+
+    return buf[0..expanded_len];
+}
+
+test "expandHomeWindows" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    var environ_map = try testing.environ.createMap(testing.allocator);
+    defer environ_map.deinit();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+
+    const home_dir = try expandHomeWindows(&environ_map, "~/", &buf);
+    try testing.expect(home_dir.len > 1);
+    try testing.expect(home_dir[home_dir.len - 1] == '/');
+
+    // Both separators reach the same place, since a config may be written
+    // either way on Windows.
+    const fwd = try expandHomeWindows(&environ_map, "~/shader.glsl", &buf);
+    try testing.expect(std.mem.endsWith(u8, fwd, "/shader.glsl"));
+    try testing.expect(!std.mem.startsWith(u8, fwd, "~"));
+
+    const back = try expandHomeWindows(&environ_map, "~\\shader.glsl", &buf);
+    try testing.expect(std.mem.endsWith(u8, back, "\\shader.glsl"));
+    try testing.expect(!std.mem.startsWith(u8, back, "~"));
+
+    // A bare tilde and a `~name` prefix are not home references.
+    try testing.expectEqualStrings("~", try expandHomeWindows(&environ_map, "~", &buf));
+    try testing.expectEqualStrings("~abc/", try expandHomeWindows(&environ_map, "~abc/", &buf));
+    try testing.expectEqualStrings("", try expandHomeWindows(&environ_map, "", &buf));
+    try testing.expectEqualStrings(
+        "C:\\shaders\\x.glsl",
+        try expandHomeWindows(&environ_map, "C:\\shaders\\x.glsl", &buf),
+    );
+
+    var small_buf = try allocator.alloc(u8, home_dir.len);
+    defer allocator.free(small_buf);
+    try testing.expectError(error.BufferTooSmall, expandHomeWindows(
+        &environ_map,
+        "~/Downloads",
+        small_buf[0..],
+    ));
 }
 
 test "expandHomeUnix" {

--- a/src/os/homedir.zig
+++ b/src/os/homedir.zig
@@ -77,6 +77,18 @@ fn homeUnix(io: std.Io, environ_map: *const std.process.Environ.Map, buf: []u8) 
 }
 
 fn homeWindows(environ_map: *const std.process.Environ.Map, buf: []u8) !?[]const u8 {
+    // USERPROFILE first. It is what everything else on Windows resolves a home
+    // reference to -- PowerShell, Git Bash, OpenSSH, Python's expanduser -- and
+    // it is what a config carried over from another machine means by `~`.
+    // HOMEDRIVE+HOMEPATH stays as the fallback rather than the primary because
+    // on a domain-joined machine it names a mapped network drive, so preferring
+    // it would send `~/projects` to a share instead of to the user's profile.
+    if (environ_map.get("USERPROFILE")) |result| {
+        if (buf.len < result.len) return Error.BufferTooSmall;
+        @memcpy(buf[0..result.len], result);
+        return buf[0..result.len];
+    }
+
     var writer: std.Io.Writer = .fixed(buf);
     _ = try writer.write(environ_map.get("HOMEDRIVE") orelse return null);
     _ = try writer.write(environ_map.get("HOMEPATH") orelse return null);
@@ -111,8 +123,12 @@ pub fn expandHome(
         // over from macOS or Linux is full of them. Left unexpanded they
         // become a relative path that cannot exist, and the option silently
         // does nothing: a custom-shader at `~/shader.glsl` reports only
-        // "check the path". Both separators are accepted because a config
-        // written on Windows will use the backslash.
+        // "check the path".
+        //
+        // `~/` only, not `~\`, because `~/` is what every caller gates on --
+        // Path.expand and Config.expandHome both test for that prefix before
+        // they get here, so a `~\` arm would be unreachable code asserting
+        // behaviour nothing can produce.
         .windows => try expandHomeWindows(environ_map, path, buf),
 
         // iOS doesn't have a user-writable home directory
@@ -147,14 +163,21 @@ fn expandHomeWindows(
     path: []const u8,
     buf: []u8,
 ) ExpandError![]const u8 {
-    if (!std.mem.startsWith(u8, path, "~/") and
-        !std.mem.startsWith(u8, path, "~\\")) return path;
+    if (!std.mem.startsWith(u8, path, "~/")) return path;
 
     // homeWindows writes into `buf` and returns a slice of it, so the rest of
     // the path is appended in place after it, exactly as the Unix path does.
-    const home_dir: []const u8 = (homeWindows(environ_map, buf) catch
-        return error.HomeDetectionFailed) orelse
-        return error.HomeDetectionFailed;
+    //
+    // Its two failures are not the same failure: the error is its fixed writer
+    // overflowing, which is a buffer problem, and only the null means the home
+    // directory could not be found. Mapping both to HomeDetectionFailed told
+    // the user their home directory was missing when it was found and
+    // truncated, and disagreed with home() above, which maps it to
+    // BufferTooSmall.
+    const home_dir: []const u8 = if (homeWindows(environ_map, buf)) |home_|
+        home_ orelse return error.HomeDetectionFailed
+    else |_|
+        return Error.BufferTooSmall;
 
     const rest = path[1..]; // Skip the ~
     const expanded_len = home_dir.len + rest.len;
@@ -174,20 +197,19 @@ test "expandHomeWindows" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
 
     const home_dir = try expandHomeWindows(&environ_map, "~/", &buf);
-    try testing.expect(home_dir.len > 1);
+    // Joining `~` with `/` leaves the separator on the end, as on Unix.
     try testing.expect(home_dir[home_dir.len - 1] == '/');
 
-    // Both separators reach the same place, since a config may be written
-    // either way on Windows.
-    const fwd = try expandHomeWindows(&environ_map, "~/shader.glsl", &buf);
-    try testing.expect(std.mem.endsWith(u8, fwd, "/shader.glsl"));
-    try testing.expect(!std.mem.startsWith(u8, fwd, "~"));
+    // The whole string, not just its tail. Asserting only that the result ends
+    // in the path and no longer starts with a tilde passes an implementation
+    // that wrote HOMEDRIVE and dropped HOMEPATH.
+    const shader = try expandHomeWindows(&environ_map, "~/shaders/crt.glsl", &buf);
+    const expected = try std.mem.concat(allocator, u8, &[_][]const u8{ home_dir, "shaders/crt.glsl" });
+    defer allocator.free(expected);
+    try testing.expectEqualStrings(expected, shader);
 
-    const back = try expandHomeWindows(&environ_map, "~\\shader.glsl", &buf);
-    try testing.expect(std.mem.endsWith(u8, back, "\\shader.glsl"));
-    try testing.expect(!std.mem.startsWith(u8, back, "~"));
-
-    // A bare tilde and a `~name` prefix are not home references.
+    // A bare tilde, a `~name` prefix and an absolute path are not home
+    // references. `~\` is not one either: every caller gates on `~/`.
     try testing.expectEqualStrings("~", try expandHomeWindows(&environ_map, "~", &buf));
     try testing.expectEqualStrings("~abc/", try expandHomeWindows(&environ_map, "~abc/", &buf));
     try testing.expectEqualStrings("", try expandHomeWindows(&environ_map, "", &buf));
@@ -196,6 +218,7 @@ test "expandHomeWindows" {
         try expandHomeWindows(&environ_map, "C:\\shaders\\x.glsl", &buf),
     );
 
+    // Big enough for the home directory, not for the expansion.
     var small_buf = try allocator.alloc(u8, home_dir.len);
     defer allocator.free(small_buf);
     try testing.expectError(error.BufferTooSmall, expandHomeWindows(

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -65,11 +65,6 @@ pub fn loadFromFiles(
                 continue;
             }
 
-            // The path, not just the error. This is the last frame that has
-            // it: the caller gets an error with no idea which entry of a
-            // repeatable option produced it, and the user-facing notice can
-            // only say "check the path" without naming one.
-            log.warn("custom shader failed path={s} err={}", .{ path, err });
             return err;
         };
         log.info("loaded custom shader path={s}", .{path});
@@ -137,7 +132,14 @@ fn compileShader(
     const src = src: {
         // Load the shader file
         const cwd = std.Io.Dir.cwd();
-        const file = try cwd.openFile(global.io(), path, .{});
+        const file = cwd.openFile(global.io(), path, .{}) catch |err| {
+            // The only failures nothing else logs. A compile failure is already
+            // reported with its path below; a file that cannot be opened was
+            // reported as a bare error name, leaving the user's "check the
+            // path" notice with no path to check.
+            log.warn("custom shader could not be opened path={s} err={}", .{ path, err });
+            return err;
+        };
         defer file.close(global.io());
         break :src try compat_file.readToEndAlloc(
             file,

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -65,6 +65,11 @@ pub fn loadFromFiles(
                 continue;
             }
 
+            // The path, not just the error. This is the last frame that has
+            // it: the caller gets an error with no idea which entry of a
+            // repeatable option produced it, and the user-facing notice can
+            // only say "check the path" without naming one.
+            log.warn("custom shader failed path={s} err={}", .{ path, err });
             return err;
         };
         log.info("loaded custom shader path={s}", .{path});

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -156,10 +156,17 @@ internal sealed partial class GhosttyHost : IDisposable
     private readonly Ghostty.Core.Notifications.IToastNotifier _toasts;
 
     // One-time gate plus copy for the "custom-shader configured but not
-    // applied" notice. Lives on the host because that is the singleton every
-    // surface's action lands on, so one gate sees the whole process rather
-    // than one banner per pane. Only touched from the UI-thread lambda below.
-    private readonly Ghostty.Core.Renderer.CustomShaderNoticeSource _customShaderNotices = new();
+    // applied" notice.
+    //
+    // Static because a host is per-window, not per-process: as an instance
+    // field this claimed to be "the singleton every surface's action lands on"
+    // while actually giving each window its own gate, so a second window
+    // re-raised a banner the user had already dismissed in the first. The
+    // shader is process-wide config, so one dismissal is the whole answer.
+    //
+    // Safe as shared state because it is only ever touched from the UI-thread
+    // lambda below, and every window in this app shares that thread.
+    private static readonly Ghostty.Core.Renderer.CustomShaderNoticeSource _customShaderNotices = new();
 
     public GhosttyApp App => _app;
 


### PR DESCRIPTION
A bad `custom-shader` path was unfixable from anything the user could see: the banner says "check the path" and names none, and a `~/` path could never resolve in the first place.

## The first attempt fixed nothing

Review caught this and it is worth stating plainly. Teaching `expandHome` about Windows does not help, because `Path.expand` breaks out of its tilde branch on Windows **before** it calls `expandHome` -- and `Path.expand` is what every `Path` / `RepeatablePath` option goes through: `custom-shader`, `background-image`, `bell-audio-path`, `config-file`. The change reached only `theme` and `working-directory`, and `custom-shader = ~/shader.glsl` still resolved under the config directory and still reported nothing useful.

The gate is gone now, so the expansion reaches the options this was written for.

**Verified end to end, not by reading.** A valid shader in the user's profile, referenced as `~/wintty-tilde-test.glsl`:

| libghostty built from | banner |
|---|---|
| `origin/windows` (this branch's fork point) | `Notice_custom-shader` |
| this branch | none -- the shader loads |

## Home directory

`USERPROFILE` first. `HOMEDRIVE`+`HOMEPATH` is what every other tool treats as the fallback, and on a domain-joined machine it names a mapped network drive, so preferring it sent `~/projects` to a share instead of to the profile. It stays as the fallback.

That matters more now than it did: `Path.expand` blanks a path whose expansion errors and emits a config diagnostic, so a home directory that cannot be found is no longer merely inert.

`homeWindows` has two failures and they are not the same one. Its error is the fixed writer overflowing -- a buffer problem; only its null means the home directory was not found. Mapping both to `HomeDetectionFailed` told the user their home directory was missing when it had been found and truncated, and disagreed with `home()`, which maps it to `BufferTooSmall`.

The `~\` arm is gone: every caller gates on `~/` before reaching here, so it was unreachable code with a test asserting behaviour nothing could produce.

## Which shader failed

`loadFromFiles` logging the failure produced three lines for one failed compile, two carrying the same path and error `compileShader` already logs. The failures nothing logged are the ones *before* the compiler runs -- a path that is not there, a directory, a permission error -- so the log sits on the file open, where it is the only trace.

## Reverted

The custom-shader notice gate is an instance field again. `OnAction` only ever runs on the bootstrap host, which is a process singleton, so the gate was already process-wide: the static changed no behaviour while its comment asserted a per-window architecture that does not exist.

## Verified

- `zig build test -Dapp-runtime=none`: 3923 passed / 78 skipped. `zig fmt --check` clean.
- `expandHomeWindows` asserts the whole expanded string, not just its tail -- asserting only the tail passes an implementation that wrote `HOMEDRIVE` and dropped `HOMEPATH`. Making the function a no-op fails it.
- 2219 passed / 1 skipped.
