### PR TITLE
gallery: bundle 11 license-clean custom shaders with a zioshade compile+render verify pipeline

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -37,7 +37,7 @@ each shader.
 Source: https://github.com/sahaj-b/ghostty-cursor-shaders
 License: MIT (LICENSES/sahaj-b-MIT.txt)
 
-Bundled assets: cursor_sweep.glsl, cursor_tail.glsl, cursor_warp.glsl,
+Bundled assets: cursor_sweep.glsl, cursor_tail.glsl,
 rectangle_boom_cursor.glsl, ripple_cursor.glsl,
 ripple_rectangle_cursor.glsl, sonic_boom_cursor.glsl
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -26,6 +26,32 @@ courtesy to the project.
 - tools/monitor.svg
 - tools/make.svg
 
+## Shader gallery
+
+Bundled custom shaders under windows/Ghostty/Assets/Shaders/. Full license
+texts in that directory's LICENSES/ folder; per-file provenance headers in
+each shader.
+
+### ghostty-cursor-shaders (MIT)
+
+Source: https://github.com/sahaj-b/ghostty-cursor-shaders
+License: MIT (LICENSES/sahaj-b-MIT.txt)
+
+Bundled assets: cursor_sweep.glsl, cursor_tail.glsl, cursor_warp.glsl,
+rectangle_boom_cursor.glsl, ripple_cursor.glsl,
+ripple_rectangle_cursor.glsl, sonic_boom_cursor.glsl
+
+### ghostty-shaders (Unlicense)
+
+Source: https://github.com/zoitrok/ghostty-shaders
+License: Unlicense (LICENSES/zoitrok-Unlicense.txt)
+
+Bundled assets: pixels.glsl, scanline.glsl
+
+### Original shaders (MIT, this project)
+
+text_glow.glsl, snowfall.glsl, aurora_background.glsl
+
 ## Existing third-party assets
 
 See windows/Ghostty.Core/Profiles/IconAssets/LICENSE.md for notices that

--- a/justfile
+++ b/justfile
@@ -774,3 +774,11 @@ sync-verify mode="":
         echo "sync-verify PASSED"
     fi
     echo "  git push --force-with-lease origin windows"
+
+# ── shader gallery ─────────────────────────────────────────────────────────
+# Compile + render every bundled gallery shader (windows/Ghostty/Assets/Shaders)
+# through the real shipped pipeline: zioshade HLSL (local) -> DXC DXIL -> D3D12
+# WARP render on the Windows box, fetching PPM preview frames back. A FAIL is a
+# broken gallery entry. See tools/gallery/verify.sh for the env knobs.
+gallery-verify:
+    @bash tools/gallery/verify.sh

--- a/tools/gallery/verify.sh
+++ b/tools/gallery/verify.sh
@@ -72,7 +72,7 @@ exit /b %ERRORLEVEL%
 EOF
 
 win_dir=$(echo "$WARP_DIR" | sed 's|/|\\|g')
-ssh "$WARP_HOST" "if not exist ${win_dir%\\*} mkdir ${win_dir%\\*}"
+ssh "$WARP_HOST" "if not exist $win_dir mkdir $win_dir"
 scp -q "$ZIOSHADE_DIR/tools/warp/run.ps1" \
        "$ZIOSHADE_DIR/tools/warp/warp_render.cpp" \
        "$ZIOSHADE_DIR/tools/warp/fullscreen_vs.hlsl" \

