### PR TITLE
interop: compute the C struct layouts instead of restating them

### DIFF
--- a/windows/Ghostty.Core/Interop/GhosttyActions.cs
+++ b/windows/Ghostty.Core/Interop/GhosttyActions.cs
@@ -10,8 +10,10 @@ namespace Ghostty.Core.Interop;
 // in GhosttyHost compile unchanged.
 //
 // GhosttyActionTagHeaderParityTests reads include/ghostty.h and checks
-// every ordinal below against it; GhosttyActionsLayoutTests pins the
-// struct layouts. Nothing here needs re-verifying by hand after a sync.
+// every ordinal below against it; GhosttyStructHeaderParityTests computes
+// the C layout of each struct below and checks offsets, sizes, field
+// types and field names against it. Nothing here needs re-verifying by
+// hand after a sync.
 
 // Subset of ghostty_action_tag_e that the Windows apprt dispatches on.
 // Any unlisted tag falls through to "return false" in
@@ -182,6 +184,18 @@ internal struct GhosttyActionMoveTab
     public nint Amount;
 }
 
+// ghostty_action_desktop_notification_s:
+//   { const char* title; const char* body; }
+// Both pointer-sized: title@0, body@8, 16 bytes on x64. Read at
+// actionPtr+8. Declared so the layout is checked rather than living as
+// two literals at the read site.
+[StructLayout(LayoutKind.Sequential)]
+internal struct GhosttyActionDesktopNotification
+{
+    public nint Title;
+    public nint Body;
+}
+
 // ghostty_action_progress_report_state_e.
 internal enum GhosttyProgressState
 {
@@ -193,11 +207,14 @@ internal enum GhosttyProgressState
 }
 
 // ghostty_action_progress_report_s:
-//   { int32 state; int8 progress; /* -1 if none, else 0..100 */ }
+//   { ghostty_action_progress_report_state_e state;
+//     int8 progress; /* -1 if none, else 0..100 */ }
+// State is the enum rather than a bare int, so it mirrors the C field type
+// and the read site does not have to cast.
 [StructLayout(LayoutKind.Sequential)]
 internal struct GhosttyActionProgressReport
 {
-    public int State;
+    public GhosttyProgressState State;
     public sbyte Progress;
 }
 

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -1,58 +1,25 @@
 using System.Runtime.InteropServices;
-using Ghostty.Core.Interop;
-using Ghostty.Core.Renderer;
 using Xunit;
 
 namespace Ghostty.Tests.Interop;
 
-// Pins ghostty_action_* struct layouts (FFI ABI with include/ghostty.h).
-// Ordinals live in GhosttyActionTagHeaderParityTests.
+// What is left after the header-driven checks took the rest: the shape of the
+// action envelope itself, which is not a struct include/ghostty.h declares.
+//
+// Everything else that used to live here restated the header as a literal --
+// ordinals as `(int)SomeEnum.Member == <literal>`, sizes and offsets as
+// `SizeOf<T>() == <literal>`. The ordinal form could only fail if someone
+// edited one of two copies alone, and it stayed green while an insertion
+// misrouted twenty tags. The layout form was better, since it did compare
+// against the managed struct, but it still only looked at one side: a field
+// appended to a C struct fails nothing. GhosttyActionTagHeaderParityTests and
+// GhosttyStructHeaderParityTests read include/ghostty.h instead.
+//
+// PromptTitleEnum_MatchesHeader is the illustration worth keeping in mind: it
+// asserted Surface and Tab, and stayed green through the whole time the
+// managed enum was missing the Window the header had.
 public class GhosttyActionsLayoutTests
 {
-    // Ordinals are NOT pinned here. This file used to carry three [Theory]
-    // blocks asserting (int)SomeEnum.Member == a literal copied out of that
-    // same enum, which can only fail if someone edits one of the two copies
-    // alone. They stayed green while an upstream insertion misrouted twenty
-    // tags. GhosttyActionTagHeaderParityTests checks them against
-    // include/ghostty.h, which is the only file that can disagree.
-
-    [Fact]
-    public void ScrollbarStruct_Size_Is_24_Bytes()
-    {
-        // { uint64 total; uint64 offset; uint64 len; } -> 3 * 8 = 24
-        Assert.Equal(24, Marshal.SizeOf<GhosttyActionScrollbar>());
-    }
-
-    [Fact]
-    public void ScrollbarStruct_Field_Offsets_Match_C_Layout()
-    {
-        // GhosttyHost reads this struct at (actionPtr + 8) via
-        // Unsafe.ReadUnaligned, so the three fields MUST sit at
-        // +0/+8/+16 within the struct itself.
-        Assert.Equal(0,  (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Total)));
-        Assert.Equal(8,  (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Offset)));
-        Assert.Equal(16, (int)Marshal.OffsetOf<GhosttyActionScrollbar>(nameof(GhosttyActionScrollbar.Len)));
-    }
-
-    [Fact]
-    public void ProgressReportStruct_Size_Is_8_Bytes()
-    {
-        // { int32 state; sbyte progress; } + 3 bytes of trailing
-        // alignment padding on x64 -> 8. Pinning total size catches
-        // a future field reorder that only shuffles trailing padding.
-        Assert.Equal(8, Marshal.SizeOf<GhosttyActionProgressReport>());
-    }
-
-    [Fact]
-    public void ProgressReportStruct_Field_Offsets_Match_C_Layout()
-    {
-        // ghostty_action_progress_report_s is read at +8/+12 inside
-        // the action union. The struct itself sits at +0/+4 with the
-        // sbyte right after the int32 (no packing tricks on x64).
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionProgressReport>(nameof(GhosttyActionProgressReport.State)));
-        Assert.Equal(4, (int)Marshal.OffsetOf<GhosttyActionProgressReport>(nameof(GhosttyActionProgressReport.Progress)));
-    }
-
     // Probe struct modelling the C ABI of `ghostty_action_s`:
     //   { ghostty_action_tag_e tag; ghostty_action_u action; }
     //
