### PR TITLE
interop: move the last unpinned FFI enums where a test can see them

### DIFF
--- a/windows/Ghostty.Core/Input/KeybindConflict.cs
+++ b/windows/Ghostty.Core/Input/KeybindConflict.cs
@@ -39,8 +39,8 @@ public static class KeybindConflictAnalyzer
     private const uint OtherMask =
         ModShift | ModShiftRight | ModAlt | ModAltRight | ModSuper | ModSuperRight;
 
-    private const int TagPhysical = 0;
-    private const int TagUnicode = 1;
+    private const int TagPhysical = (int)GhosttyTriggerTag.Physical;
+    private const int TagUnicode = (int)GhosttyTriggerTag.Unicode;
 
     // Plain Ctrl+<letter> control codes worth warning about.
     private static readonly Dictionary<char, string> Shadows = new()

--- a/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
+++ b/windows/Ghostty.Core/Input/KeybindTriggerSyntax.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Ghostty.Core.Interop;
 
 namespace Ghostty.Core.Input;
 
@@ -22,9 +23,9 @@ public static class KeybindTriggerSyntax
     private const uint ModAltRight = 1u << 8;
     private const uint ModSuperRight = 1u << 9;
 
-    private const int TagPhysical = 0;
-    private const int TagUnicode = 1;
-    private const int TagCatchAll = 2;
+    private const int TagPhysical = (int)GhosttyTriggerTag.Physical;
+    private const int TagUnicode = (int)GhosttyTriggerTag.Unicode;
+    private const int TagCatchAll = (int)GhosttyTriggerTag.CatchAll;
 
     // Fixed emission order. Maps a normalized mod token -> its rank.
     private static readonly string[] ModOrder = { "ctrl", "shift", "alt", "super" };

--- a/windows/Ghostty.Core/Input/KeyboardMapModel.cs
+++ b/windows/Ghostty.Core/Input/KeyboardMapModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Ghostty.Core.Interop;
 
 namespace Ghostty.Core.Input;
 