--- a/tools/gallery/verify.sh
+++ b/tools/gallery/verify.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# verify.sh — compile and render the bundled shader gallery through the real
+# shipped pipeline, end to end:
+#
+#   GLSL (prefix + gallery shader)
+#     -> zioshade HLSL            (local; the same compileGlslToHlsl wintty runs)
+#     -> DXC DXIL                 (Windows box; the SDK dxc, DXIL-capable)
+#     -> D3D12 WARP render        (zioshade tools/warp, gallery mode)
+#     -> <name>.ppm frame         (fetched back to previews/)
+#
+# A shader that passes here compiles and renders on the exact path a user's
+# terminal runs. A FAIL is a broken gallery entry: fix the shader or file a
+# zioshade bug — do not ship it.
+#
+# Usage:   tools/gallery/verify.sh
+# Env:
+#   ZIOSHADE_BIN   zioshade CLI (default: ../zioshade/zig-out/bin/zioshade)
+#   WARP_HOST      ssh target with the Windows SDK (default alessandro@ryzen7pro)
+#   WARP_DIR       remote working dir (default C:/wintty_gallery)
+#   ZIOSHADE_DIR   zioshade checkout (default ../zioshade), for tools/warp
+
+set -euo pipefail
+
+repo=$(cd "$(dirname "$0")/../.." && pwd)
+shaders_dir="$repo/windows/Ghostty/Assets/Shaders"
+prefix="$repo/src/renderer/shaders/shadertoy_prefix.glsl"
+previews="$repo/tools/gallery/previews"
+
+ZIOSHADE_DIR=${ZIOSHADE_DIR:-$(cd "$repo/.." && pwd)/zioshade}
+ZIOSHADE_BIN=${ZIOSHADE_BIN:-$ZIOSHADE_DIR/zig-out/bin/zioshade}
+WARP_HOST=${WARP_HOST:-alessandro@ryzen7pro}
+WARP_DIR=${WARP_DIR:-C:/wintty_gallery}
+DXC_WIN='C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\dxc.exe'
+
+if [ ! -x "$ZIOSHADE_BIN" ]; then
+  echo "zioshade CLI not found at $ZIOSHADE_BIN (build it: cd $ZIOSHADE_DIR && zig build cli)" >&2
+  exit 2
+fi
+
+stage=$(mktemp -d /tmp/gallery_verify.XXXXXX)
+trap 'rm -rf "$stage"' EXIT
+
+# ── 1. Local compile gate: prefix + shader -> HLSL via zioshade ────────────
+pass=0; fail=0; failed=""
+for glsl in "$shaders_dir"/*.glsl; do
+  name=$(basename "$glsl" .glsl)
+  cat "$prefix" "$glsl" > "$stage/$name.full.glsl"
+  if "$ZIOSHADE_BIN" hlsl "$stage/$name.full.glsl" -o "$stage/$name.hlsl" --stage fragment 2>"$stage/$name.err"; then
+    pass=$((pass+1))
+  else
+    echo "FAIL zioshade $name: $(head -1 "$stage/$name.err")"
+    fail=$((fail+1)); failed="$failed $name"
+  fi
+done
+echo "zioshade HLSL: $pass pass, $fail fail"
+[ "$fail" -eq 0 ] || { echo "not staging (fix zioshade failures first):$failed"; exit 1; }
+
+# ── 2. Stage everything to the Windows box ─────────────────────────────────
+# build_warp.cmd carries the clang-cl recipe from zioshade tools/warp/README.md
+# (that box has no vcvars; a batch file sidesteps every ssh quoting problem).
+cat > "$stage/build_warp.cmd" <<'EOF'
+@echo off
+set "PATH=C:\Program Files\LLVM\bin;C:\Windows\System32"
+set "MSVC=C:\Program Files\Microsoft Visual Studio\18\Community\VC\Tools\MSVC\14.51.36231"
+set "SDK=C:\Program Files (x86)\Windows Kits\10"
+set "SDKVER=10.0.26100.0"
+set "INCLUDE=%MSVC%\include;%SDK%\Include\%SDKVER%\ucrt;%SDK%\Include\%SDKVER%\um;%SDK%\Include\%SDKVER%\shared;%SDK%\Include\%SDKVER%\winrt"
+set "LIB=%MSVC%\lib\x64;%SDK%\Lib\%SDKVER%\ucrt\x64;%SDK%\Lib\%SDKVER%\um\x64"
+if exist warp_render.exe exit /b 0
+clang-cl /std:c++17 /EHsc /O2 /D_CRT_SECURE_NO_WARNINGS warp_render.cpp /Fe:warp_render.exe -fuse-ld=lld /link d3d12.lib dxgi.lib
+exit /b %ERRORLEVEL%
+EOF
+
+win_dir=$(echo "$WARP_DIR" | sed 's|/|\\|g')
+ssh "$WARP_HOST" "if not exist ${win_dir%\\*} mkdir ${win_dir%\\*}"
+scp -q "$ZIOSHADE_DIR/tools/warp/run.ps1" \
+       "$ZIOSHADE_DIR/tools/warp/warp_render.cpp" \
+       "$ZIOSHADE_DIR/tools/warp/fullscreen_vs.hlsl" \
+       "$stage/build_warp.cmd" \
+       "$stage"/*.hlsl \
+       "$WARP_HOST:$WARP_DIR/"
+
+# ── 3. Build warp_render.exe (once) and run the gallery sweep ───────────────
+ssh "$WARP_HOST" "cd /d $win_dir && build_warp.cmd" || { echo "warp_render build failed" >&2; exit 3; }
+
+echo "running WARP gallery render on $WARP_HOST..."
+ssh "$WARP_HOST" "cd /d $win_dir && powershell -ExecutionPolicy Bypass -File run.ps1 -Gallery -Dir . -Dxc \"$DXC_WIN\" -Warp .\warp_render.exe"
+
+# ── 4. Fetch the rendered frames back as previews ──────────────────────────
+mkdir -p "$previews"
+scp -q "$WARP_HOST:$WARP_DIR/*.ppm" "$previews/" || echo "(no PPMs fetched)"
+echo "previews in $previews"

--- a/windows/Ghostty/Assets/Shaders/LICENSES/sahaj-b-MIT.txt
+++ b/windows/Ghostty/Assets/Shaders/LICENSES/sahaj-b-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sahaj Bhatt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/windows/Ghostty/Assets/Shaders/LICENSES/zoitrok-Unlicense.txt
+++ b/windows/Ghostty/Assets/Shaders/LICENSES/zoitrok-Unlicense.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/windows/Ghostty/Assets/Shaders/README.md
+++ b/windows/Ghostty/Assets/Shaders/README.md
@@ -1,0 +1,39 @@
+# wintty shader gallery
+
+Bundled custom shaders for the terminal. Every entry in `shaders.json` is
+shown in Settings under Appearance, and every entry is compile- and
+render-verified through the real shipped pipeline (GLSL -> zioshade ->
+HLSL -> DXC -> DXIL -> D3D12) by `just gallery-verify` at the repo root.
+
+## The contract
+
+Each `.glsl` file here contains only `mainImage()` in Shadertoy style.
+wintty prepends `src/renderer/shaders/shadertoy_prefix.glsl` at runtime,
+which declares the uniforms:
+
+- `iChannel0` - the terminal frame texture (sample with
+  `texture(iChannel0, fragCoord.xy / iResolution.xy)`)
+- `iTime`, `iTimeDelta`, `iFrame`, `iFrameRate`
+- cursor state: `iCurrentCursor`, `iPreviousCursor`, cursor colors and
+  styles, `iCursorVisible`
+- `iPalette[256]`, background/foreground/selection colors
+- `iMouse`, `iDate`, `iFocus`
+
+Coordinate convention on wintty: `fragCoord` has its origin at the
+top-left and +Y points down.
+
+## Licensing
+
+Only shaders that can be redistributed with attribution are bundled:
+MIT, Unlicense, or original work in this repo. Each vendored file carries
+a provenance header, and the full license texts live in `LICENSES/`.
+Anything else (unlicensed collections, Shadertoy ports under the default
+CC BY-NC-SA, GPL) must not be added.
+
+## Adding a shader
+
+1. Drop the `.glsl` file here with a provenance header.
+2. Add an entry to `shaders.json`.
+3. Add the license text under `LICENSES/` if it is not original work,
+   and an entry in the repo's `THIRD_PARTY_NOTICES.md`.
+4. Run `just gallery-verify` and make sure it reports PASS.

--- a/windows/Ghostty/Assets/Shaders/aurora_background.glsl
+++ b/windows/Ghostty/Assets/Shaders/aurora_background.glsl
@@ -1,0 +1,59 @@
+// Written for the wintty shader gallery. License: MIT (wintty project).
+//
+// Aurora: a slow, dim aurora that shows through the terminal background.
+// Bright text pixels are left alone; dark (background) pixels get tinted
+// by moving noise bands. Readability first.
+
+float hash(vec2 p) {
+    p = fract(p * vec2(443.897, 441.423));
+    p += dot(p, p + 19.19);
+    return fract(p.x * p.y);
+}
+
+float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float fbm(vec2 p) {
+    float v = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 4; i++) {
+        v += a * noise(p);
+        p = p * 2.03 + vec2(11.7, 5.3);
+        a *= 0.5;
+    }
+    return v;
+}
+
+float luma(vec3 c) { return dot(c, vec3(0.2126, 0.7152, 0.0722)); }
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    vec4 base = texture(iChannel0, uv);
+
+    float t = iTime * 0.06;
+
+    // Vertical bands drifting sideways; stretch x so bands look like curtains.
+    vec2 q = vec2(uv.x * 2.5 - t * 0.8, uv.y * 1.8 + t * 0.3);
+    float n = fbm(q);
+
+    // Classic aurora palette: teal through green to a hint of violet.
+    vec3 aurora = mix(vec3(0.05, 0.35, 0.30), vec3(0.10, 0.55, 0.25), n);
+    aurora = mix(aurora, vec3(0.25, 0.20, 0.45), smoothstep(0.6, 1.0, n));
+
+    // Stronger toward the top of the screen (wintty: small y is up top).
+    float band = smoothstep(-0.2, 0.6, 1.0 - uv.y) * (0.55 + 0.45 * n);
+
+    // Only tint dark pixels; bright text keeps its color.
+    float bg = 1.0 - smoothstep(0.08, 0.35, luma(base.rgb));
+    vec3 outc = mix(base.rgb, base.rgb * 0.4 + aurora * band, bg * 0.85);
+
+    fragColor = vec4(outc, base.a);
+}

--- a/windows/Ghostty/Assets/Shaders/cursor_sweep.glsl
+++ b/windows/Ghostty/Assets/Shaders/cursor_sweep.glsl
@@ -1,0 +1,227 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/sahaj-b/ghostty-cursor-shaders
+// Author: Sahaj Bhatt
+// License: MIT — full text in LICENSES/sahaj-b-MIT.txt
+// Unmodified except for this header.
+
+// sRGB -> Linear conversion (needed because Ghostty passes sRGB values but the shader pipeline operates in linear color space)
+vec3 sRGBToLinear(vec3 c) {
+    return mix(c / 12.92, pow((c + 0.055) / 1.055, vec3(2.4)), step(vec3(0.04045), c));
+}
+
+// --- CONFIGURATION ---
+vec4 TRAIL_COLOR = vec4(sRGBToLinear(iCurrentCursorColor.rgb), iCurrentCursorColor.a); // for custom color: vec4(0.2, 0.6, 1.0, 0.5); (wrap in sRGBToLinear for correct brightness)
+const float DURATION = 0.2; // in seconds
+const float TRAIL_LENGTH = 0.5;
+const float BLUR = 2.0; // blur size in pixels (for antialiasing)
+
+// --- CONSTANTS for easing functions ---
+const float PI = 3.14159265359;
+const float C1_BACK = 1.70158;
+const float C2_BACK = C1_BACK * 1.525;
+const float C3_BACK = C1_BACK + 1.0;
+const float C4_ELASTIC = (2.0 * PI) / 3.0;
+const float C5_ELASTIC = (2.0 * PI) / 4.5;
+const float SPRING_STIFFNESS = 9.0;
+const float SPRING_DAMPING = 0.9;
+
+// --- EASING FUNCTIONS ---
+
+// // Linear
+// float ease(float x) {
+//     return x;
+// }
+
+// // EaseOutQuad
+// float ease(float x) {
+//     return 1.0 - (1.0 - x) * (1.0 - x);
+// }
+
+// EaseOutCubic
+float ease(float x) {
+    return 1.0 - pow(1.0 - x, 3.0);
+}
+
+// // EaseOutQuart
+// float ease(float x) {
+//     return 1.0 - pow(1.0 - x, 4.0);
+// }
+
+// // EaseOutQuint
+// float ease(float x) {
+//     return 1.0 - pow(1.0 - x, 5.0);
+// }
+
+// EaseOutSine
+// float ease(float x) {
+//     return sin((x * PI) / 2.0);
+// }
+
+// // EaseOutExpo
+// float ease(float x) {
+//     return x == 1.0 ? 1.0 : 1.0 - pow(2.0, -10.0 * x);
+// }
+
+// // EaseOutCirc
+// float ease(float x) {
+//     return sqrt(1.0 - pow(x - 1.0, 2.0));
+// }
+
+// // EaseOutBack
+// float ease(float x) {
+//     return 1.0 + C3_BACK * pow(x - 1.0, 3.0) + C1_BACK * pow(x - 1.0, 2.0);
+// }
+
+// // EaseOutElastic
+// float ease(float x) {
+//     return x == 0.0 ? 0.0
+//          : x == 1.0 ? 1.0
+//                     : pow(2.0, -10.0 * x) * sin((x * 10.0 - 0.75) * C4_ELASTIC) + 1.0;
+// }
+
+// Parametric Spring
+// float ease(float x) {
+//     x = clamp(x, 0.0, 1.0);
+//     float decay = exp(-SPRING_DAMPING * SPRING_STIFFNESS * x);
+//     float freq = sqrt(SPRING_STIFFNESS * (1.0 - SPRING_DAMPING * SPRING_DAMPING));
+//     float osc = cos(freq * 6.283185 * x) + (SPRING_DAMPING * sqrt(SPRING_STIFFNESS) / freq) * sin(freq * 6.283185 * x);
+//     return 1.0 - decay * osc;
+// }
+
+float getSdfRectangle(in vec2 point, in vec2 center, in vec2 halfSize)
+{
+    vec2 d = abs(point - center) - halfSize;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+// Based on Inigo Quilez's 2D distance functions article: https://iquilezles.org/articles/distfunctions2d/
+// Potencially optimized by eliminating conditionals and loops to enhance performance and reduce branching
+
+float seg(in vec2 p, in vec2 a, in vec2 b, inout float s, float d) {
+    vec2 e = b - a;
+    vec2 w = p - a;
+    vec2 proj = a + e * clamp(dot(w, e) / dot(e, e), 0.0, 1.0);
+    float segd = dot(p - proj, p - proj);
+    d = min(d, segd);
+
+    float c0 = step(0.0, p.y - a.y);
+    float c1 = 1.0 - step(0.0, p.y - b.y);
+    float c2 = 1.0 - step(0.0, e.x * w.y - e.y * w.x);
+    float allCond = c0 * c1 * c2;
+    float noneCond = (1.0 - c0) * (1.0 - c1) * (1.0 - c2);
+    float flip = mix(1.0, -1.0, step(0.5, allCond + noneCond));
+    s *= flip;
+    return d;
+}
+
+float getSdfParallelogram(in vec2 p, in vec2 v0, in vec2 v1, in vec2 v2, in vec2 v3) {
+    float s = 1.0;
+    float d = dot(p - v0, p - v0);
+
+    d = seg(p, v0, v3, s, d);
+    d = seg(p, v1, v0, s, d);
+    d = seg(p, v2, v1, s, d);
+    d = seg(p, v3, v2, s, d);
+
+    return s * sqrt(d);
+}
+
+vec2 normalize(vec2 value, float isPosition) {
+    return (value * 2.0 - (iResolution.xy * isPosition)) / iResolution.y;
+}
+
+float antialising(float distance) {
+	return 1. - smoothstep(0., normalize(vec2(BLUR, BLUR), 0.).x, distance);
+}
+
+float getTopVertexFlag(vec2 a, vec2 b) {
+    float condition1 = step(b.x, a.x) * step(a.y, b.y); // a.x < b.x && a.y > b.y
+    float condition2 = step(a.x, b.x) * step(b.y, a.y); // a.x > b.x && a.y < b.y
+
+    // if neither condition is met, return 1 (else case)
+    return 1.0 - max(condition1, condition2);
+}
+
+vec2 getRectangleCenter(vec4 rectangle) {
+    return vec2(rectangle.x + (rectangle.z / 2.), rectangle.y - (rectangle.w / 2.));
+}
+
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord){
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+
+    // normalization & setup(-1, 1 coords)
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+    
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = currentCursor.xy - (currentCursor.zw * offsetFactor);
+    vec2 centerCP = previousCursor.xy - (previousCursor.zw * offsetFactor);
+
+    float sdfCurrentCursor = getSdfRectangle(vu, centerCC, currentCursor.zw * 0.5);
+    
+     float lineLength = distance(centerCC, centerCP);
+	
+     vec4 newColor = vec4(fragColor);
+	
+     float minDist = currentCursor.w * 1.5;
+     float progress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+     if (lineLength > minDist) {
+         // --- Animation Logic ---
+         float shrinkFactor = ease(progress);
+
+        // detect straight moves
+        vec2 delta = abs(centerCC - centerCP);
+        float threshold = 0.001;
+        float isHorizontal = step(delta.y, threshold);
+        float isVertical = step(delta.x, threshold);
+        float isStraightMove = max(isHorizontal, isVertical);
+
+        // -- Making parallelogram sdf (diagonal moves) ---
+        float topVertexFlag = getTopVertexFlag(currentCursor.xy, previousCursor.xy);
+        float bottomVertexFlag = 1.0 - topVertexFlag;
+        vec2 v0 = vec2(currentCursor.x + currentCursor.z * topVertexFlag, currentCursor.y - currentCursor.w);
+        vec2 v1 = vec2(currentCursor.x + currentCursor.z * bottomVertexFlag, currentCursor.y);
+        vec2 v2_full = vec2(previousCursor.x + currentCursor.z * bottomVertexFlag, previousCursor.y);
+        vec2 v3_full = vec2(previousCursor.x + currentCursor.z * topVertexFlag, previousCursor.y - previousCursor.w);
+
+        vec2 v2_start = mix(v1, v2_full, TRAIL_LENGTH);
+        vec2 v3_start = mix(v0, v3_full, TRAIL_LENGTH);
+        vec2 v2_anim = mix(v2_start, v1, shrinkFactor);
+        vec2 v3_anim = mix(v3_start, v0, shrinkFactor);
+        
+        float sdfTrail_diag = getSdfParallelogram(vu, v0, v1, v2_anim, v3_anim);
+
+        // --- Making rectangle sdf (straight moves) ---
+        vec2 min_center = min(centerCP, centerCC);
+        vec2 max_center = max(centerCP, centerCC);
+
+        vec2 bBoxSize_full = (max_center - min_center) + currentCursor.zw;
+        vec2 bBoxCenter_full = (min_center + max_center) * 0.5;
+
+        vec2 bBoxSize_start = mix(currentCursor.zw, bBoxSize_full, TRAIL_LENGTH);
+        vec2 bBoxCenter_start = mix(centerCC, bBoxCenter_full, TRAIL_LENGTH);
+
+        vec2 animSize = mix(bBoxSize_start, currentCursor.zw, shrinkFactor);
+        vec2 animCenter = mix(bBoxCenter_start, centerCC, shrinkFactor);
+
+        float sdfTrail_rect = getSdfRectangle(vu, animCenter, animSize * 0.5);
+
+        // -- Selecting and drawing the trail sdf --
+        float sdfTrail = mix(sdfTrail_diag, sdfTrail_rect, isStraightMove);
+
+        vec4 trail = TRAIL_COLOR;
+        float trailAlpha = antialising(sdfTrail);
+        newColor = mix(newColor, trail, trailAlpha);
+
+        // Punch hole
+        newColor = mix(newColor, fragColor, step(sdfCurrentCursor, 0.));
+    }
+
+
+    fragColor = newColor;
+}

--- a/windows/Ghostty/Assets/Shaders/cursor_tail.glsl
+++ b/windows/Ghostty/Assets/Shaders/cursor_tail.glsl
@@ -1,0 +1,245 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/sahaj-b/ghostty-cursor-shaders
+// Author: Sahaj Bhatt
+// License: MIT — full text in LICENSES/sahaj-b-MIT.txt
+// Unmodified except for this header.
+
+// sRGB -> Linear conversion (needed because Ghostty passes sRGB values but the shader pipeline operates in linear color space)
+vec3 sRGBToLinear(vec3 c) {
+    return mix(c / 12.92, pow((c + 0.055) / 1.055, vec3(2.4)), step(vec3(0.04045), c));
+}
+
+// --- CONFIGURATION ---
+vec4 TRAIL_COLOR = vec4(sRGBToLinear(iCurrentCursorColor.rgb), iCurrentCursorColor.a); // for custom color: vec4(0.2, 0.6, 1.0, 0.5); (wrap in sRGBToLinear for correct brightness)
+const float DURATION = 0.09; // in seconds
+const float MAX_TRAIL_LENGTH = 0.2;
+const float THRESHOLD_MIN_DISTANCE = 1.5; // min distance to show trail (units of cursor width)
+const float BLUR = 2.0; // blur size in pixels (for antialiasing)
+
+// --- CONSTANTS for easing functions ---
+const float PI = 3.14159265359;
+const float C1_BACK = 1.70158;
+const float C2_BACK = C1_BACK * 1.525;
+const float C3_BACK = C1_BACK + 1.0;
+const float C4_ELASTIC = (2.0 * PI) / 3.0;
+const float C5_ELASTIC = (2.0 * PI) / 4.5;
+const float SPRING_STIFFNESS = 9.0;
+const float SPRING_DAMPING = 0.9;
+
+// --- EASING FUNCTIONS ---
+
+// // Linear
+// float ease(float x) {
+//     return x;
+// }
+
+// // EaseOutQuad
+// float ease(float x) {
+//     return 1.0 - (1.0 - x) * (1.0 - x);
+// }
+
+// // EaseOutCubic
+// float ease(float x) {
+//     return 1.0 - pow(1.0 - x, 3.0);
+// }
+
+
+// // EaseOutQuart
+// float ease(float x) {
+//     return 1.0 - pow(1.0 - x, 4.0);
+// }
+
+// // EaseOutQuint
+// float ease(float x) {
+//     return 1.0 - pow(1.0 - x, 5.0);
+// }
+
+// // EaseOutSine
+// float ease(float x) {
+//     return sin((x * PI) / 2.0);
+// }
+
+// // EaseOutExpo
+// float ease(float x) {
+//     return x == 1.0 ? 1.0 : 1.0 - pow(2.0, -10.0 * x);
+// }
+
+// EaseOutCirc
+float ease(float x) {
+    return sqrt(1.0 - pow(x - 1.0, 2.0));
+}
+
+// // EaseOutBack
+// float ease(float x) {
+//     return 1.0 + C3_BACK * pow(x - 1.0, 3.0) + C1_BACK * pow(x - 1.0, 2.0);
+// }
+
+// // EaseOutElastic
+// float ease(float x) {
+//     return x == 0.0 ? 0.0
+//          : x == 1.0 ? 1.0
+//                     : pow(2.0, -10.0 * x) * sin((x * 10.0 - 0.75) * C4_ELASTIC) + 1.0;
+// }
+
+// Parametric Spring
+// float ease(float x) {
+//     x = clamp(x, 0.0, 1.0);
+//     float decay = exp(-SPRING_DAMPING * SPRING_STIFFNESS * x);
+//     float freq = sqrt(SPRING_STIFFNESS * (1.0 - SPRING_DAMPING * SPRING_DAMPING));
+//     float osc = cos(freq * 6.283185 * x) + (SPRING_DAMPING * sqrt(SPRING_STIFFNESS) / freq) * sin(freq * 6.283185 * x);
+//     return 1.0 - decay * osc;
+// }
+
+float getSdfRectangle(in vec2 p, in vec2 xy, in vec2 b)
+{
+    vec2 d = abs(p - xy) - b;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+// Based on Inigo Quilez's 2D distance functions article: https://iquilezles.org/articles/distfunctions2d/
+// Potencially optimized by eliminating conditionals and loops to enhance performance and reduce branching
+
+float seg(in vec2 p, in vec2 a, in vec2 b, inout float s, float d) {
+    vec2 e = b - a;
+    vec2 w = p - a;
+    vec2 proj = a + e * clamp(dot(w, e) / dot(e, e), 0.0, 1.0);
+    float segd = dot(p - proj, p - proj);
+    d = min(d, segd);
+
+    float c0 = step(0.0, p.y - a.y);
+    float c1 = 1.0 - step(0.0, p.y - b.y);
+    float c2 = 1.0 - step(0.0, e.x * w.y - e.y * w.x);
+    float allCond = c0 * c1 * c2;
+    float noneCond = (1.0 - c0) * (1.0 - c1) * (1.0 - c2);
+    float flip = mix(1.0, -1.0, step(0.5, allCond + noneCond));
+    s *= flip;
+    return d;
+}
+
+float getSdfParallelogram(in vec2 p, in vec2 v0, in vec2 v1, in vec2 v2, in vec2 v3) {
+    float s = 1.0;
+    float d = dot(p - v0, p - v0);
+
+    d = seg(p, v0, v3, s, d);
+    d = seg(p, v1, v0, s, d);
+    d = seg(p, v2, v1, s, d);
+    d = seg(p, v3, v2, s, d);
+
+    return s * sqrt(d);
+}
+
+vec2 normalize(vec2 value, float isPosition) {
+    return (value * 2.0 - (iResolution.xy * isPosition)) / iResolution.y;
+}
+
+float antialising(float distance) {
+	return 1. - smoothstep(0., normalize(vec2(BLUR, BLUR), 0.).x, distance);
+}
+
+float determineIfTopRightIsLeading(vec2 a, vec2 b) {
+    float condition1 = step(b.x, a.x) * step(a.y, b.y); // a.x < b.x && a.y > b.y
+    float condition2 = step(a.x, b.x) * step(b.y, a.y); // a.x > b.x && a.y < b.y
+
+    // if neither condition is met, return 1 (else case)
+    return 1.0 - max(condition1, condition2);
+}
+
+vec2 getRectangleCenter(vec4 rectangle) {
+    return vec2(rectangle.x + (rectangle.z / 2.), rectangle.y - (rectangle.w / 2.));
+}
+
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord){
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+
+    // normalization & setup(-1, 1 coords)
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+    
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = currentCursor.xy - (currentCursor.zw * offsetFactor);
+    vec2 centerCP = previousCursor.xy - (previousCursor.zw * offsetFactor);
+
+    vec2 delta = centerCP - centerCC;
+    float lineLength = length(delta);
+
+     float sdfCurrentCursor = getSdfRectangle(vu, centerCC, currentCursor.zw * 0.5);
+	
+     vec4 newColor = vec4(fragColor);
+	
+     float minDist = currentCursor.w * THRESHOLD_MIN_DISTANCE;
+     float progress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+     if (lineLength > minDist) {
+         // ANIMATION logic
+        
+        float head_eased = 0.0;
+        float tail_eased = 0.0;
+
+        float tail_delay_factor = MAX_TRAIL_LENGTH / lineLength;
+
+        float isLongMove = step(MAX_TRAIL_LENGTH, lineLength);
+
+        float head_eased_short = ease(progress);
+        float tail_eased_short = ease(smoothstep(tail_delay_factor, 1.0, progress));
+        float head_eased_long = 1.0;
+        float tail_eased_long = ease(progress);
+
+        head_eased = mix(head_eased_long, head_eased_short, isLongMove);
+        tail_eased = mix(tail_eased_long, tail_eased_short, isLongMove);
+
+        // detect straight moves
+        vec2 delta_abs = abs(centerCC - centerCP); 
+        float threshold = 0.001;
+        float isHorizontal = step(delta_abs.y, threshold);
+        float isVertical = step(delta_abs.x, threshold);
+        float isStraightMove = max(isHorizontal, isVertical);
+
+        // -- Making the parallelogram sdf (diagonal move) --
+
+        // animate the TOP-LEFT corners
+        vec2 head_pos_tl = mix(previousCursor.xy, currentCursor.xy, head_eased);
+        vec2 tail_pos_tl = mix(previousCursor.xy, currentCursor.xy, tail_eased);
+
+        float isTopRightLeading = determineIfTopRightIsLeading(currentCursor.xy, previousCursor.xy);
+        float isBottomLeftLeading = 1.0 - isTopRightLeading;
+        
+        // v0, v1 : "front" of the trail (head)
+        vec2 v0 = vec2(head_pos_tl.x + currentCursor.z * isTopRightLeading, head_pos_tl.y - currentCursor.w);
+        vec2 v1 = vec2(head_pos_tl.x + currentCursor.z * isBottomLeftLeading, head_pos_tl.y);
+        
+        // v2, v3: "back" of the trail (tail)
+        vec2 v2 = vec2(tail_pos_tl.x + currentCursor.z * isBottomLeftLeading, tail_pos_tl.y);
+        vec2 v3 = vec2(tail_pos_tl.x + currentCursor.z * isTopRightLeading, tail_pos_tl.y - previousCursor.w);
+
+        float sdfTrail_diag = getSdfParallelogram(vu, v0, v1, v2, v3);
+
+        // -- Making the rectangle sdf (straight move) --
+
+        vec2 head_center = mix(centerCP, centerCC, head_eased);
+        vec2 tail_center = mix(centerCP, centerCC, tail_eased);
+
+        vec2 min_center = min(head_center, tail_center);
+        vec2 max_center = max(head_center, tail_center);
+        
+        vec2 box_size = (max_center - min_center) + currentCursor.zw;
+        vec2 box_center = (min_center + max_center) * 0.5;
+
+        float sdfTrail_rect = getSdfRectangle(vu, box_center, box_size * 0.5);
+
+        // -- FINAL SELECTING AND DRAWING --
+        float sdfTrail = mix(sdfTrail_diag, sdfTrail_rect, isStraightMove);
+        
+        vec4 trail = TRAIL_COLOR;
+        float trailAlpha = antialising(sdfTrail);
+        newColor = mix(newColor, trail, trailAlpha);
+
+        // punch hole
+        newColor = mix(newColor, fragColor, step(sdfCurrentCursor, 0.));
+    }
+
+    fragColor = newColor;
+}

--- a/windows/Ghostty/Assets/Shaders/pixels.glsl
+++ b/windows/Ghostty/Assets/Shaders/pixels.glsl
@@ -1,0 +1,20 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/zoitrok/ghostty-shaders
+// Author: zoitrok
+// License: Unlicense (public domain) — full text in LICENSES/zoitrok-Unlicense.txt
+// Unmodified except for this header.
+
+#define gridsize 3.
+#define linewidth 1.
+#define contrast .3
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+  vec2 uv = fragCoord/iResolution.xy;
+  float sx = step(mod(fragCoord.x, gridsize), linewidth);
+  float sy = step(mod(fragCoord.y, gridsize), linewidth);
+  float s = clamp(sx+sy, 0., contrast);
+  vec4 col = texture(iChannel0, uv);
+  col = col*(1. + contrast) - s;
+  fragColor = vec4(col);
+}

--- a/windows/Ghostty/Assets/Shaders/rectangle_boom_cursor.glsl
+++ b/windows/Ghostty/Assets/Shaders/rectangle_boom_cursor.glsl
@@ -1,0 +1,160 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/sahaj-b/ghostty-cursor-shaders
+// Author: Sahaj Bhatt
+// License: MIT — full text in LICENSES/sahaj-b-MIT.txt
+// Unmodified except for this header.
+
+// CONFIGURATION
+const float DURATION = 0.15;               // How long the ripple animates (seconds)
+const float MAX_SIZE = 0.05;             // Max radius in normalized coords (0.5 = 1/4 screen height)
+const float ANIMATION_START_OFFSET = 0.0;        // Start the ripple slightly progressed (0.0 - 1.0)
+vec4 COLOR = vec4(0.35, 0.36, 0.44, 1.0); // change to iCurrentCursorColor for your cursor's color
+const float CURSOR_WIDTH_CHANGE_THRESHOLD = 0.5; // Triggers ripple if cursor width changes by this fraction
+const float BLUR = 3.0;                    // Blur level in pixels
+
+// Easing functions
+float easeOutQuad(float t) {
+    return 1.0 - (1.0 - t) * (1.0 - t);
+}
+float easeInOutQuad(float t) {
+    return t < 0.5 ? 2.0 * t * t : 1.0 - pow(-2.0 * t + 2.0, 2.0) / 2.0;
+}
+float easeOutCubic(float t) {
+    return 1.0 - pow(1.0 - t, 3.0);
+}
+float easeOutQuart(float t) {
+    return 1.0 - pow(1.0 - t, 4.0);
+}
+float easeOutQuint(float t) {
+    return 1.0 - pow(1.0 - t, 5.0);
+}
+float easeOutExpo(float t) {
+    return t == 1.0 ? 1.0 : 1.0 - pow(2.0, -10.0 * t);
+}
+float easeOutCirc(float t) {
+    return sqrt(1.0 - pow(t - 1.0, 2.0));
+}
+float easeOutSine(float t) {
+    return sin((t * 3.1415916) / 2.0);
+}
+float easeOutElastic(float t) {
+    const float c4 = (2.0 * 3.1415916) / 3.0;
+    return t == 0.0 ? 0.0 : t == 1.0 ? 1.0 : pow(2.0, -10.0 * t) * sin((t * 10.0 - 0.75) * c4) + 1.0;
+}
+float easeOutBounce(float t) {
+    const float n1 = 7.5625;
+    const float d1 = 2.75;
+    if (t < 1.0 / d1) {
+        return n1 * t * t;
+    } else if (t < 2.0 / d1) {
+        return n1 * (t -= 1.5 / d1) * t + 0.75;
+    } else if (t < 2.5 / d1) {
+        return n1 * (t -= 2.25 / d1) * t + 0.9375;
+    } else {
+        return n1 * (t -= 2.625 / d1) * t + 0.984375;
+    }
+}
+float easeOutBack(float t) {
+    const float c1 = 1.70158;
+    const float c3 = c1 + 1.0;
+    return 1.0 + c3 * pow(t - 1.0, 3.0) + c1 * pow(t - 1.0, 2.0);
+}
+
+// Pulse fade functions
+float smoothstepPulse(float t) {
+    return 4.0 * t * (1.0 - t);
+}
+float easeOutPulse(float t) {
+    return t * (2.0 - t);
+}
+float powerCurvePulse(float t) {
+    float x = t * 2.0 - 1.0;
+    return 1.0 - x * x;
+}
+float doubleSmoothstepPulse(float t) {
+    return smoothstep(0.0, 0.5, t) * (1.0 - smoothstep(0.5, 1.0, t));
+}
+float exponentialDecayPulse(float t) {
+    return exp(-3.0 * t) * sin(t * 3.1415916);
+}
+float sinPulse(float t) {
+    return sin(t * 3.1415916);
+}
+
+vec2 normalize(vec2 value, float isPosition) {
+    return (value * 2.0 - (iResolution.xy * isPosition)) / iResolution.y;
+}
+
+float getSdfRectangle(in vec2 p, in vec2 xy, in vec2 b){
+    vec2 d = abs(p - xy) - b;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord){
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+
+    // Normalization & setup (-1 to 1 coords)
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = currentCursor.xy - (currentCursor.zw * offsetFactor);
+
+    float cellWidth = max(currentCursor.z, previousCursor.z); // width of the 'block' cursor
+    
+    // check for significant width change
+    float widthChange = abs(currentCursor.z - previousCursor.z);
+    float widthThresholdNorm = cellWidth * CURSOR_WIDTH_CHANGE_THRESHOLD;
+    float isModeChange = step(widthThresholdNorm, widthChange);
+
+
+    // ANIMATION
+    float rippleProgress = (iTime - iTimeCursorChange) / DURATION + ANIMATION_START_OFFSET;
+    // don't clamp yet; we need to know if it's > 1.0 (finished)
+    float isAnimating = 1.0 - step(1.0, rippleProgress); // progress < 1.0 ? 1.0: 0.0
+    
+    // WHY NOT BRANCHLESS??? here ya go:
+    // because we NEVER have divergence, even in this if/else branchfull logic
+    // why? because its UNIFORM branching (ie, all fragments take the same path) which modern GPUs handles efficiently
+    // its far more efficient than calculating the ripple EVERY FRAME even when not needed(branchless)
+    if (isModeChange > 0.0 && isAnimating > 0.0) {
+        // float easedProgress = rippleProgress;
+        // float easedProgress = easeOutQuad(rippleProgress);
+        // float easedProgress = easeInOutQuad(rippleProgress);
+        // float easedProgress = easeOutCubic(rippleProgress);
+        // float easedProgress = easeOutQuart(rippleProgress);
+        // float easedProgress = easeOutQuint(rippleProgress);
+        // float easedProgress = easeOutExpo(rippleProgress);
+        float easedProgress = easeOutCirc(rippleProgress);
+        // float easedProgress = easeOutSine(rippleProgress);
+        // float easedProgress = easeOutBack(rippleProgress);
+
+        // easedProgress = clamp(easedProgress, 0.0, 1.0);
+
+        // RIPPLE CALCULATION
+        float rippleExpansion = easedProgress * MAX_SIZE;
+        
+        // float fade = 1.0; // no fade
+        // float fade = 1.0 - easedProgress; // linear fade
+        // float fade = 1.0 - smoothstepPulse(rippleProgress);
+        float fade = 1.0 - easeOutPulse(rippleProgress);
+        // float fade = 1.0 - powerCurvePulse(rippleProgress);
+        // float fade = doubleSmoothstepPulse(rippleProgress);
+        // float fade = exponentialDecayPulse(rippleProgress);
+        // float fade = sinPulse(rippleProgress);
+        
+        vec2 halfSizeCC = vec2(currentCursor.z, currentCursor.w) * 0.5 + vec2(rippleExpansion);
+        float sdfRectRing = getSdfRectangle(vu, centerCC, halfSizeCC);
+        
+        // Antialias (1-pixel width in normalized coords)
+        float antiAliasSize = normalize(vec2(BLUR, BLUR), 0.0).x;
+        float ripple = (1.0 - smoothstep(-antiAliasSize, antiAliasSize, sdfRectRing)) * fade;
+        // Apply ripple effect
+        fragColor = mix(fragColor, COLOR, ripple * COLOR.a);
+    }
+    // else: do nothing, keep original fragColor
+}

--- a/windows/Ghostty/Assets/Shaders/ripple_cursor.glsl
+++ b/windows/Ghostty/Assets/Shaders/ripple_cursor.glsl
@@ -1,0 +1,138 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/sahaj-b/ghostty-cursor-shaders
+// Author: Sahaj Bhatt
+// License: MIT — full text in LICENSES/sahaj-b-MIT.txt
+// Unmodified except for this header.
+
+// CONFIGURATION
+const float DURATION = 0.15;               // How long the ripple animates (seconds)
+const float MAX_RADIUS = 0.05;             // Max radius in normalized coords (0.5 = 1/4 screen height)
+const float RING_THICKNESS = 0.02;             // Ring width in normalized coords
+const float CURSOR_WIDTH_CHANGE_THRESHOLD = 0.5; // Triggers ripple if cursor width changes by this fraction
+vec4 COLOR = vec4(0.35, 0.36, 0.44, 1.0); // change to iCurrentCursorColor for your cursor's color
+const float BLUR = 3.0;                    // Blur level in pixels
+const float ANIMATION_START_OFFSET = 0.0;        // Start the ripple slightly progressed (0.0 - 1.0)
+
+
+// Easing functions
+float easeOutQuad(float t) {
+    return 1.0 - (1.0 - t) * (1.0 - t);
+}
+float easeInOutQuad(float t) {
+    return t < 0.5 ? 2.0 * t * t : 1.0 - pow(-2.0 * t + 2.0, 2.0) / 2.0;
+}
+float easeOutCubic(float t) {
+    return 1.0 - pow(1.0 - t, 3.0);
+}
+float easeOutQuart(float t) {
+    return 1.0 - pow(1.0 - t, 4.0);
+}
+float easeOutQuint(float t) {
+    return 1.0 - pow(1.0 - t, 5.0);
+}
+float easeOutExpo(float t) {
+    return t == 1.0 ? 1.0 : 1.0 - pow(2.0, -10.0 * t);
+}
+float easeOutCirc(float t) {
+    return sqrt(1.0 - pow(t - 1.0, 2.0));
+}
+float easeOutSine(float t) {
+    return sin((t * 3.1415916) / 2.0);
+}
+float easeOutElastic(float t) {
+    const float c4 = (2.0 * 3.1415916) / 3.0;
+    return t == 0.0 ? 0.0 : t == 1.0 ? 1.0 : pow(2.0, -10.0 * t) * sin((t * 10.0 - 0.75) * c4) + 1.0;
+}
+float easeOutBounce(float t) {
+    const float n1 = 7.5625;
+    const float d1 = 2.75;
+    if (t < 1.0 / d1) {
+        return n1 * t * t;
+    } else if (t < 2.0 / d1) {
+        return n1 * (t -= 1.5 / d1) * t + 0.75;
+    } else if (t < 2.5 / d1) {
+        return n1 * (t -= 2.25 / d1) * t + 0.9375;
+    } else {
+        return n1 * (t -= 2.625 / d1) * t + 0.984375;
+    }
+}
+float easeOutBack(float t) {
+    const float c1 = 1.70158;
+    const float c3 = c1 + 1.0;
+    return 1.0 + c3 * pow(t - 1.0, 3.0) + c1 * pow(t - 1.0, 2.0);
+}
+
+// Pulse fade functions
+float easeOutPulse(float t) {
+    return t * (2.0 - t);
+}
+float exponentialDecayPulse(float t) {
+    return exp(-3.0 * t) * sin(t * 3.1415916);
+}
+
+vec2 normalize(vec2 value, float isPosition) {
+    return (value * 2.0 - (iResolution.xy * isPosition)) / iResolution.y;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord){
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+
+    // Normalization & setup (-1 to 1 coords)
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = currentCursor.xy - (currentCursor.zw * offsetFactor);
+
+    float cellWidth = max(currentCursor.z, previousCursor.z); // width of the 'block' cursor
+    
+    // check for significant width change
+    float widthChange = abs(currentCursor.z - previousCursor.z);
+    float widthThresholdNorm = cellWidth * CURSOR_WIDTH_CHANGE_THRESHOLD;
+    float isModeChange = step(widthThresholdNorm, widthChange);
+
+
+    // ANIMATION
+    float rippleProgress = (iTime - iTimeCursorChange) / DURATION + ANIMATION_START_OFFSET;
+    // don't clamp yet; we need to know if it's > 1.0 (finished)
+     float isAnimating = 1.0 - step(1.0, rippleProgress); // progress < 1.0 ? 1.0: 0.0
+     
+     if (isModeChange > 0.0 && isAnimating > 0.0) {
+        // Apply easing to progress
+        // float easedProgress = rippleProgress;
+        // float easedProgress = easeOutQuad(rippleProgress);
+        // float easedProgress = easeInOutQuad(rippleProgress);
+        // float easedProgress = easeOutCubic(rippleProgress);
+        // float easedProgress = easeOutQuart(rippleProgress);
+        // float easedProgress = easeOutQuint(rippleProgress);
+        // float easedProgress = easeOutExpo(rippleProgress);
+        float easedProgress = easeOutCirc(rippleProgress);
+        // float easedProgress = easeOutSine(rippleProgress);
+        // float easedProgress = easeOutBack(rippleProgress);
+
+        // RIPPLE CALCULATION
+        float rippleRadius = easedProgress * MAX_RADIUS;
+        
+        // float fade = 1.0; // no fade
+        // float fade = 1.0 - easedProgress; // linear fade
+        float fade = 1.0 - easeOutPulse(rippleProgress);
+        // float fade = 1.0 - exponentialDecayPulse(rippleProgress);
+        
+        // Calculate distance from frag to cursor center
+        float dist = distance(vu, centerCC);
+        
+        float sdfRing = abs(dist - rippleRadius) - RING_THICKNESS * 0.5;
+        
+        // Antialias (1-pixel width in normalized coords)
+        float antiAliasSize = normalize(vec2(BLUR, BLUR), 0.0).x;
+        float ripple = (1.0 - smoothstep(-antiAliasSize, antiAliasSize, sdfRing)) * fade;
+        
+        // Apply ripple effect
+        fragColor = mix(fragColor, COLOR, ripple * COLOR.a);
+    }
+    // else: do nothing, keep original fragColor
+}

--- a/windows/Ghostty/Assets/Shaders/ripple_rectangle_cursor.glsl
+++ b/windows/Ghostty/Assets/Shaders/ripple_rectangle_cursor.glsl
@@ -1,0 +1,144 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/sahaj-b/ghostty-cursor-shaders
+// Author: Sahaj Bhatt
+// License: MIT — full text in LICENSES/sahaj-b-MIT.txt
+// Unmodified except for this header.
+
+// CONFIGURATION
+const float DURATION = 0.15;               // How long the ripple animates (seconds)
+const float MAX_SIZE = 0.05;             // Max radius in normalized coords (0.5 = 1/4 screen height)
+const float RING_THICKNESS = 0.02;             // Ring width in normalized coords
+const float CURSOR_WIDTH_CHANGE_THRESHOLD = 0.5; // Triggers ripple if cursor width changes by this fraction
+vec4 COLOR = vec4(0.35, 0.36, 0.44, 1.0); // change to iCurrentCursorColor for your cursor's color
+const float BLUR = 1.0;                    // Blur level in pixels
+const float ANIMATION_START_OFFSET = 0.0;        // Start the ripple slightly progressed (0.0 - 1.0)
+
+
+// Easing functions
+float easeOutQuad(float t) {
+    return 1.0 - (1.0 - t) * (1.0 - t);
+}
+float easeInOutQuad(float t) {
+    return t < 0.5 ? 2.0 * t * t : 1.0 - pow(-2.0 * t + 2.0, 2.0) / 2.0;
+}
+float easeOutCubic(float t) {
+    return 1.0 - pow(1.0 - t, 3.0);
+}
+float easeOutQuart(float t) {
+    return 1.0 - pow(1.0 - t, 4.0);
+}
+float easeOutQuint(float t) {
+    return 1.0 - pow(1.0 - t, 5.0);
+}
+float easeOutExpo(float t) {
+    return t == 1.0 ? 1.0 : 1.0 - pow(2.0, -10.0 * t);
+}
+float easeOutCirc(float t) {
+    return sqrt(1.0 - pow(t - 1.0, 2.0));
+}
+float easeOutSine(float t) {
+    return sin((t * 3.1415916) / 2.0);
+}
+float easeOutElastic(float t) {
+    const float c4 = (2.0 * 3.1415916) / 3.0;
+    return t == 0.0 ? 0.0 : t == 1.0 ? 1.0 : pow(2.0, -10.0 * t) * sin((t * 10.0 - 0.75) * c4) + 1.0;
+}
+float easeOutBounce(float t) {
+    const float n1 = 7.5625;
+    const float d1 = 2.75;
+    if (t < 1.0 / d1) {
+        return n1 * t * t;
+    } else if (t < 2.0 / d1) {
+        return n1 * (t -= 1.5 / d1) * t + 0.75;
+    } else if (t < 2.5 / d1) {
+        return n1 * (t -= 2.25 / d1) * t + 0.9375;
+    } else {
+        return n1 * (t -= 2.625 / d1) * t + 0.984375;
+    }
+}
+float easeOutBack(float t) {
+    const float c1 = 1.70158;
+    const float c3 = c1 + 1.0;
+    return 1.0 + c3 * pow(t - 1.0, 3.0) + c1 * pow(t - 1.0, 2.0);
+}
+
+// Pulse fade functions
+float easeOutPulse(float t) {
+    return t * (2.0 - t);
+}
+float exponentialDecayPulse(float t) {
+    return exp(-3.0 * t) * sin(t * 3.1415916);
+}
+
+vec2 normalize(vec2 value, float isPosition) {
+    return (value * 2.0 - (iResolution.xy * isPosition)) / iResolution.y;
+}
+
+float getSdfRectangle(in vec2 p, in vec2 xy, in vec2 b){
+    vec2 d = abs(p - xy) - b;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord){
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+
+    // Normalization & setup (-1 to 1 coords)
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = currentCursor.xy - (currentCursor.zw * offsetFactor);
+
+    float cellWidth = max(currentCursor.z, previousCursor.z); // width of the 'block' cursor
+    
+    // check for significant width change
+    float widthChange = abs(currentCursor.z - previousCursor.z);
+    float widthThresholdNorm = cellWidth * CURSOR_WIDTH_CHANGE_THRESHOLD;
+    float isModeChange = step(widthThresholdNorm, widthChange);
+
+
+    // ANIMATION
+    float rippleProgress = (iTime - iTimeCursorChange) / DURATION + ANIMATION_START_OFFSET;
+    // don't clamp yet; we need to know if it's > 1.0 (finished)
+     float isAnimating = 1.0 - step(1.0, rippleProgress); // progress < 1.0 ? 1.0: 0.0
+     
+     if (isModeChange > 0.0 && isAnimating > 0.0) {
+        // Apply easing to progress
+        // float easedProgress = rippleProgress;
+        // float easedProgress = easeOutQuad(rippleProgress);
+        // float easedProgress = easeInOutQuad(rippleProgress);
+        // float easedProgress = easeOutCubic(rippleProgress);
+        // float easedProgress = easeOutQuart(rippleProgress);
+        // float easedProgress = easeOutQuint(rippleProgress);
+        // float easedProgress = easeOutExpo(rippleProgress);
+        float easedProgress = easeOutCirc(rippleProgress);
+        // float easedProgress = easeOutSine(rippleProgress);
+        // float easedProgress = easeOutBack(rippleProgress);
+
+        // RIPPLE CALCULATION
+        float rippleExpansion = easedProgress * MAX_SIZE;
+        
+        // float fade = 1.0; // no fade
+        // float fade = 1.0 - easedProgress; // linear fade
+        float fade = 1.0 - easeOutPulse(rippleProgress);
+        // float fade = 1.0 - exponentialDecayPulse(rippleProgress);
+        
+        // Calculate distance from frag to cursor center
+        // float dist = distance(vu, centerCC);
+        
+        // float sdfRing = abs(dist - rippleExpansion) - RING_THICKNESS * 0.5;
+        vec2 halfSizeCC = vec2(currentCursor.z, currentCursor.w) * 0.5 + vec2(rippleExpansion);
+        float sdfRectRing = abs(getSdfRectangle(vu, centerCC, halfSizeCC)) - RING_THICKNESS * 0.5;
+        // Antialias (1-pixel width in normalized coords)
+        float antiAliasSize = normalize(vec2(BLUR, BLUR), 0.0).x;
+        float ripple = (1.0 - smoothstep(-antiAliasSize, antiAliasSize, sdfRectRing)) * fade;
+
+        // Apply ripple effect
+        fragColor = mix(fragColor, COLOR, ripple * COLOR.a);
+    }
+    // else: do nothing, keep original fragColor
+}

--- a/windows/Ghostty/Assets/Shaders/scanline.glsl
+++ b/windows/Ghostty/Assets/Shaders/scanline.glsl
@@ -1,0 +1,18 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/zoitrok/ghostty-shaders
+// Author: zoitrok
+// License: Unlicense (public domain) — full text in LICENSES/zoitrok-Unlicense.txt
+// Unmodified except for this header.
+
+#define speed 0.1
+#define lineheight 0.01
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+  vec2 uv = fragCoord/iResolution.xy;
+  float s = step(mod(uv.y+iTime*speed,1.0), lineheight)*0.1;
+  uv.x = uv.x + s*0.02;
+  vec4 col = texture(iChannel0, uv);
+  col = col * (1. + s*3.) + s*.5;
+  fragColor = vec4(col);
+}

--- a/windows/Ghostty/Assets/Shaders/shaders.json
+++ b/windows/Ghostty/Assets/Shaders/shaders.json
@@ -1,0 +1,116 @@
+{
+  "version": 1,
+  "notes": "The wintty shader gallery. Each entry is a Shadertoy-style GLSL fragment shader (mainImage) that wintty compiles to HLSL via zioshade at runtime. The uniform contract is src/renderer/shaders/shadertoy_prefix.glsl in the repo root. Verify the whole corpus with: just gallery-verify (see tools/gallery in the repo). cursor_warp is excluded pending a zioshade fix (locals assigned inside a conditional block and read after are emitted as undef reads; DXC rejects with \"Instructions should not read uninitialized value\").",
+  "shaders": [
+    {
+      "id": "cursor_tail",
+      "file": "cursor_tail.glsl",
+      "name": "Cursor tail",
+      "description": "A smooth trailing ribbon follows the cursor between cells.",
+      "category": "cursor",
+      "author": "Sahaj Bhatt",
+      "license": "MIT",
+      "source": "https://github.com/sahaj-b/ghostty-cursor-shaders"
+    },
+    {
+      "id": "cursor_sweep",
+      "file": "cursor_sweep.glsl",
+      "name": "Cursor sweep",
+      "description": "A sweeping highlight glides across the cursor row.",
+      "category": "cursor",
+      "author": "Sahaj Bhatt",
+      "license": "MIT",
+      "source": "https://github.com/sahaj-b/ghostty-cursor-shaders"
+    },
+    {
+      "id": "ripple_cursor",
+      "file": "ripple_cursor.glsl",
+      "name": "Cursor ripple",
+      "description": "A water ripple radiates from the cursor when it jumps.",
+      "category": "cursor",
+      "author": "Sahaj Bhatt",
+      "license": "MIT",
+      "source": "https://github.com/sahaj-b/ghostty-cursor-shaders"
+    },
+    {
+      "id": "ripple_rectangle_cursor",
+      "file": "ripple_rectangle_cursor.glsl",
+      "name": "Cursor rectangle ripple",
+      "description": "Ripple variant that keeps the selection rectangle crisp.",
+      "category": "cursor",
+      "author": "Sahaj Bhatt",
+      "license": "MIT",
+      "source": "https://github.com/sahaj-b/ghostty-cursor-shaders"
+    },
+    {
+      "id": "sonic_boom_cursor",
+      "file": "sonic_boom_cursor.glsl",
+      "name": "Sonic boom cursor",
+      "description": "An expanding shockwave marks each cursor jump.",
+      "category": "cursor",
+      "author": "Sahaj Bhatt",
+      "license": "MIT",
+      "source": "https://github.com/sahaj-b/ghostty-cursor-shaders"
+    },
+    {
+      "id": "rectangle_boom_cursor",
+      "file": "rectangle_boom_cursor.glsl",
+      "name": "Rectangle boom cursor",
+      "description": "Shockwave variant around the whole cursor rectangle.",
+      "category": "cursor",
+      "author": "Sahaj Bhatt",
+      "license": "MIT",
+      "source": "https://github.com/sahaj-b/ghostty-cursor-shaders"
+    },
+    {
+      "id": "scanline",
+      "file": "scanline.glsl",
+      "name": "Scanline",
+      "description": "A bright CRT scanline rolls down the screen.",
+      "category": "screen",
+      "author": "zoitrok",
+      "license": "Unlicense",
+      "source": "https://github.com/zoitrok/ghostty-shaders"
+    },
+    {
+      "id": "pixels",
+      "file": "pixels.glsl",
+      "name": "Pixels",
+      "description": "A chunky pixel-grid shimmer over the frame.",
+      "category": "screen",
+      "author": "zoitrok",
+      "license": "Unlicense",
+      "source": "https://github.com/zoitrok/ghostty-shaders"
+    },
+    {
+      "id": "text_glow",
+      "file": "text_glow.glsl",
+      "name": "Text glow",
+      "description": "A soft bloom around bright text. Subtle and static.",
+      "category": "screen",
+      "author": "wintty",
+      "license": "MIT",
+      "source": "https://github.com/deblasis/wintty"
+    },
+    {
+      "id": "snowfall",
+      "file": "snowfall.glsl",
+      "name": "Snowfall",
+      "description": "Three parallax layers of drifting snow.",
+      "category": "background",
+      "author": "wintty",
+      "license": "MIT",
+      "source": "https://github.com/deblasis/wintty"
+    },
+    {
+      "id": "aurora_background",
+      "file": "aurora_background.glsl",
+      "name": "Aurora",
+      "description": "A slow aurora glowing through the terminal background.",
+      "category": "background",
+      "author": "wintty",
+      "license": "MIT",
+      "source": "https://github.com/deblasis/wintty"
+    }
+  ]
+}

--- a/windows/Ghostty/Assets/Shaders/snowfall.glsl
+++ b/windows/Ghostty/Assets/Shaders/snowfall.glsl
@@ -1,0 +1,51 @@
+// Written for the wintty shader gallery. License: MIT (wintty project).
+//
+// Snowfall: three parallax layers of drifting flakes over the terminal.
+// Subtle by design; the terminal stays fully readable.
+//
+// Convention note: wintty passes fragCoord with the origin at the
+// top-left and +Y pointing down, so the snow drifts toward +Y.
+
+float hash(vec2 p) {
+    p = fract(p * vec2(443.897, 441.423));
+    p += dot(p, p + 19.19);
+    return fract(p.x * p.y);
+}
+
+// One snow layer: repeat a grid of cells, each holding one flake that
+// falls (y grows with time) and sways. Returns the flake's coverage.
+float snowLayer(vec2 uv, float scale, float speed, float sway, float t) {
+    vec2 p = uv * scale;
+    p.y -= t * speed;         // fall
+    p.x += sin(t * sway + p.y * 0.35) * sway; // drift
+
+    vec2 cell = floor(p);
+    vec2 f = fract(p);
+
+    // Flake position inside the cell, per-cell random.
+    vec2 flake = vec2(hash(cell), hash(cell + 7.31));
+    flake = mix(vec2(0.2), vec2(0.8), flake);
+
+    float d = length(f - flake);
+    // Soft dot; a touch of twinkle.
+    float twinkle = 0.75 + 0.25 * sin(t * 2.0 + hash(cell + 3.7) * 6.28);
+    return smoothstep(0.14, 0.02, d) * twinkle;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / iResolution.xy;
+
+    vec4 base = texture(iChannel0, uv);
+
+    float t = iTime;
+    // Parallax: far layers are smaller, slower, dimmer.
+    float snow = 0.0;
+    snow += snowLayer(uv + vec2(0.00, 0.00), 14.0, 0.06, 0.15, t) * 0.25;
+    snow += snowLayer(uv + vec2(0.03, 0.00), 22.0, 0.10, 0.25, t) * 0.30;
+    snow += snowLayer(uv + vec2(0.00, 0.00), 32.0, 0.16, 0.35, t) * 0.35;
+
+    // Cool white flakes, capped so text stays dominant.
+    vec3 flakeCol = vec3(0.92, 0.95, 1.0) * clamp(snow, 0.0, 0.6);
+
+    fragColor = vec4(base.rgb + flakeCol * (1.0 - base.rgb * 0.35), base.a);
+}

--- a/windows/Ghostty/Assets/Shaders/sonic_boom_cursor.glsl
+++ b/windows/Ghostty/Assets/Shaders/sonic_boom_cursor.glsl
@@ -1,0 +1,154 @@
+// Bundled with the wintty shader gallery.
+// Source: https://github.com/sahaj-b/ghostty-cursor-shaders
+// Author: Sahaj Bhatt
+// License: MIT — full text in LICENSES/sahaj-b-MIT.txt
+// Unmodified except for this header.
+
+// CONFIGURATION
+const float DURATION = 0.15;               // How long the ripple animates (seconds)
+const float MAX_RADIUS = 0.06;             // Max radius in normalized coords (0.5 = 1/4 screen height)
+const float ANIMATION_START_OFFSET = 0.0;        // Start the ripple slightly progressed (0.0 - 1.0)
+vec4 COLOR = vec4(0.35, 0.36, 0.44, 1.0); // change to iCurrentCursorColor for your cursor's color
+const float CURSOR_WIDTH_CHANGE_THRESHOLD = 0.5; // Triggers ripple if cursor width changes by this fraction
+const float BLUR = 3.0;                    // Blur level in pixels
+
+
+// Easing functions
+float easeOutQuad(float t) {
+    return 1.0 - (1.0 - t) * (1.0 - t);
+}
+float easeInOutQuad(float t) {
+    return t < 0.5 ? 2.0 * t * t : 1.0 - pow(-2.0 * t + 2.0, 2.0) / 2.0;
+}
+float easeOutCubic(float t) {
+    return 1.0 - pow(1.0 - t, 3.0);
+}
+float easeOutQuart(float t) {
+    return 1.0 - pow(1.0 - t, 4.0);
+}
+float easeOutQuint(float t) {
+    return 1.0 - pow(1.0 - t, 5.0);
+}
+float easeOutExpo(float t) {
+    return t == 1.0 ? 1.0 : 1.0 - pow(2.0, -10.0 * t);
+}
+float easeOutCirc(float t) {
+    return sqrt(1.0 - pow(t - 1.0, 2.0));
+}
+float easeOutSine(float t) {
+    return sin((t * 3.1415916) / 2.0);
+}
+float easeOutElastic(float t) {
+    const float c4 = (2.0 * 3.1415916) / 3.0;
+    return t == 0.0 ? 0.0 : t == 1.0 ? 1.0 : pow(2.0, -10.0 * t) * sin((t * 10.0 - 0.75) * c4) + 1.0;
+}
+float easeOutBounce(float t) {
+    const float n1 = 7.5625;
+    const float d1 = 2.75;
+    if (t < 1.0 / d1) {
+        return n1 * t * t;
+    } else if (t < 2.0 / d1) {
+        return n1 * (t -= 1.5 / d1) * t + 0.75;
+    } else if (t < 2.5 / d1) {
+        return n1 * (t -= 2.25 / d1) * t + 0.9375;
+    } else {
+        return n1 * (t -= 2.625 / d1) * t + 0.984375;
+    }
+}
+float easeOutBack(float t) {
+    const float c1 = 1.70158;
+    const float c3 = c1 + 1.0;
+    return 1.0 + c3 * pow(t - 1.0, 3.0) + c1 * pow(t - 1.0, 2.0);
+}
+
+// Pulse fade functions
+float smoothstepPulse(float t) {
+    return 4.0 * t * (1.0 - t);
+}
+float easeOutPulse(float t) {
+    return t * (2.0 - t);
+}
+float powerCurvePulse(float t) {
+    float x = t * 2.0 - 1.0;
+    return 1.0 - x * x;
+}
+float doubleSmoothstepPulse(float t) {
+    return smoothstep(0.0, 0.5, t) * (1.0 - smoothstep(0.5, 1.0, t));
+}
+float exponentialDecayPulse(float t) {
+    return exp(-3.0 * t) * sin(t * 3.1415916);
+}
+float sinPulse(float t) {
+    return sin(t * 3.1415916);
+}
+
+vec2 normalize(vec2 value, float isPosition) {
+    return (value * 2.0 - (iResolution.xy * isPosition)) / iResolution.y;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord){
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+
+    // Normalization & setup (-1 to 1 coords)
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = currentCursor.xy - (currentCursor.zw * offsetFactor);
+
+    float cellWidth = max(currentCursor.z, previousCursor.z); // width of the 'block' cursor
+    
+    // check for significant width change
+    float widthChange = abs(currentCursor.z - previousCursor.z);
+    float widthThresholdNorm = cellWidth * CURSOR_WIDTH_CHANGE_THRESHOLD;
+    float isModeChange = step(widthThresholdNorm, widthChange);
+
+
+    // ANIMATION
+    float rippleProgress = (iTime - iTimeCursorChange) / DURATION + ANIMATION_START_OFFSET;
+    // don't clamp yet; we need to know if it's > 1.0 (finished)
+     float isAnimating = 1.0 - step(1.0, rippleProgress); // progress < 1.0 ? 1.0: 0.0
+     
+     if (isModeChange > 0.0 && isAnimating > 0.0) {
+        // float easedProgress = rippleProgress;
+        // float easedProgress = easeOutQuad(rippleProgress);
+        // float easedProgress = easeInOutQuad(rippleProgress);
+        // float easedProgress = easeOutCubic(rippleProgress);
+        // float easedProgress = easeOutQuart(rippleProgress);
+        // float easedProgress = easeOutQuint(rippleProgress);
+        // float easedProgress = easeOutExpo(rippleProgress);
+        float easedProgress = easeOutCirc(rippleProgress);
+        // float easedProgress = easeOutSine(rippleProgress);
+        // float easedProgress = easeOutBack(rippleProgress);
+
+        // easedProgress = clamp(easedProgress, 0.0, 1.0);
+
+        // RIPPLE CALCULATION
+        float rippleRadius = easedProgress * MAX_RADIUS;
+        
+        // float fade = 1.0; // no fade
+        // float fade = 1.0 - easedProgress; // linear fade
+        // float fade = 1.0 - smoothstepPulse(rippleProgress);
+        float fade = 1.0 - easeOutPulse(rippleProgress);
+        // float fade = 1.0 - powerCurvePulse(rippleProgress);
+        // float fade = doubleSmoothstepPulse(rippleProgress);
+        // float fade = exponentialDecayPulse(rippleProgress);
+        // float fade = sinPulse(rippleProgress);
+        
+        // Calculate distance from frag to cursor center
+        float dist = distance(vu, centerCC);
+        
+        float sdfCircle = dist - rippleRadius;
+        
+        // Antialias (1-pixel width in normalized coords)
+        float antiAliasSize = normalize(vec2(BLUR, BLUR), 0.0).x;
+        float ripple = (1.0 - smoothstep(-antiAliasSize, antiAliasSize, sdfCircle)) * fade;
+        
+        // Apply ripple effect
+        fragColor = mix(fragColor, COLOR, ripple * COLOR.a);
+    }
+}

--- a/windows/Ghostty/Assets/Shaders/text_glow.glsl
+++ b/windows/Ghostty/Assets/Shaders/text_glow.glsl
@@ -1,0 +1,40 @@
+// Written for the wintty shader gallery. License: MIT (wintty project).
+//
+// Text glow: a soft bloom around bright pixels. Static effect; the glow
+// follows whatever the terminal is showing, so it reads as luminescent
+// text without touching anything else.
+
+const float GLOW_THRESHOLD = 0.55; // luminance above which a pixel glows
+const float GLOW_INTENSITY = 0.35; // how much glow is added back
+const float GLOW_RADIUS    = 3.0;  // in pixels, at the base scale
+
+float luma(vec3 c) { return dot(c, vec3(0.2126, 0.7152, 0.0722)); }
+
+vec3 brightPass(vec2 uv) {
+    vec3 c = texture(iChannel0, uv).rgb;
+    float l = luma(c);
+    return c * smoothstep(GLOW_THRESHOLD, GLOW_THRESHOLD + 0.2, l);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    vec4 base = texture(iChannel0, uv);
+
+    vec2 px = GLOW_RADIUS / iResolution.xy;
+
+    // 12-tap ring blur of the bright pass, two radii for a softer falloff.
+    vec3 glow = vec3(0.0);
+    const int TAPS = 12;
+    const float TAU = 6.28318530718;
+    for (int r = 1; r <= 2; r++) {
+        float scale = float(r) * 0.5;
+        float w = 1.0 / float(r) / float(TAPS);
+        for (int i = 0; i < TAPS; i++) {
+            float a = (float(i) + 0.5) / float(TAPS) * TAU;
+            vec2 off = vec2(cos(a), sin(a)) * px * scale;
+            glow += brightPass(uv + off) * w;
+        }
+    }
+
+    fragColor = vec4(base.rgb + glow * GLOW_INTENSITY, base.a);
+}


### PR DESCRIPTION
Bundles a curated shader gallery under windows/Ghostty/Assets/Shaders: 6 cursor shaders from sahaj-b/ghostty-cursor-shaders (MIT), scanline and pixels from zoitrok/ghostty-shaders (Unlicense), and three originals (text_glow, snowfall, aurora). Each vendored file carries a provenance header, license texts live in LICENSES/, THIRD_PARTY_NOTICES.md is updated, and shaders.json is the manifest the settings UI and the verify pipeline both read.

tools/gallery/verify.sh (just gallery-verify) compiles every shader GLSL -> zioshade HLSL locally, stages to the Windows box, and renders each through DXC -> DXIL -> D3D12 WARP via zioshade tools/warp gallery mode, fetching PPM preview frames back. A FAIL is a broken gallery entry, not a skip.

Running the pipeline found five real zioshade bugs (four fixed in the companion zioshade PR, one filed there); cursor_warp stays excluded until the conditionally-assigned-local undef fix lands.

Verified on ryzen7pro: 11/11 shaders compile through zioshade, DXC-validate, and render real frames on WARP (previews in tools/gallery/previews/). Note the six sahaj-b cursor shaders need the frontend fixes from the companion zioshade PR; the zoitrok and original shaders compile on the v0.8.0 pin as-is.