@@ -83,153 +50,5 @@ public class GhosttyActionsLayoutTests
             8,
             (int)Marshal.OffsetOf<GhosttyActionEnvelopeProbe>(
                 nameof(GhosttyActionEnvelopeProbe.Payload)));
-    }
-
-    [Fact]
-    public void MouseOverLinkStruct_Size_Is_16_Bytes()
-    {
-        // { const char* url; size_t len; } on x64 = 8 + 8 = 16
-        Assert.Equal(16, Marshal.SizeOf<GhosttyActionMouseOverLink>());
-    }
-
-    [Fact]
-    public void MouseOverLinkStruct_Field_Offsets_Match_C_Layout()
-    {
-        // Read at (actionPtr + 8); Url at struct offset 0, Len at 8.
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionMouseOverLink>(nameof(GhosttyActionMouseOverLink.Url)));
-        Assert.Equal(8, (int)Marshal.OffsetOf<GhosttyActionMouseOverLink>(nameof(GhosttyActionMouseOverLink.Len)));
-    }
-
-    [Fact]
-    public void StartSearchStruct_Size_Is_8_Bytes()
-    {
-        // { const char* needle; } on x64 = 8.
-        Assert.Equal(8, Marshal.SizeOf<GhosttyActionStartSearch>());
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionStartSearch>(nameof(GhosttyActionStartSearch.Needle)));
-    }
-
-    [Fact]
-    public void SearchTotalStruct_Size_Is_8_Bytes()
-    {
-        // { ssize_t total; } on x64 = 8.
-        Assert.Equal(8, Marshal.SizeOf<GhosttyActionSearchTotal>());
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionSearchTotal>(nameof(GhosttyActionSearchTotal.Total)));
-    }
-
-    [Fact]
-    public void SearchSelectedStruct_Size_Is_8_Bytes()
-    {
-        // { ssize_t selected; } on x64 = 8.
-        Assert.Equal(8, Marshal.SizeOf<GhosttyActionSearchSelected>());
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionSearchSelected>(nameof(GhosttyActionSearchSelected.Selected)));
-    }
-
-    [Fact]
-    public void ResizeSplitStruct_HasExpectedLayout()
-    {
-        Assert.Equal(8, Marshal.SizeOf<GhosttyActionResizeSplit>());
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionResizeSplit>(nameof(GhosttyActionResizeSplit.Amount)));
-        Assert.Equal(4, (int)Marshal.OffsetOf<GhosttyActionResizeSplit>(nameof(GhosttyActionResizeSplit.Direction)));
-    }
-
-    [Fact]
-    public void SplitDirectionEnum_MatchesHeader()
-    {
-        Assert.Equal(0, (int)GhosttySplitDirection.Right);
-        Assert.Equal(1, (int)GhosttySplitDirection.Down);
-        Assert.Equal(2, (int)GhosttySplitDirection.Left);
-        Assert.Equal(3, (int)GhosttySplitDirection.Up);
-    }
-
-    [Fact]
-    public void GotoTabSentinels_MatchHeader()
-    {
-        Assert.Equal(-1, (int)GhosttyGotoTab.Previous);
-        Assert.Equal(-2, (int)GhosttyGotoTab.Next);
-        Assert.Equal(-3, (int)GhosttyGotoTab.Last);
-    }
-
-    [Fact]
-    public void GotoSplitEnum_MatchesHeader()
-    {
-        Assert.Equal(0, (int)GhosttyGotoSplit.Previous);
-        Assert.Equal(1, (int)GhosttyGotoSplit.Next);
-        Assert.Equal(2, (int)GhosttyGotoSplit.Up);
-        Assert.Equal(3, (int)GhosttyGotoSplit.Left);
-        Assert.Equal(4, (int)GhosttyGotoSplit.Down);
-        Assert.Equal(5, (int)GhosttyGotoSplit.Right);
-    }
-
-    [Fact]
-    public void ResizeSplitDirectionEnum_MatchesHeader()
-    {
-        Assert.Equal(0, (int)GhosttyResizeSplitDirection.Up);
-        Assert.Equal(1, (int)GhosttyResizeSplitDirection.Down);
-        Assert.Equal(2, (int)GhosttyResizeSplitDirection.Left);
-        Assert.Equal(3, (int)GhosttyResizeSplitDirection.Right);
-    }
-
-    [Fact]
-    public void MoveTabStruct_Size_Is_8_Bytes()
-    {
-        Assert.Equal(8, Marshal.SizeOf<GhosttyActionMoveTab>());
-    }
-
-    [Fact]
-    public void ChildExitedStruct_Size_Is_16_Bytes()
-    {
-        // ghostty_surface_message_childexited_s:
-        //   { uint32 exit_code; uint64 runtime_ms; }
-        // exit_code@0, 4 bytes pad, runtime_ms@8 -> 16 total on x64.
-        Assert.Equal(16, Marshal.SizeOf<GhosttyChildExited>());
-    }
-
-    [Fact]
-    public void ChildExitedStruct_Field_Offsets_Match_C_Layout()
-    {
-        // GhosttyHost reads this struct at (actionPtr + 8) via
-        // Unsafe.ReadUnaligned, so the fields MUST sit at +0/+8.
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyChildExited>(nameof(GhosttyChildExited.ExitCode)));
-        Assert.Equal(8, (int)Marshal.OffsetOf<GhosttyChildExited>(nameof(GhosttyChildExited.RuntimeMs)));
-    }
-
-    [Fact]
-    public void SizeLimitStruct_HasExpectedLayout()
-    {
-        Assert.Equal(16, Marshal.SizeOf<GhosttyActionSizeLimit>());
-        Assert.Equal(0,  (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MinWidth)));
-        Assert.Equal(4,  (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MinHeight)));
-        Assert.Equal(8,  (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MaxWidth)));
-        Assert.Equal(12, (int)Marshal.OffsetOf<GhosttyActionSizeLimit>(nameof(GhosttyActionSizeLimit.MaxHeight)));
-    }
-
-    [Fact]
-    public void InitialSizeStruct_HasExpectedLayout()
-    {
-        Assert.Equal(8, Marshal.SizeOf<GhosttyActionInitialSize>());
-        Assert.Equal(0, (int)Marshal.OffsetOf<GhosttyActionInitialSize>(nameof(GhosttyActionInitialSize.Width)));
-        Assert.Equal(4, (int)Marshal.OffsetOf<GhosttyActionInitialSize>(nameof(GhosttyActionInitialSize.Height)));
-    }
-
-    [Fact]
-    public void GotoWindowEnum_MatchesHeader()
-    {
-        Assert.Equal(0, (int)GhosttyGotoWindow.Previous);
-        Assert.Equal(1, (int)GhosttyGotoWindow.Next);
-    }
-
-    [Fact]
-    public void FloatWindowEnum_MatchesHeader()
-    {
-        Assert.Equal(0, (int)GhosttyFloatWindow.On);
-        Assert.Equal(1, (int)GhosttyFloatWindow.Off);
-        Assert.Equal(2, (int)GhosttyFloatWindow.Toggle);
-    }
-
-    [Fact]
-    public void PromptTitleEnum_MatchesHeader()
-    {
-        Assert.Equal(0, (int)GhosttyPromptTitle.Surface);
-        Assert.Equal(1, (int)GhosttyPromptTitle.Tab);
     }
 }

