### PR TITLE
build: bump zioshade to v0.8.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -95,8 +95,8 @@
         // between zioshade versions on unchanged input (lowering and
         // identifier fixes); regenerate any golden outputs.
         .zioshade = .{
-            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.0.tar.gz",
-            .hash = "zioshade-0.8.0-8s3a2hCFUQBFCDEAmZCLd1pctyWrOnNUh83ftGy3dbZc",
+            .url = "https://github.com/zioShade/zioshade/archive/refs/tags/v0.8.1.tar.gz",
+            .hash = "zioshade-0.8.1-8s3a2uqzUQDg5MmjBeS40zPLB7wnhTY7mi70tt3a5smR",
             .lazy = true,
         },
 


### PR DESCRIPTION
v0.8.1 carries the gallery-corpus frontend fixes; without it the shader picker shows the custom-shader-did-not-compile notice on every gallery shader, because the app's pinned v0.8.0 predates all five fixes the corpus surfaced. The verify pipeline had passed because it drove the fixed CLI, not the pinned tarball -- a gap this bump closes.