@@ -23,7 +24,7 @@ public sealed class KeyboardMapModel
 {
     private const uint Shift = 1u << 0, Ctrl = 1u << 1, Alt = 1u << 2, Super = 1u << 3;
     private const uint ShiftR = 1u << 6, CtrlR = 1u << 7, AltR = 1u << 8, SuperR = 1u << 9;
-    private const int TagPhysical = 0;
+    private const int TagPhysical = (int)GhosttyTriggerTag.Physical;
 
     public uint ModifierMask { get; }
     private readonly Dictionary<string, KeyboardKeyState> _byKey;

--- a/windows/Ghostty.Core/Input/TriggerLabeler.cs
+++ b/windows/Ghostty.Core/Input/TriggerLabeler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Ghostty.Core.Interop;
 
 namespace Ghostty.Core.Input;
 
@@ -20,9 +21,9 @@ public static class TriggerLabeler
     private const uint ModAltRight = 1u << 8;
     private const uint ModSuperRight = 1u << 9;
 
-    private const int TagPhysical = 0;
-    private const int TagUnicode = 1;
-    private const int TagCatchAll = 2;
+    private const int TagPhysical = (int)GhosttyTriggerTag.Physical;
+    private const int TagUnicode = (int)GhosttyTriggerTag.Unicode;
+    private const int TagCatchAll = (int)GhosttyTriggerTag.CatchAll;
 
     private static readonly Dictionary<string, string> Special = new(StringComparer.Ordinal)
     {

--- a/windows/Ghostty.Core/Interop/GhosttyNativeEnums.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyNativeEnums.cs
@@ -8,7 +8,7 @@ namespace Ghostty.Core.Interop;
 //
 // They live in Ghostty.Core rather than beside the P/Invokes in the WinUI
 // project for one reason: Ghostty.Tests cannot reference that project, so
-// nothing could check them. These are positions in enums upstream edits, and
+// nothing could check them. These are positions in enums edited elsewhere, and
 // an insertion renumbers every later member without breaking a build --
 // exactly what shifted twenty action tags and misrouted first_render into the
 // custom-shader handler. GhosttyActionTagHeaderParityTests now reads each of
@@ -17,15 +17,12 @@ namespace Ghostty.Core.Interop;
 // GhosttyInputKey, GhosttyPoint and the rest of the P/Invoke surface stay in
 // Ghostty/Interop/NativeMethods.cs; only the enums moved.
 
-// Macos and Ios rather than MacOS and IOS: the header spells them
-// GHOSTTY_PLATFORM_MACOS and GHOSTTY_PLATFORM_IOS, and the parity check maps a
-// managed name to a C one by breaking at capitals. Neither is referenced
-// anywhere on Windows; only Windows is.
+// Only Windows is ever passed; the rest exist to hold the ordinals.
 internal enum GhosttyPlatform
 {
     Invalid = 0,
-    Macos = 1,
-    Ios = 2,
+    MacOS = 1,
+    IOS = 2,
     Windows = 3,
 }
 
@@ -101,6 +98,14 @@ internal enum GhosttyInputAction
 }
 
 // Mirrors ghostty_point_tag_e.
+// ghostty_input_trigger_tag_e: which kind of trigger a keybind step carries.
+// Four files under Input/ had their own `private const int TagPhysical = 0`
+// copies of this; they now derive from here, so the values have one source and
+// the header check can see it. An insertion upstream would otherwise decode
+// every physical trigger as unicode and render a garbage glyph in the keybind
+// editor, with nothing reporting an error.
+internal enum GhosttyTriggerTag { Physical = 0, Unicode = 1, CatchAll = 2 }
+
 internal enum GhosttyPointTag
 {
     Active = 0,

--- a/windows/Ghostty.Core/Interop/GhosttyNativeEnums.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyNativeEnums.cs
@@ -1,0 +1,118 @@
+using System;
+
+namespace Ghostty.Core.Interop;
+
+// The plain C enums from include/ghostty.h that cross the boundary as ints:
+// platform and surface context, clipboard, mouse and key input, colour scheme,
+// and the point addressing used by the inspector and selection APIs.
+//
+// They live in Ghostty.Core rather than beside the P/Invokes in the WinUI
+// project for one reason: Ghostty.Tests cannot reference that project, so
+// nothing could check them. These are positions in enums upstream edits, and
+// an insertion renumbers every later member without breaking a build --
+// exactly what shifted twenty action tags and misrouted first_render into the
+// custom-shader handler. GhosttyActionTagHeaderParityTests now reads each of
+// them out of the header.
+//
+// GhosttyInputKey, GhosttyPoint and the rest of the P/Invoke surface stay in
+// Ghostty/Interop/NativeMethods.cs; only the enums moved.
+
+// Macos and Ios rather than MacOS and IOS: the header spells them
+// GHOSTTY_PLATFORM_MACOS and GHOSTTY_PLATFORM_IOS, and the parity check maps a
+// managed name to a C one by breaking at capitals. Neither is referenced
+// anywhere on Windows; only Windows is.
+internal enum GhosttyPlatform
+{
+    Invalid = 0,
+    Macos = 1,
+    Ios = 2,
+    Windows = 3,
+}
+
+internal enum GhosttySurfaceContext
+{
+    Window = 0,
+    Tab = 1,
+    Split = 2,
+}
+
+internal enum GhosttyClipboard
+{
+    Standard = 0,
+    Selection = 1,
+}
+
+internal enum GhosttyClipboardRequest
+{
+    Paste = 0,
+    Osc52Read = 1,
+    Osc52Write = 2,
+}
+
+internal enum GhosttyMouseState
+{
+    Release = 0,
+    Press = 1,
+}
+
+internal enum GhosttyMouseButton
+{
+    Unknown = 0,
+    Left = 1,
+    Right = 2,
+    Middle = 3,
+    Four = 4,
+    Five = 5,
+    Six = 6,
+    Seven = 7,
+    Eight = 8,
+    Nine = 9,
+    Ten = 10,
+    Eleven = 11,
+}
+
+internal enum GhosttyColorScheme
+{
+    Light = 0,
+    Dark = 1,
+}
+
+[Flags]
+internal enum GhosttyMods
+{
+    None = 0,
+    Shift = 1 << 0,
+    Ctrl = 1 << 1,
+    Alt = 1 << 2,
+    Super = 1 << 3,
+    Caps = 1 << 4,
+    Num = 1 << 5,
+    ShiftRight = 1 << 6,
+    CtrlRight = 1 << 7,
+    AltRight = 1 << 8,
+    SuperRight = 1 << 9,
+}
+
+internal enum GhosttyInputAction
+{
+    Release = 0,
+    Press = 1,
+    Repeat = 2,
+}
+
+// Mirrors ghostty_point_tag_e.
+internal enum GhosttyPointTag
+{
+    Active = 0,
+    Viewport = 1,
+    Screen = 2,
+    Surface = 3,
+}
+
+// Mirrors ghostty_point_coord_e.
+internal enum GhosttyPointCoord
+{
+    Exact = 0,
+    TopLeft = 1,
+    BottomRight = 2,
+}

--- a/windows/Ghostty.Core/Interop/KeybindInterop.cs
+++ b/windows/Ghostty.Core/Interop/KeybindInterop.cs
@@ -21,7 +21,7 @@ public enum GhosttyBindingFlags : uint
 [StructLayout(LayoutKind.Sequential)]
 public struct GhosttyTriggerC
 {
-    public int Tag;   // 0=physical, 1=unicode, 2=catch_all
+    public int Tag;   // ghostty_input_trigger_tag_e; see GhosttyTriggerTag
     public uint Key;  // union: translated/physical key or unicode codepoint
     public uint Mods; // modifier flags
 }

--- a/windows/Ghostty.Tests/Interop/GhosttyActionTagHeaderParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionTagHeaderParityTests.cs
@@ -124,6 +124,60 @@ public class GhosttyActionTagHeaderParityTests
         AssertMatchesHeader<GhosttyGotoTab>(
             "ghostty_action_goto_tab_e", "GHOSTTY_GOTO_TAB_", explicitValues: true);
 
+    // The enums that are not action payloads: what a surface is told about the
+    // platform it runs on, what the clipboard call is for, what the mouse and
+    // keyboard did, and how a point is addressed. They lived beside the
+    // P/Invokes in the WinUI project, which this assembly cannot reference, so
+    // until they moved to Ghostty.Core nothing could check any of them.
+    [Fact]
+    public void Platform_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyPlatform>("ghostty_platform_e", "GHOSTTY_PLATFORM_");
+
+    [Fact]
+    public void SurfaceContext_Values_Match_Header() =>
+        AssertMatchesHeader<GhosttySurfaceContext>(
+            "ghostty_surface_context_e", "GHOSTTY_SURFACE_CONTEXT_", explicitValues: true);
+
+    [Fact]
+    public void Clipboard_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyClipboard>("ghostty_clipboard_e", "GHOSTTY_CLIPBOARD_");
+
+    [Fact]
+    public void ClipboardRequest_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyClipboardRequest>(
+            "ghostty_clipboard_request_e", "GHOSTTY_CLIPBOARD_REQUEST_");
+
+    [Fact]
+    public void MouseState_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyMouseState>("ghostty_input_mouse_state_e", "GHOSTTY_MOUSE_");
+
+    [Fact]
+    public void MouseButton_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyMouseButton>("ghostty_input_mouse_button_e", "GHOSTTY_MOUSE_");
+
+    [Fact]
+    public void ColorScheme_Values_Match_Header() =>
+        AssertMatchesHeader<GhosttyColorScheme>(
+            "ghostty_color_scheme_e", "GHOSTTY_COLOR_SCHEME_", explicitValues: true);
+
+    // Bit flags, like the binding flags above.
+    [Fact]
+    public void Mods_Values_Match_Header() =>
+        AssertMatchesHeader<GhosttyMods>(
+            "ghostty_input_mods_e", "GHOSTTY_MODS_", explicitValues: true);
+
+    [Fact]
+    public void InputAction_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyInputAction>("ghostty_input_action_e", "GHOSTTY_ACTION_");
+
+    [Fact]
+    public void PointTag_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyPointTag>("ghostty_point_tag_e", "GHOSTTY_POINT_");
+
+    [Fact]
+    public void PointCoord_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyPointCoord>("ghostty_point_coord_e", "GHOSTTY_POINT_COORD_");
+
     // ghostty_target_tag_e decides which half of GhosttyHost.OnAction an action
     // is delivered to, so swapping these two routes every app action into the
     // surface arm. It used to be two consts beside that switch, where no test
@@ -223,19 +277,22 @@ public class GhosttyActionTagHeaderParityTests
     {
         var header = ParseHeaderEnum(headerText, typedefName, explicitValues);
 
-        // A [Flags] enum's zero member is the "no bits" convention C does not
-        // write down, so it has no header counterpart and is not drift.
+        // A [Flags] enum's zero member is sometimes the "no bits" convention C
+        // does not write down. Sometimes it is, though -- ghostty_input_mods_e
+        // spells GHOSTTY_MODS_NONE -- so this is a fallback for a zero the
+        // header does not name, not a blanket exemption. Skipping every flags
+        // zero would stop the completeness check seeing a NONE that vanished.
         var isFlags = typeof(TEnum).IsDefined(typeof(FlagsAttribute), inherit: false);
 
         var mismatches = new List<(string Name, string Detail)>();
         foreach (var name in Enum.GetNames<TEnum>())
         {
             var value = Convert.ToInt32(Enum.Parse<TEnum>(name));
-            if (isFlags && value == 0) continue;
             var cName = prefix + ToScreamingSnake(name);
 
             if (!header.TryGetValue(cName, out var expected))
             {
+                if (isFlags && value == 0) continue;
                 mismatches.Add((name, $"{name} = {value}: {cName} is not in {typedefName}"));
                 continue;
             }
@@ -253,7 +310,6 @@ public class GhosttyActionTagHeaderParityTests
         if (complete)
         {
             var mirrored = Enum.GetNames<TEnum>()
-                .Where(n => !isFlags || Convert.ToInt32(Enum.Parse<TEnum>(n)) != 0)
                 .Select(n => prefix + ToScreamingSnake(n))
                 .ToHashSet(StringComparer.Ordinal);
 
@@ -305,12 +361,21 @@ public class GhosttyActionTagHeaderParityTests
             : 1 << int.Parse(raw[(shift + 2)..].Trim(), CultureInfo.InvariantCulture);
     }
 
+    // Pascal to SCREAMING_SNAKE, breaking on a change of character class as
+    // well as on a capital: the header writes OSC_52_READ, and breaking only on
+    // capitals gives OSC52_READ, which then reports as "not in the typedef"
+    // rather than as the naming mismatch it is.
     private static string ToScreamingSnake(string pascal)
     {
         var sb = new StringBuilder(pascal.Length + 8);
         for (var i = 0; i < pascal.Length; i++)
         {
-            if (i > 0 && char.IsUpper(pascal[i])) sb.Append('_');
+            if (i > 0 && (char.IsUpper(pascal[i])
+                          || (char.IsDigit(pascal[i]) && !char.IsDigit(pascal[i - 1]))))
+            {
+                sb.Append('_');
+            }
+
             sb.Append(char.ToUpperInvariant(pascal[i]));
         }
 

--- a/windows/Ghostty.Tests/Interop/GhosttyActionTagHeaderParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionTagHeaderParityTests.cs
@@ -178,6 +178,19 @@ public class GhosttyActionTagHeaderParityTests
     public void PointCoord_Ordinals_Match_Header() =>
         AssertMatchesHeader<GhosttyPointCoord>("ghostty_point_coord_e", "GHOSTTY_POINT_COORD_");
 
+    [Fact]
+    public void TriggerTag_Ordinals_Match_Header() =>
+        AssertMatchesHeader<GhosttyTriggerTag>(
+            "ghostty_input_trigger_tag_e", "GHOSTTY_TRIGGER_");
+
+    // Mirrors config.QuickTerminalSize's tag rather than an action payload, so
+    // it sits apart from the group above. QuickTerminalSizeCLayoutTests pins
+    // the struct around it but never checked these ordinals.
+    [Fact]
+    public void QuickTerminalSizeTag_Ordinals_Match_Header() =>
+        AssertMatchesHeader<QuickTerminalSizeTag>(
+            "ghostty_quick_terminal_size_tag_e", "GHOSTTY_QUICK_TERMINAL_SIZE_");
+
     // ghostty_target_tag_e decides which half of GhosttyHost.OnAction an action
     // is delivered to, so swapping these two routes every app action into the
     // surface arm. It used to be two consts beside that switch, where no test
@@ -278,10 +291,16 @@ public class GhosttyActionTagHeaderParityTests
         var header = ParseHeaderEnum(headerText, typedefName, explicitValues);
 
         // A [Flags] enum's zero member is sometimes the "no bits" convention C
-        // does not write down. Sometimes it is, though -- ghostty_input_mods_e
-        // spells GHOSTTY_MODS_NONE -- so this is a fallback for a zero the
-        // header does not name, not a blanket exemption. Skipping every flags
-        // zero would stop the completeness check seeing a NONE that vanished.
+        // does not write down, and sometimes it is not -- ghostty_input_mods_e
+        // spells GHOSTTY_MODS_NONE. So the exemption is a fallback for a zero
+        // the header does not name, applied only after the lookup misses.
+        //
+        // Exempting it up front instead, as the first version did, also took it
+        // out of `mirrored`, which made every header that DOES name a NONE
+        // report it as unmirrored -- Mods_Values_Match_Header could not have
+        // passed. Note what this still does not catch: a NONE deleted from the
+        // header goes unnoticed either way, because the managed member is
+        // skipped and the completeness loop only walks header entries.
         var isFlags = typeof(TEnum).IsDefined(typeof(FlagsAttribute), inherit: false);
 
         var mismatches = new List<(string Name, string Detail)>();
@@ -361,11 +380,44 @@ public class GhosttyActionTagHeaderParityTests
             : 1 << int.Parse(raw[(shift + 2)..].Trim(), CultureInfo.InvariantCulture);
     }
 
+    // The names no mechanical rule reaches, managed member to C suffix.
+    //
+    // The header is not self-consistent about digits -- OSC_52_READ separates
+    // the digits, OSC8 and F1 do not -- and it runs acronyms together where C#
+    // capitalises them. Rather than grow the converter a rule per exception,
+    // each one is written down here, and StaleNameOverrides refuses an entry
+    // that has stopped being needed.
+    private static readonly Dictionary<string, string> NameOverrides = new(StringComparer.Ordinal)
+    {
+        ["MacOS"] = "MACOS",
+        ["IOS"] = "IOS",
+    };
+
+    [Fact]
+    public void No_Name_Override_Is_Stale()
+    {
+        // An override that the converter would now produce anyway is a lie
+        // about the header, and the next reader has no way to tell which of the
+        // entries here are load-bearing.
+        var redundant = NameOverrides
+            .Where(kv => ToScreamingSnakeCore(kv.Key) == kv.Value)
+            .Select(kv => kv.Key)
+            .ToArray();
+
+        Assert.True(
+            redundant.Length == 0,
+            "these name overrides now match what the converter produces, so " +
+            $"they say nothing: {string.Join(", ", redundant)}");
+    }
+
+    private static string ToScreamingSnake(string pascal) =>
+        NameOverrides.TryGetValue(pascal, out var mapped) ? mapped : ToScreamingSnakeCore(pascal);
+
     // Pascal to SCREAMING_SNAKE, breaking on a change of character class as
     // well as on a capital: the header writes OSC_52_READ, and breaking only on
     // capitals gives OSC52_READ, which then reports as "not in the typedef"
     // rather than as the naming mismatch it is.
-    private static string ToScreamingSnake(string pascal)
+    private static string ToScreamingSnakeCore(string pascal)
     {
         var sb = new StringBuilder(pascal.Length + 8);
         for (var i = 0; i < pascal.Length; i++)

--- a/windows/Ghostty/Controls/TerminalControl.xaml.cs
+++ b/windows/Ghostty/Controls/TerminalControl.xaml.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Ghostty.Core;
 using Ghostty.Core.Input;
+using Ghostty.Core.Interop;
 using Ghostty.Core.ResizeOverlay;
 using Ghostty.Core.Windows;
 using Ghostty.Core.Search;

--- a/windows/Ghostty/Hosting/ClipboardBridge.cs
+++ b/windows/Ghostty/Hosting/ClipboardBridge.cs
@@ -2,10 +2,10 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Ghostty.Core.Clipboard;
+using Ghostty.Core.Interop;
 using Ghostty.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
-using Ghostty.Core.Interop;
 
 namespace Ghostty.Hosting;
 

--- a/windows/Ghostty/Hosting/ClipboardBridge.cs
+++ b/windows/Ghostty/Hosting/ClipboardBridge.cs
@@ -5,6 +5,7 @@ using Ghostty.Core.Clipboard;
 using Ghostty.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
+using Ghostty.Core.Interop;
 
 namespace Ghostty.Hosting;
 

--- a/windows/Ghostty/InspectorWindow.xaml.cs
+++ b/windows/Ghostty/InspectorWindow.xaml.cs
@@ -12,6 +12,7 @@ using Ghostty.Core;
 using Ghostty.Interop;
 
 using WinRT.Interop;
+using Ghostty.Core.Interop;
 
 namespace Ghostty;
 

--- a/windows/Ghostty/InspectorWindow.xaml.cs
+++ b/windows/Ghostty/InspectorWindow.xaml.cs
@@ -1,18 +1,15 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-
+using Ghostty.Core;
+using Ghostty.Core.Interop;
+using Ghostty.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Input;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
-
-using Ghostty.Core;
-using Ghostty.Interop;
-
 using WinRT.Interop;
-using Ghostty.Core.Interop;
 
 namespace Ghostty;
 

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -19,85 +19,6 @@ internal readonly record struct GhosttyConfig(IntPtr Handle);
 internal readonly record struct GhosttySurface(IntPtr Handle);
 internal readonly record struct GhosttyInspector(IntPtr Handle);
 
-internal enum GhosttyPlatform
-{
-    Invalid = 0,
-    MacOS = 1,
-    IOS = 2,
-    Windows = 3,
-}
-
-internal enum GhosttySurfaceContext
-{
-    Window = 0,
-    Tab = 1,
-    Split = 2,
-}
-
-internal enum GhosttyClipboard
-{
-    Standard = 0,
-    Selection = 1,
-}
-
-internal enum GhosttyClipboardRequest
-{
-    Paste = 0,
-    Osc52Read = 1,
-    Osc52Write = 2,
-}
-
-internal enum GhosttyMouseState
-{
-    Release = 0,
-    Press = 1,
-}
-
-internal enum GhosttyMouseButton
-{
-    Unknown = 0,
-    Left = 1,
-    Right = 2,
-    Middle = 3,
-    Four = 4,
-    Five = 5,
-    Six = 6,
-    Seven = 7,
-    Eight = 8,
-    Nine = 9,
-    Ten = 10,
-    Eleven = 11,
-}
-
-internal enum GhosttyColorScheme
-{
-    Light = 0,
-    Dark = 1,
-}
-
-[Flags]
-internal enum GhosttyMods
-{
-    None = 0,
-    Shift = 1 << 0,
-    Ctrl = 1 << 1,
-    Alt = 1 << 2,
-    Super = 1 << 3,
-    Caps = 1 << 4,
-    Num = 1 << 5,
-    ShiftRight = 1 << 6,
-    CtrlRight = 1 << 7,
-    AltRight = 1 << 8,
-    SuperRight = 1 << 9,
-}
-
-internal enum GhosttyInputAction
-{
-    Release = 0,
-    Press = 1,
-    Repeat = 2,
-}
-
 [StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyInputKey
 {
@@ -196,23 +117,6 @@ internal struct GhosttyCells
     public ushort CursorRow;
     public ushort CursorCol;
     public byte CursorInViewport;
-}
-
-// Mirrors ghostty_point_tag_e.
-internal enum GhosttyPointTag
-{
-    Active = 0,
-    Viewport = 1,
-    Screen = 2,
-    Surface = 3,
-}
-
-// Mirrors ghostty_point_coord_e.
-internal enum GhosttyPointCoord
-{
-    Exact = 0,
-    TopLeft = 1,
-    BottomRight = 2,
 }
 
 // Mirrors ghostty_point_s.

--- a/windows/Ghostty/MainWindow.xaml.cs
+++ b/windows/Ghostty/MainWindow.xaml.cs
@@ -447,8 +447,8 @@ public sealed partial class MainWindow : Window
         _systemUiSettings = new Windows.UI.ViewManagement.UISettings();
         var initialDark = Ghostty.Services.OsTheme.IsDark(_systemUiSettings);
         var initialScheme = initialDark
-            ? Ghostty.Interop.GhosttyColorScheme.Dark
-            : Ghostty.Interop.GhosttyColorScheme.Light;
+            ? Ghostty.Core.Interop.GhosttyColorScheme.Dark
+            : Ghostty.Core.Interop.GhosttyColorScheme.Light;
         Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, initialScheme);
         // Closes the gap between ConfigService seeding its themed values in
         // its constructor and this window reading the scheme: a flip in
@@ -473,8 +473,8 @@ public sealed partial class MainWindow : Window
             DispatcherQueue.TryEnqueue(() =>
             {
                 var scheme = dark
-                    ? Ghostty.Interop.GhosttyColorScheme.Dark
-                    : Ghostty.Interop.GhosttyColorScheme.Light;
+                    ? Ghostty.Core.Interop.GhosttyColorScheme.Dark
+                    : Ghostty.Core.Interop.GhosttyColorScheme.Light;
                 Ghostty.Interop.NativeMethods.AppSetColorScheme(_host.App, scheme);
                 _host.NotifyColorSchemeChanged(scheme);
 


### PR DESCRIPTION
Eleven C enums lived beside the P/Invokes in the WinUI project: platform, surface context, clipboard and clipboard request, mouse state and button, colour scheme, mods, input action, point tag and point coord. `Ghostty.Tests` cannot reference that project, so nothing checked any of them.

They are the same shape as the ones that just broke: positions in an enum edited elsewhere, crossing the boundary as ints, renumbered by an insertion without breaking a build. `GhosttyMouseButton` has twelve members and `GhosttyPointTag` four, so there is plenty to shift.

Moved to `Ghostty.Core/Interop`, beside the action payload enums that were already pinned, and checked against `include/ghostty.h` in both directions. A reviewer re-derived all 25 pinned enums (172 members) independently against the header: all correct.

## After review

**A table, not a rename.** The first attempt renamed `GhosttyPlatform.MacOS`/`.IOS` to `Macos`/`Ios` so the mechanical name converter would reach them. That buys a fix that does not generalise -- the header is not self-consistent about digits either, spelling `OSC_52_READ` with separators and `OSC8` and `F1` without -- so the next enum pinned would need another rename. The BCL names are back and a `NameOverrides` table carries the irregular spellings, with a check that refuses an entry the converter would now produce anyway.

**The flags-zero comment claimed a guarantee the code does not give.** A `NONE` deleted from the header still goes unnoticed, because the managed member is skipped and the completeness loop only walks header entries. What the change actually fixes is a false failure: exempting the zero up front also took it out of the mirrored set, so a header that *does* spell `GHOSTTY_MODS_NONE` reported it as unmirrored and `Mods_Values_Match_Header` could never have passed. The comment now says that.

## Two more enums pinned

`ghostty_input_trigger_tag_e` had four private copies of its values under `Input/`, one per file that decodes a keybind step. An insertion there decodes every physical trigger as unicode and renders a garbage glyph in the keybind editor with nothing reporting an error. They derive from one declaration now, so only the initialisers changed and every switch case and comparison is untouched.

`ghostty_quick_terminal_size_tag_e` had its struct pinned but never its ordinals.

## What the header taught the checker

- The `[Flags]` zero member is exempt only when the header does not name one.
- The name mapping breaks at a letter-to-digit boundary as well as at a capital, for `OSC_52_READ`; anything that rule cannot reach goes in the override table.

## Verified

Negative controls: swapping `Osc52Read`/`Osc52Write` fails `ClipboardRequest`; deleting `GhosttyMouseButton.Eleven` fails `MouseButton` through the completeness check; adding a redundant override fails the stale-override check.

2233 passed / 1 skipped; Ghostty.Tests.Windows 44 passed / 12 skipped.

## Follow-ups, not in this PR

`KeyNames.cs` is a 176-entry positional table mirroring `ghostty_input_key_e`, guarded only by a count assertion and a few spot ordinals copied from itself -- a swap or rename passes it untouched. Currently correct (all 176 verified), but it wants the same treatment, via a lowercase-and-strip-prefix path that avoids the digit problem entirely.