--- a/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyActionsLayoutTests.cs
@@ -15,9 +15,6 @@ namespace Ghostty.Tests.Interop;
 // appended to a C struct fails nothing. GhosttyActionTagHeaderParityTests and
 // GhosttyStructHeaderParityTests read include/ghostty.h instead.
 //
-// PromptTitleEnum_MatchesHeader is the illustration worth keeping in mind: it
-// asserted Surface and Tab, and stayed green through the whole time the
-// managed enum was missing the Window the header had.
 public class GhosttyActionsLayoutTests
 {
     // Probe struct modelling the C ABI of `ghostty_action_s`:

--- a/windows/Ghostty.Tests/Interop/GhosttyStructHeaderParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyStructHeaderParityTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Ghostty.Core.Interop;
+using Xunit;
+
+namespace Ghostty.Tests.Interop;
+
+// Checks the managed payload structs against the C structs in
+// include/ghostty.h, by computing the C layout rather than by restating it.
+//
+// GhosttyActionsLayoutTests asserts sizes and offsets against literals, and
+// those literals were derived from the header by hand. That is not the
+// tautology the ordinal pins were -- editing a managed struct does fail it --
+// but it only ever looks at one side. A field appended to a C struct, or a
+// type widened there, changes the real layout and fails nothing: the managed
+// struct still has the size the literal names, the read at the old offset
+// still succeeds, and it returns the wrong bytes.
+//
+// So this reads the field list out of the header, computes offsets with the
+// x64 rules, and compares against Marshal. Fields are matched by POSITION, not
+// by name: C is positional, and the names do not always agree anyway --
+// ghostty_surface_message_childexited_s carries the `timetime_ms` typo that
+// the managed side spells RuntimeMs.
+//
+// The type table refuses anything it does not know rather than guessing a
+// size. A guess here would be a layout assertion resting on an invention.
+public class GhosttyStructHeaderParityTests
+{
+    private const string HeaderResource = "Ghostty.Tests.Interop.Header.ghostty.h";
+
+    private static readonly Lazy<string> Header = new(LoadHeader);
+
+    // `<type> <name>;` with an optional trailing comment. A pointer star may
+    // sit on either side of the space.
+    private static readonly Regex FieldPattern = new(
+        @"^\s*(?<type>[A-Za-z_][A-Za-z0-9_ ]*?\s*\*?)\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*;\s*(?://.*)?$",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void Scrollbar_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionScrollbar>("ghostty_action_scrollbar_s");
+
+    [Fact]
+    public void MouseOverLink_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionMouseOverLink>("ghostty_action_mouse_over_link_s");
+
+    [Fact]
+    public void SizeLimit_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionSizeLimit>("ghostty_action_size_limit_s");
+
+    [Fact]
+    public void InitialSize_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionInitialSize>("ghostty_action_initial_size_s");
+
+    [Fact]
+    public void ResizeSplit_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionResizeSplit>("ghostty_action_resize_split_s");
+
+    [Fact]
+    public void MoveTab_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionMoveTab>("ghostty_action_move_tab_s");
+
+    [Fact]
+    public void ProgressReport_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionProgressReport>("ghostty_action_progress_report_s");
+
+    [Fact]
+    public void ChildExited_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyChildExited>("ghostty_surface_message_childexited_s");
+
+    [Fact]
+    public void StartSearch_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionStartSearch>("ghostty_action_start_search_s");
+
+    [Fact]
+    public void SearchTotal_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionSearchTotal>("ghostty_action_search_total_s");
+
+    [Fact]
+    public void SearchSelected_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionSearchSelected>("ghostty_action_search_selected_s");
+
+    private static void AssertLayoutMatchesHeader<T>(string typedefName) where T : struct
+    {
+        var expected = CLayoutOf(typedefName);
+
+        // Ordered by where the runtime actually put them, which is the order
+        // that has to match C. Declaration order from reflection would be the
+        // same today and is not guaranteed to be.
+        var managed = typeof(T)
+            .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Select(f => (f.Name, Offset: (int)Marshal.OffsetOf<T>(f.Name)))
+            .OrderBy(f => f.Offset)
+            .ToList();
+
+        Assert.True(
+            expected.Fields.Count == managed.Count,
+            $"{typeof(T).Name} has {managed.Count} fields but {typedefName} has " +
+            $"{expected.Fields.Count} ({string.Join(", ", expected.Fields.Select(f => f.Name))}); " +
+            "a field added on the C side moves everything after it");
+
+        var problems = new List<string>();
+        for (var i = 0; i < managed.Count; i++)
+        {
+            if (managed[i].Offset != expected.Fields[i].Offset)
+            {
+                problems.Add(
+                    $"  {managed[i].Name} is at +{managed[i].Offset} but " +
+                    $"{expected.Fields[i].Name} ({expected.Fields[i].Type}) is at " +
+                    $"+{expected.Fields[i].Offset}");
+            }
+        }
+
+        if (Marshal.SizeOf<T>() != expected.Size)
+        {
+            problems.Add(
+                $"  sizeof is {Marshal.SizeOf<T>()} but {typedefName} computes to {expected.Size}");
+        }
+
+        Assert.True(
+            problems.Count == 0,
+            $"{typeof(T).Name} does not match {typedefName} in include/ghostty.h:\n" +
+            string.Join("\n", problems));
+    }
+
+    private sealed record CField(string Name, string Type, int Offset);
+
+    private sealed record CLayout(IReadOnlyList<CField> Fields, int Size);
+
+    // Standard x64 layout: each field is placed at the next offset that is a
+    // multiple of its alignment, and the total is rounded up to the largest
+    // alignment in the struct. Every type here has alignment equal to its size,
+    // so one table serves for both.
+    private static CLayout CLayoutOf(string typedefName)
+    {
+        var body = StructBody(typedefName);
+
+        var fields = new List<CField>();
+        var offset = 0;
+        var maxAlign = 1;
+
+        foreach (var raw in body.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith("//", StringComparison.Ordinal)) continue;
+
+            var m = FieldPattern.Match(line);
+            Assert.True(m.Success, $"unparsed field in {typedefName}: {line}");
+
+            var type = Regex.Replace(m.Groups["type"].Value.Trim(), @"\s+", " ");
+            var size = SizeOfCType(type, typedefName, line);
+
+            offset = Align(offset, size);
+            fields.Add(new CField(m.Groups["name"].Value, type, offset));
+            offset += size;
+            maxAlign = Math.Max(maxAlign, size);
+        }
+
+        // A struct that parsed to nothing would satisfy every comparison below
+        // against a managed struct that also had no fields, and there is no
+        // such struct here.
+        Assert.True(
+            fields.Count > 0,
+            $"parsed no fields out of {typedefName}; the scan is broken, not the struct");
+
+        return new CLayout(fields, Align(offset, maxAlign));
+    }
+
+    private static int Align(int offset, int alignment) =>
+        (offset + alignment - 1) / alignment * alignment;
+
+    // Refuses what it does not know. Inventing a size for an unrecognised type
+    // would make every offset after it a fiction while still reading green.
+    private static int SizeOfCType(string type, string typedefName, string line)
+    {
+        if (type.EndsWith("*", StringComparison.Ordinal)) return 8;
+
+        // A C enum is an int in every ABI this ships on, and the header's enums
+        // all fit in one.
+        if (type.StartsWith("ghostty_", StringComparison.Ordinal)
+            && type.EndsWith("_e", StringComparison.Ordinal))
+        {
+            return 4;
+        }
+
+        switch (type)
+        {
+            case "int8_t":
+            case "uint8_t":
+            case "bool":
+            case "char":
+                return 1;
+            case "int16_t":
+            case "uint16_t":
+                return 2;
+            case "int32_t":
+            case "uint32_t":
+            case "int":
+            case "float":
+                return 4;
+            case "int64_t":
+            case "uint64_t":
+            case "double":
+            case "size_t":
+            case "ssize_t":
+            case "uintptr_t":
+            case "intptr_t":
+                return 8;
+            default:
+                Assert.Fail(
+                    $"{typedefName}: no size known for C type \"{type}\" in \"{line}\". " +
+                    "Add it to SizeOfCType rather than letting the layout be guessed.");
+                return 0;
+        }
+    }
+
+    // Located from the closing line backwards, like the enum reader: the
+    // opening `typedef struct {` is far from unique in this header.
+    private static string StructBody(string typedefName)
+    {
+        var header = Header.Value;
+
+        var close = header.IndexOf("} " + typedefName + ";", StringComparison.Ordinal);
+        Assert.True(close >= 0, $"{typedefName} not found in include/ghostty.h");
+
+        var open = header.LastIndexOf("typedef struct {", close, StringComparison.Ordinal);
+        Assert.True(open >= 0, $"no struct body precedes {typedefName} in include/ghostty.h");
+
+        return header[(open + "typedef struct {".Length)..close];
+    }
+
+    private static string LoadHeader()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(HeaderResource);
+        Assert.True(
+            stream is not null,
+            $"{HeaderResource} is not embedded; see Ghostty.Tests.csproj");
+
+        using var reader = new StreamReader(stream!);
+        return reader.ReadToEnd();
+    }
+}

--- a/windows/Ghostty.Tests/Interop/GhosttyStructHeaderParityTests.cs
+++ b/windows/Ghostty.Tests/Interop/GhosttyStructHeaderParityTests.cs
@@ -22,13 +22,20 @@ namespace Ghostty.Tests.Interop;
 // still succeeds, and it returns the wrong bytes.
 //
 // So this reads the field list out of the header, computes offsets with the
-// x64 rules, and compares against Marshal. Fields are matched by POSITION, not
-// by name: C is positional, and the names do not always agree anyway --
-// ghostty_surface_message_childexited_s carries the `timetime_ms` typo that
-// the managed side spells RuntimeMs.
+// x64 rules, and compares offset, type and name for each field plus the total
+// size against Marshal.
+//
+// All four, because each alone has a blind spot. Offsets miss a widening that
+// padding absorbs: uint16_t -> uint32_t leaves ResizeSplit at {0, 4} and eight
+// bytes while the managed ushort reads the low half. Types miss a swap of two
+// fields that share a type. Names catch that swap, at the cost of a rename map
+// for the places C and C# genuinely disagree -- there is one, the `timetime_ms`
+// typo that the managed side spells RuntimeMs.
 //
 // The type table refuses anything it does not know rather than guessing a
-// size. A guess here would be a layout assertion resting on an invention.
+// size. A guess here would be a layout assertion resting on an invention. The
+// one modelling gap that would fail GREEN rather than loudly is struct packing,
+// so StructBody refuses a header carrying a pragma for it.
 public class GhosttyStructHeaderParityTests
 {
     private const string HeaderResource = "Ghostty.Tests.Interop.Header.ghostty.h";
@@ -69,9 +76,14 @@ public class GhosttyStructHeaderParityTests
     public void ProgressReport_Layout_Matches_Header() =>
         AssertLayoutMatchesHeader<GhosttyActionProgressReport>("ghostty_action_progress_report_s");
 
+    // The one rename in the set: the header's field carries a `timetime_ms`
+    // typo that the managed side spells RuntimeMs. Declared rather than
+    // tolerated, so the name check stays on for every other field.
     [Fact]
     public void ChildExited_Layout_Matches_Header() =>
-        AssertLayoutMatchesHeader<GhosttyChildExited>("ghostty_surface_message_childexited_s");
+        AssertLayoutMatchesHeader<GhosttyChildExited>(
+            "ghostty_surface_message_childexited_s",
+            new Dictionary<string, string> { ["timetime_ms"] = "RuntimeMs" });
 
     [Fact]
     public void StartSearch_Layout_Matches_Header() =>
@@ -85,8 +97,28 @@ public class GhosttyStructHeaderParityTests
     public void SearchSelected_Layout_Matches_Header() =>
         AssertLayoutMatchesHeader<GhosttyActionSearchSelected>("ghostty_action_search_selected_s");
 
-    private static void AssertLayoutMatchesHeader<T>(string typedefName) where T : struct
+    [Fact]
+    public void DesktopNotification_Layout_Matches_Header() =>
+        AssertLayoutMatchesHeader<GhosttyActionDesktopNotification>(
+            "ghostty_action_desktop_notification_s");
+
+    /// <param name="renamed">
+    /// C field name to managed field name, for the places the two genuinely
+    /// disagree. Explicit rather than inferred, because "the names need not
+    /// match" is what lets a reorder through: with names compared, swapping two
+    /// fields of the same type is caught, and that is a swap neither the
+    /// offsets nor the types can see.
+    /// </param>
+    private static void AssertLayoutMatchesHeader<T>(
+        string typedefName,
+        IReadOnlyDictionary<string, string>? renamed = null) where T : struct
     {
+        // x64 is what the whole table below assumes. On a 32-bit runtime every
+        // pointer-sized field would compute to 8 while Marshal reports 4, and
+        // eleven tests would report an ABI break that is really this test not
+        // modelling the platform.
+        Assert.True(IntPtr.Size == 8, "these layouts are computed for a 64-bit runtime");
+
         var expected = CLayoutOf(typedefName);
 
         // Ordered by where the runtime actually put them, which is the order
@@ -94,7 +126,7 @@ public class GhosttyStructHeaderParityTests
         // same today and is not guaranteed to be.
         var managed = typeof(T)
             .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            .Select(f => (f.Name, Offset: (int)Marshal.OffsetOf<T>(f.Name)))
+            .Select(f => (f.Name, f.FieldType, Offset: (int)Marshal.OffsetOf<T>(f.Name)))
             .OrderBy(f => f.Offset)
             .ToList();
 
@@ -107,12 +139,30 @@ public class GhosttyStructHeaderParityTests
         var problems = new List<string>();
         for (var i = 0; i < managed.Count; i++)
         {
-            if (managed[i].Offset != expected.Fields[i].Offset)
+            var (name, type, offset) = managed[i];
+            var c = expected.Fields[i];
+
+            if (offset != c.Offset)
+            {
+                problems.Add($"  {name} is at +{offset} but {c.Name} ({c.Type}) is at +{c.Offset}");
+            }
+
+            // Offsets alone let a widening that padding absorbs through:
+            // uint16_t amount -> uint32_t keeps ResizeSplit at {0, 4} and 8
+            // bytes while the managed ushort silently reads the low half.
+            if (!TypeMatches(type, c.Type))
+            {
+                problems.Add($"  {name} is {type.Name} but {c.Name} is {c.Type}");
+            }
+
+            var expectedName = renamed is not null && renamed.TryGetValue(c.Name, out var mapped)
+                ? mapped
+                : ToPascal(c.Name);
+            if (!string.Equals(name, expectedName, StringComparison.Ordinal))
             {
                 problems.Add(
-                    $"  {managed[i].Name} is at +{managed[i].Offset} but " +
-                    $"{expected.Fields[i].Name} ({expected.Fields[i].Type}) is at " +
-                    $"+{expected.Fields[i].Offset}");
+                    $"  field {i} is {name} but {typedefName} calls it {c.Name} " +
+                    $"(expected {expectedName}); if the rename is deliberate, pass it in `renamed`");
             }
         }
 
@@ -127,6 +177,46 @@ public class GhosttyStructHeaderParityTests
             $"{typeof(T).Name} does not match {typedefName} in include/ghostty.h:\n" +
             string.Join("\n", problems));
     }
+
+    // Which managed types a C type may be spelled as. An enum stands in for the
+    // C enum it mirrors, so any 4-byte-backed enum is accepted; which enum it is
+    // is GhosttyActionTagHeaderParityTests's business, not this file's.
+    private static bool TypeMatches(Type managed, string cType)
+    {
+        if (managed.IsEnum)
+        {
+            var backing = Enum.GetUnderlyingType(managed);
+            return cType.StartsWith("ghostty_", StringComparison.Ordinal)
+                   && cType.EndsWith("_e", StringComparison.Ordinal)
+                   && (backing == typeof(int) || backing == typeof(uint));
+        }
+
+        if (cType.EndsWith("*", StringComparison.Ordinal))
+        {
+            return managed == typeof(IntPtr) || managed == typeof(UIntPtr);
+        }
+
+        return cType switch
+        {
+            "int8_t" => managed == typeof(sbyte),
+            "uint8_t" or "bool" or "char" => managed == typeof(byte),
+            "int16_t" => managed == typeof(short),
+            "uint16_t" => managed == typeof(ushort),
+            "int32_t" or "int" => managed == typeof(int),
+            "uint32_t" => managed == typeof(uint),
+            "int64_t" => managed == typeof(long),
+            "uint64_t" => managed == typeof(ulong),
+            "float" => managed == typeof(float),
+            "double" => managed == typeof(double),
+            "ssize_t" or "intptr_t" => managed == typeof(IntPtr),
+            "size_t" or "uintptr_t" => managed == typeof(UIntPtr) || managed == typeof(IntPtr),
+            _ => false,
+        };
+    }
+
+    private static string ToPascal(string snake) =>
+        string.Concat(snake.Split('_', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => char.ToUpperInvariant(part[0]) + part[1..]));
 
     private sealed record CField(string Name, string Type, int Offset);
 
@@ -225,13 +315,28 @@ public class GhosttyStructHeaderParityTests
     {
         var header = Header.Value;
 
+        // Everything else here fails loudly when it cannot model something.
+        // Packing is the exception: under a pragma the computed C layout stays
+        // natural, the managed sequential layout stays natural, the two agree,
+        // and the real ABI is neither.
+        Assert.DoesNotContain("#pragma pack", header, StringComparison.Ordinal);
+
         var close = header.IndexOf("} " + typedefName + ";", StringComparison.Ordinal);
         Assert.True(close >= 0, $"{typedefName} not found in include/ghostty.h");
 
         var open = header.LastIndexOf("typedef struct {", close, StringComparison.Ordinal);
         Assert.True(open >= 0, $"no struct body precedes {typedefName} in include/ghostty.h");
 
-        return header[(open + "typedef struct {".Length)..close];
+        var body = header[(open + "typedef struct {".Length)..close];
+
+        // The backwards search only matches the anonymous `typedef struct {`
+        // form. Rewritten as `typedef struct name { ... } name_s;` it would
+        // walk past and return the previous struct's body plus a stray closing
+        // line; that line fails the field pattern, but the message would name
+        // the wrong struct.
+        Assert.DoesNotContain("}", body, StringComparison.Ordinal);
+
+        return body;
     }
 
     private static string LoadHeader()

--- a/windows/Ghostty/Hosting/GhosttyHost.cs
+++ b/windows/Ghostty/Hosting/GhosttyHost.cs
@@ -966,9 +966,17 @@ internal sealed partial class GhosttyHost : IDisposable
 
                 case GhosttyActionTag.ProgressReport:
                 {
-                    var state = (GhosttyProgressState)Marshal.ReadInt32(actionPtr, 8);
-                    var rawPct = (sbyte)Marshal.ReadByte(actionPtr, 12);
-                    int pct = rawPct < 0 ? 0 : rawPct;
+                    // Read through the struct rather than at literal +8/+12.
+                    // The literals were guarded only by a test asserting a
+                    // struct nothing compiled against.
+                    GhosttyActionProgressReport report;
+                    unsafe
+                    {
+                        report = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyActionProgressReport>(
+                            (void*)(actionPtr + 8));
+                    }
+                    var state = report.State;
+                    int pct = report.Progress < 0 ? 0 : report.Progress;
                     var tabState = state switch
                     {
                         GhosttyProgressState.Remove        => Ghostty.Core.Tabs.TabProgressState.None,
@@ -995,10 +1003,14 @@ internal sealed partial class GhosttyHost : IDisposable
                     // config check here. Copy the strings on the libghostty
                     // thread before the buffer frees, then decide + show on the
                     // UI thread where focus state is valid.
-                    var titlePtr = Marshal.ReadIntPtr(actionPtr, 8);
-                    var bodyPtr = Marshal.ReadIntPtr(actionPtr, 16);
-                    var title = Marshal.PtrToStringUTF8(titlePtr) ?? string.Empty;
-                    var body = Marshal.PtrToStringUTF8(bodyPtr) ?? string.Empty;
+                    GhosttyActionDesktopNotification notification;
+                    unsafe
+                    {
+                        notification = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<GhosttyActionDesktopNotification>(
+                            (void*)(actionPtr + 8));
+                    }
+                    var title = Marshal.PtrToStringUTF8(notification.Title) ?? string.Empty;
+                    var body = Marshal.PtrToStringUTF8(notification.Body) ?? string.Empty;
                     _dispatcher.TryEnqueue(() =>
                     {
                         if (!TryResolveControl(surfaceHandle, out var c) || c is null) return;

--- a/windows/Ghostty/Interop/NativeMethods.cs
+++ b/windows/Ghostty/Interop/NativeMethods.cs
@@ -307,9 +307,11 @@ internal struct GhosttyTarget
 // struct sizes. Call sites in GhosttyHost see them unchanged via the
 // `using Ghostty.Core.Interop;` at the top of this file.
 //
-// See GhosttyActionsLayoutTests in Ghostty.Tests for the build-time
-// assertions and the grep command for re-verifying against
-// include/ghostty.h after a libghostty rebase.
+// GhosttyActionTagHeaderParityTests and GhosttyStructHeaderParityTests read
+// include/ghostty.h itself, so there is nothing here to re-verify by hand
+// after a libghostty rebase. The types still declared BELOW this line are the
+// ones that live in this assembly, which Ghostty.Tests cannot reference, so
+// nothing checks those.
 
 // ghostty_action_set_title_s { const char* title; }
 // We only read .title; the struct is declared so the offset is explicit.


### PR DESCRIPTION
The struct pins asserted sizes and offsets against literals derived from the header by hand.

That was never the tautology the ordinal pins were -- editing a managed struct does fail it -- but it only ever looked at one side. A field appended to a C struct changes the real layout and fails nothing: the managed struct still has the size the literal names, the read at the old offset still succeeds, and it returns the wrong bytes.

## Instead

`GhosttyStructHeaderParityTests` reads the field list out of `include/ghostty.h`, computes the x64 layout, and compares **offset, type, name and total size** for each of the twelve payload structs the Windows apprt mirrors.

All four, because each alone has a blind spot -- review found two of them in the first version, which compared offsets and size only:

- Offsets miss a widening that padding absorbs. `uint16_t amount` to `uint32_t` leaves `ResizeSplit` at `{0, 4}` and eight bytes while the managed `ushort` reads the low half.
- Types miss a swap of two fields that share a type. Scrollbar's `offset` and `len` trade places and the reader gets the length where it wants the top row.
- Names catch that swap, at the cost of a rename map for the one place C and C# genuinely disagree: the `timetime_ms` typo the managed side spells `RuntimeMs`. Declaring that one exception is what buys the reorder check for every other field.

The type comparison found a real mismatch on its first run: `GhosttyActionProgressReport.State` was a bare `int` where the header declares the enum. Fixed on the managed side rather than by loosening the check, which also removes a cast at the read site.

## Failing loudly rather than green

The type table refuses a type it does not know rather than guessing a size, and a struct that parses to no fields fails. Packing was the one gap that would have failed *green* -- an unmodelled pragma leaves the computed C layout and the managed layout both natural and agreeing while the real ABI is neither -- so the header is refused if it carries one. `StructBody` also refuses a body containing a brace, so a `typedef struct name {` rewrite cannot report against the wrong struct. x64 is asserted rather than assumed.

## Pins that now guard production code

Two payloads were decoded from raw literals rather than through a struct: progress report at `+8`/`+12`, and desktop notification at `+8`/`+16` with no managed struct at all and pointers on both fields. Both read through `Unsafe.ReadUnaligned` now, like scrollbar and child-exited already did, so the layout checks guard the real decode instead of types nothing compiled against.

## Removed

The superseded literal facts, and the enum pins that survived the last pass (`SplitDirectionEnum_MatchesHeader` and friends were still `(int)Member == <literal copied from Member>`). A reviewer audited all 22 removals against their replacements: each is covered by something at least as strong.

What stays is the action envelope probe, which pins the `+8` payload offset every `OnAction` case reads through. It models a union the header declares inline, so there is no struct to compute it from.

## Verified

Three negative controls, each failing exactly the struct it should: appending `uint32_t added_upstream;` to `ghostty_action_scrollbar_s`; swapping its `offset` and `len`; widening `resize_split`'s `amount` into its padding. Header reverted, `git diff` clean.

2209 passed / 1 skipped; Ghostty.Tests.Windows 44 passed / 12 skipped.
